### PR TITLE
8240181: jextract does not generate constants for anonymous enum fields

### DIFF
--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/TreeMaker.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/TreeMaker.java
@@ -215,10 +215,14 @@ class TreeMaker {
         });
     }
 
+    private static boolean isEnum(Declaration d) {
+        return d instanceof Declaration.Scoped && ((Declaration.Scoped)d).kind() == Declaration.Scoped.Kind.ENUM;
+    }
+
     private List<Declaration> filterNestedDeclarations(List<Declaration> declarations) {
         return declarations.stream()
                 .filter(Objects::nonNull)
-                .filter(d -> !d.name().isEmpty() || ((CursorPosition)d.pos()).cursor.isAnonymousStruct())
+                .filter(d -> isEnum(d) || !d.name().isEmpty() || ((CursorPosition)d.pos()).cursor.isAnonymousStruct())
                 .collect(Collectors.toList());
     }
 

--- a/test/jdk/tools/jextract/JextractToolProviderTest.java
+++ b/test/jdk/tools/jextract/JextractToolProviderTest.java
@@ -37,6 +37,7 @@ import static org.testng.Assert.assertTrue;
  * @test
  * @modules jdk.incubator.jextract
  * @build JextractToolRunner
+ * @bug 8240181
  * @run testng/othervm -Duser.language=en --add-modules jdk.incubator.jextract JextractToolProviderTest
  */
 public class JextractToolProviderTest extends JextractToolRunner {

--- a/test/jdk/tools/jextract/JextractToolProviderTest.java
+++ b/test/jdk/tools/jextract/JextractToolProviderTest.java
@@ -97,4 +97,26 @@ public class JextractToolProviderTest extends JextractToolRunner {
     public void testTargetPackageLongOption() {
         testTargetPackage("--target-package");
     }
+
+     @Test
+    public void testAnonymousEnum() {
+        Path anonenumOutput = getOutputFilePath("anonenumgen");
+        Path anonenumH = getInputFilePath("anonenum.h");
+        run("-d", anonenumOutput.toString(), anonenumH.toString()).checkSuccess();
+        try(Loader loader = classLoader(anonenumOutput)) {
+            Class<?> cls = loader.loadClass("anonenum_h");
+            checkIntField(cls, "RED", 0xff0000);
+            checkIntField(cls, "GREEN", 0x00ff00);
+            checkIntField(cls, "BLUE", 0x0000ff);
+            checkIntField(cls, "Java", 0);
+            checkIntField(cls, "C", 1);
+            checkIntField(cls, "CPP", 2);
+            checkIntField(cls, "Python", 3);
+            checkIntField(cls, "Ruby", 4);
+            checkIntField(cls, "ONE", 1);
+            checkIntField(cls, "TWO", 2);
+        } finally {
+            deleteDir(anonenumOutput);
+        }
+    }
 }

--- a/test/jdk/tools/jextract/JextractToolRunner.java
+++ b/test/jdk/tools/jextract/JextractToolRunner.java
@@ -170,6 +170,19 @@ public class JextractToolRunner {
         }
     }
 
+    protected Field checkIntField(Class<?> cls, String name, int value) {
+        Field field = findField(cls, name);
+        assertNotNull(field);
+        assertEquals(field.getType(), int.class);
+        try {
+            assertEquals((int)field.get(null), value);
+        } catch (Exception exp) {
+            System.err.println(exp);
+            assertTrue(false, "should not reach here");
+        }
+        return field;
+    }
+
     protected static Method findMethod(Class<?> cls, String name, Class<?>... argTypes) {
         try {
             return cls.getMethod(name, argTypes);

--- a/test/jdk/tools/jextract/Test8240181.java
+++ b/test/jdk/tools/jextract/Test8240181.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.nio.file.Path;
+import org.testng.annotations.Test;
+
+/*
+ * @test
+ * @modules jdk.incubator.jextract
+ * @build JextractToolRunner
+ * @bug 8240181
+ * @run testng/othervm -Duser.language=en --add-modules jdk.incubator.jextract Test8240181
+ */
+public class Test8240181 extends JextractToolRunner {
+    @Test
+    public void testAnonymousEnum() {
+        Path anonenumOutput = getOutputFilePath("anonenumgen");
+        Path anonenumH = getInputFilePath("anonenum.h");
+        run("-d", anonenumOutput.toString(), anonenumH.toString()).checkSuccess();
+        try(Loader loader = classLoader(anonenumOutput)) {
+            Class<?> cls = loader.loadClass("anonenum_h");
+            checkIntField(cls, "RED", 0xff0000);
+            checkIntField(cls, "GREEN", 0x00ff00);
+            checkIntField(cls, "BLUE", 0x0000ff);
+            checkIntField(cls, "Java", 0);
+            checkIntField(cls, "C", 1);
+            checkIntField(cls, "CPP", 2);
+            checkIntField(cls, "Python", 3);
+            checkIntField(cls, "Ruby", 4);
+            checkIntField(cls, "ONE", 1);
+            checkIntField(cls, "TWO", 2);
+        } finally {
+            deleteDir(anonenumOutput);
+        }
+    }
+}

--- a/test/jdk/tools/jextract/anonenum.h
+++ b/test/jdk/tools/jextract/anonenum.h
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+enum {
+    RED = 0xff0000,
+    GREEN = 0x00ff00,
+    BLUE = 0x0000ff
+};
+
+typedef enum {
+   Java,
+   C,
+   CPP,
+   Python,
+   Ruby
+} codetype_t;
+
+enum SIZE {
+   XS,
+   S,
+   M,
+   L,
+   XL,
+   XXL
+};
+
+typedef enum temp {
+   ONE = 1,
+   TWO
+} temp_t;


### PR DESCRIPTION
anonymous enums were filtered by TreeMaker.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [JDK-8240181](https://bugs.openjdk.java.net/browse/JDK-8240181): jextract does not generate constants for anonymous enum fields


### Reviewers
 * Maurizio Cimadamore ([mcimadamore](@mcimadamore) - Committer) ⚠️ Review applies to 4d78fe58d5d7713a356263a508f60bff61fa583e

### Download
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/35/head:pull/35`
`$ git checkout pull/35`
