### PR TITLE
8239918: jextract generates uncompilable code for no argument C function

### DIFF
--- a/src/jdk.incubator.jextract/share/classes/jdk/incubator/jextract/tool/JavaSourceBuilder.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/incubator/jextract/tool/JavaSourceBuilder.java
@@ -255,14 +255,17 @@ class JavaSourceBuilder {
     }
 
     private void addFunction(FunctionDescriptor f) {
+        final boolean noArgs = f.argumentLayouts().isEmpty();
         if (f.returnLayout().isPresent()) {
             sb.append("FunctionDescriptor.of(");
             addLayout(f.returnLayout().get());
-            sb.append(", ");
+            if (!noArgs) {
+                sb.append(", ");
+            }
         } else {
             sb.append("FunctionDescriptor.ofVoid(");
         }
-        if (!f.argumentLayouts().isEmpty()) {
+        if (!noArgs) {
             sb.append("\n");
             incrAlign();
             String delim = "";

--- a/test/jdk/tools/jextract/test8239918/LibTest8239918Test.java
+++ b/test/jdk/tools/jextract/test8239918/LibTest8239918Test.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import org.testng.annotations.Test;
+import static org.testng.Assert.assertEquals;
+import static test.jextract.test8239918.test8239918_h.*;
+
+/*
+ * @test
+ * @library ..
+ * @modules jdk.incubator.jextract
+ * @bug 8239918
+ * @summary jextract generates uncompilable code for no argument C function
+ * @run driver JtregJextract -l Test8239918 -t test.jextract.test8239918 -- test8239918.h
+ * @run testng LibTest8239918Test
+ */
+public class LibTest8239918Test {
+    @Test
+    public void testRand() {
+        assertEquals(rand(), 1729);
+    }
+}

--- a/test/jdk/tools/jextract/test8239918/libTest8239918.c
+++ b/test/jdk/tools/jextract/test8239918/libTest8239918.c
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+#include "test8239918.h"
+
+EXPORT int rand(void) {
+    return 1729;
+}

--- a/test/jdk/tools/jextract/test8239918/test8239918.h
+++ b/test/jdk/tools/jextract/test8239918/test8239918.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+#ifdef __cplusplus
+extern "C" {
+#endif // __cplusplus
+
+#ifdef _WIN64
+#define EXPORT __declspec(dllexport)
+#else
+#define EXPORT
+#endif
+
+EXPORT int rand(void);
+
+#ifdef __cplusplus
+}
+#endif // __cplusplus


### PR DESCRIPTION
removing trailing comma when there are no arguments for the function.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [JDK-8239918](https://bugs.openjdk.java.net/browse/JDK-8239918): jextract generates uncompilable code for no argument C function


### Reviewers
 * Maurizio Cimadamore ([mcimadamore](@mcimadamore) - Committer)

### Download
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/30/head:pull/30`
`$ git checkout pull/30`
