### PR TITLE
Improve jextract error reporting

### DIFF
--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/clang/ErrorCode.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/clang/ErrorCode.java
@@ -25,31 +25,39 @@
  */
 package jdk.internal.clang;
 
-import jdk.incubator.foreign.MemoryAddress;
-import jdk.incubator.foreign.MemorySegment;
-import jdk.internal.clang.libclang.Index_h;
+import java.util.Arrays;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.function.Function;
 
-public class LibClang {
-    private static final boolean DEBUG = Boolean.getBoolean("libclang.debug");
-    private static final boolean NO_CRASH_RECOVERY = Boolean.getBoolean("libclang.disable_crash_recovery");
+import static java.util.stream.Collectors.toMap;
+import static jdk.internal.clang.libclang.Index_h.CXError_ASTReadError;
+import static jdk.internal.clang.libclang.Index_h.CXError_Crashed;
+import static jdk.internal.clang.libclang.Index_h.CXError_Failure;
+import static jdk.internal.clang.libclang.Index_h.CXError_InvalidArguments;
+import static jdk.internal.clang.libclang.Index_h.CXError_Success;
 
-    public static Index createIndex(boolean local) {
-        Index index = new Index(Index_h.clang_createIndex(local ? 1 : 0, 0));
-        Index_h.clang_toggleCrashRecovery(NO_CRASH_RECOVERY ? 0 : 1);
-        if (DEBUG && NO_CRASH_RECOVERY) {
-            System.err.println("LibClang crash recovery disabled");
-        }
-        return index;
+public enum ErrorCode {
+    Success(CXError_Success),
+    Failue(CXError_Failure),
+    Crashed(CXError_Crashed),
+    InvalidArguments(CXError_InvalidArguments),
+    ASTReadError(CXError_ASTReadError);
+
+    private final int code;
+
+    ErrorCode(int code) {
+        this.code = code;
     }
 
-    public static String CXStrToString(MemorySegment cxstr) {
-        MemoryAddress buf = Index_h.clang_getCString(cxstr);
-        String str = Utils.toJavaString(buf);
-        Index_h.clang_disposeString(cxstr);
-        return str;
+    public int code() {
+        return code;
     }
 
-    public static String version() {
-        return CXStrToString(Index_h.clang_getClangVersion());
+    private static final Map<Integer, ErrorCode> lookup = Arrays.stream(values())
+            .collect(toMap(ErrorCode::code, Function.identity()));
+
+    public static ErrorCode valueOf(int code) {
+        return lookup.computeIfAbsent(code, k -> { throw new NoSuchElementException("No ErrorCode with code: " + k); });
     }
 }

--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/clang/LibClang.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/clang/LibClang.java
@@ -36,8 +36,8 @@ public class LibClang {
     public static Index createIndex(boolean local) {
         Index index = new Index(Index_h.clang_createIndex(local ? 1 : 0, 0));
         Index_h.clang_toggleCrashRecovery(CRASH_RECOVERY ? 1 : 0);
-        if (DEBUG && !CRASH_RECOVERY) {
-            System.err.println("LibClang crash recovery disabled");
+        if (DEBUG) {
+            System.err.println("LibClang crash recovery " + (CRASH_RECOVERY ? "enabled" : "disabled"));
         }
         return index;
     }

--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/clang/LibClang.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/clang/LibClang.java
@@ -31,12 +31,12 @@ import jdk.internal.clang.libclang.Index_h;
 
 public class LibClang {
     private static final boolean DEBUG = Boolean.getBoolean("libclang.debug");
-    private static final boolean NO_CRASH_RECOVERY = Boolean.getBoolean("libclang.disable_crash_recovery");
+    private static final boolean CRASH_RECOVERY = Boolean.getBoolean("libclang.crash_recovery");
 
     public static Index createIndex(boolean local) {
         Index index = new Index(Index_h.clang_createIndex(local ? 1 : 0, 0));
-        Index_h.clang_toggleCrashRecovery(NO_CRASH_RECOVERY ? 0 : 1);
-        if (DEBUG && NO_CRASH_RECOVERY) {
+        Index_h.clang_toggleCrashRecovery(CRASH_RECOVERY ? 1 : 0);
+        if (DEBUG && !CRASH_RECOVERY) {
             System.err.println("LibClang crash recovery disabled");
         }
         return index;

--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/clang/TranslationUnit.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/clang/TranslationUnit.java
@@ -64,7 +64,7 @@ public class TranslationUnit implements AutoCloseable {
         try (MemorySegment pathStr = Utils.toNativeString(path.toAbsolutePath().toString())) {
             SaveError res = SaveError.valueOf(Index_h.clang_saveTranslationUnit(tu, pathStr.baseAddress(), 0));
             if (res != SaveError.None) {
-                throw new TranslationUnitSaveException(path);
+                throw new TranslationUnitSaveException(path, res);
             }
         }
     }
@@ -210,8 +210,11 @@ public class TranslationUnit implements AutoCloseable {
 
         static final long serialVersionUID = 1L;
 
-        TranslationUnitSaveException(Path path) {
-            super("Cannot save translation unit to: " + path.toAbsolutePath());
+        private final SaveError error;
+
+        TranslationUnitSaveException(Path path, SaveError error) {
+            super("Cannot save translation unit to: " + path.toAbsolutePath() + ". Error: " + error);
+            this.error = error;
         }
     }
 }

--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/MacroParserImpl.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/MacroParserImpl.java
@@ -80,9 +80,7 @@ class MacroParserImpl {
             return result.success() ?
                     Optional.of((Macro)result) :
                     Optional.empty();
-        } catch (Throwable ex) {
-            // This ate the NPE and cause skip of macros
-            // Why are we expecting exception here? Simply be defensive?
+        } catch (BadMacroException ex) {
             if (JextractTaskImpl.VERBOSE) {
                 System.err.println("Failed to handle macro " + macroName);
                 ex.printStackTrace(System.err);


### PR DESCRIPTION
Hi,

I spent the last couple of days tracking down a crash I was seeing sometimes when running jextract. In the process I ended up doing several improvements to jextract's error checking and reporting, that I think are useful to keep in the long run.

The changes include:
- Using `clang_parseTranslationUnit2` to parse, since that returns an error code, instead of a null translation unit. This also means we can still process diagnostic for the returned translation unit (now returned in a buffer).
- Checking the return codes for `clang_parseTranslationUnit2`, `clang_saveTranslationUnit`, and `clang_reparseTranslationUnit` (using a proper enum) and throwing an exception in case they are erroneous.
- Catching BadMacroException instead of Throwable in the macro parser. We only care about the former, and catching Throwable could lead to too many exceptions being eaten. Technically, if there is an unknown exception, we could just skip the macro, but this isn't always the right strategy. For example, when re-parsing fails the used translation unit becomes invalid, so we really need to do something else than just skipping the macro in that case (to be addressed in another patch https://bugs.openjdk.java.net/browse/JDK-8240614). Imo it's better to just crash than to skip when we encounter an unknwon exception, so that we're more likely to find issues.
- Enabling libclang crash recovery by default. By default the crash recovery was being disabled. This leads to the process exiting with OS exception code. If we enable this however, it will instead try to return an error code from the libclang call, which we can then check for and handle the failure however we want.

Thanks,
Jorn
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * Athijegannathan Sundararajan ([sundar](@sundararajana) - Committer)

### Download
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/40/head:pull/40`
`$ git checkout pull/40`
