### PR TITLE
8238712: ConcurrentModificationException thrown when forward reference to record type in function prototype

### DIFF
--- a/src/jdk.incubator.jextract/share/classes/jdk/incubator/jextract/tool/StaticWrapperSourceFactory.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/incubator/jextract/tool/StaticWrapperSourceFactory.java
@@ -25,16 +25,14 @@
 
 package jdk.incubator.jextract.tool;
 
-import jdk.incubator.jextract.Declaration;
-import jdk.incubator.jextract.Type;
+import java.lang.invoke.MethodType;
+import java.util.List;
 import jdk.incubator.foreign.FunctionDescriptor;
 import jdk.incubator.foreign.MemoryAddress;
 import jdk.incubator.foreign.MemoryLayout;
 import jdk.incubator.foreign.MemorySegment;
-
-import java.lang.invoke.MethodType;
-import java.util.List;
-import java.util.stream.Collectors;
+import jdk.incubator.jextract.Declaration;
+import jdk.incubator.jextract.Type;
 
 public class StaticWrapperSourceFactory extends HandleSourceFactory {
     public StaticWrapperSourceFactory(String clsName, String pkgName, List<String> libraryNames) {
@@ -52,6 +50,7 @@ public class StaticWrapperSourceFactory extends HandleSourceFactory {
         FunctionDescriptor descriptor = Type.descriptorFor(funcTree.type()).orElse(null);
         if (descriptor == null) {
             //abort
+            return null;
         }
         builder.addMethodHandle(funcTree, mtype, descriptor);
         //generate static wrapper for function

--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/TreeMaker.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/TreeMaker.java
@@ -25,6 +25,18 @@
  */
 package jdk.internal.jextract.impl;
 
+import java.nio.ByteOrder;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.ConcurrentModificationException;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
 import jdk.incubator.foreign.GroupLayout;
 import jdk.incubator.foreign.MemoryLayout;
 import jdk.incubator.jextract.Declaration;
@@ -34,18 +46,6 @@ import jdk.internal.clang.Cursor;
 import jdk.internal.clang.CursorKind;
 import jdk.internal.clang.SourceLocation;
 
-import java.nio.ByteOrder;
-import java.nio.file.Path;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Optional;
-import java.util.function.Supplier;
-import java.util.stream.Collectors;
-
 class TreeMaker {
     private final Map<Cursor, Declaration> treeCache = new HashMap<>();
 
@@ -54,7 +54,18 @@ class TreeMaker {
     TypeMaker typeMaker = new TypeMaker(this);
 
     private <T extends Declaration> T checkCache(Cursor c, Class<T> clazz, Supplier<Declaration> factory) {
-        return clazz.cast(treeCache.computeIfAbsent(c, cx->factory.get()));
+        // The supplier function may lead to adding some other type, which will cause CME using computeIfAbsent.
+        // This implementation relax the constraint a bit only check for same key
+        Declaration rv;
+        if (treeCache.containsKey(c)) {
+            rv = treeCache.get(c);
+        } else {
+            rv = factory.get();
+            if (null != rv && treeCache.put(c, rv) != null) {
+                throw new ConcurrentModificationException();
+            }
+        }
+        return clazz.cast(rv);
     }
 
     interface ScopedFactoryLayout {

--- a/test/jdk/java/jextract/Test8238712.h
+++ b/test/jdk/java/jextract/Test8238712.h
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ *  Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+// Forward reference of struct to cause ConcurrentModificationException
+struct foo;
+
+// Declaration above is required, without it, the argument s cause
+// a C warning as struct foo only visible to the function.
+int withRecordTypeArg(int n, struct foo s);
+struct foo returnRecordType(void);
+
+// Improper header may write such with definition in other file
+struct bar returnBar(void);
+void withBar(struct bar s);
+
+struct bar *nextBar(struct bar *current);
+
+struct foo {
+    int n;
+    struct foo *ptr;
+};


### PR DESCRIPTION
CME get thrown when nested call of createTree introduce a new declaration into the map, this is too restrictive as demonstrated by the test case that it is likely to happen when forward reference of a struct, which will introduce a new declaration while processing the function declaration.

The fix allows nested call to add new declaration and only throw CME if replace actually happens.

Also included a minor fix that should abort generate function or could cause NPE.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
## Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

## Issue
[JDK-8238712](https://bugs.openjdk.java.net/browse/JDK-8238712): ConcurrentModificationException thrown when forward reference to record type in function prototype


## Approvers
 * Maurizio Cimadamore ([mcimadamore](@mcimadamore) - Committer)