### PR TITLE
Use Windows and Aarch64 LongDouble constants in LayoutUtils

### DIFF
--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/LayoutUtils.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/LayoutUtils.java
@@ -271,7 +271,7 @@ public final class LayoutUtils {
             C_ULONGLONG = MemoryLayouts.WinABI.C_ULONGLONG;
             C_FLOAT = MemoryLayouts.WinABI.C_FLOAT;
             C_DOUBLE = MemoryLayouts.WinABI.C_DOUBLE;
-            C_LONGDOUBLE = C_DOUBLE;
+            C_LONGDOUBLE = MemoryLayouts.WinABI.C_LONGDOUBLE;
             C_POINTER = MemoryLayouts.WinABI.C_POINTER;
             INT8 = C_BOOL;
             INT16 = C_SHORT;
@@ -292,7 +292,7 @@ public final class LayoutUtils {
             C_ULONGLONG = MemoryLayouts.AArch64ABI.C_ULONGLONG;
             C_FLOAT = MemoryLayouts.AArch64ABI.C_FLOAT;
             C_DOUBLE = MemoryLayouts.AArch64ABI.C_DOUBLE;
-            C_LONGDOUBLE = C_DOUBLE;
+            C_LONGDOUBLE = MemoryLayouts.AArch64ABI.C_LONGDOUBLE;
             C_POINTER = MemoryLayouts.AArch64ABI.C_POINTER;
             INT8 = C_BOOL;
             INT16 = C_SHORT;


### PR DESCRIPTION
Hi,

Please review this small fix that lets LayoutUtils use the new LongDouble constants instead of Double on Windows and Aarch64 to initialize the global `C_LONGDOUBLE` value. Currently the use of Double results in an incorrect ABI attribute, causing a test failure.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * Maurizio Cimadamore ([mcimadamore](@mcimadamore) - Committer)

### Download
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/27/head:pull/27`
`$ git checkout pull/27`
