### PR TITLE
8238226: Revisit FunctionDescriptor

### DIFF
--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/AbstractLayout.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/AbstractLayout.java
@@ -201,8 +201,8 @@ abstract class AbstractLayout implements MemoryLayout {
                 MethodTypeDesc.of(CD_GROUP_LAYOUT, CD_LAYOUT.arrayType()));
 
     static final MethodHandleDesc MH_VOID_FUNCTION = MethodHandleDesc.ofMethod(DirectMethodHandleDesc.Kind.INTERFACE_STATIC, CD_FUNCTION_DESC, "ofVoid",
-                MethodTypeDesc.of(CD_FUNCTION_DESC, ConstantDescs.CD_boolean, CD_LAYOUT.arrayType()));
+                MethodTypeDesc.of(CD_FUNCTION_DESC, CD_LAYOUT.arrayType()));
 
     static final MethodHandleDesc MH_FUNCTION = MethodHandleDesc.ofMethod(DirectMethodHandleDesc.Kind.INTERFACE_STATIC, CD_FUNCTION_DESC, "of",
-                MethodTypeDesc.of(CD_FUNCTION_DESC, CD_LAYOUT, ConstantDescs.CD_boolean, CD_LAYOUT.arrayType()));
+                MethodTypeDesc.of(CD_FUNCTION_DESC, CD_LAYOUT, CD_LAYOUT.arrayType()));
 }

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/CallingSequenceBuilder.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/CallingSequenceBuilder.java
@@ -43,7 +43,7 @@ public class CallingSequenceBuilder {
     private List<Binding> ouputBindings = List.of();
 
     private MethodType mt = MethodType.methodType(void.class);
-    private FunctionDescriptor desc = FunctionDescriptor.ofVoid(false);
+    private FunctionDescriptor desc = FunctionDescriptor.ofVoid();
 
     public CallingSequenceBuilder(boolean forUpcall) {
         this.forUpcall = forUpcall;
@@ -54,20 +54,8 @@ public class CallingSequenceBuilder {
         verifyBindings(true, carrier, bindings);
         inputBindings.add(bindings);
         mt = mt.appendParameterTypes(carrier);
-        descAddArgument(layout);
+        desc = desc.appendArgumentLayouts(layout);
         return this;
-    }
-
-    private void descAddArgument(MemoryLayout layout) {
-        boolean isVoid = desc.returnLayout().isEmpty();
-        var args = new ArrayList<>(desc.argumentLayouts());
-        args.add(layout);
-        var argsArray = args.toArray(MemoryLayout[]::new);
-        if (isVoid) {
-            desc = FunctionDescriptor.ofVoid(false, argsArray);
-        } else {
-            desc = FunctionDescriptor.of(desc.returnLayout().get(), false, argsArray);
-        }
     }
 
     public CallingSequenceBuilder setReturnBindings(Class<?> carrier, MemoryLayout layout,
@@ -75,7 +63,7 @@ public class CallingSequenceBuilder {
         verifyBindings(false, carrier, bindings);
         this.ouputBindings = bindings;
         mt = mt.changeReturnType(carrier);
-        desc = FunctionDescriptor.of(layout, false, desc.argumentLayouts().toArray(MemoryLayout[]::new));
+        desc = desc.changeReturnLayout(layout);
         return this;
     }
 

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/aarch64/AArch64ABI.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/aarch64/AArch64ABI.java
@@ -59,19 +59,11 @@ public class AArch64ABI implements SystemABI {
 
     @Override
     public MethodHandle downcallHandle(MemoryAddress symbol, MethodType type, FunctionDescriptor function) {
-        if (function.isVariadic()) {
-            throw new IllegalArgumentException("Variadic function: " + function);
-        }
-
         return CallArranger.arrangeDowncall(MemoryAddressImpl.addressof(symbol), type, function);
     }
 
     @Override
     public MemoryAddress upcallStub(MethodHandle target, FunctionDescriptor function) {
-        if (function.isVariadic()) {
-            throw new IllegalArgumentException("Variadic function: " + function);
-        }
-
         return UpcallStubs.upcallAddress(CallArranger.arrangeUpcall(target, target.type(), function));
     }
 

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/x64/sysv/SysVx64ABI.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/x64/sysv/SysVx64ABI.java
@@ -65,19 +65,11 @@ public class SysVx64ABI implements SystemABI {
 
     @Override
     public MethodHandle downcallHandle(MemoryAddress symbol, MethodType type, FunctionDescriptor function) {
-        if (function.isVariadic()) {
-            throw new IllegalArgumentException("Variadic function: " + function);
-        }
-
         return CallArranger.arrangeDowncall(MemoryAddressImpl.addressof(symbol), type, function);
     }
 
     @Override
     public MemoryAddress upcallStub(MethodHandle target, FunctionDescriptor function) {
-        if (function.isVariadic()) {
-            throw new IllegalArgumentException("Variadic function: " + function);
-        }
-
         return UpcallStubs.upcallAddress(CallArranger.arrangeUpcall(target, target.type(), function));
     }
 

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/x64/windows/Windowsx64ABI.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/x64/windows/Windowsx64ABI.java
@@ -47,7 +47,7 @@ public class Windowsx64ABI implements SystemABI {
     public static final int MAX_REGISTER_ARGUMENTS = 4;
     public static final int MAX_REGISTER_RETURNS = 1;
 
-    public static final String VARARGS_ANNOTATION_NAME = "isVarArg";
+    public static final String VARARGS_ANNOTATION_NAME = "abi/windows/varargs";
 
     private static Windowsx64ABI instance;
 
@@ -60,19 +60,11 @@ public class Windowsx64ABI implements SystemABI {
 
     @Override
     public MethodHandle downcallHandle(MemoryAddress symbol, MethodType type, FunctionDescriptor function) {
-        if (function.isVariadic()) {
-            throw new IllegalArgumentException("Variadic function: " + function);
-        }
-
         return CallArranger.arrangeDowncall(MemoryAddressImpl.addressof(symbol), type, function);
     }
 
     @Override
     public MemoryAddress upcallStub(MethodHandle target, FunctionDescriptor function) {
-        if (function.isVariadic()) {
-            throw new IllegalArgumentException("Variadic function: " + function);
-        }
-
         return UpcallStubs.upcallAddress(CallArranger.arrangeUpcall(target, target.type(), function));
     }
 

--- a/test/jdk/java/foreign/StdLibTest.java
+++ b/test/jdk/java/foreign/StdLibTest.java
@@ -182,30 +182,29 @@ public class StdLibTest extends NativeTestHelper {
 
                 strcat = abi.downcallHandle(lookup.lookup("strcat"),
                         MethodType.methodType(MemoryAddress.class, MemoryAddress.class, MemoryAddress.class),
-                        FunctionDescriptor.of(C_POINTER, false, C_POINTER, C_POINTER));
+                        FunctionDescriptor.of(C_POINTER, C_POINTER, C_POINTER));
 
                 strcmp = abi.downcallHandle(lookup.lookup("strcmp"),
                         MethodType.methodType(int.class, MemoryAddress.class, MemoryAddress.class),
-                        FunctionDescriptor.of(C_INT, false, C_POINTER, C_POINTER));
+                        FunctionDescriptor.of(C_INT, C_POINTER, C_POINTER));
 
                 puts = abi.downcallHandle(lookup.lookup("puts"),
                         MethodType.methodType(int.class, MemoryAddress.class),
-                        FunctionDescriptor.of(C_INT, false, C_POINTER));
+                        FunctionDescriptor.of(C_INT, C_POINTER));
 
                 strlen = abi.downcallHandle(lookup.lookup("strlen"),
                         MethodType.methodType(int.class, MemoryAddress.class),
-                        FunctionDescriptor.of(C_INT, false, C_POINTER));
+                        FunctionDescriptor.of(C_INT, C_POINTER));
 
                 gmtime = abi.downcallHandle(lookup.lookup("gmtime"),
                         MethodType.methodType(MemoryAddress.class, MemoryAddress.class),
-                        FunctionDescriptor.of(C_POINTER, false, C_POINTER));
+                        FunctionDescriptor.of(C_POINTER, C_POINTER));
 
-                qsortComparFunction = FunctionDescriptor.of(C_INT, false,
-                        C_POINTER, C_POINTER);
+                qsortComparFunction = FunctionDescriptor.of(C_INT, C_POINTER, C_POINTER);
 
                 qsort = abi.downcallHandle(lookup.lookup("qsort"),
                         MethodType.methodType(void.class, MemoryAddress.class, long.class, long.class, MemoryAddress.class),
-                        FunctionDescriptor.ofVoid(false, C_POINTER, C_ULONG, C_ULONG, C_POINTER));
+                        FunctionDescriptor.ofVoid(C_POINTER, C_ULONG, C_ULONG, C_POINTER));
 
                 //qsort upcall handle
                 qsortCompar = MethodHandles.lookup().findStatic(StdLibTest.StdLibHelper.class, "qsortCompare",
@@ -213,7 +212,7 @@ public class StdLibTest extends NativeTestHelper {
 
                 rand = abi.downcallHandle(lookup.lookup("rand"),
                         MethodType.methodType(int.class),
-                        FunctionDescriptor.of(C_INT, false));
+                        FunctionDescriptor.of(C_INT));
 
                 printfAddr = lookup.lookup("printf");
             } catch (Throwable ex) {
@@ -354,7 +353,7 @@ public class StdLibTest extends NativeTestHelper {
                 argLayouts.add(arg.layout);
             }
             MethodHandle mh = abi.downcallHandle(printfAddr, mt,
-                    FunctionDescriptor.of(C_INT, false, argLayouts.toArray(new MemoryLayout[0])));
+                    FunctionDescriptor.of(C_INT, argLayouts.toArray(new MemoryLayout[0])));
             return mh.asSpreader(1, Object[].class, args.size());
         }
     }

