### PR TITLE
8238549: Add explicit cast to correct implementation type in VarHandle implementation methods

### DIFF
--- a/src/java.base/share/classes/java/lang/invoke/AddressVarHandleGenerator.java
+++ b/src/java.base/share/classes/java/lang/invoke/AddressVarHandleGenerator.java
@@ -247,7 +247,7 @@ class AddressVarHandleGenerator {
     void addAccessModeMethodIfNeeded(VarHandle.AccessMode mode, BinderClassWriter cw) {
         String methName = mode.methodName();
         MethodType methType = form.getMethodType(mode.at.ordinal())
-                .insertParameterTypes(0, BASE_CLASS);
+                .insertParameterTypes(0, VarHandle.class);
 
         try {
             MethodType helperType = methType.insertParameterTypes(2, long.class);
@@ -267,11 +267,13 @@ class AddressVarHandleGenerator {
             mv.visitCode();
 
             mv.visitVarInsn(ALOAD, 0); // handle impl
+            mv.visitTypeInsn(CHECKCAST, Type.getInternalName(BASE_CLASS));
             mv.visitVarInsn(ALOAD, 1); // receiver
 
             // offset calculation
             int slot = 2;
             mv.visitVarInsn(ALOAD, 0); // load recv
+            mv.visitTypeInsn(CHECKCAST, Type.getInternalName(BASE_CLASS));
             mv.visitFieldInsn(GETFIELD, Type.getInternalName(BASE_CLASS), "offset", "J");
             for (int i = 0 ; i < dimensions ; i++) {
                 // load ADD MH

--- a/src/java.base/share/classes/java/lang/invoke/AddressVarHandleGenerator.java
+++ b/src/java.base/share/classes/java/lang/invoke/AddressVarHandleGenerator.java
@@ -267,7 +267,6 @@ class AddressVarHandleGenerator {
             mv.visitCode();
 
             mv.visitVarInsn(ALOAD, 0); // handle impl
-            mv.visitTypeInsn(CHECKCAST, Type.getInternalName(BASE_CLASS));
             mv.visitVarInsn(ALOAD, 1); // receiver
 
             // offset calculation

--- a/src/java.base/share/classes/java/lang/invoke/Invokers.java
+++ b/src/java.base/share/classes/java/lang/invoke/Invokers.java
@@ -415,6 +415,7 @@ class Invokers {
         final int ARG_LIMIT = ARG_BASE + mtype.parameterCount();
         int nameCursor = ARG_LIMIT;
         final int VAD_ARG      = nameCursor++;
+        final int UNBOUND_VH   = nameCursor++;
         final int CHECK_TYPE   = nameCursor++;
         final int LINKER_CALL  = nameCursor++;
 
@@ -431,6 +432,8 @@ class Invokers {
         NamedFunction getter = speciesData.getterFunction(0);
         names[VAD_ARG] = new Name(getter, names[THIS_MH]);
 
+        names[UNBOUND_VH] = new Name(getFunction(NF_directVarHandleTarget), names[CALL_VH]);
+
         if (isExact) {
             names[CHECK_TYPE] = new Name(getFunction(NF_checkVarHandleExactType), names[CALL_VH], names[VAD_ARG]);
         } else {
@@ -438,7 +441,8 @@ class Invokers {
         }
         Object[] outArgs = new Object[ARG_LIMIT];
         outArgs[0] = names[CHECK_TYPE];
-        for (int i = 1; i < ARG_LIMIT; i++) {
+        outArgs[1] = names[UNBOUND_VH];
+        for (int i = 2; i < ARG_LIMIT; i++) {
             outArgs[i] = names[i];
         }
 

--- a/src/java.base/share/classes/java/lang/invoke/VarHandle.java
+++ b/src/java.base/share/classes/java/lang/invoke/VarHandle.java
@@ -1890,7 +1890,7 @@ public abstract class VarHandle implements Constable {
      *
      * @return the variable type of variables referenced by this VarHandle
      */
-    public final Class<?> varType() {
+    public Class<?> varType() {
         MethodType typeSet = accessModeType(AccessMode.SET);
         return typeSet.parameterType(typeSet.parameterCount() - 1);
     }
@@ -1901,7 +1901,7 @@ public abstract class VarHandle implements Constable {
      * @return the coordinate types for this VarHandle. The returned
      * list is unmodifiable
      */
-    public final List<Class<?>> coordinateTypes() {
+    public List<Class<?>> coordinateTypes() {
         MethodType typeGet = accessModeType(AccessMode.GET);
         return typeGet.parameterList();
     }

--- a/src/java.base/share/classes/java/lang/invoke/VarHandles.java
+++ b/src/java.base/share/classes/java/lang/invoke/VarHandles.java
@@ -334,7 +334,7 @@ final class VarHandles {
         if (!VAR_HANDLE_IDENTITY_ADAPT) return target;
         target = MethodHandles.filterValue(target,
                         MethodHandles.identity(target.varType()), MethodHandles.identity(target.varType()));
-        MethodType mtype = target.accessModeType(VarHandle.AccessMode.GET);
+        MethodType mtype = target.accessModeType(VarHandle.AccessMode.GET).dropParameterTypes(0, 1);
         for (int i = 0 ; i < mtype.parameterCount() ; i++) {
             target = MethodHandles.filterCoordinates(target, i, MethodHandles.identity(mtype.parameterType(i)));
         }

--- a/src/java.base/share/classes/java/lang/invoke/X-VarHandle.java.template
+++ b/src/java.base/share/classes/java/lang/invoke/X-VarHandle.java.template
@@ -77,25 +77,29 @@ final class VarHandle$Type$s {
         }
 
         @ForceInline
-        static $type$ get(FieldInstanceReadOnly handle, Object holder) {
+        static $type$ get(VarHandle ob, Object holder) {
+            FieldInstanceReadOnly handle = (FieldInstanceReadOnly)ob;
             return UNSAFE.get$Type$(Objects.requireNonNull(handle.receiverType.cast(holder)),
                                  handle.fieldOffset);
         }
 
         @ForceInline
-        static $type$ getVolatile(FieldInstanceReadOnly handle, Object holder) {
+        static $type$ getVolatile(VarHandle ob, Object holder) {
+            FieldInstanceReadOnly handle = (FieldInstanceReadOnly)ob;
             return UNSAFE.get$Type$Volatile(Objects.requireNonNull(handle.receiverType.cast(holder)),
                                  handle.fieldOffset);
         }
 
         @ForceInline
-        static $type$ getOpaque(FieldInstanceReadOnly handle, Object holder) {
+        static $type$ getOpaque(VarHandle ob, Object holder) {
+            FieldInstanceReadOnly handle = (FieldInstanceReadOnly)ob;
             return UNSAFE.get$Type$Opaque(Objects.requireNonNull(handle.receiverType.cast(holder)),
                                  handle.fieldOffset);
         }
 
         @ForceInline
-        static $type$ getAcquire(FieldInstanceReadOnly handle, Object holder) {
+        static $type$ getAcquire(VarHandle ob, Object holder) {
+            FieldInstanceReadOnly handle = (FieldInstanceReadOnly)ob;
             return UNSAFE.get$Type$Acquire(Objects.requireNonNull(handle.receiverType.cast(holder)),
                                  handle.fieldOffset);
         }
@@ -110,28 +114,32 @@ final class VarHandle$Type$s {
         }
 
         @ForceInline
-        static void set(FieldInstanceReadWrite handle, Object holder, $type$ value) {
+        static void set(VarHandle ob, Object holder, $type$ value) {
+            FieldInstanceReadWrite handle = (FieldInstanceReadWrite)ob;
             UNSAFE.put$Type$(Objects.requireNonNull(handle.receiverType.cast(holder)),
                              handle.fieldOffset,
                              {#if[Object]?handle.fieldType.cast(value):value});
         }
 
         @ForceInline
-        static void setVolatile(FieldInstanceReadWrite handle, Object holder, $type$ value) {
+        static void setVolatile(VarHandle ob, Object holder, $type$ value) {
+            FieldInstanceReadWrite handle = (FieldInstanceReadWrite)ob;
             UNSAFE.put$Type$Volatile(Objects.requireNonNull(handle.receiverType.cast(holder)),
                                      handle.fieldOffset,
                                      {#if[Object]?handle.fieldType.cast(value):value});
         }
 
         @ForceInline
-        static void setOpaque(FieldInstanceReadWrite handle, Object holder, $type$ value) {
+        static void setOpaque(VarHandle ob, Object holder, $type$ value) {
+            FieldInstanceReadWrite handle = (FieldInstanceReadWrite)ob;
             UNSAFE.put$Type$Opaque(Objects.requireNonNull(handle.receiverType.cast(holder)),
                                    handle.fieldOffset,
                                    {#if[Object]?handle.fieldType.cast(value):value});
         }
 
         @ForceInline
-        static void setRelease(FieldInstanceReadWrite handle, Object holder, $type$ value) {
+        static void setRelease(VarHandle ob, Object holder, $type$ value) {
+            FieldInstanceReadWrite handle = (FieldInstanceReadWrite)ob;
             UNSAFE.put$Type$Release(Objects.requireNonNull(handle.receiverType.cast(holder)),
                                     handle.fieldOffset,
                                     {#if[Object]?handle.fieldType.cast(value):value});
@@ -139,7 +147,8 @@ final class VarHandle$Type$s {
 #if[CAS]
 
         @ForceInline
-        static boolean compareAndSet(FieldInstanceReadWrite handle, Object holder, $type$ expected, $type$ value) {
+        static boolean compareAndSet(VarHandle ob, Object holder, $type$ expected, $type$ value) {
+            FieldInstanceReadWrite handle = (FieldInstanceReadWrite)ob;
             return UNSAFE.compareAndSet$Type$(Objects.requireNonNull(handle.receiverType.cast(holder)),
                                                handle.fieldOffset,
                                                {#if[Object]?handle.fieldType.cast(expected):expected},
@@ -147,7 +156,8 @@ final class VarHandle$Type$s {
         }
 
         @ForceInline
-        static $type$ compareAndExchange(FieldInstanceReadWrite handle, Object holder, $type$ expected, $type$ value) {
+        static $type$ compareAndExchange(VarHandle ob, Object holder, $type$ expected, $type$ value) {
+            FieldInstanceReadWrite handle = (FieldInstanceReadWrite)ob;
             return UNSAFE.compareAndExchange$Type$(Objects.requireNonNull(handle.receiverType.cast(holder)),
                                                handle.fieldOffset,
                                                {#if[Object]?handle.fieldType.cast(expected):expected},
@@ -155,7 +165,8 @@ final class VarHandle$Type$s {
         }
 
         @ForceInline
-        static $type$ compareAndExchangeAcquire(FieldInstanceReadWrite handle, Object holder, $type$ expected, $type$ value) {
+        static $type$ compareAndExchangeAcquire(VarHandle ob, Object holder, $type$ expected, $type$ value) {
+            FieldInstanceReadWrite handle = (FieldInstanceReadWrite)ob;
             return UNSAFE.compareAndExchange$Type$Acquire(Objects.requireNonNull(handle.receiverType.cast(holder)),
                                                handle.fieldOffset,
                                                {#if[Object]?handle.fieldType.cast(expected):expected},
@@ -163,7 +174,8 @@ final class VarHandle$Type$s {
         }
 
         @ForceInline
-        static $type$ compareAndExchangeRelease(FieldInstanceReadWrite handle, Object holder, $type$ expected, $type$ value) {
+        static $type$ compareAndExchangeRelease(VarHandle ob, Object holder, $type$ expected, $type$ value) {
+            FieldInstanceReadWrite handle = (FieldInstanceReadWrite)ob;
             return UNSAFE.compareAndExchange$Type$Release(Objects.requireNonNull(handle.receiverType.cast(holder)),
                                                handle.fieldOffset,
                                                {#if[Object]?handle.fieldType.cast(expected):expected},
@@ -171,7 +183,8 @@ final class VarHandle$Type$s {
         }
 
         @ForceInline
-        static boolean weakCompareAndSetPlain(FieldInstanceReadWrite handle, Object holder, $type$ expected, $type$ value) {
+        static boolean weakCompareAndSetPlain(VarHandle ob, Object holder, $type$ expected, $type$ value) {
+            FieldInstanceReadWrite handle = (FieldInstanceReadWrite)ob;
             return UNSAFE.weakCompareAndSet$Type$Plain(Objects.requireNonNull(handle.receiverType.cast(holder)),
                                                handle.fieldOffset,
                                                {#if[Object]?handle.fieldType.cast(expected):expected},
@@ -179,7 +192,8 @@ final class VarHandle$Type$s {
         }
 
         @ForceInline
-        static boolean weakCompareAndSet(FieldInstanceReadWrite handle, Object holder, $type$ expected, $type$ value) {
+        static boolean weakCompareAndSet(VarHandle ob, Object holder, $type$ expected, $type$ value) {
+            FieldInstanceReadWrite handle = (FieldInstanceReadWrite)ob;
             return UNSAFE.weakCompareAndSet$Type$(Objects.requireNonNull(handle.receiverType.cast(holder)),
                                                handle.fieldOffset,
                                                {#if[Object]?handle.fieldType.cast(expected):expected},
@@ -187,7 +201,8 @@ final class VarHandle$Type$s {
         }
 
         @ForceInline
-        static boolean weakCompareAndSetAcquire(FieldInstanceReadWrite handle, Object holder, $type$ expected, $type$ value) {
+        static boolean weakCompareAndSetAcquire(VarHandle ob, Object holder, $type$ expected, $type$ value) {
+            FieldInstanceReadWrite handle = (FieldInstanceReadWrite)ob;
             return UNSAFE.weakCompareAndSet$Type$Acquire(Objects.requireNonNull(handle.receiverType.cast(holder)),
                                                handle.fieldOffset,
                                                {#if[Object]?handle.fieldType.cast(expected):expected},
@@ -195,7 +210,8 @@ final class VarHandle$Type$s {
         }
 
         @ForceInline
-        static boolean weakCompareAndSetRelease(FieldInstanceReadWrite handle, Object holder, $type$ expected, $type$ value) {
+        static boolean weakCompareAndSetRelease(VarHandle ob, Object holder, $type$ expected, $type$ value) {
+            FieldInstanceReadWrite handle = (FieldInstanceReadWrite)ob;
             return UNSAFE.weakCompareAndSet$Type$Release(Objects.requireNonNull(handle.receiverType.cast(holder)),
                                                handle.fieldOffset,
                                                {#if[Object]?handle.fieldType.cast(expected):expected},
@@ -203,21 +219,24 @@ final class VarHandle$Type$s {
         }
 
         @ForceInline
-        static $type$ getAndSet(FieldInstanceReadWrite handle, Object holder, $type$ value) {
+        static $type$ getAndSet(VarHandle ob, Object holder, $type$ value) {
+            FieldInstanceReadWrite handle = (FieldInstanceReadWrite)ob;
             return UNSAFE.getAndSet$Type$(Objects.requireNonNull(handle.receiverType.cast(holder)),
                                           handle.fieldOffset,
                                           {#if[Object]?handle.fieldType.cast(value):value});
         }
 
         @ForceInline
-        static $type$ getAndSetAcquire(FieldInstanceReadWrite handle, Object holder, $type$ value) {
+        static $type$ getAndSetAcquire(VarHandle ob, Object holder, $type$ value) {
+            FieldInstanceReadWrite handle = (FieldInstanceReadWrite)ob;
             return UNSAFE.getAndSet$Type$Acquire(Objects.requireNonNull(handle.receiverType.cast(holder)),
                                           handle.fieldOffset,
                                           {#if[Object]?handle.fieldType.cast(value):value});
         }
 
         @ForceInline
-        static $type$ getAndSetRelease(FieldInstanceReadWrite handle, Object holder, $type$ value) {
+        static $type$ getAndSetRelease(VarHandle ob, Object holder, $type$ value) {
+            FieldInstanceReadWrite handle = (FieldInstanceReadWrite)ob;
             return UNSAFE.getAndSet$Type$Release(Objects.requireNonNull(handle.receiverType.cast(holder)),
                                           handle.fieldOffset,
                                           {#if[Object]?handle.fieldType.cast(value):value});
@@ -226,21 +245,24 @@ final class VarHandle$Type$s {
 #if[AtomicAdd]
 
         @ForceInline
-        static $type$ getAndAdd(FieldInstanceReadWrite handle, Object holder, $type$ value) {
+        static $type$ getAndAdd(VarHandle ob, Object holder, $type$ value) {
+            FieldInstanceReadWrite handle = (FieldInstanceReadWrite)ob;
             return UNSAFE.getAndAdd$Type$(Objects.requireNonNull(handle.receiverType.cast(holder)),
                                        handle.fieldOffset,
                                        value);
         }
 
         @ForceInline
-        static $type$ getAndAddAcquire(FieldInstanceReadWrite handle, Object holder, $type$ value) {
+        static $type$ getAndAddAcquire(VarHandle ob, Object holder, $type$ value) {
+            FieldInstanceReadWrite handle = (FieldInstanceReadWrite)ob;
             return UNSAFE.getAndAdd$Type$Acquire(Objects.requireNonNull(handle.receiverType.cast(holder)),
                                        handle.fieldOffset,
                                        value);
         }
 
         @ForceInline
-        static $type$ getAndAddRelease(FieldInstanceReadWrite handle, Object holder, $type$ value) {
+        static $type$ getAndAddRelease(VarHandle ob, Object holder, $type$ value) {
+            FieldInstanceReadWrite handle = (FieldInstanceReadWrite)ob;
             return UNSAFE.getAndAdd$Type$Release(Objects.requireNonNull(handle.receiverType.cast(holder)),
                                        handle.fieldOffset,
                                        value);
@@ -250,63 +272,72 @@ final class VarHandle$Type$s {
 #if[Bitwise]
 
         @ForceInline
-        static $type$ getAndBitwiseOr(FieldInstanceReadWrite handle, Object holder, $type$ value) {
+        static $type$ getAndBitwiseOr(VarHandle ob, Object holder, $type$ value) {
+            FieldInstanceReadWrite handle = (FieldInstanceReadWrite)ob;
             return UNSAFE.getAndBitwiseOr$Type$(Objects.requireNonNull(handle.receiverType.cast(holder)),
                                        handle.fieldOffset,
                                        value);
         }
 
         @ForceInline
-        static $type$ getAndBitwiseOrRelease(FieldInstanceReadWrite handle, Object holder, $type$ value) {
+        static $type$ getAndBitwiseOrRelease(VarHandle ob, Object holder, $type$ value) {
+            FieldInstanceReadWrite handle = (FieldInstanceReadWrite)ob;
             return UNSAFE.getAndBitwiseOr$Type$Release(Objects.requireNonNull(handle.receiverType.cast(holder)),
                                        handle.fieldOffset,
                                        value);
         }
 
         @ForceInline
-        static $type$ getAndBitwiseOrAcquire(FieldInstanceReadWrite handle, Object holder, $type$ value) {
+        static $type$ getAndBitwiseOrAcquire(VarHandle ob, Object holder, $type$ value) {
+            FieldInstanceReadWrite handle = (FieldInstanceReadWrite)ob;
             return UNSAFE.getAndBitwiseOr$Type$Acquire(Objects.requireNonNull(handle.receiverType.cast(holder)),
                                        handle.fieldOffset,
                                        value);
         }
 
         @ForceInline
-        static $type$ getAndBitwiseAnd(FieldInstanceReadWrite handle, Object holder, $type$ value) {
+        static $type$ getAndBitwiseAnd(VarHandle ob, Object holder, $type$ value) {
+            FieldInstanceReadWrite handle = (FieldInstanceReadWrite)ob;
             return UNSAFE.getAndBitwiseAnd$Type$(Objects.requireNonNull(handle.receiverType.cast(holder)),
                                        handle.fieldOffset,
                                        value);
         }
 
         @ForceInline
-        static $type$ getAndBitwiseAndRelease(FieldInstanceReadWrite handle, Object holder, $type$ value) {
+        static $type$ getAndBitwiseAndRelease(VarHandle ob, Object holder, $type$ value) {
+            FieldInstanceReadWrite handle = (FieldInstanceReadWrite)ob;
             return UNSAFE.getAndBitwiseAnd$Type$Release(Objects.requireNonNull(handle.receiverType.cast(holder)),
                                        handle.fieldOffset,
                                        value);
         }
 
         @ForceInline
-        static $type$ getAndBitwiseAndAcquire(FieldInstanceReadWrite handle, Object holder, $type$ value) {
+        static $type$ getAndBitwiseAndAcquire(VarHandle ob, Object holder, $type$ value) {
+            FieldInstanceReadWrite handle = (FieldInstanceReadWrite)ob;
             return UNSAFE.getAndBitwiseAnd$Type$Acquire(Objects.requireNonNull(handle.receiverType.cast(holder)),
                                        handle.fieldOffset,
                                        value);
         }
 
         @ForceInline
-        static $type$ getAndBitwiseXor(FieldInstanceReadWrite handle, Object holder, $type$ value) {
+        static $type$ getAndBitwiseXor(VarHandle ob, Object holder, $type$ value) {
+            FieldInstanceReadWrite handle = (FieldInstanceReadWrite)ob;
             return UNSAFE.getAndBitwiseXor$Type$(Objects.requireNonNull(handle.receiverType.cast(holder)),
                                        handle.fieldOffset,
                                        value);
         }
 
         @ForceInline
-        static $type$ getAndBitwiseXorRelease(FieldInstanceReadWrite handle, Object holder, $type$ value) {
+        static $type$ getAndBitwiseXorRelease(VarHandle ob, Object holder, $type$ value) {
+            FieldInstanceReadWrite handle = (FieldInstanceReadWrite)ob;
             return UNSAFE.getAndBitwiseXor$Type$Release(Objects.requireNonNull(handle.receiverType.cast(holder)),
                                        handle.fieldOffset,
                                        value);
         }
 
         @ForceInline
-        static $type$ getAndBitwiseXorAcquire(FieldInstanceReadWrite handle, Object holder, $type$ value) {
+        static $type$ getAndBitwiseXorAcquire(VarHandle ob, Object holder, $type$ value) {
+            FieldInstanceReadWrite handle = (FieldInstanceReadWrite)ob;
             return UNSAFE.getAndBitwiseXor$Type$Acquire(Objects.requireNonNull(handle.receiverType.cast(holder)),
                                        handle.fieldOffset,
                                        value);
@@ -359,25 +390,29 @@ final class VarHandle$Type$s {
         }
 
         @ForceInline
-        static $type$ get(FieldStaticReadOnly handle) {
+        static $type$ get(VarHandle ob) {
+            FieldStaticReadOnly handle = (FieldStaticReadOnly)ob;
             return UNSAFE.get$Type$(handle.base,
                                  handle.fieldOffset);
         }
 
         @ForceInline
-        static $type$ getVolatile(FieldStaticReadOnly handle) {
+        static $type$ getVolatile(VarHandle ob) {
+            FieldStaticReadOnly handle = (FieldStaticReadOnly)ob;
             return UNSAFE.get$Type$Volatile(handle.base,
                                  handle.fieldOffset);
         }
 
         @ForceInline
-        static $type$ getOpaque(FieldStaticReadOnly handle) {
+        static $type$ getOpaque(VarHandle ob) {
+            FieldStaticReadOnly handle = (FieldStaticReadOnly)ob;
             return UNSAFE.get$Type$Opaque(handle.base,
                                  handle.fieldOffset);
         }
 
         @ForceInline
-        static $type$ getAcquire(FieldStaticReadOnly handle) {
+        static $type$ getAcquire(VarHandle ob) {
+            FieldStaticReadOnly handle = (FieldStaticReadOnly)ob;
             return UNSAFE.get$Type$Acquire(handle.base,
                                  handle.fieldOffset);
         }
@@ -392,28 +427,32 @@ final class VarHandle$Type$s {
         }
 
         @ForceInline
-        static void set(FieldStaticReadWrite handle, $type$ value) {
+        static void set(VarHandle ob, $type$ value) {
+            FieldStaticReadWrite handle = (FieldStaticReadWrite)ob;
             UNSAFE.put$Type$(handle.base,
                              handle.fieldOffset,
                              {#if[Object]?handle.fieldType.cast(value):value});
         }
 
         @ForceInline
-        static void setVolatile(FieldStaticReadWrite handle, $type$ value) {
+        static void setVolatile(VarHandle ob, $type$ value) {
+            FieldStaticReadWrite handle = (FieldStaticReadWrite)ob;
             UNSAFE.put$Type$Volatile(handle.base,
                                      handle.fieldOffset,
                                      {#if[Object]?handle.fieldType.cast(value):value});
         }
 
         @ForceInline
-        static void setOpaque(FieldStaticReadWrite handle, $type$ value) {
+        static void setOpaque(VarHandle ob, $type$ value) {
+            FieldStaticReadWrite handle = (FieldStaticReadWrite)ob;
             UNSAFE.put$Type$Opaque(handle.base,
                                    handle.fieldOffset,
                                    {#if[Object]?handle.fieldType.cast(value):value});
         }
 
         @ForceInline
-        static void setRelease(FieldStaticReadWrite handle, $type$ value) {
+        static void setRelease(VarHandle ob, $type$ value) {
+            FieldStaticReadWrite handle = (FieldStaticReadWrite)ob;
             UNSAFE.put$Type$Release(handle.base,
                                     handle.fieldOffset,
                                     {#if[Object]?handle.fieldType.cast(value):value});
@@ -421,7 +460,8 @@ final class VarHandle$Type$s {
 #if[CAS]
 
         @ForceInline
-        static boolean compareAndSet(FieldStaticReadWrite handle, $type$ expected, $type$ value) {
+        static boolean compareAndSet(VarHandle ob, $type$ expected, $type$ value) {
+            FieldStaticReadWrite handle = (FieldStaticReadWrite)ob;
             return UNSAFE.compareAndSet$Type$(handle.base,
                                                handle.fieldOffset,
                                                {#if[Object]?handle.fieldType.cast(expected):expected},
@@ -430,7 +470,8 @@ final class VarHandle$Type$s {
 
 
         @ForceInline
-        static $type$ compareAndExchange(FieldStaticReadWrite handle, $type$ expected, $type$ value) {
+        static $type$ compareAndExchange(VarHandle ob, $type$ expected, $type$ value) {
+            FieldStaticReadWrite handle = (FieldStaticReadWrite)ob;
             return UNSAFE.compareAndExchange$Type$(handle.base,
                                                handle.fieldOffset,
                                                {#if[Object]?handle.fieldType.cast(expected):expected},
@@ -438,7 +479,8 @@ final class VarHandle$Type$s {
         }
 
         @ForceInline
-        static $type$ compareAndExchangeAcquire(FieldStaticReadWrite handle, $type$ expected, $type$ value) {
+        static $type$ compareAndExchangeAcquire(VarHandle ob, $type$ expected, $type$ value) {
+            FieldStaticReadWrite handle = (FieldStaticReadWrite)ob;
             return UNSAFE.compareAndExchange$Type$Acquire(handle.base,
                                                handle.fieldOffset,
                                                {#if[Object]?handle.fieldType.cast(expected):expected},
@@ -446,7 +488,8 @@ final class VarHandle$Type$s {
         }
 
         @ForceInline
-        static $type$ compareAndExchangeRelease(FieldStaticReadWrite handle, $type$ expected, $type$ value) {
+        static $type$ compareAndExchangeRelease(VarHandle ob, $type$ expected, $type$ value) {
+            FieldStaticReadWrite handle = (FieldStaticReadWrite)ob;
             return UNSAFE.compareAndExchange$Type$Release(handle.base,
                                                handle.fieldOffset,
                                                {#if[Object]?handle.fieldType.cast(expected):expected},
@@ -454,7 +497,8 @@ final class VarHandle$Type$s {
         }
 
         @ForceInline
-        static boolean weakCompareAndSetPlain(FieldStaticReadWrite handle, $type$ expected, $type$ value) {
+        static boolean weakCompareAndSetPlain(VarHandle ob, $type$ expected, $type$ value) {
+            FieldStaticReadWrite handle = (FieldStaticReadWrite)ob;
             return UNSAFE.weakCompareAndSet$Type$Plain(handle.base,
                                                handle.fieldOffset,
                                                {#if[Object]?handle.fieldType.cast(expected):expected},
@@ -462,7 +506,8 @@ final class VarHandle$Type$s {
         }
 
         @ForceInline
-        static boolean weakCompareAndSet(FieldStaticReadWrite handle, $type$ expected, $type$ value) {
+        static boolean weakCompareAndSet(VarHandle ob, $type$ expected, $type$ value) {
+            FieldStaticReadWrite handle = (FieldStaticReadWrite)ob;
             return UNSAFE.weakCompareAndSet$Type$(handle.base,
                                                handle.fieldOffset,
                                                {#if[Object]?handle.fieldType.cast(expected):expected},
@@ -470,7 +515,8 @@ final class VarHandle$Type$s {
         }
 
         @ForceInline
-        static boolean weakCompareAndSetAcquire(FieldStaticReadWrite handle, $type$ expected, $type$ value) {
+        static boolean weakCompareAndSetAcquire(VarHandle ob, $type$ expected, $type$ value) {
+            FieldStaticReadWrite handle = (FieldStaticReadWrite)ob;
             return UNSAFE.weakCompareAndSet$Type$Acquire(handle.base,
                                                handle.fieldOffset,
                                                {#if[Object]?handle.fieldType.cast(expected):expected},
@@ -478,7 +524,8 @@ final class VarHandle$Type$s {
         }
 
         @ForceInline
-        static boolean weakCompareAndSetRelease(FieldStaticReadWrite handle, $type$ expected, $type$ value) {
+        static boolean weakCompareAndSetRelease(VarHandle ob, $type$ expected, $type$ value) {
+            FieldStaticReadWrite handle = (FieldStaticReadWrite)ob;
             return UNSAFE.weakCompareAndSet$Type$Release(handle.base,
                                                handle.fieldOffset,
                                                {#if[Object]?handle.fieldType.cast(expected):expected},
@@ -486,21 +533,24 @@ final class VarHandle$Type$s {
         }
 
         @ForceInline
-        static $type$ getAndSet(FieldStaticReadWrite handle, $type$ value) {
+        static $type$ getAndSet(VarHandle ob, $type$ value) {
+            FieldStaticReadWrite handle = (FieldStaticReadWrite)ob;
             return UNSAFE.getAndSet$Type$(handle.base,
                                           handle.fieldOffset,
                                           {#if[Object]?handle.fieldType.cast(value):value});
         }
 
         @ForceInline
-        static $type$ getAndSetAcquire(FieldStaticReadWrite handle, $type$ value) {
+        static $type$ getAndSetAcquire(VarHandle ob, $type$ value) {
+            FieldStaticReadWrite handle = (FieldStaticReadWrite)ob;
             return UNSAFE.getAndSet$Type$Acquire(handle.base,
                                           handle.fieldOffset,
                                           {#if[Object]?handle.fieldType.cast(value):value});
         }
 
         @ForceInline
-        static $type$ getAndSetRelease(FieldStaticReadWrite handle, $type$ value) {
+        static $type$ getAndSetRelease(VarHandle ob, $type$ value) {
+            FieldStaticReadWrite handle = (FieldStaticReadWrite)ob;
             return UNSAFE.getAndSet$Type$Release(handle.base,
                                           handle.fieldOffset,
                                           {#if[Object]?handle.fieldType.cast(value):value});
@@ -509,21 +559,24 @@ final class VarHandle$Type$s {
 #if[AtomicAdd]
 
         @ForceInline
-        static $type$ getAndAdd(FieldStaticReadWrite handle, $type$ value) {
+        static $type$ getAndAdd(VarHandle ob, $type$ value) {
+            FieldStaticReadWrite handle = (FieldStaticReadWrite)ob;
             return UNSAFE.getAndAdd$Type$(handle.base,
                                        handle.fieldOffset,
                                        value);
         }
 
         @ForceInline
-        static $type$ getAndAddAcquire(FieldStaticReadWrite handle, $type$ value) {
+        static $type$ getAndAddAcquire(VarHandle ob, $type$ value) {
+            FieldStaticReadWrite handle = (FieldStaticReadWrite)ob;
             return UNSAFE.getAndAdd$Type$Acquire(handle.base,
                                        handle.fieldOffset,
                                        value);
         }
 
         @ForceInline
-        static $type$ getAndAddRelease(FieldStaticReadWrite handle, $type$ value) {
+        static $type$ getAndAddRelease(VarHandle ob, $type$ value) {
+            FieldStaticReadWrite handle = (FieldStaticReadWrite)ob;
             return UNSAFE.getAndAdd$Type$Release(handle.base,
                                        handle.fieldOffset,
                                        value);
@@ -532,63 +585,72 @@ final class VarHandle$Type$s {
 #if[Bitwise]
 
         @ForceInline
-        static $type$ getAndBitwiseOr(FieldStaticReadWrite handle, $type$ value) {
+        static $type$ getAndBitwiseOr(VarHandle ob, $type$ value) {
+            FieldStaticReadWrite handle = (FieldStaticReadWrite)ob;
             return UNSAFE.getAndBitwiseOr$Type$(handle.base,
                                        handle.fieldOffset,
                                        value);
         }
 
         @ForceInline
-        static $type$ getAndBitwiseOrRelease(FieldStaticReadWrite handle, $type$ value) {
+        static $type$ getAndBitwiseOrRelease(VarHandle ob, $type$ value) {
+            FieldStaticReadWrite handle = (FieldStaticReadWrite)ob;
             return UNSAFE.getAndBitwiseOr$Type$Release(handle.base,
                                        handle.fieldOffset,
                                        value);
         }
 
         @ForceInline
-        static $type$ getAndBitwiseOrAcquire(FieldStaticReadWrite handle, $type$ value) {
+        static $type$ getAndBitwiseOrAcquire(VarHandle ob, $type$ value) {
+            FieldStaticReadWrite handle = (FieldStaticReadWrite)ob;
             return UNSAFE.getAndBitwiseOr$Type$Acquire(handle.base,
                                        handle.fieldOffset,
                                        value);
         }
 
         @ForceInline
-        static $type$ getAndBitwiseAnd(FieldStaticReadWrite handle, $type$ value) {
+        static $type$ getAndBitwiseAnd(VarHandle ob, $type$ value) {
+            FieldStaticReadWrite handle = (FieldStaticReadWrite)ob;
             return UNSAFE.getAndBitwiseAnd$Type$(handle.base,
                                        handle.fieldOffset,
                                        value);
         }
 
         @ForceInline
-        static $type$ getAndBitwiseAndRelease(FieldStaticReadWrite handle, $type$ value) {
+        static $type$ getAndBitwiseAndRelease(VarHandle ob, $type$ value) {
+            FieldStaticReadWrite handle = (FieldStaticReadWrite)ob;
             return UNSAFE.getAndBitwiseAnd$Type$Release(handle.base,
                                        handle.fieldOffset,
                                        value);
         }
 
         @ForceInline
-        static $type$ getAndBitwiseAndAcquire(FieldStaticReadWrite handle, $type$ value) {
+        static $type$ getAndBitwiseAndAcquire(VarHandle ob, $type$ value) {
+            FieldStaticReadWrite handle = (FieldStaticReadWrite)ob;
             return UNSAFE.getAndBitwiseAnd$Type$Acquire(handle.base,
                                        handle.fieldOffset,
                                        value);
         }
 
         @ForceInline
-        static $type$ getAndBitwiseXor(FieldStaticReadWrite handle, $type$ value) {
+        static $type$ getAndBitwiseXor(VarHandle ob, $type$ value) {
+            FieldStaticReadWrite handle = (FieldStaticReadWrite)ob;
             return UNSAFE.getAndBitwiseXor$Type$(handle.base,
                                        handle.fieldOffset,
                                        value);
         }
 
         @ForceInline
-        static $type$ getAndBitwiseXorRelease(FieldStaticReadWrite handle, $type$ value) {
+        static $type$ getAndBitwiseXorRelease(VarHandle ob, $type$ value) {
+            FieldStaticReadWrite handle = (FieldStaticReadWrite)ob;
             return UNSAFE.getAndBitwiseXor$Type$Release(handle.base,
                                        handle.fieldOffset,
                                        value);
         }
 
         @ForceInline
-        static $type$ getAndBitwiseXorAcquire(FieldStaticReadWrite handle, $type$ value) {
+        static $type$ getAndBitwiseXorAcquire(VarHandle ob, $type$ value) {
+            FieldStaticReadWrite handle = (FieldStaticReadWrite)ob;
             return UNSAFE.getAndBitwiseXor$Type$Acquire(handle.base,
                                        handle.fieldOffset,
                                        value);
@@ -654,7 +716,8 @@ final class VarHandle$Type$s {
 #end[Object]
 
         @ForceInline
-        static $type$ get(Array handle, Object oarray, int index) {
+        static $type$ get(VarHandle ob, Object oarray, int index) {
+            Array handle = (Array)ob;
 #if[Object]
             Object[] array = (Object[]) handle.arrayType.cast(oarray);
 #else[Object]
@@ -664,7 +727,8 @@ final class VarHandle$Type$s {
         }
 
         @ForceInline
-        static void set(Array handle, Object oarray, int index, $type$ value) {
+        static void set(VarHandle ob, Object oarray, int index, $type$ value) {
+            Array handle = (Array)ob;
 #if[Object]
             Object[] array = (Object[]) handle.arrayType.cast(oarray);
 #else[Object]
@@ -674,7 +738,8 @@ final class VarHandle$Type$s {
         }
 
         @ForceInline
-        static $type$ getVolatile(Array handle, Object oarray, int index) {
+        static $type$ getVolatile(VarHandle ob, Object oarray, int index) {
+            Array handle = (Array)ob;
 #if[Object]
             Object[] array = (Object[]) handle.arrayType.cast(oarray);
 #else[Object]
@@ -685,7 +750,8 @@ final class VarHandle$Type$s {
         }
 
         @ForceInline
-        static void setVolatile(Array handle, Object oarray, int index, $type$ value) {
+        static void setVolatile(VarHandle ob, Object oarray, int index, $type$ value) {
+            Array handle = (Array)ob;
 #if[Object]
             Object[] array = (Object[]) handle.arrayType.cast(oarray);
 #else[Object]
@@ -697,7 +763,8 @@ final class VarHandle$Type$s {
         }
 
         @ForceInline
-        static $type$ getOpaque(Array handle, Object oarray, int index) {
+        static $type$ getOpaque(VarHandle ob, Object oarray, int index) {
+            Array handle = (Array)ob;
 #if[Object]
             Object[] array = (Object[]) handle.arrayType.cast(oarray);
 #else[Object]
@@ -708,7 +775,8 @@ final class VarHandle$Type$s {
         }
 
         @ForceInline
-        static void setOpaque(Array handle, Object oarray, int index, $type$ value) {
+        static void setOpaque(VarHandle ob, Object oarray, int index, $type$ value) {
+            Array handle = (Array)ob;
 #if[Object]
             Object[] array = (Object[]) handle.arrayType.cast(oarray);
 #else[Object]
@@ -720,7 +788,8 @@ final class VarHandle$Type$s {
         }
 
         @ForceInline
-        static $type$ getAcquire(Array handle, Object oarray, int index) {
+        static $type$ getAcquire(VarHandle ob, Object oarray, int index) {
+            Array handle = (Array)ob;
 #if[Object]
             Object[] array = (Object[]) handle.arrayType.cast(oarray);
 #else[Object]
@@ -731,7 +800,8 @@ final class VarHandle$Type$s {
         }
 
         @ForceInline
-        static void setRelease(Array handle, Object oarray, int index, $type$ value) {
+        static void setRelease(VarHandle ob, Object oarray, int index, $type$ value) {
+            Array handle = (Array)ob;
 #if[Object]
             Object[] array = (Object[]) handle.arrayType.cast(oarray);
 #else[Object]
@@ -744,7 +814,8 @@ final class VarHandle$Type$s {
 #if[CAS]
 
         @ForceInline
-        static boolean compareAndSet(Array handle, Object oarray, int index, $type$ expected, $type$ value) {
+        static boolean compareAndSet(VarHandle ob, Object oarray, int index, $type$ expected, $type$ value) {
+            Array handle = (Array)ob;
 #if[Object]
             Object[] array = (Object[]) handle.arrayType.cast(oarray);
 #else[Object]
@@ -757,7 +828,8 @@ final class VarHandle$Type$s {
         }
 
         @ForceInline
-        static $type$ compareAndExchange(Array handle, Object oarray, int index, $type$ expected, $type$ value) {
+        static $type$ compareAndExchange(VarHandle ob, Object oarray, int index, $type$ expected, $type$ value) {
+            Array handle = (Array)ob;
 #if[Object]
             Object[] array = (Object[]) handle.arrayType.cast(oarray);
 #else[Object]
@@ -770,7 +842,8 @@ final class VarHandle$Type$s {
         }
 
         @ForceInline
-        static $type$ compareAndExchangeAcquire(Array handle, Object oarray, int index, $type$ expected, $type$ value) {
+        static $type$ compareAndExchangeAcquire(VarHandle ob, Object oarray, int index, $type$ expected, $type$ value) {
+            Array handle = (Array)ob;
 #if[Object]
             Object[] array = (Object[]) handle.arrayType.cast(oarray);
 #else[Object]
@@ -783,7 +856,8 @@ final class VarHandle$Type$s {
         }
 
         @ForceInline
-        static $type$ compareAndExchangeRelease(Array handle, Object oarray, int index, $type$ expected, $type$ value) {
+        static $type$ compareAndExchangeRelease(VarHandle ob, Object oarray, int index, $type$ expected, $type$ value) {
+            Array handle = (Array)ob;
 #if[Object]
             Object[] array = (Object[]) handle.arrayType.cast(oarray);
 #else[Object]
@@ -796,7 +870,8 @@ final class VarHandle$Type$s {
         }
 
         @ForceInline
-        static boolean weakCompareAndSetPlain(Array handle, Object oarray, int index, $type$ expected, $type$ value) {
+        static boolean weakCompareAndSetPlain(VarHandle ob, Object oarray, int index, $type$ expected, $type$ value) {
+            Array handle = (Array)ob;
 #if[Object]
             Object[] array = (Object[]) handle.arrayType.cast(oarray);
 #else[Object]
@@ -809,7 +884,8 @@ final class VarHandle$Type$s {
         }
 
         @ForceInline
-        static boolean weakCompareAndSet(Array handle, Object oarray, int index, $type$ expected, $type$ value) {
+        static boolean weakCompareAndSet(VarHandle ob, Object oarray, int index, $type$ expected, $type$ value) {
+            Array handle = (Array)ob;
 #if[Object]
             Object[] array = (Object[]) handle.arrayType.cast(oarray);
 #else[Object]
@@ -822,7 +898,8 @@ final class VarHandle$Type$s {
         }
 
         @ForceInline
-        static boolean weakCompareAndSetAcquire(Array handle, Object oarray, int index, $type$ expected, $type$ value) {
+        static boolean weakCompareAndSetAcquire(VarHandle ob, Object oarray, int index, $type$ expected, $type$ value) {
+            Array handle = (Array)ob;
 #if[Object]
             Object[] array = (Object[]) handle.arrayType.cast(oarray);
 #else[Object]
@@ -835,7 +912,8 @@ final class VarHandle$Type$s {
         }
 
         @ForceInline
-        static boolean weakCompareAndSetRelease(Array handle, Object oarray, int index, $type$ expected, $type$ value) {
+        static boolean weakCompareAndSetRelease(VarHandle ob, Object oarray, int index, $type$ expected, $type$ value) {
+            Array handle = (Array)ob;
 #if[Object]
             Object[] array = (Object[]) handle.arrayType.cast(oarray);
 #else[Object]
@@ -848,7 +926,8 @@ final class VarHandle$Type$s {
         }
 
         @ForceInline
-        static $type$ getAndSet(Array handle, Object oarray, int index, $type$ value) {
+        static $type$ getAndSet(VarHandle ob, Object oarray, int index, $type$ value) {
+            Array handle = (Array)ob;
 #if[Object]
             Object[] array = (Object[]) handle.arrayType.cast(oarray);
 #else[Object]
@@ -860,7 +939,8 @@ final class VarHandle$Type$s {
         }
 
         @ForceInline
-        static $type$ getAndSetAcquire(Array handle, Object oarray, int index, $type$ value) {
+        static $type$ getAndSetAcquire(VarHandle ob, Object oarray, int index, $type$ value) {
+            Array handle = (Array)ob;
 #if[Object]
             Object[] array = (Object[]) handle.arrayType.cast(oarray);
 #else[Object]
@@ -872,7 +952,8 @@ final class VarHandle$Type$s {
         }
 
         @ForceInline
-        static $type$ getAndSetRelease(Array handle, Object oarray, int index, $type$ value) {
+        static $type$ getAndSetRelease(VarHandle ob, Object oarray, int index, $type$ value) {
+            Array handle = (Array)ob;
 #if[Object]
             Object[] array = (Object[]) handle.arrayType.cast(oarray);
 #else[Object]
@@ -886,7 +967,8 @@ final class VarHandle$Type$s {
 #if[AtomicAdd]
 
         @ForceInline
-        static $type$ getAndAdd(Array handle, Object oarray, int index, $type$ value) {
+        static $type$ getAndAdd(VarHandle ob, Object oarray, int index, $type$ value) {
+            Array handle = (Array)ob;
             $type$[] array = ($type$[]) oarray;
             return UNSAFE.getAndAdd$Type$(array,
                     (((long) Preconditions.checkIndex(index, array.length, AIOOBE_SUPPLIER)) << handle.ashift) + handle.abase,
@@ -894,7 +976,8 @@ final class VarHandle$Type$s {
         }
 
         @ForceInline
-        static $type$ getAndAddAcquire(Array handle, Object oarray, int index, $type$ value) {
+        static $type$ getAndAddAcquire(VarHandle ob, Object oarray, int index, $type$ value) {
+            Array handle = (Array)ob;
             $type$[] array = ($type$[]) oarray;
             return UNSAFE.getAndAdd$Type$Acquire(array,
                     (((long) Preconditions.checkIndex(index, array.length, AIOOBE_SUPPLIER)) << handle.ashift) + handle.abase,
@@ -902,7 +985,8 @@ final class VarHandle$Type$s {
         }
 
         @ForceInline
-        static $type$ getAndAddRelease(Array handle, Object oarray, int index, $type$ value) {
+        static $type$ getAndAddRelease(VarHandle ob, Object oarray, int index, $type$ value) {
+            Array handle = (Array)ob;
             $type$[] array = ($type$[]) oarray;
             return UNSAFE.getAndAdd$Type$Release(array,
                     (((long) Preconditions.checkIndex(index, array.length, AIOOBE_SUPPLIER)) << handle.ashift) + handle.abase,
@@ -912,7 +996,8 @@ final class VarHandle$Type$s {
 #if[Bitwise]
 
         @ForceInline
-        static $type$ getAndBitwiseOr(Array handle, Object oarray, int index, $type$ value) {
+        static $type$ getAndBitwiseOr(VarHandle ob, Object oarray, int index, $type$ value) {
+            Array handle = (Array)ob;
             $type$[] array = ($type$[]) oarray;
             return UNSAFE.getAndBitwiseOr$Type$(array,
                                        (((long) Preconditions.checkIndex(index, array.length, AIOOBE_SUPPLIER)) << handle.ashift) + handle.abase,
@@ -920,7 +1005,8 @@ final class VarHandle$Type$s {
         }
 
         @ForceInline
-        static $type$ getAndBitwiseOrRelease(Array handle, Object oarray, int index, $type$ value) {
+        static $type$ getAndBitwiseOrRelease(VarHandle ob, Object oarray, int index, $type$ value) {
+            Array handle = (Array)ob;
             $type$[] array = ($type$[]) oarray;
             return UNSAFE.getAndBitwiseOr$Type$Release(array,
                                        (((long) Preconditions.checkIndex(index, array.length, AIOOBE_SUPPLIER)) << handle.ashift) + handle.abase,
@@ -928,7 +1014,8 @@ final class VarHandle$Type$s {
         }
 
         @ForceInline
-        static $type$ getAndBitwiseOrAcquire(Array handle, Object oarray, int index, $type$ value) {
+        static $type$ getAndBitwiseOrAcquire(VarHandle ob, Object oarray, int index, $type$ value) {
+            Array handle = (Array)ob;
             $type$[] array = ($type$[]) oarray;
             return UNSAFE.getAndBitwiseOr$Type$Acquire(array,
                                        (((long) Preconditions.checkIndex(index, array.length, AIOOBE_SUPPLIER)) << handle.ashift) + handle.abase,
@@ -936,7 +1023,8 @@ final class VarHandle$Type$s {
         }
 
         @ForceInline
-        static $type$ getAndBitwiseAnd(Array handle, Object oarray, int index, $type$ value) {
+        static $type$ getAndBitwiseAnd(VarHandle ob, Object oarray, int index, $type$ value) {
+            Array handle = (Array)ob;
             $type$[] array = ($type$[]) oarray;
             return UNSAFE.getAndBitwiseAnd$Type$(array,
                                        (((long) Preconditions.checkIndex(index, array.length, AIOOBE_SUPPLIER)) << handle.ashift) + handle.abase,
@@ -944,7 +1032,8 @@ final class VarHandle$Type$s {
         }
 
         @ForceInline
-        static $type$ getAndBitwiseAndRelease(Array handle, Object oarray, int index, $type$ value) {
+        static $type$ getAndBitwiseAndRelease(VarHandle ob, Object oarray, int index, $type$ value) {
+            Array handle = (Array)ob;
             $type$[] array = ($type$[]) oarray;
             return UNSAFE.getAndBitwiseAnd$Type$Release(array,
                                        (((long) Preconditions.checkIndex(index, array.length, AIOOBE_SUPPLIER)) << handle.ashift) + handle.abase,
@@ -952,7 +1041,8 @@ final class VarHandle$Type$s {
         }
 
         @ForceInline
-        static $type$ getAndBitwiseAndAcquire(Array handle, Object oarray, int index, $type$ value) {
+        static $type$ getAndBitwiseAndAcquire(VarHandle ob, Object oarray, int index, $type$ value) {
+            Array handle = (Array)ob;
             $type$[] array = ($type$[]) oarray;
             return UNSAFE.getAndBitwiseAnd$Type$Acquire(array,
                                        (((long) Preconditions.checkIndex(index, array.length, AIOOBE_SUPPLIER)) << handle.ashift) + handle.abase,
@@ -960,7 +1050,8 @@ final class VarHandle$Type$s {
         }
 
         @ForceInline
-        static $type$ getAndBitwiseXor(Array handle, Object oarray, int index, $type$ value) {
+        static $type$ getAndBitwiseXor(VarHandle ob, Object oarray, int index, $type$ value) {
+            Array handle = (Array)ob;
             $type$[] array = ($type$[]) oarray;
             return UNSAFE.getAndBitwiseXor$Type$(array,
                                        (((long) Preconditions.checkIndex(index, array.length, AIOOBE_SUPPLIER)) << handle.ashift) + handle.abase,
@@ -968,7 +1059,8 @@ final class VarHandle$Type$s {
         }
 
         @ForceInline
-        static $type$ getAndBitwiseXorRelease(Array handle, Object oarray, int index, $type$ value) {
+        static $type$ getAndBitwiseXorRelease(VarHandle ob, Object oarray, int index, $type$ value) {
+            Array handle = (Array)ob;
             $type$[] array = ($type$[]) oarray;
             return UNSAFE.getAndBitwiseXor$Type$Release(array,
                                        (((long) Preconditions.checkIndex(index, array.length, AIOOBE_SUPPLIER)) << handle.ashift) + handle.abase,
@@ -976,7 +1068,8 @@ final class VarHandle$Type$s {
         }
 
         @ForceInline
-        static $type$ getAndBitwiseXorAcquire(Array handle, Object oarray, int index, $type$ value) {
+        static $type$ getAndBitwiseXorAcquire(VarHandle ob, Object oarray, int index, $type$ value) {
+            Array handle = (Array)ob;
             $type$[] array = ($type$[]) oarray;
             return UNSAFE.getAndBitwiseXor$Type$Acquire(array,
                                        (((long) Preconditions.checkIndex(index, array.length, AIOOBE_SUPPLIER)) << handle.ashift) + handle.abase,

--- a/src/java.base/share/classes/java/lang/invoke/X-VarHandleByteArrayView.java.template
+++ b/src/java.base/share/classes/java/lang/invoke/X-VarHandleByteArrayView.java.template
@@ -98,7 +98,8 @@ final class VarHandleByteArrayAs$Type$s extends VarHandleByteArrayBase {
         }
 
         @ForceInline
-        static $type$ get(ArrayHandle handle, Object oba, int index) {
+        static $type$ get(VarHandle ob, Object oba, int index) {
+            ArrayHandle handle = (ArrayHandle)ob;
             byte[] ba = (byte[]) oba;
 #if[floatingPoint]
             $rawType$ rawValue = UNSAFE.get$RawType$Unaligned(
@@ -115,7 +116,8 @@ final class VarHandleByteArrayAs$Type$s extends VarHandleByteArrayBase {
         }
 
         @ForceInline
-        static void set(ArrayHandle handle, Object oba, int index, $type$ value) {
+        static void set(VarHandle ob, Object oba, int index, $type$ value) {
+            ArrayHandle handle = (ArrayHandle)ob;
             byte[] ba = (byte[]) oba;
 #if[floatingPoint]
             UNSAFE.put$RawType$Unaligned(
@@ -133,7 +135,8 @@ final class VarHandleByteArrayAs$Type$s extends VarHandleByteArrayBase {
         }
 
         @ForceInline
-        static $type$ getVolatile(ArrayHandle handle, Object oba, int index) {
+        static $type$ getVolatile(VarHandle ob, Object oba, int index) {
+            ArrayHandle handle = (ArrayHandle)ob;
             byte[] ba = (byte[]) oba;
             return convEndian(handle.be,
                               UNSAFE.get$RawType$Volatile(
@@ -142,7 +145,8 @@ final class VarHandleByteArrayAs$Type$s extends VarHandleByteArrayBase {
         }
 
         @ForceInline
-        static void setVolatile(ArrayHandle handle, Object oba, int index, $type$ value) {
+        static void setVolatile(VarHandle ob, Object oba, int index, $type$ value) {
+            ArrayHandle handle = (ArrayHandle)ob;
             byte[] ba = (byte[]) oba;
             UNSAFE.put$RawType$Volatile(
                     ba,
@@ -151,7 +155,8 @@ final class VarHandleByteArrayAs$Type$s extends VarHandleByteArrayBase {
         }
 
         @ForceInline
-        static $type$ getAcquire(ArrayHandle handle, Object oba, int index) {
+        static $type$ getAcquire(VarHandle ob, Object oba, int index) {
+            ArrayHandle handle = (ArrayHandle)ob;
             byte[] ba = (byte[]) oba;
             return convEndian(handle.be,
                               UNSAFE.get$RawType$Acquire(
@@ -160,7 +165,8 @@ final class VarHandleByteArrayAs$Type$s extends VarHandleByteArrayBase {
         }
 
         @ForceInline
-        static void setRelease(ArrayHandle handle, Object oba, int index, $type$ value) {
+        static void setRelease(VarHandle ob, Object oba, int index, $type$ value) {
+            ArrayHandle handle = (ArrayHandle)ob;
             byte[] ba = (byte[]) oba;
             UNSAFE.put$RawType$Release(
                     ba,
@@ -169,7 +175,8 @@ final class VarHandleByteArrayAs$Type$s extends VarHandleByteArrayBase {
         }
 
         @ForceInline
-        static $type$ getOpaque(ArrayHandle handle, Object oba, int index) {
+        static $type$ getOpaque(VarHandle ob, Object oba, int index) {
+            ArrayHandle handle = (ArrayHandle)ob;
             byte[] ba = (byte[]) oba;
             return convEndian(handle.be,
                               UNSAFE.get$RawType$Opaque(
@@ -178,7 +185,8 @@ final class VarHandleByteArrayAs$Type$s extends VarHandleByteArrayBase {
         }
 
         @ForceInline
-        static void setOpaque(ArrayHandle handle, Object oba, int index, $type$ value) {
+        static void setOpaque(VarHandle ob, Object oba, int index, $type$ value) {
+            ArrayHandle handle = (ArrayHandle)ob;
             byte[] ba = (byte[]) oba;
             UNSAFE.put$RawType$Opaque(
                     ba,
@@ -188,7 +196,8 @@ final class VarHandleByteArrayAs$Type$s extends VarHandleByteArrayBase {
 #if[CAS]
 
         @ForceInline
-        static boolean compareAndSet(ArrayHandle handle, Object oba, int index, $type$ expected, $type$ value) {
+        static boolean compareAndSet(VarHandle ob, Object oba, int index, $type$ expected, $type$ value) {
+            ArrayHandle handle = (ArrayHandle)ob;
             byte[] ba = (byte[]) oba;
 #if[Object]
             return UNSAFE.compareAndSetReference(
@@ -204,7 +213,8 @@ final class VarHandleByteArrayAs$Type$s extends VarHandleByteArrayBase {
         }
 
         @ForceInline
-        static $type$ compareAndExchange(ArrayHandle handle, Object oba, int index, $type$ expected, $type$ value) {
+        static $type$ compareAndExchange(VarHandle ob, Object oba, int index, $type$ expected, $type$ value) {
+            ArrayHandle handle = (ArrayHandle)ob;
             byte[] ba = (byte[]) oba;
             return convEndian(handle.be,
                               UNSAFE.compareAndExchange$RawType$(
@@ -214,7 +224,8 @@ final class VarHandleByteArrayAs$Type$s extends VarHandleByteArrayBase {
         }
 
         @ForceInline
-        static $type$ compareAndExchangeAcquire(ArrayHandle handle, Object oba, int index, $type$ expected, $type$ value) {
+        static $type$ compareAndExchangeAcquire(VarHandle ob, Object oba, int index, $type$ expected, $type$ value) {
+            ArrayHandle handle = (ArrayHandle)ob;
             byte[] ba = (byte[]) oba;
             return convEndian(handle.be,
                               UNSAFE.compareAndExchange$RawType$Acquire(
@@ -224,7 +235,8 @@ final class VarHandleByteArrayAs$Type$s extends VarHandleByteArrayBase {
         }
 
         @ForceInline
-        static $type$ compareAndExchangeRelease(ArrayHandle handle, Object oba, int index, $type$ expected, $type$ value) {
+        static $type$ compareAndExchangeRelease(VarHandle ob, Object oba, int index, $type$ expected, $type$ value) {
+            ArrayHandle handle = (ArrayHandle)ob;
             byte[] ba = (byte[]) oba;
             return convEndian(handle.be,
                               UNSAFE.compareAndExchange$RawType$Release(
@@ -234,7 +246,8 @@ final class VarHandleByteArrayAs$Type$s extends VarHandleByteArrayBase {
         }
 
         @ForceInline
-        static boolean weakCompareAndSetPlain(ArrayHandle handle, Object oba, int index, $type$ expected, $type$ value) {
+        static boolean weakCompareAndSetPlain(VarHandle ob, Object oba, int index, $type$ expected, $type$ value) {
+            ArrayHandle handle = (ArrayHandle)ob;
             byte[] ba = (byte[]) oba;
             return UNSAFE.weakCompareAndSet$RawType$Plain(
                     ba,
@@ -243,7 +256,8 @@ final class VarHandleByteArrayAs$Type$s extends VarHandleByteArrayBase {
         }
 
         @ForceInline
-        static boolean weakCompareAndSet(ArrayHandle handle, Object oba, int index, $type$ expected, $type$ value) {
+        static boolean weakCompareAndSet(VarHandle ob, Object oba, int index, $type$ expected, $type$ value) {
+            ArrayHandle handle = (ArrayHandle)ob;
             byte[] ba = (byte[]) oba;
             return UNSAFE.weakCompareAndSet$RawType$(
                     ba,
@@ -252,7 +266,8 @@ final class VarHandleByteArrayAs$Type$s extends VarHandleByteArrayBase {
         }
 
         @ForceInline
-        static boolean weakCompareAndSetAcquire(ArrayHandle handle, Object oba, int index, $type$ expected, $type$ value) {
+        static boolean weakCompareAndSetAcquire(VarHandle ob, Object oba, int index, $type$ expected, $type$ value) {
+            ArrayHandle handle = (ArrayHandle)ob;
             byte[] ba = (byte[]) oba;
             return UNSAFE.weakCompareAndSet$RawType$Acquire(
                     ba,
@@ -261,7 +276,8 @@ final class VarHandleByteArrayAs$Type$s extends VarHandleByteArrayBase {
         }
 
         @ForceInline
-        static boolean weakCompareAndSetRelease(ArrayHandle handle, Object oba, int index, $type$ expected, $type$ value) {
+        static boolean weakCompareAndSetRelease(VarHandle ob, Object oba, int index, $type$ expected, $type$ value) {
+            ArrayHandle handle = (ArrayHandle)ob;
             byte[] ba = (byte[]) oba;
             return UNSAFE.weakCompareAndSet$RawType$Release(
                     ba,
@@ -270,7 +286,8 @@ final class VarHandleByteArrayAs$Type$s extends VarHandleByteArrayBase {
         }
 
         @ForceInline
-        static $type$ getAndSet(ArrayHandle handle, Object oba, int index, $type$ value) {
+        static $type$ getAndSet(VarHandle ob, Object oba, int index, $type$ value) {
+            ArrayHandle handle = (ArrayHandle)ob;
             byte[] ba = (byte[]) oba;
 #if[Object]
             return convEndian(handle.be,
@@ -288,7 +305,8 @@ final class VarHandleByteArrayAs$Type$s extends VarHandleByteArrayBase {
         }
 
         @ForceInline
-        static $type$ getAndSetAcquire(ArrayHandle handle, Object oba, int index, $type$ value) {
+        static $type$ getAndSetAcquire(VarHandle ob, Object oba, int index, $type$ value) {
+            ArrayHandle handle = (ArrayHandle)ob;
             byte[] ba = (byte[]) oba;
             return convEndian(handle.be,
                               UNSAFE.getAndSet$RawType$Acquire(
@@ -298,7 +316,8 @@ final class VarHandleByteArrayAs$Type$s extends VarHandleByteArrayBase {
         }
 
         @ForceInline
-        static $type$ getAndSetRelease(ArrayHandle handle, Object oba, int index, $type$ value) {
+        static $type$ getAndSetRelease(VarHandle ob, Object oba, int index, $type$ value) {
+            ArrayHandle handle = (ArrayHandle)ob;
             byte[] ba = (byte[]) oba;
             return convEndian(handle.be,
                               UNSAFE.getAndSet$RawType$Release(
@@ -310,7 +329,8 @@ final class VarHandleByteArrayAs$Type$s extends VarHandleByteArrayBase {
 #if[AtomicAdd]
 
         @ForceInline
-        static $type$ getAndAdd(ArrayHandle handle, Object oba, int index, $type$ delta) {
+        static $type$ getAndAdd(VarHandle ob, Object oba, int index, $type$ delta) {
+            ArrayHandle handle = (ArrayHandle)ob;
             byte[] ba = (byte[]) oba;
             if (handle.be == BE) {
                 return UNSAFE.getAndAdd$RawType$(
@@ -323,7 +343,8 @@ final class VarHandleByteArrayAs$Type$s extends VarHandleByteArrayBase {
         }
 
         @ForceInline
-        static $type$ getAndAddAcquire(ArrayHandle handle, Object oba, int index, $type$ delta) {
+        static $type$ getAndAddAcquire(VarHandle ob, Object oba, int index, $type$ delta) {
+            ArrayHandle handle = (ArrayHandle)ob;
             byte[] ba = (byte[]) oba;
             if (handle.be == BE) {
                 return UNSAFE.getAndAdd$RawType$Acquire(
@@ -336,7 +357,8 @@ final class VarHandleByteArrayAs$Type$s extends VarHandleByteArrayBase {
         }
 
         @ForceInline
-        static $type$ getAndAddRelease(ArrayHandle handle, Object oba, int index, $type$ delta) {
+        static $type$ getAndAddRelease(VarHandle ob, Object oba, int index, $type$ delta) {
+            ArrayHandle handle = (ArrayHandle)ob;
             byte[] ba = (byte[]) oba;
             if (handle.be == BE) {
                 return UNSAFE.getAndAdd$RawType$Release(
@@ -363,7 +385,8 @@ final class VarHandleByteArrayAs$Type$s extends VarHandleByteArrayBase {
 #if[Bitwise]
 
         @ForceInline
-        static $type$ getAndBitwiseOr(ArrayHandle handle, Object oba, int index, $type$ value) {
+        static $type$ getAndBitwiseOr(VarHandle ob, Object oba, int index, $type$ value) {
+            ArrayHandle handle = (ArrayHandle)ob;
             byte[] ba = (byte[]) oba;
             if (handle.be == BE) {
                 return UNSAFE.getAndBitwiseOr$RawType$(
@@ -376,7 +399,8 @@ final class VarHandleByteArrayAs$Type$s extends VarHandleByteArrayBase {
         }
 
         @ForceInline
-        static $type$ getAndBitwiseOrRelease(ArrayHandle handle, Object oba, int index, $type$ value) {
+        static $type$ getAndBitwiseOrRelease(VarHandle ob, Object oba, int index, $type$ value) {
+            ArrayHandle handle = (ArrayHandle)ob;
             byte[] ba = (byte[]) oba;
             if (handle.be == BE) {
                 return UNSAFE.getAndBitwiseOr$RawType$Release(
@@ -389,7 +413,8 @@ final class VarHandleByteArrayAs$Type$s extends VarHandleByteArrayBase {
         }
 
         @ForceInline
-        static $type$ getAndBitwiseOrAcquire(ArrayHandle handle, Object oba, int index, $type$ value) {
+        static $type$ getAndBitwiseOrAcquire(VarHandle ob, Object oba, int index, $type$ value) {
+            ArrayHandle handle = (ArrayHandle)ob;
             byte[] ba = (byte[]) oba;
             if (handle.be == BE) {
                 return UNSAFE.getAndBitwiseOr$RawType$Acquire(
@@ -414,7 +439,8 @@ final class VarHandleByteArrayAs$Type$s extends VarHandleByteArrayBase {
         }
 
         @ForceInline
-        static $type$ getAndBitwiseAnd(ArrayHandle handle, Object oba, int index, $type$ value) {
+        static $type$ getAndBitwiseAnd(VarHandle ob, Object oba, int index, $type$ value) {
+            ArrayHandle handle = (ArrayHandle)ob;
             byte[] ba = (byte[]) oba;
             if (handle.be == BE) {
                 return UNSAFE.getAndBitwiseAnd$RawType$(
@@ -427,7 +453,8 @@ final class VarHandleByteArrayAs$Type$s extends VarHandleByteArrayBase {
         }
 
         @ForceInline
-        static $type$ getAndBitwiseAndRelease(ArrayHandle handle, Object oba, int index, $type$ value) {
+        static $type$ getAndBitwiseAndRelease(VarHandle ob, Object oba, int index, $type$ value) {
+            ArrayHandle handle = (ArrayHandle)ob;
             byte[] ba = (byte[]) oba;
             if (handle.be == BE) {
                 return UNSAFE.getAndBitwiseAnd$RawType$Release(
@@ -440,7 +467,8 @@ final class VarHandleByteArrayAs$Type$s extends VarHandleByteArrayBase {
         }
 
         @ForceInline
-        static $type$ getAndBitwiseAndAcquire(ArrayHandle handle, Object oba, int index, $type$ value) {
+        static $type$ getAndBitwiseAndAcquire(VarHandle ob, Object oba, int index, $type$ value) {
+            ArrayHandle handle = (ArrayHandle)ob;
             byte[] ba = (byte[]) oba;
             if (handle.be == BE) {
                 return UNSAFE.getAndBitwiseAnd$RawType$Acquire(
@@ -465,7 +493,8 @@ final class VarHandleByteArrayAs$Type$s extends VarHandleByteArrayBase {
         }
 
         @ForceInline
-        static $type$ getAndBitwiseXor(ArrayHandle handle, Object oba, int index, $type$ value) {
+        static $type$ getAndBitwiseXor(VarHandle ob, Object oba, int index, $type$ value) {
+            ArrayHandle handle = (ArrayHandle)ob;
             byte[] ba = (byte[]) oba;
             if (handle.be == BE) {
                 return UNSAFE.getAndBitwiseXor$RawType$(
@@ -478,7 +507,8 @@ final class VarHandleByteArrayAs$Type$s extends VarHandleByteArrayBase {
         }
 
         @ForceInline
-        static $type$ getAndBitwiseXorRelease(ArrayHandle handle, Object oba, int index, $type$ value) {
+        static $type$ getAndBitwiseXorRelease(VarHandle ob, Object oba, int index, $type$ value) {
+            ArrayHandle handle = (ArrayHandle)ob;
             byte[] ba = (byte[]) oba;
             if (handle.be == BE) {
                 return UNSAFE.getAndBitwiseXor$RawType$Release(
@@ -491,7 +521,8 @@ final class VarHandleByteArrayAs$Type$s extends VarHandleByteArrayBase {
         }
 
         @ForceInline
-        static $type$ getAndBitwiseXorAcquire(ArrayHandle handle, Object oba, int index, $type$ value) {
+        static $type$ getAndBitwiseXorAcquire(VarHandle ob, Object oba, int index, $type$ value) {
+            ArrayHandle handle = (ArrayHandle)ob;
             byte[] ba = (byte[]) oba;
             if (handle.be == BE) {
                 return UNSAFE.getAndBitwiseXor$RawType$Acquire(
@@ -553,7 +584,8 @@ final class VarHandleByteArrayAs$Type$s extends VarHandleByteArrayBase {
         }
 
         @ForceInline
-        static $type$ get(ByteBufferHandle handle, Object obb, int index) {
+        static $type$ get(VarHandle ob, Object obb, int index) {
+            ByteBufferHandle handle = (ByteBufferHandle)ob;
             ByteBuffer bb = (ByteBuffer) Objects.requireNonNull(obb);
 #if[floatingPoint]
             $rawType$ rawValue = UNSAFE.get$RawType$Unaligned(
@@ -570,7 +602,8 @@ final class VarHandleByteArrayAs$Type$s extends VarHandleByteArrayBase {
         }
 
         @ForceInline
-        static void set(ByteBufferHandle handle, Object obb, int index, $type$ value) {
+        static void set(VarHandle ob, Object obb, int index, $type$ value) {
+            ByteBufferHandle handle = (ByteBufferHandle)ob;
             ByteBuffer bb = (ByteBuffer) Objects.requireNonNull(obb);
 #if[floatingPoint]
             UNSAFE.put$RawType$Unaligned(
@@ -588,7 +621,8 @@ final class VarHandleByteArrayAs$Type$s extends VarHandleByteArrayBase {
         }
 
         @ForceInline
-        static $type$ getVolatile(ByteBufferHandle handle, Object obb, int index) {
+        static $type$ getVolatile(VarHandle ob, Object obb, int index) {
+            ByteBufferHandle handle = (ByteBufferHandle)ob;
             ByteBuffer bb = (ByteBuffer) Objects.requireNonNull(obb);
             return convEndian(handle.be,
                               UNSAFE.get$RawType$Volatile(
@@ -597,7 +631,8 @@ final class VarHandleByteArrayAs$Type$s extends VarHandleByteArrayBase {
         }
 
         @ForceInline
-        static void setVolatile(ByteBufferHandle handle, Object obb, int index, $type$ value) {
+        static void setVolatile(VarHandle ob, Object obb, int index, $type$ value) {
+            ByteBufferHandle handle = (ByteBufferHandle)ob;
             ByteBuffer bb = (ByteBuffer) Objects.requireNonNull(obb);
             UNSAFE.put$RawType$Volatile(
                     UNSAFE.getReference(bb, BYTE_BUFFER_HB),
@@ -606,7 +641,8 @@ final class VarHandleByteArrayAs$Type$s extends VarHandleByteArrayBase {
         }
 
         @ForceInline
-        static $type$ getAcquire(ByteBufferHandle handle, Object obb, int index) {
+        static $type$ getAcquire(VarHandle ob, Object obb, int index) {
+            ByteBufferHandle handle = (ByteBufferHandle)ob;
             ByteBuffer bb = (ByteBuffer) Objects.requireNonNull(obb);
             return convEndian(handle.be,
                               UNSAFE.get$RawType$Acquire(
@@ -615,7 +651,8 @@ final class VarHandleByteArrayAs$Type$s extends VarHandleByteArrayBase {
         }
 
         @ForceInline
-        static void setRelease(ByteBufferHandle handle, Object obb, int index, $type$ value) {
+        static void setRelease(VarHandle ob, Object obb, int index, $type$ value) {
+            ByteBufferHandle handle = (ByteBufferHandle)ob;
             ByteBuffer bb = (ByteBuffer) Objects.requireNonNull(obb);
             UNSAFE.put$RawType$Release(
                     UNSAFE.getReference(bb, BYTE_BUFFER_HB),
@@ -624,7 +661,8 @@ final class VarHandleByteArrayAs$Type$s extends VarHandleByteArrayBase {
         }
 
         @ForceInline
-        static $type$ getOpaque(ByteBufferHandle handle, Object obb, int index) {
+        static $type$ getOpaque(VarHandle ob, Object obb, int index) {
+            ByteBufferHandle handle = (ByteBufferHandle)ob;
             ByteBuffer bb = (ByteBuffer) Objects.requireNonNull(obb);
             return convEndian(handle.be,
                               UNSAFE.get$RawType$Opaque(
@@ -633,7 +671,8 @@ final class VarHandleByteArrayAs$Type$s extends VarHandleByteArrayBase {
         }
 
         @ForceInline
-        static void setOpaque(ByteBufferHandle handle, Object obb, int index, $type$ value) {
+        static void setOpaque(VarHandle ob, Object obb, int index, $type$ value) {
+            ByteBufferHandle handle = (ByteBufferHandle)ob;
             ByteBuffer bb = (ByteBuffer) Objects.requireNonNull(obb);
             UNSAFE.put$RawType$Opaque(
                     UNSAFE.getReference(bb, BYTE_BUFFER_HB),
@@ -643,7 +682,8 @@ final class VarHandleByteArrayAs$Type$s extends VarHandleByteArrayBase {
 #if[CAS]
 
         @ForceInline
-        static boolean compareAndSet(ByteBufferHandle handle, Object obb, int index, $type$ expected, $type$ value) {
+        static boolean compareAndSet(VarHandle ob, Object obb, int index, $type$ expected, $type$ value) {
+            ByteBufferHandle handle = (ByteBufferHandle)ob;
             ByteBuffer bb = (ByteBuffer) Objects.requireNonNull(obb);
 #if[Object]
             return UNSAFE.compareAndSetReference(
@@ -659,7 +699,8 @@ final class VarHandleByteArrayAs$Type$s extends VarHandleByteArrayBase {
         }
 
         @ForceInline
-        static $type$ compareAndExchange(ByteBufferHandle handle, Object obb, int index, $type$ expected, $type$ value) {
+        static $type$ compareAndExchange(VarHandle ob, Object obb, int index, $type$ expected, $type$ value) {
+            ByteBufferHandle handle = (ByteBufferHandle)ob;
             ByteBuffer bb = (ByteBuffer) Objects.requireNonNull(obb);
             return convEndian(handle.be,
                               UNSAFE.compareAndExchange$RawType$(
@@ -669,7 +710,8 @@ final class VarHandleByteArrayAs$Type$s extends VarHandleByteArrayBase {
         }
 
         @ForceInline
-        static $type$ compareAndExchangeAcquire(ByteBufferHandle handle, Object obb, int index, $type$ expected, $type$ value) {
+        static $type$ compareAndExchangeAcquire(VarHandle ob, Object obb, int index, $type$ expected, $type$ value) {
+            ByteBufferHandle handle = (ByteBufferHandle)ob;
             ByteBuffer bb = (ByteBuffer) Objects.requireNonNull(obb);
             return convEndian(handle.be,
                               UNSAFE.compareAndExchange$RawType$Acquire(
@@ -679,7 +721,8 @@ final class VarHandleByteArrayAs$Type$s extends VarHandleByteArrayBase {
         }
 
         @ForceInline
-        static $type$ compareAndExchangeRelease(ByteBufferHandle handle, Object obb, int index, $type$ expected, $type$ value) {
+        static $type$ compareAndExchangeRelease(VarHandle ob, Object obb, int index, $type$ expected, $type$ value) {
+            ByteBufferHandle handle = (ByteBufferHandle)ob;
             ByteBuffer bb = (ByteBuffer) Objects.requireNonNull(obb);
             return convEndian(handle.be,
                               UNSAFE.compareAndExchange$RawType$Release(
@@ -689,7 +732,8 @@ final class VarHandleByteArrayAs$Type$s extends VarHandleByteArrayBase {
         }
 
         @ForceInline
-        static boolean weakCompareAndSetPlain(ByteBufferHandle handle, Object obb, int index, $type$ expected, $type$ value) {
+        static boolean weakCompareAndSetPlain(VarHandle ob, Object obb, int index, $type$ expected, $type$ value) {
+            ByteBufferHandle handle = (ByteBufferHandle)ob;
             ByteBuffer bb = (ByteBuffer) Objects.requireNonNull(obb);
             return UNSAFE.weakCompareAndSet$RawType$Plain(
                     UNSAFE.getReference(bb, BYTE_BUFFER_HB),
@@ -698,7 +742,8 @@ final class VarHandleByteArrayAs$Type$s extends VarHandleByteArrayBase {
         }
 
         @ForceInline
-        static boolean weakCompareAndSet(ByteBufferHandle handle, Object obb, int index, $type$ expected, $type$ value) {
+        static boolean weakCompareAndSet(VarHandle ob, Object obb, int index, $type$ expected, $type$ value) {
+            ByteBufferHandle handle = (ByteBufferHandle)ob;
             ByteBuffer bb = (ByteBuffer) Objects.requireNonNull(obb);
             return UNSAFE.weakCompareAndSet$RawType$(
                     UNSAFE.getReference(bb, BYTE_BUFFER_HB),
@@ -707,7 +752,8 @@ final class VarHandleByteArrayAs$Type$s extends VarHandleByteArrayBase {
         }
 
         @ForceInline
-        static boolean weakCompareAndSetAcquire(ByteBufferHandle handle, Object obb, int index, $type$ expected, $type$ value) {
+        static boolean weakCompareAndSetAcquire(VarHandle ob, Object obb, int index, $type$ expected, $type$ value) {
+            ByteBufferHandle handle = (ByteBufferHandle)ob;
             ByteBuffer bb = (ByteBuffer) Objects.requireNonNull(obb);
             return UNSAFE.weakCompareAndSet$RawType$Acquire(
                     UNSAFE.getReference(bb, BYTE_BUFFER_HB),
@@ -716,7 +762,8 @@ final class VarHandleByteArrayAs$Type$s extends VarHandleByteArrayBase {
         }
 
         @ForceInline
-        static boolean weakCompareAndSetRelease(ByteBufferHandle handle, Object obb, int index, $type$ expected, $type$ value) {
+        static boolean weakCompareAndSetRelease(VarHandle ob, Object obb, int index, $type$ expected, $type$ value) {
+            ByteBufferHandle handle = (ByteBufferHandle)ob;
             ByteBuffer bb = (ByteBuffer) Objects.requireNonNull(obb);
             return UNSAFE.weakCompareAndSet$RawType$Release(
                     UNSAFE.getReference(bb, BYTE_BUFFER_HB),
@@ -725,7 +772,8 @@ final class VarHandleByteArrayAs$Type$s extends VarHandleByteArrayBase {
         }
 
         @ForceInline
-        static $type$ getAndSet(ByteBufferHandle handle, Object obb, int index, $type$ value) {
+        static $type$ getAndSet(VarHandle ob, Object obb, int index, $type$ value) {
+            ByteBufferHandle handle = (ByteBufferHandle)ob;
             ByteBuffer bb = (ByteBuffer) Objects.requireNonNull(obb);
 #if[Object]
             return convEndian(handle.be,
@@ -743,7 +791,8 @@ final class VarHandleByteArrayAs$Type$s extends VarHandleByteArrayBase {
         }
 
         @ForceInline
-        static $type$ getAndSetAcquire(ByteBufferHandle handle, Object obb, int index, $type$ value) {
+        static $type$ getAndSetAcquire(VarHandle ob, Object obb, int index, $type$ value) {
+            ByteBufferHandle handle = (ByteBufferHandle)ob;
             ByteBuffer bb = (ByteBuffer) Objects.requireNonNull(obb);
             return convEndian(handle.be,
                               UNSAFE.getAndSet$RawType$Acquire(
@@ -753,7 +802,8 @@ final class VarHandleByteArrayAs$Type$s extends VarHandleByteArrayBase {
         }
 
         @ForceInline
-        static $type$ getAndSetRelease(ByteBufferHandle handle, Object obb, int index, $type$ value) {
+        static $type$ getAndSetRelease(VarHandle ob, Object obb, int index, $type$ value) {
+            ByteBufferHandle handle = (ByteBufferHandle)ob;
             ByteBuffer bb = (ByteBuffer) Objects.requireNonNull(obb);
             return convEndian(handle.be,
                               UNSAFE.getAndSet$RawType$Release(
@@ -765,7 +815,8 @@ final class VarHandleByteArrayAs$Type$s extends VarHandleByteArrayBase {
 #if[AtomicAdd]
 
         @ForceInline
-        static $type$ getAndAdd(ByteBufferHandle handle, Object obb, int index, $type$ delta) {
+        static $type$ getAndAdd(VarHandle ob, Object obb, int index, $type$ delta) {
+            ByteBufferHandle handle = (ByteBufferHandle)ob;
             ByteBuffer bb = (ByteBuffer) Objects.requireNonNull(obb);
             if (handle.be == BE) {
                 return UNSAFE.getAndAdd$RawType$(
@@ -778,7 +829,8 @@ final class VarHandleByteArrayAs$Type$s extends VarHandleByteArrayBase {
         }
 
         @ForceInline
-        static $type$ getAndAddAcquire(ByteBufferHandle handle, Object obb, int index, $type$ delta) {
+        static $type$ getAndAddAcquire(VarHandle ob, Object obb, int index, $type$ delta) {
+            ByteBufferHandle handle = (ByteBufferHandle)ob;
             ByteBuffer bb = (ByteBuffer) Objects.requireNonNull(obb);
             if (handle.be == BE) {
                 return UNSAFE.getAndAdd$RawType$Acquire(
@@ -791,7 +843,8 @@ final class VarHandleByteArrayAs$Type$s extends VarHandleByteArrayBase {
         }
 
         @ForceInline
-        static $type$ getAndAddRelease(ByteBufferHandle handle, Object obb, int index, $type$ delta) {
+        static $type$ getAndAddRelease(VarHandle ob, Object obb, int index, $type$ delta) {
+            ByteBufferHandle handle = (ByteBufferHandle)ob;
             ByteBuffer bb = (ByteBuffer) Objects.requireNonNull(obb);
             if (handle.be == BE) {
                 return UNSAFE.getAndAdd$RawType$Release(
@@ -819,7 +872,8 @@ final class VarHandleByteArrayAs$Type$s extends VarHandleByteArrayBase {
 #if[Bitwise]
 
         @ForceInline
-        static $type$ getAndBitwiseOr(ByteBufferHandle handle, Object obb, int index, $type$ value) {
+        static $type$ getAndBitwiseOr(VarHandle ob, Object obb, int index, $type$ value) {
+            ByteBufferHandle handle = (ByteBufferHandle)ob;
             ByteBuffer bb = (ByteBuffer) Objects.requireNonNull(obb);
             if (handle.be == BE) {
                 return UNSAFE.getAndBitwiseOr$RawType$(
@@ -832,7 +886,8 @@ final class VarHandleByteArrayAs$Type$s extends VarHandleByteArrayBase {
         }
 
         @ForceInline
-        static $type$ getAndBitwiseOrRelease(ByteBufferHandle handle, Object obb, int index, $type$ value) {
+        static $type$ getAndBitwiseOrRelease(VarHandle ob, Object obb, int index, $type$ value) {
+            ByteBufferHandle handle = (ByteBufferHandle)ob;
             ByteBuffer bb = (ByteBuffer) Objects.requireNonNull(obb);
             if (handle.be == BE) {
                 return UNSAFE.getAndBitwiseOr$RawType$Release(
@@ -845,7 +900,8 @@ final class VarHandleByteArrayAs$Type$s extends VarHandleByteArrayBase {
         }
 
         @ForceInline
-        static $type$ getAndBitwiseOrAcquire(ByteBufferHandle handle, Object obb, int index, $type$ value) {
+        static $type$ getAndBitwiseOrAcquire(VarHandle ob, Object obb, int index, $type$ value) {
+            ByteBufferHandle handle = (ByteBufferHandle)ob;
             ByteBuffer bb = (ByteBuffer) Objects.requireNonNull(obb);
             if (handle.be == BE) {
                 return UNSAFE.getAndBitwiseOr$RawType$Acquire(
@@ -871,7 +927,8 @@ final class VarHandleByteArrayAs$Type$s extends VarHandleByteArrayBase {
         }
 
         @ForceInline
-        static $type$ getAndBitwiseAnd(ByteBufferHandle handle, Object obb, int index, $type$ value) {
+        static $type$ getAndBitwiseAnd(VarHandle ob, Object obb, int index, $type$ value) {
+            ByteBufferHandle handle = (ByteBufferHandle)ob;
             ByteBuffer bb = (ByteBuffer) Objects.requireNonNull(obb);
             if (handle.be == BE) {
                 return UNSAFE.getAndBitwiseAnd$RawType$(
@@ -884,7 +941,8 @@ final class VarHandleByteArrayAs$Type$s extends VarHandleByteArrayBase {
         }
 
         @ForceInline
-        static $type$ getAndBitwiseAndRelease(ByteBufferHandle handle, Object obb, int index, $type$ value) {
+        static $type$ getAndBitwiseAndRelease(VarHandle ob, Object obb, int index, $type$ value) {
+            ByteBufferHandle handle = (ByteBufferHandle)ob;
             ByteBuffer bb = (ByteBuffer) Objects.requireNonNull(obb);
             if (handle.be == BE) {
                 return UNSAFE.getAndBitwiseAnd$RawType$Release(
@@ -897,7 +955,8 @@ final class VarHandleByteArrayAs$Type$s extends VarHandleByteArrayBase {
         }
 
         @ForceInline
-        static $type$ getAndBitwiseAndAcquire(ByteBufferHandle handle, Object obb, int index, $type$ value) {
+        static $type$ getAndBitwiseAndAcquire(VarHandle ob, Object obb, int index, $type$ value) {
+            ByteBufferHandle handle = (ByteBufferHandle)ob;
             ByteBuffer bb = (ByteBuffer) Objects.requireNonNull(obb);
             if (handle.be == BE) {
                 return UNSAFE.getAndBitwiseAnd$RawType$Acquire(
@@ -924,7 +983,8 @@ final class VarHandleByteArrayAs$Type$s extends VarHandleByteArrayBase {
 
 
         @ForceInline
-        static $type$ getAndBitwiseXor(ByteBufferHandle handle, Object obb, int index, $type$ value) {
+        static $type$ getAndBitwiseXor(VarHandle ob, Object obb, int index, $type$ value) {
+            ByteBufferHandle handle = (ByteBufferHandle)ob;
             ByteBuffer bb = (ByteBuffer) Objects.requireNonNull(obb);
             if (handle.be == BE) {
                 return UNSAFE.getAndBitwiseXor$RawType$(
@@ -937,7 +997,8 @@ final class VarHandleByteArrayAs$Type$s extends VarHandleByteArrayBase {
         }
 
         @ForceInline
-        static $type$ getAndBitwiseXorRelease(ByteBufferHandle handle, Object obb, int index, $type$ value) {
+        static $type$ getAndBitwiseXorRelease(VarHandle ob, Object obb, int index, $type$ value) {
+            ByteBufferHandle handle = (ByteBufferHandle)ob;
             ByteBuffer bb = (ByteBuffer) Objects.requireNonNull(obb);
             if (handle.be == BE) {
                 return UNSAFE.getAndBitwiseXor$RawType$Release(
@@ -950,7 +1011,8 @@ final class VarHandleByteArrayAs$Type$s extends VarHandleByteArrayBase {
         }
 
         @ForceInline
-        static $type$ getAndBitwiseXorAcquire(ByteBufferHandle handle, Object obb, int index, $type$ value) {
+        static $type$ getAndBitwiseXorAcquire(VarHandle ob, Object obb, int index, $type$ value) {
+            ByteBufferHandle handle = (ByteBufferHandle)ob;
             ByteBuffer bb = (ByteBuffer) Objects.requireNonNull(obb);
             if (handle.be == BE) {
                 return UNSAFE.getAndBitwiseXor$RawType$Acquire(

--- a/src/java.base/share/classes/java/lang/invoke/X-VarHandleMemoryAddressView.java.template
+++ b/src/java.base/share/classes/java/lang/invoke/X-VarHandleMemoryAddressView.java.template
@@ -93,7 +93,8 @@ final class VarHandleMemoryAddressAs$Type$s {
     }
     
     @ForceInline
-    static $type$ get0(VarHandleMemoryAddressBase handle, Object obb, long base) {
+    static $type$ get0(VarHandle ob, Object obb, long base) {
+        VarHandleMemoryAddressBase handle = (VarHandleMemoryAddressBase)ob;
         MemoryAddressProxy bb = checkAddress(obb, base, handle.length, true);
 #if[floatingPoint]
         $rawType$ rawValue = UNSAFE.get$RawType$Unaligned(
@@ -116,7 +117,8 @@ final class VarHandleMemoryAddressAs$Type$s {
     }
 
     @ForceInline
-    static void set0(VarHandleMemoryAddressBase handle, Object obb, long base, $type$ value) {
+    static void set0(VarHandle ob, Object obb, long base, $type$ value) {
+        VarHandleMemoryAddressBase handle = (VarHandleMemoryAddressBase)ob;
         MemoryAddressProxy bb = checkAddress(obb, base, handle.length, false);
 #if[floatingPoint]
         UNSAFE.put$RawType$Unaligned(
@@ -141,7 +143,8 @@ final class VarHandleMemoryAddressAs$Type$s {
     }
 
     @ForceInline
-    static $type$ getVolatile0(VarHandleMemoryAddressBase handle, Object obb, long base) {
+    static $type$ getVolatile0(VarHandle ob, Object obb, long base) {
+        VarHandleMemoryAddressBase handle = (VarHandleMemoryAddressBase)ob;
         MemoryAddressProxy bb = checkAddress(obb, base, handle.length, true);
         return convEndian(handle.be,
                           UNSAFE.get$RawType$Volatile(
@@ -150,7 +153,8 @@ final class VarHandleMemoryAddressAs$Type$s {
     }
 
     @ForceInline
-    static void setVolatile0(VarHandleMemoryAddressBase handle, Object obb, long base, $type$ value) {
+    static void setVolatile0(VarHandle ob, Object obb, long base, $type$ value) {
+        VarHandleMemoryAddressBase handle = (VarHandleMemoryAddressBase)ob;
         MemoryAddressProxy bb = checkAddress(obb, base, handle.length, false);
         UNSAFE.put$RawType$Volatile(
                 bb.unsafeGetBase(),
@@ -159,7 +163,8 @@ final class VarHandleMemoryAddressAs$Type$s {
     }
 
     @ForceInline
-    static $type$ getAcquire0(VarHandleMemoryAddressBase handle, Object obb, long base) {
+    static $type$ getAcquire0(VarHandle ob, Object obb, long base) {
+        VarHandleMemoryAddressBase handle = (VarHandleMemoryAddressBase)ob;
         MemoryAddressProxy bb = checkAddress(obb, base, handle.length, true);
         return convEndian(handle.be,
                           UNSAFE.get$RawType$Acquire(
@@ -168,7 +173,8 @@ final class VarHandleMemoryAddressAs$Type$s {
     }
 
     @ForceInline
-    static void setRelease0(VarHandleMemoryAddressBase handle, Object obb, long base, $type$ value) {
+    static void setRelease0(VarHandle ob, Object obb, long base, $type$ value) {
+        VarHandleMemoryAddressBase handle = (VarHandleMemoryAddressBase)ob;
         MemoryAddressProxy bb = checkAddress(obb, base, handle.length, false);
         UNSAFE.put$RawType$Release(
                 bb.unsafeGetBase(),
@@ -177,7 +183,8 @@ final class VarHandleMemoryAddressAs$Type$s {
     }
 
     @ForceInline
-    static $type$ getOpaque0(VarHandleMemoryAddressBase handle, Object obb, long base) {
+    static $type$ getOpaque0(VarHandle ob, Object obb, long base) {
+        VarHandleMemoryAddressBase handle = (VarHandleMemoryAddressBase)ob;
         MemoryAddressProxy bb = checkAddress(obb, base, handle.length, true);
         return convEndian(handle.be,
                           UNSAFE.get$RawType$Opaque(
@@ -186,7 +193,8 @@ final class VarHandleMemoryAddressAs$Type$s {
     }
 
     @ForceInline
-    static void setOpaque0(VarHandleMemoryAddressBase handle, Object obb, long base, $type$ value) {
+    static void setOpaque0(VarHandle ob, Object obb, long base, $type$ value) {
+        VarHandleMemoryAddressBase handle = (VarHandleMemoryAddressBase)ob;
         MemoryAddressProxy bb = checkAddress(obb, base, handle.length, false);
         UNSAFE.put$RawType$Opaque(
                 bb.unsafeGetBase(),
@@ -196,7 +204,8 @@ final class VarHandleMemoryAddressAs$Type$s {
 #if[CAS]
 
     @ForceInline
-    static boolean compareAndSet0(VarHandleMemoryAddressBase handle, Object obb, long base, $type$ expected, $type$ value) {
+    static boolean compareAndSet0(VarHandle ob, Object obb, long base, $type$ expected, $type$ value) {
+        VarHandleMemoryAddressBase handle = (VarHandleMemoryAddressBase)ob;
         MemoryAddressProxy bb = checkAddress(obb, base, handle.length, false);
         return UNSAFE.compareAndSet$RawType$(
                 bb.unsafeGetBase(),
@@ -205,7 +214,8 @@ final class VarHandleMemoryAddressAs$Type$s {
     }
 
     @ForceInline
-    static $type$ compareAndExchange0(VarHandleMemoryAddressBase handle, Object obb, long base, $type$ expected, $type$ value) {
+    static $type$ compareAndExchange0(VarHandle ob, Object obb, long base, $type$ expected, $type$ value) {
+        VarHandleMemoryAddressBase handle = (VarHandleMemoryAddressBase)ob;
         MemoryAddressProxy bb = checkAddress(obb, base, handle.length, false);
         return convEndian(handle.be,
                           UNSAFE.compareAndExchange$RawType$(
@@ -215,7 +225,8 @@ final class VarHandleMemoryAddressAs$Type$s {
     }
 
     @ForceInline
-    static $type$ compareAndExchangeAcquire0(VarHandleMemoryAddressBase handle, Object obb, long base, $type$ expected, $type$ value) {
+    static $type$ compareAndExchangeAcquire0(VarHandle ob, Object obb, long base, $type$ expected, $type$ value) {
+        VarHandleMemoryAddressBase handle = (VarHandleMemoryAddressBase)ob;
         MemoryAddressProxy bb = checkAddress(obb, base, handle.length, false);
         return convEndian(handle.be,
                           UNSAFE.compareAndExchange$RawType$Acquire(
@@ -225,7 +236,8 @@ final class VarHandleMemoryAddressAs$Type$s {
     }
 
     @ForceInline
-    static $type$ compareAndExchangeRelease0(VarHandleMemoryAddressBase handle, Object obb, long base, $type$ expected, $type$ value) {
+    static $type$ compareAndExchangeRelease0(VarHandle ob, Object obb, long base, $type$ expected, $type$ value) {
+        VarHandleMemoryAddressBase handle = (VarHandleMemoryAddressBase)ob;
         MemoryAddressProxy bb = checkAddress(obb, base, handle.length, false);
         return convEndian(handle.be,
                           UNSAFE.compareAndExchange$RawType$Release(
@@ -235,7 +247,8 @@ final class VarHandleMemoryAddressAs$Type$s {
     }
 
     @ForceInline
-    static boolean weakCompareAndSetPlain0(VarHandleMemoryAddressBase handle, Object obb, long base, $type$ expected, $type$ value) {
+    static boolean weakCompareAndSetPlain0(VarHandle ob, Object obb, long base, $type$ expected, $type$ value) {
+        VarHandleMemoryAddressBase handle = (VarHandleMemoryAddressBase)ob;
         MemoryAddressProxy bb = checkAddress(obb, base, handle.length, false);
         return UNSAFE.weakCompareAndSet$RawType$Plain(
                 bb.unsafeGetBase(),
@@ -244,7 +257,8 @@ final class VarHandleMemoryAddressAs$Type$s {
     }
 
     @ForceInline
-    static boolean weakCompareAndSet0(VarHandleMemoryAddressBase handle, Object obb, long base, $type$ expected, $type$ value) {
+    static boolean weakCompareAndSet0(VarHandle ob, Object obb, long base, $type$ expected, $type$ value) {
+        VarHandleMemoryAddressBase handle = (VarHandleMemoryAddressBase)ob;
         MemoryAddressProxy bb = checkAddress(obb, base, handle.length, false);
         return UNSAFE.weakCompareAndSet$RawType$(
                 bb.unsafeGetBase(),
@@ -253,7 +267,8 @@ final class VarHandleMemoryAddressAs$Type$s {
     }
 
     @ForceInline
-    static boolean weakCompareAndSetAcquire0(VarHandleMemoryAddressBase handle, Object obb, long base, $type$ expected, $type$ value) {
+    static boolean weakCompareAndSetAcquire0(VarHandle ob, Object obb, long base, $type$ expected, $type$ value) {
+        VarHandleMemoryAddressBase handle = (VarHandleMemoryAddressBase)ob;
         MemoryAddressProxy bb = checkAddress(obb, base, handle.length, false);
         return UNSAFE.weakCompareAndSet$RawType$Acquire(
                 bb.unsafeGetBase(),
@@ -262,7 +277,8 @@ final class VarHandleMemoryAddressAs$Type$s {
     }
 
     @ForceInline
-    static boolean weakCompareAndSetRelease0(VarHandleMemoryAddressBase handle, Object obb, long base, $type$ expected, $type$ value) {
+    static boolean weakCompareAndSetRelease0(VarHandle ob, Object obb, long base, $type$ expected, $type$ value) {
+        VarHandleMemoryAddressBase handle = (VarHandleMemoryAddressBase)ob;
         MemoryAddressProxy bb = checkAddress(obb, base, handle.length, false);
         return UNSAFE.weakCompareAndSet$RawType$Release(
                 bb.unsafeGetBase(),
@@ -271,7 +287,8 @@ final class VarHandleMemoryAddressAs$Type$s {
     }
 
     @ForceInline
-    static $type$ getAndSet0(VarHandleMemoryAddressBase handle, Object obb, long base, $type$ value) {
+    static $type$ getAndSet0(VarHandle ob, Object obb, long base, $type$ value) {
+        VarHandleMemoryAddressBase handle = (VarHandleMemoryAddressBase)ob;
         MemoryAddressProxy bb = checkAddress(obb, base, handle.length, false);
         return convEndian(handle.be,
                           UNSAFE.getAndSet$RawType$(
@@ -281,7 +298,8 @@ final class VarHandleMemoryAddressAs$Type$s {
     }
 
     @ForceInline
-    static $type$ getAndSetAcquire0(VarHandleMemoryAddressBase handle, Object obb, long base, $type$ value) {
+    static $type$ getAndSetAcquire0(VarHandle ob, Object obb, long base, $type$ value) {
+        VarHandleMemoryAddressBase handle = (VarHandleMemoryAddressBase)ob;
         MemoryAddressProxy bb = checkAddress(obb, base, handle.length, false);
         return convEndian(handle.be,
                           UNSAFE.getAndSet$RawType$Acquire(
@@ -291,7 +309,8 @@ final class VarHandleMemoryAddressAs$Type$s {
     }
 
     @ForceInline
-    static $type$ getAndSetRelease0(VarHandleMemoryAddressBase handle, Object obb, long base, $type$ value) {
+    static $type$ getAndSetRelease0(VarHandle ob, Object obb, long base, $type$ value) {
+        VarHandleMemoryAddressBase handle = (VarHandleMemoryAddressBase)ob;
         MemoryAddressProxy bb = checkAddress(obb, base, handle.length, false);
         return convEndian(handle.be,
                           UNSAFE.getAndSet$RawType$Release(
@@ -303,7 +322,8 @@ final class VarHandleMemoryAddressAs$Type$s {
 #if[AtomicAdd]
 
     @ForceInline
-    static $type$ getAndAdd0(VarHandleMemoryAddressBase handle, Object obb, long base, $type$ delta) {
+    static $type$ getAndAdd0(VarHandle ob, Object obb, long base, $type$ delta) {
+        VarHandleMemoryAddressBase handle = (VarHandleMemoryAddressBase)ob;
         MemoryAddressProxy bb = checkAddress(obb, base, handle.length, false);
         if (handle.be == BE) {
             return UNSAFE.getAndAdd$RawType$(
@@ -316,7 +336,8 @@ final class VarHandleMemoryAddressAs$Type$s {
     }
 
     @ForceInline
-    static $type$ getAndAddAcquire0(VarHandleMemoryAddressBase handle, Object obb, long base, $type$ delta) {
+    static $type$ getAndAddAcquire0(VarHandle ob, Object obb, long base, $type$ delta) {
+        VarHandleMemoryAddressBase handle = (VarHandleMemoryAddressBase)ob;
         MemoryAddressProxy bb = checkAddress(obb, base, handle.length, false);
         if (handle.be == BE) {
             return UNSAFE.getAndAdd$RawType$Acquire(
@@ -329,7 +350,8 @@ final class VarHandleMemoryAddressAs$Type$s {
     }
 
     @ForceInline
-    static $type$ getAndAddRelease0(VarHandleMemoryAddressBase handle, Object obb, long base, $type$ delta) {
+    static $type$ getAndAddRelease0(VarHandle ob, Object obb, long base, $type$ delta) {
+        VarHandleMemoryAddressBase handle = (VarHandleMemoryAddressBase)ob;
         MemoryAddressProxy bb = checkAddress(obb, base, handle.length, false);
         if (handle.be == BE) {
             return UNSAFE.getAndAdd$RawType$Release(
@@ -356,7 +378,8 @@ final class VarHandleMemoryAddressAs$Type$s {
 #if[Bitwise]
 
     @ForceInline
-    static $type$ getAndBitwiseOr0(VarHandleMemoryAddressBase handle, Object obb, long base, $type$ value) {
+    static $type$ getAndBitwiseOr0(VarHandle ob, Object obb, long base, $type$ value) {
+        VarHandleMemoryAddressBase handle = (VarHandleMemoryAddressBase)ob;
         MemoryAddressProxy bb = checkAddress(obb, base, handle.length, false);
         if (handle.be == BE) {
             return UNSAFE.getAndBitwiseOr$RawType$(
@@ -369,7 +392,8 @@ final class VarHandleMemoryAddressAs$Type$s {
     }
 
     @ForceInline
-    static $type$ getAndBitwiseOrRelease0(VarHandleMemoryAddressBase handle, Object obb, long base, $type$ value) {
+    static $type$ getAndBitwiseOrRelease0(VarHandle ob, Object obb, long base, $type$ value) {
+        VarHandleMemoryAddressBase handle = (VarHandleMemoryAddressBase)ob;
         MemoryAddressProxy bb = checkAddress(obb, base, handle.length, false);
         if (handle.be == BE) {
             return UNSAFE.getAndBitwiseOr$RawType$Release(
@@ -382,7 +406,8 @@ final class VarHandleMemoryAddressAs$Type$s {
     }
 
     @ForceInline
-    static $type$ getAndBitwiseOrAcquire0(VarHandleMemoryAddressBase handle, Object obb, long base, $type$ value) {
+    static $type$ getAndBitwiseOrAcquire0(VarHandle ob, Object obb, long base, $type$ value) {
+        VarHandleMemoryAddressBase handle = (VarHandleMemoryAddressBase)ob;
         MemoryAddressProxy bb = checkAddress(obb, base, handle.length, false);
         if (handle.be == BE) {
             return UNSAFE.getAndBitwiseOr$RawType$Acquire(
@@ -407,7 +432,8 @@ final class VarHandleMemoryAddressAs$Type$s {
     }
 
     @ForceInline
-    static $type$ getAndBitwiseAnd0(VarHandleMemoryAddressBase handle, Object obb, long base, $type$ value) {
+    static $type$ getAndBitwiseAnd0(VarHandle ob, Object obb, long base, $type$ value) {
+        VarHandleMemoryAddressBase handle = (VarHandleMemoryAddressBase)ob;
         MemoryAddressProxy bb = checkAddress(obb, base, handle.length, false);
         if (handle.be == BE) {
             return UNSAFE.getAndBitwiseAnd$RawType$(
@@ -420,7 +446,8 @@ final class VarHandleMemoryAddressAs$Type$s {
     }
 
     @ForceInline
-    static $type$ getAndBitwiseAndRelease0(VarHandleMemoryAddressBase handle, Object obb, long base, $type$ value) {
+    static $type$ getAndBitwiseAndRelease0(VarHandle ob, Object obb, long base, $type$ value) {
+        VarHandleMemoryAddressBase handle = (VarHandleMemoryAddressBase)ob;
         MemoryAddressProxy bb = checkAddress(obb, base, handle.length, false);
         if (handle.be == BE) {
             return UNSAFE.getAndBitwiseAnd$RawType$Release(
@@ -433,7 +460,8 @@ final class VarHandleMemoryAddressAs$Type$s {
     }
 
     @ForceInline
-    static $type$ getAndBitwiseAndAcquire0(VarHandleMemoryAddressBase handle, Object obb, long base, $type$ value) {
+    static $type$ getAndBitwiseAndAcquire0(VarHandle ob, Object obb, long base, $type$ value) {
+        VarHandleMemoryAddressBase handle = (VarHandleMemoryAddressBase)ob;
         MemoryAddressProxy bb = checkAddress(obb, base, handle.length, false);
         if (handle.be == BE) {
             return UNSAFE.getAndBitwiseAnd$RawType$Acquire(
@@ -459,7 +487,8 @@ final class VarHandleMemoryAddressAs$Type$s {
 
 
     @ForceInline
-    static $type$ getAndBitwiseXor0(VarHandleMemoryAddressBase handle, Object obb, long base, $type$ value) {
+    static $type$ getAndBitwiseXor0(VarHandle ob, Object obb, long base, $type$ value) {
+        VarHandleMemoryAddressBase handle = (VarHandleMemoryAddressBase)ob;
         MemoryAddressProxy bb = checkAddress(obb, base, handle.length, false);
         if (handle.be == BE) {
             return UNSAFE.getAndBitwiseXor$RawType$(
@@ -472,7 +501,8 @@ final class VarHandleMemoryAddressAs$Type$s {
     }
 
     @ForceInline
-    static $type$ getAndBitwiseXorRelease0(VarHandleMemoryAddressBase handle, Object obb, long base, $type$ value) {
+    static $type$ getAndBitwiseXorRelease0(VarHandle ob, Object obb, long base, $type$ value) {
+        VarHandleMemoryAddressBase handle = (VarHandleMemoryAddressBase)ob;
         MemoryAddressProxy bb = checkAddress(obb, base, handle.length, false);
         if (handle.be == BE) {
             return UNSAFE.getAndBitwiseXor$RawType$Release(
@@ -485,7 +515,8 @@ final class VarHandleMemoryAddressAs$Type$s {
     }
 
     @ForceInline
-    static $type$ getAndBitwiseXorAcquire0(VarHandleMemoryAddressBase handle, Object obb, long base, $type$ value) {
+    static $type$ getAndBitwiseXorAcquire0(VarHandle ob, Object obb, long base, $type$ value) {
+        VarHandleMemoryAddressBase handle = (VarHandleMemoryAddressBase)ob;
         MemoryAddressProxy bb = checkAddress(obb, base, handle.length, false);
         if (handle.be == BE) {
             return UNSAFE.getAndBitwiseXor$RawType$Acquire(

--- a/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodTypeBoolean.java
+++ b/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodTypeBoolean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,9 @@
  * @test
  * @bug 8156486
  * @run testng/othervm VarHandleTestMethodTypeBoolean
- * @run testng/othervm -Djava.lang.invoke.VarHandle.VAR_HANDLE_GUARDS=false VarHandleTestMethodTypeBoolean
+ * @run testng/othervm -Djava.lang.invoke.VarHandle.VAR_HANDLE_GUARDS=true -Djava.lang.invoke.VarHandle.VAR_HANDLE_IDENTITY_ADAPT=true VarHandleTestMethodTypeBoolean
+ * @run testng/othervm -Djava.lang.invoke.VarHandle.VAR_HANDLE_GUARDS=false -Djava.lang.invoke.VarHandle.VAR_HANDLE_IDENTITY_ADAPT=false VarHandleTestMethodTypeBoolean
+ * @run testng/othervm -Djava.lang.invoke.VarHandle.VAR_HANDLE_GUARDS=false -Djava.lang.invoke.VarHandle.VAR_HANDLE_IDENTITY_ADAPT=true VarHandleTestMethodTypeBoolean
  */
 
 import org.testng.annotations.BeforeClass;

--- a/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodTypeByte.java
+++ b/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodTypeByte.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,9 @@
  * @test
  * @bug 8156486
  * @run testng/othervm VarHandleTestMethodTypeByte
- * @run testng/othervm -Djava.lang.invoke.VarHandle.VAR_HANDLE_GUARDS=false VarHandleTestMethodTypeByte
+ * @run testng/othervm -Djava.lang.invoke.VarHandle.VAR_HANDLE_GUARDS=true -Djava.lang.invoke.VarHandle.VAR_HANDLE_IDENTITY_ADAPT=true VarHandleTestMethodTypeByte
+ * @run testng/othervm -Djava.lang.invoke.VarHandle.VAR_HANDLE_GUARDS=false -Djava.lang.invoke.VarHandle.VAR_HANDLE_IDENTITY_ADAPT=false VarHandleTestMethodTypeByte
+ * @run testng/othervm -Djava.lang.invoke.VarHandle.VAR_HANDLE_GUARDS=false -Djava.lang.invoke.VarHandle.VAR_HANDLE_IDENTITY_ADAPT=true VarHandleTestMethodTypeByte
  */
 
 import org.testng.annotations.BeforeClass;

--- a/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodTypeChar.java
+++ b/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodTypeChar.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,9 @@
  * @test
  * @bug 8156486
  * @run testng/othervm VarHandleTestMethodTypeChar
- * @run testng/othervm -Djava.lang.invoke.VarHandle.VAR_HANDLE_GUARDS=false VarHandleTestMethodTypeChar
+ * @run testng/othervm -Djava.lang.invoke.VarHandle.VAR_HANDLE_GUARDS=true -Djava.lang.invoke.VarHandle.VAR_HANDLE_IDENTITY_ADAPT=true VarHandleTestMethodTypeChar
+ * @run testng/othervm -Djava.lang.invoke.VarHandle.VAR_HANDLE_GUARDS=false -Djava.lang.invoke.VarHandle.VAR_HANDLE_IDENTITY_ADAPT=false VarHandleTestMethodTypeChar
+ * @run testng/othervm -Djava.lang.invoke.VarHandle.VAR_HANDLE_GUARDS=false -Djava.lang.invoke.VarHandle.VAR_HANDLE_IDENTITY_ADAPT=true VarHandleTestMethodTypeChar
  */
 
 import org.testng.annotations.BeforeClass;

--- a/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodTypeDouble.java
+++ b/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodTypeDouble.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,9 @@
  * @test
  * @bug 8156486
  * @run testng/othervm VarHandleTestMethodTypeDouble
- * @run testng/othervm -Djava.lang.invoke.VarHandle.VAR_HANDLE_GUARDS=false VarHandleTestMethodTypeDouble
+ * @run testng/othervm -Djava.lang.invoke.VarHandle.VAR_HANDLE_GUARDS=true -Djava.lang.invoke.VarHandle.VAR_HANDLE_IDENTITY_ADAPT=true VarHandleTestMethodTypeDouble
+ * @run testng/othervm -Djava.lang.invoke.VarHandle.VAR_HANDLE_GUARDS=false -Djava.lang.invoke.VarHandle.VAR_HANDLE_IDENTITY_ADAPT=false VarHandleTestMethodTypeDouble
+ * @run testng/othervm -Djava.lang.invoke.VarHandle.VAR_HANDLE_GUARDS=false -Djava.lang.invoke.VarHandle.VAR_HANDLE_IDENTITY_ADAPT=true VarHandleTestMethodTypeDouble
  */
 
 import org.testng.annotations.BeforeClass;

--- a/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodTypeFloat.java
+++ b/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodTypeFloat.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,9 @@
  * @test
  * @bug 8156486
  * @run testng/othervm VarHandleTestMethodTypeFloat
- * @run testng/othervm -Djava.lang.invoke.VarHandle.VAR_HANDLE_GUARDS=false VarHandleTestMethodTypeFloat
+ * @run testng/othervm -Djava.lang.invoke.VarHandle.VAR_HANDLE_GUARDS=true -Djava.lang.invoke.VarHandle.VAR_HANDLE_IDENTITY_ADAPT=true VarHandleTestMethodTypeFloat
+ * @run testng/othervm -Djava.lang.invoke.VarHandle.VAR_HANDLE_GUARDS=false -Djava.lang.invoke.VarHandle.VAR_HANDLE_IDENTITY_ADAPT=false VarHandleTestMethodTypeFloat
+ * @run testng/othervm -Djava.lang.invoke.VarHandle.VAR_HANDLE_GUARDS=false -Djava.lang.invoke.VarHandle.VAR_HANDLE_IDENTITY_ADAPT=true VarHandleTestMethodTypeFloat
  */
 
 import org.testng.annotations.BeforeClass;

--- a/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodTypeInt.java
+++ b/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodTypeInt.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,9 @@
  * @test
  * @bug 8156486
  * @run testng/othervm VarHandleTestMethodTypeInt
- * @run testng/othervm -Djava.lang.invoke.VarHandle.VAR_HANDLE_GUARDS=false VarHandleTestMethodTypeInt
+ * @run testng/othervm -Djava.lang.invoke.VarHandle.VAR_HANDLE_GUARDS=true -Djava.lang.invoke.VarHandle.VAR_HANDLE_IDENTITY_ADAPT=true VarHandleTestMethodTypeInt
+ * @run testng/othervm -Djava.lang.invoke.VarHandle.VAR_HANDLE_GUARDS=false -Djava.lang.invoke.VarHandle.VAR_HANDLE_IDENTITY_ADAPT=false VarHandleTestMethodTypeInt
+ * @run testng/othervm -Djava.lang.invoke.VarHandle.VAR_HANDLE_GUARDS=false -Djava.lang.invoke.VarHandle.VAR_HANDLE_IDENTITY_ADAPT=true VarHandleTestMethodTypeInt
  */
 
 import org.testng.annotations.BeforeClass;

--- a/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodTypeLong.java
+++ b/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodTypeLong.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,9 @@
  * @test
  * @bug 8156486
  * @run testng/othervm VarHandleTestMethodTypeLong
- * @run testng/othervm -Djava.lang.invoke.VarHandle.VAR_HANDLE_GUARDS=false VarHandleTestMethodTypeLong
+ * @run testng/othervm -Djava.lang.invoke.VarHandle.VAR_HANDLE_GUARDS=true -Djava.lang.invoke.VarHandle.VAR_HANDLE_IDENTITY_ADAPT=true VarHandleTestMethodTypeLong
+ * @run testng/othervm -Djava.lang.invoke.VarHandle.VAR_HANDLE_GUARDS=false -Djava.lang.invoke.VarHandle.VAR_HANDLE_IDENTITY_ADAPT=false VarHandleTestMethodTypeLong
+ * @run testng/othervm -Djava.lang.invoke.VarHandle.VAR_HANDLE_GUARDS=false -Djava.lang.invoke.VarHandle.VAR_HANDLE_IDENTITY_ADAPT=true VarHandleTestMethodTypeLong
  */
 
 import org.testng.annotations.BeforeClass;

--- a/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodTypeShort.java
+++ b/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodTypeShort.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,9 @@
  * @test
  * @bug 8156486
  * @run testng/othervm VarHandleTestMethodTypeShort
- * @run testng/othervm -Djava.lang.invoke.VarHandle.VAR_HANDLE_GUARDS=false VarHandleTestMethodTypeShort
+ * @run testng/othervm -Djava.lang.invoke.VarHandle.VAR_HANDLE_GUARDS=true -Djava.lang.invoke.VarHandle.VAR_HANDLE_IDENTITY_ADAPT=true VarHandleTestMethodTypeShort
+ * @run testng/othervm -Djava.lang.invoke.VarHandle.VAR_HANDLE_GUARDS=false -Djava.lang.invoke.VarHandle.VAR_HANDLE_IDENTITY_ADAPT=false VarHandleTestMethodTypeShort
+ * @run testng/othervm -Djava.lang.invoke.VarHandle.VAR_HANDLE_GUARDS=false -Djava.lang.invoke.VarHandle.VAR_HANDLE_IDENTITY_ADAPT=true VarHandleTestMethodTypeShort
  */
 
 import org.testng.annotations.BeforeClass;

--- a/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodTypeString.java
+++ b/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodTypeString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,9 @@
  * @test
  * @bug 8156486
  * @run testng/othervm VarHandleTestMethodTypeString
- * @run testng/othervm -Djava.lang.invoke.VarHandle.VAR_HANDLE_GUARDS=false VarHandleTestMethodTypeString
+ * @run testng/othervm -Djava.lang.invoke.VarHandle.VAR_HANDLE_GUARDS=true -Djava.lang.invoke.VarHandle.VAR_HANDLE_IDENTITY_ADAPT=true VarHandleTestMethodTypeString
+ * @run testng/othervm -Djava.lang.invoke.VarHandle.VAR_HANDLE_GUARDS=false -Djava.lang.invoke.VarHandle.VAR_HANDLE_IDENTITY_ADAPT=false VarHandleTestMethodTypeString
+ * @run testng/othervm -Djava.lang.invoke.VarHandle.VAR_HANDLE_GUARDS=false -Djava.lang.invoke.VarHandle.VAR_HANDLE_IDENTITY_ADAPT=true VarHandleTestMethodTypeString
  */
 
 import org.testng.annotations.BeforeClass;

--- a/test/jdk/java/lang/invoke/VarHandles/X-VarHandleTestMethodType.java.template
+++ b/test/jdk/java/lang/invoke/VarHandles/X-VarHandleTestMethodType.java.template
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,9 @@
  * @test
  * @bug 8156486
  * @run testng/othervm VarHandleTestMethodType$Type$
- * @run testng/othervm -Djava.lang.invoke.VarHandle.VAR_HANDLE_GUARDS=false VarHandleTestMethodType$Type$
+ * @run testng/othervm -Djava.lang.invoke.VarHandle.VAR_HANDLE_GUARDS=true -Djava.lang.invoke.VarHandle.VAR_HANDLE_IDENTITY_ADAPT=true VarHandleTestMethodType$Type$
+ * @run testng/othervm -Djava.lang.invoke.VarHandle.VAR_HANDLE_GUARDS=false -Djava.lang.invoke.VarHandle.VAR_HANDLE_IDENTITY_ADAPT=false VarHandleTestMethodType$Type$
+ * @run testng/othervm -Djava.lang.invoke.VarHandle.VAR_HANDLE_GUARDS=false -Djava.lang.invoke.VarHandle.VAR_HANDLE_IDENTITY_ADAPT=true VarHandleTestMethodType$Type$
  */
 
 import org.testng.annotations.BeforeClass;


### PR DESCRIPTION
Hi,
as promised, I took a look into adding a bit more structure under our var handle implementations - more specifically, I've tweaked the signatures of the various implementation methods to take a plain VarHandle instead of a var handle implementation class.

This was tedious, but ultimately easy to do. Since, to do this in a complete way I also had to touch regular var handles (e.g. non-memory access ones), it seemed like a good idea to take an existing var handle test (VarHandleTestMethodTypeXYZ) and tweak it so that it tests all combinations of (adpated=yes/no, guards=yes/no). This revealed several issues in the adapter logic:

* first, varType() and coordinates() triggered a resolution of some of the underlying MH attached to the indirect handle - since this can fail with UOE, these methods could also fail spuriously with UOE which is wrong

* second, accessModeTypeUncached, in addition to the aforementioned problem, also had an issue in that it didn't make correct use of the direct handle target

* third, I realized that I did not update the lambda forms for var handle invokers to also call VarHandle::asDirect - this was causing issues when calling an adapted handle through the invoker

With these changes, all tests pass despite the extra layers of adaptation. So, in the end it turned out to be a fruitful bug hunt (thanks for the hint Paul!).

Cheers
Maurizio
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
## Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

## Issue
[JDK-8238549](https://bugs.openjdk.java.net/browse/JDK-8238549): Add explicit cast to correct implementation type in VarHandle implementation methods


## Approvers
 * Jorn Vernee ([jvernee](@JornVernee) - Committer)