### PR TITLE
8238837: AArch64: TestUpcall failures after JDK-8237358

### DIFF
--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/aarch64/CallArranger.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/aarch64/CallArranger.java
@@ -314,8 +314,9 @@ public class CallArranger {
                 if (offset + STACK_SLOT_SIZE < layout.byteSize()) {
                     bindings.dup();
                 }
-                bindings.dereference(offset, long.class)
-                        .move(storage, long.class);
+                Class<?> type = SharedUtils.primitiveCarrierForSize(copy);
+                bindings.dereference(offset, type)
+                        .move(storage, type);
                 offset += STACK_SLOT_SIZE;
             }
         }
@@ -331,9 +332,10 @@ public class CallArranger {
                 long copy = Math.min(layout.byteSize() - offset, STACK_SLOT_SIZE);
                 VMStorage storage =
                     storageCalculator.stackAlloc(copy, STACK_SLOT_SIZE);
+                Class<?> type = SharedUtils.primitiveCarrierForSize(copy);
                 bindings.dup()
-                        .move(storage, long.class)
-                        .dereference(offset, long.class);
+                        .move(storage, type)
+                        .dereference(offset, type);
                 offset += STACK_SLOT_SIZE;
             }
         }

--- a/test/jdk/java/foreign/callarranger/TestAarch64CallArranger.java
+++ b/test/jdk/java/foreign/callarranger/TestAarch64CallArranger.java
@@ -329,8 +329,8 @@ public class TestAarch64CallArranger extends CallArrangerTestBase {
                 dup(),
                 dereference(0, long.class),
                 move(stackStorage(0), long.class),
-                dereference(8, long.class),
-                move(stackStorage(1), long.class),
+                dereference(8, int.class),
+                move(stackStorage(1), int.class),
             }
         });
 


### PR DESCRIPTION
The binding interpreter changes in JDK-8237358 cause a failure on
AArch64 when a struct parameter whose size is not a multiple of 8 is
spilled to the stack. Because the generated bindings dereference the
struct as a series of Java longs, the final long read will read past the
end of the MemorySegment.

Fix by dereferencing using a type that is appropriate for the size to
copy. E.g. long for 8 bytes, int for 4 bytes, etc.

Tested jdk_foreign on aarch64 and x86_64.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
## Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

## Issue
[JDK-8238837](https://bugs.openjdk.java.net/browse/JDK-8238837): AArch64: TestUpcall failures after JDK-8237358


## Approvers
 * Jorn Vernee ([jvernee](@JornVernee) - Committer)