### PR TITLE
8238316: jextract emits a C_BOOL when source says char

### DIFF
--- a/src/jdk.incubator.jextract/share/classes/jdk/incubator/jextract/tool/HandleSourceFactory.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/incubator/jextract/tool/HandleSourceFactory.java
@@ -92,7 +92,7 @@ public class HandleSourceFactory implements Declaration.Visitor<Void, Declaratio
         }
     }
 
-    private static final String C_LANG_CONSTANTS_HOLDER = getCLangConstantsHolder();
+    static final String C_LANG_CONSTANTS_HOLDER = getCLangConstantsHolder();
 
     public JavaFileObject[] generate(Declaration.Scoped decl) {
         builder.addPackagePrefix(pkgName);

--- a/src/jdk.incubator.jextract/share/classes/jdk/incubator/jextract/tool/JavaSourceBuilder.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/incubator/jextract/tool/JavaSourceBuilder.java
@@ -30,8 +30,10 @@ import jdk.incubator.foreign.GroupLayout;
 import jdk.incubator.foreign.MemoryAddress;
 import jdk.incubator.foreign.MemoryLayout;
 import jdk.incubator.foreign.MemoryLayouts;
+import jdk.incubator.foreign.MemoryLayouts.SysV;
 import jdk.incubator.foreign.MemorySegment;
 import jdk.incubator.foreign.SequenceLayout;
+import jdk.incubator.foreign.SystemABI;
 import jdk.incubator.foreign.ValueLayout;
 
 import java.lang.invoke.MethodType;
@@ -48,6 +50,7 @@ import java.util.stream.Stream;
  * method is called to get overall generated source string.
  */
 class JavaSourceBuilder {
+    private static final String ABI = SystemABI.getInstance().name();
     // buffer
     protected StringBuffer sb;
     // current line alignment (number of 4-spaces)
@@ -86,6 +89,9 @@ class JavaSourceBuilder {
         sb.append("import java.lang.invoke.VarHandle;\n");
         sb.append("import jdk.incubator.foreign.*;\n");
         sb.append("import jdk.incubator.foreign.MemoryLayout.PathElement;\n");
+        sb.append("import static ");
+        sb.append(HandleSourceFactory.C_LANG_CONSTANTS_HOLDER);
+        sb.append(".*;\n");
     }
 
     protected void classBegin(String name) {
@@ -125,24 +131,32 @@ class JavaSourceBuilder {
 
     private void addLayout(MemoryLayout l) {
         if (l instanceof ValueLayout) {
-            boolean found = false;
-            for (Field fs : MemoryLayouts.SysV.class.getDeclaredFields()) {
-                try {
-                    MemoryLayout constant = (MemoryLayout)fs.get(null);
-                    if (l.name().isPresent()) {
-                        constant = constant.withName(l.name().get());
-                    }
-                    if (constant.equals(l)) {
-                        found = true;
-                        sb.append("MemoryLayouts.SysV." + fs.getName());
-                        break;
-                    }
-                } catch (ReflectiveOperationException ex) {
-                    throw new AssertionError(ex);
+            SystemABI.Type type = l.abiType().orElseThrow(()->new AssertionError("Should not get here: " + l));
+            if (type == SystemABI.Type.LONG_DOUBLE) {
+                if (ABI != SystemABI.ABI_SYSV) {
+                    throw new RuntimeException("long double is supported only for SysV ABI");
+                } else {
+                    sb.append("C_LONGDOUBLE");
                 }
-            }
-            if (!found) {
-                throw new AssertionError("Should not get here: " + l);
+            } else {
+                sb.append(switch (type) {
+                    case BOOL -> "C_BOOL";
+                    case SIGNED_CHAR -> "C_SCHAR";
+                    case UNSIGNED_CHAR -> "C_UCHAR";
+                    case CHAR -> "C_CHAR";
+                    case SHORT -> "C_SHORT";
+                    case UNSIGNED_SHORT -> "C_USHORT";
+                    case INT -> "C_INT";
+                    case UNSIGNED_INT -> "C_UINT";
+                    case LONG -> "C_LONG";
+                    case UNSIGNED_LONG -> "C_ULONG";
+                    case LONG_LONG -> "C_LONGLONG";
+                    case UNSIGNED_LONG_LONG -> "C_ULONGLONG";
+                    case FLOAT -> "C_FLOAT";
+                    case DOUBLE -> "C_DOUBLE";
+                    case POINTER -> "C_POINTER";
+                    default -> { throw new RuntimeException("should not reach here: " + type); }
+                });
             }
         } else if (l instanceof SequenceLayout) {
             sb.append("MemoryLayout.ofSequence(");
@@ -152,23 +166,32 @@ class JavaSourceBuilder {
             addLayout(((SequenceLayout) l).elementLayout());
             sb.append(")");
         } else if (l instanceof GroupLayout) {
-            if (((GroupLayout) l).isStruct()) {
-                sb.append("MemoryLayout.ofStruct(\n");
+            SystemABI.Type type = l.abiType().orElse(null);
+            if (type == SystemABI.Type.COMPLEX_LONG_DOUBLE) {
+                if (ABI != SystemABI.ABI_SYSV) {
+                    throw new RuntimeException("complex long double is supported only for SysV ABI");
+                } else {
+                    sb.append("C_COMPLEX_LONGDOUBLE");
+                }
             } else {
-                sb.append("MemoryLayout.ofUnion(\n");
-            }
-            incrAlign();
-            String delim = "";
-            for (MemoryLayout e : ((GroupLayout) l).memberLayouts()) {
-                sb.append(delim);
+                if (((GroupLayout) l).isStruct()) {
+                    sb.append("MemoryLayout.ofStruct(\n");
+                } else {
+                    sb.append("MemoryLayout.ofUnion(\n");
+                }
+                incrAlign();
+                String delim = "";
+                for (MemoryLayout e : ((GroupLayout) l).memberLayouts()) {
+                    sb.append(delim);
+                    indent();
+                    addLayout(e);
+                    delim = ",\n";
+                }
+                sb.append("\n");
+                decrAlign();
                 indent();
-                addLayout(e);
-                delim = ",\n";
+                sb.append(")");
             }
-            sb.append("\n");
-            decrAlign();
-            indent();
-            sb.append(")");
         } else {
             //padding
             sb.append("MemoryLayout.ofPaddingBits(" + l.bitSize() + ")");

--- a/src/jdk.incubator.jextract/share/classes/jdk/incubator/jextract/tool/JavaSourceBuilder.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/incubator/jextract/tool/JavaSourceBuilder.java
@@ -30,7 +30,6 @@ import jdk.incubator.foreign.GroupLayout;
 import jdk.incubator.foreign.MemoryAddress;
 import jdk.incubator.foreign.MemoryLayout;
 import jdk.incubator.foreign.MemoryLayouts;
-import jdk.incubator.foreign.MemoryLayouts.SysV;
 import jdk.incubator.foreign.MemorySegment;
 import jdk.incubator.foreign.SequenceLayout;
 import jdk.incubator.foreign.SystemABI;
@@ -161,7 +160,7 @@ class JavaSourceBuilder {
         } else if (l instanceof GroupLayout) {
             SystemABI.Type type = l.abiType().orElse(null);
             if (type == SystemABI.Type.COMPLEX_LONG_DOUBLE) {
-                if (ABI != SystemABI.ABI_SYSV) {
+                if (!ABI.equals(SystemABI.ABI_SYSV)) {
                     throw new RuntimeException("complex long double is supported only for SysV ABI");
                 } else {
                     sb.append("C_COMPLEX_LONGDOUBLE");

--- a/src/jdk.incubator.jextract/share/classes/jdk/incubator/jextract/tool/JavaSourceBuilder.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/incubator/jextract/tool/JavaSourceBuilder.java
@@ -132,32 +132,25 @@ class JavaSourceBuilder {
     private void addLayout(MemoryLayout l) {
         if (l instanceof ValueLayout) {
             SystemABI.Type type = l.abiType().orElseThrow(()->new AssertionError("Should not get here: " + l));
-            if (type == SystemABI.Type.LONG_DOUBLE) {
-                if (ABI != SystemABI.ABI_SYSV) {
-                    throw new RuntimeException("long double is supported only for SysV ABI");
-                } else {
-                    sb.append("C_LONGDOUBLE");
-                }
-            } else {
-                sb.append(switch (type) {
-                    case BOOL -> "C_BOOL";
-                    case SIGNED_CHAR -> "C_SCHAR";
-                    case UNSIGNED_CHAR -> "C_UCHAR";
-                    case CHAR -> "C_CHAR";
-                    case SHORT -> "C_SHORT";
-                    case UNSIGNED_SHORT -> "C_USHORT";
-                    case INT -> "C_INT";
-                    case UNSIGNED_INT -> "C_UINT";
-                    case LONG -> "C_LONG";
-                    case UNSIGNED_LONG -> "C_ULONG";
-                    case LONG_LONG -> "C_LONGLONG";
-                    case UNSIGNED_LONG_LONG -> "C_ULONGLONG";
-                    case FLOAT -> "C_FLOAT";
-                    case DOUBLE -> "C_DOUBLE";
-                    case POINTER -> "C_POINTER";
-                    default -> { throw new RuntimeException("should not reach here: " + type); }
-                });
-            }
+            sb.append(switch (type) {
+                case BOOL -> "C_BOOL";
+                case SIGNED_CHAR -> "C_SCHAR";
+                case UNSIGNED_CHAR -> "C_UCHAR";
+                case CHAR -> "C_CHAR";
+                case SHORT -> "C_SHORT";
+                case UNSIGNED_SHORT -> "C_USHORT";
+                case INT -> "C_INT";
+                case UNSIGNED_INT -> "C_UINT";
+                case LONG -> "C_LONG";
+                case UNSIGNED_LONG -> "C_ULONG";
+                case LONG_LONG -> "C_LONGLONG";
+                case UNSIGNED_LONG_LONG -> "C_ULONGLONG";
+                case FLOAT -> "C_FLOAT";
+                case DOUBLE -> "C_DOUBLE";
+                case LONG_DOUBLE -> "C_LONGDOUBLE";
+                case POINTER -> "C_POINTER";
+                default -> { throw new RuntimeException("should not reach here: " + type); }
+            });
         } else if (l instanceof SequenceLayout) {
             sb.append("MemoryLayout.ofSequence(");
             if (((SequenceLayout) l).elementCount().isPresent()) {

--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/LayoutUtils.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/LayoutUtils.java
@@ -60,22 +60,28 @@ public final class LayoutUtils {
     }
 
     public static MemoryLayout getLayout(Type t) {
+        System.out.println(t.spelling() + " -> " + t.kind());
         switch(t.kind()) {
-            case Char_S:
-            case Char_U:
             case UChar:
+            case Char_U:
+                return C_UCHAR;
             case SChar:
+            case Char_S:
                 return C_SCHAR;
-            case UShort:
             case Short:
                 return C_SHORT;
+            case UShort:
+                return C_USHORT;
             case Int:
-            case UInt:
                 return C_INT;
+            case UInt:
+                return C_UINT;
             case ULong:
+                return C_ULONG;
             case Long:
                 return C_LONG;
             case ULongLong:
+                return C_ULONGLONG;
             case LongLong:
                 return C_LONGLONG;
             case UInt128:

--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/LayoutUtils.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/LayoutUtils.java
@@ -29,6 +29,7 @@ package jdk.internal.jextract.impl;
 import jdk.incubator.foreign.FunctionDescriptor;
 import jdk.incubator.foreign.MemoryLayout;
 import jdk.incubator.foreign.MemoryLayouts;
+import jdk.incubator.foreign.MemoryLayouts.SysV;
 import jdk.incubator.foreign.SequenceLayout;
 import jdk.incubator.foreign.SystemABI;
 import jdk.incubator.foreign.ValueLayout;
@@ -45,6 +46,7 @@ import java.util.Optional;
  * General Layout utility functions
  */
 public final class LayoutUtils {
+    private static SystemABI abi = SystemABI.getInstance();
     private LayoutUtils() {}
 
     public static String getName(Type type) {
@@ -94,6 +96,11 @@ public final class LayoutUtils {
                 return C_DOUBLE;
             case LongDouble:
                 return C_LONGDOUBLE;
+            case Complex:
+                if (!abi.name().equals(SystemABI.ABI_SYSV)) {
+                    throw new UnsupportedOperationException("unsupported: " + t.kind());
+                }
+                return SysV.C_COMPLEX_LONGDOUBLE;
             case Record:
                 return getRecordLayout(t);
             case Vector:
@@ -228,7 +235,6 @@ public final class LayoutUtils {
     public static final ValueLayout INT64;
 
     static {
-        SystemABI abi = SystemABI.getInstance();
         if (abi instanceof SysVx64ABI) {
             C_BOOL = MemoryLayouts.SysV.C_BOOL;
             C_CHAR = MemoryLayouts.SysV.C_CHAR;

--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/LayoutUtils.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/LayoutUtils.java
@@ -60,7 +60,6 @@ public final class LayoutUtils {
     }
 
     public static MemoryLayout getLayout(Type t) {
-        System.out.println(t.spelling() + " -> " + t.kind());
         switch(t.kind()) {
             case UChar:
             case Char_U:

--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/LayoutUtils.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/LayoutUtils.java
@@ -61,11 +61,9 @@ public final class LayoutUtils {
 
     public static MemoryLayout getLayout(Type t) {
         switch(t.kind()) {
-            case UChar:
-            case Char_U:
+            case UChar, Char_U:
                 return C_UCHAR;
-            case SChar:
-            case Char_S:
+            case SChar, Char_S:
                 return C_SCHAR;
             case Short:
                 return C_SHORT;
@@ -204,7 +202,7 @@ public final class LayoutUtils {
                 throw new IllegalStateException("Cannot infer container layout");
         }
     }
-    
+
     // platform-dependent layouts
 
     public static final ValueLayout C_BOOL;

--- a/test/jdk/tools/jextract/testStruct/LibStructTest.java
+++ b/test/jdk/tools/jextract/testStruct/LibStructTest.java
@@ -21,6 +21,8 @@
  * questions.
  */
 
+import jdk.incubator.foreign.GroupLayout;
+import jdk.incubator.foreign.SystemABI.Type;
 import org.testng.annotations.Test;
 import static org.testng.Assert.assertEquals;
 import static test.jextract.struct.struct_h.*;
@@ -39,5 +41,52 @@ public class LibStructTest {
             assertEquals(Point$x$get(seg), 42);
             assertEquals(Point$y$get(seg), -39);
         }
+    }
+
+    @Test
+    public void testFieldTypes() {
+         GroupLayout g = (GroupLayout)AllTypes$LAYOUT;
+         int fieldCount = 0;
+         for (var ml : g.memberLayouts()) {
+             var type = ml.abiType().orElse(null);
+             if (type == null) {
+                 // ignore paddings
+                 continue;
+             }
+             switch (ml.name().get()) {
+                 case "sc":
+                     assertEquals(type, Type.SIGNED_CHAR);
+                     break;
+                 case "uc":
+                     assertEquals(type, Type.UNSIGNED_CHAR);
+                     break;
+                 case "s":
+                     assertEquals(type, Type.SHORT);
+                     break;
+                 case "us":
+                     assertEquals(type, Type.UNSIGNED_SHORT);
+                     break;
+                 case "i":
+                     assertEquals(type, Type.INT);
+                     break;
+                 case "ui":
+                     assertEquals(type, Type.UNSIGNED_INT);
+                     break;
+                 case "l":
+                     assertEquals(type, Type.LONG);
+                     break;
+                 case "ul":
+                     assertEquals(type, Type.UNSIGNED_LONG);
+                     break;
+                 case "ll":
+                     assertEquals(type, Type.LONG_LONG);
+                     break;
+                 case "ull":
+                     assertEquals(type, Type.UNSIGNED_LONG_LONG);
+                     break;
+             }
+             fieldCount++;
+         }
+         assertEquals(fieldCount, 10);
     }
 }

--- a/test/jdk/tools/jextract/testStruct/LibStructTest.java
+++ b/test/jdk/tools/jextract/testStruct/LibStructTest.java
@@ -21,6 +21,7 @@
  * questions.
  */
 
+import jdk.incubator.foreign.MemoryLayout.PathElement;
 import jdk.incubator.foreign.GroupLayout;
 import jdk.incubator.foreign.SystemABI.Type;
 import org.testng.annotations.Test;
@@ -43,50 +44,25 @@ public class LibStructTest {
         }
     }
 
+    private static void checkFieldABIType(GroupLayout group, String fieldName, Type expected) {
+        assertEquals(group.select(PathElement.groupElement(fieldName)).abiType().orElseThrow(), expected);
+    }
+
     @Test
     public void testFieldTypes() {
-         GroupLayout g = (GroupLayout)AllTypes$LAYOUT;
-         int fieldCount = 0;
-         for (var ml : g.memberLayouts()) {
-             var type = ml.abiType().orElse(null);
-             if (type == null) {
-                 // ignore paddings
-                 continue;
-             }
-             switch (ml.name().get()) {
-                 case "sc":
-                     assertEquals(type, Type.SIGNED_CHAR);
-                     break;
-                 case "uc":
-                     assertEquals(type, Type.UNSIGNED_CHAR);
-                     break;
-                 case "s":
-                     assertEquals(type, Type.SHORT);
-                     break;
-                 case "us":
-                     assertEquals(type, Type.UNSIGNED_SHORT);
-                     break;
-                 case "i":
-                     assertEquals(type, Type.INT);
-                     break;
-                 case "ui":
-                     assertEquals(type, Type.UNSIGNED_INT);
-                     break;
-                 case "l":
-                     assertEquals(type, Type.LONG);
-                     break;
-                 case "ul":
-                     assertEquals(type, Type.UNSIGNED_LONG);
-                     break;
-                 case "ll":
-                     assertEquals(type, Type.LONG_LONG);
-                     break;
-                 case "ull":
-                     assertEquals(type, Type.UNSIGNED_LONG_LONG);
-                     break;
-             }
-             fieldCount++;
-         }
-         assertEquals(fieldCount, 10);
+        GroupLayout g = (GroupLayout)AllTypes$LAYOUT;
+        checkFieldABIType(g, "sc",  Type.SIGNED_CHAR);
+        checkFieldABIType(g, "uc",  Type.UNSIGNED_CHAR);
+        checkFieldABIType(g, "s",   Type.SHORT);
+        checkFieldABIType(g, "us",  Type.UNSIGNED_SHORT);
+        checkFieldABIType(g, "i",   Type.INT);
+        checkFieldABIType(g, "ui",  Type.UNSIGNED_INT);
+        checkFieldABIType(g, "l",   Type.LONG);
+        checkFieldABIType(g, "ul",  Type.UNSIGNED_LONG);
+        checkFieldABIType(g, "ll",  Type.LONG_LONG);
+        checkFieldABIType(g, "ull", Type.UNSIGNED_LONG_LONG);
+        checkFieldABIType(g, "f", Type.FLOAT);
+        checkFieldABIType(g, "d", Type.DOUBLE);
+        checkFieldABIType(g, "ld", Type.LONG_DOUBLE);
     }
 }

--- a/test/jdk/tools/jextract/testStruct/struct.h
+++ b/test/jdk/tools/jextract/testStruct/struct.h
@@ -49,6 +49,9 @@ struct AllTypes {
     unsigned long ul;
     long long ll;
     unsigned long long ull;
+    float f;
+    double d;
+    long double ld;
 };
 
 #ifdef __cplusplus

--- a/test/jdk/tools/jextract/testStruct/struct.h
+++ b/test/jdk/tools/jextract/testStruct/struct.h
@@ -38,6 +38,19 @@ typedef struct Point {
 
 EXPORT Point makePoint(int x, int y);
 
+struct AllTypes {
+    signed char sc;
+    unsigned char uc;
+    short s;
+    unsigned short us;
+    int i;
+    unsigned int ui;
+    long l;
+    unsigned long ul;
+    long long ll;
+    unsigned long long ull;
+};
+
 #ifdef __cplusplus
 }
 #endif // __cplusplus


### PR DESCRIPTION
Using SystemABI.Type of MemoryLayouts to generate layout constants
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [JDK-8238316](https://bugs.openjdk.java.net/browse/JDK-8238316): jextract emits a C_BOOL when source says char


### Reviewers
 * Jorn Vernee ([jvernee](@JornVernee) - Committer) ⚠️ Review applies to ca463ab8eebc978955a78f99e78156316b0f07f4
 * Maurizio Cimadamore ([mcimadamore](@mcimadamore) - Committer)

### Download
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/25/head:pull/25`
`$ git checkout pull/25`
