### PR TITLE
8240173: Confusing overflow error when trying to dereference a nothing segment

### DIFF
--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/MemorySegmentImpl.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/MemorySegmentImpl.java
@@ -191,7 +191,7 @@ public final class MemorySegmentImpl implements MemorySegment, MemorySegmentProx
     void checkRange(long offset, long length, boolean writeAccess) {
         checkValidState();
         if (isSet(NO_ACCESS)) {
-            throw new UnsupportedOperationException("Segment cannot be dereferenced");
+            throw new UnsupportedOperationException("Segment cannot be accessed");
         } else if (isReadOnly() && writeAccess) {
             throw new UnsupportedOperationException("Cannot write to read-only memory segment");
         }

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/Utils.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/Utils.java
@@ -176,7 +176,7 @@ public final class Utils {
         }
         long alignedBuf = Utils.alignUp(buf, alignmentBytes);
         MemoryScope scope = new MemoryScope(null, () -> unsafe.freeMemory(buf));
-        MemorySegment segment = new MemorySegmentImpl(buf, null, alignedSize, 0, Thread.currentThread(), scope);
+        MemorySegment segment = new MemorySegmentImpl(buf, null, alignedSize, Thread.currentThread(), scope);
         if (alignedBuf != buf) {
             long delta = alignedBuf - buf;
             segment = segment.asSlice(delta, bytesSize);
@@ -193,7 +193,7 @@ public final class Utils {
 
     public static MemorySegment makeNativeSegmentUnchecked(long min, long bytesSize) {
         MemoryScope scope = new MemoryScope(null, null);
-        return new MemorySegmentImpl(min, null, bytesSize, 0, Thread.currentThread(), scope);
+        return new MemorySegmentImpl(min, null, bytesSize, Thread.currentThread(), scope);
     }
 
     public static MemorySegment makeArraySegment(byte[] arr) {
@@ -226,7 +226,7 @@ public final class Utils {
 
     private static MemorySegment makeArraySegment(Object arr, int size, int base, int scale) {
         MemoryScope scope = new MemoryScope(null, null);
-        return new MemorySegmentImpl(base, arr, size * scale, 0, Thread.currentThread(), scope);
+        return new MemorySegmentImpl(base, arr, size * scale, Thread.currentThread(), scope);
     }
 
     public static MemorySegment makeBufferSegment(ByteBuffer bb) {
@@ -237,7 +237,7 @@ public final class Utils {
         int limit = bb.limit();
 
         MemoryScope bufferScope = new MemoryScope(bb, null);
-        return new MemorySegmentImpl(bbAddress + pos, base, limit - pos, 0, Thread.currentThread(), bufferScope);
+        return new MemorySegmentImpl(bbAddress + pos, base, limit - pos, Thread.currentThread(), bufferScope);
     }
 
     // create and map a file into a fresh segment
@@ -246,7 +246,7 @@ public final class Utils {
         try (FileChannelImpl channelImpl = (FileChannelImpl)FileChannel.open(path, openOptions(mapMode))) {
             UnmapperProxy unmapperProxy = channelImpl.mapInternal(mapMode, 0L, bytesSize);
             MemoryScope scope = new MemoryScope(null, unmapperProxy::unmap);
-            return new MemorySegmentImpl(unmapperProxy.address(), null, bytesSize, 0, Thread.currentThread(), scope);
+            return new MemorySegmentImpl(unmapperProxy.address(), null, bytesSize, Thread.currentThread(), scope);
         }
     }
 

--- a/test/jdk/java/foreign/TestAddressHandle.java
+++ b/test/jdk/java/foreign/TestAddressHandle.java
@@ -45,7 +45,7 @@ public class TestAddressHandle {
             try {
                 longHandle.get(address); // check OOB
                 fail();
-            } catch (IndexOutOfBoundsException ex) {
+            } catch (UnsupportedOperationException ex) {
                 assertTrue(true);
             }
             addrHandle.set(segment.baseAddress(), address.addOffset(1));

--- a/test/jdk/java/foreign/TestSegments.java
+++ b/test/jdk/java/foreign/TestSegments.java
@@ -104,7 +104,7 @@ public class TestSegments {
             try {
                 longHandle.get(addr);
             } catch (UnsupportedOperationException ex) {
-                assertTrue(ex.getMessage().contains("cannot be dereferenced"));
+                assertTrue(ex.getMessage().contains("cannot be accessed"));
             }
         }
     }

--- a/test/jdk/java/foreign/TestSegments.java
+++ b/test/jdk/java/foreign/TestSegments.java
@@ -96,6 +96,20 @@ public class TestSegments {
     }
 
     @Test
+    public void testNothingSegmentAccess() {
+        VarHandle longHandle = MemoryLayouts.JAVA_LONG.varHandle(long.class);
+        long[] values = { 0L, Integer.MAX_VALUE - 1, (long)Integer.MAX_VALUE + 1 };
+        for (long value : values) {
+            MemoryAddress addr = MemoryAddress.ofLong(value);
+            try {
+                longHandle.get(addr);
+            } catch (UnsupportedOperationException ex) {
+                assertTrue(ex.getMessage().contains("cannot be dereferenced"));
+            }
+        }
+    }
+
+    @Test
     public void testSlices() {
         VarHandle byteHandle = MemoryLayout.ofSequence(MemoryLayouts.JAVA_BYTE)
                 .varHandle(byte.class, MemoryLayout.PathElement.sequenceElement());

--- a/test/jdk/java/foreign/TestUpcallStubs.java
+++ b/test/jdk/java/foreign/TestUpcallStubs.java
@@ -58,7 +58,7 @@ public class TestUpcallStubs {
         return abi.upcallStub(MH_dummy, FunctionDescriptor.ofVoid());
     }
 
-    @Test(expectedExceptions = IndexOutOfBoundsException.class)
+    @Test(expectedExceptions = UnsupportedOperationException.class)
     public void testNoAccess() {
         MemoryAddress stub = getStub();
         try {


### PR DESCRIPTION
This simple patch attempts to generate a more explicit error message when trying to dereference an address which is based on the Nothing segment. Note that the first problem here is caused by the fact that the Nothing segment is considered "small" - which means most of the real address values will fall outside its range. While we could simply fix that (which will improve the error message - from reporting an overflow during offset computation to report an access outside the bounds of the segment), I thought it was better to mark the Nothing segment as non-accessible, and generate an explicit error message.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [JDK-8240173](https://bugs.openjdk.java.net/browse/JDK-8240173): Confusing overflow error when trying to dereference a nothing segment


### Reviewers
 * Paul Sandoz ([psandoz](@PaulSandoz) - Committer) ⚠️ Review applies to d3ea2ea0f0375d89cfbfc4ada87da4709e298944

### Download
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/34/head:pull/34`
`$ git checkout pull/34`
