### PR TITLE
8238316: jextract emits a C_BOOL when source says char

### DIFF
--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/MemoryLayouts.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/MemoryLayouts.java
@@ -309,7 +309,8 @@ public final class MemoryLayouts {
         /**
          * The {@code char} native type.
          */
-        public static final ValueLayout C_CHAR = C_SCHAR;
+        public static final ValueLayout C_CHAR = MemoryLayouts.BITS_8_LE
+                .withAnnotation(ArgumentClass.ABI_CLASS, ArgumentClassImpl.INTEGER);
 
         /**
          * The {@code short} native type.


### PR DESCRIPTION
foreign-abi change to create instance for each MemoryLayout instance.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
## Progress
- [x] Change must not contain extraneous whitespace
- [ ] Change must be properly reviewed

## Issue
[JDK-8238316](https://bugs.openjdk.java.net/browse/JDK-8238316): jextract emits a C_BOOL when source says char
