### PR TITLE
8239784: Circular initialization causes C_XXX constants to be null

### DIFF
--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/MemoryLayouts.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/MemoryLayouts.java
@@ -479,6 +479,12 @@ public final class MemoryLayouts {
                 .withAnnotation(AbstractLayout.NATIVE_TYPE, SystemABI.Type.DOUBLE);
 
         /**
+         * The {@code long double} native type.
+         */
+        public static final ValueLayout C_LONGDOUBLE = SharedLayouts.BITS_64_LE
+                .withAnnotation(AbstractLayout.NATIVE_TYPE, SystemABI.Type.LONG_DOUBLE);
+
+        /**
          * The {@code T*} native type.
          */
         public static final ValueLayout C_POINTER = SharedLayouts.BITS_64_LE
@@ -576,6 +582,12 @@ public final class MemoryLayouts {
          */
         public static final ValueLayout C_DOUBLE = SharedLayouts.BITS_64_LE
                 .withAnnotation(AbstractLayout.NATIVE_TYPE, SystemABI.Type.DOUBLE);
+
+        /**
+         * The {@code long double} native type.
+         */
+        public static final ValueLayout C_LONGDOUBLE = MemoryLayout.ofValueBits(128, ByteOrder.LITTLE_ENDIAN)
+                .withAnnotation(AbstractLayout.NATIVE_TYPE, SystemABI.Type.LONG_DOUBLE);
 
         /**
          * The {@code T*} native type.

--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/MemoryLayouts.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/MemoryLayouts.java
@@ -50,22 +50,22 @@ public final class MemoryLayouts {
     /**
      * A value layout constant with size of one byte, and byte order set to {@link ByteOrder#LITTLE_ENDIAN}.
      */
-    public static final ValueLayout BITS_8_LE = MemoryLayout.ofValueBits(8, ByteOrder.LITTLE_ENDIAN);
+    public static final ValueLayout BITS_8_LE = SharedLayouts.BITS_8_LE;
 
     /**
      * A value layout constant with size of two bytes, and byte order set to {@link ByteOrder#LITTLE_ENDIAN}.
      */
-    public static final ValueLayout BITS_16_LE = MemoryLayout.ofValueBits(16, ByteOrder.LITTLE_ENDIAN);
+    public static final ValueLayout BITS_16_LE = SharedLayouts.BITS_16_LE;
 
     /**
      * A value layout constant with size of four bytes, and byte order set to {@link ByteOrder#LITTLE_ENDIAN}.
      */
-    public static final ValueLayout BITS_32_LE = MemoryLayout.ofValueBits(32, ByteOrder.LITTLE_ENDIAN);
+    public static final ValueLayout BITS_32_LE = SharedLayouts.BITS_32_LE;
 
     /**
      * A value layout constant with size of eight bytes, and byte order set to {@link ByteOrder#LITTLE_ENDIAN}.
      */
-    public static final ValueLayout BITS_64_LE = MemoryLayout.ofValueBits(64, ByteOrder.LITTLE_ENDIAN);
+    public static final ValueLayout BITS_64_LE = SharedLayouts.BITS_64_LE;
 
     /**
      * A value layout constant with size of one byte, and byte order set to {@link ByteOrder#BIG_ENDIAN}.
@@ -286,89 +286,89 @@ public final class MemoryLayouts {
         /**
          * The {@code _Bool} native type.
          */
-        public static final ValueLayout C_BOOL = MemoryLayouts.BITS_8_LE
+        public static final ValueLayout C_BOOL = SharedLayouts.BITS_8_LE
                 .withAnnotation(AbstractLayout.NATIVE_TYPE, SystemABI.Type.BOOL);
 
 
         /**
          * The {@code unsigned char} native type.
          */
-        public static final ValueLayout C_UCHAR = MemoryLayouts.BITS_8_LE
+        public static final ValueLayout C_UCHAR = SharedLayouts.BITS_8_LE
                 .withAnnotation(AbstractLayout.NATIVE_TYPE, SystemABI.Type.UNSIGNED_CHAR);
 
 
         /**
          * The {@code signed char} native type.
          */
-        public static final ValueLayout C_SCHAR = MemoryLayouts.BITS_8_LE
+        public static final ValueLayout C_SCHAR = SharedLayouts.BITS_8_LE
                 .withAnnotation(AbstractLayout.NATIVE_TYPE, SystemABI.Type.SIGNED_CHAR);
 
 
         /**
          * The {@code char} native type.
          */
-        public static final ValueLayout C_CHAR = MemoryLayouts.BITS_8_LE
+        public static final ValueLayout C_CHAR = SharedLayouts.BITS_8_LE
                 .withAnnotation(AbstractLayout.NATIVE_TYPE, SystemABI.Type.CHAR);
 
         /**
          * The {@code short} native type.
          */
-        public static final ValueLayout C_SHORT = MemoryLayouts.BITS_16_LE
+        public static final ValueLayout C_SHORT = SharedLayouts.BITS_16_LE
                 .withAnnotation(AbstractLayout.NATIVE_TYPE, SystemABI.Type.SHORT);
 
         /**
          * The {@code unsigned short} native type.
          */
-        public static final ValueLayout C_USHORT = MemoryLayouts.BITS_16_LE
+        public static final ValueLayout C_USHORT = SharedLayouts.BITS_16_LE
                 .withAnnotation(AbstractLayout.NATIVE_TYPE, SystemABI.Type.UNSIGNED_SHORT);
 
         /**
          * The {@code int} native type.
          */
-        public static final ValueLayout C_INT = MemoryLayouts.BITS_32_LE
+        public static final ValueLayout C_INT = SharedLayouts.BITS_32_LE
                 .withAnnotation(AbstractLayout.NATIVE_TYPE, SystemABI.Type.INT);
 
         /**
          * The {@code unsigned int} native type.
          */
-        public static final ValueLayout C_UINT = MemoryLayouts.BITS_32_LE
+        public static final ValueLayout C_UINT = SharedLayouts.BITS_32_LE
                 .withAnnotation(AbstractLayout.NATIVE_TYPE, SystemABI.Type.UNSIGNED_INT);
 
         /**
          * The {@code long} native type.
          */
-        public static final ValueLayout C_LONG = MemoryLayouts.BITS_64_LE
+        public static final ValueLayout C_LONG = SharedLayouts.BITS_64_LE
                 .withAnnotation(AbstractLayout.NATIVE_TYPE, SystemABI.Type.LONG);
 
         /**
          * The {@code unsigned long} native type.
          */
-        public static final ValueLayout C_ULONG = MemoryLayouts.BITS_64_LE
+        public static final ValueLayout C_ULONG = SharedLayouts.BITS_64_LE
                 .withAnnotation(AbstractLayout.NATIVE_TYPE, SystemABI.Type.UNSIGNED_LONG);
 
 
         /**
          * The {@code long long} native type.
          */
-        public static final ValueLayout C_LONGLONG = MemoryLayouts.BITS_64_LE
+        public static final ValueLayout C_LONGLONG = SharedLayouts.BITS_64_LE
                 .withAnnotation(AbstractLayout.NATIVE_TYPE, SystemABI.Type.LONG_LONG);
 
         /**
          * The {@code unsigned long long} native type.
          */
-        public static final ValueLayout C_ULONGLONG = MemoryLayouts.BITS_64_LE
+        public static final ValueLayout C_ULONGLONG = SharedLayouts.BITS_64_LE
                 .withAnnotation(AbstractLayout.NATIVE_TYPE, SystemABI.Type.UNSIGNED_LONG_LONG);
 
         /**
          * The {@code float} native type.
          */
-        public static final ValueLayout C_FLOAT = MemoryLayouts.BITS_32_LE
+        public static final ValueLayout C_FLOAT = SharedLayouts.BITS_32_LE
                 .withAnnotation(AbstractLayout.NATIVE_TYPE, SystemABI.Type.FLOAT);
 
         /**
          * The {@code double} native type.
          */
-        public static final ValueLayout C_DOUBLE = MemoryLayouts.BITS_64_LE
+        public static final ValueLayout C_DOUBLE = SharedLayouts.BITS_64_LE
                 .withAnnotation(AbstractLayout.NATIVE_TYPE, SystemABI.Type.DOUBLE);
 
         /**
@@ -386,7 +386,7 @@ public final class MemoryLayouts {
         /**
          * The {@code T*} native type.
          */
-        public static final ValueLayout C_POINTER = MemoryLayouts.BITS_64_LE
+        public static final ValueLayout C_POINTER = SharedLayouts.BITS_64_LE
                 .withAnnotation(AbstractLayout.NATIVE_TYPE, SystemABI.Type.POINTER);
     }
 
@@ -397,91 +397,91 @@ public final class MemoryLayouts {
         /**
          * The {@code _Bool} native type.
          */
-        public static final ValueLayout C_BOOL = MemoryLayouts.BITS_8_LE
+        public static final ValueLayout C_BOOL = SharedLayouts.BITS_8_LE
                 .withAnnotation(AbstractLayout.NATIVE_TYPE, SystemABI.Type.BOOL);
-        
+
         /**
          * The {@code unsigned char} native type.
          */
-        public static final ValueLayout C_UCHAR = MemoryLayouts.BITS_8_LE
+        public static final ValueLayout C_UCHAR = SharedLayouts.BITS_8_LE
                 .withAnnotation(AbstractLayout.NATIVE_TYPE, SystemABI.Type.UNSIGNED_CHAR);
 
         /**
          * The {@code signed char} native type.
          */
-        public static final ValueLayout C_SCHAR = MemoryLayouts.BITS_8_LE
+        public static final ValueLayout C_SCHAR = SharedLayouts.BITS_8_LE
                 .withAnnotation(AbstractLayout.NATIVE_TYPE, SystemABI.Type.SIGNED_CHAR);
 
         /**
          * The {@code char} native type.
          */
-        public static final ValueLayout C_CHAR = MemoryLayouts.BITS_8_LE
+        public static final ValueLayout C_CHAR = SharedLayouts.BITS_8_LE
                 .withAnnotation(AbstractLayout.NATIVE_TYPE, SystemABI.Type.CHAR);
 
         /**
          * The {@code short} native type.
          */
-        public static final ValueLayout C_SHORT = MemoryLayouts.BITS_16_LE
+        public static final ValueLayout C_SHORT = SharedLayouts.BITS_16_LE
                 .withAnnotation(AbstractLayout.NATIVE_TYPE, SystemABI.Type.SHORT);
 
         /**
          * The {@code unsigned short} native type.
          */
-        public static final ValueLayout C_USHORT = MemoryLayouts.BITS_16_LE
+        public static final ValueLayout C_USHORT = SharedLayouts.BITS_16_LE
                 .withAnnotation(AbstractLayout.NATIVE_TYPE, SystemABI.Type.UNSIGNED_SHORT);
 
         /**
          * The {@code int} native type.
          */
-        public static final ValueLayout C_INT = MemoryLayouts.BITS_32_LE
+        public static final ValueLayout C_INT = SharedLayouts.BITS_32_LE
                 .withAnnotation(AbstractLayout.NATIVE_TYPE, SystemABI.Type.INT);
 
         /**
          * The {@code unsigned int} native type.
          */
-        public static final ValueLayout C_UINT = MemoryLayouts.BITS_32_LE
+        public static final ValueLayout C_UINT = SharedLayouts.BITS_32_LE
                 .withAnnotation(AbstractLayout.NATIVE_TYPE, SystemABI.Type.UNSIGNED_INT);
 
         /**
          * The {@code long} native type.
          */
-        public static final ValueLayout C_LONG = MemoryLayouts.BITS_32_LE
+        public static final ValueLayout C_LONG = SharedLayouts.BITS_32_LE
                 .withAnnotation(AbstractLayout.NATIVE_TYPE, SystemABI.Type.LONG);
 
         /**
          * The {@code unsigned long} native type.
          */
-        public static final ValueLayout C_ULONG = MemoryLayouts.BITS_32_LE
+        public static final ValueLayout C_ULONG = SharedLayouts.BITS_32_LE
                 .withAnnotation(AbstractLayout.NATIVE_TYPE, SystemABI.Type.UNSIGNED_LONG);
 
         /**
          * The {@code long long} native type.
          */
-        public static final ValueLayout C_LONGLONG = MemoryLayouts.BITS_64_LE
+        public static final ValueLayout C_LONGLONG = SharedLayouts.BITS_64_LE
                 .withAnnotation(AbstractLayout.NATIVE_TYPE, SystemABI.Type.LONG_LONG);
 
         /**
          * The {@code unsigned long long} native type.
          */
-        public static final ValueLayout C_ULONGLONG = MemoryLayouts.BITS_64_LE
+        public static final ValueLayout C_ULONGLONG = SharedLayouts.BITS_64_LE
                 .withAnnotation(AbstractLayout.NATIVE_TYPE, SystemABI.Type.UNSIGNED_LONG_LONG);
 
         /**
          * The {@code float} native type.
          */
-        public static final ValueLayout C_FLOAT = MemoryLayouts.BITS_32_LE
+        public static final ValueLayout C_FLOAT = SharedLayouts.BITS_32_LE
                 .withAnnotation(AbstractLayout.NATIVE_TYPE, SystemABI.Type.FLOAT);
 
         /**
          * The {@code double} native type.
          */
-        public static final ValueLayout C_DOUBLE = MemoryLayouts.BITS_64_LE
+        public static final ValueLayout C_DOUBLE = SharedLayouts.BITS_64_LE
                 .withAnnotation(AbstractLayout.NATIVE_TYPE, SystemABI.Type.DOUBLE);
 
         /**
          * The {@code T*} native type.
          */
-        public static final ValueLayout C_POINTER = MemoryLayouts.BITS_64_LE
+        public static final ValueLayout C_POINTER = SharedLayouts.BITS_64_LE
                 .withAnnotation(AbstractLayout.NATIVE_TYPE, SystemABI.Type.POINTER);
 
         public static ValueLayout asVarArg(ValueLayout l) {
@@ -496,91 +496,98 @@ public final class MemoryLayouts {
         /**
          * The {@code _Bool} native type.
          */
-        public static final ValueLayout C_BOOL = MemoryLayouts.BITS_8_LE
+        public static final ValueLayout C_BOOL = SharedLayouts.BITS_8_LE
                 .withAnnotation(AbstractLayout.NATIVE_TYPE, SystemABI.Type.BOOL);
 
         /**
          * The {@code unsigned char} native type.
          */
-        public static final ValueLayout C_UCHAR = MemoryLayouts.BITS_8_LE
+        public static final ValueLayout C_UCHAR = SharedLayouts.BITS_8_LE
                 .withAnnotation(AbstractLayout.NATIVE_TYPE, SystemABI.Type.UNSIGNED_CHAR);
 
         /**
          * The {@code signed char} native type.
          */
-        public static final ValueLayout C_SCHAR = MemoryLayouts.BITS_8_LE
+        public static final ValueLayout C_SCHAR = SharedLayouts.BITS_8_LE
                 .withAnnotation(AbstractLayout.NATIVE_TYPE, SystemABI.Type.SIGNED_CHAR);
 
         /**
          * The {@code char} native type.
          */
-        public static final ValueLayout C_CHAR = MemoryLayouts.BITS_8_LE
+        public static final ValueLayout C_CHAR = SharedLayouts.BITS_8_LE
                 .withAnnotation(AbstractLayout.NATIVE_TYPE, SystemABI.Type.CHAR);
 
         /**
          * The {@code short} native type.
          */
-        public static final ValueLayout C_SHORT = MemoryLayouts.BITS_16_LE
+        public static final ValueLayout C_SHORT = SharedLayouts.BITS_16_LE
                 .withAnnotation(AbstractLayout.NATIVE_TYPE, SystemABI.Type.SHORT);
 
         /**
          * The {@code unsigned short} native type.
          */
-        public static final ValueLayout C_USHORT = MemoryLayouts.BITS_16_LE
+        public static final ValueLayout C_USHORT = SharedLayouts.BITS_16_LE
                 .withAnnotation(AbstractLayout.NATIVE_TYPE, SystemABI.Type.UNSIGNED_SHORT);
 
         /**
          * The {@code int} native type.
          */
-        public static final ValueLayout C_INT = MemoryLayouts.BITS_32_LE
+        public static final ValueLayout C_INT = SharedLayouts.BITS_32_LE
                 .withAnnotation(AbstractLayout.NATIVE_TYPE, SystemABI.Type.INT);
 
         /**
          * The {@code unsigned int} native type.
          */
-        public static final ValueLayout C_UINT = MemoryLayouts.BITS_32_LE
+        public static final ValueLayout C_UINT = SharedLayouts.BITS_32_LE
                 .withAnnotation(AbstractLayout.NATIVE_TYPE, SystemABI.Type.UNSIGNED_INT);
 
         /**
          * The {@code long} native type.
          */
-        public static final ValueLayout C_LONG = MemoryLayouts.BITS_64_LE
+        public static final ValueLayout C_LONG = SharedLayouts.BITS_64_LE
                 .withAnnotation(AbstractLayout.NATIVE_TYPE, SystemABI.Type.LONG);
 
         /**
          * The {@code unsigned long} native type.
          */
-        public static final ValueLayout C_ULONG = MemoryLayouts.BITS_64_LE
+        public static final ValueLayout C_ULONG = SharedLayouts.BITS_64_LE
                 .withAnnotation(AbstractLayout.NATIVE_TYPE, SystemABI.Type.UNSIGNED_LONG);
 
         /**
          * The {@code long long} native type.
          */
-        public static final ValueLayout C_LONGLONG = MemoryLayouts.BITS_64_LE
+        public static final ValueLayout C_LONGLONG = SharedLayouts.BITS_64_LE
                 .withAnnotation(AbstractLayout.NATIVE_TYPE, SystemABI.Type.LONG_LONG);
 
         /**
          * The {@code unsigned long long} native type.
          */
-        public static final ValueLayout C_ULONGLONG = MemoryLayouts.BITS_64_LE
+        public static final ValueLayout C_ULONGLONG = SharedLayouts.BITS_64_LE
                 .withAnnotation(AbstractLayout.NATIVE_TYPE, SystemABI.Type.UNSIGNED_LONG_LONG);
 
         /**
          * The {@code float} native type.
          */
-        public static final ValueLayout C_FLOAT = MemoryLayouts.BITS_32_LE
+        public static final ValueLayout C_FLOAT = SharedLayouts.BITS_32_LE
                 .withAnnotation(AbstractLayout.NATIVE_TYPE, SystemABI.Type.FLOAT);
 
         /**
          * The {@code double} native type.
          */
-        public static final ValueLayout C_DOUBLE = MemoryLayouts.BITS_64_LE
+        public static final ValueLayout C_DOUBLE = SharedLayouts.BITS_64_LE
                 .withAnnotation(AbstractLayout.NATIVE_TYPE, SystemABI.Type.DOUBLE);
 
         /**
          * The {@code T*} native type.
          */
-        public static final ValueLayout C_POINTER = MemoryLayouts.BITS_64_LE
+        public static final ValueLayout C_POINTER = SharedLayouts.BITS_64_LE
                 .withAnnotation(AbstractLayout.NATIVE_TYPE, SystemABI.Type.POINTER);
+    }
+
+    private static class SharedLayouts { // Separate class to prevent circular clinit references
+        public static final ValueLayout BITS_8_LE = MemoryLayout.ofValueBits(8, ByteOrder.LITTLE_ENDIAN);
+        public static final ValueLayout BITS_16_LE = MemoryLayout.ofValueBits(16, ByteOrder.LITTLE_ENDIAN);
+        public static final ValueLayout BITS_32_LE = MemoryLayout.ofValueBits(32, ByteOrder.LITTLE_ENDIAN);
+        public static final ValueLayout BITS_64_LE = MemoryLayout.ofValueBits(64, ByteOrder.LITTLE_ENDIAN);
     }
 }

--- a/test/jdk/java/foreign/TestCircularInit.java
+++ b/test/jdk/java/foreign/TestCircularInit.java
@@ -1,0 +1,43 @@
+/*
+ *  Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ *  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ *  This code is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License version 2 only, as
+ *  published by the Free Software Foundation.
+ *
+ *  This code is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ *  version 2 for more details (a copy is included in the LICENSE file that
+ *  accompanied this code).
+ *
+ *  You should have received a copy of the GNU General Public License version
+ *  2 along with this work; if not, write to the Free Software Foundation,
+ *  Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ *  Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ *  or visit www.oracle.com if you need additional information or have any
+ *  questions.
+ */
+
+/*
+ * @test
+ * @modules jdk.incubator.foreign
+ * @run testng/othervm TestCircularInit
+ */
+
+import jdk.incubator.foreign.MemoryLayouts;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertNotNull;
+
+public class TestCircularInit {
+
+    @Test
+    public void testCircularInit() {
+        System.out.println(MemoryLayouts.WinABI.C_BOOL); // trigger clinit
+        assertNotNull(MemoryLayouts.C_BOOL); // should not be null
+    }
+
+}

--- a/test/jdk/java/foreign/TestCircularInit1.java
+++ b/test/jdk/java/foreign/TestCircularInit1.java
@@ -1,0 +1,43 @@
+/*
+ *  Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ *  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ *  This code is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License version 2 only, as
+ *  published by the Free Software Foundation.
+ *
+ *  This code is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ *  version 2 for more details (a copy is included in the LICENSE file that
+ *  accompanied this code).
+ *
+ *  You should have received a copy of the GNU General Public License version
+ *  2 along with this work; if not, write to the Free Software Foundation,
+ *  Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ *  Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ *  or visit www.oracle.com if you need additional information or have any
+ *  questions.
+ */
+
+/*
+ * @test
+ * @modules jdk.incubator.foreign
+ * @run testng/othervm TestCircularInit1
+ */
+
+import jdk.incubator.foreign.MemoryLayouts;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertNotNull;
+
+public class TestCircularInit1 {
+
+    @Test
+    public void testCircularInit() {
+        System.out.println(MemoryLayouts.WinABI.C_BOOL); // trigger clinit
+        assertNotNull(MemoryLayouts.C_BOOL); // should not be null
+    }
+
+}

--- a/test/jdk/java/foreign/TestCircularInit2.java
+++ b/test/jdk/java/foreign/TestCircularInit2.java
@@ -24,7 +24,7 @@
 /*
  * @test
  * @modules jdk.incubator.foreign
- * @run testng/othervm TestCircularInit
+ * @run testng/othervm TestCircularInit2
  */
 
 import jdk.incubator.foreign.MemoryLayouts;
@@ -32,12 +32,14 @@ import org.testng.annotations.Test;
 
 import static org.testng.Assert.assertNotNull;
 
-public class TestCircularInit {
+public class TestCircularInit2 {
 
     @Test
     public void testCircularInit() {
-        System.out.println(MemoryLayouts.WinABI.C_BOOL); // trigger clinit
-        assertNotNull(MemoryLayouts.C_BOOL); // should not be null
+        System.out.println(MemoryLayouts.C_BOOL); // trigger clinit
+        assertNotNull(MemoryLayouts.WinABI.C_BOOL);
+        assertNotNull(MemoryLayouts.SysV.C_BOOL);
+        assertNotNull(MemoryLayouts.AArch64ABI.C_BOOL);
     }
 
 }


### PR DESCRIPTION
See the bug for a complete description. Essentially, the problem is that 

```java
public static void main(String[] args) {
    System.out.println(MemoryLayouts.WinABI.C_CHAR);
    System.out.println(MemoryLayouts.C_CHAR);
} 
```

Will print 

```
b8
null
```
Because of a circular dependency between the constants.

The fix is to extract the constants that the platform specific classes depend on into a separate, shared class, which removes the circular dependency. (This fix was suggested by Sundar)
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [JDK-8239784](https://bugs.openjdk.java.net/browse/JDK-8239784): Circular initialization causes C_XXX constants to be null


### Reviewers
 * Athijegannathan Sundararajan ([sundar](@sundararajana) - Committer)

### Download
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/26/head:pull/26`
`$ git checkout pull/26`
