### PR TITLE
8240752: jextract generates non-compilable code for special floating point values

### DIFF
--- a/src/jdk.incubator.jextract/share/classes/jdk/incubator/jextract/tool/JavaSourceBuilder.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/incubator/jextract/tool/JavaSourceBuilder.java
@@ -302,14 +302,28 @@ class JavaSourceBuilder {
             sb.append(PUB_MODS + type.getName() + " " + javaSafeIdentifier(name));
             sb.append(" = ");
             if (type == float.class) {
-                sb.append(value);
-                sb.append("f");
+                float f = ((Number)value).floatValue();
+                if (Float.isNaN(f)) {
+                    sb.append("Float.NaN");
+                } else if (Float.isInfinite(f)) {
+                    sb.append(f > 0? "Float.POSITIVE_INFINITY" : "Float.NEGATIVE_INFINITY");
+                } else {
+                    sb.append(value);
+                    sb.append("f");
+                }
             } else if (type == long.class) {
                 sb.append(value);
                 sb.append("L");
             } else if (type == double.class) {
-                sb.append(value);
-                sb.append("d");
+                double d = ((Number)value).doubleValue();
+                if (Double.isNaN(d)) {
+                    sb.append("Double.NaN");
+                } else if (Double.isInfinite(d)) {
+                    sb.append(d > 0? "Double.POSITIVE_INFINITY" : "Double.NEGATIVE_INFINITY");
+                } else {
+                   sb.append(value);
+                   sb.append("d");
+                }
             } else {
                 sb.append("(" + type.getName() + ")");
                 sb.append(value + "L");

--- a/test/jdk/tools/jextract/Test8240752.java
+++ b/test/jdk/tools/jextract/Test8240752.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.lang.reflect.Field;
+import java.nio.file.Path;
+import org.testng.annotations.Test;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+
+/*
+ * @test
+ * @modules jdk.incubator.jextract
+ * @build JextractToolRunner
+ * @bug 8240752
+ * @summary jextract generates non-compilable code for special floating point values
+ * @run testng Test8240752
+ */
+public class Test8240752 extends JextractToolRunner {
+    private float getFloatConstant(Class<?> cls, String name) {
+        Field field = findField(cls, name);
+        assertNotNull(field);
+        assertEquals(field.getType(), float.class);
+        try {
+            return (float)field.get(null);
+        } catch (Exception exp) {
+            System.err.println(exp);
+            assertTrue(false, "should not reach here");
+        }
+        return 0.0f;
+    }
+
+    private double getDoubleConstant(Class<?> cls, String name) {
+        Field field = findField(cls, name);
+        assertNotNull(field);
+        assertEquals(field.getType(), double.class);
+        try {
+            return (double)field.get(null);
+        } catch (Exception exp) {
+            System.err.println(exp);
+            assertTrue(false, "should not reach here");
+        }
+        return 0.0d;
+    }
+
+    @Test
+    public void testConstants() {
+        Path floatConstsOutput = getOutputFilePath("floatconstsgen");
+        Path floatConstsH = getInputFilePath("float_constants.h");
+        run("-d", floatConstsOutput.toString(), floatConstsH.toString()).checkSuccess();
+        try(Loader loader = classLoader(floatConstsOutput)) {
+            Class<?> cls = loader.loadClass("float_constants_h");
+            assertNotNull(cls);
+
+            double d = getDoubleConstant(cls, "NAN");
+            assertTrue(Double.isNaN(d));
+            d = getDoubleConstant(cls, "PINFINITY");
+            assertTrue(Double.isInfinite(d) && d > 0);
+            d = getDoubleConstant(cls, "NINFINITY");
+            assertTrue(Double.isInfinite(d) && d < 0);
+
+            float f = getFloatConstant(cls, "NANF");
+            assertTrue(Float.isNaN(f));
+            f = getFloatConstant(cls, "PINFINITYF");
+            assertTrue(Float.isInfinite(f) && f > 0);
+            f = getFloatConstant(cls, "NINFINITYF");
+            assertTrue(Float.isInfinite(f) && f < 0);
+        } finally {
+            deleteDir(floatConstsOutput);
+        }
+    }
+}

--- a/test/jdk/tools/jextract/float_constants.h
+++ b/test/jdk/tools/jextract/float_constants.h
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+#define NANF (0.0f/0.0f)
+#define PINFINITYF (1.0f/0.0f)
+#define NINFINITYF (-1.0f/0.0f)
+
+#define NAN (0.0/0.0)
+#define PINFINITY (1.0/0.0)
+#define NINFINITY (-1.0/0.0)


### PR DESCRIPTION
Generating static fields of Double and Float for special values.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [JDK-8240752](https://bugs.openjdk.java.net/browse/JDK-8240752): jextract generates non-compilable code for special floating point values


### Reviewers
 * Henry Jen ([henryjen](@slowhog) - Committer)

### Download
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/42/head:pull/42`
`$ git checkout pull/42`
