### PR TITLE
8238192: Reimplement MemoryAddress memory access handles on top of var handle combinators

### DIFF
--- a/make/gensrc/GensrcVarHandles.gmk
+++ b/make/gensrc/GensrcVarHandles.gmk
@@ -167,6 +167,8 @@ define GenerateVarHandleMemoryAddress
 
   $1_Type := $2
 
+  $1_FILENAME := $(VARHANDLES_GENSRC_DIR)/VarHandleMemoryAddressAs$$($1_Type)s.java
+
   ifeq ($$($1_Type), Byte)
     $1_type := byte
     $1_BoxType := $$($1_Type)
@@ -246,21 +248,6 @@ define GenerateVarHandleMemoryAddress
     $1_ARGS += -KfloatingPoint
   endif
 
-  ifeq ($$($1_Type), MemoryAddress)
-    $1_type := Object
-    $1_BoxType := Object
-
-    $1_rawType := long
-    $1_RawType := Long
-    $1_RawBoxType := Long
-
-    $1_ARGS += -KMemoryAddressProxy
-
-    $1_FILENAME := $(VARHANDLES_GENSRC_DIR)/VarHandleMemoryAddressAs$$($1_Type)es.java
-  else
-    $1_FILENAME := $(VARHANDLES_GENSRC_DIR)/VarHandleMemoryAddressAs$$($1_Type)s.java
-  endif
-
   $$($1_FILENAME): $(VARHANDLES_SRC_DIR)/X-VarHandleMemoryAddressView.java.template $(BUILD_TOOLS_JDK)
 	$$(call MakeDir, $$(@D))
 	$(RM) $$@
@@ -285,7 +272,7 @@ $(foreach t, $(VARHANDLES_BYTE_ARRAY_TYPES), \
   $(eval $(call GenerateVarHandleByteArray,VAR_HANDLE_BYTE_ARRAY_$t,$t)))
 
 # List the types to generate source for, with capitalized first letter
-VARHANDLES_MEMORY_ADDRESS_TYPES := Byte Short Char Int Long Float Double MemoryAddress
+VARHANDLES_MEMORY_ADDRESS_TYPES := Byte Short Char Int Long Float Double
 $(foreach t, $(VARHANDLES_MEMORY_ADDRESS_TYPES), \
   $(eval $(call GenerateVarHandleMemoryAddress,VAR_HANDLE_MEMORY_ADDRESS_$t,$t)))
 

--- a/src/java.base/share/classes/java/lang/invoke/X-VarHandleMemoryAddressView.java.template
+++ b/src/java.base/share/classes/java/lang/invoke/X-VarHandleMemoryAddressView.java.template
@@ -33,32 +33,11 @@ import static java.lang.invoke.MethodHandleStatics.UNSAFE;
 
 #warn
 
-#if[MemoryAddressProxy]
-final class VarHandleMemoryAddressAs$Type$es {
-#else[MemoryAddressProxy]
 final class VarHandleMemoryAddressAs$Type$s {
-#end[MemoryAddressProxy]
 
     static final boolean BE = UNSAFE.isBigEndian();
 
-#if[MemoryAddressProxy]
-    static final int VM_ALIGN = Long.BYTES - 1;
-
-    static final MemoryAddressProxy NULL_ADDRESS;
-    static final MemberName MEMORY_ADDRESS_OF_LONG_MEMBER_NAME;
-
-    static {
-        try {
-            Class<?> addrClass = Class.forName("jdk.incubator.foreign.MemoryAddress");
-            NULL_ADDRESS = (MemoryAddressProxy)addrClass.getDeclaredField("NULL").get(null);
-            MEMORY_ADDRESS_OF_LONG_MEMBER_NAME = new MemberName(addrClass.getMethod("ofLong", long.class));
-        } catch (Exception ex) {
-            throw new ExceptionInInitializerError(ex);
-        }
-    }
-#else[MemoryAddressProxy]
     static final int VM_ALIGN = $BoxType$.BYTES - 1;
-#end[MemoryAddressProxy]
 
 #if[floatingPoint]
     @ForceInline
@@ -79,44 +58,10 @@ final class VarHandleMemoryAddressAs$Type$s {
         return n;
     }
 #else[byte]
-#if[MemoryAddressProxy]
-    @ForceInline
-    static $type$ convEndian(boolean big, $rawType$ n) {
-        long value = big == BE ? n : Long.reverseBytes(n);
-        return long2addr(value);
-    }
-
-    @ForceInline
-    static $rawType$ convEndian(boolean big, $type$ addr) {
-        long n = addr2long(addr);
-        return big == BE ? n : Long.reverseBytes(n);
-    }
-
-    @ForceInline
-    static $type$ long2addr($rawType$ value) {
-        try {
-            return value == 0L ?
-                NULL_ADDRESS :
-                MethodHandle.linkToStatic(value, MEMORY_ADDRESS_OF_LONG_MEMBER_NAME);
-        } catch (Throwable ex) {
-            throw new IllegalStateException(ex);
-        }
-    }
-
-    @ForceInline
-    static $rawType$ addr2long($type$ ob) {
-        MemoryAddressProxy addr = (MemoryAddressProxy)ob;
-        if (addr.unsafeGetBase() != null) {
-           throw new UnsupportedOperationException("Heap address!");
-        }
-        return addr.unsafeGetOffset();
-    }
-#else[MemoryAddressProxy]
     @ForceInline
     static $type$ convEndian(boolean big, $type$ n) {
         return big == BE ? n : $BoxType$.reverseBytes(n);
     }
-#end[MemoryAddressProxy]
 #end[byte]
 #end[floatingPoint]
 
@@ -163,17 +108,10 @@ final class VarHandleMemoryAddressAs$Type$s {
                 bb.unsafeGetBase(),
                 offsetNoVMAlignCheck(bb, base, handle.alignmentMask));
 #else[byte]
-#if[MemoryAddressProxy]
-        return long2addr(UNSAFE.getLongUnaligned(
-                bb.unsafeGetBase(),
-                offset(bb, base, handle.alignmentMask),
-                handle.be));
-#else[MemoryAddressProxy]
         return UNSAFE.get$Type$Unaligned(
                 bb.unsafeGetBase(),
                 offsetNoVMAlignCheck(bb, base, handle.alignmentMask),
                 handle.be);
-#end[MemoryAddressProxy]
 #end[byte]
 #end[floatingPoint]
     }
@@ -195,19 +133,11 @@ final class VarHandleMemoryAddressAs$Type$s {
                 offsetNoVMAlignCheck(bb, base, handle.alignmentMask),
                 value);
 #else[byte]
-#if[MemoryAddressProxy]
-        UNSAFE.putLongUnaligned(
-                bb.unsafeGetBase(),
-                offset(bb, base, handle.alignmentMask),
-                addr2long(value),
-                handle.be);
-#else[MemoryAddressProxy]
         UNSAFE.put$Type$Unaligned(
                 bb.unsafeGetBase(),
                 offsetNoVMAlignCheck(bb, base, handle.alignmentMask),
                 value,
                 handle.be);
-#end[MemoryAddressProxy]
 #end[byte]
 #end[floatingPoint]
     }