--- a/test/jdk/java/foreign/StdLibTest.java
+++ b/test/jdk/java/foreign/StdLibTest.java
@@ -346,12 +346,12 @@ public class StdLibTest extends NativeTestHelper {
         private MethodHandle specializedPrintf(List<PrintfArg> args) {
             //method type
             MethodType mt = MethodType.methodType(int.class, MemoryAddress.class);
+            FunctionDescriptor fd = printfBase;
             for (PrintfArg arg : args) {
                 mt = mt.appendParameterTypes(arg.carrier);
+                fd = fd.appendArgumentLayouts(arg.layout);
             }
-            FunctionDescriptor printfSpec = StdLibHelper.printfBase.appendArgumentLayouts(
-                    args.stream().map(a -> a.layout).toArray(MemoryLayout[]::new));
-            MethodHandle mh = abi.downcallHandle(printfAddr, mt, printfSpec);
+            MethodHandle mh = abi.downcallHandle(printfAddr, mt, fd);
             return mh.asSpreader(1, Object[].class, args.size());
         }
     }

--- a/test/jdk/java/foreign/TestDowncall.java
+++ b/test/jdk/java/foreign/TestDowncall.java
@@ -86,8 +86,8 @@ public class TestDowncall extends CallGeneratorHelper {
     static FunctionDescriptor function(Ret ret, List<ParamType> params, List<StructFieldType> fields) {
         MemoryLayout[] paramLayouts = params.stream().map(p -> p.layout(fields)).toArray(MemoryLayout[]::new);
         return ret == Ret.VOID ?
-                FunctionDescriptor.ofVoid(false, paramLayouts) :
-                FunctionDescriptor.of(paramLayouts[0], false, paramLayouts);
+                FunctionDescriptor.ofVoid(paramLayouts) :
+                FunctionDescriptor.of(paramLayouts[0], paramLayouts);
     }
 
     static Object[] makeArgs(List<ParamType> params, List<StructFieldType> fields, List<Consumer<Object>> checks) throws ReflectiveOperationException {

--- a/test/jdk/java/foreign/TestLayoutConstants.java
+++ b/test/jdk/java/foreign/TestLayoutConstants.java
@@ -49,10 +49,10 @@ public class TestLayoutConstants {
     }
 
     @Test(dataProvider = "functions")
-    public void testDescribeResolveFunction(MemoryLayout layout, boolean isVoid, boolean hasVarargs) {
+    public void testDescribeResolveFunction(MemoryLayout layout, boolean isVoid) {
         FunctionDescriptor expected = isVoid ?
-                FunctionDescriptor.ofVoid(hasVarargs, layout) :
-                FunctionDescriptor.of(layout, hasVarargs, layout);
+                FunctionDescriptor.ofVoid(layout) :
+                FunctionDescriptor.of(layout, layout);
         try {
             FunctionDescriptor actual = expected.describeConstable().get()
                     .resolveConstantDesc(MethodHandles.lookup());
@@ -112,20 +112,15 @@ public class TestLayoutConstants {
     @DataProvider(name = "functions")
     public Object[][] createFunctions() {
         Object[][] layouts = createLayouts();
-        Object[][] functions = new Object[layouts.length * 4][];
+        Object[][] functions = new Object[layouts.length * 2][];
         boolean[] values = new boolean[] { true, false };
         for (int i = 0 ; i < layouts.length ; i++) {
-            for (boolean hasVarargs : values) {
-                for (boolean isVoid : values) {
-                    int offset = 0;
-                    if (hasVarargs) {
-                        offset += 1;
-                    }
-                    if (isVoid) {
-                        offset += 2;
-                    }
-                    functions[i * 4 + offset] = new Object[] { layouts[i][0], isVoid, hasVarargs };
+            for (boolean isVoid : values) {
+                int offset = 0;
+                if (isVoid) {
+                    offset += 1;
                 }
+                functions[i * 2 + offset] = new Object[] { layouts[i][0], isVoid };
             }
         }
         return functions;

--- a/test/jdk/java/foreign/TestUpcall.java
+++ b/test/jdk/java/foreign/TestUpcall.java
@@ -75,7 +75,7 @@ public class TestUpcall extends CallGeneratorHelper {
             DUMMY = MethodHandles.lookup().findStatic(TestUpcall.class, "dummy", MethodType.methodType(void.class));
             PASS_AND_SAVE = MethodHandles.lookup().findStatic(TestUpcall.class, "passAndSave", MethodType.methodType(Object.class, Object[].class, AtomicReference.class));
 
-            dummyAddress = abi.upcallStub(DUMMY, FunctionDescriptor.ofVoid(false));
+            dummyAddress = abi.upcallStub(DUMMY, FunctionDescriptor.ofVoid());
             cleaner.register(dummyAddress, () -> abi.freeUpcallStub(dummyAddress));
         } catch (Throwable ex) {
             throw new IllegalStateException(ex);
@@ -116,8 +116,8 @@ public class TestUpcall extends CallGeneratorHelper {
         paramLayouts.add(C_POINTER); // the callback
         MemoryLayout[] layouts = paramLayouts.toArray(new MemoryLayout[0]);
         return ret == Ret.VOID ?
-                FunctionDescriptor.ofVoid(false, layouts) :
-                FunctionDescriptor.of(layouts[0], false, layouts);
+                FunctionDescriptor.ofVoid(layouts) :
+                FunctionDescriptor.of(layouts[0], layouts);
     }
 
     static Object[] makeArgs(Ret ret, List<ParamType> params, List<StructFieldType> fields, List<Consumer<Object>> checks, List<Consumer<Object[]>> argChecks) throws ReflectiveOperationException {
@@ -167,8 +167,8 @@ public class TestUpcall extends CallGeneratorHelper {
 
         MemoryLayout[] paramLayouts = params.stream().map(p -> p.layout(fields)).toArray(MemoryLayout[]::new);
         FunctionDescriptor func = ret != Ret.VOID
-                ? FunctionDescriptor.of(firstlayout, false, paramLayouts)
-                : FunctionDescriptor.ofVoid(false, paramLayouts);
+                ? FunctionDescriptor.of(firstlayout, paramLayouts)
+                : FunctionDescriptor.ofVoid(paramLayouts);
         MemoryAddress stub = abi.upcallStub(mh, func);
         cleaner.register(stub, () -> abi.freeUpcallStub(stub));
         return stub;

--- a/test/jdk/java/foreign/TestUpcallStubs.java
+++ b/test/jdk/java/foreign/TestUpcallStubs.java
@@ -55,7 +55,7 @@ public class TestUpcallStubs {
     }
 
     private static MemoryAddress getStub() {
-        return abi.upcallStub(MH_dummy, FunctionDescriptor.ofVoid(false));
+        return abi.upcallStub(MH_dummy, FunctionDescriptor.ofVoid());
     }
 
     @Test(expectedExceptions = IndexOutOfBoundsException.class)

--- a/test/jdk/java/foreign/TestVarArgs.java
+++ b/test/jdk/java/foreign/TestVarArgs.java
@@ -98,7 +98,7 @@ public class TestVarArgs extends NativeTestHelper {
             argLayouts.add(C_INT); // size
             args.forEach(a -> argLayouts.add(asVarArg(a.layout)));
 
-            FunctionDescriptor desc = FunctionDescriptor.ofVoid(false, argLayouts.toArray(MemoryLayout[]::new));
+            FunctionDescriptor desc = FunctionDescriptor.ofVoid(argLayouts.toArray(MemoryLayout[]::new));
 
             List<Class<?>> carriers = new ArrayList<>();
             carriers.add(MemoryAddress.class); // call info

--- a/test/jdk/java/foreign/callarranger/CallArrangerTestBase.java
+++ b/test/jdk/java/foreign/callarranger/CallArrangerTestBase.java
@@ -47,14 +47,4 @@ public class CallArrangerTestBase {
     public static void checkReturnBindings(CallingSequence callingSequence, Binding[] returnBindings) {
         assertEquals(callingSequence.returnBindings(), Arrays.asList(returnBindings));
     }
-
-    public static FunctionDescriptor descAddArgument(FunctionDescriptor desc, MemoryLayout... layouts) {
-        var args = new ArrayList<>(desc.argumentLayouts());
-        args.addAll(Arrays.asList(layouts));
-        var argsArray = args.toArray(MemoryLayout[]::new);
-        return desc.returnLayout().isEmpty()
-            ? FunctionDescriptor.ofVoid(false, argsArray)
-            : FunctionDescriptor.of(desc.returnLayout().get(), false, argsArray);
-    }
-
 }

--- a/test/jdk/java/foreign/callarranger/TestAarch64CallArranger.java
+++ b/test/jdk/java/foreign/callarranger/TestAarch64CallArranger.java
@@ -56,7 +56,7 @@ public class TestAarch64CallArranger extends CallArrangerTestBase {
     @Test
     public void testEmpty() {
         MethodType mt = MethodType.methodType(void.class);
-        FunctionDescriptor fd = FunctionDescriptor.ofVoid(false);
+        FunctionDescriptor fd = FunctionDescriptor.ofVoid();
         CallArranger.Bindings bindings = CallArranger.getBindings(mt, fd, false);
 
         assertFalse(bindings.isInMemoryReturn);
@@ -75,7 +75,7 @@ public class TestAarch64CallArranger extends CallArrangerTestBase {
                 int.class, int.class, int.class, int.class,
                 int.class, int.class, int.class, int.class,
                 int.class, int.class);
-        FunctionDescriptor fd = FunctionDescriptor.ofVoid(false,
+        FunctionDescriptor fd = FunctionDescriptor.ofVoid(
                 C_INT, C_INT, C_INT, C_INT,
                 C_INT, C_INT, C_INT, C_INT,
                 C_INT, C_INT);
@@ -106,7 +106,7 @@ public class TestAarch64CallArranger extends CallArrangerTestBase {
     public void testTwoIntTwoFloat() {
       MethodType mt = MethodType.methodType(void.class,
                 int.class, int.class, float.class, float.class);
-        FunctionDescriptor fd = FunctionDescriptor.ofVoid(false,
+        FunctionDescriptor fd = FunctionDescriptor.ofVoid(
                 C_INT, C_INT, C_FLOAT, C_FLOAT);
         CallArranger.Bindings bindings = CallArranger.getBindings(mt, fd, false);
 
@@ -128,7 +128,7 @@ public class TestAarch64CallArranger extends CallArrangerTestBase {
     @Test(dataProvider = "structs")
     public void testStruct(MemoryLayout struct, Binding[] expectedBindings) {
         MethodType mt = MethodType.methodType(void.class, MemorySegment.class);
-        FunctionDescriptor fd = FunctionDescriptor.ofVoid(false, struct);
+        FunctionDescriptor fd = FunctionDescriptor.ofVoid(struct);
         CallArranger.Bindings bindings = CallArranger.getBindings(mt, fd, false);
 
         assertFalse(bindings.isInMemoryReturn);
@@ -179,7 +179,7 @@ public class TestAarch64CallArranger extends CallArrangerTestBase {
         MemoryLayout struct2 = MemoryLayout.ofStruct(C_LONG, C_LONG, C_LONG);
 
         MethodType mt = MethodType.methodType(void.class, MemorySegment.class, MemorySegment.class, int.class);
-        FunctionDescriptor fd = FunctionDescriptor.ofVoid(false, struct1, struct2, C_INT);
+        FunctionDescriptor fd = FunctionDescriptor.ofVoid(struct1, struct2, C_INT);
         CallArranger.Bindings bindings = CallArranger.getBindings(mt, fd, false);
 
         assertFalse(bindings.isInMemoryReturn);
@@ -211,13 +211,13 @@ public class TestAarch64CallArranger extends CallArrangerTestBase {
         MemoryLayout struct = MemoryLayout.ofStruct(C_LONG, C_LONG, C_FLOAT);
 
         MethodType mt = MethodType.methodType(MemorySegment.class);
-        FunctionDescriptor fd = FunctionDescriptor.of(struct, false);
+        FunctionDescriptor fd = FunctionDescriptor.of(struct);
         CallArranger.Bindings bindings = CallArranger.getBindings(mt, fd, false);
 
         assertTrue(bindings.isInMemoryReturn);
         CallingSequence callingSequence = bindings.callingSequence;
         assertEquals(callingSequence.methodType(), MethodType.methodType(void.class, MemoryAddress.class));
-        assertEquals(callingSequence.functionDesc(), FunctionDescriptor.ofVoid(false, C_POINTER));
+        assertEquals(callingSequence.functionDesc(), FunctionDescriptor.ofVoid(C_POINTER));
 
         checkArgumentBindings(callingSequence, new Binding[][]{
             {
@@ -234,7 +234,7 @@ public class TestAarch64CallArranger extends CallArrangerTestBase {
         MemoryLayout struct = MemoryLayout.ofStruct(C_LONG, C_LONG);
 
         MethodType mt = MethodType.methodType(MemorySegment.class);
-        FunctionDescriptor fd = FunctionDescriptor.of(struct, false);
+        FunctionDescriptor fd = FunctionDescriptor.of(struct);
         CallArranger.Bindings bindings = CallArranger.getBindings(mt, fd, false);
 
         assertFalse(bindings.isInMemoryReturn);
@@ -260,7 +260,7 @@ public class TestAarch64CallArranger extends CallArrangerTestBase {
         MemoryLayout hfa = MemoryLayout.ofStruct(C_FLOAT, C_FLOAT);
 
         MethodType mt = MethodType.methodType(MemorySegment.class, float.class, int.class, MemorySegment.class);
-        FunctionDescriptor fd = FunctionDescriptor.of(hfa, false, C_FLOAT, C_INT, hfa);
+        FunctionDescriptor fd = FunctionDescriptor.of(hfa, C_FLOAT, C_INT, hfa);
         CallArranger.Bindings bindings = CallArranger.getBindings(mt, fd, false);
 
         assertFalse(bindings.isInMemoryReturn);
@@ -296,7 +296,7 @@ public class TestAarch64CallArranger extends CallArrangerTestBase {
         MemoryLayout struct = MemoryLayout.ofStruct(C_FLOAT, C_FLOAT, C_FLOAT);
 
         MethodType mt = MethodType.methodType(void.class, MemorySegment.class, MemorySegment.class, MemorySegment.class);
-        FunctionDescriptor fd = FunctionDescriptor.ofVoid(false, struct, struct, struct);
+        FunctionDescriptor fd = FunctionDescriptor.ofVoid(struct, struct, struct);
         CallArranger.Bindings bindings = CallArranger.getBindings(mt, fd, false);
 
         assertFalse(bindings.isInMemoryReturn);

--- a/test/jdk/java/foreign/callarranger/TestSysVCallArranger.java
+++ b/test/jdk/java/foreign/callarranger/TestSysVCallArranger.java
@@ -58,13 +58,13 @@ public class TestSysVCallArranger extends CallArrangerTestBase {
     @Test
     public void testEmpty() {
         MethodType mt = MethodType.methodType(void.class);
-        FunctionDescriptor fd = FunctionDescriptor.ofVoid(false);
+        FunctionDescriptor fd = FunctionDescriptor.ofVoid();
         CallArranger.Bindings bindings = CallArranger.getBindings(mt, fd, false);
 
         assertFalse(bindings.isInMemoryReturn);
         CallingSequence callingSequence = bindings.callingSequence;
         assertEquals(callingSequence.methodType(), mt.appendParameterTypes(long.class));
-        assertEquals(callingSequence.functionDesc(), descAddArgument(fd, C_LONG));
+        assertEquals(callingSequence.functionDesc(), fd.appendArgumentLayouts(C_LONG));
 
         checkArgumentBindings(callingSequence, new Binding[][]{
             { move(rax, long.class) }
@@ -79,14 +79,14 @@ public class TestSysVCallArranger extends CallArrangerTestBase {
     public void testIntegerRegs() {
         MethodType mt = MethodType.methodType(void.class,
                 int.class, int.class, int.class, int.class, int.class, int.class);
-        FunctionDescriptor fd = FunctionDescriptor.ofVoid(false,
+        FunctionDescriptor fd = FunctionDescriptor.ofVoid(
                 C_INT, C_INT, C_INT, C_INT, C_INT, C_INT);
         CallArranger.Bindings bindings = CallArranger.getBindings(mt, fd, false);
 
         assertFalse(bindings.isInMemoryReturn);
         CallingSequence callingSequence = bindings.callingSequence;
         assertEquals(callingSequence.methodType(), mt.appendParameterTypes(long.class));
-        assertEquals(callingSequence.functionDesc(), descAddArgument(fd, C_LONG));
+        assertEquals(callingSequence.functionDesc(), fd.appendArgumentLayouts(C_LONG));
 
         checkArgumentBindings(callingSequence, new Binding[][]{
             { move(rdi, int.class) },
@@ -108,7 +108,7 @@ public class TestSysVCallArranger extends CallArrangerTestBase {
         MethodType mt = MethodType.methodType(void.class,
                 double.class, double.class, double.class, double.class,
                 double.class, double.class, double.class, double.class);
-        FunctionDescriptor fd = FunctionDescriptor.ofVoid(false,
+        FunctionDescriptor fd = FunctionDescriptor.ofVoid(
                 C_DOUBLE, C_DOUBLE, C_DOUBLE, C_DOUBLE,
                 C_DOUBLE, C_DOUBLE, C_DOUBLE, C_DOUBLE);
         CallArranger.Bindings bindings = CallArranger.getBindings(mt, fd, false);
@@ -116,7 +116,7 @@ public class TestSysVCallArranger extends CallArrangerTestBase {
         assertFalse(bindings.isInMemoryReturn);
         CallingSequence callingSequence = bindings.callingSequence;
         assertEquals(callingSequence.methodType(), mt.appendParameterTypes(long.class));
-        assertEquals(callingSequence.functionDesc(), descAddArgument(fd, C_LONG));
+        assertEquals(callingSequence.functionDesc(), fd.appendArgumentLayouts(C_LONG));
 
         checkArgumentBindings(callingSequence, new Binding[][]{
             { move(xmm0, double.class) },
@@ -141,7 +141,7 @@ public class TestSysVCallArranger extends CallArrangerTestBase {
                 long.class, long.class, long.class, long.class, long.class, long.class, long.class, long.class,
                 float.class, float.class, float.class, float.class,
                 float.class, float.class, float.class, float.class, float.class, float.class);
-        FunctionDescriptor fd = FunctionDescriptor.ofVoid(false,
+        FunctionDescriptor fd = FunctionDescriptor.ofVoid(
                 C_LONG, C_LONG, C_LONG, C_LONG, C_LONG, C_LONG, C_LONG, C_LONG,
                 C_FLOAT, C_FLOAT, C_FLOAT, C_FLOAT,
                 C_FLOAT, C_FLOAT, C_FLOAT, C_FLOAT, C_FLOAT, C_FLOAT);
@@ -150,7 +150,7 @@ public class TestSysVCallArranger extends CallArrangerTestBase {
         assertFalse(bindings.isInMemoryReturn);
         CallingSequence callingSequence = bindings.callingSequence;
         assertEquals(callingSequence.methodType(), mt.appendParameterTypes(long.class));
-        assertEquals(callingSequence.functionDesc(), descAddArgument(fd, C_LONG));
+        assertEquals(callingSequence.functionDesc(), fd.appendArgumentLayouts(C_LONG));
 
         checkArgumentBindings(callingSequence, new Binding[][]{
             { move(rdi, long.class) },
@@ -199,14 +199,14 @@ public class TestSysVCallArranger extends CallArrangerTestBase {
         MethodType mt = MethodType.methodType(void.class,
                 int.class, int.class, MemorySegment.class, int.class, int.class,
                 double.class, double.class, int.class, int.class, int.class);
-        FunctionDescriptor fd = FunctionDescriptor.ofVoid(false,
+        FunctionDescriptor fd = FunctionDescriptor.ofVoid(
                 C_INT, C_INT, struct, C_INT, C_INT, C_DOUBLE, C_DOUBLE, C_INT, C_INT, C_INT);
         CallArranger.Bindings bindings = CallArranger.getBindings(mt, fd, false);
 
         assertFalse(bindings.isInMemoryReturn);
         CallingSequence callingSequence = bindings.callingSequence;
         assertEquals(callingSequence.methodType(), mt.appendParameterTypes(long.class));
-        assertEquals(callingSequence.functionDesc(), descAddArgument(fd, C_LONG));
+        assertEquals(callingSequence.functionDesc(), fd.appendArgumentLayouts(C_LONG));
 
         checkArgumentBindings(callingSequence, new Binding[][]{
             { move(rdi, int.class) },
@@ -242,13 +242,13 @@ public class TestSysVCallArranger extends CallArrangerTestBase {
     @Test
     public void testMemoryAddress() {
         MethodType mt = MethodType.methodType(void.class, MemoryAddress.class);
-        FunctionDescriptor fd = FunctionDescriptor.ofVoid(false, C_POINTER);
+        FunctionDescriptor fd = FunctionDescriptor.ofVoid( C_POINTER);
         CallArranger.Bindings bindings = CallArranger.getBindings(mt, fd, false);
 
         assertFalse(bindings.isInMemoryReturn);
         CallingSequence callingSequence = bindings.callingSequence;
         assertEquals(callingSequence.methodType(), mt.appendParameterTypes(long.class));
-        assertEquals(callingSequence.functionDesc(), descAddArgument(fd, C_LONG));
+        assertEquals(callingSequence.functionDesc(), fd.appendArgumentLayouts(C_LONG));
 
         checkArgumentBindings(callingSequence, new Binding[][]{
             { convertAddress(), move(rdi, long.class) },
@@ -263,13 +263,13 @@ public class TestSysVCallArranger extends CallArrangerTestBase {
     @Test(dataProvider = "structs")
     public void testStruct(MemoryLayout struct, Binding[] expectedBindings) {
         MethodType mt = MethodType.methodType(void.class, MemorySegment.class);
-        FunctionDescriptor fd = FunctionDescriptor.ofVoid(false, struct);
+        FunctionDescriptor fd = FunctionDescriptor.ofVoid(struct);
         CallArranger.Bindings bindings = CallArranger.getBindings(mt, fd, false);
 
         assertFalse(bindings.isInMemoryReturn);
         CallingSequence callingSequence = bindings.callingSequence;
         assertEquals(callingSequence.methodType(), mt.appendParameterTypes(long.class));
-        assertEquals(callingSequence.functionDesc(), descAddArgument(fd, C_LONG));
+        assertEquals(callingSequence.functionDesc(), fd.appendArgumentLayouts(C_LONG));
 
         checkArgumentBindings(callingSequence, new Binding[][]{
             expectedBindings,
@@ -321,13 +321,13 @@ public class TestSysVCallArranger extends CallArrangerTestBase {
         MemoryLayout struct = MemoryLayout.ofStruct(C_ULONG, C_ULONG);
 
         MethodType mt = MethodType.methodType(MemorySegment.class);
-        FunctionDescriptor fd = FunctionDescriptor.of(struct, false);
+        FunctionDescriptor fd = FunctionDescriptor.of(struct);
         CallArranger.Bindings bindings = CallArranger.getBindings(mt, fd, false);
 
         assertFalse(bindings.isInMemoryReturn);
         CallingSequence callingSequence = bindings.callingSequence;
         assertEquals(callingSequence.methodType(), mt.appendParameterTypes(long.class));
-        assertEquals(callingSequence.functionDesc(), descAddArgument(fd, C_LONG));
+        assertEquals(callingSequence.functionDesc(), fd.appendArgumentLayouts(C_LONG));
 
         checkArgumentBindings(callingSequence, new Binding[][]{
             { move(rax, long.class) }
@@ -351,13 +351,13 @@ public class TestSysVCallArranger extends CallArrangerTestBase {
         MemoryLayout struct = MemoryLayout.ofStruct(C_ULONG, C_ULONG, C_ULONG);
 
         MethodType mt = MethodType.methodType(MemorySegment.class);
-        FunctionDescriptor fd = FunctionDescriptor.of(struct, false);
+        FunctionDescriptor fd = FunctionDescriptor.of(struct);
         CallArranger.Bindings bindings = CallArranger.getBindings(mt, fd, false);
 
         assertTrue(bindings.isInMemoryReturn);
         CallingSequence callingSequence = bindings.callingSequence;
         assertEquals(callingSequence.methodType(), MethodType.methodType(void.class, MemoryAddress.class, long.class));
-        assertEquals(callingSequence.functionDesc(), FunctionDescriptor.ofVoid(false, C_POINTER, C_LONG));
+        assertEquals(callingSequence.functionDesc(), FunctionDescriptor.ofVoid(C_POINTER, C_LONG));
 
         checkArgumentBindings(callingSequence, new Binding[][]{
             { convertAddress(), move(rdi, long.class) },

--- a/test/jdk/java/foreign/callarranger/TestWindowsCallArranger.java
+++ b/test/jdk/java/foreign/callarranger/TestWindowsCallArranger.java
@@ -56,7 +56,7 @@ public class TestWindowsCallArranger extends CallArrangerTestBase {
     @Test
     public void testEmpty() {
         MethodType mt = MethodType.methodType(void.class);
-        FunctionDescriptor fd = FunctionDescriptor.ofVoid(false);
+        FunctionDescriptor fd = FunctionDescriptor.ofVoid();
         CallArranger.Bindings bindings = CallArranger.getBindings(mt, fd, false);
 
         assertFalse(bindings.isInMemoryReturn);
@@ -71,7 +71,7 @@ public class TestWindowsCallArranger extends CallArrangerTestBase {
     @Test
     public void testIntegerRegs() {
         MethodType mt = MethodType.methodType(void.class, int.class, int.class, int.class, int.class);
-        FunctionDescriptor fd = FunctionDescriptor.ofVoid(false, C_INT, C_INT, C_INT, C_INT);
+        FunctionDescriptor fd = FunctionDescriptor.ofVoid(C_INT, C_INT, C_INT, C_INT);
         CallArranger.Bindings bindings = CallArranger.getBindings(mt, fd, false);
 
         assertFalse(bindings.isInMemoryReturn);
@@ -92,7 +92,7 @@ public class TestWindowsCallArranger extends CallArrangerTestBase {
     @Test
     public void testDoubleRegs() {
         MethodType mt = MethodType.methodType(void.class, double.class, double.class, double.class, double.class);
-        FunctionDescriptor fd = FunctionDescriptor.ofVoid(false, C_DOUBLE, C_DOUBLE, C_DOUBLE, C_DOUBLE);
+        FunctionDescriptor fd = FunctionDescriptor.ofVoid(C_DOUBLE, C_DOUBLE, C_DOUBLE, C_DOUBLE);
         CallArranger.Bindings bindings = CallArranger.getBindings(mt, fd, false);
 
         assertFalse(bindings.isInMemoryReturn);
@@ -114,7 +114,7 @@ public class TestWindowsCallArranger extends CallArrangerTestBase {
     public void testMixed() {
         MethodType mt = MethodType.methodType(void.class,
                 long.class, long.class, float.class, float.class, long.class, long.class, float.class, float.class);
-        FunctionDescriptor fd = FunctionDescriptor.ofVoid(false,
+        FunctionDescriptor fd = FunctionDescriptor.ofVoid(
                 C_LONGLONG, C_LONGLONG, C_FLOAT, C_FLOAT, C_LONGLONG, C_LONGLONG, C_FLOAT, C_FLOAT);
         CallArranger.Bindings bindings = CallArranger.getBindings(mt, fd, false);
 
@@ -143,7 +143,7 @@ public class TestWindowsCallArranger extends CallArrangerTestBase {
         MethodType mt = MethodType.methodType(void.class,
                 int.class, int.class, MemorySegment.class, int.class, int.class,
                 double.class, double.class, double.class, int.class, int.class, int.class);
-        FunctionDescriptor fd = FunctionDescriptor.ofVoid(false,
+        FunctionDescriptor fd = FunctionDescriptor.ofVoid(
                 C_INT, C_INT, structLayout, C_INT, C_INT,
                 C_DOUBLE, C_DOUBLE, C_DOUBLE, C_INT, C_INT, C_INT);
         CallArranger.Bindings bindings = CallArranger.getBindings(mt, fd, false);
@@ -179,7 +179,7 @@ public class TestWindowsCallArranger extends CallArrangerTestBase {
     public void testAbiExampleVarargs() {
         MethodType mt = MethodType.methodType(void.class,
                 int.class, double.class, int.class, double.class, double.class);
-        FunctionDescriptor fd = FunctionDescriptor.ofVoid(false,
+        FunctionDescriptor fd = FunctionDescriptor.ofVoid(
                 C_INT, C_DOUBLE, asVarArg(C_INT), asVarArg(C_DOUBLE), asVarArg(C_DOUBLE));
         CallArranger.Bindings bindings = CallArranger.getBindings(mt, fd, false);
 
@@ -213,7 +213,7 @@ public class TestWindowsCallArranger extends CallArrangerTestBase {
         MemoryLayout struct = MemoryLayout.ofStruct(C_ULONGLONG);
 
         MethodType mt = MethodType.methodType(void.class, MemorySegment.class);
-        FunctionDescriptor fd = FunctionDescriptor.ofVoid(false, struct);
+        FunctionDescriptor fd = FunctionDescriptor.ofVoid(struct);
         CallArranger.Bindings bindings = CallArranger.getBindings(mt, fd, false);
 
         assertFalse(bindings.isInMemoryReturn);
@@ -242,7 +242,7 @@ public class TestWindowsCallArranger extends CallArrangerTestBase {
         MemoryLayout struct = MemoryLayout.ofStruct(C_ULONGLONG, C_ULONGLONG);
 
         MethodType mt = MethodType.methodType(void.class, MemorySegment.class);
-        FunctionDescriptor fd = FunctionDescriptor.ofVoid(false, struct);
+        FunctionDescriptor fd = FunctionDescriptor.ofVoid(struct);
         CallArranger.Bindings bindings = CallArranger.getBindings(mt, fd, false);
 
         assertFalse(bindings.isInMemoryReturn);
@@ -273,7 +273,7 @@ public class TestWindowsCallArranger extends CallArrangerTestBase {
     @Test
     public void testMemoryAddress() {
         MethodType mt = MethodType.methodType(void.class, MemoryAddress.class);
-        FunctionDescriptor fd = FunctionDescriptor.ofVoid(false, C_POINTER);
+        FunctionDescriptor fd = FunctionDescriptor.ofVoid(C_POINTER);
         CallArranger.Bindings bindings = CallArranger.getBindings(mt, fd, false);
 
         assertFalse(bindings.isInMemoryReturn);
@@ -293,7 +293,7 @@ public class TestWindowsCallArranger extends CallArrangerTestBase {
         MemoryLayout struct = MemoryLayout.ofStruct(C_ULONGLONG);
 
         MethodType mt = MethodType.methodType(MemorySegment.class);
-        FunctionDescriptor fd = FunctionDescriptor.of(struct, false);
+        FunctionDescriptor fd = FunctionDescriptor.of(struct);
         CallArranger.Bindings bindings = CallArranger.getBindings(mt, fd, false);
 
         assertFalse(bindings.isInMemoryReturn);
@@ -315,13 +315,13 @@ public class TestWindowsCallArranger extends CallArrangerTestBase {
         MemoryLayout struct = MemoryLayout.ofStruct(C_ULONGLONG, C_ULONGLONG);
 
         MethodType mt = MethodType.methodType(MemorySegment.class);
-        FunctionDescriptor fd = FunctionDescriptor.of(struct, false);
+        FunctionDescriptor fd = FunctionDescriptor.of(struct);
         CallArranger.Bindings bindings = CallArranger.getBindings(mt, fd, false);
 
         assertTrue(bindings.isInMemoryReturn);
         CallingSequence callingSequence = bindings.callingSequence;
         assertEquals(callingSequence.methodType(), MethodType.methodType(void.class, MemoryAddress.class));
-        assertEquals(callingSequence.functionDesc(), FunctionDescriptor.ofVoid(false, C_POINTER));
+        assertEquals(callingSequence.functionDesc(), FunctionDescriptor.ofVoid(C_POINTER));
 
         checkArgumentBindings(callingSequence, new Binding[][]{
             { convertAddress(), move(rcx, long.class) }


### PR DESCRIPTION
Continuation of: https://mail.openjdk.java.net/pipermail/panama-dev/2020-February/007418.html

> Hi,
> 
> Please review the following patch that revisits FunctionDescriptor: 1. 
> Adds appendArgumentLayouts, and changeReturnLayout combinator methods. 
> 2. Removes the variadic flag. This flag was not really being used in 
> practice, since we can not link variadic functions directly any ways. 
> Using the new appendArgumentLayouts method we can 'specialize' a base FD 
> with different argument layouts representing vararg arguments. I think 
> if a similar flag is needed in the future, we should consider adding 
> annotations to FunctionDescriptor, and making it an annotation instead, 
> but currently it doesn't seem like it's pulling it's weight by being in 
> the API.
> 
> Webrev: 
> http://cr.openjdk.java.net/~jvernee/panama/webrevs/cleanup_fd/webrev.00/
> Bugs: https://bugs.openjdk.java.net/browse/JDK-8238226, 
> https://bugs.openjdk.java.net/browse/JDK-8237580
> 
> Again, this patch applies on top of the Binding cleanup patch.
> 
> Thanks,
> Jorn
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
## Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

## Issues
[JDK-8238226](https://bugs.openjdk.java.net/browse/JDK-8238226): Add combinators to FunctionDescriptor
[JDK-8237580](https://bugs.openjdk.java.net/browse/JDK-8237580): Add a method for transforming varargs FunctionDescriptors into fixed-arity ones


## Approvers
 * Maurizio Cimadamore ([mcimadamore](@mcimadamore) - Committer)