### PR TITLE
8241309: foreign-abi branch has javadoc errors

### DIFF
--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/AllocationScope.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/AllocationScope.java
@@ -63,7 +63,7 @@ public abstract class AllocationScope implements AutoCloseable {
      * @return an address which points to the newly allocated memory block.
      * @throws OutOfMemoryError if there is not enough space left in this allocation scope, that is, if
      * {@code limit() - size() < layout.byteSize()}.
-     * @throws IllegalArgumentException if {@code layout.byteSize()) does not conform to the size of a byte value.
+     * @throws IllegalArgumentException if {@code layout.byteSize()} does not conform to the size of a byte value.
      */
     public MemoryAddress allocate(MemoryLayout layout, byte value) {
         VarHandle handle = layout.varHandle(byte.class);
@@ -81,7 +81,7 @@ public abstract class AllocationScope implements AutoCloseable {
      * @return an address which points to the newly allocated memory block.
      * @throws OutOfMemoryError if there is not enough space left in this allocation scope, that is, if
      * {@code limit() - size() < layout.byteSize()}.
-     * @throws IllegalArgumentException if {@code layout.byteSize()) does not conform to the size of a short value.
+     * @throws IllegalArgumentException if {@code layout.byteSize()} does not conform to the size of a short value.
      */
     public MemoryAddress allocate(MemoryLayout layout, short value) {
         VarHandle handle = layout.varHandle(short.class);
@@ -99,7 +99,7 @@ public abstract class AllocationScope implements AutoCloseable {
      * @return an address which points to the newly allocated memory block.
      * @throws OutOfMemoryError if there is not enough space left in this allocation scope, that is, if
      * {@code limit() - size() < layout.byteSize()}.
-     * @throws IllegalArgumentException if {@code layout.byteSize()) does not conform to the size of a int value.
+     * @throws IllegalArgumentException if {@code layout.byteSize()} does not conform to the size of a int value.
      */
     public MemoryAddress allocate(MemoryLayout layout, int value) {
         VarHandle handle = layout.varHandle(int.class);
@@ -117,7 +117,7 @@ public abstract class AllocationScope implements AutoCloseable {
      * @return an address which points to the newly allocated memory block.
      * @throws OutOfMemoryError if there is not enough space left in this allocation scope, that is, if
      * {@code limit() - size() < layout.byteSize()}.
-     * @throws IllegalArgumentException if {@code layout.byteSize()) does not conform to the size of a float value.
+     * @throws IllegalArgumentException if {@code layout.byteSize()} does not conform to the size of a float value.
      */
     public MemoryAddress allocate(MemoryLayout layout, float value) {
         VarHandle handle = layout.varHandle(float.class);
@@ -135,7 +135,7 @@ public abstract class AllocationScope implements AutoCloseable {
      * @return an address which points to the newly allocated memory block.
      * @throws OutOfMemoryError if there is not enough space left in this allocation scope, that is, if
      * {@code limit() - size() < layout.byteSize()}.
-     * @throws IllegalArgumentException if {@code layout.byteSize()) does not conform to the size of a long value.
+     * @throws IllegalArgumentException if {@code layout.byteSize()} does not conform to the size of a long value.
      */
     public MemoryAddress allocate(MemoryLayout layout, long value) {
         VarHandle handle = layout.varHandle(long.class);
@@ -153,7 +153,7 @@ public abstract class AllocationScope implements AutoCloseable {
      * @return an address which points to the newly allocated memory block.
      * @throws OutOfMemoryError if there is not enough space left in this allocation scope, that is, if
      * {@code limit() - size() < layout.byteSize()}.
-     * @throws IllegalArgumentException if {@code layout.byteSize()) does not conform to the size of a double value.
+     * @throws IllegalArgumentException if {@code layout.byteSize()} does not conform to the size of a double value.
      */
     public MemoryAddress allocate(MemoryLayout layout, double value) {
         VarHandle handle = layout.varHandle(double.class);
@@ -167,10 +167,11 @@ public abstract class AllocationScope implements AutoCloseable {
      * The address returned by this method is associated with a segment which cannot be closed. Moreover, the returned
      * address must conform to the layout alignment constraints.
      * @param layout the layout of the block of memory to be allocated.
+     * @param value the value to be set on the newly allocated memory block.
      * @return an address which points to the newly allocated memory block.
      * @throws OutOfMemoryError if there is not enough space left in this allocation scope, that is, if
      * {@code limit() - size() < layout.byteSize()}.
-     * @throws IllegalArgumentException if {@code layout.byteSize()) does not conform to the size of an address value.
+     * @throws IllegalArgumentException if {@code layout.byteSize()} does not conform to the size of an address value.
      */
     public MemoryAddress allocate(MemoryLayout layout, MemoryAddress value) {
         VarHandle handle = layout.varHandle(MemoryAddress.class);

--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/MemoryAddress.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/MemoryAddress.java
@@ -75,7 +75,7 @@ public interface MemoryAddress {
 
     /**
      * Reinterpret this address as an offset into the provided segment.
-     * @param segment
+     * @param segment the segment to be rebased
      * @return a new address pointing to the same memory location through the provided segment
      * @throws IllegalArgumentException if the provided segment is not a valid rebase target for this address. This
      * can happen, for instance, if an heap-based addressed is rebased to an off-heap memory segment.
@@ -129,7 +129,6 @@ public interface MemoryAddress {
     /**
      * A native memory address instance modelling the {@code NULL} pointer. This address is backed by a memory segment
      * which can be neither closed, nor dereferenced.
-     * @return the NULL memory address.
      */
     MemoryAddress NULL = MemorySegmentImpl.NOTHING.baseAddress();
 

--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/MemorySegment.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/MemorySegment.java
@@ -188,7 +188,7 @@ public interface MemorySegment extends AutoCloseable {
     /**
      * Does this segment support a given set of access modes?
      * @param accessModes an ORed mask of zero or more access modes.
-     * @return true, if the access modes in {@accessModes} are stricter than the ones supported by this segment.
+     * @return true, if the access modes in {@code accessModes} are stricter than the ones supported by this segment.
      */
     boolean hasAccessModes(int accessModes);
 

--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/SystemABI.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/SystemABI.java
@@ -200,6 +200,8 @@ public interface SystemABI {
 
     /**
      * Returns memory layout for the given native type if supported by the platform ABI.
+     * @param type the native type for which the layout is to be retrieved.
+     * @return the layout (if any) associated with {@code type}
      */
     public Optional<MemoryLayout> layoutFor(Type type);
 }


### PR DESCRIPTION
This is a simple patch which fixes a bunch of doc errors preventing javadoc from terminating correctly.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [JDK-8241309](https://bugs.openjdk.java.net/browse/JDK-8241309): foreign-abi branch has javadoc errors


### Reviewers
 * Athijegannathan Sundararajan ([sundar](@sundararajana) - Committer)

### Download
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/58/head:pull/58`
`$ git checkout pull/58`