--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/MemoryAddress.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/MemoryAddress.java
@@ -138,6 +138,8 @@ public interface MemoryAddress {
      * @return the new memory address instance.
      */
     static MemoryAddress ofLong(long value) {
-        return MemorySegmentImpl.NOTHING.baseAddress().addOffset(value);
+        return value == 0 ?
+                NULL :
+                MemorySegmentImpl.NOTHING.baseAddress().addOffset(value);
     }
 }

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/Utils.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/Utils.java
@@ -28,18 +28,13 @@ package jdk.internal.foreign;
 
 import jdk.incubator.foreign.MemoryAddress;
 import jdk.incubator.foreign.MemoryLayout;
-import jdk.incubator.foreign.MemoryLayouts;
 import jdk.incubator.foreign.MemorySegment;
-import jdk.incubator.foreign.SystemABI;
 import jdk.incubator.foreign.ValueLayout;
 import jdk.internal.access.JavaLangInvokeAccess;
 import jdk.internal.access.JavaNioAccess;
 import jdk.internal.access.SharedSecrets;
 import jdk.internal.access.foreign.MemoryAddressProxy;
 import jdk.internal.access.foreign.UnmapperProxy;
-import jdk.internal.foreign.abi.aarch64.AArch64ABI;
-import jdk.internal.foreign.abi.x64.sysv.SysVx64ABI;
-import jdk.internal.foreign.abi.x64.windows.Windowsx64ABI;
 import jdk.internal.misc.Unsafe;
 import sun.invoke.util.Wrapper;
 import sun.nio.ch.FileChannelImpl;
@@ -76,9 +71,9 @@ public final class Utils {
             ADDRESS_FILTER = MethodHandles.lookup().findStatic(Utils.class, "filterAddress",
                     MethodType.methodType(MemoryAddressProxy.class, MemoryAddress.class));
             LONG_TO_ADDRESS = MethodHandles.lookup().findStatic(Utils.class, "longToAddress",
-                    MethodType.methodType(MemoryAddressProxy.class, long.class));
+                    MethodType.methodType(MemoryAddress.class, long.class));
             ADDRESS_TO_LONG = MethodHandles.lookup().findStatic(Utils.class, "addressToLong",
-                    MethodType.methodType(long.class, MemoryAddressProxy.class));
+                    MethodType.methodType(long.class, MemoryAddress.class));
         } catch (Throwable ex) {
             throw new ExceptionInInitializerError(ex);
         }
@@ -278,13 +273,11 @@ public final class Utils {
         return (MemoryAddressImpl)addr;
     }
 
