### PR TITLE
8241011: Internal access modes should be filtered

### DIFF
--- a/test/jdk/java/foreign/TestSegments.java
+++ b/test/jdk/java/foreign/TestSegments.java
@@ -128,6 +128,7 @@ public class TestSegments {
         for (AccessActions action : AccessActions.values()) {
             MemorySegment segment = MemorySegment.ofArray(arr);
             MemorySegment restrictedSegment = segment.withAccessModes(accessModes);
+            assertEquals(restrictedSegment.accessModes(), accessModes);
             boolean shouldFail = !restrictedSegment.hasAccessModes(action.accessMode);
             try {
                 action.run(restrictedSegment);
@@ -136,6 +137,20 @@ public class TestSegments {
                 assertTrue(shouldFail);
             }
         }
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testBadWithAccessModes() {
+        int[] arr = new int[1];
+        MemorySegment segment = MemorySegment.ofArray(arr);
+        segment.withAccessModes((1 << AccessActions.values().length) + 1);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testBadHasAccessModes() {
+        int[] arr = new int[1];
+        MemorySegment segment = MemorySegment.ofArray(arr);
+        segment.hasAccessModes((1 << AccessActions.values().length) + 1);
     }
 
     @DataProvider(name = "badSizeAndAlignments")


### PR DESCRIPTION
This patch fixes some of the issues introduced by JDK-8240874; since MemorySegmentImpl is using some internal flags, we should filter out internal flags when user queries for access modes. Moreover, we should detect situations where the user is trying to set or set access modes which fall outside the supported mask.

Few tests have been added to catch these situations.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [JDK-8241011](https://bugs.openjdk.java.net/browse/JDK-8241011): Internal access modes should be filtered


### Reviewers
 * Jorn Vernee ([jvernee](@JornVernee) - Committer)

### Download
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/52/head:pull/52`
`$ git checkout pull/52`
