### PR TITLE
8237585: Dismantle ForeignUnsafe  (foreign-jextract part)

### DIFF
--- a/make/launcher/Launcher-jdk.incubator.jextract.gmk
+++ b/make/launcher/Launcher-jdk.incubator.jextract.gmk
@@ -28,6 +28,6 @@ include LauncherCommon.gmk
 $(eval $(call SetupBuildLauncher, jextract,\
     CFLAGS := -DENABLE_ARG_FILES, \
     MAIN_CLASS := jdk.incubator.jextract.tool.Main, \
-		JAVA_ARGS := -Djdk.incubator.foreign.permitUncheckedSegments=true, \
+    JAVA_ARGS := -Djdk.incubator.foreign.permitUncheckedSegments=true, \
 ))
 

--- a/make/launcher/Launcher-jdk.incubator.jextract.gmk
+++ b/make/launcher/Launcher-jdk.incubator.jextract.gmk
@@ -28,5 +28,6 @@ include LauncherCommon.gmk
 $(eval $(call SetupBuildLauncher, jextract,\
     CFLAGS := -DENABLE_ARG_FILES, \
     MAIN_CLASS := jdk.incubator.jextract.tool.Main, \
+		JAVA_ARGS := -Djdk.incubator.foreign.permitUncheckedSegments=true, \
 ))
 

--- a/make/launcher/Launcher-jdk.incubator.jextract.gmk
+++ b/make/launcher/Launcher-jdk.incubator.jextract.gmk
@@ -28,6 +28,6 @@ include LauncherCommon.gmk
 $(eval $(call SetupBuildLauncher, jextract,\
     CFLAGS := -DENABLE_ARG_FILES, \
     MAIN_CLASS := jdk.incubator.jextract.tool.Main, \
-    JAVA_ARGS := -Djdk.incubator.foreign.permitUncheckedSegments=true, \
+    JAVA_ARGS := -Djdk.incubator.foreign.restrictedMethods=permit, \
 ))
 

--- a/src/jdk.incubator.foreign/share/classes/module-info.java
+++ b/src/jdk.incubator.foreign/share/classes/module-info.java
@@ -35,5 +35,4 @@ module jdk.incubator.foreign {
     exports jdk.internal.foreign.abi.aarch64 to jdk.incubator.jextract;
     exports jdk.internal.foreign.abi.x64.sysv to jdk.incubator.jextract;
     exports jdk.internal.foreign.abi.x64.windows to jdk.incubator.jextract;
-    exports jdk.incubator.foreign.unsafe to jdk.incubator.jextract;
 }

--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/clang/TranslationUnit.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/clang/TranslationUnit.java
@@ -29,7 +29,6 @@ package jdk.internal.clang;
 import jdk.incubator.foreign.MemoryAddress;
 import jdk.incubator.foreign.MemoryLayout;
 import jdk.incubator.foreign.MemorySegment;
-import jdk.incubator.foreign.unsafe.ForeignUnsafe;
 import jdk.internal.clang.libclang.Index_h;
 import jdk.internal.jextract.impl.LayoutUtils;
 
@@ -151,7 +150,7 @@ public class TranslationUnit implements AutoCloseable {
 
         public MemorySegment getTokenSegment(int idx) {
             MemoryAddress p = ar.addOffset(idx * Index_h.CXToken$LAYOUT.byteSize());
-            return ForeignUnsafe.ofNativeUnchecked(p, Index_h.CXToken$LAYOUT.byteSize());
+            return MemorySegment.ofNativeUnchecked(p, Index_h.CXToken$LAYOUT.byteSize());
         }
 
         public Token getToken(int index) {

--- a/test/jdk/java/jextract/SmokeTest.java
+++ b/test/jdk/java/jextract/SmokeTest.java
@@ -27,7 +27,7 @@
 /*
  * @test
  * @build JextractApiTestBase
- * @run testng/othervm -Djdk.incubator.foreign.permitUncheckedSegments=true SmokeTest
+ * @run testng/othervm -Djdk.incubator.foreign.restrictedMethods=permit SmokeTest
  */
 
 import jdk.incubator.jextract.Declaration;

--- a/test/jdk/java/jextract/SmokeTest.java
+++ b/test/jdk/java/jextract/SmokeTest.java
@@ -27,7 +27,7 @@
 /*
  * @test
  * @build JextractApiTestBase
- * @run testng SmokeTest
+ * @run testng/othervm -Djdk.incubator.foreign.permitUncheckedSegments=true SmokeTest
  */
 
 import jdk.incubator.jextract.Declaration;

--- a/test/jdk/java/jextract/TestMacros.java
+++ b/test/jdk/java/jextract/TestMacros.java
@@ -28,7 +28,7 @@
  * @test
  * @bug 8239128
  * @build JextractApiTestBase
- * @run testng/othervm -Djdk.incubator.foreign.permitUncheckedSegments=true TestMacros
+ * @run testng/othervm -Djdk.incubator.foreign.restrictedMethods=permit TestMacros
  */
 
 import java.nio.file.Path;

--- a/test/jdk/java/jextract/TestMacros.java
+++ b/test/jdk/java/jextract/TestMacros.java
@@ -28,7 +28,7 @@
  * @test
  * @bug 8239128
  * @build JextractApiTestBase
- * @run testng TestMacros
+ * @run testng/othervm -Djdk.incubator.foreign.permitUncheckedSegments=true TestMacros
  */
 
 import java.nio.file.Path;

--- a/test/jdk/tools/jextract/JextractToolProviderTest.java
+++ b/test/jdk/tools/jextract/JextractToolProviderTest.java
@@ -37,7 +37,11 @@ import static org.testng.Assert.assertTrue;
  * @test
  * @modules jdk.incubator.jextract
  * @build JextractToolRunner
- * @run testng/othervm -Duser.language=en --add-modules jdk.incubator.jextract JextractToolProviderTest
+ * @run testng/othervm
+ *          -Djdk.incubator.foreign.permitUncheckedSegments=true
+ *          -Duser.language=en
+ *          --add-modules jdk.incubator.jextract
+ *          JextractToolProviderTest
  */
 public class JextractToolProviderTest extends JextractToolRunner {
     @Test

--- a/test/jdk/tools/jextract/JextractToolProviderTest.java
+++ b/test/jdk/tools/jextract/JextractToolProviderTest.java
@@ -38,7 +38,7 @@ import static org.testng.Assert.assertTrue;
  * @modules jdk.incubator.jextract
  * @build JextractToolRunner
  * @run testng/othervm
- *          -Djdk.incubator.foreign.permitUncheckedSegments=true
+ *          -Djdk.incubator.foreign.restrictedMethods=permit
  *          -Duser.language=en
  *          --add-modules jdk.incubator.jextract
  *          JextractToolProviderTest


### PR DESCRIPTION
These are the jextract fixes that go with https://github.com/openjdk/panama-foreign/pull/31
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8237585](https://bugs.openjdk.java.net/browse/JDK-8237585): Dismantle ForeignUnsafe


### Download
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/32/head:pull/32`
`$ git checkout pull/32`
