### PR TITLE
8240300: jextract produces non compilable code with repeated declarations

### DIFF
--- a/src/jdk.incubator.jextract/share/classes/jdk/incubator/jextract/Declaration.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/incubator/jextract/Declaration.java
@@ -96,6 +96,23 @@ public interface Declaration {
     <R,D> R accept(Visitor<R, D> visitor, D data);
 
     /**
+     * Compares the specified object with this Declaration for equality.  Returns
+     * {@code true} if and only if the specified object is also a Declaration and both
+     * the declarations are <i>equal</i>.
+     *
+     * @param o the object to be compared for equality with this Declaration
+     * @return {@code true} if the specified object is equal to this Declaration
+     */
+    boolean equals(Object o);
+
+    /**
+     * Returns the hash code value for this Declaration.
+     *
+     * @return the hash code value for this Declaration.
+     */
+    int hashCode();
+
+    /**
      * A function declaration.
      */
     interface Function extends Declaration {

--- a/src/jdk.incubator.jextract/share/classes/jdk/incubator/jextract/Type.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/incubator/jextract/Type.java
@@ -62,6 +62,23 @@ public interface Type {
     <R,D> R accept(Visitor<R, D> visitor, D data);
 
     /**
+     * Compares the specified object with this Type for equality.  Returns
+     * {@code true} if and only if the specified object is also a Type and both
+     * the Types are <i>equal</i>.
+     *
+     * @param o the object to be compared for equality with this Type
+     * @return {@code true} if the specified object is equal to this Type
+     */
+    boolean equals(Object o);
+
+    /**
+     * Returns the hash code value for this Type.
+     *
+     * @return the hash code value for this Type.
+     */
+    int hashCode();
+
+    /**
      * A primitive type.
      */
     interface Primitive extends Type {

--- a/src/jdk.incubator.jextract/share/classes/jdk/incubator/jextract/tool/StaticWrapperSourceFactory.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/incubator/jextract/tool/StaticWrapperSourceFactory.java
@@ -26,7 +26,9 @@
 package jdk.incubator.jextract.tool;
 
 import java.lang.invoke.MethodType;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import jdk.incubator.foreign.FunctionDescriptor;
 import jdk.incubator.foreign.MemoryAddress;
 import jdk.incubator.foreign.MemoryLayout;
@@ -35,6 +37,9 @@ import jdk.incubator.jextract.Declaration;
 import jdk.incubator.jextract.Type;
 
 public class StaticWrapperSourceFactory extends HandleSourceFactory {
+    private final Set<Declaration.Variable> variables = new HashSet<>();
+    private final Set<Declaration.Function> functions = new HashSet<>();
+
     public StaticWrapperSourceFactory(String clsName, String pkgName, List<String> libraryNames) {
         super(clsName, pkgName, libraryNames);
     }
@@ -46,6 +51,9 @@ public class StaticWrapperSourceFactory extends HandleSourceFactory {
 
     @Override
     public Void visitFunction(Declaration.Function funcTree, Declaration parent) {
+        if (! functions.add(funcTree)) {
+            return null;
+        }
         MethodType mtype = typeTranslator.getMethodType(funcTree.type());
         FunctionDescriptor descriptor = Type.descriptorFor(funcTree.type()).orElse(null);
         if (descriptor == null) {
@@ -91,6 +99,10 @@ public class StaticWrapperSourceFactory extends HandleSourceFactory {
 
     @Override
     public Void visitVariable(Declaration.Variable tree, Declaration parent) {
+        if (parent == null && !(variables.add(tree))) {
+            return null;
+        }
+
         String fieldName = tree.name();
         String symbol = tree.name();
         assert !symbol.isEmpty();

--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/DeclarationImpl.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/DeclarationImpl.java
@@ -94,6 +94,11 @@ public abstract class DeclarationImpl implements Declaration {
         return name().equals(decl.name());
     }
 
+    @Override
+    public int hashCode() {
+        return Objects.hash(name);
+    }
+
     public static final class VariableImpl extends DeclarationImpl implements Declaration.Variable {
 
         final Variable.Kind kind;
@@ -157,7 +162,7 @@ public abstract class DeclarationImpl implements Declaration {
 
         @Override
         public int hashCode() {
-            return Objects.hash(kind, type);
+            return Objects.hash(super.hashCode(), kind, type);
         }
     }
 
@@ -206,13 +211,14 @@ public abstract class DeclarationImpl implements Declaration {
             if (this == o) return true;
             if (!(o instanceof Declaration.Function)) return false;
             if (!super.equals(o)) return false;
+
             Declaration.Function function = (Declaration.Function) o;
             return type.equals(function.type());
         }
 
         @Override
         public int hashCode() {
-            return Objects.hash(params, type);
+            return Objects.hash(super.hashCode(), type);
         }
     }
 
@@ -280,7 +286,7 @@ public abstract class DeclarationImpl implements Declaration {
 
         @Override
         public int hashCode() {
-            return Objects.hash(kind, declarations);
+            return Objects.hash(super.hashCode(), kind, declarations);
         }
     }
 
@@ -336,7 +342,7 @@ public abstract class DeclarationImpl implements Declaration {
 
         @Override
         public int hashCode() {
-            return Objects.hash(value, type);
+            return Objects.hash(super.hashCode(), value, type);
         }
     }
 }

--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/DeclarationImpl.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/DeclarationImpl.java
@@ -31,6 +31,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import jdk.incubator.foreign.MemoryLayout;
@@ -93,9 +94,9 @@ public abstract class DeclarationImpl implements Declaration {
 
         private VariableImpl(Type type, Optional<MemoryLayout> layout, Variable.Kind kind, String name, Position pos, Map<String, List<Constable>> attrs) {
             super(name, pos, attrs);
-            this.kind = kind;
-            this.type = type;
-            this.layout = layout;
+            this.kind = Objects.requireNonNull(kind);
+            this.type = Objects.requireNonNull(type);
+            this.layout = Objects.requireNonNull(layout);
         }
 
         public VariableImpl(Type type, Variable.Kind kind, String name, Position pos) {
@@ -135,6 +136,20 @@ public abstract class DeclarationImpl implements Declaration {
         public Variable stripAttributes() {
             return new VariableImpl(type, layout, kind, name(), pos(), null);
         }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            VariableImpl variable = (VariableImpl) o;
+            return kind == variable.kind &&
+                    type.equals(variable.type);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(kind, type);
+        }
     }
 
     public static class FunctionImpl extends DeclarationImpl implements Declaration.Function {
@@ -148,8 +163,8 @@ public abstract class DeclarationImpl implements Declaration {
 
         public FunctionImpl(Type.Function type, List<Variable> params, String name, Position pos, Map<String, List<Constable>> attrs) {
             super(name, pos, attrs);
-            this.params = params;
-            this.type = type;
+            this.params = Objects.requireNonNull(params);
+            this.type = Objects.requireNonNull(type);
         }
 
         @Override
@@ -176,6 +191,20 @@ public abstract class DeclarationImpl implements Declaration {
         public Function stripAttributes() {
             return new FunctionImpl(type, params, name(), pos(), null);
         }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            FunctionImpl function = (FunctionImpl) o;
+            return params.equals(function.params) &&
+                    type.equals(function.type);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(params, type);
+        }
     }
 
     public static class ScopedImpl extends DeclarationImpl implements Declaration.Scoped {
@@ -195,9 +224,9 @@ public abstract class DeclarationImpl implements Declaration {
         ScopedImpl(Kind kind, Optional<MemoryLayout> optLayout, List<Declaration> declarations,
                 String name, Position pos, Map<String, List<Constable>> attrs) {
             super(name, pos, attrs);
-            this.kind = kind;
-            this.declarations = declarations;
-            this.optLayout = optLayout;
+            this.kind = Objects.requireNonNull(kind);
+            this.declarations = Objects.requireNonNull(declarations);
+            this.optLayout = Objects.requireNonNull(optLayout);
         }
 
         @Override
@@ -229,6 +258,20 @@ public abstract class DeclarationImpl implements Declaration {
         public Scoped stripAttributes() {
             return new ScopedImpl(kind, optLayout, declarations, name(), pos(), null);
         }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            ScopedImpl scoped = (ScopedImpl) o;
+            return kind == scoped.kind &&
+                    declarations.equals(scoped.declarations);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(kind, declarations);
+        }
     }
 
     public static class ConstantImpl extends DeclarationImpl implements Declaration.Constant {
@@ -242,8 +285,8 @@ public abstract class DeclarationImpl implements Declaration {
 
         public ConstantImpl(Type type, Object value, String name, Position pos, Map<String, List<Constable>> attrs) {
             super(name, pos, attrs);
-            this.value = value;
-            this.type = type;
+            this.value = Objects.requireNonNull(value);
+            this.type = Objects.requireNonNull(type);
         }
 
         @Override
@@ -269,6 +312,20 @@ public abstract class DeclarationImpl implements Declaration {
         @Override
         public Constant stripAttributes() {
             return new ConstantImpl(type, value, name(), pos(), null);
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            ConstantImpl constant = (ConstantImpl) o;
+            return value.equals(constant.value) &&
+                    type.equals(constant.type);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(value, type);
         }
     }
 }

--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/DeclarationImpl.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/DeclarationImpl.java
@@ -86,7 +86,15 @@ public abstract class DeclarationImpl implements Declaration {
 
     abstract protected Declaration withAttributes(Map<String, List<Constable>> attrs);
 
-    public static class VariableImpl extends DeclarationImpl implements Declaration.Variable {
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof Declaration)) return false;
+        Declaration decl = (Declaration) o;
+        return name().equals(decl.name());
+    }
+
+    public static final class VariableImpl extends DeclarationImpl implements Declaration.Variable {
 
         final Variable.Kind kind;
         final Type type;
@@ -140,10 +148,11 @@ public abstract class DeclarationImpl implements Declaration {
         @Override
         public boolean equals(Object o) {
             if (this == o) return true;
-            if (o == null || getClass() != o.getClass()) return false;
-            VariableImpl variable = (VariableImpl) o;
-            return kind == variable.kind &&
-                    type.equals(variable.type);
+            if (!(o instanceof Declaration.Variable)) return false;
+            if (!super.equals(o)) return false;
+            Declaration.Variable variable = (Declaration.Variable) o;
+            return kind == variable.kind() &&
+                    type.equals(variable.type());
         }
 
         @Override
@@ -152,7 +161,7 @@ public abstract class DeclarationImpl implements Declaration {
         }
     }
 
-    public static class FunctionImpl extends DeclarationImpl implements Declaration.Function {
+    public static final class FunctionImpl extends DeclarationImpl implements Declaration.Function {
 
         final List<Variable> params;
         final Type.Function type;
@@ -195,10 +204,10 @@ public abstract class DeclarationImpl implements Declaration {
         @Override
         public boolean equals(Object o) {
             if (this == o) return true;
-            if (o == null || getClass() != o.getClass()) return false;
-            FunctionImpl function = (FunctionImpl) o;
-            return params.equals(function.params) &&
-                    type.equals(function.type);
+            if (!(o instanceof Declaration.Function)) return false;
+            if (!super.equals(o)) return false;
+            Declaration.Function function = (Declaration.Function) o;
+            return type.equals(function.type());
         }
 
         @Override
@@ -262,10 +271,11 @@ public abstract class DeclarationImpl implements Declaration {
         @Override
         public boolean equals(Object o) {
             if (this == o) return true;
-            if (o == null || getClass() != o.getClass()) return false;
-            ScopedImpl scoped = (ScopedImpl) o;
-            return kind == scoped.kind &&
-                    declarations.equals(scoped.declarations);
+            if (!(o instanceof Declaration.Scoped)) return false;
+            if (!super.equals(o)) return false;
+            Declaration.Scoped scoped = (Declaration.Scoped) o;
+            return kind == scoped.kind() &&
+                    declarations.equals(scoped.members());
         }
 
         @Override
@@ -274,7 +284,7 @@ public abstract class DeclarationImpl implements Declaration {
         }
     }
 
-    public static class ConstantImpl extends DeclarationImpl implements Declaration.Constant {
+    public static final class ConstantImpl extends DeclarationImpl implements Declaration.Constant {
 
         final Object value;
         final Type type;
@@ -317,10 +327,11 @@ public abstract class DeclarationImpl implements Declaration {
         @Override
         public boolean equals(Object o) {
             if (this == o) return true;
-            if (o == null || getClass() != o.getClass()) return false;
-            ConstantImpl constant = (ConstantImpl) o;
-            return value.equals(constant.value) &&
-                    type.equals(constant.type);
+            if (!(o instanceof Declaration.Constant)) return false;
+            if (!super.equals(o)) return false;
+            Declaration.Constant constant = (Declaration.Constant) o;
+            return value.equals(constant.value()) &&
+                    type.equals(constant.type());
         }
 
         @Override

--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/TypeImpl.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/TypeImpl.java
@@ -91,9 +91,9 @@ public abstract class TypeImpl implements Type {
         @Override
         public boolean equals(Object o) {
             if (this == o) return true;
-            if (o == null || getClass() != o.getClass()) return false;
-            PrimitiveImpl primitive = (PrimitiveImpl) o;
-            return kind == primitive.kind;
+            if (!(o instanceof Type.Primitive)) return false;
+            Type.Primitive primitive = (Type.Primitive) o;
+            return kind == primitive.kind();
         }
 
         @Override
@@ -129,10 +129,10 @@ public abstract class TypeImpl implements Type {
         @Override
         public boolean equals(Object o) {
             if (this == o) return true;
-            if (o == null || getClass() != o.getClass()) return false;
-            DelegatedBase that = (DelegatedBase) o;
-            return kind == that.kind &&
-                    name.equals(that.name);
+            if (!(o instanceof Type.Delegated)) return false;
+            Type.Delegated that = (Type.Delegated) o;
+            return kind == that.kind() &&
+                    name.equals(that.name());
         }
 
         @Override
@@ -141,7 +141,7 @@ public abstract class TypeImpl implements Type {
         }
     }
 
-    public static class QualifiedImpl extends DelegatedBase {
+    public static final class QualifiedImpl extends DelegatedBase {
         private final Type type;
 
         public QualifiedImpl(Kind kind, Type type) {
@@ -165,10 +165,10 @@ public abstract class TypeImpl implements Type {
         @Override
         public boolean equals(Object o) {
             if (this == o) return true;
-            if (o == null || getClass() != o.getClass()) return false;
+            if (!(o instanceof Type.Delegated)) return false;
             if (!super.equals(o)) return false;
-            QualifiedImpl qualified = (QualifiedImpl) o;
-            return Objects.equals(type, qualified.type);
+            Type.Delegated qualified = (Type.Delegated) o;
+            return Objects.equals(type, qualified.type());
         }
 
         @Override
@@ -177,7 +177,7 @@ public abstract class TypeImpl implements Type {
         }
     }
 
-    public static class PointerImpl extends DelegatedBase {
+    public static final class PointerImpl extends DelegatedBase {
         private final Supplier<Type> pointeeFactory;
 
         public PointerImpl(Supplier<Type> pointeeFactory) {
@@ -195,7 +195,7 @@ public abstract class TypeImpl implements Type {
         }
     }
 
-    public static class DeclaredImpl extends TypeImpl implements Type.Declared {
+    public static final class DeclaredImpl extends TypeImpl implements Type.Declared {
 
         private final Declaration.Scoped declaration;
 
@@ -217,9 +217,9 @@ public abstract class TypeImpl implements Type {
         @Override
         public boolean equals(Object o) {
             if (this == o) return true;
-            if (o == null || getClass() != o.getClass()) return false;
-            DeclaredImpl declared = (DeclaredImpl) o;
-            return declaration.equals(declared.declaration);
+            if (!(o instanceof Type.Declared)) return false;
+            Type.Declared declared = (Type.Declared) o;
+            return declaration.equals(declared.tree());
         }
 
         @Override
@@ -228,7 +228,7 @@ public abstract class TypeImpl implements Type {
         }
     }
 
-    public static class FunctionImpl extends TypeImpl implements Type.Function {
+    public static final class FunctionImpl extends TypeImpl implements Type.Function {
 
         private final boolean varargs;
         private final List<Type> argtypes;
@@ -264,11 +264,11 @@ public abstract class TypeImpl implements Type {
         @Override
         public boolean equals(Object o) {
             if (this == o) return true;
-            if (o == null || getClass() != o.getClass()) return false;
-            FunctionImpl function = (FunctionImpl) o;
-            return varargs == function.varargs &&
-                    argtypes.equals(function.argtypes) &&
-                    restype.equals(function.restype);
+            if (!(o instanceof Type.Function)) return false;
+            Type.Function function = (Type.Function) o;
+            return varargs == function.varargs() &&
+                    argtypes.equals(function.argumentTypes()) &&
+                    restype.equals(function.returnType());
         }
 
         @Override
@@ -277,7 +277,7 @@ public abstract class TypeImpl implements Type {
         }
     }
 
-    public static class ArrayImpl extends TypeImpl implements Type.Array {
+    public static final class ArrayImpl extends TypeImpl implements Type.Array {
 
         private final Kind kind;
         private final OptionalLong elemCount;
@@ -321,10 +321,10 @@ public abstract class TypeImpl implements Type {
         @Override
         public boolean equals(Object o) {
             if (this == o) return true;
-            if (o == null || getClass() != o.getClass()) return false;
-            ArrayImpl array = (ArrayImpl) o;
-            return kind == array.kind &&
-                    elemType.equals(array.elemType);
+            if (!(o instanceof Type.Array)) return false;
+            Type.Array array = (Type.Array) o;
+            return kind == array.kind() &&
+                    elemType.equals(array.elementType());
         }
 
         @Override

--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/TypeImpl.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/TypeImpl.java
@@ -42,6 +42,13 @@ public abstract class TypeImpl implements Type {
         return false;
     }
 
+    static boolean equals(Type t1, Type.Delegated t2) {
+        assert t1 != null;
+        assert t2 != null;
+
+        return (t2.kind() == Delegated.Kind.TYPEDEF)? t1.equals(t2.type()) : false;
+    }
+
     public static final TypeImpl ERROR = new TypeImpl() {
         @Override
         public <R, D> R accept(Visitor<R, D> visitor, D data) {
@@ -91,7 +98,9 @@ public abstract class TypeImpl implements Type {
         @Override
         public boolean equals(Object o) {
             if (this == o) return true;
-            if (!(o instanceof Type.Primitive)) return false;
+            if (!(o instanceof Type.Primitive)) {
+                return (o instanceof Type.Delegated)? equals(this, (Type.Delegated)o) : false;
+            }
             Type.Primitive primitive = (Type.Primitive) o;
             return kind == primitive.kind();
         }
@@ -117,19 +126,21 @@ public abstract class TypeImpl implements Type {
         }
 
         @Override
-        public Delegated.Kind kind() {
+        public final Delegated.Kind kind() {
             return kind;
         }
 
         @Override
-        public Optional<String> name() {
+        public final Optional<String> name() {
             return name;
         }
 
         @Override
         public boolean equals(Object o) {
             if (this == o) return true;
-            if (!(o instanceof Type.Delegated)) return false;
+            if (!(o instanceof Type.Delegated)) {
+                return (o instanceof Type)? equals((Type)o, this) : false;
+            }
             Type.Delegated that = (Type.Delegated) o;
             return kind == that.kind() &&
                     name.equals(that.name());
@@ -166,14 +177,16 @@ public abstract class TypeImpl implements Type {
         public boolean equals(Object o) {
             if (this == o) return true;
             if (!(o instanceof Type.Delegated)) return false;
-            if (!super.equals(o)) return false;
+            if (!super.equals(o)) {
+                return (o instanceof Type.Delegated)? equals(this, (Type.Delegated)o) : false;
+            }
             Type.Delegated qualified = (Type.Delegated) o;
             return Objects.equals(type, qualified.type());
         }
 
         @Override
         public int hashCode() {
-            return Objects.hash(super.hashCode(), type);
+            return (kind() == Kind.TYPEDEF)? type().hashCode() : Objects.hash(super.hashCode(), type);
         }
     }
 
@@ -217,7 +230,9 @@ public abstract class TypeImpl implements Type {
         @Override
         public boolean equals(Object o) {
             if (this == o) return true;
-            if (!(o instanceof Type.Declared)) return false;
+            if (!(o instanceof Type.Declared)) {
+                return (o instanceof Type.Delegated)? equals(this, (Type.Delegated)o) : false;
+            }
             Type.Declared declared = (Type.Declared) o;
             return declaration.equals(declared.tree());
         }
@@ -264,7 +279,9 @@ public abstract class TypeImpl implements Type {
         @Override
         public boolean equals(Object o) {
             if (this == o) return true;
-            if (!(o instanceof Type.Function)) return false;
+            if (!(o instanceof Type.Function)) {
+                return (o instanceof Type.Delegated)? equals(this, (Type.Delegated)o) : false;
+            }
             Type.Function function = (Type.Function) o;
             return varargs == function.varargs() &&
                     argtypes.equals(function.argumentTypes()) &&
@@ -321,7 +338,9 @@ public abstract class TypeImpl implements Type {
         @Override
         public boolean equals(Object o) {
             if (this == o) return true;
-            if (!(o instanceof Type.Array)) return false;
+            if (!(o instanceof Type.Array)) {
+                return (o instanceof Type.Delegated)? equals(this, (Type.Delegated)o) : false;
+            }
             Type.Array array = (Type.Array) o;
             return kind == array.kind() &&
                     elemType.equals(array.elementType());

--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/TypeImpl.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/TypeImpl.java
@@ -27,6 +27,7 @@
 package jdk.internal.jextract.impl;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.OptionalLong;
 import java.util.function.Supplier;
@@ -53,7 +54,7 @@ public abstract class TypeImpl implements Type {
         }
     };
 
-    public static class PrimitiveImpl extends TypeImpl implements Type.Primitive {
+    public static final class PrimitiveImpl extends TypeImpl implements Type.Primitive {
 
         private final Primitive.Kind kind;
         private final Optional<MemoryLayout> layoutOpt;
@@ -68,8 +69,8 @@ public abstract class TypeImpl implements Type {
 
         private PrimitiveImpl(Kind kind, Optional<MemoryLayout> layoutOpt) {
             super();
-            this.kind = kind;
-            this.layoutOpt = layoutOpt;
+            this.kind = Objects.requireNonNull(kind);
+            this.layoutOpt = Objects.requireNonNull(layoutOpt);
         }
 
         @Override
@@ -86,6 +87,19 @@ public abstract class TypeImpl implements Type {
         public Optional<MemoryLayout> layout() {
             return layoutOpt;
         }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            PrimitiveImpl primitive = (PrimitiveImpl) o;
+            return kind == primitive.kind;
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(kind);
+        }
     }
 
     static abstract class DelegatedBase extends TypeImpl implements Type.Delegated {
@@ -93,8 +107,8 @@ public abstract class TypeImpl implements Type {
         Optional<String> name;
 
         DelegatedBase(Kind kind, Optional<String> name) {
-            this.kind = kind;
-            this.name = name;
+            this.kind = Objects.requireNonNull(kind);
+            this.name = Objects.requireNonNull(name);
         }
 
         @Override
@@ -110,6 +124,20 @@ public abstract class TypeImpl implements Type {
         @Override
         public Optional<String> name() {
             return name;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            DelegatedBase that = (DelegatedBase) o;
+            return kind == that.kind &&
+                    name.equals(that.name);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(kind, name);
         }
     }
 
@@ -133,6 +161,20 @@ public abstract class TypeImpl implements Type {
         public Type type() {
             return type;
         }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            if (!super.equals(o)) return false;
+            QualifiedImpl qualified = (QualifiedImpl) o;
+            return Objects.equals(type, qualified.type);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(super.hashCode(), type);
+        }
     }
 
     public static class PointerImpl extends DelegatedBase {
@@ -140,7 +182,7 @@ public abstract class TypeImpl implements Type {
 
         public PointerImpl(Supplier<Type> pointeeFactory) {
             super(Kind.POINTER, Optional.empty());
-            this.pointeeFactory = pointeeFactory;
+            this.pointeeFactory = Objects.requireNonNull(pointeeFactory);
         }
 
         public PointerImpl(Type pointee) {
@@ -159,7 +201,7 @@ public abstract class TypeImpl implements Type {
 
         public DeclaredImpl(Declaration.Scoped declaration) {
             super();
-            this.declaration = declaration;
+            this.declaration = Objects.requireNonNull(declaration);
         }
 
         @Override
@@ -170,6 +212,19 @@ public abstract class TypeImpl implements Type {
         @Override
         public Declaration.Scoped tree() {
             return declaration;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            DeclaredImpl declared = (DeclaredImpl) o;
+            return declaration.equals(declared.declaration);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(declaration);
         }
     }
 
@@ -182,8 +237,8 @@ public abstract class TypeImpl implements Type {
         public FunctionImpl(boolean varargs, List<Type> argtypes, Type restype) {
             super();
             this.varargs = varargs;
-            this.argtypes = argtypes;
-            this.restype = restype;
+            this.argtypes = Objects.requireNonNull(argtypes);
+            this.restype = Objects.requireNonNull(restype);
         }
 
         @Override
@@ -205,6 +260,21 @@ public abstract class TypeImpl implements Type {
         public Type returnType() {
             return restype;
         }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            FunctionImpl function = (FunctionImpl) o;
+            return varargs == function.varargs &&
+                    argtypes.equals(function.argtypes) &&
+                    restype.equals(function.restype);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(varargs, argtypes, restype);
+        }
     }
 
     public static class ArrayImpl extends TypeImpl implements Type.Array {
@@ -223,9 +293,9 @@ public abstract class TypeImpl implements Type {
 
         private ArrayImpl(Kind kind, Type elemType, OptionalLong elemCount) {
             super();
-            this.kind = kind;
-            this.elemCount = elemCount;
-            this.elemType = elemType;
+            this.kind = Objects.requireNonNull(kind);
+            this.elemCount = Objects.requireNonNull(elemCount);
+            this.elemType = Objects.requireNonNull(elemType);
         }
 
         @Override
@@ -246,6 +316,20 @@ public abstract class TypeImpl implements Type {
         @Override
         public Kind kind() {
             return kind;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            ArrayImpl array = (ArrayImpl) o;
+            return kind == array.kind &&
+                    elemType.equals(array.elemType);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(kind, elemType);
         }
     }
 

--- a/test/jdk/tools/jextract/JextractToolProviderTest.java
+++ b/test/jdk/tools/jextract/JextractToolProviderTest.java
@@ -98,26 +98,4 @@ public class JextractToolProviderTest extends JextractToolRunner {
     public void testTargetPackageLongOption() {
         testTargetPackage("--target-package");
     }
-
-     @Test
-    public void testAnonymousEnum() {
-        Path anonenumOutput = getOutputFilePath("anonenumgen");
-        Path anonenumH = getInputFilePath("anonenum.h");
-        run("-d", anonenumOutput.toString(), anonenumH.toString()).checkSuccess();
-        try(Loader loader = classLoader(anonenumOutput)) {
-            Class<?> cls = loader.loadClass("anonenum_h");
-            checkIntField(cls, "RED", 0xff0000);
-            checkIntField(cls, "GREEN", 0x00ff00);
-            checkIntField(cls, "BLUE", 0x0000ff);
-            checkIntField(cls, "Java", 0);
-            checkIntField(cls, "C", 1);
-            checkIntField(cls, "CPP", 2);
-            checkIntField(cls, "Python", 3);
-            checkIntField(cls, "Ruby", 4);
-            checkIntField(cls, "ONE", 1);
-            checkIntField(cls, "TWO", 2);
-        } finally {
-            deleteDir(anonenumOutput);
-        }
-    }
 }

--- a/test/jdk/tools/jextract/JextractToolRunner.java
+++ b/test/jdk/tools/jextract/JextractToolRunner.java
@@ -36,6 +36,9 @@ import java.nio.file.SimpleFileVisitor;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.util.Objects;
 import java.util.spi.ToolProvider;
+import jdk.incubator.foreign.MemoryLayout;
+import jdk.incubator.foreign.MemoryLayout.PathElement;
+import jdk.incubator.foreign.SystemABI.Type;
 
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotEquals;
@@ -224,6 +227,23 @@ public class JextractToolRunner {
             fail("Expect method " + name);
         }
         return null;
+    }
+
+    protected MemoryLayout findLayout(Class<?> cls, String name) {
+        Field field = findField(cls, name + "$LAYOUT");
+        assertNotNull(field);
+        assertEquals(field.getType(), MemoryLayout.class);
+        try {
+            return (MemoryLayout)field.get(null);
+        } catch (Exception exp) {
+            System.err.println(exp);
+            assertTrue(false, "should not reach here");
+        }
+        return null;
+    }
+
+    protected static void checkFieldABIType(MemoryLayout layout, String fieldName, Type expected) {
+        assertEquals(layout.select(PathElement.groupElement(fieldName)).abiType().orElseThrow(), expected);
     }
 
     protected static class Loader implements AutoCloseable {

--- a/test/jdk/tools/jextract/RepeatedDeclsTest.java
+++ b/test/jdk/tools/jextract/RepeatedDeclsTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import org.testng.annotations.Test;
+
+import java.lang.reflect.Method;
+import java.nio.file.Path;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+
+/*
+ * @test
+ * @bug 8240300
+ * @summary jextract produces non compilable code with repeated declarations
+ * @modules jdk.incubator.jextract
+ * @build JextractToolRunner
+ * @run testng RepeatedDeclsTest
+ */
+public class RepeatedDeclsTest extends JextractToolRunner {
+    @Test
+    public void repeatedDecls() {
+        Path repeatedDeclsOutput = getOutputFilePath("repeatedDeclsgen");
+        Path repeatedDeclsH = getInputFilePath("repeatedDecls.h");
+        run("-d", repeatedDeclsOutput.toString(), repeatedDeclsH.toString()).checkSuccess();
+        try(Loader loader = classLoader(repeatedDeclsOutput)) {
+            Class<?> cls = loader.loadClass("repeatedDecls_h");
+            // check a method for "void func(int)"
+            assertNotNull(findMethod(cls, "func", int.class));
+
+            // check a getter method for "i"
+            assertNotNull(findMethod(cls, "i$get"));
+
+            // check a setter method for "i"
+            assertNotNull(findMethod(cls, "i$set", int.class));
+        } finally {
+            deleteDir(repeatedDeclsOutput);
+        }
+    }
+}

--- a/test/jdk/tools/jextract/RepeatedDeclsTest.java
+++ b/test/jdk/tools/jextract/RepeatedDeclsTest.java
@@ -25,6 +25,8 @@ import org.testng.annotations.Test;
 
 import java.lang.reflect.Method;
 import java.nio.file.Path;
+import jdk.incubator.foreign.MemoryLayout;
+import jdk.incubator.foreign.SystemABI.Type;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
@@ -48,11 +50,35 @@ public class RepeatedDeclsTest extends JextractToolRunner {
             // check a method for "void func(int)"
             assertNotNull(findMethod(cls, "func", int.class));
 
+            // check a method for "void func2(int)"
+            assertNotNull(findMethod(cls, "func2", int.class));
+
             // check a getter method for "i"
             assertNotNull(findMethod(cls, "i$get"));
 
             // check a setter method for "i"
             assertNotNull(findMethod(cls, "i$set", int.class));
+
+            // make sure that enum constants are generated fine
+            checkIntField(cls, "R", 0);
+            checkIntField(cls, "G", 1);
+            checkIntField(cls, "B", 2);
+            checkIntField(cls, "C", 0);
+            checkIntField(cls, "M", 1);
+            checkIntField(cls, "Y", 2);
+
+            // check Point layout
+            MemoryLayout pointLayout = findLayout(cls, "Point");
+            assertNotNull(pointLayout);
+            checkFieldABIType(pointLayout, "i",  Type.INT);
+            checkFieldABIType(pointLayout, "j",  Type.INT);
+
+            // check Point3D layout
+            MemoryLayout point3DLayout = findLayout(cls, "Point3D");
+            assertNotNull(point3DLayout);
+            checkFieldABIType(point3DLayout, "i",  Type.INT);
+            checkFieldABIType(point3DLayout, "j",  Type.INT);
+            checkFieldABIType(point3DLayout, "k",  Type.INT);
         } finally {
             deleteDir(repeatedDeclsOutput);
         }

--- a/test/jdk/tools/jextract/RepeatedDeclsTest.java
+++ b/test/jdk/tools/jextract/RepeatedDeclsTest.java
@@ -25,7 +25,9 @@ import org.testng.annotations.Test;
 
 import java.lang.reflect.Method;
 import java.nio.file.Path;
+import jdk.incubator.foreign.MemoryAddress;
 import jdk.incubator.foreign.MemoryLayout;
+import jdk.incubator.foreign.MemorySegment;
 import jdk.incubator.foreign.SystemABI.Type;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
@@ -52,6 +54,18 @@ public class RepeatedDeclsTest extends JextractToolRunner {
 
             // check a method for "void func2(int)"
             assertNotNull(findMethod(cls, "func2", int.class));
+
+            // check a method for "void func3(int*)"
+            assertNotNull(findMethod(cls, "func3", MemoryAddress.class));
+
+            // check a method for "void func4(int*)"
+            assertNotNull(findMethod(cls, "func4", MemoryAddress.class));
+
+            // check a method for "void func5(int)"
+            assertNotNull(findMethod(cls, "func5", int.class));
+
+            // check a method for "double distance(struct Point)"
+            assertNotNull(findMethod(cls, "distance", MemorySegment.class));
 
             // check a getter method for "i"
             assertNotNull(findMethod(cls, "i$get"));

--- a/test/jdk/tools/jextract/repeatedDecls.h
+++ b/test/jdk/tools/jextract/repeatedDecls.h
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+struct Point;
+struct Point;
+
+int i;
+int i;
+
+void func(int);
+void func(int);
+
+struct Point;
+struct Point {
+   int i;
+   int j;
+};
+
+struct Point3D {
+    int i;
+    int j;
+    int k;
+};
+struct Point3D;
+
+enum RGBColor;
+enum RGBColor {
+   R, G, B
+};
+
+enum CMYColor {
+  C, M, Y
+};
+enum CMYColor;

--- a/test/jdk/tools/jextract/repeatedDecls.h
+++ b/test/jdk/tools/jextract/repeatedDecls.h
@@ -34,11 +34,35 @@ void func2(int);
 void func2(int abc);
 void func2(int xyz);
 
+typedef int INT;
+void func(INT);
+void func(INT abc);
+void func(INT xyz);
+void func2(INT);
+void func2(INT abc);
+void func2(INT xyz);
+
+typedef int* INTPTR;
+void func3(INTPTR x);
+void func3(int* x);
+void func4(INTPTR x);
+void func4(int* x);
+
+typedef int Integer;
+void func(Integer x);
+void func5(int x);
+void func5(Integer x);
+void func5(INT x);
+
 struct Point;
 struct Point {
    int i;
    int j;
 };
+
+typedef struct Point POINT;
+double distance(struct Point p);
+double distance(POINT p);
 
 struct Point3D {
     int i;

--- a/test/jdk/tools/jextract/repeatedDecls.h
+++ b/test/jdk/tools/jextract/repeatedDecls.h
@@ -28,7 +28,11 @@ int i;
 int i;
 
 void func(int);
-void func(int);
+void func(int abc);
+void func(int xyz);
+void func2(int);
+void func2(int abc);
+void func2(int xyz);
 
 struct Point;
 struct Point {


### PR DESCRIPTION
Filtering repeated global variables and functions in code generator (added necessary hashCode, equals for decls, types)
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [JDK-8240300](https://bugs.openjdk.java.net/browse/JDK-8240300): jextract produces non compilable code with repeated declarations


### Reviewers
 * Maurizio Cimadamore ([mcimadamore](@mcimadamore) - Committer) ⚠️ Review applies to f1720cf0f8c23ab2abcf671b8000082493cab707
 * Henry Jen ([henryjen](@slowhog) - Committer)

### Download
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/37/head:pull/37`
`$ git checkout pull/37`
