### PR TITLE
8240874: Add finer-grained access control for memory segments

### DIFF
--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/MemoryAddress.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/MemoryAddress.java
@@ -108,7 +108,9 @@ public interface MemoryAddress {
      * associated with either {@code src} or {@code dst}.
      * @throws IllegalStateException if either the source address or the target address belong to memory segments
      * which have been already closed, or if access occurs from a thread other than the thread owning either segment.
-     * @throws UnsupportedOperationException if {@code dst} is associated with a read-only segment (see {@link MemorySegment#isReadOnly()}).
+     * @throws UnsupportedOperationException if either {@code src} or {@code dst} do not feature required access modes;
+     * more specifically, {@code src} should be associated with a segment with {@link MemorySegment#READ} access mode,
+     * while {@code dst} should be associated with a segment with {@link MemorySegment#WRITE} access mode.
      */
     static void copy(MemoryAddress src, MemoryAddress dst, long bytes) {
         MemoryAddressImpl.copy((MemoryAddressImpl)src, (MemoryAddressImpl)dst, bytes);

--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/MemorySegment.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/MemorySegment.java
@@ -102,17 +102,34 @@ import java.nio.file.Path;
  * explicitly close the original segment from which the acquired memory segments have been obtained in order to truly
  * ensure that off-heap resources associated with the memory segment are released.
  *
+ * <h2><a id = "access-modes">Access modes</a></h2>
+ *
+ * Memory segments supports zero or more <em>access modes</em>. Supported access modes are {@link #READ},
+ * {@link #WRITE}, {@link #CLOSE} and {@link #ACQUIRE}. The set of access modes supported by a segment alters the
+ * set of operations that are supported by that segment. For instance, attempting to call {@link #close()} on
+ * a segment which does not support the {@link #CLOSE} access mode will result in an exception.
+ * <p>
+ * The set of supported access modes can only be made stricter (by supporting <em>less</em> access modes). This means
+ * that restricting the set of access modes supported by a segment before sharing it with other clients
+ * is generally a good practice if the creator of the segment wants to retain some control over how the segment
+ * is going to be accessed.
+ *
  * <h2>Memory segment views</h2>
  *
- * Memory segments support <em>views</em>. It is possible to create an <em>immutable</em> view of a memory segment
- * (see {@link MemorySegment#asReadOnly()}) which does not support write operations. It is also possible to create views
- * whose spatial bounds are stricter than the ones of the original segment (see {@link MemorySegment#asSlice(long, long)}).
+ * Memory segments support <em>views</em>. For instance, it is possible to alter the set of supported access modes,
+ * by creating an <em>immutable</em> view of a memory segment, as follows:
+ * <blockquote><pre>{@code
+MemorySegment segment = ...
+MemorySegment roSegment = segment.withAccessModes(segment.accessModes() & ~WRITE);
+ * }</pre></blockquote>
+ * It is also possible to create views whose spatial bounds are stricter than the ones of the original segment
+ * (see {@link MemorySegment#asSlice(long, long)}).
  * <p>
  * Temporal bounds of the original segment are inherited by the view; that is, closing a segment view, such as a sliced
  * view, will cause the original segment to be closed; as such special care must be taken when sharing views
  * between multiple clients. If a client want to protect itself against early closure of a segment by
- * another actor, it is the responsibility of that client to take protective measures, such as calling
- * {@link MemorySegment#acquire()} before sharing the view with another client.
+ * another actor, it is the responsibility of that client to take protective measures, such as removing {@link #CLOSE}
+ * from the set of supported access modes, before sharing the view with another client.
  * <p>
  * To allow for interoperability with existing code, a byte buffer view can be obtained from a memory segment
  * (see {@link #asByteBuffer()}). This can be useful, for instance, for those clients that want to keep using the
@@ -157,13 +174,23 @@ public interface MemorySegment extends AutoCloseable {
     long byteSize();
 
     /**
-     * Obtains a read-only view of this segment. An attempt to write memory associated with a read-only memory segment
-     * will fail with {@link UnsupportedOperationException}.
-     * @return a read-only view of this segment.
-     * @throws IllegalStateException if this segment has been closed, or if access occurs from a thread other than the
-     * thread owning this segment.
+     * Obtains a segment view with specific <a href="#access-modes">access modes</a>. Supported access modes are {@link #READ}, {@link #WRITE},
+     * {@link #CLOSE} and {@link #ACQUIRE}. It is generally not possible to go from a segment with stricter access modes
+     * to one with less strict access modes. For instance, attempting to add {@link #WRITE} access mode to a read-only segment
+     * will be met with an exception.
+     * @param accessModes an ORed mask of zero or more access modes.
+     * @return a segment view with specific access modes.
+     * @throws UnsupportedOperationException when {@code mask} is an access mask which is less strict than the one supported by this
+     * segment.
      */
-    MemorySegment asReadOnly();
+    MemorySegment withAccessModes(int accessModes);
+
+    /**
+     * Returns the <a href="#access-modes">access modes</a> associated with this segment; the result is represented as ORed values from
+     * {@link #READ}, {@link #WRITE}, {@link #CLOSE} and {@link #ACQUIRE}.
+     * @return the access modes associated with this segment.
+     */
+    int accessModes();
 
     /**
      * Obtains a new memory segment view whose base address is the same as the base address of this segment plus a given offset,
@@ -172,8 +199,6 @@ public interface MemorySegment extends AutoCloseable {
      * @param newSize The new segment size, specified in bytes.
      * @return a new memory segment view with updated base/limit addresses.
      * @throws IndexOutOfBoundsException if {@code offset < 0}, {@code offset > byteSize()}, {@code newSize < 0}, or {@code newSize > byteSize() - offset}
-     * @throws IllegalStateException if this segment has been closed, or if access occurs from a thread other than the
-     * thread owning this segment.
      */
     MemorySegment asSlice(long offset, long newSize);
 
@@ -185,26 +210,20 @@ public interface MemorySegment extends AutoCloseable {
     boolean isAlive();
 
     /**
-     * Is this segment read-only?
-     * @return true, if the segment is read-only.
-     * @see MemorySegment#asReadOnly()
-     */
-    boolean isReadOnly();
-
-    /**
      * Closes this memory segment. Once a memory segment has been closed, any attempt to use the memory segment,
      * or to access the memory associated with the segment will fail with {@link IllegalStateException}. Depending on
      * the kind of memory segment being closed, calling this method further trigger deallocation of all the resources
      * associated with the memory segment.
-     * @throws IllegalStateException if this segment has been closed, or if access occurs from a thread other than the
-     * thread owning this segment, or if existing acquired views of this segment are still in use (see {@link MemorySegment#acquire()}).
+     * @throws IllegalStateException if this segment is not <em>alive</em>, or if access occurs from a thread other than the
+     * thread owning this segment.
+     * @throws UnsupportedOperationException if this segment does not support the {@link #CLOSE} access mode.
      */
     void close();
 
     /**
      * Wraps this segment in a {@link ByteBuffer}. Some of the properties of the returned buffer are linked to
      * the properties of this segment. For instance, if this segment is <em>immutable</em>
-     * (see {@link MemorySegment#asReadOnly()}, then the resulting buffer is <em>read-only</em>
+     * (e.g. the segment has access mode {@link #READ} but not {@link #WRITE}), then the resulting buffer is <em>read-only</em>
      * (see {@link ByteBuffer#isReadOnly()}. Additionally, if this is a native memory segment, the resulting buffer is
      * <em>direct</em> (see {@link ByteBuffer#isDirect()}).
      * <p>
@@ -218,9 +237,7 @@ public interface MemorySegment extends AutoCloseable {
      * @return a {@link ByteBuffer} view of this memory segment.
      * @throws UnsupportedOperationException if this segment cannot be mapped onto a {@link ByteBuffer} instance,
      * e.g. because it models an heap-based segment that is not based on a {@code byte[]}), or if its size is greater
-     * than {@link Integer#MAX_VALUE}.
-     * @throws IllegalStateException if this segment has been closed, or if access occurs from a thread other than the
-     * thread owning this segment.
+     * than {@link Integer#MAX_VALUE}, or if the segment does not support the {@link #READ} access mode.
      */
     ByteBuffer asByteBuffer();
 
@@ -365,7 +382,7 @@ public interface MemorySegment extends AutoCloseable {
      * <p>
      * This is equivalent to the following code:
      * <blockquote><pre>{@code
-    allocateNative(bytesSize, 1);
+allocateNative(bytesSize, 1);
      * }</pre></blockquote>
      *
      * @implNote The block of off-heap memory associated with the returned native memory segment is initialized to zero.
@@ -424,4 +441,34 @@ public interface MemorySegment extends AutoCloseable {
 
         return Utils.makeNativeSegment(bytesSize, alignmentBytes);
     }
+
+    // access mode masks
+
+    /**
+     * Read access mode; read operations are supported by a segment which supports this access mode.
+     * @see MemorySegment#accessModes()
+     * @see MemorySegment#withAccessModes(int)
+     */
+    int READ = 1;
+
+    /**
+     * Write access mode; write operations are supported by a segment which supports this access mode.
+     * @see MemorySegment#accessModes()
+     * @see MemorySegment#withAccessModes(int)
+     */
+    int WRITE = READ << 1;
+
+    /**
+     * Close access mode; calling {@link #close()} is supported by a segment which supports this access mode.
+     * @see MemorySegment#accessModes()
+     * @see MemorySegment#withAccessModes(int)
+     */
+    int CLOSE = WRITE << 1;
+
+    /**
+     * Acquire access mode; calling {@link #acquire()} is supported by a segment which supports this access mode.
+     * @see MemorySegment#accessModes()
+     * @see MemorySegment#withAccessModes(int)
+     */
+    int ACQUIRE = CLOSE << 1;
 }

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/MemorySegmentImpl.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/MemorySegmentImpl.java
@@ -35,6 +35,8 @@ import jdk.internal.misc.Unsafe;
 import jdk.internal.vm.annotation.ForceInline;
 
 import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Objects;
 import java.util.Random;
 
@@ -58,11 +60,16 @@ public final class MemorySegmentImpl implements MemorySegment, MemorySegmentProx
     final Thread owner;
     final MemoryScope scope;
 
-    final static int READ_ONLY = 1;
-    final static int SMALL = READ_ONLY << 1;
+    final static int SMALL = ACQUIRE << 1;
     final static long NONCE = new Random().nextLong();
 
-    public MemorySegmentImpl(long min, Object base, long length, int mask, Thread owner, MemoryScope scope) {
+    final static int DEFAULT_MASK = READ | WRITE | CLOSE | ACQUIRE;
+
+    public MemorySegmentImpl(long min, Object base, long length, Thread owner, MemoryScope scope) {
+        this(min, base, length, DEFAULT_MASK, owner, scope);
+    }
+
+    private MemorySegmentImpl(long min, Object base, long length, int mask, Thread owner, MemoryScope scope) {
         this.length = length;
         this.mask = length > Integer.MAX_VALUE ? mask : (mask | SMALL);
         this.min = min;
@@ -75,13 +82,15 @@ public final class MemorySegmentImpl implements MemorySegment, MemorySegmentProx
 
     @Override
     public final MemorySegmentImpl asSlice(long offset, long newSize) {
-        checkValidState();
         checkBounds(offset, newSize);
         return new MemorySegmentImpl(min + offset, base, newSize, mask, owner, scope);
     }
 
     @Override
     public MemorySegment acquire() {
+        if (!isSet(ACQUIRE)) {
+            throw unsupportedAccessMode(ACQUIRE);
+        }
         return new MemorySegmentImpl(min, base, length, mask, Thread.currentThread(), scope.acquire());
     }
 
@@ -97,19 +106,8 @@ public final class MemorySegmentImpl implements MemorySegment, MemorySegmentProx
     }
 
     @Override
-    public final MemorySegmentImpl asReadOnly() {
-        checkValidState();
-        return new MemorySegmentImpl(min, base, length, mask | READ_ONLY, owner, scope);
-    }
-
-    @Override
     public final boolean isAlive() {
         return scope.isAliveThreadSafe();
-    }
-
-    @Override
-    public final boolean isReadOnly() {
-        return isSet(READ_ONLY);
     }
 
     @Override
@@ -119,13 +117,18 @@ public final class MemorySegmentImpl implements MemorySegment, MemorySegmentProx
 
     @Override
     public final void close() {
+        if (!isSet(CLOSE)) {
+            throw unsupportedAccessMode(CLOSE);
+        }
         checkValidState();
         scope.close();
     }
 
     @Override
     public ByteBuffer asByteBuffer() {
-        checkValidState();
+        if (!isSet(READ)) {
+            throw unsupportedAccessMode(READ);
+        }
         checkIntSize("ByteBuffer");
         JavaNioAccess nioAccess = SharedSecrets.getJavaNioAccess();
         ByteBuffer _bb;
@@ -137,7 +140,7 @@ public final class MemorySegmentImpl implements MemorySegment, MemorySegmentProx
         } else {
             _bb = nioAccess.newDirectByteBuffer(min, (int) length, null, this);
         }
-        if (isReadOnly()) {
+        if (!isSet(WRITE)) {
             //scope is IMMUTABLE - obtain a RO byte buffer
             _bb = _bb.asReadOnlyBuffer();
         }
@@ -145,8 +148,20 @@ public final class MemorySegmentImpl implements MemorySegment, MemorySegmentProx
     }
 
     @Override
+    public MemorySegment withAccessModes(int accessModes) {
+        if ((~this.mask & accessModes) != 0) {
+            throw new UnsupportedOperationException("Cannot acquire more access modes");
+        }
+        return new MemorySegmentImpl(min, base, length, accessModes, owner, scope);
+    }
+
+    @Override
+    public int accessModes() {
+        return mask;
+    }
+
+    @Override
     public byte[] toByteArray() {
-        checkValidState();
         checkIntSize("byte[]");
         byte[] arr = new byte[(int)length];
         MemorySegment arrSegment = MemorySegment.ofArray(arr);
@@ -179,8 +194,10 @@ public final class MemorySegmentImpl implements MemorySegment, MemorySegmentProx
 
     void checkRange(long offset, long length, boolean writeAccess) {
         checkValidState();
-        if (isReadOnly() && writeAccess) {
-            throw new UnsupportedOperationException("Cannot write to read-only memory segment");
+        if (writeAccess && !isSet(WRITE)) {
+            throw unsupportedAccessMode(WRITE);
+        } else if (!writeAccess && !isSet(READ)) {
+            throw unsupportedAccessMode(READ);
         }
         checkBounds(offset, length);
     }
@@ -218,6 +235,28 @@ public final class MemorySegmentImpl implements MemorySegment, MemorySegmentProx
                 offset > (int)this.length - length) { // careful of overflow
             throw outOfBoundException(offset, length);
         }
+    }
+
+    UnsupportedOperationException unsupportedAccessMode(int expected) {
+        return new UnsupportedOperationException((String.format("Required access mode %s ; current access modes: %s",
+                modeStrings(expected).get(0), modeStrings(mask))));
+    }
+
+    private List<String> modeStrings(int mode) {
+        List<String> modes = new ArrayList<>();
+        if ((mode & READ) != 0) {
+            modes.add("READ");
+        }
+        if ((mode & WRITE) != 0) {
+            modes.add("WRITE");
+        }
+        if ((mode & CLOSE) != 0) {
+            modes.add("CLOSE");
+        }
+        if ((mode & ACQUIRE) != 0) {
+            modes.add("ACQUIRE");
+        }
+        return modes;
     }
 
     private IndexOutOfBoundsException outOfBoundException(long offset, long length) {

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/Utils.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/Utils.java
@@ -101,7 +101,7 @@ public final class Utils {
         }
         long alignedBuf = Utils.alignUp(buf, alignmentBytes);
         MemoryScope scope = new MemoryScope(null, () -> unsafe.freeMemory(buf));
-        MemorySegment segment = new MemorySegmentImpl(buf, null, alignedSize, 0, Thread.currentThread(), scope);
+        MemorySegment segment = new MemorySegmentImpl(buf, null, alignedSize, Thread.currentThread(), scope);
         if (alignedBuf != buf) {
             long delta = alignedBuf - buf;
             segment = segment.asSlice(delta, bytesSize);
@@ -139,7 +139,7 @@ public final class Utils {
 
     private static MemorySegment makeArraySegment(Object arr, int size, int base, int scale) {
         MemoryScope scope = new MemoryScope(null, null);
-        return new MemorySegmentImpl(base, arr, size * scale, 0, Thread.currentThread(), scope);
+        return new MemorySegmentImpl(base, arr, size * scale, Thread.currentThread(), scope);
     }
 
     public static MemorySegment makeBufferSegment(ByteBuffer bb) {
@@ -150,7 +150,7 @@ public final class Utils {
         int limit = bb.limit();
 
         MemoryScope bufferScope = new MemoryScope(bb, null);
-        return new MemorySegmentImpl(bbAddress + pos, base, limit - pos, 0, Thread.currentThread(), bufferScope);
+        return new MemorySegmentImpl(bbAddress + pos, base, limit - pos, Thread.currentThread(), bufferScope);
     }
 
     // create and map a file into a fresh segment
@@ -159,7 +159,7 @@ public final class Utils {
         try (FileChannelImpl channelImpl = (FileChannelImpl)FileChannel.open(path, openOptions(mapMode))) {
             UnmapperProxy unmapperProxy = channelImpl.mapInternal(mapMode, 0L, bytesSize);
             MemoryScope scope = new MemoryScope(null, unmapperProxy::unmap);
-            return new MemorySegmentImpl(unmapperProxy.address(), null, bytesSize, 0, Thread.currentThread(), scope);
+            return new MemorySegmentImpl(unmapperProxy.address(), null, bytesSize, Thread.currentThread(), scope);
         }
     }
 

--- a/test/jdk/java/foreign/TestByteBuffer.java
+++ b/test/jdk/java/foreign/TestByteBuffer.java
@@ -390,7 +390,8 @@ public class TestByteBuffer {
         try (MemorySegment segment = MemorySegment.allocateNative(bytes)) {
             leaked = segment;
         }
-        leaked.asByteBuffer();
+        ByteBuffer byteBuffer = leaked.asByteBuffer(); // ok
+        byteBuffer.get(); // should throw
     }
 
     @Test(expectedExceptions = { UnsupportedOperationException.class,

--- a/test/jdk/java/foreign/TestMemoryAccess.java
+++ b/test/jdk/java/foreign/TestMemoryAccess.java
@@ -84,14 +84,15 @@ public class TestMemoryAccess {
     private void testAccessInternal(Function<MemorySegment, MemorySegment> viewFactory, MemoryLayout layout, VarHandle handle, Checker checker) {
         MemoryAddress outer_address;
         try (MemorySegment segment = viewFactory.apply(MemorySegment.allocateNative(layout))) {
+            boolean isRO = (segment.accessModes() & MemorySegment.WRITE) == 0;
             MemoryAddress addr = segment.baseAddress();
             try {
                 checker.check(handle, addr);
-                if (segment.isReadOnly()) {
+                if (isRO) {
                     throw new AssertionError(); //not ok, memory should be immutable
                 }
             } catch (UnsupportedOperationException ex) {
-                if (!segment.isReadOnly()) {
+                if (!isRO) {
                     throw new AssertionError(); //we should not have failed!
                 }
                 return;
@@ -115,16 +116,17 @@ public class TestMemoryAccess {
     private void testArrayAccessInternal(Function<MemorySegment, MemorySegment> viewFactory, SequenceLayout seq, VarHandle handle, ArrayChecker checker) {
         MemoryAddress outer_address;
         try (MemorySegment segment = viewFactory.apply(MemorySegment.allocateNative(seq))) {
+            boolean isRO = (segment.accessModes() & MemorySegment.WRITE) == 0;
             MemoryAddress addr = segment.baseAddress();
             try {
                 for (int i = 0; i < seq.elementCount().getAsLong(); i++) {
                     checker.check(handle, addr, i);
                 }
-                if (segment.isReadOnly()) {
+                if (isRO) {
                     throw new AssertionError(); //not ok, memory should be immutable
                 }
             } catch (UnsupportedOperationException ex) {
-                if (!segment.isReadOnly()) {
+                if (!isRO) {
                     throw new AssertionError(); //we should not have failed!
                 }
                 return;
@@ -183,6 +185,7 @@ public class TestMemoryAccess {
     private void testMatrixAccessInternal(Function<MemorySegment, MemorySegment> viewFactory, SequenceLayout seq, VarHandle handle, MatrixChecker checker) {
         MemoryAddress outer_address;
         try (MemorySegment segment = viewFactory.apply(MemorySegment.allocateNative(seq))) {
+            boolean isRO = (segment.accessModes() & MemorySegment.WRITE) == 0;
             MemoryAddress addr = segment.baseAddress();
             try {
                 for (int i = 0; i < seq.elementCount().getAsLong(); i++) {
@@ -190,11 +193,11 @@ public class TestMemoryAccess {
                         checker.check(handle, addr, i, j);
                     }
                 }
-                if (segment.isReadOnly()) {
+                if (isRO) {
                     throw new AssertionError(); //not ok, memory should be immutable
                 }
             } catch (UnsupportedOperationException ex) {
-                if (!segment.isReadOnly()) {
+                if (!isRO) {
                     throw new AssertionError(); //we should not have failed!
                 }
                 return;
@@ -217,7 +220,7 @@ public class TestMemoryAccess {
     }
 
     static Function<MemorySegment, MemorySegment> ID = Function.identity();
-    static Function<MemorySegment, MemorySegment> IMMUTABLE = MemorySegment::asReadOnly;
+    static Function<MemorySegment, MemorySegment> IMMUTABLE = ms -> ms.withAccessModes(MemorySegment.READ | MemorySegment.CLOSE);
 
     @DataProvider(name = "elements")
     public Object[][] createData() {

--- a/test/jdk/java/foreign/TestSegments.java
+++ b/test/jdk/java/foreign/TestSegments.java
@@ -38,6 +38,7 @@ import java.nio.ByteOrder;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Consumer;
 import java.util.function.LongFunction;
 import java.util.stream.Stream;
 
@@ -121,6 +122,21 @@ public class TestSegments {
         }
     }
 
+    @Test(dataProvider = "accessModes")
+    public void testAccessModes(int accessModes) {
+        int[] arr = new int[1];
+        for (AccessActions action : AccessActions.values()) {
+            MemorySegment segment = MemorySegment.ofArray(arr);
+            boolean shouldFail = (accessModes & action.accessMode) == 0;
+            try {
+                action.run(segment.withAccessModes(accessModes));
+                assertFalse(shouldFail);
+            } catch (UnsupportedOperationException ex) {
+                assertTrue(shouldFail);
+            }
+        }
+    }
+
     @DataProvider(name = "badSizeAndAlignments")
     public Object[][] sizesAndAlignments() {
         return new Object[][] {
@@ -176,16 +192,18 @@ public class TestSegments {
         final Method method;
         final Object[] params;
 
+        final static List<String> CONFINED_NAMES = List.of(
+                "close",
+                "toByteArray"
+        );
+
         public SegmentMember(Method method, Object[] params) {
             this.method = method;
             this.params = params;
         }
 
         boolean isConfined() {
-            return method.getName().startsWith("as") ||
-                    method.getName().startsWith("to") ||
-                    method.getName().equals("close") ||
-                    method.getName().equals("slice");
+            return CONFINED_NAMES.contains(method.getName());
         }
 
         @Override
@@ -218,5 +236,52 @@ public class TestSegments {
         } else {
             return null;
         }
+    }
+
+    @DataProvider(name = "accessModes")
+    public Object[][] accessModes() {
+        int nActions = AccessActions.values().length;
+        Object[][] results = new Object[nActions * nActions][];
+        for (int accessModes = 0 ; accessModes < results.length ; accessModes++) {
+            results[accessModes] = new Object[] { accessModes };
+        }
+        return results;
+    }
+
+    enum AccessActions {
+        ACQUIRE(MemorySegment.ACQUIRE) {
+            @Override
+            void run(MemorySegment segment) {
+                segment.acquire();
+            }
+        },
+        CLOSE(MemorySegment.CLOSE) {
+            @Override
+            void run(MemorySegment segment) {
+                segment.close();
+            }
+        },
+        READ(MemorySegment.READ) {
+            @Override
+            void run(MemorySegment segment) {
+                INT_HANDLE.get(segment.baseAddress());
+            }
+        },
+        WRITE(MemorySegment.WRITE) {
+            @Override
+            void run(MemorySegment segment) {
+                INT_HANDLE.set(segment.baseAddress(), 42);
+            }
+        };
+
+        final int accessMode;
+
+        static VarHandle INT_HANDLE = MemoryLayouts.JAVA_INT.varHandle(int.class);
+
+        AccessActions(int accessMode) {
+            this.accessMode = accessMode;
+        }
+
+        abstract void run(MemorySegment segment);
     }
 }


### PR DESCRIPTION
This patch adds a finer-grained access control for memory segments; instead of the ad-hoc MemorySegment::asReadOnly, we now support a more complete MemorySegment::withAccessModes(), where access modes is an int mask.

Supported access modes are READ, WRITE, CLOSE and ACQUIRE, which gives much more freedom to clients when it comes to create restricted views (I've added a new section on that in the MemorySegment toplevel javadoc).

I also did some minor changes, mostly to get rid of confinement restrictions where such restrictions were not needed (e.g. MemorySegment::asSlice).
