### PR TITLE
8238951: Update jextract after JDK-8238226

### DIFF
--- a/src/jdk.incubator.jextract/share/classes/jdk/incubator/jextract/tool/JavaSourceBuilder.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/incubator/jextract/tool/JavaSourceBuilder.java
@@ -225,6 +225,9 @@ class JavaSourceBuilder {
         sb.append("\"" + mtype.toMethodDescriptorString() + "\",\n");
         indent();
         addFunction(desc);
+        sb.append(",\n");
+        indent();
+        sb.append(funcTree.type().varargs());
         decrAlign();
         sb.append("\n");
         indent();
@@ -244,9 +247,8 @@ class JavaSourceBuilder {
         } else {
             sb.append("FunctionDescriptor.ofVoid(");
         }
-        sb.append(f.isVariadic());
         if (!f.argumentLayouts().isEmpty()) {
-            sb.append(",\n");
+            sb.append("\n");
             incrAlign();
             String delim = "";
             for (MemoryLayout e : f.argumentLayouts()) {

--- a/src/jdk.incubator.jextract/share/classes/jdk/incubator/jextract/tool/resources/RuntimeHelper.template
+++ b/src/jdk.incubator.jextract/share/classes/jdk/incubator/jextract/tool/resources/RuntimeHelper.template
@@ -51,11 +51,11 @@ public class RuntimeHelper {
         return lookup(LIBRARIES, name).orElse(null);
     }
 
-    public static final MethodHandle downcallHandle(LibraryLookup[] LIBRARIES, String name, String desc, FunctionDescriptor fdesc) {
+    public static final MethodHandle downcallHandle(LibraryLookup[] LIBRARIES, String name, String desc, FunctionDescriptor fdesc, boolean variadic) {
         return lookup(LIBRARIES, name).map(
                 addr -> {
                     MethodType mt = MethodType.fromMethodDescriptorString(desc, LOADER);
-                    return fdesc.isVariadic() ?
+                    return variadic ?
                         VarargsInvoker.make(addr, mt, fdesc) :
                         ABI.downcallHandle(addr, mt, fdesc);
                 }).orElse(null);
@@ -129,8 +129,8 @@ public class RuntimeHelper {
 
             MethodType mt = MethodType.methodType(varargs.returnType(), argTypes);
             FunctionDescriptor f = (function.returnLayout().isEmpty()) ?
-                    FunctionDescriptor.ofVoid(false, argLayouts) :
-                    FunctionDescriptor.of(function.returnLayout().get(), false, argLayouts);
+                    FunctionDescriptor.ofVoid(argLayouts) :
+                    FunctionDescriptor.of(function.returnLayout().get(), argLayouts);
             MethodHandle mh = SystemABI.getInstance().downcallHandle(symbol, mt, f);
             // flatten argument list so that it can be passed to an asSpreader MH
             Object[] allArgs = new Object[nNamedArgs + unnamedArgs.length];

--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/clang/Utils.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/clang/Utils.java
@@ -55,12 +55,12 @@ public class Utils {
             STRLEN = SystemABI.getInstance().downcallHandle(
                     LibraryLookup.ofDefault().lookup("strlen"),
                     MethodType.methodType(int.class, MemoryAddress.class),
-                    FunctionDescriptor.of(LayoutUtils.C_INT, false, LayoutUtils.C_POINTER));
+                    FunctionDescriptor.of(LayoutUtils.C_INT, LayoutUtils.C_POINTER));
 
             STRCPY = SystemABI.getInstance().downcallHandle(
                     LibraryLookup.ofDefault().lookup("strcpy"),
                     MethodType.methodType(MemoryAddress.class, MemoryAddress.class, MemoryAddress.class),
-                    FunctionDescriptor.of(LayoutUtils.C_POINTER, false, LayoutUtils.C_POINTER, LayoutUtils.C_POINTER));
+                    FunctionDescriptor.of(LayoutUtils.C_POINTER, LayoutUtils.C_POINTER, LayoutUtils.C_POINTER));
         } catch (Throwable ex) {
             throw new ExceptionInInitializerError(ex);
         }

--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/clang/libclang/Index_h.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/clang/libclang/Index_h.java
@@ -42,7 +42,14 @@ import static jdk.internal.jextract.impl.LayoutUtils.*;
         
 public final class Index_h {
 
-    private static final LibraryLookup[] LIBRARIES = RuntimeHelper.libraries(new String[] {"clang"}, new String[] {});
+    private static String libName() {
+        if (System.getProperty("os.name").startsWith("Windows")) {
+            return "libclang";
+        }
+        return "clang";
+    }
+
+    private static final LibraryLookup[] LIBRARIES = RuntimeHelper.libraries(new String[] {libName()}, new String[] {});
     public static final long NULL = 0L;
     public static final int CINDEX_VERSION_MAJOR = (int)0L;
     public static final int CINDEX_VERSION_MINOR = (int)59L;

--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/clang/libclang/Index_h.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/clang/libclang/Index_h.java
@@ -86,7 +86,7 @@ public final class Index_h {
     public static final MethodHandle clang_getCString = RuntimeHelper.downcallHandle(
         LIBRARIES, "clang_getCString",
         "(Ljdk/incubator/foreign/MemorySegment;)Ljdk/incubator/foreign/MemoryAddress;",
-        FunctionDescriptor.of(C_POINTER, false,
+        FunctionDescriptor.of(C_POINTER,
             MemoryLayout.ofStruct(
                 C_POINTER.withName("data"),
                 C_INT.withName("private_flags"),
@@ -104,7 +104,7 @@ public final class Index_h {
     public static final MethodHandle clang_disposeString = RuntimeHelper.downcallHandle(
         LIBRARIES, "clang_disposeString",
         "(Ljdk/incubator/foreign/MemorySegment;)V",
-        FunctionDescriptor.ofVoid(false,
+        FunctionDescriptor.ofVoid(
             MemoryLayout.ofStruct(
                 C_POINTER.withName("data"),
                 C_INT.withName("private_flags"),
@@ -122,7 +122,7 @@ public final class Index_h {
     public static final MethodHandle clang_disposeStringSet = RuntimeHelper.downcallHandle(
         LIBRARIES, "clang_disposeStringSet",
         "(Ljdk/incubator/foreign/MemoryAddress;)V",
-        FunctionDescriptor.ofVoid(false,
+        FunctionDescriptor.ofVoid(
             C_POINTER
         )
     );
@@ -136,7 +136,7 @@ public final class Index_h {
     public static final MethodHandle clang_getBuildSessionTimestamp = RuntimeHelper.downcallHandle(
         LIBRARIES, "clang_getBuildSessionTimestamp",
         "()J",
-        FunctionDescriptor.of(C_LONGLONG, false)
+        FunctionDescriptor.of(C_LONGLONG)
     );
     public static final long clang_getBuildSessionTimestamp () {
         try {
@@ -148,7 +148,7 @@ public final class Index_h {
     public static final MethodHandle clang_VirtualFileOverlay_create = RuntimeHelper.downcallHandle(
         LIBRARIES, "clang_VirtualFileOverlay_create",
         "(I)Ljdk/incubator/foreign/MemoryAddress;",
-        FunctionDescriptor.of(C_POINTER, false,
+        FunctionDescriptor.of(C_POINTER,
             C_INT
         )
     );
@@ -162,7 +162,7 @@ public final class Index_h {
     public static final MethodHandle clang_VirtualFileOverlay_addFileMapping = RuntimeHelper.downcallHandle(
         LIBRARIES, "clang_VirtualFileOverlay_addFileMapping",
         "(Ljdk/incubator/foreign/MemoryAddress;Ljdk/incubator/foreign/MemoryAddress;Ljdk/incubator/foreign/MemoryAddress;)I",
-        FunctionDescriptor.of(C_INT, false,
+        FunctionDescriptor.of(C_INT,
             C_POINTER,
             C_POINTER,
             C_POINTER
@@ -178,7 +178,7 @@ public final class Index_h {
     public static final MethodHandle clang_VirtualFileOverlay_setCaseSensitivity = RuntimeHelper.downcallHandle(
         LIBRARIES, "clang_VirtualFileOverlay_setCaseSensitivity",
         "(Ljdk/incubator/foreign/MemoryAddress;I)I",
-        FunctionDescriptor.of(C_INT, false,
+        FunctionDescriptor.of(C_INT,
             C_POINTER,
             C_INT
         )
@@ -193,7 +193,7 @@ public final class Index_h {
     public static final MethodHandle clang_VirtualFileOverlay_writeToBuffer = RuntimeHelper.downcallHandle(
         LIBRARIES, "clang_VirtualFileOverlay_writeToBuffer",
         "(Ljdk/incubator/foreign/MemoryAddress;ILjdk/incubator/foreign/MemoryAddress;Ljdk/incubator/foreign/MemoryAddress;)I",
-        FunctionDescriptor.of(C_INT, false,
+        FunctionDescriptor.of(C_INT,
             C_POINTER,
             C_INT,
             C_POINTER,
@@ -210,7 +210,7 @@ public final class Index_h {
     public static final MethodHandle clang_free = RuntimeHelper.downcallHandle(
         LIBRARIES, "clang_free",
         "(Ljdk/incubator/foreign/MemoryAddress;)V",
-        FunctionDescriptor.ofVoid(false,
+        FunctionDescriptor.ofVoid(
             C_POINTER
         )
     );
@@ -224,7 +224,7 @@ public final class Index_h {
     public static final MethodHandle clang_VirtualFileOverlay_dispose = RuntimeHelper.downcallHandle(
         LIBRARIES, "clang_VirtualFileOverlay_dispose",
         "(Ljdk/incubator/foreign/MemoryAddress;)V",
-        FunctionDescriptor.ofVoid(false,
+        FunctionDescriptor.ofVoid(
             C_POINTER
         )
     );
@@ -238,7 +238,7 @@ public final class Index_h {
     public static final MethodHandle clang_ModuleMapDescriptor_create = RuntimeHelper.downcallHandle(
         LIBRARIES, "clang_ModuleMapDescriptor_create",
         "(I)Ljdk/incubator/foreign/MemoryAddress;",
-        FunctionDescriptor.of(C_POINTER, false,
+        FunctionDescriptor.of(C_POINTER,
             C_INT
         )
     );
@@ -252,7 +252,7 @@ public final class Index_h {
     public static final MethodHandle clang_ModuleMapDescriptor_setFrameworkModuleName = RuntimeHelper.downcallHandle(
         LIBRARIES, "clang_ModuleMapDescriptor_setFrameworkModuleName",
         "(Ljdk/incubator/foreign/MemoryAddress;Ljdk/incubator/foreign/MemoryAddress;)I",
-        FunctionDescriptor.of(C_INT, false,
+        FunctionDescriptor.of(C_INT,
             C_POINTER,
             C_POINTER
         )
@@ -267,7 +267,7 @@ public final class Index_h {
     public static final MethodHandle clang_ModuleMapDescriptor_setUmbrellaHeader = RuntimeHelper.downcallHandle(
         LIBRARIES, "clang_ModuleMapDescriptor_setUmbrellaHeader",
         "(Ljdk/incubator/foreign/MemoryAddress;Ljdk/incubator/foreign/MemoryAddress;)I",
-        FunctionDescriptor.of(C_INT, false,
+        FunctionDescriptor.of(C_INT,
             C_POINTER,
             C_POINTER
         )
@@ -282,7 +282,7 @@ public final class Index_h {
     public static final MethodHandle clang_ModuleMapDescriptor_writeToBuffer = RuntimeHelper.downcallHandle(
         LIBRARIES, "clang_ModuleMapDescriptor_writeToBuffer",
         "(Ljdk/incubator/foreign/MemoryAddress;ILjdk/incubator/foreign/MemoryAddress;Ljdk/incubator/foreign/MemoryAddress;)I",
-        FunctionDescriptor.of(C_INT, false,
+        FunctionDescriptor.of(C_INT,
             C_POINTER,
             C_INT,
             C_POINTER,
@@ -299,7 +299,7 @@ public final class Index_h {
     public static final MethodHandle clang_ModuleMapDescriptor_dispose = RuntimeHelper.downcallHandle(
         LIBRARIES, "clang_ModuleMapDescriptor_dispose",
         "(Ljdk/incubator/foreign/MemoryAddress;)V",
-        FunctionDescriptor.ofVoid(false,
+        FunctionDescriptor.ofVoid(
             C_POINTER
         )
     );
@@ -365,7 +365,7 @@ public final class Index_h {
     public static final MethodHandle clang_createIndex = RuntimeHelper.downcallHandle(
         LIBRARIES, "clang_createIndex",
         "(II)Ljdk/incubator/foreign/MemoryAddress;",
-        FunctionDescriptor.of(C_POINTER, false,
+        FunctionDescriptor.of(C_POINTER,
             C_INT,
             C_INT
         )
@@ -380,7 +380,7 @@ public final class Index_h {
     public static final MethodHandle clang_disposeIndex = RuntimeHelper.downcallHandle(
         LIBRARIES, "clang_disposeIndex",
         "(Ljdk/incubator/foreign/MemoryAddress;)V",
-        FunctionDescriptor.ofVoid(false,
+        FunctionDescriptor.ofVoid(
             C_POINTER
         )
     );
@@ -398,7 +398,7 @@ public final class Index_h {
     public static final MethodHandle clang_CXIndex_setGlobalOptions = RuntimeHelper.downcallHandle(
         LIBRARIES, "clang_CXIndex_setGlobalOptions",
         "(Ljdk/incubator/foreign/MemoryAddress;I)V",
-        FunctionDescriptor.ofVoid(false,
+        FunctionDescriptor.ofVoid(
             C_POINTER,
             C_INT
         )
@@ -413,7 +413,7 @@ public final class Index_h {
     public static final MethodHandle clang_CXIndex_getGlobalOptions = RuntimeHelper.downcallHandle(
         LIBRARIES, "clang_CXIndex_getGlobalOptions",
         "(Ljdk/incubator/foreign/MemoryAddress;)I",
-        FunctionDescriptor.of(C_INT, false,
+        FunctionDescriptor.of(C_INT,
             C_POINTER
         )
     );
@@ -427,7 +427,7 @@ public final class Index_h {
     public static final MethodHandle clang_CXIndex_setInvocationEmissionPathOption = RuntimeHelper.downcallHandle(
         LIBRARIES, "clang_CXIndex_setInvocationEmissionPathOption",
         "(Ljdk/incubator/foreign/MemoryAddress;Ljdk/incubator/foreign/MemoryAddress;)V",
-        FunctionDescriptor.ofVoid(false,
+        FunctionDescriptor.ofVoid(
             C_POINTER,
             C_POINTER
         )
@@ -446,7 +446,7 @@ public final class Index_h {
             C_POINTER.withName("data"),
             C_INT.withName("private_flags"),
             MemoryLayout.ofPaddingBits(32)
-        ), false,
+        ),
             C_POINTER
         )
     );
@@ -460,7 +460,7 @@ public final class Index_h {
     public static final MethodHandle clang_getFileTime = RuntimeHelper.downcallHandle(
         LIBRARIES, "clang_getFileTime",
         "(Ljdk/incubator/foreign/MemoryAddress;)J",
-        FunctionDescriptor.of(C_LONGLONG, false,
+        FunctionDescriptor.of(C_LONGLONG,
             C_POINTER
         )
     );
@@ -477,7 +477,7 @@ public final class Index_h {
     public static final MethodHandle clang_getFileUniqueID = RuntimeHelper.downcallHandle(
         LIBRARIES, "clang_getFileUniqueID",
         "(Ljdk/incubator/foreign/MemoryAddress;Ljdk/incubator/foreign/MemoryAddress;)I",
-        FunctionDescriptor.of(C_INT, false,
+        FunctionDescriptor.of(C_INT,
             C_POINTER,
             C_POINTER
         )
@@ -492,7 +492,7 @@ public final class Index_h {
     public static final MethodHandle clang_isFileMultipleIncludeGuarded = RuntimeHelper.downcallHandle(
         LIBRARIES, "clang_isFileMultipleIncludeGuarded",
         "(Ljdk/incubator/foreign/MemoryAddress;Ljdk/incubator/foreign/MemoryAddress;)I",
-        FunctionDescriptor.of(C_INT, false,
+        FunctionDescriptor.of(C_INT,
             C_POINTER,
             C_POINTER
         )
@@ -507,7 +507,7 @@ public final class Index_h {
     public static final MethodHandle clang_getFile = RuntimeHelper.downcallHandle(
         LIBRARIES, "clang_getFile",
         "(Ljdk/incubator/foreign/MemoryAddress;Ljdk/incubator/foreign/MemoryAddress;)Ljdk/incubator/foreign/MemoryAddress;",
-        FunctionDescriptor.of(C_POINTER, false,
+        FunctionDescriptor.of(C_POINTER,
             C_POINTER,
             C_POINTER
         )
@@ -522,7 +522,7 @@ public final class Index_h {
     public static final MethodHandle clang_getFileContents = RuntimeHelper.downcallHandle(
         LIBRARIES, "clang_getFileContents",
         "(Ljdk/incubator/foreign/MemoryAddress;Ljdk/incubator/foreign/MemoryAddress;Ljdk/incubator/foreign/MemoryAddress;)Ljdk/incubator/foreign/MemoryAddress;",
-        FunctionDescriptor.of(C_POINTER, false,
+        FunctionDescriptor.of(C_POINTER,
             C_POINTER,
             C_POINTER,
             C_POINTER
@@ -538,7 +538,7 @@ public final class Index_h {
     public static final MethodHandle clang_File_isEqual = RuntimeHelper.downcallHandle(
         LIBRARIES, "clang_File_isEqual",
         "(Ljdk/incubator/foreign/MemoryAddress;Ljdk/incubator/foreign/MemoryAddress;)I",
-        FunctionDescriptor.of(C_INT, false,
+        FunctionDescriptor.of(C_INT,
             C_POINTER,
             C_POINTER
         )
@@ -557,7 +557,7 @@ public final class Index_h {
             C_POINTER.withName("data"),
             C_INT.withName("private_flags"),
             MemoryLayout.ofPaddingBits(32)
-        ), false,
+        ),
             C_POINTER
         )
     );
@@ -606,7 +606,7 @@ public final class Index_h {
             MemoryLayout.ofSequence(2, C_POINTER).withName("ptr_data"),
             C_INT.withName("int_data"),
             MemoryLayout.ofPaddingBits(32)
-        ), false)
+        ))
     );
     public static final MemorySegment clang_getNullLocation () {
         try {
@@ -618,7 +618,7 @@ public final class Index_h {
     public static final MethodHandle clang_equalLocations = RuntimeHelper.downcallHandle(
         LIBRARIES, "clang_equalLocations",
         "(Ljdk/incubator/foreign/MemorySegment;Ljdk/incubator/foreign/MemorySegment;)I",
-        FunctionDescriptor.of(C_INT, false,
+        FunctionDescriptor.of(C_INT,
             MemoryLayout.ofStruct(
                 MemoryLayout.ofSequence(2, C_POINTER).withName("ptr_data"),
                 C_INT.withName("int_data"),
@@ -645,7 +645,7 @@ public final class Index_h {
             MemoryLayout.ofSequence(2, C_POINTER).withName("ptr_data"),
             C_INT.withName("int_data"),
             MemoryLayout.ofPaddingBits(32)
-        ), false,
+        ),
             C_POINTER,
             C_POINTER,
             C_INT,
@@ -666,7 +666,7 @@ public final class Index_h {
             MemoryLayout.ofSequence(2, C_POINTER).withName("ptr_data"),
             C_INT.withName("int_data"),
             MemoryLayout.ofPaddingBits(32)
-        ), false,
+        ),
             C_POINTER,
             C_POINTER,
             C_INT
@@ -682,7 +682,7 @@ public final class Index_h {
     public static final MethodHandle clang_Location_isInSystemHeader = RuntimeHelper.downcallHandle(
         LIBRARIES, "clang_Location_isInSystemHeader",
         "(Ljdk/incubator/foreign/MemorySegment;)I",
-        FunctionDescriptor.of(C_INT, false,
+        FunctionDescriptor.of(C_INT,
             MemoryLayout.ofStruct(
                 MemoryLayout.ofSequence(2, C_POINTER).withName("ptr_data"),
                 C_INT.withName("int_data"),
@@ -700,7 +700,7 @@ public final class Index_h {
     public static final MethodHandle clang_Location_isFromMainFile = RuntimeHelper.downcallHandle(
         LIBRARIES, "clang_Location_isFromMainFile",
         "(Ljdk/incubator/foreign/MemorySegment;)I",
-        FunctionDescriptor.of(C_INT, false,
+        FunctionDescriptor.of(C_INT,
             MemoryLayout.ofStruct(
                 MemoryLayout.ofSequence(2, C_POINTER).withName("ptr_data"),
                 C_INT.withName("int_data"),
@@ -722,7 +722,7 @@ public final class Index_h {
             MemoryLayout.ofSequence(2, C_POINTER).withName("ptr_data"),
             C_INT.withName("begin_int_data"),
             C_INT.withName("end_int_data")
-        ), false)
+        ))
     );
     public static final MemorySegment clang_getNullRange () {
         try {
@@ -738,7 +738,7 @@ public final class Index_h {
             MemoryLayout.ofSequence(2, C_POINTER).withName("ptr_data"),
             C_INT.withName("begin_int_data"),
             C_INT.withName("end_int_data")
-        ), false,
+        ),
             MemoryLayout.ofStruct(
                 MemoryLayout.ofSequence(2, C_POINTER).withName("ptr_data"),
                 C_INT.withName("int_data"),
@@ -761,7 +761,7 @@ public final class Index_h {
     public static final MethodHandle clang_equalRanges = RuntimeHelper.downcallHandle(
         LIBRARIES, "clang_equalRanges",
         "(Ljdk/incubator/foreign/MemorySegment;Ljdk/incubator/foreign/MemorySegment;)I",
-        FunctionDescriptor.of(C_INT, false,
+        FunctionDescriptor.of(C_INT,
             MemoryLayout.ofStruct(
                 MemoryLayout.ofSequence(2, C_POINTER).withName("ptr_data"),
                 C_INT.withName("begin_int_data"),
@@ -784,7 +784,7 @@ public final class Index_h {
     public static final MethodHandle clang_Range_isNull = RuntimeHelper.downcallHandle(
         LIBRARIES, "clang_Range_isNull",
         "(Ljdk/incubator/foreign/MemorySegment;)I",
-        FunctionDescriptor.of(C_INT, false,
+        FunctionDescriptor.of(C_INT,
             MemoryLayout.ofStruct(
                 MemoryLayout.ofSequence(2, C_POINTER).withName("ptr_data"),
                 C_INT.withName("begin_int_data"),
@@ -802,7 +802,7 @@ public final class Index_h {
     public static final MethodHandle clang_getExpansionLocation = RuntimeHelper.downcallHandle(
         LIBRARIES, "clang_getExpansionLocation",
         "(Ljdk/incubator/foreign/MemorySegment;Ljdk/incubator/foreign/MemoryAddress;Ljdk/incubator/foreign/MemoryAddress;Ljdk/incubator/foreign/MemoryAddress;Ljdk/incubator/foreign/MemoryAddress;)V",
-        FunctionDescriptor.ofVoid(false,
+        FunctionDescriptor.ofVoid(
             MemoryLayout.ofStruct(
                 MemoryLayout.ofSequence(2, C_POINTER).withName("ptr_data"),
                 C_INT.withName("int_data"),
@@ -824,7 +824,7 @@ public final class Index_h {
     public static final MethodHandle clang_getPresumedLocation = RuntimeHelper.downcallHandle(
         LIBRARIES, "clang_getPresumedLocation",
         "(Ljdk/incubator/foreign/MemorySegment;Ljdk/incubator/foreign/MemoryAddress;Ljdk/incubator/foreign/MemoryAddress;Ljdk/incubator/foreign/MemoryAddress;)V",
-        FunctionDescriptor.ofVoid(false,
+        FunctionDescriptor.ofVoid(
             MemoryLayout.ofStruct(
                 MemoryLayout.ofSequence(2, C_POINTER).withName("ptr_data"),
                 C_INT.withName("int_data"),
@@ -845,7 +845,7 @@ public final class Index_h {
     public static final MethodHandle clang_getInstantiationLocation = RuntimeHelper.downcallHandle(
         LIBRARIES, "clang_getInstantiationLocation",
         "(Ljdk/incubator/foreign/MemorySegment;Ljdk/incubator/foreign/MemoryAddress;Ljdk/incubator/foreign/MemoryAddress;Ljdk/incubator/foreign/MemoryAddress;Ljdk/incubator/foreign/MemoryAddress;)V",
-        FunctionDescriptor.ofVoid(false,
+        FunctionDescriptor.ofVoid(
             MemoryLayout.ofStruct(
                 MemoryLayout.ofSequence(2, C_POINTER).withName("ptr_data"),
                 C_INT.withName("int_data"),
@@ -867,7 +867,7 @@ public final class Index_h {
     public static final MethodHandle clang_getSpellingLocation = RuntimeHelper.downcallHandle(
         LIBRARIES, "clang_getSpellingLocation",
         "(Ljdk/incubator/foreign/MemorySegment;Ljdk/incubator/foreign/MemoryAddress;Ljdk/incubator/foreign/MemoryAddress;Ljdk/incubator/foreign/MemoryAddress;Ljdk/incubator/foreign/MemoryAddress;)V",
-        FunctionDescriptor.ofVoid(false,
+        FunctionDescriptor.ofVoid(
             MemoryLayout.ofStruct(
                 MemoryLayout.ofSequence(2, C_POINTER).withName("ptr_data"),
                 C_INT.withName("int_data"),
@@ -889,7 +889,7 @@ public final class Index_h {
     public static final MethodHandle clang_getFileLocation = RuntimeHelper.downcallHandle(
         LIBRARIES, "clang_getFileLocation",
         "(Ljdk/incubator/foreign/MemorySegment;Ljdk/incubator/foreign/MemoryAddress;Ljdk/incubator/foreign/MemoryAddress;Ljdk/incubator/foreign/MemoryAddress;Ljdk/incubator/foreign/MemoryAddress;)V",
-        FunctionDescriptor.ofVoid(false,
+        FunctionDescriptor.ofVoid(
             MemoryLayout.ofStruct(
                 MemoryLayout.ofSequence(2, C_POINTER).withName("ptr_data"),
                 C_INT.withName("int_data"),
@@ -915,7 +915,7 @@ public final class Index_h {
             MemoryLayout.ofSequence(2, C_POINTER).withName("ptr_data"),
             C_INT.withName("int_data"),
             MemoryLayout.ofPaddingBits(32)
-        ), false,
+        ),
             MemoryLayout.ofStruct(
                 MemoryLayout.ofSequence(2, C_POINTER).withName("ptr_data"),
                 C_INT.withName("begin_int_data"),
@@ -937,7 +937,7 @@ public final class Index_h {
             MemoryLayout.ofSequence(2, C_POINTER).withName("ptr_data"),
             C_INT.withName("int_data"),
             MemoryLayout.ofPaddingBits(32)
-        ), false,
+        ),
             MemoryLayout.ofStruct(
                 MemoryLayout.ofSequence(2, C_POINTER).withName("ptr_data"),
                 C_INT.withName("begin_int_data"),
@@ -967,7 +967,7 @@ public final class Index_h {
     public static final MethodHandle clang_getSkippedRanges = RuntimeHelper.downcallHandle(
         LIBRARIES, "clang_getSkippedRanges",
         "(Ljdk/incubator/foreign/MemoryAddress;Ljdk/incubator/foreign/MemoryAddress;)Ljdk/incubator/foreign/MemoryAddress;",
-        FunctionDescriptor.of(C_POINTER, false,
+        FunctionDescriptor.of(C_POINTER,
             C_POINTER,
             C_POINTER
         )
@@ -982,7 +982,7 @@ public final class Index_h {
     public static final MethodHandle clang_getAllSkippedRanges = RuntimeHelper.downcallHandle(
         LIBRARIES, "clang_getAllSkippedRanges",
         "(Ljdk/incubator/foreign/MemoryAddress;)Ljdk/incubator/foreign/MemoryAddress;",
-        FunctionDescriptor.of(C_POINTER, false,
+        FunctionDescriptor.of(C_POINTER,
             C_POINTER
         )
     );
@@ -996,7 +996,7 @@ public final class Index_h {
     public static final MethodHandle clang_disposeSourceRangeList = RuntimeHelper.downcallHandle(
         LIBRARIES, "clang_disposeSourceRangeList",
         "(Ljdk/incubator/foreign/MemoryAddress;)V",
-        FunctionDescriptor.ofVoid(false,
+        FunctionDescriptor.ofVoid(
             C_POINTER
         )
     );
@@ -1015,7 +1015,7 @@ public final class Index_h {
     public static final MethodHandle clang_getNumDiagnosticsInSet = RuntimeHelper.downcallHandle(
         LIBRARIES, "clang_getNumDiagnosticsInSet",
         "(Ljdk/incubator/foreign/MemoryAddress;)I",
-        FunctionDescriptor.of(C_INT, false,
+        FunctionDescriptor.of(C_INT,
             C_POINTER
         )
     );
@@ -1029,7 +1029,7 @@ public final class Index_h {
     public static final MethodHandle clang_getDiagnosticInSet = RuntimeHelper.downcallHandle(
         LIBRARIES, "clang_getDiagnosticInSet",
         "(Ljdk/incubator/foreign/MemoryAddress;I)Ljdk/incubator/foreign/MemoryAddress;",
-        FunctionDescriptor.of(C_POINTER, false,
+        FunctionDescriptor.of(C_POINTER,
             C_POINTER,
             C_INT
         )
@@ -1048,7 +1048,7 @@ public final class Index_h {
     public static final MethodHandle clang_loadDiagnostics = RuntimeHelper.downcallHandle(
         LIBRARIES, "clang_loadDiagnostics",
         "(Ljdk/incubator/foreign/MemoryAddress;Ljdk/incubator/foreign/MemoryAddress;Ljdk/incubator/foreign/MemoryAddress;)Ljdk/incubator/foreign/MemoryAddress;",
-        FunctionDescriptor.of(C_POINTER, false,
+        FunctionDescriptor.of(C_POINTER,
             C_POINTER,
             C_POINTER,
             C_POINTER
@@ -1064,7 +1064,7 @@ public final class Index_h {
     public static final MethodHandle clang_disposeDiagnosticSet = RuntimeHelper.downcallHandle(
         LIBRARIES, "clang_disposeDiagnosticSet",
         "(Ljdk/incubator/foreign/MemoryAddress;)V",
-        FunctionDescriptor.ofVoid(false,
+        FunctionDescriptor.ofVoid(
             C_POINTER
         )
     );
@@ -1078,7 +1078,7 @@ public final class Index_h {
     public static final MethodHandle clang_getChildDiagnostics = RuntimeHelper.downcallHandle(
         LIBRARIES, "clang_getChildDiagnostics",
         "(Ljdk/incubator/foreign/MemoryAddress;)Ljdk/incubator/foreign/MemoryAddress;",
-        FunctionDescriptor.of(C_POINTER, false,
+        FunctionDescriptor.of(C_POINTER,
             C_POINTER
         )
     );
@@ -1092,7 +1092,7 @@ public final class Index_h {
     public static final MethodHandle clang_getNumDiagnostics = RuntimeHelper.downcallHandle(
         LIBRARIES, "clang_getNumDiagnostics",
         "(Ljdk/incubator/foreign/MemoryAddress;)I",
-        FunctionDescriptor.of(C_INT, false,
+        FunctionDescriptor.of(C_INT,
             C_POINTER
         )
     );
@@ -1106,7 +1106,7 @@ public final class Index_h {
     public static final MethodHandle clang_getDiagnostic = RuntimeHelper.downcallHandle(
         LIBRARIES, "clang_getDiagnostic",
         "(Ljdk/incubator/foreign/MemoryAddress;I)Ljdk/incubator/foreign/MemoryAddress;",
-        FunctionDescriptor.of(C_POINTER, false,
+        FunctionDescriptor.of(C_POINTER,
             C_POINTER,
             C_INT
         )
@@ -1121,7 +1121,7 @@ public final class Index_h {
     public static final MethodHandle clang_getDiagnosticSetFromTU = RuntimeHelper.downcallHandle(
         LIBRARIES, "clang_getDiagnosticSetFromTU",
         "(Ljdk/incubator/foreign/MemoryAddress;)Ljdk/incubator/foreign/MemoryAddress;",
-        FunctionDescriptor.of(C_POINTER, false,
+        FunctionDescriptor.of(C_POINTER,
             C_POINTER
         )
     );
@@ -1135,7 +1135,7 @@ public final class Index_h {
     public static final MethodHandle clang_disposeDiagnostic = RuntimeHelper.downcallHandle(
         LIBRARIES, "clang_disposeDiagnostic",
         "(Ljdk/incubator/foreign/MemoryAddress;)V",
-        FunctionDescriptor.ofVoid(false,
+        FunctionDescriptor.ofVoid(
             C_POINTER
         )
     );
@@ -1159,7 +1159,7 @@ public final class Index_h {
             C_POINTER.withName("data"),
             C_INT.withName("private_flags"),
             MemoryLayout.ofPaddingBits(32)
-        ), false,
+        ),
             C_POINTER,
             C_INT
         )
@@ -1174,7 +1174,7 @@ public final class Index_h {
     public static final MethodHandle clang_defaultDiagnosticDisplayOptions = RuntimeHelper.downcallHandle(
         LIBRARIES, "clang_defaultDiagnosticDisplayOptions",
         "()I",
-        FunctionDescriptor.of(C_INT, false)
+        FunctionDescriptor.of(C_INT)
     );
     public static final int clang_defaultDiagnosticDisplayOptions () {
         try {
@@ -1186,7 +1186,7 @@ public final class Index_h {
     public static final MethodHandle clang_getDiagnosticSeverity = RuntimeHelper.downcallHandle(
         LIBRARIES, "clang_getDiagnosticSeverity",
         "(Ljdk/incubator/foreign/MemoryAddress;)I",
-        FunctionDescriptor.of(C_INT, false,
+        FunctionDescriptor.of(C_INT,
             C_POINTER
         )
     );
@@ -1204,7 +1204,7 @@ public final class Index_h {
             MemoryLayout.ofSequence(2, C_POINTER).withName("ptr_data"),
             C_INT.withName("int_data"),
             MemoryLayout.ofPaddingBits(32)
-        ), false,
+        ),
             C_POINTER
         )
     );
@@ -1222,7 +1222,7 @@ public final class Index_h {
             C_POINTER.withName("data"),
             C_INT.withName("private_flags"),
             MemoryLayout.ofPaddingBits(32)
-        ), false,
+        ),
             C_POINTER
         )
     );
@@ -1240,7 +1240,7 @@ public final class Index_h {
             C_POINTER.withName("data"),
             C_INT.withName("private_flags"),
             MemoryLayout.ofPaddingBits(32)
-        ), false,
+        ),
             C_POINTER,
             C_POINTER
         )
@@ -1255,7 +1255,7 @@ public final class Index_h {
     public static final MethodHandle clang_getDiagnosticCategory = RuntimeHelper.downcallHandle(
         LIBRARIES, "clang_getDiagnosticCategory",
         "(Ljdk/incubator/foreign/MemoryAddress;)I",
-        FunctionDescriptor.of(C_INT, false,
+        FunctionDescriptor.of(C_INT,
             C_POINTER
         )
     );
@@ -1273,7 +1273,7 @@ public final class Index_h {
             C_POINTER.withName("data"),
             C_INT.withName("private_flags"),
             MemoryLayout.ofPaddingBits(32)
-        ), false,
+        ),
             C_INT
         )
     );
@@ -1291,7 +1291,7 @@ public final class Index_h {
             C_POINTER.withName("data"),
             C_INT.withName("private_flags"),
             MemoryLayout.ofPaddingBits(32)
-        ), false,
+        ),
             C_POINTER
         )
     );
@@ -1305,7 +1305,7 @@ public final class Index_h {
     public static final MethodHandle clang_getDiagnosticNumRanges = RuntimeHelper.downcallHandle(
         LIBRARIES, "clang_getDiagnosticNumRanges",
         "(Ljdk/incubator/foreign/MemoryAddress;)I",
-        FunctionDescriptor.of(C_INT, false,
+        FunctionDescriptor.of(C_INT,
             C_POINTER
         )
     );
@@ -1323,7 +1323,7 @@ public final class Index_h {
             MemoryLayout.ofSequence(2, C_POINTER).withName("ptr_data"),
             C_INT.withName("begin_int_data"),
             C_INT.withName("end_int_data")
-        ), false,
+        ),
             C_POINTER,
             C_INT
         )
@@ -1338,7 +1338,7 @@ public final class Index_h {
     public static final MethodHandle clang_getDiagnosticNumFixIts = RuntimeHelper.downcallHandle(
         LIBRARIES, "clang_getDiagnosticNumFixIts",
         "(Ljdk/incubator/foreign/MemoryAddress;)I",
-        FunctionDescriptor.of(C_INT, false,
+        FunctionDescriptor.of(C_INT,
             C_POINTER
         )
     );
@@ -1356,7 +1356,7 @@ public final class Index_h {
             C_POINTER.withName("data"),
             C_INT.withName("private_flags"),
             MemoryLayout.ofPaddingBits(32)
-        ), false,
+        ),
             C_POINTER,
             C_INT,
             C_POINTER
@@ -1376,7 +1376,7 @@ public final class Index_h {
             C_POINTER.withName("data"),
             C_INT.withName("private_flags"),
             MemoryLayout.ofPaddingBits(32)
-        ), false,
+        ),
             C_POINTER
         )
     );
@@ -1390,7 +1390,7 @@ public final class Index_h {
     public static final MethodHandle clang_createTranslationUnitFromSourceFile = RuntimeHelper.downcallHandle(
         LIBRARIES, "clang_createTranslationUnitFromSourceFile",
         "(Ljdk/incubator/foreign/MemoryAddress;Ljdk/incubator/foreign/MemoryAddress;ILjdk/incubator/foreign/MemoryAddress;ILjdk/incubator/foreign/MemoryAddress;)Ljdk/incubator/foreign/MemoryAddress;",
-        FunctionDescriptor.of(C_POINTER, false,
+        FunctionDescriptor.of(C_POINTER,
             C_POINTER,
             C_POINTER,
             C_INT,
@@ -1409,7 +1409,7 @@ public final class Index_h {
     public static final MethodHandle clang_createTranslationUnit = RuntimeHelper.downcallHandle(
         LIBRARIES, "clang_createTranslationUnit",
         "(Ljdk/incubator/foreign/MemoryAddress;Ljdk/incubator/foreign/MemoryAddress;)Ljdk/incubator/foreign/MemoryAddress;",
-        FunctionDescriptor.of(C_POINTER, false,
+        FunctionDescriptor.of(C_POINTER,
             C_POINTER,
             C_POINTER
         )
@@ -1424,7 +1424,7 @@ public final class Index_h {
     public static final MethodHandle clang_createTranslationUnit2 = RuntimeHelper.downcallHandle(
         LIBRARIES, "clang_createTranslationUnit2",
         "(Ljdk/incubator/foreign/MemoryAddress;Ljdk/incubator/foreign/MemoryAddress;Ljdk/incubator/foreign/MemoryAddress;)I",
-        FunctionDescriptor.of(C_INT, false,
+        FunctionDescriptor.of(C_INT,
             C_POINTER,
             C_POINTER,
             C_POINTER
@@ -1456,7 +1456,7 @@ public final class Index_h {
     public static final MethodHandle clang_defaultEditingTranslationUnitOptions = RuntimeHelper.downcallHandle(
         LIBRARIES, "clang_defaultEditingTranslationUnitOptions",
         "()I",
-        FunctionDescriptor.of(C_INT, false)
+        FunctionDescriptor.of(C_INT)
     );
     public static final int clang_defaultEditingTranslationUnitOptions () {
         try {
@@ -1468,7 +1468,7 @@ public final class Index_h {
     public static final MethodHandle clang_parseTranslationUnit = RuntimeHelper.downcallHandle(
         LIBRARIES, "clang_parseTranslationUnit",
         "(Ljdk/incubator/foreign/MemoryAddress;Ljdk/incubator/foreign/MemoryAddress;Ljdk/incubator/foreign/MemoryAddress;ILjdk/incubator/foreign/MemoryAddress;II)Ljdk/incubator/foreign/MemoryAddress;",
-        FunctionDescriptor.of(C_POINTER, false,
+        FunctionDescriptor.of(C_POINTER,
             C_POINTER,
             C_POINTER,
             C_POINTER,
@@ -1488,7 +1488,7 @@ public final class Index_h {
     public static final MethodHandle clang_parseTranslationUnit2 = RuntimeHelper.downcallHandle(
         LIBRARIES, "clang_parseTranslationUnit2",
         "(Ljdk/incubator/foreign/MemoryAddress;Ljdk/incubator/foreign/MemoryAddress;Ljdk/incubator/foreign/MemoryAddress;ILjdk/incubator/foreign/MemoryAddress;IILjdk/incubator/foreign/MemoryAddress;)I",
-        FunctionDescriptor.of(C_INT, false,
+        FunctionDescriptor.of(C_INT,
             C_POINTER,
             C_POINTER,
             C_POINTER,
@@ -1509,7 +1509,7 @@ public final class Index_h {
     public static final MethodHandle clang_parseTranslationUnit2FullArgv = RuntimeHelper.downcallHandle(
         LIBRARIES, "clang_parseTranslationUnit2FullArgv",
         "(Ljdk/incubator/foreign/MemoryAddress;Ljdk/incubator/foreign/MemoryAddress;Ljdk/incubator/foreign/MemoryAddress;ILjdk/incubator/foreign/MemoryAddress;IILjdk/incubator/foreign/MemoryAddress;)I",
-        FunctionDescriptor.of(C_INT, false,
+        FunctionDescriptor.of(C_INT,
             C_POINTER,
             C_POINTER,
             C_POINTER,
@@ -1531,7 +1531,7 @@ public final class Index_h {
     public static final MethodHandle clang_defaultSaveOptions = RuntimeHelper.downcallHandle(
         LIBRARIES, "clang_defaultSaveOptions",
         "(Ljdk/incubator/foreign/MemoryAddress;)I",
-        FunctionDescriptor.of(C_INT, false,
+        FunctionDescriptor.of(C_INT,
             C_POINTER
         )
     );
@@ -1549,7 +1549,7 @@ public final class Index_h {
     public static final MethodHandle clang_saveTranslationUnit = RuntimeHelper.downcallHandle(
         LIBRARIES, "clang_saveTranslationUnit",
         "(Ljdk/incubator/foreign/MemoryAddress;Ljdk/incubator/foreign/MemoryAddress;I)I",
-        FunctionDescriptor.of(C_INT, false,
+        FunctionDescriptor.of(C_INT,
             C_POINTER,
             C_POINTER,
             C_INT
@@ -1565,7 +1565,7 @@ public final class Index_h {
     public static final MethodHandle clang_suspendTranslationUnit = RuntimeHelper.downcallHandle(
         LIBRARIES, "clang_suspendTranslationUnit",
         "(Ljdk/incubator/foreign/MemoryAddress;)I",
-        FunctionDescriptor.of(C_INT, false,
+        FunctionDescriptor.of(C_INT,
             C_POINTER
         )
     );
@@ -1579,7 +1579,7 @@ public final class Index_h {
     public static final MethodHandle clang_disposeTranslationUnit = RuntimeHelper.downcallHandle(
         LIBRARIES, "clang_disposeTranslationUnit",
         "(Ljdk/incubator/foreign/MemoryAddress;)V",
-        FunctionDescriptor.ofVoid(false,
+        FunctionDescriptor.ofVoid(
             C_POINTER
         )
     );
@@ -1594,7 +1594,7 @@ public final class Index_h {
     public static final MethodHandle clang_defaultReparseOptions = RuntimeHelper.downcallHandle(
         LIBRARIES, "clang_defaultReparseOptions",
         "(Ljdk/incubator/foreign/MemoryAddress;)I",
-        FunctionDescriptor.of(C_INT, false,
+        FunctionDescriptor.of(C_INT,
             C_POINTER
         )
     );
@@ -1608,7 +1608,7 @@ public final class Index_h {
     public static final MethodHandle clang_reparseTranslationUnit = RuntimeHelper.downcallHandle(
         LIBRARIES, "clang_reparseTranslationUnit",
         "(Ljdk/incubator/foreign/MemoryAddress;ILjdk/incubator/foreign/MemoryAddress;I)I",
-        FunctionDescriptor.of(C_INT, false,
+        FunctionDescriptor.of(C_INT,
             C_POINTER,
             C_INT,
             C_POINTER,
@@ -1643,7 +1643,7 @@ public final class Index_h {
     public static final MethodHandle clang_getTUResourceUsageName = RuntimeHelper.downcallHandle(
         LIBRARIES, "clang_getTUResourceUsageName",
         "(I)Ljdk/incubator/foreign/MemoryAddress;",
-        FunctionDescriptor.of(C_POINTER, false,
+        FunctionDescriptor.of(C_POINTER,
             C_INT
         )
     );
@@ -1694,7 +1694,7 @@ public final class Index_h {
             C_INT.withName("numEntries"),
             MemoryLayout.ofPaddingBits(32),
             C_POINTER.withName("entries")
-        ).withName("CXTUResourceUsage"), false,
+        ).withName("CXTUResourceUsage"),
             C_POINTER
         )
     );
@@ -1708,7 +1708,7 @@ public final class Index_h {
     public static final MethodHandle clang_disposeCXTUResourceUsage = RuntimeHelper.downcallHandle(
         LIBRARIES, "clang_disposeCXTUResourceUsage",
         "(Ljdk/incubator/foreign/MemorySegment;)V",
-        FunctionDescriptor.ofVoid(false,
+        FunctionDescriptor.ofVoid(
             MemoryLayout.ofStruct(
                 C_POINTER.withName("data"),
                 C_INT.withName("numEntries"),
@@ -1727,7 +1727,7 @@ public final class Index_h {
     public static final MethodHandle clang_getTranslationUnitTargetInfo = RuntimeHelper.downcallHandle(
         LIBRARIES, "clang_getTranslationUnitTargetInfo",
         "(Ljdk/incubator/foreign/MemoryAddress;)Ljdk/incubator/foreign/MemoryAddress;",
-        FunctionDescriptor.of(C_POINTER, false,
+        FunctionDescriptor.of(C_POINTER,
             C_POINTER
         )
     );
@@ -1741,7 +1741,7 @@ public final class Index_h {
     public static final MethodHandle clang_TargetInfo_dispose = RuntimeHelper.downcallHandle(
         LIBRARIES, "clang_TargetInfo_dispose",
         "(Ljdk/incubator/foreign/MemoryAddress;)V",
-        FunctionDescriptor.ofVoid(false,
+        FunctionDescriptor.ofVoid(
             C_POINTER
         )
     );
@@ -1759,7 +1759,7 @@ public final class Index_h {
             C_POINTER.withName("data"),
             C_INT.withName("private_flags"),
             MemoryLayout.ofPaddingBits(32)
-        ), false,
+        ),
             C_POINTER
         )
     );
@@ -1773,7 +1773,7 @@ public final class Index_h {
     public static final MethodHandle clang_TargetInfo_getPointerWidth = RuntimeHelper.downcallHandle(
         LIBRARIES, "clang_TargetInfo_getPointerWidth",
         "(Ljdk/incubator/foreign/MemoryAddress;)I",
-        FunctionDescriptor.of(C_INT, false,
+        FunctionDescriptor.of(C_INT,
             C_POINTER
         )
     );
@@ -2065,7 +2065,7 @@ public final class Index_h {
             C_INT.withName("kind"),
             C_INT.withName("xdata"),
             MemoryLayout.ofSequence(3, C_POINTER).withName("data")
-        ), false)
+        ))
     );
     public static final MemorySegment clang_getNullCursor () {
         try {
@@ -2081,7 +2081,7 @@ public final class Index_h {
             C_INT.withName("kind"),
             C_INT.withName("xdata"),
             MemoryLayout.ofSequence(3, C_POINTER).withName("data")
-        ), false,
+        ),
             C_POINTER
         )
     );
@@ -2095,7 +2095,7 @@ public final class Index_h {
     public static final MethodHandle clang_equalCursors = RuntimeHelper.downcallHandle(
         LIBRARIES, "clang_equalCursors",
         "(Ljdk/incubator/foreign/MemorySegment;Ljdk/incubator/foreign/MemorySegment;)I",
-        FunctionDescriptor.of(C_INT, false,
+        FunctionDescriptor.of(C_INT,
             MemoryLayout.ofStruct(
                 C_INT.withName("kind"),
                 C_INT.withName("xdata"),
@@ -2118,7 +2118,7 @@ public final class Index_h {
     public static final MethodHandle clang_Cursor_isNull = RuntimeHelper.downcallHandle(
         LIBRARIES, "clang_Cursor_isNull",
         "(Ljdk/incubator/foreign/MemorySegment;)I",
-        FunctionDescriptor.of(C_INT, false,
+        FunctionDescriptor.of(C_INT,
             MemoryLayout.ofStruct(
                 C_INT.withName("kind"),
                 C_INT.withName("xdata"),
@@ -2136,7 +2136,7 @@ public final class Index_h {
     public static final MethodHandle clang_hashCursor = RuntimeHelper.downcallHandle(
         LIBRARIES, "clang_hashCursor",
         "(Ljdk/incubator/foreign/MemorySegment;)I",
-        FunctionDescriptor.of(C_INT, false,
+        FunctionDescriptor.of(C_INT,
             MemoryLayout.ofStruct(
                 C_INT.withName("kind"),
                 C_INT.withName("xdata"),
@@ -2154,7 +2154,7 @@ public final class Index_h {
     public static final MethodHandle clang_getCursorKind = RuntimeHelper.downcallHandle(
         LIBRARIES, "clang_getCursorKind",
         "(Ljdk/incubator/foreign/MemorySegment;)I",
-        FunctionDescriptor.of(C_INT, false,
+        FunctionDescriptor.of(C_INT,
             MemoryLayout.ofStruct(
                 C_INT.withName("kind"),
                 C_INT.withName("xdata"),
@@ -2172,7 +2172,7 @@ public final class Index_h {
     public static final MethodHandle clang_isDeclaration = RuntimeHelper.downcallHandle(
         LIBRARIES, "clang_isDeclaration",
         "(I)I",
-        FunctionDescriptor.of(C_INT, false,
+        FunctionDescriptor.of(C_INT,
             C_INT
         )
     );
@@ -2186,7 +2186,7 @@ public final class Index_h {
     public static final MethodHandle clang_isInvalidDeclaration = RuntimeHelper.downcallHandle(
         LIBRARIES, "clang_isInvalidDeclaration",
         "(Ljdk/incubator/foreign/MemorySegment;)I",
-        FunctionDescriptor.of(C_INT, false,
+        FunctionDescriptor.of(C_INT,
             MemoryLayout.ofStruct(
                 C_INT.withName("kind"),
                 C_INT.withName("xdata"),
@@ -2204,7 +2204,7 @@ public final class Index_h {
     public static final MethodHandle clang_isReference = RuntimeHelper.downcallHandle(
         LIBRARIES, "clang_isReference",
         "(I)I",
-        FunctionDescriptor.of(C_INT, false,
+        FunctionDescriptor.of(C_INT,
             C_INT
         )
     );
@@ -2218,7 +2218,7 @@ public final class Index_h {
     public static final MethodHandle clang_isExpression = RuntimeHelper.downcallHandle(
         LIBRARIES, "clang_isExpression",
         "(I)I",
-        FunctionDescriptor.of(C_INT, false,
+        FunctionDescriptor.of(C_INT,
             C_INT
         )
     );
@@ -2232,7 +2232,7 @@ public final class Index_h {
     public static final MethodHandle clang_isStatement = RuntimeHelper.downcallHandle(
         LIBRARIES, "clang_isStatement",
         "(I)I",
-        FunctionDescriptor.of(C_INT, false,
+        FunctionDescriptor.of(C_INT,
             C_INT
         )
     );
@@ -2246,7 +2246,7 @@ public final class Index_h {
     public static final MethodHandle clang_isAttribute = RuntimeHelper.downcallHandle(
         LIBRARIES, "clang_isAttribute",
         "(I)I",
-        FunctionDescriptor.of(C_INT, false,
+        FunctionDescriptor.of(C_INT,
             C_INT
         )
     );
@@ -2260,7 +2260,7 @@ public final class Index_h {
     public static final MethodHandle clang_Cursor_hasAttrs = RuntimeHelper.downcallHandle(
         LIBRARIES, "clang_Cursor_hasAttrs",
         "(Ljdk/incubator/foreign/MemorySegment;)I",
-        FunctionDescriptor.of(C_INT, false,
+        FunctionDescriptor.of(C_INT,
             MemoryLayout.ofStruct(
                 C_INT.withName("kind"),
                 C_INT.withName("xdata"),
@@ -2278,7 +2278,7 @@ public final class Index_h {
     public static final MethodHandle clang_isInvalid = RuntimeHelper.downcallHandle(
         LIBRARIES, "clang_isInvalid",
         "(I)I",
-        FunctionDescriptor.of(C_INT, false,
+        FunctionDescriptor.of(C_INT,
             C_INT
         )
     );
@@ -2292,7 +2292,7 @@ public final class Index_h {
     public static final MethodHandle clang_isTranslationUnit = RuntimeHelper.downcallHandle(
         LIBRARIES, "clang_isTranslationUnit",
         "(I)I",
-        FunctionDescriptor.of(C_INT, false,
+        FunctionDescriptor.of(C_INT,
             C_INT
         )
     );
@@ -2306,7 +2306,7 @@ public final class Index_h {
     public static final MethodHandle clang_isPreprocessing = RuntimeHelper.downcallHandle(
         LIBRARIES, "clang_isPreprocessing",
         "(I)I",
-        FunctionDescriptor.of(C_INT, false,
+        FunctionDescriptor.of(C_INT,
             C_INT
         )
     );
@@ -2320,7 +2320,7 @@ public final class Index_h {
     public static final MethodHandle clang_isUnexposed = RuntimeHelper.downcallHandle(
         LIBRARIES, "clang_isUnexposed",
         "(I)I",
-        FunctionDescriptor.of(C_INT, false,
+        FunctionDescriptor.of(C_INT,
             C_INT
         )
     );
@@ -2339,7 +2339,7 @@ public final class Index_h {
     public static final MethodHandle clang_getCursorLinkage = RuntimeHelper.downcallHandle(
         LIBRARIES, "clang_getCursorLinkage",
         "(Ljdk/incubator/foreign/MemorySegment;)I",
-        FunctionDescriptor.of(C_INT, false,
+        FunctionDescriptor.of(C_INT,
             MemoryLayout.ofStruct(
                 C_INT.withName("kind"),
                 C_INT.withName("xdata"),
@@ -2361,7 +2361,7 @@ public final class Index_h {
     public static final MethodHandle clang_getCursorVisibility = RuntimeHelper.downcallHandle(
         LIBRARIES, "clang_getCursorVisibility",
         "(Ljdk/incubator/foreign/MemorySegment;)I",
-        FunctionDescriptor.of(C_INT, false,
+        FunctionDescriptor.of(C_INT,
             MemoryLayout.ofStruct(
                 C_INT.withName("kind"),
                 C_INT.withName("xdata"),
@@ -2379,7 +2379,7 @@ public final class Index_h {
     public static final MethodHandle clang_getCursorAvailability = RuntimeHelper.downcallHandle(
         LIBRARIES, "clang_getCursorAvailability",
         "(Ljdk/incubator/foreign/MemorySegment;)I",
-        FunctionDescriptor.of(C_INT, false,
+        FunctionDescriptor.of(C_INT,
             MemoryLayout.ofStruct(
                 C_INT.withName("kind"),
                 C_INT.withName("xdata"),
@@ -2432,7 +2432,7 @@ public final class Index_h {
     public static final MethodHandle clang_getCursorPlatformAvailability = RuntimeHelper.downcallHandle(
         LIBRARIES, "clang_getCursorPlatformAvailability",
         "(Ljdk/incubator/foreign/MemorySegment;Ljdk/incubator/foreign/MemoryAddress;Ljdk/incubator/foreign/MemoryAddress;Ljdk/incubator/foreign/MemoryAddress;Ljdk/incubator/foreign/MemoryAddress;Ljdk/incubator/foreign/MemoryAddress;I)I",
-        FunctionDescriptor.of(C_INT, false,
+        FunctionDescriptor.of(C_INT,
             MemoryLayout.ofStruct(
                 C_INT.withName("kind"),
                 C_INT.withName("xdata"),
@@ -2456,7 +2456,7 @@ public final class Index_h {
     public static final MethodHandle clang_disposeCXPlatformAvailability = RuntimeHelper.downcallHandle(
         LIBRARIES, "clang_disposeCXPlatformAvailability",
         "(Ljdk/incubator/foreign/MemoryAddress;)V",
-        FunctionDescriptor.ofVoid(false,
+        FunctionDescriptor.ofVoid(
             C_POINTER
         )
     );
@@ -2474,7 +2474,7 @@ public final class Index_h {
     public static final MethodHandle clang_getCursorLanguage = RuntimeHelper.downcallHandle(
         LIBRARIES, "clang_getCursorLanguage",
         "(Ljdk/incubator/foreign/MemorySegment;)I",
-        FunctionDescriptor.of(C_INT, false,
+        FunctionDescriptor.of(C_INT,
             MemoryLayout.ofStruct(
                 C_INT.withName("kind"),
                 C_INT.withName("xdata"),
@@ -2495,7 +2495,7 @@ public final class Index_h {
     public static final MethodHandle clang_getCursorTLSKind = RuntimeHelper.downcallHandle(
         LIBRARIES, "clang_getCursorTLSKind",
         "(Ljdk/incubator/foreign/MemorySegment;)I",
-        FunctionDescriptor.of(C_INT, false,
+        FunctionDescriptor.of(C_INT,
             MemoryLayout.ofStruct(
                 C_INT.withName("kind"),
                 C_INT.withName("xdata"),
@@ -2513,7 +2513,7 @@ public final class Index_h {
     public static final MethodHandle clang_Cursor_getTranslationUnit = RuntimeHelper.downcallHandle(
         LIBRARIES, "clang_Cursor_getTranslationUnit",
         "(Ljdk/incubator/foreign/MemorySegment;)Ljdk/incubator/foreign/MemoryAddress;",
-        FunctionDescriptor.of(C_POINTER, false,
+        FunctionDescriptor.of(C_POINTER,
             MemoryLayout.ofStruct(
                 C_INT.withName("kind"),
                 C_INT.withName("xdata"),
@@ -2531,7 +2531,7 @@ public final class Index_h {
     public static final MethodHandle clang_createCXCursorSet = RuntimeHelper.downcallHandle(
         LIBRARIES, "clang_createCXCursorSet",
         "()Ljdk/incubator/foreign/MemoryAddress;",
-        FunctionDescriptor.of(C_POINTER, false)
+        FunctionDescriptor.of(C_POINTER)
     );
     public static final MemoryAddress clang_createCXCursorSet () {
         try {
@@ -2543,7 +2543,7 @@ public final class Index_h {
     public static final MethodHandle clang_disposeCXCursorSet = RuntimeHelper.downcallHandle(
         LIBRARIES, "clang_disposeCXCursorSet",
         "(Ljdk/incubator/foreign/MemoryAddress;)V",
-        FunctionDescriptor.ofVoid(false,
+        FunctionDescriptor.ofVoid(
             C_POINTER
         )
     );
@@ -2557,7 +2557,7 @@ public final class Index_h {
     public static final MethodHandle clang_CXCursorSet_contains = RuntimeHelper.downcallHandle(
         LIBRARIES, "clang_CXCursorSet_contains",
         "(Ljdk/incubator/foreign/MemoryAddress;Ljdk/incubator/foreign/MemorySegment;)I",
-        FunctionDescriptor.of(C_INT, false,
+        FunctionDescriptor.of(C_INT,
             C_POINTER,
             MemoryLayout.ofStruct(
                 C_INT.withName("kind"),
@@ -2576,7 +2576,7 @@ public final class Index_h {
     public static final MethodHandle clang_CXCursorSet_insert = RuntimeHelper.downcallHandle(
         LIBRARIES, "clang_CXCursorSet_insert",
         "(Ljdk/incubator/foreign/MemoryAddress;Ljdk/incubator/foreign/MemorySegment;)I",
-        FunctionDescriptor.of(C_INT, false,
+        FunctionDescriptor.of(C_INT,
             C_POINTER,
             MemoryLayout.ofStruct(
                 C_INT.withName("kind"),
@@ -2599,7 +2599,7 @@ public final class Index_h {
             C_INT.withName("kind"),
             C_INT.withName("xdata"),
             MemoryLayout.ofSequence(3, C_POINTER).withName("data")
-        ), false,
+        ),
             MemoryLayout.ofStruct(
                 C_INT.withName("kind"),
                 C_INT.withName("xdata"),
@@ -2621,7 +2621,7 @@ public final class Index_h {
             C_INT.withName("kind"),
             C_INT.withName("xdata"),
             MemoryLayout.ofSequence(3, C_POINTER).withName("data")
-        ), false,
+        ),
             MemoryLayout.ofStruct(
                 C_INT.withName("kind"),
                 C_INT.withName("xdata"),
@@ -2639,7 +2639,7 @@ public final class Index_h {
     public static final MethodHandle clang_getOverriddenCursors = RuntimeHelper.downcallHandle(
         LIBRARIES, "clang_getOverriddenCursors",
         "(Ljdk/incubator/foreign/MemorySegment;Ljdk/incubator/foreign/MemoryAddress;Ljdk/incubator/foreign/MemoryAddress;)V",
-        FunctionDescriptor.ofVoid(false,
+        FunctionDescriptor.ofVoid(
             MemoryLayout.ofStruct(
                 C_INT.withName("kind"),
                 C_INT.withName("xdata"),
@@ -2659,7 +2659,7 @@ public final class Index_h {
     public static final MethodHandle clang_disposeOverriddenCursors = RuntimeHelper.downcallHandle(
         LIBRARIES, "clang_disposeOverriddenCursors",
         "(Ljdk/incubator/foreign/MemoryAddress;)V",
-        FunctionDescriptor.ofVoid(false,
+        FunctionDescriptor.ofVoid(
             C_POINTER
         )
     );
@@ -2673,7 +2673,7 @@ public final class Index_h {
     public static final MethodHandle clang_getIncludedFile = RuntimeHelper.downcallHandle(
         LIBRARIES, "clang_getIncludedFile",
         "(Ljdk/incubator/foreign/MemorySegment;)Ljdk/incubator/foreign/MemoryAddress;",
-        FunctionDescriptor.of(C_POINTER, false,
+        FunctionDescriptor.of(C_POINTER,
             MemoryLayout.ofStruct(
                 C_INT.withName("kind"),
                 C_INT.withName("xdata"),
@@ -2695,7 +2695,7 @@ public final class Index_h {
             C_INT.withName("kind"),
             C_INT.withName("xdata"),
             MemoryLayout.ofSequence(3, C_POINTER).withName("data")
-        ), false,
+        ),
             C_POINTER,
             MemoryLayout.ofStruct(
                 MemoryLayout.ofSequence(2, C_POINTER).withName("ptr_data"),
@@ -2718,7 +2718,7 @@ public final class Index_h {
             MemoryLayout.ofSequence(2, C_POINTER).withName("ptr_data"),
             C_INT.withName("int_data"),
             MemoryLayout.ofPaddingBits(32)
-        ), false,
+        ),
             MemoryLayout.ofStruct(
                 C_INT.withName("kind"),
                 C_INT.withName("xdata"),
@@ -2740,7 +2740,7 @@ public final class Index_h {
             MemoryLayout.ofSequence(2, C_POINTER).withName("ptr_data"),
             C_INT.withName("begin_int_data"),
             C_INT.withName("end_int_data")
-        ), false,
+        ),
             MemoryLayout.ofStruct(
                 C_INT.withName("kind"),
                 C_INT.withName("xdata"),
@@ -2912,7 +2912,7 @@ public final class Index_h {
             C_INT.withName("kind"),
             MemoryLayout.ofPaddingBits(32),
             MemoryLayout.ofSequence(2, C_POINTER).withName("data")
-        ), false,
+        ),
             MemoryLayout.ofStruct(
                 C_INT.withName("kind"),
                 C_INT.withName("xdata"),
@@ -2934,7 +2934,7 @@ public final class Index_h {
             C_POINTER.withName("data"),
             C_INT.withName("private_flags"),
             MemoryLayout.ofPaddingBits(32)
-        ), false,
+        ),
             MemoryLayout.ofStruct(
                 C_INT.withName("kind"),
                 MemoryLayout.ofPaddingBits(32),
@@ -2956,7 +2956,7 @@ public final class Index_h {
             C_INT.withName("kind"),
             MemoryLayout.ofPaddingBits(32),
             MemoryLayout.ofSequence(2, C_POINTER).withName("data")
-        ), false,
+        ),
             MemoryLayout.ofStruct(
                 C_INT.withName("kind"),
                 C_INT.withName("xdata"),
@@ -2978,7 +2978,7 @@ public final class Index_h {
             C_INT.withName("kind"),
             MemoryLayout.ofPaddingBits(32),
             MemoryLayout.ofSequence(2, C_POINTER).withName("data")
-        ), false,
+        ),
             MemoryLayout.ofStruct(
                 C_INT.withName("kind"),
                 C_INT.withName("xdata"),
@@ -2996,7 +2996,7 @@ public final class Index_h {
     public static final MethodHandle clang_getEnumConstantDeclValue = RuntimeHelper.downcallHandle(
         LIBRARIES, "clang_getEnumConstantDeclValue",
         "(Ljdk/incubator/foreign/MemorySegment;)J",
-        FunctionDescriptor.of(C_LONGLONG, false,
+        FunctionDescriptor.of(C_LONGLONG,
             MemoryLayout.ofStruct(
                 C_INT.withName("kind"),
                 C_INT.withName("xdata"),
@@ -3014,7 +3014,7 @@ public final class Index_h {
     public static final MethodHandle clang_getEnumConstantDeclUnsignedValue = RuntimeHelper.downcallHandle(
         LIBRARIES, "clang_getEnumConstantDeclUnsignedValue",
         "(Ljdk/incubator/foreign/MemorySegment;)J",
-        FunctionDescriptor.of(C_LONGLONG, false,
+        FunctionDescriptor.of(C_LONGLONG,
             MemoryLayout.ofStruct(
                 C_INT.withName("kind"),
                 C_INT.withName("xdata"),
@@ -3032,7 +3032,7 @@ public final class Index_h {
     public static final MethodHandle clang_getFieldDeclBitWidth = RuntimeHelper.downcallHandle(
         LIBRARIES, "clang_getFieldDeclBitWidth",
         "(Ljdk/incubator/foreign/MemorySegment;)I",
-        FunctionDescriptor.of(C_INT, false,
+        FunctionDescriptor.of(C_INT,
             MemoryLayout.ofStruct(
                 C_INT.withName("kind"),
                 C_INT.withName("xdata"),
@@ -3050,7 +3050,7 @@ public final class Index_h {
     public static final MethodHandle clang_Cursor_getNumArguments = RuntimeHelper.downcallHandle(
         LIBRARIES, "clang_Cursor_getNumArguments",
         "(Ljdk/incubator/foreign/MemorySegment;)I",
-        FunctionDescriptor.of(C_INT, false,
+        FunctionDescriptor.of(C_INT,
             MemoryLayout.ofStruct(
                 C_INT.withName("kind"),
                 C_INT.withName("xdata"),
@@ -3072,7 +3072,7 @@ public final class Index_h {
             C_INT.withName("kind"),
             C_INT.withName("xdata"),
             MemoryLayout.ofSequence(3, C_POINTER).withName("data")
-        ), false,
+        ),
             MemoryLayout.ofStruct(
                 C_INT.withName("kind"),
                 C_INT.withName("xdata"),
@@ -3101,7 +3101,7 @@ public final class Index_h {
     public static final MethodHandle clang_Cursor_getNumTemplateArguments = RuntimeHelper.downcallHandle(
         LIBRARIES, "clang_Cursor_getNumTemplateArguments",
         "(Ljdk/incubator/foreign/MemorySegment;)I",
-        FunctionDescriptor.of(C_INT, false,
+        FunctionDescriptor.of(C_INT,
             MemoryLayout.ofStruct(
                 C_INT.withName("kind"),
                 C_INT.withName("xdata"),
@@ -3119,7 +3119,7 @@ public final class Index_h {
     public static final MethodHandle clang_Cursor_getTemplateArgumentKind = RuntimeHelper.downcallHandle(
         LIBRARIES, "clang_Cursor_getTemplateArgumentKind",
         "(Ljdk/incubator/foreign/MemorySegment;I)I",
-        FunctionDescriptor.of(C_INT, false,
+        FunctionDescriptor.of(C_INT,
             MemoryLayout.ofStruct(
                 C_INT.withName("kind"),
                 C_INT.withName("xdata"),
@@ -3142,7 +3142,7 @@ public final class Index_h {
             C_INT.withName("kind"),
             MemoryLayout.ofPaddingBits(32),
             MemoryLayout.ofSequence(2, C_POINTER).withName("data")
-        ), false,
+        ),
             MemoryLayout.ofStruct(
                 C_INT.withName("kind"),
                 C_INT.withName("xdata"),
@@ -3161,7 +3161,7 @@ public final class Index_h {
     public static final MethodHandle clang_Cursor_getTemplateArgumentValue = RuntimeHelper.downcallHandle(
         LIBRARIES, "clang_Cursor_getTemplateArgumentValue",
         "(Ljdk/incubator/foreign/MemorySegment;I)J",
-        FunctionDescriptor.of(C_LONGLONG, false,
+        FunctionDescriptor.of(C_LONGLONG,
             MemoryLayout.ofStruct(
                 C_INT.withName("kind"),
                 C_INT.withName("xdata"),
@@ -3180,7 +3180,7 @@ public final class Index_h {
     public static final MethodHandle clang_Cursor_getTemplateArgumentUnsignedValue = RuntimeHelper.downcallHandle(
         LIBRARIES, "clang_Cursor_getTemplateArgumentUnsignedValue",
         "(Ljdk/incubator/foreign/MemorySegment;I)J",
-        FunctionDescriptor.of(C_LONGLONG, false,
+        FunctionDescriptor.of(C_LONGLONG,
             MemoryLayout.ofStruct(
                 C_INT.withName("kind"),
                 C_INT.withName("xdata"),
@@ -3199,7 +3199,7 @@ public final class Index_h {
     public static final MethodHandle clang_equalTypes = RuntimeHelper.downcallHandle(
         LIBRARIES, "clang_equalTypes",
         "(Ljdk/incubator/foreign/MemorySegment;Ljdk/incubator/foreign/MemorySegment;)I",
-        FunctionDescriptor.of(C_INT, false,
+        FunctionDescriptor.of(C_INT,
             MemoryLayout.ofStruct(
                 C_INT.withName("kind"),
                 MemoryLayout.ofPaddingBits(32),
@@ -3226,7 +3226,7 @@ public final class Index_h {
             C_INT.withName("kind"),
             MemoryLayout.ofPaddingBits(32),
             MemoryLayout.ofSequence(2, C_POINTER).withName("data")
-        ), false,
+        ),
             MemoryLayout.ofStruct(
                 C_INT.withName("kind"),
                 MemoryLayout.ofPaddingBits(32),
@@ -3244,7 +3244,7 @@ public final class Index_h {
     public static final MethodHandle clang_isConstQualifiedType = RuntimeHelper.downcallHandle(
         LIBRARIES, "clang_isConstQualifiedType",
         "(Ljdk/incubator/foreign/MemorySegment;)I",
-        FunctionDescriptor.of(C_INT, false,
+        FunctionDescriptor.of(C_INT,
             MemoryLayout.ofStruct(
                 C_INT.withName("kind"),
                 MemoryLayout.ofPaddingBits(32),
@@ -3262,7 +3262,7 @@ public final class Index_h {
     public static final MethodHandle clang_Cursor_isMacroFunctionLike = RuntimeHelper.downcallHandle(
         LIBRARIES, "clang_Cursor_isMacroFunctionLike",
         "(Ljdk/incubator/foreign/MemorySegment;)I",
-        FunctionDescriptor.of(C_INT, false,
+        FunctionDescriptor.of(C_INT,
             MemoryLayout.ofStruct(
                 C_INT.withName("kind"),
                 C_INT.withName("xdata"),
@@ -3280,7 +3280,7 @@ public final class Index_h {
     public static final MethodHandle clang_Cursor_isMacroBuiltin = RuntimeHelper.downcallHandle(
         LIBRARIES, "clang_Cursor_isMacroBuiltin",
         "(Ljdk/incubator/foreign/MemorySegment;)I",
-        FunctionDescriptor.of(C_INT, false,
+        FunctionDescriptor.of(C_INT,
             MemoryLayout.ofStruct(
                 C_INT.withName("kind"),
                 C_INT.withName("xdata"),
@@ -3298,7 +3298,7 @@ public final class Index_h {
     public static final MethodHandle clang_Cursor_isFunctionInlined = RuntimeHelper.downcallHandle(
         LIBRARIES, "clang_Cursor_isFunctionInlined",
         "(Ljdk/incubator/foreign/MemorySegment;)I",
-        FunctionDescriptor.of(C_INT, false,
+        FunctionDescriptor.of(C_INT,
             MemoryLayout.ofStruct(
                 C_INT.withName("kind"),
                 C_INT.withName("xdata"),
@@ -3316,7 +3316,7 @@ public final class Index_h {
     public static final MethodHandle clang_isVolatileQualifiedType = RuntimeHelper.downcallHandle(
         LIBRARIES, "clang_isVolatileQualifiedType",
         "(Ljdk/incubator/foreign/MemorySegment;)I",
-        FunctionDescriptor.of(C_INT, false,
+        FunctionDescriptor.of(C_INT,
             MemoryLayout.ofStruct(
                 C_INT.withName("kind"),
                 MemoryLayout.ofPaddingBits(32),
@@ -3334,7 +3334,7 @@ public final class Index_h {
     public static final MethodHandle clang_isRestrictQualifiedType = RuntimeHelper.downcallHandle(
         LIBRARIES, "clang_isRestrictQualifiedType",
         "(Ljdk/incubator/foreign/MemorySegment;)I",
-        FunctionDescriptor.of(C_INT, false,
+        FunctionDescriptor.of(C_INT,
             MemoryLayout.ofStruct(
                 C_INT.withName("kind"),
                 MemoryLayout.ofPaddingBits(32),
@@ -3352,7 +3352,7 @@ public final class Index_h {
     public static final MethodHandle clang_getAddressSpace = RuntimeHelper.downcallHandle(
         LIBRARIES, "clang_getAddressSpace",
         "(Ljdk/incubator/foreign/MemorySegment;)I",
-        FunctionDescriptor.of(C_INT, false,
+        FunctionDescriptor.of(C_INT,
             MemoryLayout.ofStruct(
                 C_INT.withName("kind"),
                 MemoryLayout.ofPaddingBits(32),
@@ -3374,7 +3374,7 @@ public final class Index_h {
             C_POINTER.withName("data"),
             C_INT.withName("private_flags"),
             MemoryLayout.ofPaddingBits(32)
-        ), false,
+        ),
             MemoryLayout.ofStruct(
                 C_INT.withName("kind"),
                 MemoryLayout.ofPaddingBits(32),
@@ -3396,7 +3396,7 @@ public final class Index_h {
             C_INT.withName("kind"),
             MemoryLayout.ofPaddingBits(32),
             MemoryLayout.ofSequence(2, C_POINTER).withName("data")
-        ), false,
+        ),
             MemoryLayout.ofStruct(
                 C_INT.withName("kind"),
                 MemoryLayout.ofPaddingBits(32),
@@ -3418,7 +3418,7 @@ public final class Index_h {
             C_INT.withName("kind"),
             C_INT.withName("xdata"),
             MemoryLayout.ofSequence(3, C_POINTER).withName("data")
-        ), false,
+        ),
             MemoryLayout.ofStruct(
                 C_INT.withName("kind"),
                 MemoryLayout.ofPaddingBits(32),
@@ -3440,7 +3440,7 @@ public final class Index_h {
             C_POINTER.withName("data"),
             C_INT.withName("private_flags"),
             MemoryLayout.ofPaddingBits(32)
-        ), false,
+        ),
             MemoryLayout.ofStruct(
                 C_INT.withName("kind"),
                 C_INT.withName("xdata"),
@@ -3462,7 +3462,7 @@ public final class Index_h {
             C_POINTER.withName("data"),
             C_INT.withName("private_flags"),
             MemoryLayout.ofPaddingBits(32)
-        ), false,
+        ),
             MemoryLayout.ofStruct(
                 C_INT.withName("kind"),
                 MemoryLayout.ofPaddingBits(32),
@@ -3484,7 +3484,7 @@ public final class Index_h {
             C_POINTER.withName("data"),
             C_INT.withName("private_flags"),
             MemoryLayout.ofPaddingBits(32)
-        ), false,
+        ),
             C_INT
         )
     );
@@ -3498,7 +3498,7 @@ public final class Index_h {
     public static final MethodHandle clang_getFunctionTypeCallingConv = RuntimeHelper.downcallHandle(
         LIBRARIES, "clang_getFunctionTypeCallingConv",
         "(Ljdk/incubator/foreign/MemorySegment;)I",
-        FunctionDescriptor.of(C_INT, false,
+        FunctionDescriptor.of(C_INT,
             MemoryLayout.ofStruct(
                 C_INT.withName("kind"),
                 MemoryLayout.ofPaddingBits(32),
@@ -3520,7 +3520,7 @@ public final class Index_h {
             C_INT.withName("kind"),
             MemoryLayout.ofPaddingBits(32),
             MemoryLayout.ofSequence(2, C_POINTER).withName("data")
-        ), false,
+        ),
             MemoryLayout.ofStruct(
                 C_INT.withName("kind"),
                 MemoryLayout.ofPaddingBits(32),
@@ -3538,7 +3538,7 @@ public final class Index_h {
     public static final MethodHandle clang_getExceptionSpecificationType = RuntimeHelper.downcallHandle(
         LIBRARIES, "clang_getExceptionSpecificationType",
         "(Ljdk/incubator/foreign/MemorySegment;)I",
-        FunctionDescriptor.of(C_INT, false,
+        FunctionDescriptor.of(C_INT,
             MemoryLayout.ofStruct(
                 C_INT.withName("kind"),
                 MemoryLayout.ofPaddingBits(32),
@@ -3556,7 +3556,7 @@ public final class Index_h {
     public static final MethodHandle clang_getNumArgTypes = RuntimeHelper.downcallHandle(
         LIBRARIES, "clang_getNumArgTypes",
         "(Ljdk/incubator/foreign/MemorySegment;)I",
-        FunctionDescriptor.of(C_INT, false,
+        FunctionDescriptor.of(C_INT,
             MemoryLayout.ofStruct(
                 C_INT.withName("kind"),
                 MemoryLayout.ofPaddingBits(32),
@@ -3578,7 +3578,7 @@ public final class Index_h {
             C_INT.withName("kind"),
             MemoryLayout.ofPaddingBits(32),
             MemoryLayout.ofSequence(2, C_POINTER).withName("data")
-        ), false,
+        ),
             MemoryLayout.ofStruct(
                 C_INT.withName("kind"),
                 MemoryLayout.ofPaddingBits(32),
@@ -3601,7 +3601,7 @@ public final class Index_h {
             C_INT.withName("kind"),
             MemoryLayout.ofPaddingBits(32),
             MemoryLayout.ofSequence(2, C_POINTER).withName("data")
-        ), false,
+        ),
             MemoryLayout.ofStruct(
                 C_INT.withName("kind"),
                 MemoryLayout.ofPaddingBits(32),
@@ -3619,7 +3619,7 @@ public final class Index_h {
     public static final MethodHandle clang_Type_getNumObjCProtocolRefs = RuntimeHelper.downcallHandle(
         LIBRARIES, "clang_Type_getNumObjCProtocolRefs",
         "(Ljdk/incubator/foreign/MemorySegment;)I",
-        FunctionDescriptor.of(C_INT, false,
+        FunctionDescriptor.of(C_INT,
             MemoryLayout.ofStruct(
                 C_INT.withName("kind"),
                 MemoryLayout.ofPaddingBits(32),
@@ -3641,7 +3641,7 @@ public final class Index_h {
             C_INT.withName("kind"),
             C_INT.withName("xdata"),
             MemoryLayout.ofSequence(3, C_POINTER).withName("data")
-        ), false,
+        ),
             MemoryLayout.ofStruct(
                 C_INT.withName("kind"),
                 MemoryLayout.ofPaddingBits(32),
@@ -3660,7 +3660,7 @@ public final class Index_h {
     public static final MethodHandle clang_Type_getNumObjCTypeArgs = RuntimeHelper.downcallHandle(
         LIBRARIES, "clang_Type_getNumObjCTypeArgs",
         "(Ljdk/incubator/foreign/MemorySegment;)I",
-        FunctionDescriptor.of(C_INT, false,
+        FunctionDescriptor.of(C_INT,
             MemoryLayout.ofStruct(
                 C_INT.withName("kind"),
                 MemoryLayout.ofPaddingBits(32),
@@ -3682,7 +3682,7 @@ public final class Index_h {
             C_INT.withName("kind"),
             MemoryLayout.ofPaddingBits(32),
             MemoryLayout.ofSequence(2, C_POINTER).withName("data")
-        ), false,
+        ),
             MemoryLayout.ofStruct(
                 C_INT.withName("kind"),
                 MemoryLayout.ofPaddingBits(32),
@@ -3701,7 +3701,7 @@ public final class Index_h {
     public static final MethodHandle clang_isFunctionTypeVariadic = RuntimeHelper.downcallHandle(
         LIBRARIES, "clang_isFunctionTypeVariadic",
         "(Ljdk/incubator/foreign/MemorySegment;)I",
-        FunctionDescriptor.of(C_INT, false,
+        FunctionDescriptor.of(C_INT,
             MemoryLayout.ofStruct(
                 C_INT.withName("kind"),
                 MemoryLayout.ofPaddingBits(32),
@@ -3723,7 +3723,7 @@ public final class Index_h {
             C_INT.withName("kind"),
             MemoryLayout.ofPaddingBits(32),
             MemoryLayout.ofSequence(2, C_POINTER).withName("data")
-        ), false,
+        ),
             MemoryLayout.ofStruct(
                 C_INT.withName("kind"),
                 C_INT.withName("xdata"),
@@ -3741,7 +3741,7 @@ public final class Index_h {
     public static final MethodHandle clang_getCursorExceptionSpecificationType = RuntimeHelper.downcallHandle(
         LIBRARIES, "clang_getCursorExceptionSpecificationType",
         "(Ljdk/incubator/foreign/MemorySegment;)I",
-        FunctionDescriptor.of(C_INT, false,
+        FunctionDescriptor.of(C_INT,
             MemoryLayout.ofStruct(
                 C_INT.withName("kind"),
                 C_INT.withName("xdata"),
@@ -3759,7 +3759,7 @@ public final class Index_h {
     public static final MethodHandle clang_isPODType = RuntimeHelper.downcallHandle(
         LIBRARIES, "clang_isPODType",
         "(Ljdk/incubator/foreign/MemorySegment;)I",
-        FunctionDescriptor.of(C_INT, false,
+        FunctionDescriptor.of(C_INT,
             MemoryLayout.ofStruct(
                 C_INT.withName("kind"),
                 MemoryLayout.ofPaddingBits(32),
@@ -3781,7 +3781,7 @@ public final class Index_h {
             C_INT.withName("kind"),
             MemoryLayout.ofPaddingBits(32),
             MemoryLayout.ofSequence(2, C_POINTER).withName("data")
-        ), false,
+        ),
             MemoryLayout.ofStruct(
                 C_INT.withName("kind"),
                 MemoryLayout.ofPaddingBits(32),
@@ -3799,7 +3799,7 @@ public final class Index_h {
     public static final MethodHandle clang_getNumElements = RuntimeHelper.downcallHandle(
         LIBRARIES, "clang_getNumElements",
         "(Ljdk/incubator/foreign/MemorySegment;)J",
-        FunctionDescriptor.of(C_LONGLONG, false,
+        FunctionDescriptor.of(C_LONGLONG,
             MemoryLayout.ofStruct(
                 C_INT.withName("kind"),
                 MemoryLayout.ofPaddingBits(32),
@@ -3821,7 +3821,7 @@ public final class Index_h {
             C_INT.withName("kind"),
             MemoryLayout.ofPaddingBits(32),
             MemoryLayout.ofSequence(2, C_POINTER).withName("data")
-        ), false,
+        ),
             MemoryLayout.ofStruct(
                 C_INT.withName("kind"),
                 MemoryLayout.ofPaddingBits(32),
@@ -3839,7 +3839,7 @@ public final class Index_h {
     public static final MethodHandle clang_getArraySize = RuntimeHelper.downcallHandle(
         LIBRARIES, "clang_getArraySize",
         "(Ljdk/incubator/foreign/MemorySegment;)J",
-        FunctionDescriptor.of(C_LONGLONG, false,
+        FunctionDescriptor.of(C_LONGLONG,
             MemoryLayout.ofStruct(
                 C_INT.withName("kind"),
                 MemoryLayout.ofPaddingBits(32),
@@ -3861,7 +3861,7 @@ public final class Index_h {
             C_INT.withName("kind"),
             MemoryLayout.ofPaddingBits(32),
             MemoryLayout.ofSequence(2, C_POINTER).withName("data")
-        ), false,
+        ),
             MemoryLayout.ofStruct(
                 C_INT.withName("kind"),
                 MemoryLayout.ofPaddingBits(32),
@@ -3879,7 +3879,7 @@ public final class Index_h {
     public static final MethodHandle clang_Type_isTransparentTagTypedef = RuntimeHelper.downcallHandle(
         LIBRARIES, "clang_Type_isTransparentTagTypedef",
         "(Ljdk/incubator/foreign/MemorySegment;)I",
-        FunctionDescriptor.of(C_INT, false,
+        FunctionDescriptor.of(C_INT,
             MemoryLayout.ofStruct(
                 C_INT.withName("kind"),
                 MemoryLayout.ofPaddingBits(32),
@@ -3901,7 +3901,7 @@ public final class Index_h {
     public static final MethodHandle clang_Type_getNullability = RuntimeHelper.downcallHandle(
         LIBRARIES, "clang_Type_getNullability",
         "(Ljdk/incubator/foreign/MemorySegment;)I",
-        FunctionDescriptor.of(C_INT, false,
+        FunctionDescriptor.of(C_INT,
             MemoryLayout.ofStruct(
                 C_INT.withName("kind"),
                 MemoryLayout.ofPaddingBits(32),
@@ -3925,7 +3925,7 @@ public final class Index_h {
     public static final MethodHandle clang_Type_getAlignOf = RuntimeHelper.downcallHandle(
         LIBRARIES, "clang_Type_getAlignOf",
         "(Ljdk/incubator/foreign/MemorySegment;)J",
-        FunctionDescriptor.of(C_LONGLONG, false,
+        FunctionDescriptor.of(C_LONGLONG,
             MemoryLayout.ofStruct(
                 C_INT.withName("kind"),
                 MemoryLayout.ofPaddingBits(32),
@@ -3947,7 +3947,7 @@ public final class Index_h {
             C_INT.withName("kind"),
             MemoryLayout.ofPaddingBits(32),
             MemoryLayout.ofSequence(2, C_POINTER).withName("data")
-        ), false,
+        ),
             MemoryLayout.ofStruct(
                 C_INT.withName("kind"),
                 MemoryLayout.ofPaddingBits(32),
@@ -3965,7 +3965,7 @@ public final class Index_h {
     public static final MethodHandle clang_Type_getSizeOf = RuntimeHelper.downcallHandle(
         LIBRARIES, "clang_Type_getSizeOf",
         "(Ljdk/incubator/foreign/MemorySegment;)J",
-        FunctionDescriptor.of(C_LONGLONG, false,
+        FunctionDescriptor.of(C_LONGLONG,
             MemoryLayout.ofStruct(
                 C_INT.withName("kind"),
                 MemoryLayout.ofPaddingBits(32),
@@ -3983,7 +3983,7 @@ public final class Index_h {
     public static final MethodHandle clang_Type_getOffsetOf = RuntimeHelper.downcallHandle(
         LIBRARIES, "clang_Type_getOffsetOf",
         "(Ljdk/incubator/foreign/MemorySegment;Ljdk/incubator/foreign/MemoryAddress;)J",
-        FunctionDescriptor.of(C_LONGLONG, false,
+        FunctionDescriptor.of(C_LONGLONG,
             MemoryLayout.ofStruct(
                 C_INT.withName("kind"),
                 MemoryLayout.ofPaddingBits(32),
@@ -4006,7 +4006,7 @@ public final class Index_h {
             C_INT.withName("kind"),
             MemoryLayout.ofPaddingBits(32),
             MemoryLayout.ofSequence(2, C_POINTER).withName("data")
-        ), false,
+        ),
             MemoryLayout.ofStruct(
                 C_INT.withName("kind"),
                 MemoryLayout.ofPaddingBits(32),
@@ -4024,7 +4024,7 @@ public final class Index_h {
     public static final MethodHandle clang_Cursor_getOffsetOfField = RuntimeHelper.downcallHandle(
         LIBRARIES, "clang_Cursor_getOffsetOfField",
         "(Ljdk/incubator/foreign/MemorySegment;)J",
-        FunctionDescriptor.of(C_LONGLONG, false,
+        FunctionDescriptor.of(C_LONGLONG,
             MemoryLayout.ofStruct(
                 C_INT.withName("kind"),
                 C_INT.withName("xdata"),
@@ -4042,7 +4042,7 @@ public final class Index_h {
     public static final MethodHandle clang_Cursor_isAnonymous = RuntimeHelper.downcallHandle(
         LIBRARIES, "clang_Cursor_isAnonymous",
         "(Ljdk/incubator/foreign/MemorySegment;)I",
-        FunctionDescriptor.of(C_INT, false,
+        FunctionDescriptor.of(C_INT,
             MemoryLayout.ofStruct(
                 C_INT.withName("kind"),
                 C_INT.withName("xdata"),
@@ -4060,7 +4060,7 @@ public final class Index_h {
     public static final MethodHandle clang_Cursor_isAnonymousRecordDecl = RuntimeHelper.downcallHandle(
         LIBRARIES, "clang_Cursor_isAnonymousRecordDecl",
         "(Ljdk/incubator/foreign/MemorySegment;)I",
-        FunctionDescriptor.of(C_INT, false,
+        FunctionDescriptor.of(C_INT,
             MemoryLayout.ofStruct(
                 C_INT.withName("kind"),
                 C_INT.withName("xdata"),
@@ -4078,7 +4078,7 @@ public final class Index_h {
     public static final MethodHandle clang_Cursor_isInlineNamespace = RuntimeHelper.downcallHandle(
         LIBRARIES, "clang_Cursor_isInlineNamespace",
         "(Ljdk/incubator/foreign/MemorySegment;)I",
-        FunctionDescriptor.of(C_INT, false,
+        FunctionDescriptor.of(C_INT,
             MemoryLayout.ofStruct(
                 C_INT.withName("kind"),
                 C_INT.withName("xdata"),
@@ -4099,7 +4099,7 @@ public final class Index_h {
     public static final MethodHandle clang_Type_getNumTemplateArguments = RuntimeHelper.downcallHandle(
         LIBRARIES, "clang_Type_getNumTemplateArguments",
         "(Ljdk/incubator/foreign/MemorySegment;)I",
-        FunctionDescriptor.of(C_INT, false,
+        FunctionDescriptor.of(C_INT,
             MemoryLayout.ofStruct(
                 C_INT.withName("kind"),
                 MemoryLayout.ofPaddingBits(32),
@@ -4121,7 +4121,7 @@ public final class Index_h {
             C_INT.withName("kind"),
             MemoryLayout.ofPaddingBits(32),
             MemoryLayout.ofSequence(2, C_POINTER).withName("data")
-        ), false,
+        ),
             MemoryLayout.ofStruct(
                 C_INT.withName("kind"),
                 MemoryLayout.ofPaddingBits(32),
@@ -4140,7 +4140,7 @@ public final class Index_h {
     public static final MethodHandle clang_Type_getCXXRefQualifier = RuntimeHelper.downcallHandle(
         LIBRARIES, "clang_Type_getCXXRefQualifier",
         "(Ljdk/incubator/foreign/MemorySegment;)I",
-        FunctionDescriptor.of(C_INT, false,
+        FunctionDescriptor.of(C_INT,
             MemoryLayout.ofStruct(
                 C_INT.withName("kind"),
                 MemoryLayout.ofPaddingBits(32),
@@ -4158,7 +4158,7 @@ public final class Index_h {
     public static final MethodHandle clang_Cursor_isBitField = RuntimeHelper.downcallHandle(
         LIBRARIES, "clang_Cursor_isBitField",
         "(Ljdk/incubator/foreign/MemorySegment;)I",
-        FunctionDescriptor.of(C_INT, false,
+        FunctionDescriptor.of(C_INT,
             MemoryLayout.ofStruct(
                 C_INT.withName("kind"),
                 C_INT.withName("xdata"),
@@ -4176,7 +4176,7 @@ public final class Index_h {
     public static final MethodHandle clang_isVirtualBase = RuntimeHelper.downcallHandle(
         LIBRARIES, "clang_isVirtualBase",
         "(Ljdk/incubator/foreign/MemorySegment;)I",
-        FunctionDescriptor.of(C_INT, false,
+        FunctionDescriptor.of(C_INT,
             MemoryLayout.ofStruct(
                 C_INT.withName("kind"),
                 C_INT.withName("xdata"),
@@ -4198,7 +4198,7 @@ public final class Index_h {
     public static final MethodHandle clang_getCXXAccessSpecifier = RuntimeHelper.downcallHandle(
         LIBRARIES, "clang_getCXXAccessSpecifier",
         "(Ljdk/incubator/foreign/MemorySegment;)I",
-        FunctionDescriptor.of(C_INT, false,
+        FunctionDescriptor.of(C_INT,
             MemoryLayout.ofStruct(
                 C_INT.withName("kind"),
                 C_INT.withName("xdata"),
@@ -4224,7 +4224,7 @@ public final class Index_h {
     public static final MethodHandle clang_Cursor_getStorageClass = RuntimeHelper.downcallHandle(
         LIBRARIES, "clang_Cursor_getStorageClass",
         "(Ljdk/incubator/foreign/MemorySegment;)I",
-        FunctionDescriptor.of(C_INT, false,
+        FunctionDescriptor.of(C_INT,
             MemoryLayout.ofStruct(
                 C_INT.withName("kind"),
                 C_INT.withName("xdata"),
@@ -4242,7 +4242,7 @@ public final class Index_h {
     public static final MethodHandle clang_getNumOverloadedDecls = RuntimeHelper.downcallHandle(
         LIBRARIES, "clang_getNumOverloadedDecls",
         "(Ljdk/incubator/foreign/MemorySegment;)I",
-        FunctionDescriptor.of(C_INT, false,
+        FunctionDescriptor.of(C_INT,
             MemoryLayout.ofStruct(
                 C_INT.withName("kind"),
                 C_INT.withName("xdata"),
@@ -4264,7 +4264,7 @@ public final class Index_h {
             C_INT.withName("kind"),
             C_INT.withName("xdata"),
             MemoryLayout.ofSequence(3, C_POINTER).withName("data")
-        ), false,
+        ),
             MemoryLayout.ofStruct(
                 C_INT.withName("kind"),
                 C_INT.withName("xdata"),
@@ -4287,7 +4287,7 @@ public final class Index_h {
             C_INT.withName("kind"),
             MemoryLayout.ofPaddingBits(32),
             MemoryLayout.ofSequence(2, C_POINTER).withName("data")
-        ), false,
+        ),
             MemoryLayout.ofStruct(
                 C_INT.withName("kind"),
                 C_INT.withName("xdata"),
@@ -4308,7 +4308,7 @@ public final class Index_h {
     public static final MethodHandle clang_visitChildren = RuntimeHelper.downcallHandle(
         LIBRARIES, "clang_visitChildren",
         "(Ljdk/incubator/foreign/MemorySegment;Ljdk/incubator/foreign/MemoryAddress;Ljdk/incubator/foreign/MemoryAddress;)I",
-        FunctionDescriptor.of(C_INT, false,
+        FunctionDescriptor.of(C_INT,
             MemoryLayout.ofStruct(
                 C_INT.withName("kind"),
                 C_INT.withName("xdata"),
@@ -4325,7 +4325,7 @@ public final class Index_h {
             throw new AssertionError(ex);
         }
     }
-    private static final FunctionDescriptor clang_visitChildren$visitor$DESC = FunctionDescriptor.of(C_INT, false,
+    private static final FunctionDescriptor clang_visitChildren$visitor$DESC = FunctionDescriptor.of(C_INT,
         MemoryLayout.ofStruct(
             C_INT.withName("kind"),
             C_INT.withName("xdata"),
@@ -4351,7 +4351,7 @@ public final class Index_h {
             C_POINTER.withName("data"),
             C_INT.withName("private_flags"),
             MemoryLayout.ofPaddingBits(32)
-        ), false,
+        ),
             MemoryLayout.ofStruct(
                 C_INT.withName("kind"),
                 C_INT.withName("xdata"),
@@ -4373,7 +4373,7 @@ public final class Index_h {
             C_POINTER.withName("data"),
             C_INT.withName("private_flags"),
             MemoryLayout.ofPaddingBits(32)
-        ), false,
+        ),
             C_POINTER
         )
     );
@@ -4391,7 +4391,7 @@ public final class Index_h {
             C_POINTER.withName("data"),
             C_INT.withName("private_flags"),
             MemoryLayout.ofPaddingBits(32)
-        ), false,
+        ),
             C_POINTER,
             C_POINTER
         )
@@ -4410,7 +4410,7 @@ public final class Index_h {
             C_POINTER.withName("data"),
             C_INT.withName("private_flags"),
             MemoryLayout.ofPaddingBits(32)
-        ), false,
+        ),
             C_POINTER
         )
     );
@@ -4428,7 +4428,7 @@ public final class Index_h {
             C_POINTER.withName("data"),
             C_INT.withName("private_flags"),
             MemoryLayout.ofPaddingBits(32)
-        ), false,
+        ),
             C_POINTER,
             MemoryLayout.ofStruct(
                 C_POINTER.withName("data"),
@@ -4451,7 +4451,7 @@ public final class Index_h {
             C_POINTER.withName("data"),
             C_INT.withName("private_flags"),
             MemoryLayout.ofPaddingBits(32)
-        ), false,
+        ),
             C_POINTER,
             C_INT,
             MemoryLayout.ofStruct(
@@ -4475,7 +4475,7 @@ public final class Index_h {
             C_POINTER.withName("data"),
             C_INT.withName("private_flags"),
             MemoryLayout.ofPaddingBits(32)
-        ), false,
+        ),
             C_POINTER,
             MemoryLayout.ofStruct(
                 C_POINTER.withName("data"),
@@ -4498,7 +4498,7 @@ public final class Index_h {
             C_POINTER.withName("data"),
             C_INT.withName("private_flags"),
             MemoryLayout.ofPaddingBits(32)
-        ), false,
+        ),
             MemoryLayout.ofStruct(
                 C_INT.withName("kind"),
                 C_INT.withName("xdata"),
@@ -4520,7 +4520,7 @@ public final class Index_h {
             MemoryLayout.ofSequence(2, C_POINTER).withName("ptr_data"),
             C_INT.withName("begin_int_data"),
             C_INT.withName("end_int_data")
-        ), false,
+        ),
             MemoryLayout.ofStruct(
                 C_INT.withName("kind"),
                 C_INT.withName("xdata"),
@@ -4567,7 +4567,7 @@ public final class Index_h {
     public static final MethodHandle clang_PrintingPolicy_getProperty = RuntimeHelper.downcallHandle(
         LIBRARIES, "clang_PrintingPolicy_getProperty",
         "(Ljdk/incubator/foreign/MemoryAddress;I)I",
-        FunctionDescriptor.of(C_INT, false,
+        FunctionDescriptor.of(C_INT,
             C_POINTER,
             C_INT
         )
@@ -4582,7 +4582,7 @@ public final class Index_h {
     public static final MethodHandle clang_PrintingPolicy_setProperty = RuntimeHelper.downcallHandle(
         LIBRARIES, "clang_PrintingPolicy_setProperty",
         "(Ljdk/incubator/foreign/MemoryAddress;II)V",
-        FunctionDescriptor.ofVoid(false,
+        FunctionDescriptor.ofVoid(
             C_POINTER,
             C_INT,
             C_INT
@@ -4598,7 +4598,7 @@ public final class Index_h {
     public static final MethodHandle clang_getCursorPrintingPolicy = RuntimeHelper.downcallHandle(
         LIBRARIES, "clang_getCursorPrintingPolicy",
         "(Ljdk/incubator/foreign/MemorySegment;)Ljdk/incubator/foreign/MemoryAddress;",
-        FunctionDescriptor.of(C_POINTER, false,
+        FunctionDescriptor.of(C_POINTER,
             MemoryLayout.ofStruct(
                 C_INT.withName("kind"),
                 C_INT.withName("xdata"),
@@ -4616,7 +4616,7 @@ public final class Index_h {
     public static final MethodHandle clang_PrintingPolicy_dispose = RuntimeHelper.downcallHandle(
         LIBRARIES, "clang_PrintingPolicy_dispose",
         "(Ljdk/incubator/foreign/MemoryAddress;)V",
-        FunctionDescriptor.ofVoid(false,
+        FunctionDescriptor.ofVoid(
             C_POINTER
         )
     );
@@ -4634,7 +4634,7 @@ public final class Index_h {
             C_POINTER.withName("data"),
             C_INT.withName("private_flags"),
             MemoryLayout.ofPaddingBits(32)
-        ), false,
+        ),
             MemoryLayout.ofStruct(
                 C_INT.withName("kind"),
                 C_INT.withName("xdata"),
@@ -4657,7 +4657,7 @@ public final class Index_h {
             C_POINTER.withName("data"),
             C_INT.withName("private_flags"),
             MemoryLayout.ofPaddingBits(32)
-        ), false,
+        ),
             MemoryLayout.ofStruct(
                 C_INT.withName("kind"),
                 C_INT.withName("xdata"),
@@ -4679,7 +4679,7 @@ public final class Index_h {
             C_INT.withName("kind"),
             C_INT.withName("xdata"),
             MemoryLayout.ofSequence(3, C_POINTER).withName("data")
-        ), false,
+        ),
             MemoryLayout.ofStruct(
                 C_INT.withName("kind"),
                 C_INT.withName("xdata"),
@@ -4701,7 +4701,7 @@ public final class Index_h {
             C_INT.withName("kind"),
             C_INT.withName("xdata"),
             MemoryLayout.ofSequence(3, C_POINTER).withName("data")
-        ), false,
+        ),
             MemoryLayout.ofStruct(
                 C_INT.withName("kind"),
                 C_INT.withName("xdata"),
@@ -4719,7 +4719,7 @@ public final class Index_h {
     public static final MethodHandle clang_isCursorDefinition = RuntimeHelper.downcallHandle(
         LIBRARIES, "clang_isCursorDefinition",
         "(Ljdk/incubator/foreign/MemorySegment;)I",
-        FunctionDescriptor.of(C_INT, false,
+        FunctionDescriptor.of(C_INT,
             MemoryLayout.ofStruct(
                 C_INT.withName("kind"),
                 C_INT.withName("xdata"),
@@ -4741,7 +4741,7 @@ public final class Index_h {
             C_INT.withName("kind"),
             C_INT.withName("xdata"),
             MemoryLayout.ofSequence(3, C_POINTER).withName("data")
-        ), false,
+        ),
             MemoryLayout.ofStruct(
                 C_INT.withName("kind"),
                 C_INT.withName("xdata"),
@@ -4759,7 +4759,7 @@ public final class Index_h {
     public static final MethodHandle clang_Cursor_getObjCSelectorIndex = RuntimeHelper.downcallHandle(
         LIBRARIES, "clang_Cursor_getObjCSelectorIndex",
         "(Ljdk/incubator/foreign/MemorySegment;)I",
-        FunctionDescriptor.of(C_INT, false,
+        FunctionDescriptor.of(C_INT,
             MemoryLayout.ofStruct(
                 C_INT.withName("kind"),
                 C_INT.withName("xdata"),
@@ -4777,7 +4777,7 @@ public final class Index_h {
     public static final MethodHandle clang_Cursor_isDynamicCall = RuntimeHelper.downcallHandle(
         LIBRARIES, "clang_Cursor_isDynamicCall",
         "(Ljdk/incubator/foreign/MemorySegment;)I",
-        FunctionDescriptor.of(C_INT, false,
+        FunctionDescriptor.of(C_INT,
             MemoryLayout.ofStruct(
                 C_INT.withName("kind"),
                 C_INT.withName("xdata"),
@@ -4799,7 +4799,7 @@ public final class Index_h {
             C_INT.withName("kind"),
             MemoryLayout.ofPaddingBits(32),
             MemoryLayout.ofSequence(2, C_POINTER).withName("data")
-        ), false,
+        ),
             MemoryLayout.ofStruct(
                 C_INT.withName("kind"),
                 C_INT.withName("xdata"),
@@ -4831,7 +4831,7 @@ public final class Index_h {
     public static final MethodHandle clang_Cursor_getObjCPropertyAttributes = RuntimeHelper.downcallHandle(
         LIBRARIES, "clang_Cursor_getObjCPropertyAttributes",
         "(Ljdk/incubator/foreign/MemorySegment;I)I",
-        FunctionDescriptor.of(C_INT, false,
+        FunctionDescriptor.of(C_INT,
             MemoryLayout.ofStruct(
                 C_INT.withName("kind"),
                 C_INT.withName("xdata"),
@@ -4854,7 +4854,7 @@ public final class Index_h {
             C_POINTER.withName("data"),
             C_INT.withName("private_flags"),
             MemoryLayout.ofPaddingBits(32)
-        ), false,
+        ),
             MemoryLayout.ofStruct(
                 C_INT.withName("kind"),
                 C_INT.withName("xdata"),
@@ -4876,7 +4876,7 @@ public final class Index_h {
             C_POINTER.withName("data"),
             C_INT.withName("private_flags"),
             MemoryLayout.ofPaddingBits(32)
-        ), false,
+        ),
             MemoryLayout.ofStruct(
                 C_INT.withName("kind"),
                 C_INT.withName("xdata"),
@@ -4901,7 +4901,7 @@ public final class Index_h {
     public static final MethodHandle clang_Cursor_getObjCDeclQualifiers = RuntimeHelper.downcallHandle(
         LIBRARIES, "clang_Cursor_getObjCDeclQualifiers",
         "(Ljdk/incubator/foreign/MemorySegment;)I",
-        FunctionDescriptor.of(C_INT, false,
+        FunctionDescriptor.of(C_INT,
             MemoryLayout.ofStruct(
                 C_INT.withName("kind"),
                 C_INT.withName("xdata"),
@@ -4919,7 +4919,7 @@ public final class Index_h {
     public static final MethodHandle clang_Cursor_isObjCOptional = RuntimeHelper.downcallHandle(
         LIBRARIES, "clang_Cursor_isObjCOptional",
         "(Ljdk/incubator/foreign/MemorySegment;)I",
-        FunctionDescriptor.of(C_INT, false,
+        FunctionDescriptor.of(C_INT,
             MemoryLayout.ofStruct(
                 C_INT.withName("kind"),
                 C_INT.withName("xdata"),
@@ -4937,7 +4937,7 @@ public final class Index_h {
     public static final MethodHandle clang_Cursor_isVariadic = RuntimeHelper.downcallHandle(
         LIBRARIES, "clang_Cursor_isVariadic",
         "(Ljdk/incubator/foreign/MemorySegment;)I",
-        FunctionDescriptor.of(C_INT, false,
+        FunctionDescriptor.of(C_INT,
             MemoryLayout.ofStruct(
                 C_INT.withName("kind"),
                 C_INT.withName("xdata"),
@@ -4955,7 +4955,7 @@ public final class Index_h {
     public static final MethodHandle clang_Cursor_isExternalSymbol = RuntimeHelper.downcallHandle(
         LIBRARIES, "clang_Cursor_isExternalSymbol",
         "(Ljdk/incubator/foreign/MemorySegment;Ljdk/incubator/foreign/MemoryAddress;Ljdk/incubator/foreign/MemoryAddress;Ljdk/incubator/foreign/MemoryAddress;)I",
-        FunctionDescriptor.of(C_INT, false,
+        FunctionDescriptor.of(C_INT,
             MemoryLayout.ofStruct(
                 C_INT.withName("kind"),
                 C_INT.withName("xdata"),
@@ -4980,7 +4980,7 @@ public final class Index_h {
             MemoryLayout.ofSequence(2, C_POINTER).withName("ptr_data"),
             C_INT.withName("begin_int_data"),
             C_INT.withName("end_int_data")
-        ), false,
+        ),
             MemoryLayout.ofStruct(
                 C_INT.withName("kind"),
                 C_INT.withName("xdata"),
@@ -5002,7 +5002,7 @@ public final class Index_h {
             C_POINTER.withName("data"),
             C_INT.withName("private_flags"),
             MemoryLayout.ofPaddingBits(32)
-        ), false,
+        ),
             MemoryLayout.ofStruct(
                 C_INT.withName("kind"),
                 C_INT.withName("xdata"),
@@ -5024,7 +5024,7 @@ public final class Index_h {
             C_POINTER.withName("data"),
             C_INT.withName("private_flags"),
             MemoryLayout.ofPaddingBits(32)
-        ), false,
+        ),
             MemoryLayout.ofStruct(
                 C_INT.withName("kind"),
                 C_INT.withName("xdata"),
@@ -5046,7 +5046,7 @@ public final class Index_h {
             C_POINTER.withName("data"),
             C_INT.withName("private_flags"),
             MemoryLayout.ofPaddingBits(32)
-        ), false,
+        ),
             MemoryLayout.ofStruct(
                 C_INT.withName("kind"),
                 C_INT.withName("xdata"),
@@ -5064,7 +5064,7 @@ public final class Index_h {
     public static final MethodHandle clang_Cursor_getCXXManglings = RuntimeHelper.downcallHandle(
         LIBRARIES, "clang_Cursor_getCXXManglings",
         "(Ljdk/incubator/foreign/MemorySegment;)Ljdk/incubator/foreign/MemoryAddress;",
-        FunctionDescriptor.of(C_POINTER, false,
+        FunctionDescriptor.of(C_POINTER,
             MemoryLayout.ofStruct(
                 C_INT.withName("kind"),
                 C_INT.withName("xdata"),
@@ -5082,7 +5082,7 @@ public final class Index_h {
     public static final MethodHandle clang_Cursor_getObjCManglings = RuntimeHelper.downcallHandle(
         LIBRARIES, "clang_Cursor_getObjCManglings",
         "(Ljdk/incubator/foreign/MemorySegment;)Ljdk/incubator/foreign/MemoryAddress;",
-        FunctionDescriptor.of(C_POINTER, false,
+        FunctionDescriptor.of(C_POINTER,
             MemoryLayout.ofStruct(
                 C_INT.withName("kind"),
                 C_INT.withName("xdata"),
@@ -5100,7 +5100,7 @@ public final class Index_h {
     public static final MethodHandle clang_Cursor_getModule = RuntimeHelper.downcallHandle(
         LIBRARIES, "clang_Cursor_getModule",
         "(Ljdk/incubator/foreign/MemorySegment;)Ljdk/incubator/foreign/MemoryAddress;",
-        FunctionDescriptor.of(C_POINTER, false,
+        FunctionDescriptor.of(C_POINTER,
             MemoryLayout.ofStruct(
                 C_INT.withName("kind"),
                 C_INT.withName("xdata"),
@@ -5118,7 +5118,7 @@ public final class Index_h {
     public static final MethodHandle clang_getModuleForFile = RuntimeHelper.downcallHandle(
         LIBRARIES, "clang_getModuleForFile",
         "(Ljdk/incubator/foreign/MemoryAddress;Ljdk/incubator/foreign/MemoryAddress;)Ljdk/incubator/foreign/MemoryAddress;",
-        FunctionDescriptor.of(C_POINTER, false,
+        FunctionDescriptor.of(C_POINTER,
             C_POINTER,
             C_POINTER
         )
@@ -5133,7 +5133,7 @@ public final class Index_h {
     public static final MethodHandle clang_Module_getASTFile = RuntimeHelper.downcallHandle(
         LIBRARIES, "clang_Module_getASTFile",
         "(Ljdk/incubator/foreign/MemoryAddress;)Ljdk/incubator/foreign/MemoryAddress;",
-        FunctionDescriptor.of(C_POINTER, false,
+        FunctionDescriptor.of(C_POINTER,
             C_POINTER
         )
     );
@@ -5147,7 +5147,7 @@ public final class Index_h {
     public static final MethodHandle clang_Module_getParent = RuntimeHelper.downcallHandle(
         LIBRARIES, "clang_Module_getParent",
         "(Ljdk/incubator/foreign/MemoryAddress;)Ljdk/incubator/foreign/MemoryAddress;",
-        FunctionDescriptor.of(C_POINTER, false,
+        FunctionDescriptor.of(C_POINTER,
             C_POINTER
         )
     );
@@ -5165,7 +5165,7 @@ public final class Index_h {
             C_POINTER.withName("data"),
             C_INT.withName("private_flags"),
             MemoryLayout.ofPaddingBits(32)
-        ), false,
+        ),
             C_POINTER
         )
     );
@@ -5183,7 +5183,7 @@ public final class Index_h {
             C_POINTER.withName("data"),
             C_INT.withName("private_flags"),
             MemoryLayout.ofPaddingBits(32)
-        ), false,
+        ),
             C_POINTER
         )
     );
@@ -5197,7 +5197,7 @@ public final class Index_h {
     public static final MethodHandle clang_Module_isSystem = RuntimeHelper.downcallHandle(
         LIBRARIES, "clang_Module_isSystem",
         "(Ljdk/incubator/foreign/MemoryAddress;)I",
-        FunctionDescriptor.of(C_INT, false,
+        FunctionDescriptor.of(C_INT,
             C_POINTER
         )
     );
@@ -5211,7 +5211,7 @@ public final class Index_h {
     public static final MethodHandle clang_Module_getNumTopLevelHeaders = RuntimeHelper.downcallHandle(
         LIBRARIES, "clang_Module_getNumTopLevelHeaders",
         "(Ljdk/incubator/foreign/MemoryAddress;Ljdk/incubator/foreign/MemoryAddress;)I",
-        FunctionDescriptor.of(C_INT, false,
+        FunctionDescriptor.of(C_INT,
             C_POINTER,
             C_POINTER
         )
@@ -5226,7 +5226,7 @@ public final class Index_h {
     public static final MethodHandle clang_Module_getTopLevelHeader = RuntimeHelper.downcallHandle(
         LIBRARIES, "clang_Module_getTopLevelHeader",
         "(Ljdk/incubator/foreign/MemoryAddress;Ljdk/incubator/foreign/MemoryAddress;I)Ljdk/incubator/foreign/MemoryAddress;",
-        FunctionDescriptor.of(C_POINTER, false,
+        FunctionDescriptor.of(C_POINTER,
             C_POINTER,
             C_POINTER,
             C_INT
@@ -5242,7 +5242,7 @@ public final class Index_h {
     public static final MethodHandle clang_CXXConstructor_isConvertingConstructor = RuntimeHelper.downcallHandle(
         LIBRARIES, "clang_CXXConstructor_isConvertingConstructor",
         "(Ljdk/incubator/foreign/MemorySegment;)I",
-        FunctionDescriptor.of(C_INT, false,
+        FunctionDescriptor.of(C_INT,
             MemoryLayout.ofStruct(
                 C_INT.withName("kind"),
                 C_INT.withName("xdata"),
@@ -5260,7 +5260,7 @@ public final class Index_h {
     public static final MethodHandle clang_CXXConstructor_isCopyConstructor = RuntimeHelper.downcallHandle(
         LIBRARIES, "clang_CXXConstructor_isCopyConstructor",
         "(Ljdk/incubator/foreign/MemorySegment;)I",
-        FunctionDescriptor.of(C_INT, false,
+        FunctionDescriptor.of(C_INT,
             MemoryLayout.ofStruct(
                 C_INT.withName("kind"),
                 C_INT.withName("xdata"),
@@ -5278,7 +5278,7 @@ public final class Index_h {
     public static final MethodHandle clang_CXXConstructor_isDefaultConstructor = RuntimeHelper.downcallHandle(
         LIBRARIES, "clang_CXXConstructor_isDefaultConstructor",
         "(Ljdk/incubator/foreign/MemorySegment;)I",
-        FunctionDescriptor.of(C_INT, false,
+        FunctionDescriptor.of(C_INT,
             MemoryLayout.ofStruct(
                 C_INT.withName("kind"),
                 C_INT.withName("xdata"),
@@ -5296,7 +5296,7 @@ public final class Index_h {
     public static final MethodHandle clang_CXXConstructor_isMoveConstructor = RuntimeHelper.downcallHandle(
         LIBRARIES, "clang_CXXConstructor_isMoveConstructor",
         "(Ljdk/incubator/foreign/MemorySegment;)I",
-        FunctionDescriptor.of(C_INT, false,
+        FunctionDescriptor.of(C_INT,
             MemoryLayout.ofStruct(
                 C_INT.withName("kind"),
                 C_INT.withName("xdata"),
@@ -5314,7 +5314,7 @@ public final class Index_h {
     public static final MethodHandle clang_CXXField_isMutable = RuntimeHelper.downcallHandle(
         LIBRARIES, "clang_CXXField_isMutable",
         "(Ljdk/incubator/foreign/MemorySegment;)I",
-        FunctionDescriptor.of(C_INT, false,
+        FunctionDescriptor.of(C_INT,
             MemoryLayout.ofStruct(
                 C_INT.withName("kind"),
                 C_INT.withName("xdata"),
@@ -5332,7 +5332,7 @@ public final class Index_h {
     public static final MethodHandle clang_CXXMethod_isDefaulted = RuntimeHelper.downcallHandle(
         LIBRARIES, "clang_CXXMethod_isDefaulted",
         "(Ljdk/incubator/foreign/MemorySegment;)I",
-        FunctionDescriptor.of(C_INT, false,
+        FunctionDescriptor.of(C_INT,
             MemoryLayout.ofStruct(
                 C_INT.withName("kind"),
                 C_INT.withName("xdata"),
@@ -5350,7 +5350,7 @@ public final class Index_h {
     public static final MethodHandle clang_CXXMethod_isPureVirtual = RuntimeHelper.downcallHandle(
         LIBRARIES, "clang_CXXMethod_isPureVirtual",
         "(Ljdk/incubator/foreign/MemorySegment;)I",
-        FunctionDescriptor.of(C_INT, false,
+        FunctionDescriptor.of(C_INT,
             MemoryLayout.ofStruct(
                 C_INT.withName("kind"),
                 C_INT.withName("xdata"),
@@ -5368,7 +5368,7 @@ public final class Index_h {
     public static final MethodHandle clang_CXXMethod_isStatic = RuntimeHelper.downcallHandle(
         LIBRARIES, "clang_CXXMethod_isStatic",
         "(Ljdk/incubator/foreign/MemorySegment;)I",
-        FunctionDescriptor.of(C_INT, false,
+        FunctionDescriptor.of(C_INT,
             MemoryLayout.ofStruct(
                 C_INT.withName("kind"),
                 C_INT.withName("xdata"),
@@ -5386,7 +5386,7 @@ public final class Index_h {
     public static final MethodHandle clang_CXXMethod_isVirtual = RuntimeHelper.downcallHandle(
         LIBRARIES, "clang_CXXMethod_isVirtual",
         "(Ljdk/incubator/foreign/MemorySegment;)I",
-        FunctionDescriptor.of(C_INT, false,
+        FunctionDescriptor.of(C_INT,
             MemoryLayout.ofStruct(
                 C_INT.withName("kind"),
                 C_INT.withName("xdata"),
@@ -5404,7 +5404,7 @@ public final class Index_h {
     public static final MethodHandle clang_CXXRecord_isAbstract = RuntimeHelper.downcallHandle(
         LIBRARIES, "clang_CXXRecord_isAbstract",
         "(Ljdk/incubator/foreign/MemorySegment;)I",
-        FunctionDescriptor.of(C_INT, false,
+        FunctionDescriptor.of(C_INT,
             MemoryLayout.ofStruct(
                 C_INT.withName("kind"),
                 C_INT.withName("xdata"),
@@ -5422,7 +5422,7 @@ public final class Index_h {
     public static final MethodHandle clang_EnumDecl_isScoped = RuntimeHelper.downcallHandle(
         LIBRARIES, "clang_EnumDecl_isScoped",
         "(Ljdk/incubator/foreign/MemorySegment;)I",
-        FunctionDescriptor.of(C_INT, false,
+        FunctionDescriptor.of(C_INT,
             MemoryLayout.ofStruct(
                 C_INT.withName("kind"),
                 C_INT.withName("xdata"),
@@ -5440,7 +5440,7 @@ public final class Index_h {
     public static final MethodHandle clang_CXXMethod_isConst = RuntimeHelper.downcallHandle(
         LIBRARIES, "clang_CXXMethod_isConst",
         "(Ljdk/incubator/foreign/MemorySegment;)I",
-        FunctionDescriptor.of(C_INT, false,
+        FunctionDescriptor.of(C_INT,
             MemoryLayout.ofStruct(
                 C_INT.withName("kind"),
                 C_INT.withName("xdata"),
@@ -5458,7 +5458,7 @@ public final class Index_h {
     public static final MethodHandle clang_getTemplateCursorKind = RuntimeHelper.downcallHandle(
         LIBRARIES, "clang_getTemplateCursorKind",
         "(Ljdk/incubator/foreign/MemorySegment;)I",
-        FunctionDescriptor.of(C_INT, false,
+        FunctionDescriptor.of(C_INT,
             MemoryLayout.ofStruct(
                 C_INT.withName("kind"),
                 C_INT.withName("xdata"),
@@ -5480,7 +5480,7 @@ public final class Index_h {
             C_INT.withName("kind"),
             C_INT.withName("xdata"),
             MemoryLayout.ofSequence(3, C_POINTER).withName("data")
-        ), false,
+        ),
             MemoryLayout.ofStruct(
                 C_INT.withName("kind"),
                 C_INT.withName("xdata"),
@@ -5502,7 +5502,7 @@ public final class Index_h {
             MemoryLayout.ofSequence(2, C_POINTER).withName("ptr_data"),
             C_INT.withName("begin_int_data"),
             C_INT.withName("end_int_data")
-        ), false,
+        ),
             MemoryLayout.ofStruct(
                 C_INT.withName("kind"),
                 C_INT.withName("xdata"),
@@ -5534,7 +5534,7 @@ public final class Index_h {
     public static final MethodHandle clang_getToken = RuntimeHelper.downcallHandle(
         LIBRARIES, "clang_getToken",
         "(Ljdk/incubator/foreign/MemoryAddress;Ljdk/incubator/foreign/MemorySegment;)Ljdk/incubator/foreign/MemoryAddress;",
-        FunctionDescriptor.of(C_POINTER, false,
+        FunctionDescriptor.of(C_POINTER,
             C_POINTER,
             MemoryLayout.ofStruct(
                 MemoryLayout.ofSequence(2, C_POINTER).withName("ptr_data"),
@@ -5553,7 +5553,7 @@ public final class Index_h {
     public static final MethodHandle clang_getTokenKind = RuntimeHelper.downcallHandle(
         LIBRARIES, "clang_getTokenKind",
         "(Ljdk/incubator/foreign/MemorySegment;)I",
-        FunctionDescriptor.of(C_INT, false,
+        FunctionDescriptor.of(C_INT,
             MemoryLayout.ofStruct(
                 MemoryLayout.ofSequence(4, C_INT).withName("int_data"),
                 C_POINTER.withName("ptr_data")
@@ -5574,7 +5574,7 @@ public final class Index_h {
             C_POINTER.withName("data"),
             C_INT.withName("private_flags"),
             MemoryLayout.ofPaddingBits(32)
-        ), false,
+        ),
             C_POINTER,
             MemoryLayout.ofStruct(
                 MemoryLayout.ofSequence(4, C_INT).withName("int_data"),
@@ -5596,7 +5596,7 @@ public final class Index_h {
             MemoryLayout.ofSequence(2, C_POINTER).withName("ptr_data"),
             C_INT.withName("int_data"),
             MemoryLayout.ofPaddingBits(32)
-        ), false,
+        ),
             C_POINTER,
             MemoryLayout.ofStruct(
                 MemoryLayout.ofSequence(4, C_INT).withName("int_data"),
@@ -5618,7 +5618,7 @@ public final class Index_h {
             MemoryLayout.ofSequence(2, C_POINTER).withName("ptr_data"),
             C_INT.withName("begin_int_data"),
             C_INT.withName("end_int_data")
-        ), false,
+        ),
             C_POINTER,
             MemoryLayout.ofStruct(
                 MemoryLayout.ofSequence(4, C_INT).withName("int_data"),
@@ -5636,7 +5636,7 @@ public final class Index_h {
     public static final MethodHandle clang_tokenize = RuntimeHelper.downcallHandle(
         LIBRARIES, "clang_tokenize",
         "(Ljdk/incubator/foreign/MemoryAddress;Ljdk/incubator/foreign/MemorySegment;Ljdk/incubator/foreign/MemoryAddress;Ljdk/incubator/foreign/MemoryAddress;)V",
-        FunctionDescriptor.ofVoid(false,
+        FunctionDescriptor.ofVoid(
             C_POINTER,
             MemoryLayout.ofStruct(
                 MemoryLayout.ofSequence(2, C_POINTER).withName("ptr_data"),
@@ -5657,7 +5657,7 @@ public final class Index_h {
     public static final MethodHandle clang_annotateTokens = RuntimeHelper.downcallHandle(
         LIBRARIES, "clang_annotateTokens",
         "(Ljdk/incubator/foreign/MemoryAddress;Ljdk/incubator/foreign/MemoryAddress;ILjdk/incubator/foreign/MemoryAddress;)V",
-        FunctionDescriptor.ofVoid(false,
+        FunctionDescriptor.ofVoid(
             C_POINTER,
             C_POINTER,
             C_INT,
@@ -5674,7 +5674,7 @@ public final class Index_h {
     public static final MethodHandle clang_disposeTokens = RuntimeHelper.downcallHandle(
         LIBRARIES, "clang_disposeTokens",
         "(Ljdk/incubator/foreign/MemoryAddress;Ljdk/incubator/foreign/MemoryAddress;I)V",
-        FunctionDescriptor.ofVoid(false,
+        FunctionDescriptor.ofVoid(
             C_POINTER,
             C_POINTER,
             C_INT
@@ -5694,7 +5694,7 @@ public final class Index_h {
             C_POINTER.withName("data"),
             C_INT.withName("private_flags"),
             MemoryLayout.ofPaddingBits(32)
-        ), false,
+        ),
             C_INT
         )
     );
@@ -5708,7 +5708,7 @@ public final class Index_h {
     public static final MethodHandle clang_getDefinitionSpellingAndExtent = RuntimeHelper.downcallHandle(
         LIBRARIES, "clang_getDefinitionSpellingAndExtent",
         "(Ljdk/incubator/foreign/MemorySegment;Ljdk/incubator/foreign/MemoryAddress;Ljdk/incubator/foreign/MemoryAddress;Ljdk/incubator/foreign/MemoryAddress;Ljdk/incubator/foreign/MemoryAddress;Ljdk/incubator/foreign/MemoryAddress;Ljdk/incubator/foreign/MemoryAddress;)V",
-        FunctionDescriptor.ofVoid(false,
+        FunctionDescriptor.ofVoid(
             MemoryLayout.ofStruct(
                 C_INT.withName("kind"),
                 C_INT.withName("xdata"),
@@ -5732,7 +5732,7 @@ public final class Index_h {
     public static final MethodHandle clang_enableStackTraces = RuntimeHelper.downcallHandle(
         LIBRARIES, "clang_enableStackTraces",
         "()V",
-        FunctionDescriptor.ofVoid(false)
+        FunctionDescriptor.ofVoid()
     );
     public static final void clang_enableStackTraces () {
         try {
@@ -5744,7 +5744,7 @@ public final class Index_h {
     public static final MethodHandle clang_executeOnThread = RuntimeHelper.downcallHandle(
         LIBRARIES, "clang_executeOnThread",
         "(Ljdk/incubator/foreign/MemoryAddress;Ljdk/incubator/foreign/MemoryAddress;I)V",
-        FunctionDescriptor.ofVoid(false,
+        FunctionDescriptor.ofVoid(
             C_POINTER,
             C_POINTER,
             C_INT
@@ -5757,7 +5757,7 @@ public final class Index_h {
             throw new AssertionError(ex);
         }
     }
-    private static final FunctionDescriptor clang_executeOnThread$fn$DESC = FunctionDescriptor.ofVoid(false,
+    private static final FunctionDescriptor clang_executeOnThread$fn$DESC = FunctionDescriptor.ofVoid(
         C_POINTER
     );
     public interface clang_executeOnThread$fn {
@@ -5802,7 +5802,7 @@ public final class Index_h {
     public static final MethodHandle clang_getCompletionChunkKind = RuntimeHelper.downcallHandle(
         LIBRARIES, "clang_getCompletionChunkKind",
         "(Ljdk/incubator/foreign/MemoryAddress;I)I",
-        FunctionDescriptor.of(C_INT, false,
+        FunctionDescriptor.of(C_INT,
             C_POINTER,
             C_INT
         )
@@ -5821,7 +5821,7 @@ public final class Index_h {
             C_POINTER.withName("data"),
             C_INT.withName("private_flags"),
             MemoryLayout.ofPaddingBits(32)
-        ), false,
+        ),
             C_POINTER,
             C_INT
         )
@@ -5836,7 +5836,7 @@ public final class Index_h {
     public static final MethodHandle clang_getCompletionChunkCompletionString = RuntimeHelper.downcallHandle(
         LIBRARIES, "clang_getCompletionChunkCompletionString",
         "(Ljdk/incubator/foreign/MemoryAddress;I)Ljdk/incubator/foreign/MemoryAddress;",
-        FunctionDescriptor.of(C_POINTER, false,
+        FunctionDescriptor.of(C_POINTER,
             C_POINTER,
             C_INT
         )
@@ -5851,7 +5851,7 @@ public final class Index_h {
     public static final MethodHandle clang_getNumCompletionChunks = RuntimeHelper.downcallHandle(
         LIBRARIES, "clang_getNumCompletionChunks",
         "(Ljdk/incubator/foreign/MemoryAddress;)I",
-        FunctionDescriptor.of(C_INT, false,
+        FunctionDescriptor.of(C_INT,
             C_POINTER
         )
     );
@@ -5865,7 +5865,7 @@ public final class Index_h {
     public static final MethodHandle clang_getCompletionPriority = RuntimeHelper.downcallHandle(
         LIBRARIES, "clang_getCompletionPriority",
         "(Ljdk/incubator/foreign/MemoryAddress;)I",
-        FunctionDescriptor.of(C_INT, false,
+        FunctionDescriptor.of(C_INT,
             C_POINTER
         )
     );
@@ -5879,7 +5879,7 @@ public final class Index_h {
     public static final MethodHandle clang_getCompletionAvailability = RuntimeHelper.downcallHandle(
         LIBRARIES, "clang_getCompletionAvailability",
         "(Ljdk/incubator/foreign/MemoryAddress;)I",
-        FunctionDescriptor.of(C_INT, false,
+        FunctionDescriptor.of(C_INT,
             C_POINTER
         )
     );
@@ -5893,7 +5893,7 @@ public final class Index_h {
     public static final MethodHandle clang_getCompletionNumAnnotations = RuntimeHelper.downcallHandle(
         LIBRARIES, "clang_getCompletionNumAnnotations",
         "(Ljdk/incubator/foreign/MemoryAddress;)I",
-        FunctionDescriptor.of(C_INT, false,
+        FunctionDescriptor.of(C_INT,
             C_POINTER
         )
     );
@@ -5911,7 +5911,7 @@ public final class Index_h {
             C_POINTER.withName("data"),
             C_INT.withName("private_flags"),
             MemoryLayout.ofPaddingBits(32)
-        ), false,
+        ),
             C_POINTER,
             C_INT
         )
@@ -5930,7 +5930,7 @@ public final class Index_h {
             C_POINTER.withName("data"),
             C_INT.withName("private_flags"),
             MemoryLayout.ofPaddingBits(32)
-        ), false,
+        ),
             C_POINTER,
             C_POINTER
         )
@@ -5949,7 +5949,7 @@ public final class Index_h {
             C_POINTER.withName("data"),
             C_INT.withName("private_flags"),
             MemoryLayout.ofPaddingBits(32)
-        ), false,
+        ),
             C_POINTER
         )
     );
@@ -5963,7 +5963,7 @@ public final class Index_h {
     public static final MethodHandle clang_getCursorCompletionString = RuntimeHelper.downcallHandle(
         LIBRARIES, "clang_getCursorCompletionString",
         "(Ljdk/incubator/foreign/MemorySegment;)Ljdk/incubator/foreign/MemoryAddress;",
-        FunctionDescriptor.of(C_POINTER, false,
+        FunctionDescriptor.of(C_POINTER,
             MemoryLayout.ofStruct(
                 C_INT.withName("kind"),
                 C_INT.withName("xdata"),
@@ -5993,7 +5993,7 @@ public final class Index_h {
     public static final MethodHandle clang_getCompletionNumFixIts = RuntimeHelper.downcallHandle(
         LIBRARIES, "clang_getCompletionNumFixIts",
         "(Ljdk/incubator/foreign/MemoryAddress;I)I",
-        FunctionDescriptor.of(C_INT, false,
+        FunctionDescriptor.of(C_INT,
             C_POINTER,
             C_INT
         )
@@ -6012,7 +6012,7 @@ public final class Index_h {
             C_POINTER.withName("data"),
             C_INT.withName("private_flags"),
             MemoryLayout.ofPaddingBits(32)
-        ), false,
+        ),
             C_POINTER,
             C_INT,
             C_INT,
@@ -6059,7 +6059,7 @@ public final class Index_h {
     public static final MethodHandle clang_defaultCodeCompleteOptions = RuntimeHelper.downcallHandle(
         LIBRARIES, "clang_defaultCodeCompleteOptions",
         "()I",
-        FunctionDescriptor.of(C_INT, false)
+        FunctionDescriptor.of(C_INT)
     );
     public static final int clang_defaultCodeCompleteOptions () {
         try {
@@ -6071,7 +6071,7 @@ public final class Index_h {
     public static final MethodHandle clang_codeCompleteAt = RuntimeHelper.downcallHandle(
         LIBRARIES, "clang_codeCompleteAt",
         "(Ljdk/incubator/foreign/MemoryAddress;Ljdk/incubator/foreign/MemoryAddress;IILjdk/incubator/foreign/MemoryAddress;II)Ljdk/incubator/foreign/MemoryAddress;",
-        FunctionDescriptor.of(C_POINTER, false,
+        FunctionDescriptor.of(C_POINTER,
             C_POINTER,
             C_POINTER,
             C_INT,
@@ -6091,7 +6091,7 @@ public final class Index_h {
     public static final MethodHandle clang_sortCodeCompletionResults = RuntimeHelper.downcallHandle(
         LIBRARIES, "clang_sortCodeCompletionResults",
         "(Ljdk/incubator/foreign/MemoryAddress;I)V",
-        FunctionDescriptor.ofVoid(false,
+        FunctionDescriptor.ofVoid(
             C_POINTER,
             C_INT
         )
@@ -6106,7 +6106,7 @@ public final class Index_h {
     public static final MethodHandle clang_disposeCodeCompleteResults = RuntimeHelper.downcallHandle(
         LIBRARIES, "clang_disposeCodeCompleteResults",
         "(Ljdk/incubator/foreign/MemoryAddress;)V",
-        FunctionDescriptor.ofVoid(false,
+        FunctionDescriptor.ofVoid(
             C_POINTER
         )
     );
@@ -6120,7 +6120,7 @@ public final class Index_h {
     public static final MethodHandle clang_codeCompleteGetNumDiagnostics = RuntimeHelper.downcallHandle(
         LIBRARIES, "clang_codeCompleteGetNumDiagnostics",
         "(Ljdk/incubator/foreign/MemoryAddress;)I",
-        FunctionDescriptor.of(C_INT, false,
+        FunctionDescriptor.of(C_INT,
             C_POINTER
         )
     );
@@ -6134,7 +6134,7 @@ public final class Index_h {
     public static final MethodHandle clang_codeCompleteGetDiagnostic = RuntimeHelper.downcallHandle(
         LIBRARIES, "clang_codeCompleteGetDiagnostic",
         "(Ljdk/incubator/foreign/MemoryAddress;I)Ljdk/incubator/foreign/MemoryAddress;",
-        FunctionDescriptor.of(C_POINTER, false,
+        FunctionDescriptor.of(C_POINTER,
             C_POINTER,
             C_INT
         )
@@ -6149,7 +6149,7 @@ public final class Index_h {
     public static final MethodHandle clang_codeCompleteGetContexts = RuntimeHelper.downcallHandle(
         LIBRARIES, "clang_codeCompleteGetContexts",
         "(Ljdk/incubator/foreign/MemoryAddress;)J",
-        FunctionDescriptor.of(C_LONGLONG, false,
+        FunctionDescriptor.of(C_LONGLONG,
             C_POINTER
         )
     );
@@ -6163,7 +6163,7 @@ public final class Index_h {
     public static final MethodHandle clang_codeCompleteGetContainerKind = RuntimeHelper.downcallHandle(
         LIBRARIES, "clang_codeCompleteGetContainerKind",
         "(Ljdk/incubator/foreign/MemoryAddress;Ljdk/incubator/foreign/MemoryAddress;)I",
-        FunctionDescriptor.of(C_INT, false,
+        FunctionDescriptor.of(C_INT,
             C_POINTER,
             C_POINTER
         )
@@ -6182,7 +6182,7 @@ public final class Index_h {
             C_POINTER.withName("data"),
             C_INT.withName("private_flags"),
             MemoryLayout.ofPaddingBits(32)
-        ), false,
+        ),
             C_POINTER
         )
     );
@@ -6200,7 +6200,7 @@ public final class Index_h {
             C_POINTER.withName("data"),
             C_INT.withName("private_flags"),
             MemoryLayout.ofPaddingBits(32)
-        ), false,
+        ),
             C_POINTER
         )
     );
@@ -6218,7 +6218,7 @@ public final class Index_h {
             C_POINTER.withName("data"),
             C_INT.withName("private_flags"),
             MemoryLayout.ofPaddingBits(32)
-        ), false)
+        ))
     );
     public static final MemorySegment clang_getClangVersion () {
         try {
@@ -6230,7 +6230,7 @@ public final class Index_h {
     public static final MethodHandle clang_toggleCrashRecovery = RuntimeHelper.downcallHandle(
         LIBRARIES, "clang_toggleCrashRecovery",
         "(I)V",
-        FunctionDescriptor.ofVoid(false,
+        FunctionDescriptor.ofVoid(
             C_INT
         )
     );
@@ -6244,7 +6244,7 @@ public final class Index_h {
     public static final MethodHandle clang_getInclusions = RuntimeHelper.downcallHandle(
         LIBRARIES, "clang_getInclusions",
         "(Ljdk/incubator/foreign/MemoryAddress;Ljdk/incubator/foreign/MemoryAddress;Ljdk/incubator/foreign/MemoryAddress;)V",
-        FunctionDescriptor.ofVoid(false,
+        FunctionDescriptor.ofVoid(
             C_POINTER,
             C_POINTER,
             C_POINTER
@@ -6257,7 +6257,7 @@ public final class Index_h {
             throw new AssertionError(ex);
         }
     }
-    private static final FunctionDescriptor clang_getInclusions$visitor$DESC = FunctionDescriptor.ofVoid(false,
+    private static final FunctionDescriptor clang_getInclusions$visitor$DESC = FunctionDescriptor.ofVoid(
         C_POINTER,
         C_POINTER,
         C_INT,
@@ -6279,7 +6279,7 @@ public final class Index_h {
     public static final MethodHandle clang_Cursor_Evaluate = RuntimeHelper.downcallHandle(
         LIBRARIES, "clang_Cursor_Evaluate",
         "(Ljdk/incubator/foreign/MemorySegment;)Ljdk/incubator/foreign/MemoryAddress;",
-        FunctionDescriptor.of(C_POINTER, false,
+        FunctionDescriptor.of(C_POINTER,
             MemoryLayout.ofStruct(
                 C_INT.withName("kind"),
                 C_INT.withName("xdata"),
@@ -6297,7 +6297,7 @@ public final class Index_h {
     public static final MethodHandle clang_EvalResult_getKind = RuntimeHelper.downcallHandle(
         LIBRARIES, "clang_EvalResult_getKind",
         "(Ljdk/incubator/foreign/MemoryAddress;)I",
-        FunctionDescriptor.of(C_INT, false,
+        FunctionDescriptor.of(C_INT,
             C_POINTER
         )
     );
@@ -6311,7 +6311,7 @@ public final class Index_h {
     public static final MethodHandle clang_EvalResult_getAsInt = RuntimeHelper.downcallHandle(
         LIBRARIES, "clang_EvalResult_getAsInt",
         "(Ljdk/incubator/foreign/MemoryAddress;)I",
-        FunctionDescriptor.of(C_INT, false,
+        FunctionDescriptor.of(C_INT,
             C_POINTER
         )
     );
@@ -6325,7 +6325,7 @@ public final class Index_h {
     public static final MethodHandle clang_EvalResult_getAsLongLong = RuntimeHelper.downcallHandle(
         LIBRARIES, "clang_EvalResult_getAsLongLong",
         "(Ljdk/incubator/foreign/MemoryAddress;)J",
-        FunctionDescriptor.of(C_LONGLONG, false,
+        FunctionDescriptor.of(C_LONGLONG,
             C_POINTER
         )
     );
@@ -6339,7 +6339,7 @@ public final class Index_h {
     public static final MethodHandle clang_EvalResult_isUnsignedInt = RuntimeHelper.downcallHandle(
         LIBRARIES, "clang_EvalResult_isUnsignedInt",
         "(Ljdk/incubator/foreign/MemoryAddress;)I",
-        FunctionDescriptor.of(C_INT, false,
+        FunctionDescriptor.of(C_INT,
             C_POINTER
         )
     );
@@ -6353,7 +6353,7 @@ public final class Index_h {
     public static final MethodHandle clang_EvalResult_getAsUnsigned = RuntimeHelper.downcallHandle(
         LIBRARIES, "clang_EvalResult_getAsUnsigned",
         "(Ljdk/incubator/foreign/MemoryAddress;)J",
-        FunctionDescriptor.of(C_LONGLONG, false,
+        FunctionDescriptor.of(C_LONGLONG,
             C_POINTER
         )
     );
@@ -6367,7 +6367,7 @@ public final class Index_h {
     public static final MethodHandle clang_EvalResult_getAsDouble = RuntimeHelper.downcallHandle(
         LIBRARIES, "clang_EvalResult_getAsDouble",
         "(Ljdk/incubator/foreign/MemoryAddress;)D",
-        FunctionDescriptor.of(C_DOUBLE, false,
+        FunctionDescriptor.of(C_DOUBLE,
             C_POINTER
         )
     );
@@ -6381,7 +6381,7 @@ public final class Index_h {
     public static final MethodHandle clang_EvalResult_getAsStr = RuntimeHelper.downcallHandle(
         LIBRARIES, "clang_EvalResult_getAsStr",
         "(Ljdk/incubator/foreign/MemoryAddress;)Ljdk/incubator/foreign/MemoryAddress;",
-        FunctionDescriptor.of(C_POINTER, false,
+        FunctionDescriptor.of(C_POINTER,
             C_POINTER
         )
     );
@@ -6395,7 +6395,7 @@ public final class Index_h {
     public static final MethodHandle clang_EvalResult_dispose = RuntimeHelper.downcallHandle(
         LIBRARIES, "clang_EvalResult_dispose",
         "(Ljdk/incubator/foreign/MemoryAddress;)V",
-        FunctionDescriptor.ofVoid(false,
+        FunctionDescriptor.ofVoid(
             C_POINTER
         )
     );
@@ -6409,7 +6409,7 @@ public final class Index_h {
     public static final MethodHandle clang_getRemappings = RuntimeHelper.downcallHandle(
         LIBRARIES, "clang_getRemappings",
         "(Ljdk/incubator/foreign/MemoryAddress;)Ljdk/incubator/foreign/MemoryAddress;",
-        FunctionDescriptor.of(C_POINTER, false,
+        FunctionDescriptor.of(C_POINTER,
             C_POINTER
         )
     );
@@ -6423,7 +6423,7 @@ public final class Index_h {
     public static final MethodHandle clang_getRemappingsFromFileList = RuntimeHelper.downcallHandle(
         LIBRARIES, "clang_getRemappingsFromFileList",
         "(Ljdk/incubator/foreign/MemoryAddress;I)Ljdk/incubator/foreign/MemoryAddress;",
-        FunctionDescriptor.of(C_POINTER, false,
+        FunctionDescriptor.of(C_POINTER,
             C_POINTER,
             C_INT
         )
@@ -6438,7 +6438,7 @@ public final class Index_h {
     public static final MethodHandle clang_remap_getNumFiles = RuntimeHelper.downcallHandle(
         LIBRARIES, "clang_remap_getNumFiles",
         "(Ljdk/incubator/foreign/MemoryAddress;)I",
-        FunctionDescriptor.of(C_INT, false,
+        FunctionDescriptor.of(C_INT,
             C_POINTER
         )
     );
@@ -6452,7 +6452,7 @@ public final class Index_h {
     public static final MethodHandle clang_remap_getFilenames = RuntimeHelper.downcallHandle(
         LIBRARIES, "clang_remap_getFilenames",
         "(Ljdk/incubator/foreign/MemoryAddress;ILjdk/incubator/foreign/MemoryAddress;Ljdk/incubator/foreign/MemoryAddress;)V",
-        FunctionDescriptor.ofVoid(false,
+        FunctionDescriptor.ofVoid(
             C_POINTER,
             C_INT,
             C_POINTER,
@@ -6469,7 +6469,7 @@ public final class Index_h {
     public static final MethodHandle clang_remap_dispose = RuntimeHelper.downcallHandle(
         LIBRARIES, "clang_remap_dispose",
         "(Ljdk/incubator/foreign/MemoryAddress;)V",
-        FunctionDescriptor.ofVoid(false,
+        FunctionDescriptor.ofVoid(
             C_POINTER
         )
     );
@@ -6492,7 +6492,7 @@ public final class Index_h {
     public static final MethodHandle clang_findReferencesInFile = RuntimeHelper.downcallHandle(
         LIBRARIES, "clang_findReferencesInFile",
         "(Ljdk/incubator/foreign/MemorySegment;Ljdk/incubator/foreign/MemoryAddress;Ljdk/incubator/foreign/MemorySegment;)I",
-        FunctionDescriptor.of(C_INT, false,
+        FunctionDescriptor.of(C_INT,
             MemoryLayout.ofStruct(
                 C_INT.withName("kind"),
                 C_INT.withName("xdata"),
@@ -6515,7 +6515,7 @@ public final class Index_h {
     public static final MethodHandle clang_findIncludesInFile = RuntimeHelper.downcallHandle(
         LIBRARIES, "clang_findIncludesInFile",
         "(Ljdk/incubator/foreign/MemoryAddress;Ljdk/incubator/foreign/MemoryAddress;Ljdk/incubator/foreign/MemorySegment;)I",
-        FunctionDescriptor.of(C_INT, false,
+        FunctionDescriptor.of(C_INT,
             C_POINTER,
             C_POINTER,
             MemoryLayout.ofStruct(
@@ -6938,7 +6938,7 @@ public final class Index_h {
     public static final MethodHandle clang_index_isEntityObjCContainerKind = RuntimeHelper.downcallHandle(
         LIBRARIES, "clang_index_isEntityObjCContainerKind",
         "(I)I",
-        FunctionDescriptor.of(C_INT, false,
+        FunctionDescriptor.of(C_INT,
             C_INT
         )
     );
@@ -6952,7 +6952,7 @@ public final class Index_h {
     public static final MethodHandle clang_index_getObjCContainerDeclInfo = RuntimeHelper.downcallHandle(
         LIBRARIES, "clang_index_getObjCContainerDeclInfo",
         "(Ljdk/incubator/foreign/MemoryAddress;)Ljdk/incubator/foreign/MemoryAddress;",
-        FunctionDescriptor.of(C_POINTER, false,
+        FunctionDescriptor.of(C_POINTER,
             C_POINTER
         )
     );
@@ -6966,7 +6966,7 @@ public final class Index_h {
     public static final MethodHandle clang_index_getObjCInterfaceDeclInfo = RuntimeHelper.downcallHandle(
         LIBRARIES, "clang_index_getObjCInterfaceDeclInfo",
         "(Ljdk/incubator/foreign/MemoryAddress;)Ljdk/incubator/foreign/MemoryAddress;",
-        FunctionDescriptor.of(C_POINTER, false,
+        FunctionDescriptor.of(C_POINTER,
             C_POINTER
         )
     );
@@ -6980,7 +6980,7 @@ public final class Index_h {
     public static final MethodHandle clang_index_getObjCCategoryDeclInfo = RuntimeHelper.downcallHandle(
         LIBRARIES, "clang_index_getObjCCategoryDeclInfo",
         "(Ljdk/incubator/foreign/MemoryAddress;)Ljdk/incubator/foreign/MemoryAddress;",
-        FunctionDescriptor.of(C_POINTER, false,
+        FunctionDescriptor.of(C_POINTER,
             C_POINTER
         )
     );
@@ -6994,7 +6994,7 @@ public final class Index_h {
     public static final MethodHandle clang_index_getObjCProtocolRefListInfo = RuntimeHelper.downcallHandle(
         LIBRARIES, "clang_index_getObjCProtocolRefListInfo",
         "(Ljdk/incubator/foreign/MemoryAddress;)Ljdk/incubator/foreign/MemoryAddress;",
-        FunctionDescriptor.of(C_POINTER, false,
+        FunctionDescriptor.of(C_POINTER,
             C_POINTER
         )
     );
@@ -7008,7 +7008,7 @@ public final class Index_h {
     public static final MethodHandle clang_index_getObjCPropertyDeclInfo = RuntimeHelper.downcallHandle(
         LIBRARIES, "clang_index_getObjCPropertyDeclInfo",
         "(Ljdk/incubator/foreign/MemoryAddress;)Ljdk/incubator/foreign/MemoryAddress;",
-        FunctionDescriptor.of(C_POINTER, false,
+        FunctionDescriptor.of(C_POINTER,
             C_POINTER
         )
     );
@@ -7022,7 +7022,7 @@ public final class Index_h {
     public static final MethodHandle clang_index_getIBOutletCollectionAttrInfo = RuntimeHelper.downcallHandle(
         LIBRARIES, "clang_index_getIBOutletCollectionAttrInfo",
         "(Ljdk/incubator/foreign/MemoryAddress;)Ljdk/incubator/foreign/MemoryAddress;",
-        FunctionDescriptor.of(C_POINTER, false,
+        FunctionDescriptor.of(C_POINTER,
             C_POINTER
         )
     );
@@ -7036,7 +7036,7 @@ public final class Index_h {
     public static final MethodHandle clang_index_getCXXClassDeclInfo = RuntimeHelper.downcallHandle(
         LIBRARIES, "clang_index_getCXXClassDeclInfo",
         "(Ljdk/incubator/foreign/MemoryAddress;)Ljdk/incubator/foreign/MemoryAddress;",
-        FunctionDescriptor.of(C_POINTER, false,
+        FunctionDescriptor.of(C_POINTER,
             C_POINTER
         )
     );
@@ -7050,7 +7050,7 @@ public final class Index_h {
     public static final MethodHandle clang_index_getClientContainer = RuntimeHelper.downcallHandle(
         LIBRARIES, "clang_index_getClientContainer",
         "(Ljdk/incubator/foreign/MemoryAddress;)Ljdk/incubator/foreign/MemoryAddress;",
-        FunctionDescriptor.of(C_POINTER, false,
+        FunctionDescriptor.of(C_POINTER,
             C_POINTER
         )
     );
@@ -7064,7 +7064,7 @@ public final class Index_h {
     public static final MethodHandle clang_index_setClientContainer = RuntimeHelper.downcallHandle(
         LIBRARIES, "clang_index_setClientContainer",
         "(Ljdk/incubator/foreign/MemoryAddress;Ljdk/incubator/foreign/MemoryAddress;)V",
-        FunctionDescriptor.ofVoid(false,
+        FunctionDescriptor.ofVoid(
             C_POINTER,
             C_POINTER
         )
@@ -7079,7 +7079,7 @@ public final class Index_h {
     public static final MethodHandle clang_index_getClientEntity = RuntimeHelper.downcallHandle(
         LIBRARIES, "clang_index_getClientEntity",
         "(Ljdk/incubator/foreign/MemoryAddress;)Ljdk/incubator/foreign/MemoryAddress;",
-        FunctionDescriptor.of(C_POINTER, false,
+        FunctionDescriptor.of(C_POINTER,
             C_POINTER
         )
     );
@@ -7093,7 +7093,7 @@ public final class Index_h {
     public static final MethodHandle clang_index_setClientEntity = RuntimeHelper.downcallHandle(
         LIBRARIES, "clang_index_setClientEntity",
         "(Ljdk/incubator/foreign/MemoryAddress;Ljdk/incubator/foreign/MemoryAddress;)V",
-        FunctionDescriptor.ofVoid(false,
+        FunctionDescriptor.ofVoid(
             C_POINTER,
             C_POINTER
         )
@@ -7108,7 +7108,7 @@ public final class Index_h {
     public static final MethodHandle clang_IndexAction_create = RuntimeHelper.downcallHandle(
         LIBRARIES, "clang_IndexAction_create",
         "(Ljdk/incubator/foreign/MemoryAddress;)Ljdk/incubator/foreign/MemoryAddress;",
-        FunctionDescriptor.of(C_POINTER, false,
+        FunctionDescriptor.of(C_POINTER,
             C_POINTER
         )
     );
@@ -7122,7 +7122,7 @@ public final class Index_h {
     public static final MethodHandle clang_IndexAction_dispose = RuntimeHelper.downcallHandle(
         LIBRARIES, "clang_IndexAction_dispose",
         "(Ljdk/incubator/foreign/MemoryAddress;)V",
-        FunctionDescriptor.ofVoid(false,
+        FunctionDescriptor.ofVoid(
             C_POINTER
         )
     );
@@ -7142,7 +7142,7 @@ public final class Index_h {
     public static final MethodHandle clang_indexSourceFile = RuntimeHelper.downcallHandle(
         LIBRARIES, "clang_indexSourceFile",
         "(Ljdk/incubator/foreign/MemoryAddress;Ljdk/incubator/foreign/MemoryAddress;Ljdk/incubator/foreign/MemoryAddress;IILjdk/incubator/foreign/MemoryAddress;Ljdk/incubator/foreign/MemoryAddress;ILjdk/incubator/foreign/MemoryAddress;ILjdk/incubator/foreign/MemoryAddress;I)I",
-        FunctionDescriptor.of(C_INT, false,
+        FunctionDescriptor.of(C_INT,
             C_POINTER,
             C_POINTER,
             C_POINTER,
@@ -7167,7 +7167,7 @@ public final class Index_h {
     public static final MethodHandle clang_indexSourceFileFullArgv = RuntimeHelper.downcallHandle(
         LIBRARIES, "clang_indexSourceFileFullArgv",
         "(Ljdk/incubator/foreign/MemoryAddress;Ljdk/incubator/foreign/MemoryAddress;Ljdk/incubator/foreign/MemoryAddress;IILjdk/incubator/foreign/MemoryAddress;Ljdk/incubator/foreign/MemoryAddress;ILjdk/incubator/foreign/MemoryAddress;ILjdk/incubator/foreign/MemoryAddress;I)I",
-        FunctionDescriptor.of(C_INT, false,
+        FunctionDescriptor.of(C_INT,
             C_POINTER,
             C_POINTER,
             C_POINTER,
@@ -7192,7 +7192,7 @@ public final class Index_h {
     public static final MethodHandle clang_indexTranslationUnit = RuntimeHelper.downcallHandle(
         LIBRARIES, "clang_indexTranslationUnit",
         "(Ljdk/incubator/foreign/MemoryAddress;Ljdk/incubator/foreign/MemoryAddress;Ljdk/incubator/foreign/MemoryAddress;IILjdk/incubator/foreign/MemoryAddress;)I",
-        FunctionDescriptor.of(C_INT, false,
+        FunctionDescriptor.of(C_INT,
             C_POINTER,
             C_POINTER,
             C_POINTER,
@@ -7211,7 +7211,7 @@ public final class Index_h {
     public static final MethodHandle clang_indexLoc_getFileLocation = RuntimeHelper.downcallHandle(
         LIBRARIES, "clang_indexLoc_getFileLocation",
         "(Ljdk/incubator/foreign/MemorySegment;Ljdk/incubator/foreign/MemoryAddress;Ljdk/incubator/foreign/MemoryAddress;Ljdk/incubator/foreign/MemoryAddress;Ljdk/incubator/foreign/MemoryAddress;Ljdk/incubator/foreign/MemoryAddress;)V",
-        FunctionDescriptor.ofVoid(false,
+        FunctionDescriptor.ofVoid(
             MemoryLayout.ofStruct(
                 MemoryLayout.ofSequence(2, C_POINTER).withName("ptr_data"),
                 C_INT.withName("int_data"),
@@ -7238,7 +7238,7 @@ public final class Index_h {
             MemoryLayout.ofSequence(2, C_POINTER).withName("ptr_data"),
             C_INT.withName("int_data"),
             MemoryLayout.ofPaddingBits(32)
-        ), false,
+        ),
             MemoryLayout.ofStruct(
                 MemoryLayout.ofSequence(2, C_POINTER).withName("ptr_data"),
                 C_INT.withName("int_data"),
@@ -7256,7 +7256,7 @@ public final class Index_h {
     public static final MethodHandle clang_Type_visitFields = RuntimeHelper.downcallHandle(
         LIBRARIES, "clang_Type_visitFields",
         "(Ljdk/incubator/foreign/MemorySegment;Ljdk/incubator/foreign/MemoryAddress;Ljdk/incubator/foreign/MemoryAddress;)I",
-        FunctionDescriptor.of(C_INT, false,
+        FunctionDescriptor.of(C_INT,
             MemoryLayout.ofStruct(
                 C_INT.withName("kind"),
                 MemoryLayout.ofPaddingBits(32),
@@ -7273,7 +7273,7 @@ public final class Index_h {
             throw new AssertionError(ex);
         }
     }
-    private static final FunctionDescriptor clang_Type_visitFields$visitor$DESC = FunctionDescriptor.of(C_INT, false,
+    private static final FunctionDescriptor clang_Type_visitFields$visitor$DESC = FunctionDescriptor.of(C_INT,
         MemoryLayout.ofStruct(
             C_INT.withName("kind"),
             C_INT.withName("xdata"),

--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/LayoutUtils.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/LayoutUtils.java
@@ -180,9 +180,9 @@ public final class LayoutUtils {
                     .toArray(MemoryLayout[]::new);
             if (t.returnType() instanceof jdk.incubator.jextract.Type.Primitive &&
                     ((jdk.incubator.jextract.Type.Primitive) t.returnType()).kind() == jdk.incubator.jextract.Type.Primitive.Kind.Void) {
-                return Optional.of(FunctionDescriptor.ofVoid(t.varargs(), args));
+                return Optional.of(FunctionDescriptor.ofVoid(args));
             } else {
-                return Optional.of(FunctionDescriptor.of(getLayoutInternal(t.returnType()), t.varargs(), args));
+                return Optional.of(FunctionDescriptor.of(getLayoutInternal(t.returnType()), args));
             }
         } catch (Throwable ex) {
             return Optional.empty();

--- a/test/jdk/tools/jextract/testStruct/struct.h
+++ b/test/jdk/tools/jextract/testStruct/struct.h
@@ -36,7 +36,7 @@ typedef struct Point {
     int y;
 } Point;
 
-Point makePoint(int x, int y);
+EXPORT Point makePoint(int x, int y);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Hi,

PR #15 removed variadic information from FunctionDescriptor. We need to update it's uses in jextract as well.

Besides removing the boolean argument everywhere a FunctionDescriptor is being created, the only real change needed is adding a boolean parameter to RuntimeHelper::downcallHandle which indicates whether to use the VarargsInvoker, since that information can no longer be derived from the FunctionDescriptor argument.

This also includes 2 small fixes to make the tests pass on Windows (see https://github.com/openjdk/panama-foreign/pull/17/commits/4407d800736db2296ac2784f9a7768fdf5a1b561):
- Missing EXPORT in makePoint declaration
- library name on Windows should be 'libclang' not 'clang'

Jorn
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
## Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

## Issue
[JDK-8238951](https://bugs.openjdk.java.net/browse/JDK-8238951): Update jextract  after JDK-8238226


## Approvers
 * Maurizio Cimadamore ([mcimadamore](@mcimadamore) - Committer)