### PR TITLE
8238320: What is the alignment of padding layouts?

### DIFF
--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/MemoryLayout.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/MemoryLayout.java
@@ -76,7 +76,10 @@ import java.util.function.UnaryOperator;
  * <p>
  * Furthermore, all layouts feature a <em>natural alignment</em> which can be inferred as follows:
  * <ul>
- *     <li>for value and padding layout <em>L</em> whose size is <em>N</em>, the natural alignment of <em>L</em> is <em>N</em></li>
+ *     <li>for a padding layout <em>L</em>, the natural alignment is 1, regardless of its size; that is, in the absence
+ *     of an explicit alignment constraint, a padding layout should not affect the alignment constraint of the group
+ *     layout it is nested into</li>
+ *     <li>for a value layout <em>L</em> whose size is <em>N</em>, the natural alignment of <em>L</em> is <em>N</em></li>
  *     <li>for a sequence layout <em>S</em> whose element layout is <em>E</em>, the natural alignment of <em>S</em> is that of <em>E</em></li>
  *     <li>for a group layout <em>G</em> with member layouts <em>M1</em>, <em>M2</em>, ... <em>Mn</em> whose alignments are
  *     <em>A1</em>, <em>A2</em>, ... <em>An</em>, respectively, the natural alignment of <em>G</em> is <em>max(A1, A2 ... An)</em></li>

--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/PaddingLayout.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/PaddingLayout.java
@@ -47,7 +47,7 @@ import java.util.OptionalLong;
 /* package-private */ final class PaddingLayout extends AbstractLayout implements MemoryLayout {
 
     PaddingLayout(long size) {
-        this(size, size, Optional.empty());
+        this(size, 1, Optional.empty());
     }
 
     PaddingLayout(long size, long alignment, Optional<String> name) {

--- a/test/jdk/java/foreign/TestLayouts.java
+++ b/test/jdk/java/foreign/TestLayouts.java
@@ -32,6 +32,7 @@ import jdk.incubator.foreign.MemoryLayout;
 import java.lang.invoke.VarHandle;
 import java.nio.ByteOrder;
 import java.util.function.LongFunction;
+import java.util.stream.Stream;
 
 import jdk.incubator.foreign.MemorySegment;
 import jdk.incubator.foreign.SequenceLayout;
@@ -176,6 +177,25 @@ public class TestLayouts {
         assertEquals(struct.byteAlignment(), 8);
     }
 
+    @Test(dataProvider="basicLayouts")
+    public void testPaddingNoAlign(MemoryLayout layout) {
+        assertEquals(MemoryLayout.ofPaddingBits(layout.bitSize()).bitAlignment(), 1);
+    }
+
+    @Test(dataProvider="basicLayouts")
+    public void testStructPaddingAndAlign(MemoryLayout layout) {
+        MemoryLayout struct = MemoryLayout.ofStruct(
+                layout, MemoryLayout.ofPaddingBits(128 - layout.bitSize()));
+        assertEquals(struct.bitAlignment(), layout.bitAlignment());
+    }
+
+    @Test(dataProvider="basicLayouts")
+    public void testUnionPaddingAndAlign(MemoryLayout layout) {
+        MemoryLayout struct = MemoryLayout.ofUnion(
+                layout, MemoryLayout.ofPaddingBits(128 - layout.bitSize()));
+        assertEquals(struct.bitAlignment(), layout.bitAlignment());
+    }
+
     @Test
     public void testUnionSizeAndAlign() {
         MemoryLayout struct = MemoryLayout.ofUnion(
@@ -268,17 +288,15 @@ public class TestLayouts {
         }
     }
 
+    @DataProvider(name = "basicLayouts")
+    public Object[][] basicLayouts() {
+        return Stream.of(basicLayouts)
+                .map(l -> new Object[] { l })
+                .toArray(Object[][]::new);
+    }
+
     @DataProvider(name = "layoutsAndAlignments")
     public Object[][] layoutsAndAlignments() {
-        MemoryLayout[] basicLayouts = {
-                MemoryLayouts.JAVA_BYTE,
-                MemoryLayouts.JAVA_CHAR,
-                MemoryLayouts.JAVA_SHORT,
-                MemoryLayouts.JAVA_INT,
-                MemoryLayouts.JAVA_FLOAT,
-                MemoryLayouts.JAVA_LONG,
-                MemoryLayouts.JAVA_DOUBLE,
-        };
         Object[][] layoutsAndAlignments = new Object[basicLayouts.length * 5][];
         int i = 0;
         //add basic layouts
@@ -303,4 +321,14 @@ public class TestLayouts {
         }
         return layoutsAndAlignments;
     }
+
+    static MemoryLayout[] basicLayouts = {
+            MemoryLayouts.JAVA_BYTE,
+            MemoryLayouts.JAVA_CHAR,
+            MemoryLayouts.JAVA_SHORT,
+            MemoryLayouts.JAVA_INT,
+            MemoryLayouts.JAVA_FLOAT,
+            MemoryLayouts.JAVA_LONG,
+            MemoryLayouts.JAVA_DOUBLE,
+    };
 }


### PR DESCRIPTION
Fix padding layout natural alignment so that it is always set to 1 (mininum value). This means that adding a padding layout to a compound layout will be immaterial w.r.t. the group layout's alignment constraint.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
## Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

## Issue
[JDK-8238320](https://bugs.openjdk.java.net/browse/JDK-8238320): What is the alignment of padding layouts?


## Approvers
 * Jorn Vernee ([jvernee](@JornVernee) - Committer)
 * Paul Sandoz ([psandoz](@PaulSandoz) - Committer)