### PR TITLE
8237360: Add tests that test binding recipe generation directly

### DIFF
--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/Binding.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/Binding.java
@@ -24,6 +24,8 @@ package jdk.internal.foreign.abi;
 
 import jdk.incubator.foreign.MemoryLayout;
 
+import java.util.Objects;
+
 public abstract class Binding {
     static final int MOVE_TAG = 0;
     static final int DEREFERENCE_TAG = 1;
@@ -33,7 +35,7 @@ public abstract class Binding {
     static final int BASE_ADDRESS_TAG = 5;
     static final int DUP_TAG = 6;
 
-    final int tag;
+    private final int tag;
 
     private Binding(int tag) {
         this.tag = tag;
@@ -67,10 +69,24 @@ public abstract class Binding {
         @Override
         public String toString() {
             return "Move{" +
-                    "tag=" + tag +
+                    "tag=" + tag() +
                     ", storage=" + storage +
                     ", type=" + type +
                     '}';
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            Move move = (Move) o;
+            return storage.equals(move.storage) &&
+                    type.equals(move.type);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(tag(), storage, type);
         }
     }
 
@@ -98,10 +114,24 @@ public abstract class Binding {
         @Override
         public String toString() {
             return "Dereference{" +
-                    "tag=" + tag +
+                    "tag=" + tag() +
                     ", offset=" + offset +
                     ", type=" + type +
                     '}';
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            Dereference that = (Dereference) o;
+            return offset == that.offset &&
+                    type.equals(that.type);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(tag(), offset, type);
         }
     }
 
@@ -129,10 +159,24 @@ public abstract class Binding {
         @Override
         public String toString() {
             return "Copy{" +
-                    "tag=" + tag +
+                    "tag=" + tag() +
                     ", size=" + size +
                     ", alignment=" + alignment +
                     '}';
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            Copy copy = (Copy) o;
+            return size == copy.size &&
+                    alignment == copy.alignment;
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(tag(), size, alignment);
         }
     }
 
@@ -160,9 +204,24 @@ public abstract class Binding {
         @Override
         public String toString() {
             return "AllocateBuffer{" +
+                    "tag=" + tag() +
                     "size=" + size +
                     ", alignment=" + alignment +
                     '}';
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            AllocateBuffer that = (AllocateBuffer) o;
+            return size == that.size &&
+                    alignment == that.alignment;
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(tag(), size, alignment);
         }
     }
 
@@ -176,7 +235,20 @@ public abstract class Binding {
 
         @Override
         public String toString() {
-            return "BoxAddress{}";
+            return "BoxAddress{" +
+                    "tag=" + tag() +
+                    "}";
+        }
+
+        @Override
+        public int hashCode() {
+            return tag();
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            return o != null && getClass() == o.getClass();
         }
     }
 
@@ -190,7 +262,20 @@ public abstract class Binding {
 
         @Override
         public String toString() {
-            return "BaseAddress{}";
+            return "BaseAddress{" +
+                    "tag=" + tag() +
+                    "}";
+        }
+
+        @Override
+        public int hashCode() {
+            return tag();
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            return o != null && getClass() == o.getClass();
         }
     }
 
@@ -204,7 +289,20 @@ public abstract class Binding {
 
         @Override
         public String toString() {
-            return "Dup{}";
+            return "Dup{" +
+                    "tag=" + tag() +
+                    "}";
+        }
+
+        @Override
+        public int hashCode() {
+            return tag();
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            return o != null && getClass() == o.getClass();
         }
     }
 }

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/CallingSequence.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/CallingSequence.java
@@ -50,6 +50,10 @@ public class CallingSequence {
                 .map(Binding.Move.class::cast);
     }
 
+    public int argumentCount() {
+        return argumentBindings.size();
+    }
+
     public List<Binding> argumentBindings(int i) {
         return argumentBindings.get(i);
     }

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/aarch64/CallArranger.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/aarch64/CallArranger.java
@@ -87,9 +87,9 @@ public class CallArranger {
     );
 
     // record
-    private static class Bindings {
-        final CallingSequence callingSequence;
-        final boolean isInMemoryReturn;
+    public static class Bindings {
+        public final CallingSequence callingSequence;
+        public final boolean isInMemoryReturn;
 
         Bindings(CallingSequence callingSequence, boolean isInMemoryReturn) {
             this.callingSequence = callingSequence;
@@ -97,7 +97,7 @@ public class CallArranger {
         }
     }
 
-    private static Bindings getBindings(MethodType mt, FunctionDescriptor cDesc, boolean forUpcall) {
+    public static Bindings getBindings(MethodType mt, FunctionDescriptor cDesc, boolean forUpcall) {
         SharedUtils.checkFunctionTypes(mt, cDesc);
 
         CallingSequenceBuilder csb = new CallingSequenceBuilder(forUpcall);
@@ -378,6 +378,7 @@ public class CallArranger {
                             }
                             bindings.add(new Binding.Dereference(offset, type));
                             bindings.add(new Binding.Move(storage, type));
+                            offset += copy;
                         }
                     } else {
                         spillStructUnbox(bindings, layout);
@@ -402,7 +403,7 @@ public class CallArranger {
                     if (regs != null) {
                         long offset = 0;
                         for (int i = 0; i < group.memberLayouts().size(); i++) {
-                            VMStorage storage = regs[i++];
+                            VMStorage storage = regs[i];
                             final long size = group.memberLayouts().get(i).byteSize();
                             Class<?> type = SharedUtils.primitiveCarrierForSize(size);
                             if (i + 1 < group.memberLayouts().size()) {
@@ -503,7 +504,7 @@ public class CallArranger {
                     if (regs != null) {
                         long offset = 0;
                         for (int i = 0; i < group.memberLayouts().size(); i++) {
-                            VMStorage storage = regs[i++];
+                            VMStorage storage = regs[i];
                             final long size = group.memberLayouts().get(i).byteSize();
                             Class<?> type = SharedUtils.primitiveCarrierForSize(size);
                             bindings.add(new Binding.Dup());

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/x64/sysv/CallArranger.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/x64/sysv/CallArranger.java
@@ -79,10 +79,10 @@ public class CallArranger {
     );
 
     // record
-    private static class Bindings {
-        final CallingSequence callingSequence;
-        final boolean isInMemoryReturn;
-        final int nVectorArgs;
+    public static class Bindings {
+        public final CallingSequence callingSequence;
+        public final boolean isInMemoryReturn;
+        public final int nVectorArgs;
 
         Bindings(CallingSequence callingSequence, boolean isInMemoryReturn, int nVectorArgs) {
             this.callingSequence = callingSequence;
@@ -91,7 +91,7 @@ public class CallArranger {
         }
     }
 
-    private static Bindings getBindings(MethodType mt, FunctionDescriptor cDesc, boolean forUpcall) {
+    public static Bindings getBindings(MethodType mt, FunctionDescriptor cDesc, boolean forUpcall) {
         SharedUtils.checkFunctionTypes(mt, cDesc);
 
         CallingSequenceBuilder csb = new CallingSequenceBuilder(forUpcall);
@@ -173,7 +173,7 @@ public class CallArranger {
 
         public static TypeClass ofValue(List<ArgumentClassImpl> classes) {
             if (classes.size() != 1) {
-                throw new IllegalStateException();
+                throw new IllegalStateException("Multiple classes not supported: " + classes);
             }
             final Kind kind;
             switch (classes.get(0)) {

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/x64/windows/CallArranger.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/x64/windows/CallArranger.java
@@ -74,7 +74,7 @@ public class CallArranger {
     );
 
     // record
-    private static class Bindings {
+    public static class Bindings {
         public final CallingSequence callingSequence;
         public final boolean isInMemoryReturn;
 
@@ -84,7 +84,7 @@ public class CallArranger {
         }
     }
 
-    private static Bindings getBindings(MethodType mt, FunctionDescriptor cDesc, boolean forUpcall) {
+    public static Bindings getBindings(MethodType mt, FunctionDescriptor cDesc, boolean forUpcall) {
         SharedUtils.checkFunctionTypes(mt, cDesc);
 
         class CallingSequenceBuilderHelper {

--- a/test/jdk/java/foreign/callarranger/CallArrangerTestBase.java
+++ b/test/jdk/java/foreign/callarranger/CallArrangerTestBase.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import jdk.incubator.foreign.FunctionDescriptor;
+import jdk.incubator.foreign.MemoryLayout;
+import jdk.internal.foreign.abi.Binding;
+import jdk.internal.foreign.abi.CallingSequence;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.testng.Assert.assertEquals;
+
+public class CallArrangerTestBase {
+
+    public static void checkArgumentBindings(CallingSequence callingSequence, Binding[][] argumentBindings) {
+        assertEquals(callingSequence.argumentCount(), argumentBindings.length);
+
+        for (int i = 0; i < callingSequence.argumentCount(); i++) {
+            List<Binding> actual = callingSequence.argumentBindings(i);
+            Binding[] expected = argumentBindings[i];
+            assertEquals(actual, Arrays.asList(expected));
+        }
+    }
+
+    public static void checkReturnBindings(CallingSequence callingSequence, Binding[] returnBindings) {
+        assertEquals(callingSequence.returnBindings(), Arrays.asList(returnBindings));
+    }
+
+    public static FunctionDescriptor descAddArgument(FunctionDescriptor desc, MemoryLayout... layouts) {
+        var args = new ArrayList<>(desc.argumentLayouts());
+        args.addAll(Arrays.asList(layouts));
+        var argsArray = args.toArray(MemoryLayout[]::new);
+        return desc.returnLayout().isEmpty()
+            ? FunctionDescriptor.ofVoid(false, argsArray)
+            : FunctionDescriptor.of(desc.returnLayout().get(), false, argsArray);
+    }
+
+}

--- a/test/jdk/java/foreign/callarranger/TestAarch64CallArranger.java
+++ b/test/jdk/java/foreign/callarranger/TestAarch64CallArranger.java
@@ -1,0 +1,338 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ *  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ *  This code is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License version 2 only, as
+ *  published by the Free Software Foundation.
+ *
+ *  This code is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ *  version 2 for more details (a copy is included in the LICENSE file that
+ *  accompanied this code).
+ *
+ *  You should have received a copy of the GNU General Public License version
+ *  2 along with this work; if not, write to the Free Software Foundation,
+ *  Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ *   Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ *  or visit www.oracle.com if you need additional information or have any
+ *  questions.
+ *
+ */
+
+/*
+ * @test
+ * @modules java.base/sun.nio.ch
+ *          jdk.incubator.foreign/jdk.internal.foreign
+ *          jdk.incubator.foreign/jdk.internal.foreign.abi
+ *          jdk.incubator.foreign/jdk.internal.foreign.abi.aarch64
+ * @build CallArrangerTestBase
+ * @run testng TestAarch64CallArranger
+ */
+
+import jdk.incubator.foreign.FunctionDescriptor;
+import jdk.incubator.foreign.MemoryAddress;
+import jdk.incubator.foreign.MemoryLayout;
+import jdk.incubator.foreign.MemorySegment;
+import jdk.internal.foreign.abi.Binding;
+import jdk.internal.foreign.abi.CallingSequence;
+import jdk.internal.foreign.abi.aarch64.CallArranger;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.lang.invoke.MethodType;
+
+import static jdk.incubator.foreign.MemoryLayouts.AArch64ABI.*;
+import static jdk.internal.foreign.abi.aarch64.AArch64Architecture.*;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+public class TestAarch64CallArranger extends CallArrangerTestBase {
+
+    @Test
+    public void testEmpty() {
+        MethodType mt = MethodType.methodType(void.class);
+        FunctionDescriptor fd = FunctionDescriptor.ofVoid(false);
+        CallArranger.Bindings bindings = CallArranger.getBindings(mt, fd, false);
+
+        assertFalse(bindings.isInMemoryReturn);
+        CallingSequence callingSequence = bindings.callingSequence;
+        assertEquals(callingSequence.methodType(), mt);
+        assertEquals(callingSequence.functionDesc(), fd);
+
+        checkArgumentBindings(callingSequence, new Binding[][]{});
+
+        checkReturnBindings(callingSequence, new Binding[]{});
+    }
+
+    @Test
+    public void testInteger() {
+        MethodType mt = MethodType.methodType(void.class,
+                int.class, int.class, int.class, int.class,
+                int.class, int.class, int.class, int.class,
+                int.class, int.class);
+        FunctionDescriptor fd = FunctionDescriptor.ofVoid(false,
+                C_INT, C_INT, C_INT, C_INT,
+                C_INT, C_INT, C_INT, C_INT,
+                C_INT, C_INT);
+        CallArranger.Bindings bindings = CallArranger.getBindings(mt, fd, false);
+
+        assertFalse(bindings.isInMemoryReturn);
+        CallingSequence callingSequence = bindings.callingSequence;
+        assertEquals(callingSequence.methodType(), mt);
+        assertEquals(callingSequence.functionDesc(), fd);
+
+        checkArgumentBindings(callingSequence, new Binding[][]{
+            { new Binding.Move(r0, int.class) },
+            { new Binding.Move(r1, int.class) },
+            { new Binding.Move(r2, int.class) },
+            { new Binding.Move(r3, int.class) },
+            { new Binding.Move(r4, int.class) },
+            { new Binding.Move(r5, int.class) },
+            { new Binding.Move(r6, int.class) },
+            { new Binding.Move(r7, int.class) },
+            { new Binding.Move(stackStorage(0), int.class) },
+            { new Binding.Move(stackStorage(1), int.class) },
+        });
+
+        checkReturnBindings(callingSequence, new Binding[]{});
+    }
+
+    @Test
+    public void testTwoIntTwoFloat() {
+      MethodType mt = MethodType.methodType(void.class,
+                int.class, int.class, float.class, float.class);
+        FunctionDescriptor fd = FunctionDescriptor.ofVoid(false,
+                C_INT, C_INT, C_FLOAT, C_FLOAT);
+        CallArranger.Bindings bindings = CallArranger.getBindings(mt, fd, false);
+
+        assertFalse(bindings.isInMemoryReturn);
+        CallingSequence callingSequence = bindings.callingSequence;
+        assertEquals(callingSequence.methodType(), mt);
+        assertEquals(callingSequence.functionDesc(), fd);
+
+        checkArgumentBindings(callingSequence, new Binding[][]{
+            { new Binding.Move(r0, int.class) },
+            { new Binding.Move(r1, int.class) },
+            { new Binding.Move(v0, float.class) },
+            { new Binding.Move(v1, float.class) },
+        });
+
+        checkReturnBindings(callingSequence, new Binding[]{});
+    }
+
+    @Test(dataProvider = "structs")
+    public void testStruct(MemoryLayout struct, Binding[] expectedBindings) {
+        MethodType mt = MethodType.methodType(void.class, MemorySegment.class);
+        FunctionDescriptor fd = FunctionDescriptor.ofVoid(false, struct);
+        CallArranger.Bindings bindings = CallArranger.getBindings(mt, fd, false);
+
+        assertFalse(bindings.isInMemoryReturn);
+        CallingSequence callingSequence = bindings.callingSequence;
+        assertEquals(callingSequence.methodType(), mt);
+        assertEquals(callingSequence.functionDesc(), fd);
+
+        checkArgumentBindings(callingSequence, new Binding[][]{
+            expectedBindings
+        });
+
+        checkReturnBindings(callingSequence, new Binding[]{});
+    }
+
+    @DataProvider
+    public static Object[][] structs() {
+        MemoryLayout struct2 = MemoryLayout.ofStruct(C_INT, C_INT, C_DOUBLE, C_INT);
+        return new Object[][]{
+            // struct s { int32_t a, b; double c; };
+            { MemoryLayout.ofStruct(C_INT, C_INT, C_DOUBLE), new Binding[] {
+                new Binding.Dup(),
+                    // s.a & s.b
+                    new Binding.Dereference(0, long.class), new Binding.Move(r0, long.class),
+                    // s.c --> note AArch64 passes this in an *integer* register
+                    new Binding.Dereference(8, long.class), new Binding.Move(r1, long.class),
+            }},
+            // struct s { int32_t a, b; double c; int32_t d };
+            { struct2, new Binding[] {
+                new Binding.Copy(struct2.byteSize(), struct2.byteAlignment()),
+                new Binding.BaseAddress(),
+                new Binding.BoxAddress(),
+                new Binding.Move(r0, long.class)
+            }},
+            // struct s { int32_t a[2]; float b[2] };
+            { MemoryLayout.ofStruct(C_INT, C_INT, C_FLOAT, C_FLOAT), new Binding[] {
+                new Binding.Dup(),
+                    // s.a[0] & s.a[1]
+                    new Binding.Dereference(0, long.class), new Binding.Move(r0, long.class),
+                    // s.b[0] & s.b[1]
+                    new Binding.Dereference(8, long.class), new Binding.Move(r1, long.class),
+            }},
+        };
+    }
+
+    @Test
+    public void testMultipleStructs() {
+        MemoryLayout struct1 = MemoryLayout.ofStruct(C_INT, C_INT, C_DOUBLE, C_INT);
+        MemoryLayout struct2 = MemoryLayout.ofStruct(C_LONG, C_LONG, C_LONG);
+
+        MethodType mt = MethodType.methodType(void.class, MemorySegment.class, MemorySegment.class, int.class);
+        FunctionDescriptor fd = FunctionDescriptor.ofVoid(false, struct1, struct2, C_INT);
+        CallArranger.Bindings bindings = CallArranger.getBindings(mt, fd, false);
+
+        assertFalse(bindings.isInMemoryReturn);
+        CallingSequence callingSequence = bindings.callingSequence;
+        assertEquals(callingSequence.methodType(), mt);
+        assertEquals(callingSequence.functionDesc(), fd);
+
+        checkArgumentBindings(callingSequence, new Binding[][]{
+            {
+                new Binding.Copy(struct1.byteSize(), struct1.byteAlignment()),
+                new Binding.BaseAddress(),
+                new Binding.BoxAddress(),
+                new Binding.Move(r0, long.class)
+            },
+            {
+                new Binding.Copy(struct2.byteSize(), struct2.byteAlignment()),
+                new Binding.BaseAddress(),
+                new Binding.BoxAddress(),
+                new Binding.Move(r1, long.class)
+            },
+            { new Binding.Move(r2, int.class) }
+        });
+
+        checkReturnBindings(callingSequence, new Binding[]{});
+    }
+
+    @Test
+    public void testReturnStruct1() {
+        MemoryLayout struct = MemoryLayout.ofStruct(C_LONG, C_LONG, C_FLOAT);
+
+        MethodType mt = MethodType.methodType(MemorySegment.class);
+        FunctionDescriptor fd = FunctionDescriptor.of(struct, false);
+        CallArranger.Bindings bindings = CallArranger.getBindings(mt, fd, false);
+
+        assertTrue(bindings.isInMemoryReturn);
+        CallingSequence callingSequence = bindings.callingSequence;
+        assertEquals(callingSequence.methodType(), MethodType.methodType(void.class, MemoryAddress.class));
+        assertEquals(callingSequence.functionDesc(), FunctionDescriptor.ofVoid(false, C_POINTER));
+
+        checkArgumentBindings(callingSequence, new Binding[][]{
+            {
+                new Binding.BoxAddress(),
+                new Binding.Move(r8, long.class)
+            }
+        });
+
+        checkReturnBindings(callingSequence, new Binding[]{});
+    }
+
+    @Test
+    public void testReturnStruct2() {
+        MemoryLayout struct = MemoryLayout.ofStruct(C_LONG, C_LONG);
+
+        MethodType mt = MethodType.methodType(MemorySegment.class);
+        FunctionDescriptor fd = FunctionDescriptor.of(struct, false);
+        CallArranger.Bindings bindings = CallArranger.getBindings(mt, fd, false);
+
+        assertFalse(bindings.isInMemoryReturn);
+        CallingSequence callingSequence = bindings.callingSequence;
+        assertEquals(callingSequence.methodType(), mt);
+        assertEquals(callingSequence.functionDesc(), fd);
+
+        checkArgumentBindings(callingSequence, new Binding[][]{});
+
+        checkReturnBindings(callingSequence, new Binding[]{
+            new Binding.AllocateBuffer(struct),
+            new Binding.Dup(),
+            new Binding.Move(r0, long.class),
+            new Binding.Dereference(0, long.class),
+            new Binding.Dup(),
+            new Binding.Move(r1, long.class),
+            new Binding.Dereference(8, long.class),
+        });
+    }
+
+    @Test
+    public void testStructHFA1() {
+        MemoryLayout hfa = MemoryLayout.ofStruct(C_FLOAT, C_FLOAT);
+
+        MethodType mt = MethodType.methodType(MemorySegment.class, float.class, int.class, MemorySegment.class);
+        FunctionDescriptor fd = FunctionDescriptor.of(hfa, false, C_FLOAT, C_INT, hfa);
+        CallArranger.Bindings bindings = CallArranger.getBindings(mt, fd, false);
+
+        assertFalse(bindings.isInMemoryReturn);
+        CallingSequence callingSequence = bindings.callingSequence;
+        assertEquals(callingSequence.methodType(), mt);
+        assertEquals(callingSequence.functionDesc(), fd);
+
+        checkArgumentBindings(callingSequence, new Binding[][]{
+            { new Binding.Move(v0, float.class) },
+            { new Binding.Move(r0, int.class) },
+            {
+                new Binding.Dup(),
+                new Binding.Dereference(0, int.class),
+                new Binding.Move(v1, int.class),
+                new Binding.Dereference(4, int.class),
+                new Binding.Move(v2, int.class)
+            }
+        });
+
+        checkReturnBindings(callingSequence, new Binding[]{
+            new Binding.AllocateBuffer(hfa),
+            new Binding.Dup(),
+            new Binding.Move(v0, int.class),
+            new Binding.Dereference(0, int.class),
+            new Binding.Dup(),
+            new Binding.Move(v1, int.class),
+            new Binding.Dereference(4, int.class),
+        });
+    }
+
+    @Test
+    public void testStructHFA3() {
+        MemoryLayout struct = MemoryLayout.ofStruct(C_FLOAT, C_FLOAT, C_FLOAT);
+
+        MethodType mt = MethodType.methodType(void.class, MemorySegment.class, MemorySegment.class, MemorySegment.class);
+        FunctionDescriptor fd = FunctionDescriptor.ofVoid(false, struct, struct, struct);
+        CallArranger.Bindings bindings = CallArranger.getBindings(mt, fd, false);
+
+        assertFalse(bindings.isInMemoryReturn);
+        CallingSequence callingSequence = bindings.callingSequence;
+        assertEquals(callingSequence.methodType(), mt);
+        assertEquals(callingSequence.functionDesc(), fd);
+
+        checkArgumentBindings(callingSequence, new Binding[][]{
+            {
+                new Binding.Dup(),
+                new Binding.Dereference(0, int.class),
+                new Binding.Move(v0, int.class),
+                new Binding.Dup(),
+                new Binding.Dereference(4, int.class),
+                new Binding.Move(v1, int.class),
+                new Binding.Dereference(8, int.class),
+                new Binding.Move(v2, int.class)
+            },
+            {
+                new Binding.Dup(),
+                new Binding.Dereference(0, int.class),
+                new Binding.Move(v3, int.class),
+                new Binding.Dup(),
+                new Binding.Dereference(4, int.class),
+                new Binding.Move(v4, int.class),
+                new Binding.Dereference(8, int.class),
+                new Binding.Move(v5, int.class)
+            },
+            {
+                new Binding.Dup(),
+                new Binding.Dereference(0, long.class),
+                new Binding.Move(stackStorage(0), long.class),
+                new Binding.Dereference(8, long.class),
+                new Binding.Move(stackStorage(1), long.class),
+            }
+        });
+
+        checkReturnBindings(callingSequence, new Binding[]{});
+    }
+}

--- a/test/jdk/java/foreign/callarranger/TestSysVCallArranger.java
+++ b/test/jdk/java/foreign/callarranger/TestSysVCallArranger.java
@@ -1,0 +1,370 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ *  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ *  This code is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License version 2 only, as
+ *  published by the Free Software Foundation.
+ *
+ *  This code is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ *  version 2 for more details (a copy is included in the LICENSE file that
+ *  accompanied this code).
+ *
+ *  You should have received a copy of the GNU General Public License version
+ *  2 along with this work; if not, write to the Free Software Foundation,
+ *  Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ *   Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ *  or visit www.oracle.com if you need additional information or have any
+ *  questions.
+ *
+ */
+
+/*
+ * @test
+ * @modules java.base/sun.nio.ch
+ *          jdk.incubator.foreign/jdk.internal.foreign
+ *          jdk.incubator.foreign/jdk.internal.foreign.abi
+ *          jdk.incubator.foreign/jdk.internal.foreign.abi.x64
+ *          jdk.incubator.foreign/jdk.internal.foreign.abi.x64.sysv
+ * @build CallArrangerTestBase
+ * @run testng TestSysVCallArranger
+ */
+
+import jdk.incubator.foreign.FunctionDescriptor;
+import jdk.incubator.foreign.MemoryAddress;
+import jdk.incubator.foreign.MemoryLayout;
+import jdk.incubator.foreign.MemorySegment;
+import jdk.internal.foreign.abi.Binding;
+import jdk.internal.foreign.abi.CallingSequence;
+import jdk.internal.foreign.abi.x64.sysv.CallArranger;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.lang.invoke.MethodType;
+
+import static jdk.incubator.foreign.MemoryLayouts.SysV.*;
+import static jdk.incubator.foreign.MemoryLayouts.WinABI.C_POINTER;
+import static jdk.internal.foreign.abi.x64.X86_64Architecture.*;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+public class TestSysVCallArranger extends CallArrangerTestBase {
+
+    @Test
+    public void testEmpty() {
+        MethodType mt = MethodType.methodType(void.class);
+        FunctionDescriptor fd = FunctionDescriptor.ofVoid(false);
+        CallArranger.Bindings bindings = CallArranger.getBindings(mt, fd, false);
+
+        assertFalse(bindings.isInMemoryReturn);
+        CallingSequence callingSequence = bindings.callingSequence;
+        assertEquals(callingSequence.methodType(), mt.appendParameterTypes(long.class));
+        assertEquals(callingSequence.functionDesc(), descAddArgument(fd, C_LONG));
+
+        checkArgumentBindings(callingSequence, new Binding[][]{
+            { new Binding.Move(rax, long.class) }
+        });
+
+        checkReturnBindings(callingSequence, new Binding[]{});
+
+        assertEquals(bindings.nVectorArgs, 0);
+    }
+
+    @Test
+    public void testIntegerRegs() {
+        MethodType mt = MethodType.methodType(void.class,
+                int.class, int.class, int.class, int.class, int.class, int.class);
+        FunctionDescriptor fd = FunctionDescriptor.ofVoid(false,
+                C_INT, C_INT, C_INT, C_INT, C_INT, C_INT);
+        CallArranger.Bindings bindings = CallArranger.getBindings(mt, fd, false);
+
+        assertFalse(bindings.isInMemoryReturn);
+        CallingSequence callingSequence = bindings.callingSequence;
+        assertEquals(callingSequence.methodType(), mt.appendParameterTypes(long.class));
+        assertEquals(callingSequence.functionDesc(), descAddArgument(fd, C_LONG));
+
+        checkArgumentBindings(callingSequence, new Binding[][]{
+            { new Binding.Move(rdi, int.class) },
+            { new Binding.Move(rsi, int.class) },
+            { new Binding.Move(rdx, int.class) },
+            { new Binding.Move(rcx, int.class) },
+            { new Binding.Move(r8, int.class) },
+            { new Binding.Move(r9, int.class) },
+            { new Binding.Move(rax, long.class) },
+        });
+
+        checkReturnBindings(callingSequence, new Binding[]{});
+
+        assertEquals(bindings.nVectorArgs, 0);
+    }
+
+    @Test
+    public void testDoubleRegs() {
+        MethodType mt = MethodType.methodType(void.class,
+                double.class, double.class, double.class, double.class,
+                double.class, double.class, double.class, double.class);
+        FunctionDescriptor fd = FunctionDescriptor.ofVoid(false,
+                C_DOUBLE, C_DOUBLE, C_DOUBLE, C_DOUBLE,
+                C_DOUBLE, C_DOUBLE, C_DOUBLE, C_DOUBLE);
+        CallArranger.Bindings bindings = CallArranger.getBindings(mt, fd, false);
+
+        assertFalse(bindings.isInMemoryReturn);
+        CallingSequence callingSequence = bindings.callingSequence;
+        assertEquals(callingSequence.methodType(), mt.appendParameterTypes(long.class));
+        assertEquals(callingSequence.functionDesc(), descAddArgument(fd, C_LONG));
+
+        checkArgumentBindings(callingSequence, new Binding[][]{
+            { new Binding.Move(xmm0, double.class) },
+            { new Binding.Move(xmm1, double.class) },
+            { new Binding.Move(xmm2, double.class) },
+            { new Binding.Move(xmm3, double.class) },
+            { new Binding.Move(xmm4, double.class) },
+            { new Binding.Move(xmm5, double.class) },
+            { new Binding.Move(xmm6, double.class) },
+            { new Binding.Move(xmm7, double.class) },
+            { new Binding.Move(rax, long.class) },
+        });
+
+        checkReturnBindings(callingSequence, new Binding[]{});
+
+        assertEquals(bindings.nVectorArgs, 8);
+    }
+
+    @Test
+    public void testMixed() {
+        MethodType mt = MethodType.methodType(void.class,
+                long.class, long.class, long.class, long.class, long.class, long.class, long.class, long.class,
+                float.class, float.class, float.class, float.class,
+                float.class, float.class, float.class, float.class, float.class, float.class);
+        FunctionDescriptor fd = FunctionDescriptor.ofVoid(false,
+                C_LONG, C_LONG, C_LONG, C_LONG, C_LONG, C_LONG, C_LONG, C_LONG,
+                C_FLOAT, C_FLOAT, C_FLOAT, C_FLOAT,
+                C_FLOAT, C_FLOAT, C_FLOAT, C_FLOAT, C_FLOAT, C_FLOAT);
+        CallArranger.Bindings bindings = CallArranger.getBindings(mt, fd, false);
+
+        assertFalse(bindings.isInMemoryReturn);
+        CallingSequence callingSequence = bindings.callingSequence;
+        assertEquals(callingSequence.methodType(), mt.appendParameterTypes(long.class));
+        assertEquals(callingSequence.functionDesc(), descAddArgument(fd, C_LONG));
+
+        checkArgumentBindings(callingSequence, new Binding[][]{
+            { new Binding.Move(rdi, long.class) },
+            { new Binding.Move(rsi, long.class) },
+            { new Binding.Move(rdx, long.class) },
+            { new Binding.Move(rcx, long.class) },
+            { new Binding.Move(r8, long.class) },
+            { new Binding.Move(r9, long.class) },
+            { new Binding.Move(stackStorage(0), long.class) },
+            { new Binding.Move(stackStorage(1), long.class) },
+            { new Binding.Move(xmm0, float.class) },
+            { new Binding.Move(xmm1, float.class) },
+            { new Binding.Move(xmm2, float.class) },
+            { new Binding.Move(xmm3, float.class) },
+            { new Binding.Move(xmm4, float.class) },
+            { new Binding.Move(xmm5, float.class) },
+            { new Binding.Move(xmm6, float.class) },
+            { new Binding.Move(xmm7, float.class) },
+            { new Binding.Move(stackStorage(2), float.class) },
+            { new Binding.Move(stackStorage(3), float.class) },
+            { new Binding.Move(rax, long.class) },
+        });
+
+        checkReturnBindings(callingSequence, new Binding[]{});
+
+        assertEquals(bindings.nVectorArgs, 8);
+    }
+
+    /**
+     * This is the example from the System V ABI AMD64 document
+     *
+     * struct structparm {
+     *   int32_t a, int32_t b, double d;
+     * } s;
+     * int32_t e, f, g, h, i, j, k;
+     * double m, n;
+     *
+     * void m(e, f, s, g, h, m, n, i, j, k);
+     *
+     * m(s);
+     */
+    @Test
+    public void testAbiExample() {
+        MemoryLayout struct = MemoryLayout.ofStruct(C_INT, C_INT, C_DOUBLE);
+
+        MethodType mt = MethodType.methodType(void.class,
+                int.class, int.class, MemorySegment.class, int.class, int.class,
+                double.class, double.class, int.class, int.class, int.class);
+        FunctionDescriptor fd = FunctionDescriptor.ofVoid(false,
+                C_INT, C_INT, struct, C_INT, C_INT, C_DOUBLE, C_DOUBLE, C_INT, C_INT, C_INT);
+        CallArranger.Bindings bindings = CallArranger.getBindings(mt, fd, false);
+
+        assertFalse(bindings.isInMemoryReturn);
+        CallingSequence callingSequence = bindings.callingSequence;
+        assertEquals(callingSequence.methodType(), mt.appendParameterTypes(long.class));
+        assertEquals(callingSequence.functionDesc(), descAddArgument(fd, C_LONG));
+
+        checkArgumentBindings(callingSequence, new Binding[][]{
+            { new Binding.Move(rdi, int.class) },
+            { new Binding.Move(rsi, int.class) },
+            { new Binding.Dup(),
+                new Binding.Dereference(0, long.class), new Binding.Move(rdx, long.class),
+                new Binding.Dereference(8, long.class), new Binding.Move(xmm0, long.class)
+            },
+            { new Binding.Move(rcx, int.class) },
+            { new Binding.Move(r8, int.class) },
+            { new Binding.Move(xmm1, double.class) },
+            { new Binding.Move(xmm2, double.class) },
+            { new Binding.Move(r9, int.class) },
+            { new Binding.Move(stackStorage(0), int.class) },
+            { new Binding.Move(stackStorage(1), int.class) },
+            { new Binding.Move(rax, long.class) },
+        });
+
+        checkReturnBindings(callingSequence, new Binding[]{});
+
+        assertEquals(bindings.nVectorArgs, 3);
+    }
+
+    /**
+     * typedef void (*f)(void);
+     *
+     * void m(f f);
+     * void f_impl(void);
+     *
+     * m(f_impl);
+     */
+    @Test
+    public void testMemoryAddress() {
+        MethodType mt = MethodType.methodType(void.class, MemoryAddress.class);
+        FunctionDescriptor fd = FunctionDescriptor.ofVoid(false, C_POINTER);
+        CallArranger.Bindings bindings = CallArranger.getBindings(mt, fd, false);
+
+        assertFalse(bindings.isInMemoryReturn);
+        CallingSequence callingSequence = bindings.callingSequence;
+        assertEquals(callingSequence.methodType(), mt.appendParameterTypes(long.class));
+        assertEquals(callingSequence.functionDesc(), descAddArgument(fd, C_LONG));
+
+        checkArgumentBindings(callingSequence, new Binding[][]{
+            { new Binding.BoxAddress(), new Binding.Move(rdi, long.class) },
+            { new Binding.Move(rax, long.class) },
+        });
+
+        checkReturnBindings(callingSequence, new Binding[]{});
+
+        assertEquals(bindings.nVectorArgs, 0);
+    }
+
+    @Test(dataProvider = "structs")
+    public void testStruct(MemoryLayout struct, Binding[] expectedBindings) {
+        MethodType mt = MethodType.methodType(void.class, MemorySegment.class);
+        FunctionDescriptor fd = FunctionDescriptor.ofVoid(false, struct);
+        CallArranger.Bindings bindings = CallArranger.getBindings(mt, fd, false);
+
+        assertFalse(bindings.isInMemoryReturn);
+        CallingSequence callingSequence = bindings.callingSequence;
+        assertEquals(callingSequence.methodType(), mt.appendParameterTypes(long.class));
+        assertEquals(callingSequence.functionDesc(), descAddArgument(fd, C_LONG));
+
+        checkArgumentBindings(callingSequence, new Binding[][]{
+            expectedBindings,
+            { new Binding.Move(rax, long.class) },
+        });
+
+        checkReturnBindings(callingSequence, new Binding[]{});
+
+        assertEquals(bindings.nVectorArgs, 0);
+    }
+
+
+    @DataProvider
+    public static Object[][] structs() {
+        return new Object[][]{
+            { MemoryLayout.ofStruct(C_ULONG), new Binding[]{
+                    new Binding.Dereference(0, long.class), new Binding.Move(rdi, long.class)
+                }
+            },
+            { MemoryLayout.ofStruct(C_ULONG, C_ULONG), new Binding[]{
+                    new Binding.Dup(),
+                    new Binding.Dereference(0, long.class), new Binding.Move(rdi, long.class),
+                    new Binding.Dereference(8, long.class), new Binding.Move(rsi, long.class)
+                }
+            },
+            { MemoryLayout.ofStruct(C_ULONG, C_ULONG, C_ULONG), new Binding[]{
+                    new Binding.Dup(),
+                    new Binding.Dereference(0, long.class), new Binding.Move(stackStorage(0), long.class),
+                    new Binding.Dup(),
+                    new Binding.Dereference(8, long.class), new Binding.Move(stackStorage(1), long.class),
+                    new Binding.Dereference(16, long.class), new Binding.Move(stackStorage(2), long.class)
+                }
+            },
+            { MemoryLayout.ofStruct(C_ULONG, C_ULONG, C_ULONG, C_ULONG), new Binding[]{
+                    new Binding.Dup(),
+                    new Binding.Dereference(0, long.class), new Binding.Move(stackStorage(0), long.class),
+                    new Binding.Dup(),
+                    new Binding.Dereference(8, long.class), new Binding.Move(stackStorage(1), long.class),
+                    new Binding.Dup(),
+                    new Binding.Dereference(16, long.class), new Binding.Move(stackStorage(2), long.class),
+                    new Binding.Dereference(24, long.class), new Binding.Move(stackStorage(3), long.class)
+                }
+            },
+        };
+    }
+
+    @Test
+    public void testReturnRegisterStruct() {
+        MemoryLayout struct = MemoryLayout.ofStruct(C_ULONG, C_ULONG);
+
+        MethodType mt = MethodType.methodType(MemorySegment.class);
+        FunctionDescriptor fd = FunctionDescriptor.of(struct, false);
+        CallArranger.Bindings bindings = CallArranger.getBindings(mt, fd, false);
+
+        assertFalse(bindings.isInMemoryReturn);
+        CallingSequence callingSequence = bindings.callingSequence;
+        assertEquals(callingSequence.methodType(), mt.appendParameterTypes(long.class));
+        assertEquals(callingSequence.functionDesc(), descAddArgument(fd, C_LONG));
+
+        checkArgumentBindings(callingSequence, new Binding[][]{
+            { new Binding.Move(rax, long.class) }
+        });
+
+        checkReturnBindings(callingSequence, new Binding[] {
+            new Binding.AllocateBuffer(struct),
+            new Binding.Dup(),
+            new Binding.Move(rax, long.class),
+            new Binding.Dereference(0, long.class),
+            new Binding.Dup(),
+            new Binding.Move(rdx, long.class),
+            new Binding.Dereference(8, long.class)
+        });
+
+        assertEquals(bindings.nVectorArgs, 0);
+    }
+
+    @Test
+    public void testIMR() {
+        MemoryLayout struct = MemoryLayout.ofStruct(C_ULONG, C_ULONG, C_ULONG);
+
+        MethodType mt = MethodType.methodType(MemorySegment.class);
+        FunctionDescriptor fd = FunctionDescriptor.of(struct, false);
+        CallArranger.Bindings bindings = CallArranger.getBindings(mt, fd, false);
+
+        assertTrue(bindings.isInMemoryReturn);
+        CallingSequence callingSequence = bindings.callingSequence;
+        assertEquals(callingSequence.methodType(), MethodType.methodType(void.class, MemoryAddress.class, long.class));
+        assertEquals(callingSequence.functionDesc(), FunctionDescriptor.ofVoid(false, C_POINTER, C_LONG));
+
+        checkArgumentBindings(callingSequence, new Binding[][]{
+            { new Binding.BoxAddress(), new Binding.Move(rdi, long.class) },
+            { new Binding.Move(rax, long.class) }
+        });
+
+        checkReturnBindings(callingSequence, new Binding[] {});
+
+        assertEquals(bindings.nVectorArgs, 0);
+    }
+
+}

--- a/test/jdk/java/foreign/callarranger/TestWindowsCallArranger.java
+++ b/test/jdk/java/foreign/callarranger/TestWindowsCallArranger.java
@@ -1,0 +1,326 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ *  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ *  This code is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License version 2 only, as
+ *  published by the Free Software Foundation.
+ *
+ *  This code is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ *  version 2 for more details (a copy is included in the LICENSE file that
+ *  accompanied this code).
+ *
+ *  You should have received a copy of the GNU General Public License version
+ *  2 along with this work; if not, write to the Free Software Foundation,
+ *  Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ *   Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ *  or visit www.oracle.com if you need additional information or have any
+ *  questions.
+ *
+ */
+
+/*
+ * @test
+ * @modules java.base/sun.nio.ch
+ *          jdk.incubator.foreign/jdk.internal.foreign
+ *          jdk.incubator.foreign/jdk.internal.foreign.abi
+ *          jdk.incubator.foreign/jdk.internal.foreign.abi.x64
+ *          jdk.incubator.foreign/jdk.internal.foreign.abi.x64.windows
+ * @build CallArrangerTestBase
+ * @run testng TestWindowsCallArranger
+ */
+
+import jdk.incubator.foreign.FunctionDescriptor;
+import jdk.incubator.foreign.MemoryAddress;
+import jdk.incubator.foreign.MemoryLayout;
+import jdk.incubator.foreign.MemorySegment;
+import jdk.internal.foreign.abi.Binding;
+import jdk.internal.foreign.abi.CallingSequence;
+import jdk.internal.foreign.abi.x64.windows.CallArranger;
+import org.testng.annotations.Test;
+
+import java.lang.invoke.MethodType;
+
+import static jdk.incubator.foreign.MemoryLayouts.WinABI.*;
+import static jdk.incubator.foreign.MemoryLayouts.WinABI.asVarArg;
+import static jdk.internal.foreign.abi.x64.X86_64Architecture.*;
+import static org.testng.Assert.*;
+
+public class TestWindowsCallArranger extends CallArrangerTestBase {
+
+    @Test
+    public void testEmpty() {
+        MethodType mt = MethodType.methodType(void.class);
+        FunctionDescriptor fd = FunctionDescriptor.ofVoid(false);
+        CallArranger.Bindings bindings = CallArranger.getBindings(mt, fd, false);
+
+        assertFalse(bindings.isInMemoryReturn);
+        CallingSequence callingSequence = bindings.callingSequence;
+        assertEquals(callingSequence.methodType(), mt);
+        assertEquals(callingSequence.functionDesc(), fd);
+
+        checkArgumentBindings(callingSequence, new Binding[][]{});
+        checkReturnBindings(callingSequence, new Binding[]{});
+    }
+
+    @Test
+    public void testIntegerRegs() {
+        MethodType mt = MethodType.methodType(void.class, int.class, int.class, int.class, int.class);
+        FunctionDescriptor fd = FunctionDescriptor.ofVoid(false, C_INT, C_INT, C_INT, C_INT);
+        CallArranger.Bindings bindings = CallArranger.getBindings(mt, fd, false);
+
+        assertFalse(bindings.isInMemoryReturn);
+        CallingSequence callingSequence = bindings.callingSequence;
+        assertEquals(callingSequence.methodType(), mt);
+        assertEquals(callingSequence.functionDesc(), fd);
+
+        checkArgumentBindings(callingSequence, new Binding[][]{
+            { new Binding.Move(rcx, int.class) },
+            { new Binding.Move(rdx, int.class) },
+            { new Binding.Move(r8, int.class) },
+            { new Binding.Move(r9, int.class) }
+        });
+
+        checkReturnBindings(callingSequence, new Binding[]{});
+    }
+
+    @Test
+    public void testDoubleRegs() {
+        MethodType mt = MethodType.methodType(void.class, double.class, double.class, double.class, double.class);
+        FunctionDescriptor fd = FunctionDescriptor.ofVoid(false, C_DOUBLE, C_DOUBLE, C_DOUBLE, C_DOUBLE);
+        CallArranger.Bindings bindings = CallArranger.getBindings(mt, fd, false);
+
+        assertFalse(bindings.isInMemoryReturn);
+        CallingSequence callingSequence = bindings.callingSequence;
+        assertEquals(callingSequence.methodType(), mt);
+        assertEquals(callingSequence.functionDesc(), fd);
+
+        checkArgumentBindings(callingSequence, new Binding[][]{
+            { new Binding.Move(xmm0, double.class) },
+            { new Binding.Move(xmm1, double.class) },
+            { new Binding.Move(xmm2, double.class) },
+            { new Binding.Move(xmm3, double.class) }
+        });
+
+        checkReturnBindings(callingSequence, new Binding[]{});
+    }
+
+    @Test
+    public void testMixed() {
+        MethodType mt = MethodType.methodType(void.class,
+                long.class, long.class, float.class, float.class, long.class, long.class, float.class, float.class);
+        FunctionDescriptor fd = FunctionDescriptor.ofVoid(false,
+                C_LONGLONG, C_LONGLONG, C_FLOAT, C_FLOAT, C_LONGLONG, C_LONGLONG, C_FLOAT, C_FLOAT);
+        CallArranger.Bindings bindings = CallArranger.getBindings(mt, fd, false);
+
+        assertFalse(bindings.isInMemoryReturn);
+        CallingSequence callingSequence = bindings.callingSequence;
+        assertEquals(callingSequence.methodType(), mt);
+        assertEquals(callingSequence.functionDesc(), fd);
+
+        checkArgumentBindings(callingSequence, new Binding[][]{
+            { new Binding.Move(rcx, long.class) },
+            { new Binding.Move(rdx, long.class) },
+            { new Binding.Move(xmm2, float.class) },
+            { new Binding.Move(xmm3, float.class) },
+            { new Binding.Move(stackStorage(0), long.class) },
+            { new Binding.Move(stackStorage(1), long.class) },
+            { new Binding.Move(stackStorage(2), float.class) },
+            { new Binding.Move(stackStorage(3), float.class) }
+        });
+
+        checkReturnBindings(callingSequence, new Binding[]{});
+    }
+
+    @Test
+    public void testAbiExample() {
+        MemoryLayout structLayout = MemoryLayout.ofStruct(C_INT, C_INT, C_DOUBLE);
+        MethodType mt = MethodType.methodType(void.class,
+                int.class, int.class, MemorySegment.class, int.class, int.class,
+                double.class, double.class, double.class, int.class, int.class, int.class);
+        FunctionDescriptor fd = FunctionDescriptor.ofVoid(false,
+                C_INT, C_INT, structLayout, C_INT, C_INT,
+                C_DOUBLE, C_DOUBLE, C_DOUBLE, C_INT, C_INT, C_INT);
+        CallArranger.Bindings bindings = CallArranger.getBindings(mt, fd, false);
+
+        assertFalse(bindings.isInMemoryReturn);
+        CallingSequence callingSequence = bindings.callingSequence;
+        assertEquals(callingSequence.methodType(), mt);
+        assertEquals(callingSequence.functionDesc(), fd);
+
+        checkArgumentBindings(callingSequence, new Binding[][]{
+            { new Binding.Move(rcx, int.class) },
+            { new Binding.Move(rdx, int.class) },
+            { new Binding.Copy(structLayout.byteSize(), structLayout.byteAlignment()),
+                new Binding.BaseAddress(),
+                new Binding.BoxAddress(),
+                new Binding.Move(r8, long.class) },
+            { new Binding.Move(r9, int.class) },
+            { new Binding.Move(stackStorage(0), int.class) },
+            { new Binding.Move(stackStorage(1), double.class) },
+            { new Binding.Move(stackStorage(2), double.class) },
+            { new Binding.Move(stackStorage(3), double.class) },
+            { new Binding.Move(stackStorage(4), int.class) },
+            { new Binding.Move(stackStorage(5), int.class) },
+            { new Binding.Move(stackStorage(6), int.class) }
+        });
+
+        checkReturnBindings(callingSequence, new Binding[]{});
+    }
+
+    @Test
+    public void testAbiExampleVarargs() {
+        MethodType mt = MethodType.methodType(void.class,
+                int.class, double.class, int.class, double.class, double.class);
+        FunctionDescriptor fd = FunctionDescriptor.ofVoid(false,
+                C_INT, C_DOUBLE, asVarArg(C_INT), asVarArg(C_DOUBLE), asVarArg(C_DOUBLE));
+        CallArranger.Bindings bindings = CallArranger.getBindings(mt, fd, false);
+
+        assertFalse(bindings.isInMemoryReturn);
+        CallingSequence callingSequence = bindings.callingSequence;
+        assertEquals(callingSequence.methodType(), mt);
+        assertEquals(callingSequence.functionDesc(), fd);
+
+        checkArgumentBindings(callingSequence, new Binding[][]{
+            { new Binding.Move(rcx, int.class) },
+            { new Binding.Move(xmm1, double.class) },
+            { new Binding.Move(r8, int.class) },
+            { new Binding.Dup(), new Binding.Move(r9, double.class), new Binding.Move(xmm3, double.class) },
+            { new Binding.Move(stackStorage(0), double.class) },
+        });
+
+        checkReturnBindings(callingSequence, new Binding[]{});
+    }
+
+    /**
+     * struct s {
+     *   uint64_t u0;
+     * } s;
+     *
+     * void m(struct s s);
+     *
+     * m(s);
+     */
+    @Test
+    public void testStructRegister() {
+        MemoryLayout struct = MemoryLayout.ofStruct(C_ULONGLONG);
+
+        MethodType mt = MethodType.methodType(void.class, MemorySegment.class);
+        FunctionDescriptor fd = FunctionDescriptor.ofVoid(false, struct);
+        CallArranger.Bindings bindings = CallArranger.getBindings(mt, fd, false);
+
+        assertFalse(bindings.isInMemoryReturn);
+        CallingSequence callingSequence = bindings.callingSequence;
+        assertEquals(callingSequence.methodType(), mt);
+        assertEquals(callingSequence.functionDesc(), fd);
+
+        checkArgumentBindings(callingSequence, new Binding[][]{
+            { new Binding.Dereference(0, long.class), new Binding.Move(rcx, long.class) }
+        });
+
+        checkReturnBindings(callingSequence, new Binding[]{});
+    }
+
+    /**
+     * struct s {
+     *   uint64_t u0, u1;
+     * } s;
+     *
+     * void m(struct s s);
+     *
+     * m(s);
+     */
+    @Test
+    public void testStructReference() {
+        MemoryLayout struct = MemoryLayout.ofStruct(C_ULONGLONG, C_ULONGLONG);
+
+        MethodType mt = MethodType.methodType(void.class, MemorySegment.class);
+        FunctionDescriptor fd = FunctionDescriptor.ofVoid(false, struct);
+        CallArranger.Bindings bindings = CallArranger.getBindings(mt, fd, false);
+
+        assertFalse(bindings.isInMemoryReturn);
+        CallingSequence callingSequence = bindings.callingSequence;
+        assertEquals(callingSequence.methodType(), mt);
+        assertEquals(callingSequence.functionDesc(), fd);
+
+        checkArgumentBindings(callingSequence, new Binding[][]{
+            { new Binding.Copy(struct.byteSize(), struct.byteAlignment()),
+                    new Binding.BaseAddress(),
+                    new Binding.BoxAddress(),
+                    new Binding.Move(rcx, long.class) }
+        });
+
+        checkReturnBindings(callingSequence, new Binding[]{});
+    }
+
+    /**
+     * typedef void (*f)(void);
+     *
+     * void m(f f);
+     * void f_impl(void);
+     *
+     * m(f_impl);
+     */
+    @Test
+    public void testMemoryAddress() {
+        MethodType mt = MethodType.methodType(void.class, MemoryAddress.class);
+        FunctionDescriptor fd = FunctionDescriptor.ofVoid(false, C_POINTER);
+        CallArranger.Bindings bindings = CallArranger.getBindings(mt, fd, false);
+
+        assertFalse(bindings.isInMemoryReturn);
+        CallingSequence callingSequence = bindings.callingSequence;
+        assertEquals(callingSequence.methodType(), mt);
+        assertEquals(callingSequence.functionDesc(), fd);
+
+        checkArgumentBindings(callingSequence, new Binding[][]{
+            { new Binding.BoxAddress(), new Binding.Move(rcx, long.class) }
+        });
+
+        checkReturnBindings(callingSequence, new Binding[]{});
+    }
+
+    @Test
+    public void testReturnRegisterStruct() {
+        MemoryLayout struct = MemoryLayout.ofStruct(C_ULONGLONG);
+
+        MethodType mt = MethodType.methodType(MemorySegment.class);
+        FunctionDescriptor fd = FunctionDescriptor.of(struct, false);
+        CallArranger.Bindings bindings = CallArranger.getBindings(mt, fd, false);
+
+        assertFalse(bindings.isInMemoryReturn);
+        CallingSequence callingSequence = bindings.callingSequence;
+        assertEquals(callingSequence.methodType(), mt);
+        assertEquals(callingSequence.functionDesc(), fd);
+
+        checkArgumentBindings(callingSequence, new Binding[][]{});
+
+        checkReturnBindings(callingSequence,
+            new Binding[]{ new Binding.AllocateBuffer(struct),
+                new Binding.Dup(),
+                new Binding.Move(rax, long.class),
+                new Binding.Dereference(0, long.class) });
+    }
+
+    @Test
+    public void testIMR() {
+        MemoryLayout struct = MemoryLayout.ofStruct(C_ULONGLONG, C_ULONGLONG);
+
+        MethodType mt = MethodType.methodType(MemorySegment.class);
+        FunctionDescriptor fd = FunctionDescriptor.of(struct, false);
+        CallArranger.Bindings bindings = CallArranger.getBindings(mt, fd, false);
+
+        assertTrue(bindings.isInMemoryReturn);
+        CallingSequence callingSequence = bindings.callingSequence;
+        assertEquals(callingSequence.methodType(), MethodType.methodType(void.class, MemoryAddress.class));
+        assertEquals(callingSequence.functionDesc(), FunctionDescriptor.ofVoid(false, C_POINTER));
+
+        checkArgumentBindings(callingSequence, new Binding[][]{
+            { new Binding.BoxAddress(), new Binding.Move(rcx, long.class) }
+        });
+
+        checkReturnBindings(callingSequence, new Binding[]{});
+    }
+}


### PR DESCRIPTION
Continuation of: _https://mail.openjdk.java.net/pipermail/panama-dev/2020-February/007417.html_
 
> Hi,
> 
> Please review the following patch that adds tests for the binding recipe 
> generators. These tests are more or less transcribed from the old 
> CallingSequenceBuilder tests on the foreign branch.
> 
> Bug: https://bugs.openjdk.java.net/browse/JDK-8237360
> Webrev: 
> http://cr.openjdk.java.net/~jvernee/panama/webrevs/8237360/webrev.00/
> 
> This also helped me find a couple of bugs in the Aarch64 CallArranger 
> that I introduced in an earlier patch, which I've fixed.
> 
> Thanks,
> Jorn
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
## Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

## Issue
[JDK-8237360](https://bugs.openjdk.java.net/browse/JDK-8237360): Add tests that test binding recipe generation directly


## Approvers
 * Maurizio Cimadamore ([mcimadamore](@mcimadamore) - Committer)