### PR TITLE
8240602: port more tests from old jextract tests

### DIFF
--- a/src/jdk.incubator.jextract/share/classes/jdk/incubator/jextract/tool/Main.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/incubator/jextract/tool/Main.java
@@ -171,22 +171,22 @@ public class Main {
             return INPUT_ERROR;
         }
 
-        //parse
-        JextractTask jextractTask = JextractTask.newTask(!options.source, header);
-        Declaration.Scoped toplevel = jextractTask.parse(options.clangArgs.toArray(new String[0]));
-
-        //filter
-        if (!options.filters.isEmpty()) {
-            toplevel = Filter.filter(toplevel, options.filters.toArray(new String[0]));
-        }
-
-        if (Main.DEBUG) {
-            System.out.println(toplevel);
-        }
-
-        Path output = Path.of(options.outputDir);
-        //generate
+        //parse    //generate
         try {
+            JextractTask jextractTask = JextractTask.newTask(!options.source, header);
+            Declaration.Scoped toplevel = jextractTask.parse(options.clangArgs.toArray(new String[0]));
+
+            //filter
+            if (!options.filters.isEmpty()) {
+                toplevel = Filter.filter(toplevel, options.filters.toArray(new String[0]));
+            }
+
+            if (Main.DEBUG) {
+                System.out.println(toplevel);
+            }
+
+            Path output = Path.of(options.outputDir);
+
             JavaFileObject[] files = HandleSourceFactory.generateWrapped(
                 toplevel,
                 header.getFileName().toString().replace(".h", "_h"),

--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/TypeImpl.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/TypeImpl.java
@@ -46,7 +46,7 @@ public abstract class TypeImpl implements Type {
         assert t1 != null;
         assert t2 != null;
 
-        return (t2.kind() == Delegated.Kind.TYPEDEF)? t1.equals(t2.type()) : false;
+        return (t2.kind() == Delegated.Kind.TYPEDEF) && t1.equals(t2.type());
     }
 
     public static final TypeImpl ERROR = new TypeImpl() {
@@ -99,7 +99,7 @@ public abstract class TypeImpl implements Type {
         public boolean equals(Object o) {
             if (this == o) return true;
             if (!(o instanceof Type.Primitive)) {
-                return (o instanceof Type.Delegated)? equals(this, (Type.Delegated)o) : false;
+                return (o instanceof Delegated) && equals(this, (Delegated)o);
             }
             Type.Primitive primitive = (Type.Primitive) o;
             return kind == primitive.kind();
@@ -139,7 +139,7 @@ public abstract class TypeImpl implements Type {
         public boolean equals(Object o) {
             if (this == o) return true;
             if (!(o instanceof Type.Delegated)) {
-                return (o instanceof Type)? equals((Type)o, this) : false;
+                return (o instanceof Type) && equals((Type)o, this);
             }
             Type.Delegated that = (Type.Delegated) o;
             return kind == that.kind() &&
@@ -178,7 +178,7 @@ public abstract class TypeImpl implements Type {
             if (this == o) return true;
             if (!(o instanceof Type.Delegated)) return false;
             if (!super.equals(o)) {
-                return (o instanceof Type.Delegated)? equals(this, (Type.Delegated)o) : false;
+                return (o instanceof Delegated) && equals(this, (Delegated) o);
             }
             Type.Delegated qualified = (Type.Delegated) o;
             return Objects.equals(type, qualified.type());
@@ -231,7 +231,7 @@ public abstract class TypeImpl implements Type {
         public boolean equals(Object o) {
             if (this == o) return true;
             if (!(o instanceof Type.Declared)) {
-                return (o instanceof Type.Delegated)? equals(this, (Type.Delegated)o) : false;
+                return (o instanceof Delegated) && equals(this, (Delegated) o);
             }
             Type.Declared declared = (Type.Declared) o;
             return declaration.equals(declared.tree());
@@ -280,7 +280,7 @@ public abstract class TypeImpl implements Type {
         public boolean equals(Object o) {
             if (this == o) return true;
             if (!(o instanceof Type.Function)) {
-                return (o instanceof Type.Delegated)? equals(this, (Type.Delegated)o) : false;
+                return (o instanceof Delegated) && equals(this, (Delegated) o);
             }
             Type.Function function = (Type.Function) o;
             return varargs == function.varargs() &&
@@ -339,7 +339,7 @@ public abstract class TypeImpl implements Type {
         public boolean equals(Object o) {
             if (this == o) return true;
             if (!(o instanceof Type.Array)) {
-                return (o instanceof Type.Delegated)? equals(this, (Type.Delegated)o) : false;
+                return (o instanceof Delegated) && equals(this, (Delegated) o);
             }
             Type.Array array = (Type.Array) o;
             return kind == array.kind() &&

--- a/test/jdk/tools/jextract/BadBitfieldTest.java
+++ b/test/jdk/tools/jextract/BadBitfieldTest.java
@@ -4,9 +4,7 @@
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 only, as
- * published by the Free Software Foundation.  Oracle designates this
- * particular file as subject to the "Classpath" exception as provided
- * by Oracle in the LICENSE file that accompanied this code.
+ * published by the Free Software Foundation.
  *
  * This code is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or

--- a/test/jdk/tools/jextract/BadBitfieldTest.java
+++ b/test/jdk/tools/jextract/BadBitfieldTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @requires os.family != "windows"
+ * @modules jdk.incubator.jextract
+ * @build BadBitfieldTest
+ * @run testng BadBitfieldTest
+ */
+
+/*
+ * Not running on Windows since MSVC will not cross storage unit boundaries.
+ * Resulting struct on SysV is 16 bytes, but 24 on MSx64
+ *
+ * MSVC: (/d1reportSingleClassLayoutFoo)
+ * class Foo	size(24):
+ *      +---
+ *  0.	| a (bitstart=0,nbits=45)
+ *  8.	| b (bitstart=0,nbits=24)
+ *  8.	| c (bitstart=24,nbits=1)
+ * 16.	| d (bitstart=0,nbits=58)
+ *      +---
+ *
+ * SysV: (PAHole)
+ * struct Foo {
+ *     long long int a:45;                0:19   8
+ *     long long int b:24;                0:251  8
+ *     XXX 251 bits hole, try to pack
+ *     long long int c:1;                 8:58   8
+ *     long long int d:58;                8: 0   8
+ *
+ *     size: 16, cachelines: 1, members: 4
+ *     bit holes: 1, sum bit holes: 251 bits
+ *     bit_padding: 5 bits
+ *     last cacheline: 16 bytes
+ * };
+ *
+ */
+
+import org.testng.annotations.Test;
+
+public class BadBitfieldTest extends JextractToolRunner {
+    @Test
+    public void testBadBitfield() {
+        run("-d", getOutputFilePath("badBitfieldsGen").toString(),
+                getInputFilePath("badBitfields.h").toString())
+            .checkFailure()
+            .checkContainsOutput("Crossing storage unit boundaries");
+    }
+}

--- a/test/jdk/tools/jextract/BadBitfieldTest.java
+++ b/test/jdk/tools/jextract/BadBitfieldTest.java
@@ -36,12 +36,12 @@
  * Resulting struct on SysV is 16 bytes, but 24 on MSx64
  *
  * MSVC: (/d1reportSingleClassLayoutFoo)
- * class Foo	size(24):
+ * class Foo    size(24):
  *      +---
- *  0.	| a (bitstart=0,nbits=45)
- *  8.	| b (bitstart=0,nbits=24)
- *  8.	| c (bitstart=24,nbits=1)
- * 16.	| d (bitstart=0,nbits=58)
+ *  0.    | a (bitstart=0,nbits=45)
+ *  8.    | b (bitstart=0,nbits=24)
+ *  8.    | c (bitstart=24,nbits=1)
+ * 16.    | d (bitstart=0,nbits=58)
  *      +---
  *
  * SysV: (PAHole)

--- a/test/jdk/tools/jextract/ConstantsTest.java
+++ b/test/jdk/tools/jextract/ConstantsTest.java
@@ -4,9 +4,7 @@
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 only, as
- * published by the Free Software Foundation.  Oracle designates this
- * particular file as subject to the "Classpath" exception as provided
- * by Oracle in the LICENSE file that accompanied this code.
+ * published by the Free Software Foundation.
  *
  * This code is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or

--- a/test/jdk/tools/jextract/ConstantsTest.java
+++ b/test/jdk/tools/jextract/ConstantsTest.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import org.testng.annotations.AfterTest;
+import org.testng.annotations.BeforeTest;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+import java.nio.file.Path;
+import java.util.function.Predicate;
+import java.util.stream.Stream;
+import jdk.incubator.foreign.GroupLayout;
+import jdk.incubator.foreign.MemoryAddress;
+import jdk.incubator.foreign.SystemABI.Type;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+
+/*
+ * @test
+ * @modules jdk.incubator.jextract
+ * @build ConstantsTest
+ * @run testng ConstantsTest
+ */
+public class ConstantsTest extends JextractToolRunner {
+    private Class<?> constants;
+    private Path dirPath;
+    private Loader loader;
+
+    @BeforeTest
+    public void setup() {
+        dirPath = getOutputFilePath("ConstantsTest_output");
+        run( "-d", dirPath.toString(), getInputFilePath("constants.h").toString()).checkSuccess();
+        loader = classLoader(dirPath);
+        constants = loader.loadClass("constants_h");
+    }
+
+    @AfterTest
+    public void cleanup() {
+        constants = null;
+        loader.close();
+        deleteDir(dirPath);
+    }
+
+
+    @Test(dataProvider = "definedConstants")
+    public void checkConstantsSignatures(String name, Class<?> type, Object value) {
+        var f = findField(constants, name);
+        assertNotNull(f);
+        assertTrue(f.getType() == type);
+    }
+
+    @Test(dataProvider = "definedConstants")
+    public void checkConstantsValues(String name, Class<?> type, Predicate<Object> checker) throws ReflectiveOperationException {
+        Object actual = findField(constants, name).get(null);
+        assertTrue(checker.test(actual));
+    }
+
+    @Test(dataProvider = "missingConstants")
+    public void checkMissingConstants(String name) {
+        assertTrue(Stream.of(constants.getDeclaredFields())
+                .noneMatch(m -> m.getName().equals(name)));
+    }
+
+    @DataProvider
+    public static Object[][] definedConstants() {
+        return new Object[][] {
+                { "SUP", int.class, equalsTo(5) },
+                { "ZERO", int.class, equalsTo(0) },
+                { "ONE", int.class, equalsTo(1) },
+                { "TWO", int.class, equalsTo(2) },
+                { "THREE", int.class, equalsTo(3) },
+                { "FOUR", long.class, equalsTo(4L) },
+                { "FIVE", long.class, equalsTo(5L) },
+                { "SIX", int.class, equalsTo(6) },
+                { "FLOAT_VALUE", float.class, equalsTo(1.32f) },
+                { "DOUBLE_VALUE", double.class, equalsTo(1.32) },
+                { "CHAR_VALUE", int.class, equalsTo(104) }, //integer char constants have type int
+                { "MULTICHAR_VALUE", int.class, equalsTo(26728) },  //integer char constants have type int
+                { "BOOL_VALUE", byte.class, equalsTo((byte)1) },
+                { "SUB", int.class, equalsTo( 7 ) }
+        };
+    }
+
+    static Predicate<Object> equalsTo(Object that) {
+        return o -> o.equals(that);
+    }
+
+    @DataProvider
+    public static Object[][] missingConstants() {
+        return new Object[][] {
+                { "ID" },
+                { "SUM" },
+                { "BLOCK_BEGIN" },
+                { "BLOCK_END" },
+                { "INTEGER_MAX_VALUE" },
+                { "CYCLIC_1" },
+                { "CYCLIC_2" },
+                { "UNUSED" },
+                // pointer type values
+                { "STR" },
+                { "QUOTE" },
+                { "ZERO_PTR" },
+                { "F_PTR" }
+        };
+    }
+}

--- a/test/jdk/tools/jextract/RepeatedDeclsTest.java
+++ b/test/jdk/tools/jextract/RepeatedDeclsTest.java
@@ -25,6 +25,7 @@ import org.testng.annotations.Test;
 
 import java.lang.reflect.Method;
 import java.nio.file.Path;
+import jdk.incubator.foreign.GroupLayout;
 import jdk.incubator.foreign.MemoryAddress;
 import jdk.incubator.foreign.MemoryLayout;
 import jdk.incubator.foreign.MemorySegment;
@@ -84,12 +85,14 @@ public class RepeatedDeclsTest extends JextractToolRunner {
             // check Point layout
             MemoryLayout pointLayout = findLayout(cls, "Point");
             assertNotNull(pointLayout);
+            assertTrue(((GroupLayout)pointLayout).isStruct());
             checkFieldABIType(pointLayout, "i",  Type.INT);
             checkFieldABIType(pointLayout, "j",  Type.INT);
 
             // check Point3D layout
             MemoryLayout point3DLayout = findLayout(cls, "Point3D");
             assertNotNull(point3DLayout);
+            assertTrue(((GroupLayout)point3DLayout).isStruct());
             checkFieldABIType(point3DLayout, "i",  Type.INT);
             checkFieldABIType(point3DLayout, "j",  Type.INT);
             checkFieldABIType(point3DLayout, "k",  Type.INT);

--- a/test/jdk/tools/jextract/UniondeclTest.java
+++ b/test/jdk/tools/jextract/UniondeclTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import org.testng.annotations.Test;
+import java.nio.file.Path;
+import jdk.incubator.foreign.GroupLayout;
+import jdk.incubator.foreign.MemoryAddress;
+import jdk.incubator.foreign.SystemABI.Type;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+
+/*
+ * @test
+ * @modules jdk.incubator.jextract
+ * @build JextractToolRunner
+ * @run testng UniondeclTest
+ */
+public class UniondeclTest extends JextractToolRunner {
+    @Test
+    public void unionDecl() {
+        Path uniondeclOutput = getOutputFilePath("uniondecl.h");
+        Path uniondeclH = getInputFilePath("uniondecl.h");
+        run("-d", uniondeclOutput.toString(), uniondeclH.toString()).checkSuccess();
+        try(Loader loader = classLoader(uniondeclOutput)) {
+            Class<?> cls = loader.loadClass("uniondecl_h");
+            // check a method for "void func(IntOrFloat*)"
+            assertNotNull(findMethod(cls, "func", MemoryAddress.class));
+            // check Point layout
+            GroupLayout intOrFloatLayout = (GroupLayout)findLayout(cls, "IntOrFloat");
+            assertNotNull(intOrFloatLayout);
+            assertTrue(intOrFloatLayout.isUnion());
+            checkFieldABIType(intOrFloatLayout, "i",  Type.INT);
+            checkFieldABIType(intOrFloatLayout, "f",  Type.FLOAT);
+        } finally {
+            deleteDir(uniondeclOutput);
+        }
+    }
+}

--- a/test/jdk/tools/jextract/badBitfields.h
+++ b/test/jdk/tools/jextract/badBitfields.h
@@ -4,9 +4,7 @@
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 only, as
- * published by the Free Software Foundation.  Oracle designates this
- * particular file as subject to the "Classpath" exception as provided
- * by Oracle in the LICENSE file that accompanied this code.
+ * published by the Free Software Foundation.
  *
  * This code is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or

--- a/test/jdk/tools/jextract/badBitfields.h
+++ b/test/jdk/tools/jextract/badBitfields.h
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+#pragma pack(1)
+struct Foo {
+    long  a         : 45;
+    long  b         : 24;
+    long  c         : 1;
+    long  d         : 58;
+};

--- a/test/jdk/tools/jextract/constants.h
+++ b/test/jdk/tools/jextract/constants.h
@@ -4,9 +4,7 @@
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 only, as
- * published by the Free Software Foundation.  Oracle designates this
- * particular file as subject to the "Classpath" exception as provided
- * by Oracle in the LICENSE file that accompanied this code.
+ * published by the Free Software Foundation.
  *
  * This code is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or

--- a/test/jdk/tools/jextract/constants.h
+++ b/test/jdk/tools/jextract/constants.h
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+#include "constants_aux.h"
+
+#define ZERO 0
+#define ONE ZERO + 1 //backward ref
+#define THREE ONE + TWO /* forward ref */
+#define TWO ONE + ONE
+
+#define FOUR (long long)0x1L + THREE //hack: force long carrier
+#define FIVE (long long)0x1UL + FOUR //hack: force long carrier
+
+#define SIX ONE +\
+              TWO +\
+              THREE
+
+#define STR "Hello" // a string
+
+#define ID(x) x //function-like
+#define SUM(x,y) x + y //function-like
+
+#define BLOCK_BEGIN { //not a constant
+#define BLOCK_END } //not a constant
+
+#define INTEGER_MAX_VALUE Integer.MAX_VALUE //constant in Java, not in C
+#define QUOTE "QUOTE" //should be ok
+
+#define FLOAT_VALUE 1.32F;
+#define DOUBLE_VALUE 1.32;
+
+#define CYCLIC_1 1 + CYCLIC_1 //cycle
+
+#define CYCLIC_2 1 + TEMP //indirect cycle
+#define TEMP 1 + CYCLIC_2
+
+#define CHAR_VALUE 'h'
+#define MULTICHAR_VALUE 'hh'
+
+#define BOOL_VALUE (_Bool)1
+//we should have tests for char and shorts, but these are likely to be platform dependent
+
+#define SUB SUP + 2 //dependency
+
+#define ZERO_PTR (void*)0;
+#define F_PTR (void*) 0xFFFFFFFFFFFFFFFFLL; // all 1s

--- a/test/jdk/tools/jextract/constants_aux.h
+++ b/test/jdk/tools/jextract/constants_aux.h
@@ -4,9 +4,7 @@
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 only, as
- * published by the Free Software Foundation.  Oracle designates this
- * particular file as subject to the "Classpath" exception as provided
- * by Oracle in the LICENSE file that accompanied this code.
+ * published by the Free Software Foundation.
  *
  * This code is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or

--- a/test/jdk/tools/jextract/constants_aux.h
+++ b/test/jdk/tools/jextract/constants_aux.h
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+#define SUP 5 //this is used by the main test header file
+
+#define UNUSED "unused" //this should not be used

--- a/test/jdk/tools/jextract/uniondecl.h
+++ b/test/jdk/tools/jextract/uniondecl.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/tools/jextract/uniondecl.h
+++ b/test/jdk/tools/jextract/uniondecl.h
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+typedef union {
+    int i;
+    float f;
+} IntOrFloat;
+
+void func(IntOrFloat* value);


### PR DESCRIPTION
* catch RuntimeException around header parser and return failure exit code.
* add union, (macro) constants and bad bitfield tests.
* IDE suggested simplyfing refactorings
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [JDK-8240602](https://bugs.openjdk.java.net/browse/JDK-8240602): port more tests from old jextract tests


### Reviewers
 * Jorn Vernee ([jvernee](@JornVernee) - Committer)

### Download
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/39/head:pull/39`
`$ git checkout pull/39`
