### PR TITLE
8239809: Need API to access attributes

### DIFF
--- a/src/jdk.incubator.jextract/share/classes/jdk/incubator/jextract/Declaration.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/incubator/jextract/Declaration.java
@@ -26,8 +26,9 @@
 
 package jdk.incubator.jextract;
 
-import java.lang.constant.ConstantDesc;
+import java.lang.constant.Constable;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -56,11 +57,24 @@ public interface Declaration {
     String name();
 
     /**
+     * Get a declaration with specified attributes
+     * @param attributes The map of attribute names and their values
+     * @return the Declaration with attributes
+     */
+    Declaration withAttributes(Map<String, List<Constable>> attributes);
+
+    /**
+     * Get a declaration without current attributes
+     * @return the Declatation without any attributes
+     */
+    Declaration stripAttributes();
+
+    /**
      * The values of the specified attribute.
      * @param name The attribute to retrieve
      * @return The list of values associate with this attribute
      */
-    Optional<List<ConstantDesc>> getAttribute(String name);
+    Optional<List<Constable>> getAttribute(String name);
 
     /**
      * The attributes associated with this declaration

--- a/src/jdk.incubator.jextract/share/classes/jdk/incubator/jextract/Declaration.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/incubator/jextract/Declaration.java
@@ -28,7 +28,6 @@ package jdk.incubator.jextract;
 
 import java.lang.constant.Constable;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -57,11 +56,15 @@ public interface Declaration {
     String name();
 
     /**
-     * Get a declaration with specified attributes
-     * @param attributes The map of attribute names and their values
+     * Get a declaration with specified attribute.
+     * Set the values to the specified attribute while other attributes remains unchanged. If the specified attribute
+     * already exist, the new values are replacing the old ones. By not specifying any value, the attribute will become
+     * empty as {@link #getAttribute(String) getAttribute(name).isEmpty()} will return true.
+     * @param name The attribute name
+     * @param values More attribute values
      * @return the Declaration with attributes
      */
-    Declaration withAttributes(Map<String, List<Constable>> attributes);
+    Declaration withAttribute(String name, Constable... values);
 
     /**
      * Get a declaration without current attributes

--- a/src/jdk.incubator.jextract/share/classes/jdk/incubator/jextract/Declaration.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/incubator/jextract/Declaration.java
@@ -26,13 +26,15 @@
 
 package jdk.incubator.jextract;
 
-import jdk.incubator.foreign.MemoryLayout;
-import jdk.internal.jextract.impl.DeclarationImpl;
-
+import java.lang.constant.ConstantDesc;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import jdk.incubator.foreign.MemoryLayout;
+import jdk.internal.jextract.impl.DeclarationImpl;
 
 /**
  * Instances of this class are used to model declaration elements in the foreign language.
@@ -53,6 +55,9 @@ public interface Declaration {
      * @return The name associated with this declaration.
      */
     String name();
+
+    Optional<List<ConstantDesc>> getAttribute(String name);
+    Set<String> availableAttributes();
 
     /**
      * Entry point for visiting declaration instances.
@@ -277,8 +282,8 @@ public interface Declaration {
      * @param type the global variable declaration type.
      * @return a new global variable declaration with given name and type.
      */
-    static Declaration.Variable globalVariable(Position pos, String name, Type type) {
-        return new DeclarationImpl.VariableImpl(type, Declaration.Variable.Kind.GLOBAL, name, pos);
+    static Declaration.Variable globalVariable(Position pos, String name, Type type, Map<String, List<ConstantDesc>> attrs) {
+        return new DeclarationImpl.VariableImpl(type, Declaration.Variable.Kind.GLOBAL, name, pos, attrs);
     }
 
     /**
@@ -288,8 +293,8 @@ public interface Declaration {
      * @param type the field declaration type.
      * @return a new field declaration with given name and type.
      */
-    static Declaration.Variable field(Position pos, String name, Type type) {
-        return new DeclarationImpl.VariableImpl(type, Declaration.Variable.Kind.FIELD, name, pos);
+    static Declaration.Variable field(Position pos, String name, Type type, Map<String, List<ConstantDesc>> attrs) {
+        return new DeclarationImpl.VariableImpl(type, Declaration.Variable.Kind.FIELD, name, pos, attrs);
     }
 
     /**
@@ -300,8 +305,8 @@ public interface Declaration {
      * @param layout the bitfield declaration layout.
      * @return a new bitfield declaration with given name, type and layout.
      */
-    static Declaration.Variable bitfield(Position pos, String name, Type type, MemoryLayout layout) {
-        return new DeclarationImpl.VariableImpl(type, layout, Declaration.Variable.Kind.BITFIELD, name, pos);
+    static Declaration.Variable bitfield(Position pos, String name, Type type, MemoryLayout layout, Map<String, List<ConstantDesc>> attrs) {
+        return new DeclarationImpl.VariableImpl(type, layout, Declaration.Variable.Kind.BITFIELD, name, pos, attrs);
     }
 
     /**
@@ -311,8 +316,8 @@ public interface Declaration {
      * @param type the parameter declaration type.
      * @return a new parameter declaration with given name and type.
      */
-    static Declaration.Variable parameter(Position pos, String name, Type type) {
-        return new DeclarationImpl.VariableImpl(type, Declaration.Variable.Kind.PARAMETER, name, pos);
+    static Declaration.Variable parameter(Position pos, String name, Type type, Map<String, List<ConstantDesc>> attrs) {
+        return new DeclarationImpl.VariableImpl(type, Declaration.Variable.Kind.PARAMETER, name, pos, attrs);
     }
 
     /**
@@ -459,9 +464,9 @@ public interface Declaration {
      * @param params the function declaration parameter declarations.
      * @return a new function declaration with given name, type and parameter declarations.
      */
-    static Declaration.Function function(Position pos, String name, Type.Function type, Declaration.Variable... params) {
+    static Declaration.Function function(Position pos, String name, Map<String, List<ConstantDesc>> attrs, Type.Function type, Declaration.Variable... params) {
         List<Variable> paramList = Stream.of(params).collect(Collectors.toList());
-        return new DeclarationImpl.FunctionImpl(type, paramList, name, pos);
+        return new DeclarationImpl.FunctionImpl(type, paramList, name, pos, attrs);
     }
 
     /**

--- a/src/jdk.incubator.jextract/share/classes/jdk/incubator/jextract/Declaration.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/incubator/jextract/Declaration.java
@@ -28,7 +28,6 @@ package jdk.incubator.jextract;
 
 import java.lang.constant.ConstantDesc;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -67,7 +66,7 @@ public interface Declaration {
      * The attributes associated with this declaration
      * @return The attributes associated with this declaration
      */
-    Set<String> availableAttributes();
+    Set<String> attributeNames();
 
     /**
      * Entry point for visiting declaration instances.
@@ -292,8 +291,8 @@ public interface Declaration {
      * @param type the global variable declaration type.
      * @return a new global variable declaration with given name and type.
      */
-    static Declaration.Variable globalVariable(Position pos, String name, Type type, Map<String, List<ConstantDesc>> attrs) {
-        return new DeclarationImpl.VariableImpl(type, Declaration.Variable.Kind.GLOBAL, name, pos, attrs);
+    static Declaration.Variable globalVariable(Position pos, String name, Type type) {
+        return new DeclarationImpl.VariableImpl(type, Declaration.Variable.Kind.GLOBAL, name, pos);
     }
 
     /**
@@ -303,8 +302,8 @@ public interface Declaration {
      * @param type the field declaration type.
      * @return a new field declaration with given name and type.
      */
-    static Declaration.Variable field(Position pos, String name, Type type, Map<String, List<ConstantDesc>> attrs) {
-        return new DeclarationImpl.VariableImpl(type, Declaration.Variable.Kind.FIELD, name, pos, attrs);
+    static Declaration.Variable field(Position pos, String name, Type type) {
+        return new DeclarationImpl.VariableImpl(type, Declaration.Variable.Kind.FIELD, name, pos);
     }
 
     /**
@@ -315,8 +314,8 @@ public interface Declaration {
      * @param layout the bitfield declaration layout.
      * @return a new bitfield declaration with given name, type and layout.
      */
-    static Declaration.Variable bitfield(Position pos, String name, Type type, MemoryLayout layout, Map<String, List<ConstantDesc>> attrs) {
-        return new DeclarationImpl.VariableImpl(type, layout, Declaration.Variable.Kind.BITFIELD, name, pos, attrs);
+    static Declaration.Variable bitfield(Position pos, String name, Type type, MemoryLayout layout) {
+        return new DeclarationImpl.VariableImpl(type, layout, Declaration.Variable.Kind.BITFIELD, name, pos);
     }
 
     /**
@@ -326,8 +325,8 @@ public interface Declaration {
      * @param type the parameter declaration type.
      * @return a new parameter declaration with given name and type.
      */
-    static Declaration.Variable parameter(Position pos, String name, Type type, Map<String, List<ConstantDesc>> attrs) {
-        return new DeclarationImpl.VariableImpl(type, Declaration.Variable.Kind.PARAMETER, name, pos, attrs);
+    static Declaration.Variable parameter(Position pos, String name, Type type) {
+        return new DeclarationImpl.VariableImpl(type, Declaration.Variable.Kind.PARAMETER, name, pos);
     }
 
     /**
@@ -474,9 +473,9 @@ public interface Declaration {
      * @param params the function declaration parameter declarations.
      * @return a new function declaration with given name, type and parameter declarations.
      */
-    static Declaration.Function function(Position pos, String name, Map<String, List<ConstantDesc>> attrs, Type.Function type, Declaration.Variable... params) {
+    static Declaration.Function function(Position pos, String name, Type.Function type, Declaration.Variable... params) {
         List<Variable> paramList = Stream.of(params).collect(Collectors.toList());
-        return new DeclarationImpl.FunctionImpl(type, paramList, name, pos, attrs);
+        return new DeclarationImpl.FunctionImpl(type, paramList, name, pos);
     }
 
     /**

--- a/src/jdk.incubator.jextract/share/classes/jdk/incubator/jextract/Declaration.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/incubator/jextract/Declaration.java
@@ -56,7 +56,17 @@ public interface Declaration {
      */
     String name();
 
+    /**
+     * The values of the specified attribute.
+     * @param name The attribute to retrieve
+     * @return The list of values associate with this attribute
+     */
     Optional<List<ConstantDesc>> getAttribute(String name);
+
+    /**
+     * The attributes associated with this declaration
+     * @return The attributes associated with this declaration
+     */
     Set<String> availableAttributes();
 
     /**

--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/clang/Cursor.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/clang/Cursor.java
@@ -59,6 +59,8 @@ public final class Cursor {
         return Index_h.clang_isCursorDefinition(cursor) != 0;
     }
 
+    public boolean isAttribute() { return Index_h.clang_isAttribute(kind) != 0; }
+
     public boolean isAnonymousStruct() {
         return Index_h.clang_Cursor_isAnonymousRecordDecl(cursor) != 0;
     }

--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/DeclarationImpl.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/DeclarationImpl.java
@@ -68,7 +68,7 @@ public abstract class DeclarationImpl implements Declaration {
     }
 
     @Override
-    public Set<String> availableAttributes() { return Collections.unmodifiableSet(attributes.keySet()); }
+    public Set<String> attributeNames() { return Collections.unmodifiableSet(attributes.keySet()); }
 
     public static class VariableImpl extends DeclarationImpl implements Declaration.Variable {
 
@@ -76,19 +76,27 @@ public abstract class DeclarationImpl implements Declaration {
         final Type type;
         final Optional<MemoryLayout> layout;
 
-        public VariableImpl(Type type, Variable.Kind kind, String name, Position pos, Map<String, List<ConstantDesc>> attrs) {
-            this(type, LayoutUtils.getLayout(type), kind, name, pos, attrs);
-        }
-
-        public VariableImpl(Type type, MemoryLayout layout, Variable.Kind kind, String name, Position pos, Map<String, List<ConstantDesc>> attrs) {
-            this(type, Optional.of(layout), kind, name, pos, attrs);
-        }
-
         private VariableImpl(Type type, Optional<MemoryLayout> layout, Variable.Kind kind, String name, Position pos, Map<String, List<ConstantDesc>> attrs) {
             super(name, pos, attrs);
             this.kind = kind;
             this.type = type;
             this.layout = layout;
+        }
+
+        public VariableImpl(Type type, Variable.Kind kind, String name, Position pos) {
+            this(type, LayoutUtils.getLayout(type), kind, name, pos, Collections.emptyMap());
+        }
+
+        public VariableImpl(Type type, MemoryLayout layout, Variable.Kind kind, String name, Position pos) {
+            this(type, Optional.of(layout), kind, name, pos, Collections.emptyMap());
+        }
+
+        public static VariableImpl of(Type type, Variable.Kind kind, String name, Position pos, Map<String, List<ConstantDesc>> attrs) {
+            return new VariableImpl(type, LayoutUtils.getLayout(type), kind, name, pos, attrs);
+        }
+
+        public static VariableImpl of(Type type, MemoryLayout layout, Variable.Kind kind, String name, Position pos, Map<String, List<ConstantDesc>> attrs) {
+            return new VariableImpl(type, Optional.of(layout), kind, name, pos, attrs);
         }
 
         @Override
@@ -116,6 +124,10 @@ public abstract class DeclarationImpl implements Declaration {
 
         final List<Variable> params;
         final Type.Function type;
+
+        public FunctionImpl(Type.Function type, List<Variable> params, String name, Position pos) {
+            this(type, params, name, pos, Collections.emptyMap());
+        }
 
         public FunctionImpl(Type.Function type, List<Variable> params, String name, Position pos, Map<String, List<ConstantDesc>> attrs) {
             super(name, pos, attrs);

--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/DeclarationImpl.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/DeclarationImpl.java
@@ -28,6 +28,7 @@ package jdk.internal.jextract.impl;
 
 import java.lang.constant.Constable;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -71,6 +72,18 @@ public abstract class DeclarationImpl implements Declaration {
     public Set<String> attributeNames() { return Collections.unmodifiableSet(
             attributes.map(Map::keySet).orElse(Collections.emptySet()));
     }
+
+    @Override
+    public Declaration withAttribute(String name, Constable... values) {
+        if (values == null || values.length == 0) {
+            return withAttributes(null);
+        }
+        var attrs = attributes.map(HashMap::new).orElseGet(HashMap::new);
+        attrs.put(name, List.of(values));
+        return withAttributes(attrs);
+    }
+
+    abstract protected Declaration withAttributes(Map<String, List<Constable>> attrs);
 
     public static class VariableImpl extends DeclarationImpl implements Declaration.Variable {
 

--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/PrettyPrinter.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/PrettyPrinter.java
@@ -26,7 +26,7 @@
 
 package jdk.internal.jextract.impl;
 
-import java.lang.constant.ConstantDesc;
+import java.lang.constant.Constable;
 import java.util.Set;
 import java.util.stream.Collectors;
 import jdk.incubator.foreign.MemoryLayout;
@@ -64,7 +64,7 @@ class PrettyPrinter implements Declaration.Visitor<Void, Void> {
             builder.append(k);
             builder.append(" -> [");
             builder.append(decl.getAttribute(k).get().stream()
-                .map(ConstantDesc::toString)
+                .map(Constable::toString)
                 .collect(Collectors.joining(", ")));
             builder.append("]\n");
         }

--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/PrettyPrinter.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/PrettyPrinter.java
@@ -26,12 +26,13 @@
 
 package jdk.internal.jextract.impl;
 
+import java.lang.constant.ConstantDesc;
+import java.util.Set;
+import java.util.stream.Collectors;
 import jdk.incubator.foreign.MemoryLayout;
 import jdk.incubator.jextract.Declaration;
 import jdk.incubator.jextract.Position;
 import jdk.incubator.jextract.Type;
-
-import java.util.stream.Collectors;
 
 class PrettyPrinter implements Declaration.Visitor<Void, Void> {
 
@@ -51,6 +52,25 @@ class PrettyPrinter implements Declaration.Visitor<Void, Void> {
     
     StringBuilder builder = new StringBuilder();
 
+    private void getAttributes(Declaration decl) {
+        Set<String> attrs = decl.availableAttributes();
+        if (attrs.isEmpty()) {
+            return;
+        }
+        incr();
+        indent();
+        for (String k: attrs) {
+            builder.append("Attr: ");
+            builder.append(k);
+            builder.append(" -> [");
+            builder.append(decl.getAttribute(k).get().stream()
+                .map(ConstantDesc::toString)
+                .collect(Collectors.joining(", ")));
+            builder.append("]\n");
+        }
+        decr();
+    }
+
     public String print(Declaration decl) {
         decl.accept(this, null);
         return builder.toString();
@@ -61,6 +81,7 @@ class PrettyPrinter implements Declaration.Visitor<Void, Void> {
         indent();
         builder.append("Scoped: " + d.kind() + " " + d.name() + d.layout().map(l -> " layout = " + l).orElse(""));
         builder.append("\n");
+        getAttributes(d);
         incr();
         d.members().forEach(m -> m.accept(this, null));
         decr();
@@ -72,6 +93,7 @@ class PrettyPrinter implements Declaration.Visitor<Void, Void> {
         indent();
         builder.append("Function: " + d.name() + " type = " + d.type().accept(typeVisitor, null));
         builder.append("\n");
+        getAttributes(d);
         incr();
         d.parameters().forEach(m -> m.accept(this, null));
         decr();
@@ -83,6 +105,7 @@ class PrettyPrinter implements Declaration.Visitor<Void, Void> {
         indent();
         builder.append("Variable: " + d.kind() + " " + d.name() + " type = " + d.type().accept(typeVisitor, null) + ", layout = " + d.layout());
         builder.append("\n");
+        getAttributes(d);
         return null;
     }
 
@@ -91,6 +114,7 @@ class PrettyPrinter implements Declaration.Visitor<Void, Void> {
         indent();
         builder.append("Constant: " + d.name() + " " + d.value() + " type = " + d.type().accept(typeVisitor, null));
         builder.append("\n");
+        getAttributes(d);
         return null;
     }
 

--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/PrettyPrinter.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/PrettyPrinter.java
@@ -53,7 +53,7 @@ class PrettyPrinter implements Declaration.Visitor<Void, Void> {
     StringBuilder builder = new StringBuilder();
 
     private void getAttributes(Declaration decl) {
-        Set<String> attrs = decl.availableAttributes();
+        Set<String> attrs = decl.attributeNames();
         if (attrs.isEmpty()) {
             return;
         }

--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/TreeMaker.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/TreeMaker.java
@@ -25,7 +25,7 @@
  */
 package jdk.internal.jextract.impl;
 
-import java.lang.constant.ConstantDesc;
+import java.lang.constant.Constable;
 import java.nio.ByteOrder;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -58,7 +58,7 @@ class TreeMaker {
         typeMaker.resolveTypeReferences();
     }
 
-    private <T extends Declaration> T checkCache(Cursor c, Class<T> clazz, Supplier<Declaration> factory) {
+    private Declaration checkCache(Cursor c, Supplier<Declaration> factory) {
         // The supplier function may lead to adding some other type, which will cause CME using computeIfAbsent.
         // This implementation relax the constraint a bit only check for same key
         Declaration rv;
@@ -70,7 +70,7 @@ class TreeMaker {
                 throw new ConcurrentModificationException();
             }
         }
-        return clazz.cast(rv);
+        return rv;
     }
 
     interface ScopedFactoryLayout {
@@ -81,7 +81,11 @@ class TreeMaker {
         Declaration.Scoped make(Position pos, String name, Declaration... decls);
     }
 
-    Map<String, List<ConstantDesc>> collectAttributes(Cursor c) {
+    interface VarFactoryNoLayout {
+        Declaration.Variable make(Position pos, String name, Type type);
+    }
+
+    Map<String, List<Constable>> collectAttributes(Cursor c) {
         return c.children().filter(Cursor::isAttribute)
                 .collect(Collectors.groupingBy(
                         attr -> attr.kind().name(),
@@ -91,7 +95,13 @@ class TreeMaker {
 
     public Declaration createTree(Cursor c) {
         Objects.requireNonNull(c);
-        Map<String, List<ConstantDesc>> attrs = collectAttributes(c);
+        return checkCache(c, () -> {
+            Declaration rv = createTreeInternal(c);
+            return (rv == null) ? null : rv.withAttributes(collectAttributes(c));
+        });
+    }
+
+    private Declaration createTreeInternal(Cursor c) {
         switch (c.kind()) {
             case EnumDecl:
                 return createScoped(c, Declaration.Scoped.Kind.ENUM, Declaration::enum_, Declaration::enum_);
@@ -99,11 +109,11 @@ class TreeMaker {
                 return createEnumConstant(c);
             case FieldDecl:
                 return createVar(c.isBitField() ?
-                        Declaration.Variable.Kind.BITFIELD : Declaration.Variable.Kind.FIELD, c, attrs);
+                        Declaration.Variable.Kind.BITFIELD : Declaration.Variable.Kind.FIELD, c, Declaration::field);
             case ParmDecl:
-                return createVar(Declaration.Variable.Kind.PARAMETER, c, attrs);
+                return createVar(Declaration.Variable.Kind.PARAMETER, c, Declaration::parameter);
             case FunctionDecl:
-                return createFunction(c, attrs);
+                return createFunction(c);
             case StructDecl:
                 return createScoped(c, Declaration.Scoped.Kind.STRUCT, Declaration::struct, Declaration::struct);
             case UnionDecl:
@@ -112,7 +122,7 @@ class TreeMaker {
                 return createTypedef(c);
             }
             case VarDecl:
-                return createVar(Declaration.Variable.Kind.GLOBAL, c, attrs);
+                return createVar(Declaration.Variable.Kind.GLOBAL, c, Declaration::globalVariable);
             default:
                 return null;
         }
@@ -164,17 +174,19 @@ class TreeMaker {
         }
 
         @Override
-        public String toString() { return PrettyPrinter.position(this); }
+        public String toString() {
+            return PrettyPrinter.position(this);
+        }
     }
 
-    public Declaration.Function createFunction(Cursor c, Map<String, List<ConstantDesc>> attrs) {
+    public Declaration.Function createFunction(Cursor c) {
         checkCursor(c, CursorKind.FunctionDecl);
         List<Declaration.Variable> params = new ArrayList<>();
         for (int i = 0 ; i < c.numberOfArgs() ; i++) {
             params.add((Declaration.Variable)createTree(c.getArgument(i)));
         }
-        return checkCache(c, Declaration.Function.class,
-                () -> new DeclarationImpl.FunctionImpl((Type.Function)toType(c), params, c.spelling(), toPos(c), attrs));
+        return Declaration.function(toPos(c), c.spelling(), (Type.Function)toType(c),
+                params.toArray(new Declaration.Variable[0]));
     }
 
     public Declaration.Constant createMacro(Cursor c, Optional<MacroParserImpl.Macro> macro) {
@@ -183,46 +195,41 @@ class TreeMaker {
             return null;
         } else {
             MacroParserImpl.Macro parsedMacro = macro.get();
-            return checkCache(c, Declaration.Constant.class,
-                    ()->Declaration.constant(toPos(c), c.spelling(), parsedMacro.value, parsedMacro.type()));
+            return Declaration.constant(toPos(c), c.spelling(), parsedMacro.value, parsedMacro.type());
         }
     }
 
     public Declaration.Constant createEnumConstant(Cursor c) {
-        return checkCache(c, Declaration.Constant.class,
-                ()->Declaration.constant(toPos(c), c.spelling(), c.getEnumConstantValue(), typeMaker.makeType(c.type())));
+        return Declaration.constant(toPos(c), c.spelling(), c.getEnumConstantValue(), typeMaker.makeType(c.type()));
     }
 
     public Declaration.Scoped createHeader(Cursor c, List<Declaration> decls) {
-        return checkCache(c, Declaration.Scoped.class,
-                ()->Declaration.toplevel(toPos(c), filterNestedDeclarations(decls).toArray(new Declaration[0])));
+        return Declaration.toplevel(toPos(c), filterNestedDeclarations(decls).toArray(new Declaration[0]));
     }
 
     public Declaration.Scoped createScoped(Cursor c, Declaration.Scoped.Kind scopeKind, ScopedFactoryLayout factoryLayout, ScopedFactoryNoLayout factoryNoLayout) {
         List<Declaration> decls = filterNestedDeclarations(c.children()
                 .map(this::createTree).collect(Collectors.toList()));
-        return checkCache(c, Declaration.Scoped.class, () -> {
-            if (c.isDefinition()) {
-                //just a declaration AND definition, we have a layout
-                MemoryLayout layout = LayoutUtils.getLayout(c.type());
-                List<Declaration> adaptedDecls = layout instanceof GroupLayout ?
-                        collectBitfields(layout, decls) :
-                        decls;
-                return factoryLayout.make(toPos(c), c.spelling(), layout, adaptedDecls.toArray(new Declaration[0]));
-            } else {
-                //just a declaration
-                if (scopeKind == Declaration.Scoped.Kind.STRUCT ||
-                        scopeKind == Declaration.Scoped.Kind.UNION ||
-                        scopeKind == Declaration.Scoped.Kind.ENUM ||
-                        scopeKind == Declaration.Scoped.Kind.CLASS) {
-                    //if there's a real definition somewhere else, skip this redundant declaration
-                    if (!c.getDefinition().isInvalid()) {
-                        return null;
-                    }
+        if (c.isDefinition()) {
+            //just a declaration AND definition, we have a layout
+            MemoryLayout layout = LayoutUtils.getLayout(c.type());
+            List<Declaration> adaptedDecls = layout instanceof GroupLayout ?
+                    collectBitfields(layout, decls) :
+                    decls;
+            return factoryLayout.make(toPos(c), c.spelling(), layout, adaptedDecls.toArray(new Declaration[0]));
+        } else {
+            //just a declaration
+            if (scopeKind == Declaration.Scoped.Kind.STRUCT ||
+                    scopeKind == Declaration.Scoped.Kind.UNION ||
+                    scopeKind == Declaration.Scoped.Kind.ENUM ||
+                    scopeKind == Declaration.Scoped.Kind.CLASS) {
+                //if there's a real definition somewhere else, skip this redundant declaration
+                if (!c.getDefinition().isInvalid()) {
+                    return null;
                 }
-                return factoryNoLayout.make(toPos(c), c.spelling(), decls.toArray(new Declaration[0]));
             }
-        });
+            return factoryNoLayout.make(toPos(c), c.spelling(), decls.toArray(new Declaration[0]));
+        }
     }
 
     private List<Declaration> filterNestedDeclarations(List<Declaration> declarations) {
@@ -240,24 +247,19 @@ class TreeMaker {
         if (decl.isPresent() && decl.get().isDefinition() && decl.get().spelling().isEmpty()) {
             Declaration def = createTree(decl.get());
             if (def instanceof Declaration.Scoped) {
-                return checkCache(c, Declaration.Scoped.class,
-                        () -> Declaration.typedef(toPos(c), c.spelling(), def));
+                return Declaration.typedef(toPos(c), c.spelling(), def);
             }
         }
         return null;
     }
 
-    private Declaration.Variable createVar(Declaration.Variable.Kind kind, Cursor c, Map<String, List<ConstantDesc>> attrs) {
+    private Declaration.Variable createVar(Declaration.Variable.Kind kind, Cursor c, VarFactoryNoLayout varFactory) {
         checkCursorAny(c, CursorKind.VarDecl, CursorKind.FieldDecl, CursorKind.ParmDecl);
         if (c.isBitField()) {
-            return checkCache(c, Declaration.Variable.class,
-                    () -> DeclarationImpl.VariableImpl.of(toType(c),
-                            MemoryLayout.ofValueBits(c.getBitFieldWidth(), ByteOrder.nativeOrder()),
-                            Declaration.Variable.Kind.BITFIELD,
-                            c.spelling(), toPos(c), attrs));
+            return Declaration.bitfield(toPos(c), c.spelling(), toType(c),
+                    MemoryLayout.ofValueBits(c.getBitFieldWidth(), ByteOrder.nativeOrder()));
         } else {
-            return checkCache(c, Declaration.Variable.class,
-                    () -> DeclarationImpl.VariableImpl.of(toType(c), kind, c.spelling(), toPos(c), attrs));
+            return varFactory.make(toPos(c), c.spelling(), toType(c));
         }
     }
 

--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/TreeMaker.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/TreeMaker.java
@@ -96,7 +96,7 @@ class TreeMaker {
     public Declaration createTree(Cursor c) {
         Objects.requireNonNull(c);
         return checkCache(c, () -> {
-            Declaration rv = createTreeInternal(c);
+            var rv = (DeclarationImpl) createTreeInternal(c);
             return (rv == null) ? null : rv.withAttributes(collectAttributes(c));
         });
     }

--- a/test/jdk/java/jextract/JextractApiTestBase.java
+++ b/test/jdk/java/jextract/JextractApiTestBase.java
@@ -36,6 +36,10 @@ import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.fail;
 
 public class JextractApiTestBase {
+    static final boolean isMacOSX =
+            System.getProperty("os.name", "unknown").contains("OS X");
+    static final boolean isWindows =
+            System.getProperty("os.name", "unknown").startsWith("Windows");
 
     public static  Declaration.Scoped parse(String headerFilename, String... parseOptions) {
         Path header = Paths.get(System.getProperty("test.src.path", "."), headerFilename);
@@ -70,8 +74,8 @@ public class JextractApiTestBase {
         assertEquals(global.kind(), Declaration.Variable.Kind.FIELD);
         return global;
     }
-    public static Declaration.Function checkFunction(Declaration.Scoped toplevel, String name, Type ret, Type... params) {
-        Declaration.Function function = findDecl(toplevel, name, Declaration.Function.class);
+
+    public static void checkFunction(Declaration.Function function, Type ret, Type... params) {
         assertTypeEquals(ret, function.type().returnType());
         assertEquals(function.parameters().size(), params.length);
         for (int i = 0 ; i < params.length ; i++) {
@@ -83,6 +87,11 @@ public class JextractApiTestBase {
                 assertTypeEquals(params[i], function.parameters().get(i).type());
             }
         }
+    }
+
+    public static Declaration.Function checkFunction(Declaration.Scoped toplevel,String name , Type ret, Type... params) {
+        Declaration.Function function = findDecl(toplevel, name, Declaration.Function.class);
+        checkFunction(function, ret,params);
         return function;
     }
 

--- a/test/jdk/java/jextract/TestAttributes.java
+++ b/test/jdk/java/jextract/TestAttributes.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+/*
+ * @test
+ * @bug 8239808
+ * @build JextractApiTestBase
+ * @run testng TestAttributes
+ */
+
+import java.lang.constant.ConstantDesc;
+import java.util.List;
+import java.util.stream.Collectors;
+import jdk.incubator.foreign.MemoryLayouts;
+import jdk.incubator.jextract.Declaration;
+import jdk.incubator.jextract.Type;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+
+public class TestAttributes extends JextractApiTestBase {
+    private final static Type C_INT = Type.primitive(Type.Primitive.Kind.Int, MemoryLayouts.C_INT);
+    private final static String ASMLABEL = "AsmLabelAttr";
+
+    private void validateAsmLabel(Declaration d, boolean isAdd) {
+        List<ConstantDesc> attrs = d.getAttribute(ASMLABEL).get();
+        String value = isMacOSX ? "_" : "";
+        value += d.name();
+        value += isAdd ? "A" : "B";
+        assertEquals(attrs.get(0), value);
+    }
+
+    private void validateHeader(Declaration.Scoped top, boolean isAdd) {
+        if (isWindows) {
+            // TODO: add Windows validation
+            // Simply dump declaration for now
+            System.out.println(top);
+            return;
+        }
+        var list = top.members().stream()
+                .filter(byNameAndType("foo", Declaration.Variable.class))
+                .map(Declaration.Variable.class::cast)
+                .collect(Collectors.toList());
+        assertEquals(list.size(), 3);
+        int hasAttrs = 0;
+        for (Declaration.Variable foo: list) {
+            assertEquals(Declaration.Variable.Kind.GLOBAL, foo.kind());
+            assertTypeEquals(C_INT, foo.type());
+            if (foo.getAttribute(ASMLABEL).isPresent()) {
+                hasAttrs++;
+                validateAsmLabel(foo, isAdd);
+            }
+        }
+        assertEquals(hasAttrs, 2);
+        var listFunc = top.members().stream()
+                .filter(byNameAndType("func", Declaration.Function.class))
+                .map(Declaration.Function.class::cast)
+                .collect(Collectors.toList());
+        assertEquals(listFunc.size(), 3);
+        hasAttrs = 0;
+        for (Declaration.Function func: listFunc) {
+            checkFunction(func, C_INT, C_INT, C_INT);
+            if (func.getAttribute(ASMLABEL).isPresent()) {
+                hasAttrs++;
+                validateAsmLabel(func, isAdd);
+            }
+        }
+        assertEquals(hasAttrs, 2);
+    }
+
+    @Test
+    public void testA() {
+        Declaration.Scoped d = parse("libAsmSymbol.h", "-DADD");
+        validateHeader(d, true);
+    }
+
+    @Test
+    public void testB() {
+        Declaration.Scoped d = parse("libAsmSymbol.h");
+        validateHeader(d, false);
+    }
+}

--- a/test/jdk/java/jextract/TestAttributes.java
+++ b/test/jdk/java/jextract/TestAttributes.java
@@ -31,13 +31,19 @@
  * @run testng TestAttributes
  */
 
+import java.lang.constant.Constable;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import jdk.incubator.foreign.MemoryLayouts;
 import jdk.incubator.jextract.Declaration;
 import jdk.incubator.jextract.Type;
 import org.testng.annotations.Test;
 
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
 
 public class TestAttributes extends JextractApiTestBase {
     private final static Type C_INT = Type.primitive(Type.Primitive.Kind.Int, MemoryLayouts.C_INT);
@@ -99,5 +105,60 @@ public class TestAttributes extends JextractApiTestBase {
     public void testB() {
         Declaration.Scoped d = parse("libAsmSymbol.h");
         validateHeader(d, false);
+    }
+
+    private static  Constable getSingleValue(Declaration d, String name) {
+        List<Constable> values = d.getAttribute(name).get();
+        assertEquals(1, values.size());
+        return values.get(0);
+    }
+
+    @Test
+    public void testAddAttribute() {
+        final String ts = "timestamp";
+        Declaration.Scoped d = parse("libAsmSymbol.h");
+        String timestamp = LocalDateTime.now().format(DateTimeFormatter.ISO_DATE_TIME);
+        Declaration withAttrs = d.withAttribute("header", d.name())
+                .withAttribute(ts, timestamp);
+
+        assertEquals(getSingleValue(withAttrs, "header"), d.name());
+        assertEquals(getSingleValue(withAttrs, ts), timestamp);
+
+        String timestamp2 = LocalDateTime.now().format(DateTimeFormatter.ISO_LOCAL_DATE_TIME);
+        Declaration withNewAttrs = withAttrs.withAttribute(ts, timestamp2);
+        assertEquals(getSingleValue(withNewAttrs, ts), timestamp2);
+
+        // Make sure original Declaration is not altered
+        assertEquals(getSingleValue(withAttrs, ts), timestamp);
+
+        // Add more value to same attribute
+        withNewAttrs = withAttrs.withAttribute(ts, Stream.concat(
+                withAttrs.getAttribute(ts).map(List::stream).orElse(Stream.empty()),
+                Stream.of(timestamp2)
+            ).toArray(Constable[]::new));
+        assertEquals(withNewAttrs.getAttribute(ts).get(), List.of(timestamp, timestamp2));
+        assertEquals(getSingleValue(withNewAttrs,"header"), d.name());
+
+        // Remove attribute
+        withAttrs = withNewAttrs.withAttribute(ts);
+        assertTrue(withAttrs.getAttribute(ts).isEmpty());
+
+        // Strip attribute
+        withNewAttrs = withNewAttrs.stripAttributes();
+        assertTrue(withNewAttrs.attributeNames().isEmpty());
+    }
+
+    @Test
+    public void replaceFunctionSymbol() {
+        Declaration.Scoped d = parse("libAsmSymbol.h", "-DADD");
+        validateHeader(d, true);
+
+        var members = d.members().stream()
+            .map(m -> m.getAttribute(ASMLABEL)
+                    .map(attr -> m.withAttribute(ASMLABEL, attr.get(0).toString().replace('A', 'B')))
+                    .orElse(m))
+            .toArray(Declaration[]::new);
+        Declaration.Scoped patched = Declaration.toplevel(d.pos(), members);
+        validateHeader(patched, false);
     }
 }

--- a/test/jdk/java/jextract/TestAttributes.java
+++ b/test/jdk/java/jextract/TestAttributes.java
@@ -31,8 +31,6 @@
  * @run testng TestAttributes
  */
 
-import java.lang.constant.ConstantDesc;
-import java.util.List;
 import java.util.stream.Collectors;
 import jdk.incubator.foreign.MemoryLayouts;
 import jdk.incubator.jextract.Declaration;
@@ -46,7 +44,7 @@ public class TestAttributes extends JextractApiTestBase {
     private final static String ASMLABEL = "AsmLabelAttr";
 
     private void validateAsmLabel(Declaration d, boolean isAdd) {
-        List<ConstantDesc> attrs = d.getAttribute(ASMLABEL).get();
+        var attrs = d.getAttribute(ASMLABEL).get();
         String value = isMacOSX ? "_" : "";
         value += d.name();
         value += isAdd ? "A" : "B";

--- a/test/jdk/java/jextract/libAsmSymbol.h
+++ b/test/jdk/java/jextract/libAsmSymbol.h
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+#ifdef _WIN64
+  #ifdef IMPL
+    #define EXPORT __declspec(dllexport)
+  #else
+    #define EXPORT __declspec(dllimport)
+  #endif // IMPL
+#else
+#define EXPORT
+#endif //_WIN64
+
+#ifdef _WIN32
+// Windows doesn't really support asm symbol, this is similar approach for C code to
+// achieve similar, but this won't work with Panama until we support such Macro
+#ifdef ADD
+#define foo fooA
+#define func funcA
+#else
+#define foo fooB
+#define func funcB
+#endif //ADD
+#define ALIAS(sym)
+
+#elif __APPLE__
+#define ALIAS(sym) __asm("_" #sym)
+#else
+#define ALIAS(sym) __asm__(#sym)
+#endif // _WIN32
+
+// We do 3 declarations to make sure we will pick up alias no matter the sequence of encounter
+// Without alias
+EXPORT extern int foo;
+EXPORT int func (int x, int y);
+
+// With alias
+#ifdef ADD
+
+EXPORT extern int foo ALIAS(fooA);
+EXPORT int func (int x, int y) ALIAS(funcA);
+
+#else
+
+EXPORT extern int foo ALIAS(fooB);
+EXPORT int func (int x, int y) ALIAS(funcB);
+
+#endif // ADD
+
+// Without alias again
+EXPORT extern int foo;
+EXPORT int func (int x, int y);
+


### PR DESCRIPTION
Add API to allow associate attributes with Declaration.

An attribute can have multiple values, thus a list of ConstantDesc.

The test case is based on [JDK-8223105](https://bugs.openjdk.java.net/browse/JDK-8223105), Windows test is simply parsing at this point, need to add validation as the header is implemented differently. 

We may want to add a more generic test case with some standard attributes.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [JDK-8239809](https://bugs.openjdk.java.net/browse/JDK-8239809): Need API to access attributes


### Reviewers
 * Maurizio Cimadamore ([mcimadamore](@mcimadamore) - Committer) ⚠️ Review applies to 49b308e475d996474f13a5726cfba08ec6d6a6e0

### Download
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/33/head:pull/33`
`$ git checkout pull/33`
