### PR TITLE
8241017: Enhance AllocationScope to support "unbounded" mode

### DIFF
--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/AllocationScope.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/AllocationScope.java
@@ -38,7 +38,7 @@ import java.util.OptionalLong;
  * of the allocation scope is known statically. If an application knows before-hand how much memory it needs to allocate the values it needs,
  * using a <em>bounded</em> allocation scope will typically provide better performances than independently allocating the memory
  * for each value (e.g. using {@link MemorySegment#allocateNative(long)}), or using an <em>unbounded</em> allocation scope.
- * For this reason, using a bound allocation scope is recommended in cases where programs might need to emulate native stack allocation.
+ * For this reason, using a bounded allocation scope is recommended in cases where programs might need to emulate native stack allocation.
  */
 public abstract class AllocationScope implements AutoCloseable {
 

--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/AllocationScope.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/AllocationScope.java
@@ -43,7 +43,7 @@ import java.util.OptionalLong;
 public abstract class AllocationScope implements AutoCloseable {
 
     /**
-     * If this allocation scope is bound, returns the size, in bytes, of this allocation scope.
+     * If this allocation scope is bounded, returns the size, in bytes, of this allocation scope.
      * @return the size, in bytes, of this allocation scope (if available).
      */
     public abstract OptionalLong byteSize();

--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/AllocationScope.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/AllocationScope.java
@@ -26,44 +26,33 @@
 
 package jdk.incubator.foreign;
 
-import jdk.internal.foreign.MemoryAddressImpl;
-import jdk.internal.foreign.MemorySegmentImpl;
-import jdk.internal.foreign.Utils;
+import jdk.internal.foreign.BoundedAllocationScope;
+import jdk.internal.foreign.UnboundedAllocationScope;
 
 import java.lang.invoke.VarHandle;
+import java.util.OptionalLong;
 
 /**
  * This class provides a scope of given size, within which several allocations can be performed. An allocation scope can be backed
- * either by heap, or off-heap memory (see {@link AllocationScope#heapScope(int)} and {@link AllocationScope#nativeScope(long)},
- * respectively). If an application knows before-hand how much memory it needs to allocate the values it needs,
- * using an allocation scope will typically provide better performances than independently allocating the memory for each value
- * (e.g. using {@link MemorySegment#allocateNative(long)}). For this reason, using an allocation scope is recommended
- * in cases where programs might need to emulate native stack allocation.
+ * either by heap, or off-heap memory. Allocation scopes can be either <em>bounded</em> or <em>unbounded</em>, depending on whether the size
+ * of the allocation scope is known statically. If an application knows before-hand how much memory it needs to allocate the values it needs,
+ * using a <em>bound</em> allocation scope will typically provide better performances than independently allocating the memory
+ * for each value (e.g. using {@link MemorySegment#allocateNative(long)}), or using an <em>unbounded</em> allocation scope.
+ * For this reason, using a bound allocation scope is recommended in cases where programs might need to emulate native stack allocation.
  */
-public class AllocationScope implements AutoCloseable {
-    private final MemorySegment segment, acquiredSegment;
-    private long sp = 0L;
+public abstract class AllocationScope implements AutoCloseable {
 
     /**
-     * Returns the size, in bytes, of this allocation scope.
-     * @return the size, in bytes, of this allocation scope.
+     * If this allocation scope is bound, returns the size, in bytes, of this allocation scope.
+     * @return the size, in bytes, of this allocation scope (if available).
      */
-    public long byteSize() {
-        return segment.byteSize();
-    }
+    public abstract OptionalLong byteSize();
 
     /**
      * Returns the number of allocated bytes in this allocation scope.
      * @return the number of allocated bytes in this allocation scope.
      */
-    public long allocatedBytes() {
-        return sp;
-    }
-
-    private AllocationScope(MemorySegment segment) {
-        this.segment = segment;
-        this.acquiredSegment = segment.acquire();
-    }
+    public abstract long allocatedBytes();
 
     /**
      * Allocate a block of memory in this allocation scope with given layout and initialize it with given byte value.
@@ -224,43 +213,46 @@ public class AllocationScope implements AutoCloseable {
      * @throws OutOfMemoryError if there is not enough space left in this allocation scope, that is, if
      * {@code limit() - size() < bytesSize}.
      */
-    public MemoryAddress allocate(long bytesSize, long bytesAlignment) {
-        long min = ((MemoryAddressImpl)segment.baseAddress()).unsafeGetOffset();
-        long start = Utils.alignUp(min + sp, bytesAlignment) - min;
-        try {
-            MemorySegment slice = segment.asSlice(start, bytesSize);
-            sp = start + bytesSize;
-            return slice.baseAddress();
-        } catch (IndexOutOfBoundsException ex) {
-            throw new OutOfMemoryError("Not enough space left to allocate");
-        }
-    }
+    public abstract MemoryAddress allocate(long bytesSize, long bytesAlignment);
 
     /**
      * Close this allocation scope; calling this method will render any address obtained through this allocation scope
      * unusable and might release any backing memory resources associated with this allocation scope.
      */
     @Override
-    public void close() {
-        acquiredSegment.close();
-        segment.close();
+    public abstract void close();
+
+    /**
+     * Creates a new bounded native allocation scope, backed by off-heap memory.
+     * @param size the size of the allocation scope.
+     * @return a new bounded native allocation scope, with given size (in bytes).
+     */
+    public static AllocationScope boundedNativeScope(long size) {
+        return new BoundedAllocationScope(MemorySegment.allocateNative(size));
     }
 
     /**
-     * Creates a new native allocation scope. A native allocation scope is backed by off-heap memory.
+     * Creates a new bounded heap allocation scope, backed by heap memory.
      * @param size the size of the allocation scope.
-     * @return a new native allocation scope, with given size (in bytes).
+     * @return a new bounded heap allocation scope, with given size (in bytes).
      */
-    public static AllocationScope nativeScope(long size) {
-        return new AllocationScope(MemorySegment.allocateNative(size));
+    public static AllocationScope boundedHeapScope(int size) {
+        return new BoundedAllocationScope(MemorySegment.ofArray(new byte[size]));
     }
 
     /**
-     * Creates a new heap allocation scope. A heap allocation scope is backed by heap memory.
-     * @param size the size of the allocation scope.
-     * @return a new heap allocation scope, with given size (in bytes).
+     * Creates a new unbounded native allocation scope, backed by off-heap memory.
+     * @return a new unbounded native allocation scope.
      */
-    public static AllocationScope heapScope(int size) {
-        return new AllocationScope(MemorySegment.ofArray(new byte[size]));
+    public static AllocationScope unboundedNativeScope() {
+        return new UnboundedAllocationScope(MemorySegment::allocateNative);
+    }
+
+    /**
+     * Creates a new unbounded heap allocation scope, backed by heap memory.
+     * @return a new unbounded heap allocation scope.
+     */
+    public static AllocationScope unboundedHeapScope() {
+        return new UnboundedAllocationScope((size) -> MemorySegment.ofArray(new byte[(int) size]));
     }
 }

--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/AllocationScope.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/AllocationScope.java
@@ -36,7 +36,7 @@ import java.util.OptionalLong;
  * This class provides a scope of given size, within which several allocations can be performed. An allocation scope can be backed
  * either by heap, or off-heap memory. Allocation scopes can be either <em>bounded</em> or <em>unbounded</em>, depending on whether the size
  * of the allocation scope is known statically. If an application knows before-hand how much memory it needs to allocate the values it needs,
- * using a <em>bound</em> allocation scope will typically provide better performances than independently allocating the memory
+ * using a <em>bounded</em> allocation scope will typically provide better performances than independently allocating the memory
  * for each value (e.g. using {@link MemorySegment#allocateNative(long)}), or using an <em>unbounded</em> allocation scope.
  * For this reason, using a bound allocation scope is recommended in cases where programs might need to emulate native stack allocation.
  */

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/BoundedAllocationScope.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/BoundedAllocationScope.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package jdk.internal.foreign;
+
+import jdk.incubator.foreign.AllocationScope;
+import jdk.incubator.foreign.MemoryAddress;
+import jdk.incubator.foreign.MemorySegment;
+
+import java.util.OptionalLong;
+
+public class BoundedAllocationScope extends AllocationScope {
+    private final MemorySegment segment;
+    private long sp = 0L;
+
+    @Override
+    public OptionalLong byteSize() {
+        return OptionalLong.of(segment.byteSize());
+    }
+
+    @Override
+    public long allocatedBytes() {
+        return sp;
+    }
+
+    public BoundedAllocationScope(MemorySegment segment) {
+        this.segment = segment;
+    }
+
+    @Override
+    public MemoryAddress allocate(long bytesSize, long bytesAlignment) {
+        long min = ((MemoryAddressImpl)segment.baseAddress()).unsafeGetOffset();
+        long start = Utils.alignUp(min + sp, bytesAlignment) - min;
+        try {
+            MemorySegment slice = segment.asSlice(start, bytesSize)
+                    .withAccessModes(MemorySegment.READ | MemorySegment.WRITE | MemorySegment.ACQUIRE);
+            sp = start + bytesSize;
+            return slice.baseAddress();
+        } catch (IndexOutOfBoundsException ex) {
+            throw new OutOfMemoryError("Not enough space left to allocate");
+        }
+    }
+
+    @Override
+    public void close() {
+        segment.close();
+    }
+}

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/UnboundedAllocationScope.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/UnboundedAllocationScope.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package jdk.internal.foreign;
+
+import jdk.incubator.foreign.AllocationScope;
+import jdk.incubator.foreign.MemoryAddress;
+import jdk.incubator.foreign.MemorySegment;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.OptionalLong;
+import java.util.function.LongFunction;
+
+public class UnboundedAllocationScope extends AllocationScope {
+
+    private static final long BLOCK_SIZE = 4 * 1024;
+
+    private final LongFunction<MemorySegment> segmentFactory;
+    private final List<MemorySegment> usedSegments = new ArrayList<>();
+    private MemorySegment segment;
+    private long sp = 0L;
+    private long size = 0L;
+
+    @Override
+    public OptionalLong byteSize() {
+        return OptionalLong.empty();
+    }
+
+    @Override
+    public long allocatedBytes() {
+        return size;
+    }
+
+    public UnboundedAllocationScope(LongFunction<MemorySegment> segmentFactory) {
+        this.segmentFactory = segmentFactory;
+        this.segment = segmentFactory.apply(BLOCK_SIZE);
+    }
+
+    @Override
+    public MemoryAddress allocate(long bytesSize, long bytesAlignment) {
+        for (int i = 0; i < 2; i++) {
+            long min = ((MemoryAddressImpl) segment.baseAddress()).unsafeGetOffset();
+            long start = Utils.alignUp(min + sp, bytesAlignment) - min;
+            try {
+                MemorySegment slice = segment.asSlice(start, bytesSize)
+                        .withAccessModes(MemorySegment.READ | MemorySegment.WRITE | MemorySegment.ACQUIRE);
+                sp = start + bytesSize;
+                size += Utils.alignUp(bytesSize, bytesAlignment);
+                return slice.baseAddress();
+            } catch (IndexOutOfBoundsException ex) {
+                sp = 0L;
+                usedSegments.add(segment);
+                segment = segmentFactory.apply(BLOCK_SIZE);
+            }
+        }
+        throw new OutOfMemoryError("Allocation request exceeds scope block size");
+    }
+
+    @Override
+    public void close() {
+        segment.close();
+        usedSegments.forEach(MemorySegment::close);
+    }
+}

--- a/test/jdk/java/foreign/TestAllocationScope.java
+++ b/test/jdk/java/foreign/TestAllocationScope.java
@@ -63,17 +63,18 @@ public class TestAllocationScope {
                     try {
                         address.segment().close();
                         fail();
-                    } catch (IllegalStateException uoe) {
+                    } catch (UnsupportedOperationException uoe) {
                         //failure is expected
                         assertTrue(true);
                     }
                 }
+                boolean isBound = scope.byteSize().isPresent();
                 try {
-                    allocationFunction.allocate(scope, alignedLayout, value); //too much, should fail
-                    fail();
+                    allocationFunction.allocate(scope, alignedLayout, value); //too much, should fail if bound
+                    assertFalse(isBound);
                 } catch (OutOfMemoryError ex) {
-                    //failure is expected
-                    assertTrue(true);
+                    //failure is expected if bound
+                    assertTrue(isBound);
                 }
             }
             // addresses should be invalid now
@@ -87,37 +88,102 @@ public class TestAllocationScope {
     @DataProvider(name = "allocationScopes")
     static Object[][] allocationScopes() {
         return new Object[][] {
-                { (byte)42, (ScopeFactory)AllocationScope::heapScope, MemoryLayouts.BITS_8_BE, byte.class, (AllocationFunction<Byte>)AllocationScope::allocate },
-                { (short)42, (ScopeFactory)AllocationScope::heapScope, MemoryLayouts.BITS_16_BE, short.class, (AllocationFunction<Short>)AllocationScope::allocate },
-                { 42, (ScopeFactory)AllocationScope::heapScope, MemoryLayouts.BITS_32_BE, int.class, (AllocationFunction<Integer>)AllocationScope::allocate },
-                { 42f, (ScopeFactory)AllocationScope::heapScope, MemoryLayouts.BITS_32_BE, float.class, (AllocationFunction<Float>)AllocationScope::allocate },
-                { 42L, (ScopeFactory)AllocationScope::heapScope, MemoryLayouts.BITS_64_BE, long.class, (AllocationFunction<Long>)AllocationScope::allocate },
-                { 42d, (ScopeFactory)AllocationScope::heapScope, MemoryLayouts.BITS_64_BE, double.class, (AllocationFunction<Double>)AllocationScope::allocate },
-                { MemoryAddress.ofLong(42), (ScopeFactory)AllocationScope::heapScope, MemoryLayouts.BITS_64_BE, MemoryAddress.class, (AllocationFunction<MemoryAddress>)AllocationScope::allocate },
+                { (byte)42, (ScopeFactory)AllocationScope::boundedHeapScope, MemoryLayouts.BITS_8_BE, byte.class, (AllocationFunction<Byte>)AllocationScope::allocate },
+                { (short)42, (ScopeFactory)AllocationScope::boundedHeapScope, MemoryLayouts.BITS_16_BE, short.class, (AllocationFunction<Short>)AllocationScope::allocate },
+                { 42, (ScopeFactory)AllocationScope::boundedHeapScope, MemoryLayouts.BITS_32_BE, int.class, (AllocationFunction<Integer>)AllocationScope::allocate },
+                { 42f, (ScopeFactory)AllocationScope::boundedHeapScope, MemoryLayouts.BITS_32_BE, float.class, (AllocationFunction<Float>)AllocationScope::allocate },
+                { 42L, (ScopeFactory)AllocationScope::boundedHeapScope, MemoryLayouts.BITS_64_BE, long.class, (AllocationFunction<Long>)AllocationScope::allocate },
+                { 42d, (ScopeFactory)AllocationScope::boundedHeapScope, MemoryLayouts.BITS_64_BE, double.class, (AllocationFunction<Double>)AllocationScope::allocate },
+                { MemoryAddress.ofLong(42), (ScopeFactory)AllocationScope::boundedHeapScope, MemoryLayouts.BITS_64_BE, MemoryAddress.class, (AllocationFunction<MemoryAddress>)AllocationScope::allocate },
                 
-                { (byte)42, (ScopeFactory)AllocationScope::nativeScope, MemoryLayouts.BITS_8_BE, byte.class, (AllocationFunction<Byte>)AllocationScope::allocate },
-                { (short)42, (ScopeFactory)AllocationScope::nativeScope, MemoryLayouts.BITS_16_BE, short.class, (AllocationFunction<Short>)AllocationScope::allocate },
-                { 42, (ScopeFactory)AllocationScope::nativeScope, MemoryLayouts.BITS_32_BE, int.class, (AllocationFunction<Integer>)AllocationScope::allocate },
-                { 42f, (ScopeFactory)AllocationScope::nativeScope, MemoryLayouts.BITS_32_BE, float.class, (AllocationFunction<Float>)AllocationScope::allocate },
-                { 42L, (ScopeFactory)AllocationScope::nativeScope, MemoryLayouts.BITS_64_BE, long.class, (AllocationFunction<Long>)AllocationScope::allocate },
-                { 42d, (ScopeFactory)AllocationScope::nativeScope, MemoryLayouts.BITS_64_BE, double.class, (AllocationFunction<Double>)AllocationScope::allocate },
-                { MemoryAddress.ofLong(42), (ScopeFactory)AllocationScope::nativeScope, MemoryLayouts.BITS_64_BE, MemoryAddress.class, (AllocationFunction<MemoryAddress>)AllocationScope::allocate },
+                { (byte)42, (ScopeFactory)AllocationScope::boundedNativeScope, MemoryLayouts.BITS_8_BE, byte.class, (AllocationFunction<Byte>)AllocationScope::allocate },
+                { (short)42, (ScopeFactory)AllocationScope::boundedNativeScope, MemoryLayouts.BITS_16_BE, short.class, (AllocationFunction<Short>)AllocationScope::allocate },
+                { 42, (ScopeFactory)AllocationScope::boundedNativeScope, MemoryLayouts.BITS_32_BE, int.class, (AllocationFunction<Integer>)AllocationScope::allocate },
+                { 42f, (ScopeFactory)AllocationScope::boundedNativeScope, MemoryLayouts.BITS_32_BE, float.class, (AllocationFunction<Float>)AllocationScope::allocate },
+                { 42L, (ScopeFactory)AllocationScope::boundedNativeScope, MemoryLayouts.BITS_64_BE, long.class, (AllocationFunction<Long>)AllocationScope::allocate },
+                { 42d, (ScopeFactory)AllocationScope::boundedNativeScope, MemoryLayouts.BITS_64_BE, double.class, (AllocationFunction<Double>)AllocationScope::allocate },
+                { MemoryAddress.ofLong(42), (ScopeFactory)AllocationScope::boundedNativeScope, MemoryLayouts.BITS_64_BE, MemoryAddress.class, (AllocationFunction<MemoryAddress>)AllocationScope::allocate },
                 
-                { (byte)42, (ScopeFactory)AllocationScope::heapScope, MemoryLayouts.BITS_8_LE, byte.class, (AllocationFunction<Byte>)AllocationScope::allocate },
-                { (short)42, (ScopeFactory)AllocationScope::heapScope, MemoryLayouts.BITS_16_LE, short.class, (AllocationFunction<Short>)AllocationScope::allocate },
-                { 42, (ScopeFactory)AllocationScope::heapScope, MemoryLayouts.BITS_32_LE, int.class, (AllocationFunction<Integer>)AllocationScope::allocate },
-                { 42f, (ScopeFactory)AllocationScope::heapScope, MemoryLayouts.BITS_32_LE, float.class, (AllocationFunction<Float>)AllocationScope::allocate },
-                { 42L, (ScopeFactory)AllocationScope::heapScope, MemoryLayouts.BITS_64_LE, long.class, (AllocationFunction<Long>)AllocationScope::allocate },
-                { 42d, (ScopeFactory)AllocationScope::heapScope, MemoryLayouts.BITS_64_LE, double.class, (AllocationFunction<Double>)AllocationScope::allocate },
-                { MemoryAddress.ofLong(42), (ScopeFactory)AllocationScope::heapScope, MemoryLayouts.BITS_64_LE, MemoryAddress.class, (AllocationFunction<MemoryAddress>)AllocationScope::allocate },
+                { (byte)42, (ScopeFactory)AllocationScope::boundedHeapScope, MemoryLayouts.BITS_8_LE, byte.class, (AllocationFunction<Byte>)AllocationScope::allocate },
+                { (short)42, (ScopeFactory)AllocationScope::boundedHeapScope, MemoryLayouts.BITS_16_LE, short.class, (AllocationFunction<Short>)AllocationScope::allocate },
+                { 42, (ScopeFactory)AllocationScope::boundedHeapScope, MemoryLayouts.BITS_32_LE, int.class, (AllocationFunction<Integer>)AllocationScope::allocate },
+                { 42f, (ScopeFactory)AllocationScope::boundedHeapScope, MemoryLayouts.BITS_32_LE, float.class, (AllocationFunction<Float>)AllocationScope::allocate },
+                { 42L, (ScopeFactory)AllocationScope::boundedHeapScope, MemoryLayouts.BITS_64_LE, long.class, (AllocationFunction<Long>)AllocationScope::allocate },
+                { 42d, (ScopeFactory)AllocationScope::boundedHeapScope, MemoryLayouts.BITS_64_LE, double.class, (AllocationFunction<Double>)AllocationScope::allocate },
+                { MemoryAddress.ofLong(42), (ScopeFactory)AllocationScope::boundedHeapScope, MemoryLayouts.BITS_64_LE, MemoryAddress.class, (AllocationFunction<MemoryAddress>)AllocationScope::allocate },
                 
-                { (byte)42, (ScopeFactory)AllocationScope::nativeScope, MemoryLayouts.BITS_8_LE, byte.class, (AllocationFunction<Byte>)AllocationScope::allocate },
-                { (short)42, (ScopeFactory)AllocationScope::nativeScope, MemoryLayouts.BITS_16_LE, short.class, (AllocationFunction<Short>)AllocationScope::allocate },
-                { 42, (ScopeFactory)AllocationScope::nativeScope, MemoryLayouts.BITS_32_LE, int.class, (AllocationFunction<Integer>)AllocationScope::allocate },
-                { 42f, (ScopeFactory)AllocationScope::nativeScope, MemoryLayouts.BITS_32_LE, float.class, (AllocationFunction<Float>)AllocationScope::allocate },
-                { 42L, (ScopeFactory)AllocationScope::nativeScope, MemoryLayouts.BITS_64_LE, long.class, (AllocationFunction<Long>)AllocationScope::allocate },
-                { 42d, (ScopeFactory)AllocationScope::nativeScope, MemoryLayouts.BITS_64_LE, double.class, (AllocationFunction<Double>)AllocationScope::allocate },
-                { MemoryAddress.ofLong(42), (ScopeFactory)AllocationScope::nativeScope, MemoryLayouts.BITS_64_LE, MemoryAddress.class, (AllocationFunction<MemoryAddress>)AllocationScope::allocate },
+                { (byte)42, (ScopeFactory)AllocationScope::boundedNativeScope, MemoryLayouts.BITS_8_LE, byte.class, (AllocationFunction<Byte>)AllocationScope::allocate },
+                { (short)42, (ScopeFactory)AllocationScope::boundedNativeScope, MemoryLayouts.BITS_16_LE, short.class, (AllocationFunction<Short>)AllocationScope::allocate },
+                { 42, (ScopeFactory)AllocationScope::boundedNativeScope, MemoryLayouts.BITS_32_LE, int.class, (AllocationFunction<Integer>)AllocationScope::allocate },
+                { 42f, (ScopeFactory)AllocationScope::boundedNativeScope, MemoryLayouts.BITS_32_LE, float.class, (AllocationFunction<Float>)AllocationScope::allocate },
+                { 42L, (ScopeFactory)AllocationScope::boundedNativeScope, MemoryLayouts.BITS_64_LE, long.class, (AllocationFunction<Long>)AllocationScope::allocate },
+                { 42d, (ScopeFactory)AllocationScope::boundedNativeScope, MemoryLayouts.BITS_64_LE, double.class, (AllocationFunction<Double>)AllocationScope::allocate },
+                { MemoryAddress.ofLong(42), (ScopeFactory)AllocationScope::boundedNativeScope, MemoryLayouts.BITS_64_LE, MemoryAddress.class, (AllocationFunction<MemoryAddress>)AllocationScope::allocate },
+
+                { (byte)42, (ScopeFactory)AllocationScope::boundedHeapScope, MemoryLayouts.BITS_8_BE, byte.class, (AllocationFunction<Byte>)AllocationScope::allocate },
+                { (short)42, (ScopeFactory)AllocationScope::boundedHeapScope, MemoryLayouts.BITS_16_BE, short.class, (AllocationFunction<Short>)AllocationScope::allocate },
+                { 42, (ScopeFactory)AllocationScope::boundedHeapScope, MemoryLayouts.BITS_32_BE, int.class, (AllocationFunction<Integer>)AllocationScope::allocate },
+                { 42f, (ScopeFactory)AllocationScope::boundedHeapScope, MemoryLayouts.BITS_32_BE, float.class, (AllocationFunction<Float>)AllocationScope::allocate },
+                { 42L, (ScopeFactory)AllocationScope::boundedHeapScope, MemoryLayouts.BITS_64_BE, long.class, (AllocationFunction<Long>)AllocationScope::allocate },
+                { 42d, (ScopeFactory)AllocationScope::boundedHeapScope, MemoryLayouts.BITS_64_BE, double.class, (AllocationFunction<Double>)AllocationScope::allocate },
+                { MemoryAddress.ofLong(42), (ScopeFactory)AllocationScope::boundedHeapScope, MemoryLayouts.BITS_64_BE, MemoryAddress.class, (AllocationFunction<MemoryAddress>)AllocationScope::allocate },
+
+                { (byte)42, (ScopeFactory)AllocationScope::boundedNativeScope, MemoryLayouts.BITS_8_BE, byte.class, (AllocationFunction<Byte>)AllocationScope::allocate },
+                { (short)42, (ScopeFactory)AllocationScope::boundedNativeScope, MemoryLayouts.BITS_16_BE, short.class, (AllocationFunction<Short>)AllocationScope::allocate },
+                { 42, (ScopeFactory)AllocationScope::boundedNativeScope, MemoryLayouts.BITS_32_BE, int.class, (AllocationFunction<Integer>)AllocationScope::allocate },
+                { 42f, (ScopeFactory)AllocationScope::boundedNativeScope, MemoryLayouts.BITS_32_BE, float.class, (AllocationFunction<Float>)AllocationScope::allocate },
+                { 42L, (ScopeFactory)AllocationScope::boundedNativeScope, MemoryLayouts.BITS_64_BE, long.class, (AllocationFunction<Long>)AllocationScope::allocate },
+                { 42d, (ScopeFactory)AllocationScope::boundedNativeScope, MemoryLayouts.BITS_64_BE, double.class, (AllocationFunction<Double>)AllocationScope::allocate },
+                { MemoryAddress.ofLong(42), (ScopeFactory)AllocationScope::boundedNativeScope, MemoryLayouts.BITS_64_BE, MemoryAddress.class, (AllocationFunction<MemoryAddress>)AllocationScope::allocate },
+
+                { (byte)42, (ScopeFactory)AllocationScope::boundedHeapScope, MemoryLayouts.BITS_8_LE, byte.class, (AllocationFunction<Byte>)AllocationScope::allocate },
+                { (short)42, (ScopeFactory)AllocationScope::boundedHeapScope, MemoryLayouts.BITS_16_LE, short.class, (AllocationFunction<Short>)AllocationScope::allocate },
+                { 42, (ScopeFactory)AllocationScope::boundedHeapScope, MemoryLayouts.BITS_32_LE, int.class, (AllocationFunction<Integer>)AllocationScope::allocate },
+                { 42f, (ScopeFactory)AllocationScope::boundedHeapScope, MemoryLayouts.BITS_32_LE, float.class, (AllocationFunction<Float>)AllocationScope::allocate },
+                { 42L, (ScopeFactory)AllocationScope::boundedHeapScope, MemoryLayouts.BITS_64_LE, long.class, (AllocationFunction<Long>)AllocationScope::allocate },
+                { 42d, (ScopeFactory)AllocationScope::boundedHeapScope, MemoryLayouts.BITS_64_LE, double.class, (AllocationFunction<Double>)AllocationScope::allocate },
+                { MemoryAddress.ofLong(42), (ScopeFactory)AllocationScope::boundedHeapScope, MemoryLayouts.BITS_64_LE, MemoryAddress.class, (AllocationFunction<MemoryAddress>)AllocationScope::allocate },
+
+                { (byte)42, (ScopeFactory)AllocationScope::boundedNativeScope, MemoryLayouts.BITS_8_LE, byte.class, (AllocationFunction<Byte>)AllocationScope::allocate },
+                { (short)42, (ScopeFactory)AllocationScope::boundedNativeScope, MemoryLayouts.BITS_16_LE, short.class, (AllocationFunction<Short>)AllocationScope::allocate },
+                { 42, (ScopeFactory)AllocationScope::boundedNativeScope, MemoryLayouts.BITS_32_LE, int.class, (AllocationFunction<Integer>)AllocationScope::allocate },
+                { 42f, (ScopeFactory)AllocationScope::boundedNativeScope, MemoryLayouts.BITS_32_LE, float.class, (AllocationFunction<Float>)AllocationScope::allocate },
+                { 42L, (ScopeFactory)AllocationScope::boundedNativeScope, MemoryLayouts.BITS_64_LE, long.class, (AllocationFunction<Long>)AllocationScope::allocate },
+                { 42d, (ScopeFactory)AllocationScope::boundedNativeScope, MemoryLayouts.BITS_64_LE, double.class, (AllocationFunction<Double>)AllocationScope::allocate },
+                { MemoryAddress.ofLong(42), (ScopeFactory)AllocationScope::boundedNativeScope, MemoryLayouts.BITS_64_LE, MemoryAddress.class, (AllocationFunction<MemoryAddress>)AllocationScope::allocate },
+
+
+                { (byte)42, (ScopeFactory)size -> AllocationScope.unboundedHeapScope(), MemoryLayouts.BITS_8_BE, byte.class, (AllocationFunction<Byte>)AllocationScope::allocate },
+                { (short)42, (ScopeFactory)size -> AllocationScope.unboundedHeapScope(), MemoryLayouts.BITS_16_BE, short.class, (AllocationFunction<Short>)AllocationScope::allocate },
+                { 42, (ScopeFactory)size -> AllocationScope.unboundedHeapScope(), MemoryLayouts.BITS_32_BE, int.class, (AllocationFunction<Integer>)AllocationScope::allocate },
+                { 42f, (ScopeFactory)size -> AllocationScope.unboundedHeapScope(), MemoryLayouts.BITS_32_BE, float.class, (AllocationFunction<Float>)AllocationScope::allocate },
+                { 42L, (ScopeFactory)size -> AllocationScope.unboundedHeapScope(), MemoryLayouts.BITS_64_BE, long.class, (AllocationFunction<Long>)AllocationScope::allocate },
+                { 42d, (ScopeFactory)size -> AllocationScope.unboundedHeapScope(), MemoryLayouts.BITS_64_BE, double.class, (AllocationFunction<Double>)AllocationScope::allocate },
+                { MemoryAddress.ofLong(42), (ScopeFactory)size -> AllocationScope.unboundedHeapScope(), MemoryLayouts.BITS_64_BE, MemoryAddress.class, (AllocationFunction<MemoryAddress>)AllocationScope::allocate },
+
+                { (byte)42, (ScopeFactory)size -> AllocationScope.unboundedNativeScope(), MemoryLayouts.BITS_8_BE, byte.class, (AllocationFunction<Byte>)AllocationScope::allocate },
+                { (short)42, (ScopeFactory)size -> AllocationScope.unboundedNativeScope(), MemoryLayouts.BITS_16_BE, short.class, (AllocationFunction<Short>)AllocationScope::allocate },
+                { 42, (ScopeFactory)size -> AllocationScope.unboundedNativeScope(), MemoryLayouts.BITS_32_BE, int.class, (AllocationFunction<Integer>)AllocationScope::allocate },
+                { 42f, (ScopeFactory)size -> AllocationScope.unboundedNativeScope(), MemoryLayouts.BITS_32_BE, float.class, (AllocationFunction<Float>)AllocationScope::allocate },
+                { 42L, (ScopeFactory)size -> AllocationScope.unboundedNativeScope(), MemoryLayouts.BITS_64_BE, long.class, (AllocationFunction<Long>)AllocationScope::allocate },
+                { 42d, (ScopeFactory)size -> AllocationScope.unboundedNativeScope(), MemoryLayouts.BITS_64_BE, double.class, (AllocationFunction<Double>)AllocationScope::allocate },
+                { MemoryAddress.ofLong(42), (ScopeFactory)size -> AllocationScope.unboundedNativeScope(), MemoryLayouts.BITS_64_BE, MemoryAddress.class, (AllocationFunction<MemoryAddress>)AllocationScope::allocate },
+
+                { (byte)42, (ScopeFactory)size -> AllocationScope.unboundedHeapScope(), MemoryLayouts.BITS_8_LE, byte.class, (AllocationFunction<Byte>)AllocationScope::allocate },
+                { (short)42, (ScopeFactory)size -> AllocationScope.unboundedHeapScope(), MemoryLayouts.BITS_16_LE, short.class, (AllocationFunction<Short>)AllocationScope::allocate },
+                { 42, (ScopeFactory)size -> AllocationScope.unboundedHeapScope(), MemoryLayouts.BITS_32_LE, int.class, (AllocationFunction<Integer>)AllocationScope::allocate },
+                { 42f, (ScopeFactory)size -> AllocationScope.unboundedHeapScope(), MemoryLayouts.BITS_32_LE, float.class, (AllocationFunction<Float>)AllocationScope::allocate },
+                { 42L, (ScopeFactory)size -> AllocationScope.unboundedHeapScope(), MemoryLayouts.BITS_64_LE, long.class, (AllocationFunction<Long>)AllocationScope::allocate },
+                { 42d, (ScopeFactory)size -> AllocationScope.unboundedHeapScope(), MemoryLayouts.BITS_64_LE, double.class, (AllocationFunction<Double>)AllocationScope::allocate },
+                { MemoryAddress.ofLong(42), (ScopeFactory)size -> AllocationScope.unboundedHeapScope(), MemoryLayouts.BITS_64_LE, MemoryAddress.class, (AllocationFunction<MemoryAddress>)AllocationScope::allocate },
+
+                { (byte)42, (ScopeFactory)size -> AllocationScope.unboundedNativeScope(), MemoryLayouts.BITS_8_LE, byte.class, (AllocationFunction<Byte>)AllocationScope::allocate },
+                { (short)42, (ScopeFactory)size -> AllocationScope.unboundedNativeScope(), MemoryLayouts.BITS_16_LE, short.class, (AllocationFunction<Short>)AllocationScope::allocate },
+                { 42, (ScopeFactory)size -> AllocationScope.unboundedNativeScope(), MemoryLayouts.BITS_32_LE, int.class, (AllocationFunction<Integer>)AllocationScope::allocate },
+                { 42f, (ScopeFactory)size -> AllocationScope.unboundedNativeScope(), MemoryLayouts.BITS_32_LE, float.class, (AllocationFunction<Float>)AllocationScope::allocate },
+                { 42L, (ScopeFactory)size -> AllocationScope.unboundedNativeScope(), MemoryLayouts.BITS_64_LE, long.class, (AllocationFunction<Long>)AllocationScope::allocate },
+                { 42d, (ScopeFactory)size -> AllocationScope.unboundedNativeScope(), MemoryLayouts.BITS_64_LE, double.class, (AllocationFunction<Double>)AllocationScope::allocate },
+                { MemoryAddress.ofLong(42), (ScopeFactory)size -> AllocationScope.unboundedNativeScope(), MemoryLayouts.BITS_64_LE, MemoryAddress.class, (AllocationFunction<MemoryAddress>)AllocationScope::allocate },
         };
     }
 


### PR DESCRIPTION
This patch adds support for allocation scopes whose size is not known statically; as such these new unbounded allocation scope can be used in more dynamic use cases where e.g. the amount of memory to be allocated depends on the result of other native calls.

Internally, the bounded version works as before, and is the more optimized. The unbounded version is similar in spirit to the old Panama/foreign scope - where new segments are allocated depending on needs.

I've enhanced the existing test covering allocation scopes to also cover the unbounded variants, as well as the bounded.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [JDK-8241017](https://bugs.openjdk.java.net/browse/JDK-8241017): Enhance AllocationScope to support "unbounded" mode


### Reviewers
 * Jorn Vernee ([jvernee](@JornVernee) - Committer) ⚠️ Review applies to fbf5ef776be35e38adb98e710aade0dd1e3b268b
 * Athijegannathan Sundararajan ([sundar](@sundararajana) - Committer)

### Download
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/53/head:pull/53`
`$ git checkout pull/53`