-    private static MemoryAddressProxy longToAddress(long value) {
-        return value == 0L ?
-                (MemoryAddressImpl)MemoryAddress.NULL :
-                (MemoryAddressImpl)MemoryAddress.ofLong(value);
+    private static MemoryAddress longToAddress(long value) {
+        return MemoryAddress.ofLong(value);
     }
 
-    private static long addressToLong(MemoryAddressProxy value) {
-        return value.unsafeGetOffset();
+    private static long addressToLong(MemoryAddress value) {
+        return ((MemoryAddressImpl)value).unsafeGetOffset();
     }
 }

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/Utils.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/Utils.java
@@ -32,6 +32,7 @@ import jdk.incubator.foreign.MemoryLayouts;
 import jdk.incubator.foreign.MemorySegment;
 import jdk.incubator.foreign.SystemABI;
 import jdk.incubator.foreign.ValueLayout;
+import jdk.internal.access.JavaLangInvokeAccess;
 import jdk.internal.access.JavaNioAccess;
 import jdk.internal.access.SharedSecrets;
 import jdk.internal.access.foreign.MemoryAddressProxy;
@@ -67,11 +68,17 @@ public final class Utils {
     private static Unsafe unsafe = Unsafe.getUnsafe();
 
     private static final MethodHandle ADDRESS_FILTER;
+    private static final MethodHandle LONG_TO_ADDRESS;
+    private static final MethodHandle ADDRESS_TO_LONG;
 
     static {
         try {
             ADDRESS_FILTER = MethodHandles.lookup().findStatic(Utils.class, "filterAddress",
                     MethodType.methodType(MemoryAddressProxy.class, MemoryAddress.class));
+            LONG_TO_ADDRESS = MethodHandles.lookup().findStatic(Utils.class, "longToAddress",
+                    MethodType.methodType(MemoryAddressProxy.class, long.class));
+            ADDRESS_TO_LONG = MethodHandles.lookup().findStatic(Utils.class, "addressToLong",
+                    MethodType.methodType(long.class, MemoryAddressProxy.class));
         } catch (Throwable ex) {
             throw new ExceptionInInitializerError(ex);
         }
@@ -85,6 +92,7 @@ public final class Utils {
     private final static long POINTER_SIZE = 8;
 
     private static final JavaNioAccess javaNioAccess = SharedSecrets.getJavaNioAccess();
+    private static final JavaLangInvokeAccess javaLangInvokeAccess = SharedSecrets.getJavaLangInvokeAccess();
 
     private static final boolean skipZeroMemory = GetBooleanAction.privilegedGetProperty("jdk.internal.foreign.skipZeroMemory");
 
@@ -260,10 +268,23 @@ public final class Utils {
     public static VarHandle fixUpVarHandle(VarHandle handle) {
         // This adaptation is required, otherwise the memory access var handle will have type MemoryAddressProxy,
         // and not MemoryAddress (which the user expects), which causes performance issues with asType() adaptations.
-        return MethodHandles.filterCoordinates(handle, 0, ADDRESS_FILTER);
+        handle = MethodHandles.filterCoordinates(handle, 0, ADDRESS_FILTER);
+        return (javaLangInvokeAccess.memoryAddressCarrier(handle) == MemoryAddressProxy.class) ?
+                MethodHandles.filterValue(handle, ADDRESS_TO_LONG, LONG_TO_ADDRESS) :
+                handle;
     }
 
     private static MemoryAddressProxy filterAddress(MemoryAddress addr) {
         return (MemoryAddressImpl)addr;
+    }
+
+    private static MemoryAddressProxy longToAddress(long value) {
+        return value == 0L ?
+                (MemoryAddressImpl)MemoryAddress.NULL :
+                (MemoryAddressImpl)MemoryAddress.ofLong(value);
+    }
+
+    private static long addressToLong(MemoryAddressProxy value) {
+        return value.unsafeGetOffset();
     }
 }

--- a/test/jdk/java/foreign/TestTypeAccess.java
+++ b/test/jdk/java/foreign/TestTypeAccess.java
@@ -71,14 +71,14 @@ public class TestTypeAccess {
         }
     }
 
-    @Test(expectedExceptions=ClassCastException.class)
+    @Test(expectedExceptions=WrongMethodTypeException.class)
     public void testMemoryAddressValueGetAsPrimitive() {
         try (MemorySegment s = MemorySegment.allocateNative(8)) {
             int address = (int)ADDR_HANDLE.get(s.baseAddress());
         }
     }
 
-    @Test(expectedExceptions=ClassCastException.class)
+    @Test(expectedExceptions=WrongMethodTypeException.class)
     public void testMemoryAddressValueSetAsPrimitive() {
         try (MemorySegment s = MemorySegment.allocateNative(8)) {
             ADDR_HANDLE.set(s.baseAddress(), 1);


### PR DESCRIPTION
This is a continuation of the RFR here:
https://mail.openjdk.java.net/pipermail/panama-dev/2020-January/007366.html
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
## Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

## Issue
[JDK-8238192](https://bugs.openjdk.java.net/browse/JDK-8238192): Reimplement MemoryAddress memory access handles on top of var handle combinators


## Approvers
 * Jorn Vernee ([jvernee](@JornVernee) - Committer)