### PR TITLE
8240657: when Java keywords are used as identifiers in C header, jextract generates non-compilable java code

### DIFF
--- a/test/jdk/tools/jextract/Test8240657.java
+++ b/test/jdk/tools/jextract/Test8240657.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.nio.file.Path;
+import org.testng.annotations.Test;
+import static org.testng.Assert.assertNotNull;
+
+/*
+ * @test
+ * @modules jdk.incubator.jextract
+ * @build JextractToolRunner
+ * @bug 8240657
+ * @summary when Java keywords are used as identifiers in C header, jextract generates non-compilable java code
+ * @run testng Test8240657
+ */
+public class Test8240657 extends JextractToolRunner {
+    @Test
+    public void testKeywordIdentifiers() {
+        Path exportsOutput = getOutputFilePath("exportsgen");
+        Path exportsH = getInputFilePath("exports.h");
+        run("-d", exportsOutput.toString(), exportsH.toString()).checkSuccess();
+        try(Loader loader = classLoader(exportsOutput)) {
+            Class<?> cls = loader.loadClass("exports_h");
+            assertNotNull(cls);
+        } finally {
+            deleteDir(exportsOutput);
+        }
+    }
+}

--- a/test/jdk/tools/jextract/exports.h
+++ b/test/jdk/tools/jextract/exports.h
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+void foo(int boolean);
+
+int finally;
+
+struct abstract {
+    short is;
+    short throws;
+} abstract;
+
+typedef char Byte;
+void func(Byte byte, Byte* out);
+
+#define byte 1
+#define content byte + 1
+
+typedef struct {
+    short s1;
+    short s2;
+} Long;
+
+long twoShorts(Long s, Long* out, long* rv);


### PR DESCRIPTION
If java keywords are found to be used as C identifiers, "_" is appended.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [JDK-8240657](https://bugs.openjdk.java.net/browse/JDK-8240657): when Java keywords are used as identifiers in C header, jextract generates non-compilable java code


### Reviewers
 * Jorn Vernee ([jvernee](@JornVernee) - Committer)

### Download
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/41/head:pull/41`
`$ git checkout pull/41`
