### PR TITLE
8240811: jextract generates non-compilable code for name collision between a struct and a global variable

### DIFF
--- a/src/jdk.incubator.jextract/share/classes/jdk/incubator/jextract/tool/HandleSourceFactory.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/incubator/jextract/tool/HandleSourceFactory.java
@@ -206,6 +206,7 @@ public class HandleSourceFactory implements Declaration.Visitor<Void, Declaratio
         assert !symbol.isEmpty();
         assert !fieldName.isEmpty();
 
+        // FIXME: we need tree transformer. The mangling should be a separate tree transform phase
         if (parent == null) {
             setMangledName(tree);
             fieldName = getMangledName(tree);
@@ -272,6 +273,7 @@ public class HandleSourceFactory implements Declaration.Visitor<Void, Declaratio
             return null;
         }
         String name = d.name();
+        // FIXME: we need tree transformer. The mangling should be a separate tree transform phase
         if (d.name().isEmpty() && parent != null) {
             name = getMangledName(parent);
         } else {

--- a/src/jdk.incubator.jextract/share/classes/jdk/incubator/jextract/tool/HandleSourceFactory.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/incubator/jextract/tool/HandleSourceFactory.java
@@ -34,7 +34,6 @@ import jdk.incubator.foreign.SystemABI;
 
 import javax.tools.JavaFileObject;
 import javax.tools.SimpleJavaFileObject;
-import java.io.File;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.lang.invoke.MethodType;
@@ -43,9 +42,10 @@ import java.net.URL;
 import java.net.URISyntaxException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Optional;
+import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -55,13 +55,60 @@ import java.util.stream.Collectors;
  * particular Tree is processed or skipped.
  */
 public class HandleSourceFactory implements Declaration.Visitor<Void, Declaration> {
-
     private final Set<String> constants = new HashSet<>();
+    // To detect duplicate Variable and Function declarations.
+    private final Set<Declaration.Variable> variables = new HashSet<>();
+    private final Set<Declaration.Function> functions = new HashSet<>();
+
+    private final Set<String> structsAndVars = new HashSet<>();
+    private final Map<String, String> mangledNames = new HashMap<>();
+
     protected final JavaSourceBuilder builder = new JavaSourceBuilder();
     protected final TypeTranslator typeTranslator = new TypeTranslator();
     private final List<String> libraryNames;
     private final String clsName;
     private final String pkgName;
+
+    // have we visited this Variable earlier?
+    protected boolean visitedVariable(Declaration.Variable tree) {
+        return !variables.add(tree);
+    }
+
+    // have we visited this Function earlier?
+    protected boolean visitedFunction(Declaration.Function tree) {
+        return !functions.add(tree);
+    }
+
+    // have we visited a struct/union or a global variable of given name?
+    protected boolean visitedStructOrVariable(String name) {
+        return !structsAndVars.add(name);
+    }
+
+    private void setMangledName(String name, String prefix) {
+        if (!name.isEmpty() && visitedStructOrVariable(name)) {
+            mangledNames.put(name, prefix + name);
+        }
+    }
+
+    protected void setMangledName(Declaration.Scoped d) {
+        switch (d.kind()) {
+            case STRUCT:
+                setMangledName(d.name(), "struct$");
+                break;
+            case UNION:
+                setMangledName(d.name(), "union$");
+                break;
+        }
+    }
+
+    protected void setMangledName(Declaration.Variable v) {
+        setMangledName(v.name(), "var$");
+    }
+
+    protected String getMangledName(Declaration d) {
+        String name = d.name();
+        return name.isEmpty()? name : mangledNames.getOrDefault(name, name);
+    }
 
     static JavaFileObject[] generateRaw(Declaration.Scoped decl, String clsName, String pkgName, List<String> libraryNames) {
         return new HandleSourceFactory(clsName, pkgName, libraryNames).generate(decl);
@@ -150,10 +197,20 @@ public class HandleSourceFactory implements Declaration.Visitor<Void, Declaratio
 
     @Override
     public Void visitVariable(Declaration.Variable tree, Declaration parent) {
+        if (parent == null && visitedVariable(tree)) {
+            return null;
+        }
+
         String fieldName = tree.name();
         String symbol = tree.name();
         assert !symbol.isEmpty();
         assert !fieldName.isEmpty();
+
+        if (parent == null) {
+            setMangledName(tree);
+            fieldName = getMangledName(tree);
+        }
+
         Type type = tree.type();
         MemoryLayout layout = tree.layout().orElse(Type.layoutFor(type).orElse(null));
         if (layout == null) {
@@ -169,7 +226,7 @@ public class HandleSourceFactory implements Declaration.Visitor<Void, Declaratio
 
         if (parent != null) {
             //struct field
-            builder.addVarHandle(fieldName, clazz, parent.name());
+            builder.addVarHandle(fieldName, clazz, getMangledName(parent));
         } else {
             builder.addLayout(fieldName, layout);
             builder.addVarHandle(fieldName, clazz, null);
@@ -181,6 +238,10 @@ public class HandleSourceFactory implements Declaration.Visitor<Void, Declaratio
 
     @Override
     public Void visitFunction(Declaration.Function funcTree, Declaration parent) {
+        if (visitedFunction(funcTree)) {
+            return null;
+        }
+
         FunctionDescriptor descriptor = Type.descriptorFor(funcTree.type()).orElse(null);
         if (descriptor == null) {
             //abort
@@ -212,16 +273,19 @@ public class HandleSourceFactory implements Declaration.Visitor<Void, Declaratio
         }
         String name = d.name();
         if (d.name().isEmpty() && parent != null) {
-            name = parent.name();
+            name = getMangledName(parent);
+        } else {
+            setMangledName(d);
+            name = getMangledName(d);
         }
-
         if (!d.name().isEmpty() || !isRecord(parent)) {
             //only add explicit struct layout if the struct is not to be flattened inside another struct
             switch (d.kind()) {
                 case STRUCT:
-                case UNION:
+                case UNION: {
                     builder.addLayout(name, d.layout().get());
                     break;
+                }
             }
         }
         d.members().forEach(fieldTree -> fieldTree.accept(this, d.name().isEmpty() ? parent : d));

--- a/src/jdk.incubator.jextract/share/classes/jdk/incubator/jextract/tool/JavaSourceBuilder.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/incubator/jextract/tool/JavaSourceBuilder.java
@@ -448,11 +448,11 @@ class JavaSourceBuilder {
         decrAlign();
     }
 
-    void addGetter(String name, Class<?> type, Declaration parent) {
+    void addGetter(String name, Class<?> type, String parent) {
         incrAlign();
         indent();
         name = javaSafeIdentifier(name);
-        String vhName = (parent != null ? (javaSafeIdentifier(parent.name()) + "$") : "") + name;
+        String vhName = (parent != null ? (javaSafeIdentifier(parent) + "$") : "") + name;
         String param = parent != null ? (MemorySegment.class.getName() + " seg") : "";
         sb.append(PUB_MODS + type.getName() + " " + vhName + "$get(" + param + ") {\n");
         incrAlign();
@@ -466,11 +466,11 @@ class JavaSourceBuilder {
         decrAlign();
     }
 
-    void addSetter(String name, Class<?> type, Declaration parent) {
+    void addSetter(String name, Class<?> type, String parent) {
         incrAlign();
         indent();
         name = javaSafeIdentifier(name);
-        String vhName = (parent != null ? (javaSafeIdentifier(parent.name()) + "$") : "") + name;
+        String vhName = (parent != null ? (javaSafeIdentifier(parent) + "$") : "") + name;
         String param = parent != null ? (MemorySegment.class.getName() + " seg, ") : "";
         sb.append(PUB_MODS + "void " + vhName + "$set(" + param + type.getName() + " x) {\n");
         incrAlign();

--- a/src/jdk.incubator.jextract/share/classes/jdk/incubator/jextract/tool/StaticWrapperSourceFactory.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/incubator/jextract/tool/StaticWrapperSourceFactory.java
@@ -104,6 +104,7 @@ public class StaticWrapperSourceFactory extends HandleSourceFactory {
         assert !symbol.isEmpty();
         assert !fieldName.isEmpty();
 
+        // FIXME: we need tree transformer. The mangling should be a separate tree transform phase
         if (parent == null) {
             setMangledName(tree);
             fieldName = getMangledName(tree);

--- a/src/jdk.incubator.jextract/share/classes/jdk/incubator/jextract/tool/StaticWrapperSourceFactory.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/incubator/jextract/tool/StaticWrapperSourceFactory.java
@@ -26,9 +26,7 @@
 package jdk.incubator.jextract.tool;
 
 import java.lang.invoke.MethodType;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 import jdk.incubator.foreign.FunctionDescriptor;
 import jdk.incubator.foreign.MemoryAddress;
 import jdk.incubator.foreign.MemoryLayout;
@@ -37,9 +35,6 @@ import jdk.incubator.jextract.Declaration;
 import jdk.incubator.jextract.Type;
 
 public class StaticWrapperSourceFactory extends HandleSourceFactory {
-    private final Set<Declaration.Variable> variables = new HashSet<>();
-    private final Set<Declaration.Function> functions = new HashSet<>();
-
     public StaticWrapperSourceFactory(String clsName, String pkgName, List<String> libraryNames) {
         super(clsName, pkgName, libraryNames);
     }
@@ -51,9 +46,10 @@ public class StaticWrapperSourceFactory extends HandleSourceFactory {
 
     @Override
     public Void visitFunction(Declaration.Function funcTree, Declaration parent) {
-        if (! functions.add(funcTree)) {
+        if (visitedFunction(funcTree)) {
             return null;
         }
+
         MethodType mtype = typeTranslator.getMethodType(funcTree.type());
         FunctionDescriptor descriptor = Type.descriptorFor(funcTree.type()).orElse(null);
         if (descriptor == null) {
@@ -99,7 +95,7 @@ public class StaticWrapperSourceFactory extends HandleSourceFactory {
 
     @Override
     public Void visitVariable(Declaration.Variable tree, Declaration parent) {
-        if (parent == null && !(variables.add(tree))) {
+        if (parent == null && visitedVariable(tree)) {
             return null;
         }
 
@@ -107,6 +103,12 @@ public class StaticWrapperSourceFactory extends HandleSourceFactory {
         String symbol = tree.name();
         assert !symbol.isEmpty();
         assert !fieldName.isEmpty();
+
+        if (parent == null) {
+            setMangledName(tree);
+            fieldName = getMangledName(tree);
+        }
+
         Type type = tree.type();
         MemoryLayout layout = tree.layout().orElse(Type.layoutFor(type).orElse(null));
         if (layout == null) {
@@ -120,17 +122,18 @@ public class StaticWrapperSourceFactory extends HandleSourceFactory {
             return null;
         }
 
+        String parentName = parent != null? getMangledName(parent) : null;
         if (parent != null) {
             //struct field
-            builder.addVarHandle(fieldName, clazz, parent.name());
+            builder.addVarHandle(fieldName, clazz, parentName);
         } else {
             builder.addLayout(fieldName, layout);
             builder.addVarHandle(fieldName, clazz, null);
             builder.addAddress(fieldName);
         }
         //add getter and setters
-        builder.addGetter(fieldName, clazz, parent);
-        builder.addSetter(fieldName, clazz, parent);
+        builder.addGetter(fieldName, clazz, parentName);
+        builder.addSetter(fieldName, clazz, parentName);
 
         return null;
     }

--- a/test/jdk/tools/jextract/Test8240811.java
+++ b/test/jdk/tools/jextract/Test8240811.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.nio.file.Path;
+import jdk.incubator.foreign.GroupLayout;
+import jdk.incubator.foreign.MemoryLayout;
+import jdk.incubator.foreign.SystemABI.Type;
+import org.testng.annotations.Test;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+
+/*
+ * @test
+ * @modules jdk.incubator.jextract
+ * @build JextractToolRunner
+ * @bug 8240811
+ * @summary jextract generates non-compilable code for name collision between a struct and a global variable
+ * @run testng Test8240811
+ */
+public class Test8240811 extends JextractToolRunner {
+    @Test
+    public void testNameCollision() {
+        Path nameCollisionOutput = getOutputFilePath("name_collision_gen");
+        Path nameCollisionH = getInputFilePath("name_collision.h");
+        run("-d", nameCollisionOutput.toString(), nameCollisionH.toString()).checkSuccess();
+        try(Loader loader = classLoader(nameCollisionOutput)) {
+            Class<?> cls = loader.loadClass("name_collision_h");
+            assertNotNull(cls);
+
+            // check foo layout
+            MemoryLayout fooLayout = findLayout(cls, "foo");
+            assertNotNull(fooLayout);
+            assertTrue(((GroupLayout)fooLayout).isStruct());
+            checkFieldABIType(fooLayout, "x",  Type.INT);
+            checkFieldABIType(fooLayout, "y",  Type.INT);
+            checkFieldABIType(fooLayout, "z",  Type.INT);
+
+            MemoryLayout fooVarLayout = findLayout(cls, "var$foo");
+            assertNotNull(fooVarLayout);
+
+            // check foo2 layout
+            MemoryLayout foo2Layout = findLayout(cls, "foo2");
+            assertNotNull(foo2Layout);
+            assertTrue(((GroupLayout)foo2Layout).isUnion());
+            checkFieldABIType(foo2Layout, "i",  Type.INT);
+            checkFieldABIType(foo2Layout, "l",  Type.LONG);
+
+            MemoryLayout foo2VarLayout = findLayout(cls, "var$foo2");
+            assertNotNull(foo2VarLayout);
+
+            MemoryLayout barVarLayout = findLayout(cls, "bar");
+            assertNotNull(barVarLayout);
+
+            // check bar layout
+            MemoryLayout barLayout = findLayout(cls, "struct$bar");
+            assertNotNull(barLayout);
+            assertTrue(((GroupLayout)barLayout).isStruct());
+            checkFieldABIType(barLayout, "f1",  Type.FLOAT);
+            checkFieldABIType(barLayout, "f2",  Type.FLOAT);
+
+            MemoryLayout bar2VarLayout = findLayout(cls, "bar2");
+            assertNotNull(bar2VarLayout);
+
+            // check bar layout
+            MemoryLayout bar2Layout = findLayout(cls, "union$bar2");
+            assertNotNull(bar2Layout);
+            assertTrue(((GroupLayout)bar2Layout).isUnion());
+            checkFieldABIType(bar2Layout, "f",  Type.FLOAT);
+            checkFieldABIType(bar2Layout, "d",  Type.DOUBLE);
+        } finally {
+            deleteDir(nameCollisionOutput);
+        }
+    }
+}

--- a/test/jdk/tools/jextract/name_collision.h
+++ b/test/jdk/tools/jextract/name_collision.h
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+struct foo {
+  int x;
+  int y;
+  int z;
+};
+
+// variable name clashing with struct name declared earlier
+long foo;
+
+union foo2 {
+   int i;
+   long l;
+};
+
+// variable name clashing with union name declared earlier
+char foo2;
+
+int bar;
+
+// struct name clashing with variable name declared earlier
+struct bar {
+   float f1;
+   float f2;
+};
+
+int bar2;
+
+// union name clashing with variable name declared earlier
+union bar2 {
+   float f;
+   double d;
+};


### PR DESCRIPTION
names are mangled when there are collisions.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [JDK-8240811](https://bugs.openjdk.java.net/browse/JDK-8240811): jextract generates non-compilable code for name collision between a struct and a global variable


### Reviewers
 * Maurizio Cimadamore ([mcimadamore](@mcimadamore) - Committer)

### Download
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/44/head:pull/44`
`$ git checkout pull/44`
