### PR TITLE
8237359: Clean up Binding

### DIFF
--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/Binding.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/Binding.java
@@ -180,21 +180,23 @@ import java.util.Objects;
  * --------------------
  */
 public abstract class Binding {
-    static final int MOVE_TAG = 0;
-    static final int DEREFERENCE_TAG = 1;
-    static final int COPY_BUFFER_TAG = 2;
-    static final int ALLOC_BUFFER_TAG = 3;
-    static final int CONVERT_ADDRESS_TAG = 4;
-    static final int BASE_ADDRESS_TAG = 5;
-    static final int DUP_TAG = 6;
+    enum Tag {
+        MOVE,
+        DEREFERENCE,
+        COPY_BUFFER,
+        ALLOC_BUFFER,
+        CONVERT_ADDRESS,
+        BASE_ADDRESS,
+        DUP
+    }
 
-    private final int tag;
+    private final Tag tag;
 
-    private Binding(int tag) {
+    private Binding(Tag tag) {
         this.tag = tag;
     }
 
-    public int tag() {
+    public Tag tag() {
         return tag;
     }
 
@@ -246,7 +248,7 @@ public abstract class Binding {
         private final Class<?> type;
 
         private Move(VMStorage storage, Class<?> type) {
-            super(MOVE_TAG);
+            super(Tag.MOVE);
             this.storage = storage;
             this.type = type;
         }
@@ -296,7 +298,7 @@ public abstract class Binding {
         private final Class<?> type;
 
         private Dereference(long offset, Class<?> type) {
-            super(DEREFERENCE_TAG);
+            super(Tag.DEREFERENCE);
             this.offset = offset;
             this.type = type;
         }
@@ -344,7 +346,7 @@ public abstract class Binding {
         private final long alignment;
 
         private Copy(long size, long alignment) {
-            super(COPY_BUFFER_TAG);
+            super(Tag.COPY_BUFFER);
             this.size = size;
             this.alignment = alignment;
         }
@@ -390,7 +392,7 @@ public abstract class Binding {
         private final long alignment;
 
         private Allocate(long size, long alignment) {
-            super(ALLOC_BUFFER_TAG);
+            super(Tag.ALLOC_BUFFER);
             this.size = size;
             this.alignment = alignment;
         }
@@ -437,7 +439,7 @@ public abstract class Binding {
     public static class ConvertAddress extends Binding {
         private static final ConvertAddress INSTANCE = new ConvertAddress();
         private ConvertAddress() {
-            super(CONVERT_ADDRESS_TAG);
+            super(Tag.CONVERT_ADDRESS);
         }
 
         @Override
@@ -449,7 +451,7 @@ public abstract class Binding {
 
         @Override
         public int hashCode() {
-            return tag();
+            return tag().hashCode();
         }
 
         @Override
@@ -467,7 +469,7 @@ public abstract class Binding {
     public static class BaseAddress extends Binding {
         private static final BaseAddress INSTANCE = new BaseAddress();
         private BaseAddress() {
-            super(BASE_ADDRESS_TAG);
+            super(Tag.BASE_ADDRESS);
         }
 
         @Override
@@ -479,7 +481,7 @@ public abstract class Binding {
 
         @Override
         public int hashCode() {
-            return tag();
+            return tag().hashCode();
         }
 
         @Override
@@ -497,7 +499,7 @@ public abstract class Binding {
     public static class Dup extends Binding {
         private static final Dup INSTANCE = new Dup();
         private Dup() {
-            super(DUP_TAG);
+            super(Tag.DUP);
         }
 
         @Override
@@ -509,7 +511,7 @@ public abstract class Binding {
 
         @Override
         public int hashCode() {
-            return tag();
+            return tag().hashCode();
         }
 
         @Override

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/Binding.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/Binding.java
@@ -26,12 +26,165 @@ import jdk.incubator.foreign.MemoryLayout;
 
 import java.util.Objects;
 
+/**
+ * The binding operators defined in the Binding class can be combined into argument and return value processing 'recipes'.
+ *
+ * The binding operators are interpreted using a stack-base interpreter. Operators can either consume operands from the
+ * stack, or push them onto the stack.
+ *
+ * In the description of each binding we talk about 'boxing' and 'unboxing'.
+ *  - Unboxing is the process of taking a Java value and decomposing it, and storing components into machine
+ *    storage locations. As such, the binding interpreter stack starts with the Java value on it, and should end empty.
+ *  - Boxing is the process of re-composing a Java value by pulling components from machine storage locations.
+ *    If a MemorySegment is needed to store the result, one should be allocated using the ALLOCATE_BUFFER operator.
+ *    The binding interpreter stack starts off empty, and ends with the value to be returned as the only value on it.
+ * A binding operator can be interpreted differently based on whether we are boxing or unboxing a value. For example,
+ * the CONVERT_ADDRESS operator 'unboxes' a MemoryAddress to a long, but 'boxes' a long to a MemoryAddress.
+ *
+ * Here are some examples of binding recipes derived from C declarations, and according to the Windows ABI (recipes are
+ * ABI-specific). Note that each argument has it's own recipe, which is indicated by '[number]:' (though, the only
+ * example that has multiple arguments is the one using varargs).
+ *
+ * --------------------
+ *
+ * void f(int i);
+ *
+ * Argument bindings:
+ * 0: MOVE(rcx, int.class) // move an 'int' into the RCX register
+ *
+ * Return bindings:
+ * none
+ *
+ * --------------------
+ *
+ * void f(int* i);
+ *
+ * Argument bindings:
+ * 0: CONVERT_ADDRESS // the 'MemoryAddress' is converted into a 'long'
+ *    MOVE(rcx, long.class) // the 'long' is moved into the RCX register
+ *
+ * Return bindings:
+ * none
+ *
+ * --------------------
+ *
+ * int* f();
+ *
+ * Argument bindings:
+ * none
+ *
+ * Return bindings:
+ * 0: MOVE(rax, long) // load a 'long' from the RAX register
+ *    CONVERT_ADDRESS // convert the 'long' into a 'MemoryAddress'
+ *
+ * --------------------
+ *
+ * typedef struct { // fits into single register
+ * 	int x;
+ * 	int y;
+ * } MyStruct;
+ *
+ * void f(MyStruct ms);
+ *
+ * Argument bindings:
+ * 0: DEREFERENCE(0, long.class) // From the struct's memory region, load a 'long' from offset '0'
+ *    MOVE(rcx, long.class) // and copy that into the RCX regitster
+ *
+ * Return bindings:
+ * none
+ *
+ * --------------------
+ *
+ * typedef struct { // does not fit into single register
+ * 	__int64 x;
+ * 	__int64 y;
+ * } MyStruct;
+ *
+ * void f(MyStruct ms);
+ *
+ * For the Windows ABI:
+ *
+ * Argument bindings:
+ * 0: COPY(16, 8) // copy the memory region containing the struct
+ *    BASE_ADDRESS // take the base address of the copy
+ *    CONVERT_ADDRESS // converts the base address to a 'long'
+ *    MOVE(rcx, long.class) // moves the 'long' into the RCX register
+ *
+ * Return bindings:
+ * none
+ *
+ * For the SysV ABI:
+ *
+ * Argument bindings:
+ * 0: DUP // duplicates the MemoryRegion operand
+ *    DEREFERENCE(0, long.class) // loads a 'long' from offset '0'
+ *    MOVE(rdx, long.class) // moves the long into the RDX register
+ *    DEREFERENCE(8, long.class) // loads a 'long' from offset '8'
+ *    MOVE(rcx, long.class) // moves the long into the RCX register
+ *
+ * Return bindings:
+ * none
+ *
+ * --------------------
+ *
+ * typedef struct { // fits into single register
+ * 	int x;
+ * 	int y;
+ * } MyStruct;
+ *
+ * MyStruct f();
+ *
+ * Argument bindings:
+ * none
+ *
+ * Return bindings:
+ * 0: ALLOCATE(GroupLayout(C_INT, C_INT)) // allocate a buffer with the memory layout of the struct
+ *    DUP // duplicate the allocated buffer
+ *    MOVE(rax, long.class) // loads a 'long' from rax
+ *    DEREFERENCE(0, long.class) // stores a 'long' at offset 0
+ *
+ * --------------------
+ *
+ * typedef struct { // does not fit into single register
+ * 	__int64 x;
+ * 	__int64 y;
+ * } MyStruct;
+ *
+ * MyStruct f();
+ *
+ * !! uses synthetic argument, which is a pointer to a pre-allocated buffer
+ *
+ * Argument bindings:
+ * 0: CONVERT_ADDRESS // unbox the MemoryAddress synthetic argument
+ *    MOVE(rcx, long.class) // moves the 'long' into the RCX register
+ *
+ * Return bindings:
+ * none
+ *
+ * --------------------
+ *
+ * void f(int dummy, ...); // varargs
+ *
+ * f(0, 10f); // passing a float
+ *
+ * Argument bindings:
+ * 0: MOVE(rcx, int.class) // moves the 'int dummy' into the RCX register
+ *
+ * 1: DUP // duplicates the '10f' argument
+ *    MOVE(rdx, float.class) // move one copy into the RDX register
+ *    MOVE(xmm1, float.class) // moves the other copy into the xmm2 register
+ *
+ * Return bindings:
+ * none
+ *
+ * --------------------
+ */
 public abstract class Binding {
     static final int MOVE_TAG = 0;
     static final int DEREFERENCE_TAG = 1;
     static final int COPY_BUFFER_TAG = 2;
     static final int ALLOC_BUFFER_TAG = 3;
-    static final int BOX_ADDRESS_TAG = 4;
+    static final int CONVERT_ADDRESS_TAG = 4;
     static final int BASE_ADDRESS_TAG = 5;
     static final int DUP_TAG = 6;
 
@@ -45,14 +198,54 @@ public abstract class Binding {
         return tag;
     }
 
+    private static void checkType(Class<?> type) {
+        if (!type.isPrimitive() || type == void.class || type == boolean.class)
+            throw new IllegalArgumentException("Illegal type: " + type);
+    }
+
+    public static Move move(VMStorage storage, Class<?> type) {
+        checkType(type);
+        return new Move(storage, type);
+    }
+
+    public static Dereference dereference(long offset, Class<?> type) {
+        checkType(type);
+        if (offset < 0)
+            throw new IllegalArgumentException("Negative offset: " + offset);
+        return new Dereference(offset, type);
+    }
+
+    public static Copy copy(MemoryLayout layout) {
+        return new Copy(layout.byteSize(), layout.byteAlignment());
+    }
+
+    public static Allocate allocate(MemoryLayout layout) {
+        return new Allocate(layout.byteSize(), layout.byteAlignment());
+    }
+
+    public static ConvertAddress convertAddress() {
+        return ConvertAddress.INSTANCE;
+    }
+
+    public static BaseAddress baseAddress() {
+        return BaseAddress.INSTANCE;
+    }
+
+    public static Dup dup() {
+        return Dup.INSTANCE;
+    }
+
     /**
-     * Moves from a primitve to a VMStorage
+     * MOVE([storage location], [type])
+     *   When unboxing: pops a [type] from the operand stack, and moves it to [storage location]
+     *   When boxing: loads a [type] from [storage location], and pushes it onto the operand stack
+     * The [type] must be one of byte, short, char, int, long, float, or double
      */
     public static class Move extends Binding {
         private final VMStorage storage;
         private final Class<?> type;
 
-        public Move(VMStorage storage, Class<?> type) {
+        private Move(VMStorage storage, Class<?> type) {
             super(MOVE_TAG);
             this.storage = storage;
             this.type = type;
@@ -91,13 +284,18 @@ public abstract class Binding {
     }
 
     /**
-     * Loads or stores a Java primitive to a MemorySegment at a certain offset
+     * DEREFERENCE([offset into memory region], [type])
+     *   When unboxing: pops a MemorySegment from the operand stack,
+     *       loads a [type] from [offset into memory region] from it, and pushes it onto the operand stack
+     *   When boxing: pops a [type], and then a MemorySegment from the operand stack,
+     *       and then stores [type] to [offset into memory region] of the MemorySegment
+     * The [type] must be one of byte, short, char, int, long, float, or double
      */
     public static class Dereference extends Binding {
         private final long offset;
         private final Class<?> type;
 
-        public Dereference(long offset, Class<?> type) {
+        private Dereference(long offset, Class<?> type) {
             super(DEREFERENCE_TAG);
             this.offset = offset;
             this.type = type;
@@ -136,13 +334,16 @@ public abstract class Binding {
     }
 
     /**
-     * Copies from a MemoryAddress into a newly allocated MemorySegment
+     * COPY([size], [alignment])
+     *   Creates a new MemorySegment with the given [size] and [alignment],
+     * 	     and copies contents from a MemorySegment popped from the top of the operand stack into this new buffer,
+     * 	     and pushes the new buffer onto the operand stack
      */
     public static class Copy extends Binding {
         private final long size;
         private final long alignment;
 
-        public Copy(long size, long alignment) {
+        private Copy(long size, long alignment) {
             super(COPY_BUFFER_TAG);
             this.size = size;
             this.alignment = alignment;
@@ -181,16 +382,17 @@ public abstract class Binding {
     }
 
     /**
-     * Allocates a MemorySegment
+     * ALLOCATE([size], [alignment])
+     *   Creates a new MemorySegment with the give [size] and [alignment], and pushes it onto the operand stack.
      */
-    public static class AllocateBuffer extends Binding {
+    public static class Allocate extends Binding {
         private final long size;
         private final long alignment;
 
-        public AllocateBuffer(MemoryLayout layout) {
+        private Allocate(long size, long alignment) {
             super(ALLOC_BUFFER_TAG);
-            this.size = layout.byteSize();
-            this.alignment = layout.byteAlignment();
+            this.size = size;
+            this.alignment = alignment;
         }
 
         public long size() {
@@ -214,7 +416,7 @@ public abstract class Binding {
         public boolean equals(Object o) {
             if (this == o) return true;
             if (o == null || getClass() != o.getClass()) return false;
-            AllocateBuffer that = (AllocateBuffer) o;
+            Allocate that = (Allocate) o;
             return size == that.size &&
                     alignment == that.alignment;
         }
@@ -226,11 +428,16 @@ public abstract class Binding {
     }
 
     /**
-     * Boxes or unboxes a MemoryAddress to a long and vice versa (depending on box/unbox interpreter)
+     * CONVERT_ADDRESS()
+     *   When unboxing: pops a 'MemoryAddress' from the operand stack, converts it to a 'long',
+     *       and pushes that onto the operand stack
+     *   When boxing: pops a 'long' from the operand stack, converts it to a 'MemoryAddress',
+     *       and pushes that onto the operand stack
      */
-    public static class BoxAddress extends Binding {
-        public BoxAddress() {
-            super(BOX_ADDRESS_TAG);
+    public static class ConvertAddress extends Binding {
+        private static final ConvertAddress INSTANCE = new ConvertAddress();
+        private ConvertAddress() {
+            super(CONVERT_ADDRESS_TAG);
         }
 
         @Override
@@ -253,10 +460,13 @@ public abstract class Binding {
     }
 
     /**
-     * Takes the base address of a MemorySegment
+     * BASE_ADDRESS()
+     *   Pops a MemorySegment from the operand stack, and takes the base address of the segment
+     *   (the MemoryAddress that points to the start), and pushes that onto the operand stack
      */
     public static class BaseAddress extends Binding {
-        public BaseAddress() {
+        private static final BaseAddress INSTANCE = new BaseAddress();
+        private BaseAddress() {
             super(BASE_ADDRESS_TAG);
         }
 
@@ -280,10 +490,13 @@ public abstract class Binding {
     }
 
     /**
-     * Duplicates a value on top of the interpreter stack
+     * DUP()
+     *   Duplicates the value on the top of the operand stack (without popping it!),
+     *   and pushes the duplicate onto the operand stack
      */
     public static class Dup extends Binding {
-        public Dup() {
+        private static final Dup INSTANCE = new Dup();
+        private Dup() {
             super(DUP_TAG);
         }
 

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/Binding.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/Binding.java
@@ -82,8 +82,8 @@ import java.util.Objects;
  * --------------------
  *
  * typedef struct { // fits into single register
- * 	int x;
- * 	int y;
+ *   int x;
+ *   int y;
  * } MyStruct;
  *
  * void f(MyStruct ms);
@@ -98,8 +98,8 @@ import java.util.Objects;
  * --------------------
  *
  * typedef struct { // does not fit into single register
- * 	__int64 x;
- * 	__int64 y;
+ *   long long x;
+ *   long long y;
  * } MyStruct;
  *
  * void f(MyStruct ms);
@@ -130,8 +130,8 @@ import java.util.Objects;
  * --------------------
  *
  * typedef struct { // fits into single register
- * 	int x;
- * 	int y;
+ *   int x;
+ *   int y;
  * } MyStruct;
  *
  * MyStruct f();
@@ -148,8 +148,8 @@ import java.util.Objects;
  * --------------------
  *
  * typedef struct { // does not fit into single register
- * 	__int64 x;
- * 	__int64 y;
+ *   long long x;
+ *   long long y;
  * } MyStruct;
  *
  * MyStruct f();
@@ -341,9 +341,9 @@ public abstract class Binding {
     /**
      * DEREFERENCE([offset into memory region], [type])
      *   When unboxing: pops a MemorySegment from the operand stack,
-     *       loads a [type] from [offset into memory region] from it, and pushes it onto the operand stack
+     *     loads a [type] from [offset into memory region] from it, and pushes it onto the operand stack
      *   When boxing: pops a [type], and then a MemorySegment from the operand stack,
-     *       and then stores [type] to [offset into memory region] of the MemorySegment
+     *     and then stores [type] to [offset into memory region] of the MemorySegment
      * The [type] must be one of byte, short, char, int, long, float, or double
      */
     public static class Dereference extends Binding {
@@ -391,8 +391,8 @@ public abstract class Binding {
     /**
      * COPY([size], [alignment])
      *   Creates a new MemorySegment with the given [size] and [alignment],
-     * 	     and copies contents from a MemorySegment popped from the top of the operand stack into this new buffer,
-     * 	     and pushes the new buffer onto the operand stack
+     *     and copies contents from a MemorySegment popped from the top of the operand stack into this new buffer,
+     *     and pushes the new buffer onto the operand stack
      */
     public static class Copy extends Binding {
         private final long size;
@@ -485,9 +485,9 @@ public abstract class Binding {
     /**
      * CONVERT_ADDRESS()
      *   When unboxing: pops a 'MemoryAddress' from the operand stack, converts it to a 'long',
-     *       and pushes that onto the operand stack
+     *     and pushes that onto the operand stack
      *   When boxing: pops a 'long' from the operand stack, converts it to a 'MemoryAddress',
-     *       and pushes that onto the operand stack
+     *     and pushes that onto the operand stack
      */
     public static class ConvertAddress extends Binding {
         private static final ConvertAddress INSTANCE = new ConvertAddress();

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/Binding.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/Binding.java
@@ -24,6 +24,8 @@ package jdk.internal.foreign.abi;
 
 import jdk.incubator.foreign.MemoryLayout;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Objects;
 
 /**
@@ -235,6 +237,57 @@ public abstract class Binding {
 
     public static Dup dup() {
         return Dup.INSTANCE;
+    }
+
+
+    public static Binding.Builder builder() {
+        return new Binding.Builder();
+    }
+
+    /**
+     * A builder helper class for generating lists of Bindings
+     */
+    public static class Builder {
+        private final List<Binding> bindings = new ArrayList<>();
+
+        public Binding.Builder move(VMStorage storage, Class<?> type) {
+            bindings.add(Binding.move(storage, type));
+            return this;
+        }
+
+        public Binding.Builder dereference(long offset, Class<?> type) {
+            bindings.add(Binding.dereference(offset, type));
+            return this;
+        }
+
+        public Binding.Builder copy(MemoryLayout layout) {
+            bindings.add(Binding.copy(layout));
+            return this;
+        }
+
+        public Binding.Builder allocate(MemoryLayout layout) {
+            bindings.add(Binding.allocate(layout));
+            return this;
+        }
+
+        public Binding.Builder convertAddress() {
+            bindings.add(Binding.convertAddress());
+            return this;
+        }
+
+        public Binding.Builder baseAddress() {
+            bindings.add(Binding.baseAddress());
+            return this;
+        }
+
+        public Binding.Builder dup() {
+            bindings.add(Binding.dup());
+            return this;
+        }
+
+        public List<Binding> build() {
+            return new ArrayList<>(bindings);
+        }
     }
 
     /**

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/BindingInterpreter.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/BindingInterpreter.java
@@ -50,19 +50,19 @@ public class BindingInterpreter {
         stack.push(arg);
         for (Binding b : bindings) {
             switch (b.tag()) {
-                case Binding.MOVE_TAG: {
+                case MOVE: {
                     Binding.Move binding = (Binding.Move) b;
                     MemoryAddress ptr = ptrFunction.apply(binding.storage());
                     writeOverSized(ptr, binding.type(), stack.pop());
                 } break;
-                case Binding.DEREFERENCE_TAG: {
+                case DEREFERENCE: {
                     Binding.Dereference deref = (Binding.Dereference) b;
                     MemorySegment operand = (MemorySegment) stack.pop();
                     MemoryAddress baseAddress = operand.baseAddress();
                     MemoryAddress readAddress = baseAddress.addOffset(deref.offset());
                     stack.push(read(readAddress, deref.type()));
                 } break;
-                case Binding.COPY_BUFFER_TAG: {
+                case COPY_BUFFER: {
                     Binding.Copy binding = (Binding.Copy) b;
                     MemorySegment operand = (MemorySegment) stack.pop();
                     assert operand.byteSize() == binding.size() : "operand size mismatch";
@@ -71,16 +71,16 @@ public class BindingInterpreter {
                     buffers.add(copy);
                     stack.push(copy);
                 } break;
-                case Binding.ALLOC_BUFFER_TAG: {
+                case ALLOC_BUFFER: {
                     throw new UnsupportedOperationException();
                 }
-                case Binding.CONVERT_ADDRESS_TAG: {
+                case CONVERT_ADDRESS: {
                     stack.push(MemoryAddressImpl.addressof((MemoryAddress) stack.pop()));
                 } break;
-                case Binding.BASE_ADDRESS_TAG: {
+                case BASE_ADDRESS: {
                     stack.push(((MemorySegment) stack.pop()).baseAddress());
                 } break;
-                case Binding.DUP_TAG: {
+                case DUP: {
                     stack.push(stack.peekLast());
                 } break;
                 default: throw new IllegalArgumentException("Unsupported tag: " + b);
@@ -92,12 +92,12 @@ public class BindingInterpreter {
         Deque<Object> stack = new ArrayDeque<>();
         for (Binding b : bindings) {
             switch (b.tag()) {
-                case Binding.MOVE_TAG: {
+                case MOVE: {
                     Binding.Move binding = (Binding.Move) b;
                     MemoryAddress ptr = ptrFunction.apply(binding.storage());
                     stack.push(read(ptr, binding.type()));
                 } break;
-                case Binding.DEREFERENCE_TAG: {
+                case DEREFERENCE: {
                     Binding.Dereference binding = (Binding.Dereference) b;
                     Object value = stack.pop();
                     MemorySegment operand = (MemorySegment) stack.pop();
@@ -105,7 +105,7 @@ public class BindingInterpreter {
                     MemoryAddress writeAddress = baseAddress.addOffset(binding.offset());
                     write(writeAddress, binding.type(), value);
                 } break;
-                case Binding.COPY_BUFFER_TAG: {
+                case COPY_BUFFER: {
                     Binding.Copy binding = (Binding.Copy) b;
                     MemoryAddress operand = (MemoryAddress) stack.pop();
                     operand = Utils.resizeNativeAddress(operand, binding.size());
@@ -113,17 +113,17 @@ public class BindingInterpreter {
                     MemoryAddress.copy(operand, copy.baseAddress(), binding.size());
                     stack.push(copy); // leaked
                 } break;
-                case Binding.ALLOC_BUFFER_TAG: {
+                case ALLOC_BUFFER: {
                     Binding.Allocate binding = (Binding.Allocate) b;
                     stack.push(MemorySegment.allocateNative(binding.size(), binding.alignment()));
                 } break;
-                case Binding.CONVERT_ADDRESS_TAG: {
+                case CONVERT_ADDRESS: {
                     stack.push(MemoryAddress.ofLong((long) stack.pop()));
                 } break;
-                case Binding.BASE_ADDRESS_TAG: {
+                case BASE_ADDRESS: {
                     stack.push(((MemorySegment) stack.pop()).baseAddress());
                 } break;
-                case Binding.DUP_TAG: {
+                case DUP: {
                     stack.push(stack.peekLast());
                 } break;
                 default: throw new IllegalArgumentException("Unsupported tag: " + b);

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/BindingInterpreter.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/BindingInterpreter.java
@@ -74,7 +74,7 @@ public class BindingInterpreter {
                 case Binding.ALLOC_BUFFER_TAG: {
                     throw new UnsupportedOperationException();
                 }
-                case Binding.BOX_ADDRESS_TAG: {
+                case Binding.CONVERT_ADDRESS_TAG: {
                     stack.push(MemoryAddressImpl.addressof((MemoryAddress) stack.pop()));
                 } break;
                 case Binding.BASE_ADDRESS_TAG: {
@@ -114,10 +114,10 @@ public class BindingInterpreter {
                     stack.push(copy); // leaked
                 } break;
                 case Binding.ALLOC_BUFFER_TAG: {
-                    Binding.AllocateBuffer binding = (Binding.AllocateBuffer) b;
+                    Binding.Allocate binding = (Binding.Allocate) b;
                     stack.push(MemorySegment.allocateNative(binding.size(), binding.alignment()));
                 } break;
-                case Binding.BOX_ADDRESS_TAG: {
+                case Binding.CONVERT_ADDRESS_TAG: {
                     stack.push(MemoryAddress.ofLong((long) stack.pop()));
                 } break;
                 case Binding.BASE_ADDRESS_TAG: {

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/BindingInterpreter.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/BindingInterpreter.java
@@ -50,19 +50,19 @@ public class BindingInterpreter {
         stack.push(arg);
         for (Binding b : bindings) {
             switch (b.tag()) {
-                case MOVE: {
+                case MOVE -> {
                     Binding.Move binding = (Binding.Move) b;
                     MemoryAddress ptr = ptrFunction.apply(binding.storage());
                     writeOverSized(ptr, binding.type(), stack.pop());
-                } break;
-                case DEREFERENCE: {
+                }
+                case DEREFERENCE -> {
                     Binding.Dereference deref = (Binding.Dereference) b;
                     MemorySegment operand = (MemorySegment) stack.pop();
                     MemoryAddress baseAddress = operand.baseAddress();
                     MemoryAddress readAddress = baseAddress.addOffset(deref.offset());
                     stack.push(read(readAddress, deref.type()));
-                } break;
-                case COPY_BUFFER: {
+                }
+                case COPY_BUFFER -> {
                     Binding.Copy binding = (Binding.Copy) b;
                     MemorySegment operand = (MemorySegment) stack.pop();
                     assert operand.byteSize() == binding.size() : "operand size mismatch";
@@ -70,20 +70,16 @@ public class BindingInterpreter {
                     MemoryAddress.copy(operand.baseAddress(), copy.baseAddress(), binding.size());
                     buffers.add(copy);
                     stack.push(copy);
-                } break;
-                case ALLOC_BUFFER: {
-                    throw new UnsupportedOperationException();
                 }
-                case CONVERT_ADDRESS: {
+                case ALLOC_BUFFER ->
+                    throw new UnsupportedOperationException();
+                case CONVERT_ADDRESS ->
                     stack.push(MemoryAddressImpl.addressof((MemoryAddress) stack.pop()));
-                } break;
-                case BASE_ADDRESS: {
+                case BASE_ADDRESS ->
                     stack.push(((MemorySegment) stack.pop()).baseAddress());
-                } break;
-                case DUP: {
+                case DUP ->
                     stack.push(stack.peekLast());
-                } break;
-                default: throw new IllegalArgumentException("Unsupported tag: " + b);
+                default -> throw new IllegalArgumentException("Unsupported tag: " + b);
             }
         }
     }
@@ -92,41 +88,38 @@ public class BindingInterpreter {
         Deque<Object> stack = new ArrayDeque<>();
         for (Binding b : bindings) {
             switch (b.tag()) {
-                case MOVE: {
+                case MOVE -> {
                     Binding.Move binding = (Binding.Move) b;
                     MemoryAddress ptr = ptrFunction.apply(binding.storage());
                     stack.push(read(ptr, binding.type()));
-                } break;
-                case DEREFERENCE: {
+                }
+                case DEREFERENCE -> {
                     Binding.Dereference binding = (Binding.Dereference) b;
                     Object value = stack.pop();
                     MemorySegment operand = (MemorySegment) stack.pop();
                     MemoryAddress baseAddress = operand.baseAddress();
                     MemoryAddress writeAddress = baseAddress.addOffset(binding.offset());
                     write(writeAddress, binding.type(), value);
-                } break;
-                case COPY_BUFFER: {
+                }
+                case COPY_BUFFER -> {
                     Binding.Copy binding = (Binding.Copy) b;
                     MemoryAddress operand = (MemoryAddress) stack.pop();
                     operand = Utils.resizeNativeAddress(operand, binding.size());
                     MemorySegment copy = MemorySegment.allocateNative(binding.size(), binding.alignment());
                     MemoryAddress.copy(operand, copy.baseAddress(), binding.size());
                     stack.push(copy); // leaked
-                } break;
-                case ALLOC_BUFFER: {
+                }
+                case ALLOC_BUFFER -> {
                     Binding.Allocate binding = (Binding.Allocate) b;
                     stack.push(MemorySegment.allocateNative(binding.size(), binding.alignment()));
-                } break;
-                case CONVERT_ADDRESS: {
+                }
+                case CONVERT_ADDRESS ->
                     stack.push(MemoryAddress.ofLong((long) stack.pop()));
-                } break;
-                case BASE_ADDRESS: {
+                case BASE_ADDRESS ->
                     stack.push(((MemorySegment) stack.pop()).baseAddress());
-                } break;
-                case DUP: {
+                case DUP ->
                     stack.push(stack.peekLast());
-                } break;
-                default: throw new IllegalArgumentException("Unsupported tag: " + b);
+                default -> throw new IllegalArgumentException("Unsupported tag: " + b);
             }
         }
 

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/CallingSequenceBuilder.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/CallingSequenceBuilder.java
@@ -122,7 +122,7 @@ public class CallingSequenceBuilder {
                     checkType(actualType, MemorySegment.class);
                     stack.push(MemoryAddress.class);
                 } break;
-                case Binding.BOX_ADDRESS_TAG: {
+                case Binding.CONVERT_ADDRESS_TAG: {
                     Class<?> actualType = stack.pop();
                     checkType(actualType, MemoryAddress.class);
                     stack.push(long.class);
@@ -162,7 +162,7 @@ public class CallingSequenceBuilder {
                     Class<?> segmentType = stack.pop();
                     checkType(segmentType, MemorySegment.class);
                 } break;
-                case Binding.BOX_ADDRESS_TAG: {
+                case Binding.CONVERT_ADDRESS_TAG: {
                     Class<?> actualType = stack.pop();
                     checkType(actualType, long.class);
                     stack.push(MemoryAddress.class);

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/CallingSequenceBuilder.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/CallingSequenceBuilder.java
@@ -106,36 +106,36 @@ public class CallingSequenceBuilder {
 
         for (Binding b : bindings) {
             switch (b.tag()) {
-                case Binding.MOVE_TAG: {
+                case MOVE: {
                     Class<?> actualType = stack.pop();
                     Class<?> expectedType = ((Binding.Move) b).type();
                     checkType(actualType, expectedType);
                 } break;
-                case Binding.DEREFERENCE_TAG: {
+                case DEREFERENCE: {
                     Class<?> actualType = stack.pop();
                     checkType(actualType, MemorySegment.class);
                     Class<?> newType = ((Binding.Dereference) b).type();
                     stack.push(newType);
                 } break;
-                case Binding.BASE_ADDRESS_TAG: {
+                case BASE_ADDRESS: {
                     Class<?> actualType = stack.pop();
                     checkType(actualType, MemorySegment.class);
                     stack.push(MemoryAddress.class);
                 } break;
-                case Binding.CONVERT_ADDRESS_TAG: {
+                case CONVERT_ADDRESS: {
                     Class<?> actualType = stack.pop();
                     checkType(actualType, MemoryAddress.class);
                     stack.push(long.class);
                 } break;
-                case Binding.ALLOC_BUFFER_TAG: {
+                case ALLOC_BUFFER: {
                     stack.push(MemorySegment.class);
                 } break;
-                case Binding.COPY_BUFFER_TAG: {
+                case COPY_BUFFER: {
                     Class<?> actualType = stack.pop();
                     checkType(actualType, MemorySegment.class);
                     stack.push(MemorySegment.class);
                 } break;
-                case Binding.DUP_TAG: {
+                case DUP: {
                     stack.push(stack.peekLast());
                 } break;
                 default: throw new IllegalArgumentException("Unknown binding: " + b);
@@ -152,35 +152,35 @@ public class CallingSequenceBuilder {
 
         for (Binding b : bindings) {
             switch (b.tag()) {
-                case Binding.MOVE_TAG: {
+                case MOVE: {
                     Class<?> newType = ((Binding.Move) b).type();
                     stack.push(newType);
                 } break;
-                case Binding.DEREFERENCE_TAG: {
+                case DEREFERENCE: {
                     Class<?> storeType = stack.pop();
                     checkType(storeType, ((Binding.Dereference) b).type());
                     Class<?> segmentType = stack.pop();
                     checkType(segmentType, MemorySegment.class);
                 } break;
-                case Binding.CONVERT_ADDRESS_TAG: {
+                case CONVERT_ADDRESS: {
                     Class<?> actualType = stack.pop();
                     checkType(actualType, long.class);
                     stack.push(MemoryAddress.class);
                 } break;
-                case Binding.BASE_ADDRESS_TAG: {
+                case BASE_ADDRESS: {
                     Class<?> actualType = stack.pop();
                     checkType(actualType, MemorySegment.class);
                     stack.push(MemoryAddress.class);
                 } break;
-                case Binding.ALLOC_BUFFER_TAG: {
+                case ALLOC_BUFFER: {
                     stack.push(MemorySegment.class);
                 } break;
-                case Binding.COPY_BUFFER_TAG: {
+                case COPY_BUFFER: {
                     Class<?> actualType = stack.pop();
                     checkType(actualType, MemoryAddress.class);
                     stack.push(MemorySegment.class);
                 } break;
-                case Binding.DUP_TAG: {
+                case DUP: {
                     stack.push(stack.peekLast());
                 } break;
                 default: throw new IllegalArgumentException("Unknown binding: " + b);

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/CallingSequenceBuilder.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/CallingSequenceBuilder.java
@@ -106,39 +106,37 @@ public class CallingSequenceBuilder {
 
         for (Binding b : bindings) {
             switch (b.tag()) {
-                case MOVE: {
+                case MOVE -> {
                     Class<?> actualType = stack.pop();
                     Class<?> expectedType = ((Binding.Move) b).type();
                     checkType(actualType, expectedType);
-                } break;
-                case DEREFERENCE: {
+                }
+                case DEREFERENCE -> {
                     Class<?> actualType = stack.pop();
                     checkType(actualType, MemorySegment.class);
                     Class<?> newType = ((Binding.Dereference) b).type();
                     stack.push(newType);
-                } break;
-                case BASE_ADDRESS: {
+                }
+                case BASE_ADDRESS -> {
                     Class<?> actualType = stack.pop();
                     checkType(actualType, MemorySegment.class);
                     stack.push(MemoryAddress.class);
-                } break;
-                case CONVERT_ADDRESS: {
+                }
+                case CONVERT_ADDRESS -> {
                     Class<?> actualType = stack.pop();
                     checkType(actualType, MemoryAddress.class);
                     stack.push(long.class);
-                } break;
-                case ALLOC_BUFFER: {
-                    stack.push(MemorySegment.class);
-                } break;
-                case COPY_BUFFER: {
+                }
+                case ALLOC_BUFFER ->
+                    throw new UnsupportedOperationException();
+                case COPY_BUFFER -> {
                     Class<?> actualType = stack.pop();
                     checkType(actualType, MemorySegment.class);
                     stack.push(MemorySegment.class);
-                } break;
-                case DUP: {
+                }
+                case DUP ->
                     stack.push(stack.peekLast());
-                } break;
-                default: throw new IllegalArgumentException("Unknown binding: " + b);
+                default -> throw new IllegalArgumentException("Unknown binding: " + b);
             }
         }
 
@@ -152,38 +150,37 @@ public class CallingSequenceBuilder {
 
         for (Binding b : bindings) {
             switch (b.tag()) {
-                case MOVE: {
+                case MOVE -> {
                     Class<?> newType = ((Binding.Move) b).type();
                     stack.push(newType);
-                } break;
-                case DEREFERENCE: {
+                }
+                case DEREFERENCE -> {
                     Class<?> storeType = stack.pop();
                     checkType(storeType, ((Binding.Dereference) b).type());
                     Class<?> segmentType = stack.pop();
                     checkType(segmentType, MemorySegment.class);
-                } break;
-                case CONVERT_ADDRESS: {
+                }
+                case CONVERT_ADDRESS -> {
                     Class<?> actualType = stack.pop();
                     checkType(actualType, long.class);
                     stack.push(MemoryAddress.class);
-                } break;
-                case BASE_ADDRESS: {
+                }
+                case BASE_ADDRESS -> {
                     Class<?> actualType = stack.pop();
                     checkType(actualType, MemorySegment.class);
                     stack.push(MemoryAddress.class);
-                } break;
-                case ALLOC_BUFFER: {
+                }
+                case ALLOC_BUFFER -> {
                     stack.push(MemorySegment.class);
-                } break;
-                case COPY_BUFFER: {
+                }
+                case COPY_BUFFER -> {
                     Class<?> actualType = stack.pop();
                     checkType(actualType, MemoryAddress.class);
                     stack.push(MemorySegment.class);
-                } break;
-                case DUP: {
+                }
+                case DUP ->
                     stack.push(stack.peekLast());
-                } break;
-                default: throw new IllegalArgumentException("Unknown binding: " + b);
+                default -> throw new IllegalArgumentException("Unknown binding: " + b);
             }
         }
 

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/x64/sysv/CallArranger.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/x64/sysv/CallArranger.java
@@ -55,6 +55,7 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
+import static jdk.internal.foreign.abi.Binding.*;
 import static jdk.internal.foreign.abi.x64.X86_64Architecture.*;
 import static jdk.internal.foreign.abi.x64.sysv.SysVx64ABI.MAX_INTEGER_ARGUMENT_REGISTERS;
 import static jdk.internal.foreign.abi.x64.sysv.SysVx64ABI.MAX_VECTOR_ARGUMENT_REGISTERS;
@@ -119,7 +120,7 @@ public class CallArranger {
         if (!forUpcall) {
             //add extra binding for number of used vector registers (used for variadic calls)
             csb.addArgumentBindings(long.class, MemoryLayouts.SysV.C_LONG,
-                    List.of(new Binding.Move(rax, long.class)));
+                    List.of(move(rax, long.class)));
         }
 
         return new Bindings(csb.build(), returnInMemory, argCalc.storageCalculator.nVectorReg);
@@ -319,28 +320,28 @@ public class CallArranger {
                         VMStorage storage = regs[regIndex++];
                         Class<?> type = SharedUtils.primitiveCarrierForSize(copy);
                         if (offset + copy < layout.byteSize()) {
-                            bindings.add(new Binding.Dup());
+                            bindings.add(dup());
                         }
-                        bindings.add(new Binding.Dereference(offset, type));
-                        bindings.add(new Binding.Move(storage, type));
+                        bindings.add(dereference(offset, type));
+                        bindings.add(move(storage, type));
                         offset += copy;
                     }
                     break;
                 }
                 case POINTER: {
-                    bindings.add(new Binding.BoxAddress());
+                    bindings.add(convertAddress());
                     VMStorage storage = storageCalculator.nextStorage(StorageClasses.INTEGER);
-                    bindings.add(new Binding.Move(storage, long.class));
+                    bindings.add(move(storage, long.class));
                     break;
                 }
                 case INTEGER: {
                     VMStorage storage = storageCalculator.nextStorage(StorageClasses.INTEGER);
-                    bindings.add(new Binding.Move(storage, carrier));
+                    bindings.add(move(storage, carrier));
                     break;
                 }
                 case FLOAT: {
                     VMStorage storage = storageCalculator.nextStorage(StorageClasses.VECTOR);
-                    bindings.add(new Binding.Move(storage, carrier));
+                    bindings.add(move(storage, carrier));
                     break;
                 }
                 default:
@@ -364,35 +365,35 @@ public class CallArranger {
             switch (argumentClass.kind) {
                 case STRUCT: {
                     assert carrier == MemorySegment.class;
-                    bindings.add(new Binding.AllocateBuffer(layout));
+                    bindings.add(allocate(layout));
                     VMStorage[] regs = storageCalculator.structStorages(argumentClass);
                     int regIndex = 0;
                     long offset = 0;
                     while (offset < layout.byteSize()) {
                         final long copy = Math.min(layout.byteSize() - offset, 8);
                         VMStorage storage = regs[regIndex++];
-                        bindings.add(new Binding.Dup());
+                        bindings.add(dup());
                         Class<?> type = SharedUtils.primitiveCarrierForSize(copy);
-                        bindings.add(new Binding.Move(storage, type));
-                        bindings.add(new Binding.Dereference(offset, type));
+                        bindings.add(move(storage, type));
+                        bindings.add(dereference(offset, type));
                         offset += copy;
                     }
                     break;
                 }
                 case POINTER: {
                     VMStorage storage = storageCalculator.nextStorage(StorageClasses.INTEGER);
-                    bindings.add(new Binding.Move(storage, long.class));
-                    bindings.add(new Binding.BoxAddress());
+                    bindings.add(move(storage, long.class));
+                    bindings.add(convertAddress());
                     break;
                 }
                 case INTEGER: {
                     VMStorage storage = storageCalculator.nextStorage(StorageClasses.INTEGER);
-                    bindings.add(new Binding.Move(storage, carrier));
+                    bindings.add(move(storage, carrier));
                     break;
                 }
                 case FLOAT: {
                     VMStorage storage = storageCalculator.nextStorage(StorageClasses.VECTOR);
-                    bindings.add(new Binding.Move(storage, carrier));
+                    bindings.add(move(storage, carrier));
                     break;
                 }
                 default:

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/x64/sysv/CallArranger.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/x64/sysv/CallArranger.java
@@ -120,7 +120,7 @@ public class CallArranger {
         if (!forUpcall) {
             //add extra binding for number of used vector registers (used for variadic calls)
             csb.addArgumentBindings(long.class, MemoryLayouts.SysV.C_LONG,
-                    Binding.builder().move(rax, long.class).build());
+                    List.of(move(rax, long.class)));
         }
 
         return new Bindings(csb.build(), returnInMemory, argCalc.storageCalculator.nVectorReg);

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/x64/windows/CallArranger.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/x64/windows/CallArranger.java
@@ -49,6 +49,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
+import static jdk.internal.foreign.abi.Binding.*;
 import static jdk.internal.foreign.abi.x64.X86_64Architecture.*;
 import static jdk.internal.foreign.abi.x64.windows.Windowsx64ABI.VARARGS_ANNOTATION_NAME;
 
@@ -270,44 +271,44 @@ public class CallArranger {
                     assert carrier == MemorySegment.class;
                     VMStorage storage = storageCalculator.nextStorage(StorageClasses.INTEGER, layout);
                     Class<?> type = SharedUtils.primitiveCarrierForSize(layout.byteSize());
-                    bindings.add(new Binding.Dereference(0, type));
-                    bindings.add(new Binding.Move(storage, type));
+                    bindings.add(dereference(0, type));
+                    bindings.add(move(storage, type));
                     break;
                 }
                 case STRUCT_REFERENCE: {
                     assert carrier == MemorySegment.class;
-                    bindings.add(new Binding.Copy(layout.byteSize(), layout.byteAlignment()));
-                    bindings.add(new Binding.BaseAddress());
-                    bindings.add(new Binding.BoxAddress());
+                    bindings.add(copy(layout));
+                    bindings.add(baseAddress());
+                    bindings.add(convertAddress());
                     VMStorage storage = storageCalculator.nextStorage(StorageClasses.INTEGER, layout);
-                    bindings.add(new Binding.Move(storage, long.class));
+                    bindings.add(move(storage, long.class));
                     break;
                 }
                 case POINTER: {
-                    bindings.add(new Binding.BoxAddress());
+                    bindings.add(convertAddress());
                     VMStorage storage = storageCalculator.nextStorage(StorageClasses.INTEGER, layout);
-                    bindings.add(new Binding.Move(storage, long.class));
+                    bindings.add(move(storage, long.class));
                     break;
                 }
                 case INTEGER: {
                     VMStorage storage = storageCalculator.nextStorage(StorageClasses.INTEGER, layout);
-                    bindings.add(new Binding.Move(storage, carrier));
+                    bindings.add(move(storage, carrier));
                     break;
                 }
                 case FLOAT: {
                     VMStorage storage = storageCalculator.nextStorage(StorageClasses.VECTOR, layout);
-                    bindings.add(new Binding.Move(storage, carrier));
+                    bindings.add(move(storage, carrier));
                     break;
                 }
                 case VARARG_FLOAT: {
                     VMStorage storage = storageCalculator.nextStorage(StorageClasses.VECTOR, layout);
                     if (!INSTANCE.isStackType(storage.type())) { // need extra for register arg
                         VMStorage extraStorage = storageCalculator.extraVarargsStorage();
-                        bindings.add(new Binding.Dup());
-                        bindings.add(new Binding.Move(extraStorage, carrier));
+                        bindings.add(dup());
+                        bindings.add(move(extraStorage, carrier));
                     }
 
-                    bindings.add(new Binding.Move(storage, carrier));
+                    bindings.add(move(storage, carrier));
                     break;
                 }
                 default:
@@ -332,38 +333,38 @@ public class CallArranger {
             switch (argumentClass) {
                 case STRUCT_REGISTER: {
                     assert carrier == MemorySegment.class;
-                    bindings.add(new Binding.AllocateBuffer(layout));
-                    bindings.add(new Binding.Dup());
+                    bindings.add(allocate(layout));
+                    bindings.add(dup());
                     VMStorage storage = storageCalculator.nextStorage(StorageClasses.INTEGER, layout);
                     Class<?> type = SharedUtils.primitiveCarrierForSize(layout.byteSize());
-                    bindings.add(new Binding.Move(storage, type));
-                    bindings.add(new Binding.Dereference(0, type));
+                    bindings.add(move(storage, type));
+                    bindings.add(dereference(0, type));
                     break;
                 }
                 case STRUCT_REFERENCE: {
                     assert carrier == MemorySegment.class;
                     VMStorage storage = storageCalculator.nextStorage(StorageClasses.INTEGER, layout);
-                    bindings.add(new Binding.Move(storage, long.class));
-                    bindings.add(new Binding.BoxAddress());
+                    bindings.add(move(storage, long.class));
+                    bindings.add(convertAddress());
                     // ASSERT SCOPE OF BOXED ADDRESS HERE
                     // caveat. buffer should instead go out of scope after call
-                    bindings.add(new Binding.Copy(layout.byteSize(), layout.byteAlignment()));
+                    bindings.add(copy(layout));
                     break;
                 }
                 case POINTER: {
                     VMStorage storage = storageCalculator.nextStorage(StorageClasses.INTEGER, layout);
-                    bindings.add(new Binding.Move(storage, long.class));
-                    bindings.add(new Binding.BoxAddress());
+                    bindings.add(move(storage, long.class));
+                    bindings.add(convertAddress());
                     break;
                 }
                 case INTEGER: {
                     VMStorage storage = storageCalculator.nextStorage(StorageClasses.INTEGER, layout);
-                    bindings.add(new Binding.Move(storage, carrier));
+                    bindings.add(move(storage, carrier));
                     break;
                 }
                 case FLOAT: {
                     VMStorage storage = storageCalculator.nextStorage(StorageClasses.VECTOR, layout);
-                    bindings.add(new Binding.Move(storage, carrier));
+                    bindings.add(move(storage, carrier));
                     break;
                 }
                 default:

--- a/test/jdk/java/foreign/callarranger/TestAarch64CallArranger.java
+++ b/test/jdk/java/foreign/callarranger/TestAarch64CallArranger.java
@@ -45,6 +45,7 @@ import org.testng.annotations.Test;
 import java.lang.invoke.MethodType;
 
 import static jdk.incubator.foreign.MemoryLayouts.AArch64ABI.*;
+import static jdk.internal.foreign.abi.Binding.*;
 import static jdk.internal.foreign.abi.aarch64.AArch64Architecture.*;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
@@ -86,16 +87,16 @@ public class TestAarch64CallArranger extends CallArrangerTestBase {
         assertEquals(callingSequence.functionDesc(), fd);
 
         checkArgumentBindings(callingSequence, new Binding[][]{
-            { new Binding.Move(r0, int.class) },
-            { new Binding.Move(r1, int.class) },
-            { new Binding.Move(r2, int.class) },
-            { new Binding.Move(r3, int.class) },
-            { new Binding.Move(r4, int.class) },
-            { new Binding.Move(r5, int.class) },
-            { new Binding.Move(r6, int.class) },
-            { new Binding.Move(r7, int.class) },
-            { new Binding.Move(stackStorage(0), int.class) },
-            { new Binding.Move(stackStorage(1), int.class) },
+            { move(r0, int.class) },
+            { move(r1, int.class) },
+            { move(r2, int.class) },
+            { move(r3, int.class) },
+            { move(r4, int.class) },
+            { move(r5, int.class) },
+            { move(r6, int.class) },
+            { move(r7, int.class) },
+            { move(stackStorage(0), int.class) },
+            { move(stackStorage(1), int.class) },
         });
 
         checkReturnBindings(callingSequence, new Binding[]{});
@@ -115,10 +116,10 @@ public class TestAarch64CallArranger extends CallArrangerTestBase {
         assertEquals(callingSequence.functionDesc(), fd);
 
         checkArgumentBindings(callingSequence, new Binding[][]{
-            { new Binding.Move(r0, int.class) },
-            { new Binding.Move(r1, int.class) },
-            { new Binding.Move(v0, float.class) },
-            { new Binding.Move(v1, float.class) },
+            { move(r0, int.class) },
+            { move(r1, int.class) },
+            { move(v0, float.class) },
+            { move(v1, float.class) },
         });
 
         checkReturnBindings(callingSequence, new Binding[]{});
@@ -148,26 +149,26 @@ public class TestAarch64CallArranger extends CallArrangerTestBase {
         return new Object[][]{
             // struct s { int32_t a, b; double c; };
             { MemoryLayout.ofStruct(C_INT, C_INT, C_DOUBLE), new Binding[] {
-                new Binding.Dup(),
+                dup(),
                     // s.a & s.b
-                    new Binding.Dereference(0, long.class), new Binding.Move(r0, long.class),
+                    dereference(0, long.class), move(r0, long.class),
                     // s.c --> note AArch64 passes this in an *integer* register
-                    new Binding.Dereference(8, long.class), new Binding.Move(r1, long.class),
+                    dereference(8, long.class), move(r1, long.class),
             }},
             // struct s { int32_t a, b; double c; int32_t d };
             { struct2, new Binding[] {
-                new Binding.Copy(struct2.byteSize(), struct2.byteAlignment()),
-                new Binding.BaseAddress(),
-                new Binding.BoxAddress(),
-                new Binding.Move(r0, long.class)
+                copy(struct2),
+                baseAddress(),
+                convertAddress(),
+                move(r0, long.class)
             }},
             // struct s { int32_t a[2]; float b[2] };
             { MemoryLayout.ofStruct(C_INT, C_INT, C_FLOAT, C_FLOAT), new Binding[] {
-                new Binding.Dup(),
+                dup(),
                     // s.a[0] & s.a[1]
-                    new Binding.Dereference(0, long.class), new Binding.Move(r0, long.class),
+                    dereference(0, long.class), move(r0, long.class),
                     // s.b[0] & s.b[1]
-                    new Binding.Dereference(8, long.class), new Binding.Move(r1, long.class),
+                    dereference(8, long.class), move(r1, long.class),
             }},
         };
     }
@@ -188,18 +189,18 @@ public class TestAarch64CallArranger extends CallArrangerTestBase {
 
         checkArgumentBindings(callingSequence, new Binding[][]{
             {
-                new Binding.Copy(struct1.byteSize(), struct1.byteAlignment()),
-                new Binding.BaseAddress(),
-                new Binding.BoxAddress(),
-                new Binding.Move(r0, long.class)
+                copy(struct1),
+                baseAddress(),
+                convertAddress(),
+                move(r0, long.class)
             },
             {
-                new Binding.Copy(struct2.byteSize(), struct2.byteAlignment()),
-                new Binding.BaseAddress(),
-                new Binding.BoxAddress(),
-                new Binding.Move(r1, long.class)
+                copy(struct2),
+                baseAddress(),
+                convertAddress(),
+                move(r1, long.class)
             },
-            { new Binding.Move(r2, int.class) }
+            { move(r2, int.class) }
         });
 
         checkReturnBindings(callingSequence, new Binding[]{});
@@ -220,8 +221,8 @@ public class TestAarch64CallArranger extends CallArrangerTestBase {
 
         checkArgumentBindings(callingSequence, new Binding[][]{
             {
-                new Binding.BoxAddress(),
-                new Binding.Move(r8, long.class)
+                convertAddress(),
+                move(r8, long.class)
             }
         });
 
@@ -244,13 +245,13 @@ public class TestAarch64CallArranger extends CallArrangerTestBase {
         checkArgumentBindings(callingSequence, new Binding[][]{});
 
         checkReturnBindings(callingSequence, new Binding[]{
-            new Binding.AllocateBuffer(struct),
-            new Binding.Dup(),
-            new Binding.Move(r0, long.class),
-            new Binding.Dereference(0, long.class),
-            new Binding.Dup(),
-            new Binding.Move(r1, long.class),
-            new Binding.Dereference(8, long.class),
+            allocate(struct),
+            dup(),
+            move(r0, long.class),
+            dereference(0, long.class),
+            dup(),
+            move(r1, long.class),
+            dereference(8, long.class),
         });
     }
 
@@ -268,25 +269,25 @@ public class TestAarch64CallArranger extends CallArrangerTestBase {
         assertEquals(callingSequence.functionDesc(), fd);
 
         checkArgumentBindings(callingSequence, new Binding[][]{
-            { new Binding.Move(v0, float.class) },
-            { new Binding.Move(r0, int.class) },
+            { move(v0, float.class) },
+            { move(r0, int.class) },
             {
-                new Binding.Dup(),
-                new Binding.Dereference(0, int.class),
-                new Binding.Move(v1, int.class),
-                new Binding.Dereference(4, int.class),
-                new Binding.Move(v2, int.class)
+                dup(),
+                dereference(0, int.class),
+                move(v1, int.class),
+                dereference(4, int.class),
+                move(v2, int.class)
             }
         });
 
         checkReturnBindings(callingSequence, new Binding[]{
-            new Binding.AllocateBuffer(hfa),
-            new Binding.Dup(),
-            new Binding.Move(v0, int.class),
-            new Binding.Dereference(0, int.class),
-            new Binding.Dup(),
-            new Binding.Move(v1, int.class),
-            new Binding.Dereference(4, int.class),
+            allocate(hfa),
+            dup(),
+            move(v0, int.class),
+            dereference(0, int.class),
+            dup(),
+            move(v1, int.class),
+            dereference(4, int.class),
         });
     }
 
@@ -305,31 +306,31 @@ public class TestAarch64CallArranger extends CallArrangerTestBase {
 
         checkArgumentBindings(callingSequence, new Binding[][]{
             {
-                new Binding.Dup(),
-                new Binding.Dereference(0, int.class),
-                new Binding.Move(v0, int.class),
-                new Binding.Dup(),
-                new Binding.Dereference(4, int.class),
-                new Binding.Move(v1, int.class),
-                new Binding.Dereference(8, int.class),
-                new Binding.Move(v2, int.class)
+                dup(),
+                dereference(0, int.class),
+                move(v0, int.class),
+                dup(),
+                dereference(4, int.class),
+                move(v1, int.class),
+                dereference(8, int.class),
+                move(v2, int.class)
             },
             {
-                new Binding.Dup(),
-                new Binding.Dereference(0, int.class),
-                new Binding.Move(v3, int.class),
-                new Binding.Dup(),
-                new Binding.Dereference(4, int.class),
-                new Binding.Move(v4, int.class),
-                new Binding.Dereference(8, int.class),
-                new Binding.Move(v5, int.class)
+                dup(),
+                dereference(0, int.class),
+                move(v3, int.class),
+                dup(),
+                dereference(4, int.class),
+                move(v4, int.class),
+                dereference(8, int.class),
+                move(v5, int.class)
             },
             {
-                new Binding.Dup(),
-                new Binding.Dereference(0, long.class),
-                new Binding.Move(stackStorage(0), long.class),
-                new Binding.Dereference(8, long.class),
-                new Binding.Move(stackStorage(1), long.class),
+                dup(),
+                dereference(0, long.class),
+                move(stackStorage(0), long.class),
+                dereference(8, long.class),
+                move(stackStorage(1), long.class),
             }
         });
 

--- a/test/jdk/java/foreign/callarranger/TestSysVCallArranger.java
+++ b/test/jdk/java/foreign/callarranger/TestSysVCallArranger.java
@@ -47,6 +47,7 @@ import java.lang.invoke.MethodType;
 
 import static jdk.incubator.foreign.MemoryLayouts.SysV.*;
 import static jdk.incubator.foreign.MemoryLayouts.WinABI.C_POINTER;
+import static jdk.internal.foreign.abi.Binding.*;
 import static jdk.internal.foreign.abi.x64.X86_64Architecture.*;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
@@ -66,7 +67,7 @@ public class TestSysVCallArranger extends CallArrangerTestBase {
         assertEquals(callingSequence.functionDesc(), descAddArgument(fd, C_LONG));
 
         checkArgumentBindings(callingSequence, new Binding[][]{
-            { new Binding.Move(rax, long.class) }
+            { move(rax, long.class) }
         });
 
         checkReturnBindings(callingSequence, new Binding[]{});
@@ -88,13 +89,13 @@ public class TestSysVCallArranger extends CallArrangerTestBase {
         assertEquals(callingSequence.functionDesc(), descAddArgument(fd, C_LONG));
 
         checkArgumentBindings(callingSequence, new Binding[][]{
-            { new Binding.Move(rdi, int.class) },
-            { new Binding.Move(rsi, int.class) },
-            { new Binding.Move(rdx, int.class) },
-            { new Binding.Move(rcx, int.class) },
-            { new Binding.Move(r8, int.class) },
-            { new Binding.Move(r9, int.class) },
-            { new Binding.Move(rax, long.class) },
+            { move(rdi, int.class) },
+            { move(rsi, int.class) },
+            { move(rdx, int.class) },
+            { move(rcx, int.class) },
+            { move(r8, int.class) },
+            { move(r9, int.class) },
+            { move(rax, long.class) },
         });
 
         checkReturnBindings(callingSequence, new Binding[]{});
@@ -118,15 +119,15 @@ public class TestSysVCallArranger extends CallArrangerTestBase {
         assertEquals(callingSequence.functionDesc(), descAddArgument(fd, C_LONG));
 
         checkArgumentBindings(callingSequence, new Binding[][]{
-            { new Binding.Move(xmm0, double.class) },
-            { new Binding.Move(xmm1, double.class) },
-            { new Binding.Move(xmm2, double.class) },
-            { new Binding.Move(xmm3, double.class) },
-            { new Binding.Move(xmm4, double.class) },
-            { new Binding.Move(xmm5, double.class) },
-            { new Binding.Move(xmm6, double.class) },
-            { new Binding.Move(xmm7, double.class) },
-            { new Binding.Move(rax, long.class) },
+            { move(xmm0, double.class) },
+            { move(xmm1, double.class) },
+            { move(xmm2, double.class) },
+            { move(xmm3, double.class) },
+            { move(xmm4, double.class) },
+            { move(xmm5, double.class) },
+            { move(xmm6, double.class) },
+            { move(xmm7, double.class) },
+            { move(rax, long.class) },
         });
 
         checkReturnBindings(callingSequence, new Binding[]{});
@@ -152,25 +153,25 @@ public class TestSysVCallArranger extends CallArrangerTestBase {
         assertEquals(callingSequence.functionDesc(), descAddArgument(fd, C_LONG));
 
         checkArgumentBindings(callingSequence, new Binding[][]{
-            { new Binding.Move(rdi, long.class) },
-            { new Binding.Move(rsi, long.class) },
-            { new Binding.Move(rdx, long.class) },
-            { new Binding.Move(rcx, long.class) },
-            { new Binding.Move(r8, long.class) },
-            { new Binding.Move(r9, long.class) },
-            { new Binding.Move(stackStorage(0), long.class) },
-            { new Binding.Move(stackStorage(1), long.class) },
-            { new Binding.Move(xmm0, float.class) },
-            { new Binding.Move(xmm1, float.class) },
-            { new Binding.Move(xmm2, float.class) },
-            { new Binding.Move(xmm3, float.class) },
-            { new Binding.Move(xmm4, float.class) },
-            { new Binding.Move(xmm5, float.class) },
-            { new Binding.Move(xmm6, float.class) },
-            { new Binding.Move(xmm7, float.class) },
-            { new Binding.Move(stackStorage(2), float.class) },
-            { new Binding.Move(stackStorage(3), float.class) },
-            { new Binding.Move(rax, long.class) },
+            { move(rdi, long.class) },
+            { move(rsi, long.class) },
+            { move(rdx, long.class) },
+            { move(rcx, long.class) },
+            { move(r8, long.class) },
+            { move(r9, long.class) },
+            { move(stackStorage(0), long.class) },
+            { move(stackStorage(1), long.class) },
+            { move(xmm0, float.class) },
+            { move(xmm1, float.class) },
+            { move(xmm2, float.class) },
+            { move(xmm3, float.class) },
+            { move(xmm4, float.class) },
+            { move(xmm5, float.class) },
+            { move(xmm6, float.class) },
+            { move(xmm7, float.class) },
+            { move(stackStorage(2), float.class) },
+            { move(stackStorage(3), float.class) },
+            { move(rax, long.class) },
         });
 
         checkReturnBindings(callingSequence, new Binding[]{});
@@ -208,20 +209,21 @@ public class TestSysVCallArranger extends CallArrangerTestBase {
         assertEquals(callingSequence.functionDesc(), descAddArgument(fd, C_LONG));
 
         checkArgumentBindings(callingSequence, new Binding[][]{
-            { new Binding.Move(rdi, int.class) },
-            { new Binding.Move(rsi, int.class) },
-            { new Binding.Dup(),
-                new Binding.Dereference(0, long.class), new Binding.Move(rdx, long.class),
-                new Binding.Dereference(8, long.class), new Binding.Move(xmm0, long.class)
+            { move(rdi, int.class) },
+            { move(rsi, int.class) },
+            {
+                dup(),
+                dereference(0, long.class), move(rdx, long.class),
+                dereference(8, long.class), move(xmm0, long.class)
             },
-            { new Binding.Move(rcx, int.class) },
-            { new Binding.Move(r8, int.class) },
-            { new Binding.Move(xmm1, double.class) },
-            { new Binding.Move(xmm2, double.class) },
-            { new Binding.Move(r9, int.class) },
-            { new Binding.Move(stackStorage(0), int.class) },
-            { new Binding.Move(stackStorage(1), int.class) },
-            { new Binding.Move(rax, long.class) },
+            { move(rcx, int.class) },
+            { move(r8, int.class) },
+            { move(xmm1, double.class) },
+            { move(xmm2, double.class) },
+            { move(r9, int.class) },
+            { move(stackStorage(0), int.class) },
+            { move(stackStorage(1), int.class) },
+            { move(rax, long.class) },
         });
 
         checkReturnBindings(callingSequence, new Binding[]{});
@@ -249,8 +251,8 @@ public class TestSysVCallArranger extends CallArrangerTestBase {
         assertEquals(callingSequence.functionDesc(), descAddArgument(fd, C_LONG));
 
         checkArgumentBindings(callingSequence, new Binding[][]{
-            { new Binding.BoxAddress(), new Binding.Move(rdi, long.class) },
-            { new Binding.Move(rax, long.class) },
+            { convertAddress(), move(rdi, long.class) },
+            { move(rax, long.class) },
         });
 
         checkReturnBindings(callingSequence, new Binding[]{});
@@ -271,7 +273,7 @@ public class TestSysVCallArranger extends CallArrangerTestBase {
 
         checkArgumentBindings(callingSequence, new Binding[][]{
             expectedBindings,
-            { new Binding.Move(rax, long.class) },
+            { move(rax, long.class) },
         });
 
         checkReturnBindings(callingSequence, new Binding[]{});
@@ -284,31 +286,31 @@ public class TestSysVCallArranger extends CallArrangerTestBase {
     public static Object[][] structs() {
         return new Object[][]{
             { MemoryLayout.ofStruct(C_ULONG), new Binding[]{
-                    new Binding.Dereference(0, long.class), new Binding.Move(rdi, long.class)
+                    dereference(0, long.class), move(rdi, long.class)
                 }
             },
             { MemoryLayout.ofStruct(C_ULONG, C_ULONG), new Binding[]{
-                    new Binding.Dup(),
-                    new Binding.Dereference(0, long.class), new Binding.Move(rdi, long.class),
-                    new Binding.Dereference(8, long.class), new Binding.Move(rsi, long.class)
+                    dup(),
+                    dereference(0, long.class), move(rdi, long.class),
+                    dereference(8, long.class), move(rsi, long.class)
                 }
             },
             { MemoryLayout.ofStruct(C_ULONG, C_ULONG, C_ULONG), new Binding[]{
-                    new Binding.Dup(),
-                    new Binding.Dereference(0, long.class), new Binding.Move(stackStorage(0), long.class),
-                    new Binding.Dup(),
-                    new Binding.Dereference(8, long.class), new Binding.Move(stackStorage(1), long.class),
-                    new Binding.Dereference(16, long.class), new Binding.Move(stackStorage(2), long.class)
+                    dup(),
+                    dereference(0, long.class), move(stackStorage(0), long.class),
+                    dup(),
+                    dereference(8, long.class), move(stackStorage(1), long.class),
+                    dereference(16, long.class), move(stackStorage(2), long.class)
                 }
             },
             { MemoryLayout.ofStruct(C_ULONG, C_ULONG, C_ULONG, C_ULONG), new Binding[]{
-                    new Binding.Dup(),
-                    new Binding.Dereference(0, long.class), new Binding.Move(stackStorage(0), long.class),
-                    new Binding.Dup(),
-                    new Binding.Dereference(8, long.class), new Binding.Move(stackStorage(1), long.class),
-                    new Binding.Dup(),
-                    new Binding.Dereference(16, long.class), new Binding.Move(stackStorage(2), long.class),
-                    new Binding.Dereference(24, long.class), new Binding.Move(stackStorage(3), long.class)
+                    dup(),
+                    dereference(0, long.class), move(stackStorage(0), long.class),
+                    dup(),
+                    dereference(8, long.class), move(stackStorage(1), long.class),
+                    dup(),
+                    dereference(16, long.class), move(stackStorage(2), long.class),
+                    dereference(24, long.class), move(stackStorage(3), long.class)
                 }
             },
         };
@@ -328,17 +330,17 @@ public class TestSysVCallArranger extends CallArrangerTestBase {
         assertEquals(callingSequence.functionDesc(), descAddArgument(fd, C_LONG));
 
         checkArgumentBindings(callingSequence, new Binding[][]{
-            { new Binding.Move(rax, long.class) }
+            { move(rax, long.class) }
         });
 
         checkReturnBindings(callingSequence, new Binding[] {
-            new Binding.AllocateBuffer(struct),
-            new Binding.Dup(),
-            new Binding.Move(rax, long.class),
-            new Binding.Dereference(0, long.class),
-            new Binding.Dup(),
-            new Binding.Move(rdx, long.class),
-            new Binding.Dereference(8, long.class)
+            allocate(struct),
+            dup(),
+            move(rax, long.class),
+            dereference(0, long.class),
+            dup(),
+            move(rdx, long.class),
+            dereference(8, long.class)
         });
 
         assertEquals(bindings.nVectorArgs, 0);
@@ -358,8 +360,8 @@ public class TestSysVCallArranger extends CallArrangerTestBase {
         assertEquals(callingSequence.functionDesc(), FunctionDescriptor.ofVoid(false, C_POINTER, C_LONG));
 
         checkArgumentBindings(callingSequence, new Binding[][]{
-            { new Binding.BoxAddress(), new Binding.Move(rdi, long.class) },
-            { new Binding.Move(rax, long.class) }
+            { convertAddress(), move(rdi, long.class) },
+            { move(rax, long.class) }
         });
 
         checkReturnBindings(callingSequence, new Binding[] {});

--- a/test/jdk/java/foreign/callarranger/TestWindowsCallArranger.java
+++ b/test/jdk/java/foreign/callarranger/TestWindowsCallArranger.java
@@ -46,6 +46,8 @@ import java.lang.invoke.MethodType;
 
 import static jdk.incubator.foreign.MemoryLayouts.WinABI.*;
 import static jdk.incubator.foreign.MemoryLayouts.WinABI.asVarArg;
+import static jdk.internal.foreign.abi.Binding.*;
+import static jdk.internal.foreign.abi.Binding.copy;
 import static jdk.internal.foreign.abi.x64.X86_64Architecture.*;
 import static org.testng.Assert.*;
 
@@ -78,10 +80,10 @@ public class TestWindowsCallArranger extends CallArrangerTestBase {
         assertEquals(callingSequence.functionDesc(), fd);
 
         checkArgumentBindings(callingSequence, new Binding[][]{
-            { new Binding.Move(rcx, int.class) },
-            { new Binding.Move(rdx, int.class) },
-            { new Binding.Move(r8, int.class) },
-            { new Binding.Move(r9, int.class) }
+            { move(rcx, int.class) },
+            { move(rdx, int.class) },
+            { move(r8, int.class) },
+            { move(r9, int.class) }
         });
 
         checkReturnBindings(callingSequence, new Binding[]{});
@@ -99,10 +101,10 @@ public class TestWindowsCallArranger extends CallArrangerTestBase {
         assertEquals(callingSequence.functionDesc(), fd);
 
         checkArgumentBindings(callingSequence, new Binding[][]{
-            { new Binding.Move(xmm0, double.class) },
-            { new Binding.Move(xmm1, double.class) },
-            { new Binding.Move(xmm2, double.class) },
-            { new Binding.Move(xmm3, double.class) }
+            { move(xmm0, double.class) },
+            { move(xmm1, double.class) },
+            { move(xmm2, double.class) },
+            { move(xmm3, double.class) }
         });
 
         checkReturnBindings(callingSequence, new Binding[]{});
@@ -122,14 +124,14 @@ public class TestWindowsCallArranger extends CallArrangerTestBase {
         assertEquals(callingSequence.functionDesc(), fd);
 
         checkArgumentBindings(callingSequence, new Binding[][]{
-            { new Binding.Move(rcx, long.class) },
-            { new Binding.Move(rdx, long.class) },
-            { new Binding.Move(xmm2, float.class) },
-            { new Binding.Move(xmm3, float.class) },
-            { new Binding.Move(stackStorage(0), long.class) },
-            { new Binding.Move(stackStorage(1), long.class) },
-            { new Binding.Move(stackStorage(2), float.class) },
-            { new Binding.Move(stackStorage(3), float.class) }
+            { move(rcx, long.class) },
+            { move(rdx, long.class) },
+            { move(xmm2, float.class) },
+            { move(xmm3, float.class) },
+            { move(stackStorage(0), long.class) },
+            { move(stackStorage(1), long.class) },
+            { move(stackStorage(2), float.class) },
+            { move(stackStorage(3), float.class) }
         });
 
         checkReturnBindings(callingSequence, new Binding[]{});
@@ -152,20 +154,22 @@ public class TestWindowsCallArranger extends CallArrangerTestBase {
         assertEquals(callingSequence.functionDesc(), fd);
 
         checkArgumentBindings(callingSequence, new Binding[][]{
-            { new Binding.Move(rcx, int.class) },
-            { new Binding.Move(rdx, int.class) },
-            { new Binding.Copy(structLayout.byteSize(), structLayout.byteAlignment()),
-                new Binding.BaseAddress(),
-                new Binding.BoxAddress(),
-                new Binding.Move(r8, long.class) },
-            { new Binding.Move(r9, int.class) },
-            { new Binding.Move(stackStorage(0), int.class) },
-            { new Binding.Move(stackStorage(1), double.class) },
-            { new Binding.Move(stackStorage(2), double.class) },
-            { new Binding.Move(stackStorage(3), double.class) },
-            { new Binding.Move(stackStorage(4), int.class) },
-            { new Binding.Move(stackStorage(5), int.class) },
-            { new Binding.Move(stackStorage(6), int.class) }
+            { move(rcx, int.class) },
+            { move(rdx, int.class) },
+            {
+                copy(structLayout),
+                baseAddress(),
+                convertAddress(),
+                move(r8, long.class)
+            },
+            { move(r9, int.class) },
+            { move(stackStorage(0), int.class) },
+            { move(stackStorage(1), double.class) },
+            { move(stackStorage(2), double.class) },
+            { move(stackStorage(3), double.class) },
+            { move(stackStorage(4), int.class) },
+            { move(stackStorage(5), int.class) },
+            { move(stackStorage(6), int.class) }
         });
 
         checkReturnBindings(callingSequence, new Binding[]{});
@@ -185,11 +189,11 @@ public class TestWindowsCallArranger extends CallArrangerTestBase {
         assertEquals(callingSequence.functionDesc(), fd);
 
         checkArgumentBindings(callingSequence, new Binding[][]{
-            { new Binding.Move(rcx, int.class) },
-            { new Binding.Move(xmm1, double.class) },
-            { new Binding.Move(r8, int.class) },
-            { new Binding.Dup(), new Binding.Move(r9, double.class), new Binding.Move(xmm3, double.class) },
-            { new Binding.Move(stackStorage(0), double.class) },
+            { move(rcx, int.class) },
+            { move(xmm1, double.class) },
+            { move(r8, int.class) },
+            { dup(), move(r9, double.class), move(xmm3, double.class) },
+            { move(stackStorage(0), double.class) },
         });
 
         checkReturnBindings(callingSequence, new Binding[]{});
@@ -218,7 +222,7 @@ public class TestWindowsCallArranger extends CallArrangerTestBase {
         assertEquals(callingSequence.functionDesc(), fd);
 
         checkArgumentBindings(callingSequence, new Binding[][]{
-            { new Binding.Dereference(0, long.class), new Binding.Move(rcx, long.class) }
+            { dereference(0, long.class), move(rcx, long.class) }
         });
 
         checkReturnBindings(callingSequence, new Binding[]{});
@@ -247,10 +251,12 @@ public class TestWindowsCallArranger extends CallArrangerTestBase {
         assertEquals(callingSequence.functionDesc(), fd);
 
         checkArgumentBindings(callingSequence, new Binding[][]{
-            { new Binding.Copy(struct.byteSize(), struct.byteAlignment()),
-                    new Binding.BaseAddress(),
-                    new Binding.BoxAddress(),
-                    new Binding.Move(rcx, long.class) }
+            {
+                copy(struct),
+                baseAddress(),
+                convertAddress(),
+                move(rcx, long.class)
+            }
         });
 
         checkReturnBindings(callingSequence, new Binding[]{});
@@ -276,7 +282,7 @@ public class TestWindowsCallArranger extends CallArrangerTestBase {
         assertEquals(callingSequence.functionDesc(), fd);
 
         checkArgumentBindings(callingSequence, new Binding[][]{
-            { new Binding.BoxAddress(), new Binding.Move(rcx, long.class) }
+            { convertAddress(), move(rcx, long.class) }
         });
 
         checkReturnBindings(callingSequence, new Binding[]{});
@@ -298,10 +304,10 @@ public class TestWindowsCallArranger extends CallArrangerTestBase {
         checkArgumentBindings(callingSequence, new Binding[][]{});
 
         checkReturnBindings(callingSequence,
-            new Binding[]{ new Binding.AllocateBuffer(struct),
-                new Binding.Dup(),
-                new Binding.Move(rax, long.class),
-                new Binding.Dereference(0, long.class) });
+            new Binding[]{ allocate(struct),
+                dup(),
+                move(rax, long.class),
+                dereference(0, long.class) });
     }
 
     @Test
@@ -318,7 +324,7 @@ public class TestWindowsCallArranger extends CallArrangerTestBase {
         assertEquals(callingSequence.functionDesc(), FunctionDescriptor.ofVoid(false, C_POINTER));
 
         checkArgumentBindings(callingSequence, new Binding[][]{
-            { new Binding.BoxAddress(), new Binding.Move(rcx, long.class) }
+            { convertAddress(), move(rcx, long.class) }
         });
 
         checkReturnBindings(callingSequence, new Binding[]{});


### PR DESCRIPTION
Continuation of: https://mail.openjdk.java.net/pipermail/panama-dev/2020-February/007417.html

> Hi,
> 
> Please review the following patch that does a few cleanups of the 
> Binding class implementation:
> - Adds javadoc
> - Uses static factory methods instead of raw constructors. This allows 
> returning singletons for some of the operators for instance.
> - Constructing a COPY_BUFFER binding now requires a MemoryLayout, 
> instead of a separate size & alignment. This was easier given the use-cases.
> - Binding.AllocateBuffer renamed to Binding.Allocate (since we already 
> had Copy as well).
> - BoxAddress renamed to ConvertAddress, as a more general name to 
> describe the boxing & unboxing that can occur. Suggested by Maurizio.
> 
> Webrev: 
> http://cr.openjdk.java.net/~jvernee/panama/webrevs/cleanup_bindings/webrev.00/
> Bugs: https://bugs.openjdk.java.net/browse/JDK-8237359, 
> https://bugs.openjdk.java.net/browse/JDK-8238227, 
> https://bugs.openjdk.java.net/browse/JDK-8238235
> 
> This patch take care of several smaller issues all at once. It applies 
> on top of the JDK-8237360 patch.
> 
> Thanks,
> Jorn
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
## Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

## Issues
[JDK-8237359](https://bugs.openjdk.java.net/browse/JDK-8237359): Use static factory methods to create Binding instances
[JDK-8238227](https://bugs.openjdk.java.net/browse/JDK-8238227): The COPY_BUFFER operator should take a MemoryLayout
[JDK-8238235](https://bugs.openjdk.java.net/browse/JDK-8238235): Add extensive documentation to Binding


## Approvers
 * Maurizio Cimadamore ([mcimadamore](@mcimadamore) - Committer) **Note!** Review applies to 40562472bef72dfc1058fd3aba2b594946190170