### PR TITLE
8241148: need a way to create MemorySegment with contents from java String and a way to read a C char* as java String

### DIFF
--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/unsafe/ForeignUnsafe.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/unsafe/ForeignUnsafe.java
@@ -26,11 +26,13 @@
 
 package jdk.incubator.foreign.unsafe;
 
+import java.lang.invoke.VarHandle;
 import jdk.incubator.foreign.MemoryAddress;
+import jdk.incubator.foreign.MemoryLayout;
 import jdk.incubator.foreign.MemorySegment;
 import jdk.internal.foreign.MemoryAddressImpl;
-import jdk.internal.foreign.MemorySegmentImpl;
 import jdk.internal.foreign.Utils;
+import static jdk.incubator.foreign.MemoryLayouts.C_CHAR;
 
 /**
  * Unsafe methods to allow interop between sun.misc.unsafe and memory access API.
@@ -80,5 +82,50 @@ public final class ForeignUnsafe {
      */
     public static MemorySegment ofNativeUnchecked(MemoryAddress base, long byteSize) {
         return Utils.makeNativeSegmentUnchecked(base, byteSize);
+    }
+
+    private static VarHandle arrayHandle(MemoryLayout elemLayout, Class<?> elemCarrier) {
+        return MemoryLayout.ofSequence(1, elemLayout)
+                .varHandle(elemCarrier, MemoryLayout.PathElement.sequenceElement());
+    }
+    private final static VarHandle byteArrHandle = arrayHandle(C_CHAR, byte.class);
+
+    /**
+     * Returns a new native memory segment holding contents of the given Java String
+     * @param str the Java String
+     * @return a new native memory segment
+     */
+    public static MemorySegment makeNativeString(String str) {
+        return makeNativeString(str, str.length() + 1);
+    }
+
+    private static MemorySegment makeNativeString(String str, int length) {
+        MemoryLayout strLayout = MemoryLayout.ofSequence(length, C_CHAR);
+        MemorySegment segment = MemorySegment.allocateNative(strLayout);
+        MemoryAddress addr = segment.baseAddress();
+        for (int i = 0 ; i < str.length() ; i++) {
+            byteArrHandle.set(addr, i, (byte)str.charAt(i));
+        }
+        byteArrHandle.set(addr, (long)str.length(), (byte)0);
+        return segment;
+    }
+
+    /**
+     * Returns a Java String from the contents of the given C '\0' terminated string
+     * @param addr the address of the C string
+     * @return a Java String
+     */
+    public static String toJavaString(MemoryAddress addr) {
+        StringBuilder buf = new StringBuilder();
+        try (MemorySegment seg = ofNativeUnchecked(addr, Long.MAX_VALUE)) {
+            MemoryAddress baseAddr = seg.baseAddress();
+            byte curr = (byte) byteArrHandle.get(baseAddr, 0);
+            long offset = 0;
+            while (curr != 0) {
+                buf.append((char) curr);
+                curr = (byte) byteArrHandle.get(baseAddr, ++offset);
+            }
+        }
+        return buf.toString();
     }
 }

--- a/test/jdk/java/foreign/StdLibTest.java
+++ b/test/jdk/java/foreign/StdLibTest.java
@@ -452,28 +452,10 @@ public class StdLibTest extends NativeTestHelper {
     }
 
     static MemorySegment makeNativeString(String value) {
-        return makeNativeString(value, value.length() + 1);
-    }
-
-    static MemorySegment makeNativeString(String value, int length) {
-        MemoryLayout strLayout = MemoryLayout.ofSequence(length, C_CHAR);
-        MemorySegment segment = MemorySegment.allocateNative(strLayout);
-        MemoryAddress addr = segment.baseAddress();
-        for (int i = 0 ; i < value.length() ; i++) {
-            byteArrHandle.set(addr, i, (byte)value.charAt(i));
-        }
-        byteArrHandle.set(addr, (long)value.length(), (byte)0);
-        return segment;
+        return ForeignUnsafe.makeNativeString(value);
     }
 
     static String toJavaString(MemoryAddress address) {
-        StringBuilder buf = new StringBuilder();
-        byte curr = (byte)byteArrHandle.get(address, 0);
-        long offset = 0;
-        while (curr != 0) {
-            buf.append((char)curr);
-            curr = (byte)byteArrHandle.get(address, ++offset);
-        }
-        return buf.toString();
+        return ForeignUnsafe.toJavaString(address);
     }
 }

