### PR TITLE
8240853: Declaration.union() method sets wrong kind for the declaration object created

### DIFF
--- a/src/jdk.incubator.jextract/share/classes/jdk/incubator/jextract/Declaration.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/incubator/jextract/Declaration.java
@@ -121,7 +121,7 @@ public interface Declaration {
          * @return The parameters associated with this function declaration.
          */
         List<Variable> parameters();
-        
+
         /**
          * The foreign type associated with this function declaration.
          * @return The foreign type associated with this function declaration.
@@ -446,7 +446,7 @@ public interface Declaration {
      */
     static Declaration.Scoped union(Position pos, String name, MemoryLayout layout, Declaration... decls) {
         List<Declaration> declList = Stream.of(decls).collect(Collectors.toList());
-        return new DeclarationImpl.ScopedImpl(Declaration.Scoped.Kind.STRUCT, layout, declList, name, pos);
+        return new DeclarationImpl.ScopedImpl(Declaration.Scoped.Kind.UNION, layout, declList, name, pos);
     }
 
     /**

--- a/test/jdk/java/jextract/JextractApiTestBase.java
+++ b/test/jdk/java/jextract/JextractApiTestBase.java
@@ -30,6 +30,7 @@ import jdk.incubator.jextract.JextractTask;
 import jdk.incubator.jextract.Type;
 
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
 
 public class JextractApiTestBase {
@@ -45,13 +46,26 @@ public class JextractApiTestBase {
         return task.parse(parseOptions);
     }
 
-    public static Declaration.Scoped checkStruct(Declaration.Scoped toplevel, String name, String... fields) {
-        Declaration.Scoped struct = findDecl(toplevel, name, Declaration.Scoped.class);
-        assertEquals(struct.members().size(), fields.length);
-        for (int i = 0 ; i < fields.length ; i++) {
-            assertEquals(struct.members().get(i).name(), fields[i]);
+    public static Declaration.Scoped checkScoped(Declaration.Scoped toplevel, String name, Declaration.Scoped.Kind kind,  String... fields) {
+        Declaration.Scoped scoped = findDecl(toplevel, name, Declaration.Scoped.class);
+        assertEquals(scoped.members().size(), fields.length);
+        assertTrue(scoped.kind() == kind);
+        for (int i = 0; i < fields.length; i++) {
+            assertEquals(scoped.members().get(i).name(), fields[i]);
         }
-        return struct;
+        return scoped;
+    }
+
+    public static Declaration.Scoped checkStruct(Declaration.Scoped toplevel, String name, String... fields) {
+        return checkScoped(toplevel, name, Declaration.Scoped.Kind.STRUCT, fields);
+    }
+
+    public static Declaration.Scoped checkBitfields(Declaration.Scoped toplevel, String name, String... fields) {
+        return checkScoped(toplevel, name, Declaration.Scoped.Kind.BITFIELDS, fields);
+    }
+
+    public static Declaration.Scoped checkUnion(Declaration.Scoped toplevel, String name, String... fields) {
+        return checkScoped(toplevel, name, Declaration.Scoped.Kind.UNION, fields);
     }
 
     public static Declaration.Variable checkConstant(Declaration.Scoped scope, String name, Type type) {

--- a/test/jdk/java/jextract/Test8240853.h
+++ b/test/jdk/java/jextract/Test8240853.h
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+union Foo {
+    int i;
+    long l;
+};

--- a/test/jdk/java/jextract/Test8240853.java
+++ b/test/jdk/java/jextract/Test8240853.java
@@ -28,32 +28,13 @@
  */
 
 import jdk.incubator.jextract.Declaration;
-import jdk.incubator.jextract.Type;
 import org.testng.annotations.Test;
 
-import static org.testng.Assert.*;
-
-public class Test8239490 extends JextractApiTestBase {
+public class Test8240853 extends JextractApiTestBase {
     @Test
-    public void test8239490() {
-        Declaration.Scoped d = parse("Test8239490.h");
+    public void test8240853() {
+        Declaration.Scoped d = parse("Test8240853.h");
         // check Foo
-        String[] fooBitfieldNames = { "a", "b", "c" };
-        int[] fooBitfieldSizes = { 1, 1, 30 };
-        Declaration.Scoped structFoo = checkStruct(d, "Foo", "");
-        Declaration.Scoped bitfieldsFoo = checkBitfields(structFoo, "", "a", "b", "c");
-        Type intType = ((Declaration.Variable)bitfieldsFoo.members().get(0)).type();
-        for (int i = 0 ; i < fooBitfieldNames.length ; i++) {
-            checkBitField(bitfieldsFoo, fooBitfieldNames[i], intType, fooBitfieldSizes[i]);
-        }
-        // check Bar
-        String[] barBitfieldNames = { "x", "y" };
-        int[] barBitfieldSizes = { 1, 31 };
-        Declaration.Scoped structBar = checkStruct(d, "Bar", "", "z");
-        Declaration.Scoped bitfieldsBar = checkBitfields(structBar, "", "x", "y");
-        for (int i = 0 ; i < barBitfieldNames.length ; i++) {
-            checkBitField(bitfieldsBar, barBitfieldNames[i], intType, barBitfieldSizes[i]);
-        }
-        checkField(structBar, "z", Type.array(1, Type.declared(structFoo)));
+        checkUnion(d, "Foo", "i", "l");
     }
 }


### PR DESCRIPTION
Fixing the Kind enum value
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [JDK-8240853](https://bugs.openjdk.java.net/browse/JDK-8240853): Declaration.union() method sets wrong kind for the declaration object created


### Reviewers
 * Maurizio Cimadamore ([mcimadamore](@mcimadamore) - Committer)

### Download
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/43/head:pull/43`
`$ git checkout pull/43`