--- a/test/jdk/java/foreign/StdLibTest.java
+++ b/test/jdk/java/foreign/StdLibTest.java
@@ -225,7 +225,7 @@ public class StdLibTest extends NativeTestHelper {
 
         String strcat(String s1, String s2) throws Throwable {
             try (MemorySegment buf = MemorySegment.allocateNative(s1.length() + s2.length() + 1) ;
-                 MemorySegment other = makeNativeString(s2)) {
+                 MemorySegment other = toCString(s2)) {
                 char[] chars = s1.toCharArray();
                 for (long i = 0 ; i < chars.length ; i++) {
                     byteArrHandle.set(buf.baseAddress(), i, (byte)chars[(int)i]);
@@ -236,20 +236,20 @@ public class StdLibTest extends NativeTestHelper {
         }
 
         int strcmp(String s1, String s2) throws Throwable {
-            try (MemorySegment ns1 = makeNativeString(s1) ;
-                 MemorySegment ns2 = makeNativeString(s2)) {
+            try (MemorySegment ns1 = toCString(s1) ;
+                 MemorySegment ns2 = toCString(s2)) {
                 return (int)strcmp.invokeExact(ns1.baseAddress(), ns2.baseAddress());
             }
         }
 
         int puts(String msg) throws Throwable {
-            try (MemorySegment s = makeNativeString(msg)) {
+            try (MemorySegment s = toCString(msg)) {
                 return (int)puts.invokeExact(s.baseAddress());
             }
         }
 
         int strlen(String msg) throws Throwable {
-            try (MemorySegment s = makeNativeString(msg)) {
+            try (MemorySegment s = toCString(msg)) {
                 return (int)strlen.invokeExact(s.baseAddress());
             }
         }
@@ -337,7 +337,7 @@ public class StdLibTest extends NativeTestHelper {
         }
 
         int printf(String format, List<PrintfArg> args) throws Throwable {
-            try (MemorySegment formatStr = makeNativeString(format)) {
+            try (MemorySegment formatStr = toCString(format)) {
                 return (int)specializedPrintf(args).invokeExact(formatStr.baseAddress(),
                         args.stream().map(a -> a.nativeValue).toArray());
             }
@@ -412,7 +412,7 @@ public class StdLibTest extends NativeTestHelper {
 
     enum PrintfArg {
         INTEGRAL(int.class, asVarArg(C_INT), "%d", 42, 42),
-        STRING(MemoryAddress.class, asVarArg(C_POINTER), "%s", makeNativeString("str").baseAddress(), "str"),
+        STRING(MemoryAddress.class, asVarArg(C_POINTER), "%s", toCString("str").baseAddress(), "str"),
         CHAR(char.class, asVarArg(C_CHAR), "%c", 'h', 'h'),
         DOUBLE(double.class, asVarArg(C_DOUBLE), "%.4f", 1.2345d, 1.2345d);
 
@@ -451,8 +451,8 @@ public class StdLibTest extends NativeTestHelper {
         }
     }
 
-    static MemorySegment makeNativeString(String value) {
-        return ForeignUnsafe.makeNativeString(value);
+    static MemorySegment toCString(String value) {
+        return ForeignUnsafe.toCString(value);
     }
 
     static String toJavaString(MemoryAddress address) {

--- a/test/jdk/java/foreign/Test8241148.java
+++ b/test/jdk/java/foreign/Test8241148.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodType;
+import jdk.incubator.foreign.FunctionDescriptor;
+import jdk.incubator.foreign.LibraryLookup;
+import jdk.incubator.foreign.MemoryAddress;
+import jdk.incubator.foreign.SystemABI;
+import jdk.incubator.foreign.unsafe.ForeignUnsafe;
+
+import org.testng.annotations.*;
+import static jdk.incubator.foreign.MemoryAddress.NULL;
+import static jdk.incubator.foreign.MemoryLayouts.*;
+import static org.testng.Assert.*;
+
+/*
+ * @test
+ * @bug 8241148
+ * @summary need a way to create MemorySegment with contents from java String and a way to read a C char* as java String
+ * @modules jdk.incubator.foreign/jdk.incubator.foreign.unsafe
+ *          jdk.incubator.foreign/jdk.internal.foreign
+ *          jdk.incubator.foreign/jdk.internal.foreign.abi
+ * @run testng Test8241148
+ */
+@Test
+public class Test8241148 {
+    private final static MethodHandle getenv;
+    private final static MethodHandle strlen;
+
+    static {
+        try {
+            SystemABI abi = SystemABI.getInstance();
+            LibraryLookup lookup = LibraryLookup.ofDefault();
+
+            getenv = abi.downcallHandle(lookup.lookup("getenv"),
+                    MethodType.methodType(MemoryAddress.class, MemoryAddress.class),
+                    FunctionDescriptor.of(C_POINTER, C_POINTER));
+
+            strlen = abi.downcallHandle(lookup.lookup("strlen"),
+                    MethodType.methodType(int.class, MemoryAddress.class),
+                    FunctionDescriptor.of(C_INT, C_POINTER));
+        } catch (Throwable ex) {
+            throw new IllegalStateException(ex);
+        }
+    }
+
+    @Test
+    public void test() throws Throwable {
+        try (var seg = ForeignUnsafe.makeNativeString("java")) {
+            assertEquals((int) strlen.invoke(seg.baseAddress()), 4);
+        }
+        try (var pathSeg = ForeignUnsafe.makeNativeString("PATH")) {
+            var path = (MemoryAddress) getenv.invoke(pathSeg.baseAddress());
+            if (!path.equals(NULL)) {
+                int len = (int) strlen.invoke(path);
+                var pathStr = ForeignUnsafe.toJavaString(path);
+                assertEquals(pathStr.length(), len);
+                System.out.println("PATH = " + pathStr);
+            }
+        }
+    }
+}

--- a/test/jdk/java/foreign/Test8241148.java
+++ b/test/jdk/java/foreign/Test8241148.java
@@ -69,16 +69,17 @@ public class Test8241148 {
 
     @Test
     public void test() throws Throwable {
-        try (var seg = ForeignUnsafe.makeNativeString("java")) {
+        try (var seg = ForeignUnsafe.toCString("java")) {
             assertEquals((int) strlen.invoke(seg.baseAddress()), 4);
         }
-        try (var pathSeg = ForeignUnsafe.makeNativeString("PATH")) {
+        try (var pathSeg = ForeignUnsafe.toCString("PATH")) {
             var path = (MemoryAddress) getenv.invoke(pathSeg.baseAddress());
             if (!path.equals(NULL)) {
                 int len = (int) strlen.invoke(path);
                 var pathStr = ForeignUnsafe.toJavaString(path);
                 assertEquals(pathStr.length(), len);
                 System.out.println("PATH = " + pathStr);
+                assertEquals(pathStr, System.getenv("PATH"));
             }
         }
     }


### PR DESCRIPTION
Adding utility methods to ForeignUnsafe class.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [JDK-8241148](https://bugs.openjdk.java.net/browse/JDK-8241148): need a way to create MemorySegment with contents from java String and a way to read a C char* as java String


### Reviewers
 * Maurizio Cimadamore ([mcimadamore](@mcimadamore) - Committer)

### Download
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/55/head:pull/55`
`$ git checkout pull/55`
