### PR TITLE
Miscellaneous cleanups

### DIFF
--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/Foreign.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/Foreign.java
@@ -27,11 +27,6 @@
 package jdk.incubator.foreign;
 
 import jdk.internal.foreign.InternalForeign;
-import jdk.internal.foreign.MemoryAddressImpl;
-import jdk.internal.foreign.Utils;
-import jdk.internal.foreign.abi.aarch64.AArch64ABI;
-import jdk.internal.foreign.abi.x64.sysv.SysVx64ABI;
-import jdk.internal.foreign.abi.x64.windows.Windowsx64ABI;
 
 import java.nio.charset.Charset;
 

--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/FunctionDescriptor.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/FunctionDescriptor.java
@@ -153,8 +153,8 @@ public final class FunctionDescriptor implements Constable {
         if (resLayout != null) {
             constants.add(resLayout.describeConstable().get());
         }
-        for (int i = 0 ; i < argLayouts.length ; i++) {
-            constants.add(argLayouts[i].describeConstable().get());
+        for (MemoryLayout argLayout : argLayouts) {
+            constants.add(argLayout.describeConstable().get());
         }
         return Optional.of(DynamicConstantDesc.ofNamed(
                     ConstantDescs.BSM_INVOKE, "function", AbstractLayout.CD_FUNCTION_DESC, constants.toArray(new ConstantDesc[0])));

--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/MemoryHandles.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/MemoryHandles.java
@@ -27,9 +27,7 @@ package jdk.incubator.foreign;
 
 import jdk.internal.access.JavaLangInvokeAccess;
 import jdk.internal.access.SharedSecrets;
-import jdk.internal.access.foreign.MemoryAddressProxy;
 import jdk.internal.foreign.Utils;
-import sun.invoke.util.Wrapper;
 
 import java.lang.invoke.VarHandle;
 import java.nio.ByteOrder;

--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/MemoryLayout.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/MemoryLayout.java
@@ -477,7 +477,7 @@ E * (S + I * F)
      * the same kind, have the same size, name and alignment constraints. Furthermore, depending on the layout kind, additional
      * conditions must be satisfied:
      * <ul>
-     *     <li>two value layouts are considered equal if they have the same endianness (see {@link ValueLayout#order()})</li>
+     *     <li>two value layouts are considered equal if they have the same byte order (see {@link ValueLayout#order()})</li>
      *     <li>two sequence layouts are considered equal if they have the same element count (see {@link SequenceLayout#elementCount()}), and
      *     if their element layouts (see {@link SequenceLayout#elementLayout()}) are also equal</li>
      *     <li>two group layouts are considered equal if they are of the same kind (see {@link GroupLayout#isStruct()},

--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/MemoryLayouts.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/MemoryLayouts.java
@@ -219,7 +219,7 @@ public final class MemoryLayouts {
     public static final ValueLayout C_POINTER;
 
     static {
-        SystemABI abi = InternalForeign.getInstancePriviledged().getSystemABI();
+        SystemABI abi = InternalForeign.getInstancePrivileged().getSystemABI();
         switch (abi.name()) {
             case ABI_SYSV -> {
                 C_BOOL = SysV.C_BOOL;

--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/SystemABI.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/SystemABI.java
@@ -26,9 +26,6 @@
 package jdk.incubator.foreign;
 
 import jdk.internal.foreign.abi.UpcallStubs;
-import jdk.internal.foreign.abi.aarch64.AArch64ABI;
-import jdk.internal.foreign.abi.x64.sysv.SysVx64ABI;
-import jdk.internal.foreign.abi.x64.windows.Windowsx64ABI;
 
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodType;
@@ -56,8 +53,7 @@ public interface SystemABI {
     String ABI_AARCH64 = "AArch64";
 
     /**
-     * Obtain a method handle which can be used to call a given native function,
-     * given default calling covention.
+     * Obtain a method handle which can be used to call a given native function.
      *
      * @param symbol downcall symbol.
      * @param type the method type.
@@ -67,7 +63,7 @@ public interface SystemABI {
     MethodHandle downcallHandle(MemoryAddress symbol, MethodType type, FunctionDescriptor function);
 
     /**
-     * Obtain the pointer to a native stub (using default calling convention) which
+     * Obtain the pointer to a native stub which
      * can be used to upcall into a given method handle.
      *
      * @param target the target method handle.
@@ -178,7 +174,7 @@ public interface SystemABI {
         /**
          * The {@code T*} native type.
          */
-        POINTER;
+        POINTER
     }
 
     /**

--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/ValueLayout.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/ValueLayout.java
@@ -28,7 +28,6 @@ package jdk.incubator.foreign;
 import java.lang.constant.Constable;
 import java.lang.constant.ConstantDescs;
 import java.lang.constant.DynamicConstantDesc;
-import java.lang.constant.MethodHandleDesc;
 import java.nio.ByteOrder;
 import java.util.Map;
 import java.util.Objects;

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/InternalForeign.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/InternalForeign.java
@@ -49,11 +49,11 @@ public class InternalForeign implements Foreign {
     private InternalForeign() {}
 
     public static InternalForeign getInstance() {
-        checkRestrictedAcccess();
-        return getInstancePriviledged();
+        checkRestrictedAccess();
+        return getInstancePrivileged();
     }
 
-    public static InternalForeign getInstancePriviledged() {
+    public static InternalForeign getInstancePrivileged() {
         return INSTANCE;
     }
 
@@ -83,7 +83,7 @@ public class InternalForeign implements Foreign {
         throw new UnsupportedOperationException("Unsupported os or arch: " + os + ", " + arch);
     }
 
-    private static void checkRestrictedAcccess() {
+    private static void checkRestrictedAccess() {
         switch (foreignAccess) {
             case "deny" -> throwIllegalAccessError(foreignAccess);
             case "warn" -> System.err.println("WARNING: Accessing jdk.incubator.foreign.Foreign.");
@@ -91,7 +91,7 @@ public class InternalForeign implements Foreign {
                 StringBuilder sb = new StringBuilder("DEBUG: Accessing jdk.incubator.foreign.Foreign.");
                 StackWalker.getInstance().walk(s -> {
                      s
-                     .forEach(f -> sb.append(System.lineSeparator()).append("\tat " + f));
+                     .forEach(f -> sb.append(System.lineSeparator()).append("\tat ").append(f));
                     return null;
                 });
                 System.out.println(sb.toString());

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/LayoutPath.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/LayoutPath.java
@@ -25,12 +25,9 @@
  */
 package jdk.internal.foreign;
 
-import jdk.incubator.foreign.MemoryAddress;
 import jdk.incubator.foreign.MemoryLayout;
 import jdk.internal.access.JavaLangInvokeAccess;
 import jdk.internal.access.SharedSecrets;
-import jdk.internal.access.foreign.MemoryAddressProxy;
-import sun.invoke.util.Wrapper;
 
 import jdk.incubator.foreign.GroupLayout;
 import jdk.incubator.foreign.SequenceLayout;
@@ -43,7 +40,7 @@ import java.util.function.UnaryOperator;
 import java.util.stream.LongStream;
 
 /**
- * This class provide support for constructing layout paths; that is, starting from a root path (see {@link #rootPath(MemoryLayout)},
+ * This class provide support for constructing layout paths; that is, starting from a root path (see {@link #rootPath(MemoryLayout, ToLongFunction)},
  * a path can be constructed by selecting layout elements using the selector methods provided by this class
  * (see {@link #sequenceElement()}, {@link #sequenceElement(long)}, {@link #sequenceElement(long, long)}, {@link #groupElement(String)}).
  * Once a path has been fully constructed, clients can ask for the offset associated with the layout element selected
@@ -52,7 +49,7 @@ import java.util.stream.LongStream;
  */
 public class LayoutPath {
 
-    private static JavaLangInvokeAccess JLI = SharedSecrets.getJavaLangInvokeAccess();
+    private static final JavaLangInvokeAccess JLI = SharedSecrets.getJavaLangInvokeAccess();
 
     private final MemoryLayout layout;
     private final long offset;
@@ -247,7 +244,7 @@ public class LayoutPath {
         return newStrides;
     }
 
-    private static long[] EMPTY_STRIDES = new long[0];
+    private static final long[] EMPTY_STRIDES = new long[0];
 
     /**
      * This class provides an immutable implementation for the {@code PathElement} interface. A path element implementation

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/LibrariesHelper.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/LibrariesHelper.java
@@ -89,7 +89,7 @@ public final class LibrariesHelper {
     }
 
     static class LibraryLookupImpl implements LibraryLookup {
-        NativeLibrary library;
+        final NativeLibrary library;
 
         LibraryLookupImpl(NativeLibrary library) {
             this.library = library;

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/MemoryAddressImpl.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/MemoryAddressImpl.java
@@ -31,7 +31,6 @@ import jdk.internal.misc.Unsafe;
 import jdk.incubator.foreign.MemoryAddress;
 import jdk.incubator.foreign.MemorySegment;
 
-import java.lang.ref.Reference;
 import java.util.Objects;
 
 /**

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/MemorySegmentImpl.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/MemorySegmentImpl.java
@@ -67,7 +67,7 @@ public final class MemorySegmentImpl implements MemorySegment, MemorySegmentProx
     final static long NONCE = new Random().nextLong();
 
     final static int DEFAULT_MASK = READ | WRITE | CLOSE | ACQUIRE;
-    public static MemorySegmentImpl NOTHING = new MemorySegmentImpl();
+    public static final MemorySegmentImpl NOTHING = new MemorySegmentImpl();
 
     private MemorySegmentImpl() {
         this.length = 0L;

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/Utils.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/Utils.java
@@ -60,7 +60,7 @@ import java.util.function.Supplier;
  */
 public final class Utils {
 
-    private static Unsafe unsafe = Unsafe.getUnsafe();
+    private static final Unsafe unsafe = Unsafe.getUnsafe();
 
     private static final MethodHandle ADDRESS_FILTER;
     private static final MethodHandle LONG_TO_ADDRESS;

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/Binding.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/Binding.java
@@ -90,7 +90,7 @@ import java.util.Objects;
  *
  * Argument bindings:
  * 0: DEREFERENCE(0, long.class) // From the struct's memory region, load a 'long' from offset '0'
- *    MOVE(rcx, long.class) // and copy that into the RCX regitster
+ *    MOVE(rcx, long.class) // and copy that into the RCX register
  *
  * Return bindings:
  * none

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/CallingSequence.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/CallingSequence.java
@@ -66,8 +66,8 @@ public class CallingSequence {
         StringBuilder sb = new StringBuilder();
 
         sb.append("CallingSequence: {\n");
-        sb.append("  MethodType: " + mt);
-        sb.append("  FunctionDescriptor: " + desc);
+        sb.append("  MethodType: ").append(mt);
+        sb.append("  FunctionDescriptor: ").append(desc);
         sb.append("  Argument Bindings:\n");
         for (int i = 0; i < mt.parameterCount(); i++) {
             sb.append("    ").append(i).append(": ").append(argumentBindings.get(i)).append("\n");

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/CallingSequenceBuilder.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/CallingSequenceBuilder.java
@@ -40,7 +40,7 @@ public class CallingSequenceBuilder {
 
     private final boolean forUpcall;
     private final List<List<Binding>> inputBindings = new ArrayList<>();
-    private List<Binding> ouputBindings = List.of();
+    private List<Binding> outputBindings = List.of();
 
     private MethodType mt = MethodType.methodType(void.class);
     private FunctionDescriptor desc = FunctionDescriptor.ofVoid();
@@ -61,14 +61,14 @@ public class CallingSequenceBuilder {
     public CallingSequenceBuilder setReturnBindings(Class<?> carrier, MemoryLayout layout,
                                                     List<Binding> bindings) {
         verifyBindings(false, carrier, bindings);
-        this.ouputBindings = bindings;
+        this.outputBindings = bindings;
         mt = mt.changeReturnType(carrier);
         desc = desc.changeReturnLayout(layout);
         return this;
     }
 
     public CallingSequence build() {
-        return new CallingSequence(mt, desc, inputBindings, ouputBindings);
+        return new CallingSequence(mt, desc, inputBindings, outputBindings);
     }
 
     private void verifyBindings(boolean forArguments, Class<?> carrier, List<Binding> bindings) {

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/ProgrammableUpcallHandler.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/ProgrammableUpcallHandler.java
@@ -23,7 +23,6 @@
 
 package jdk.internal.foreign.abi;
 
-import jdk.incubator.foreign.FunctionDescriptor;
 import jdk.incubator.foreign.MemoryAddress;
 import jdk.incubator.foreign.MemoryHandles;
 import jdk.internal.foreign.MemoryAddressImpl;
@@ -55,7 +54,6 @@ public class ProgrammableUpcallHandler implements UpcallHandler {
     @Stable
     private final MethodHandle mh;
     private final MethodType type;
-    private final FunctionDescriptor function;
     private final CallingSequence callingSequence;
     private final long entryPoint;
 
@@ -66,7 +64,6 @@ public class ProgrammableUpcallHandler implements UpcallHandler {
         this.abi = abi;
         this.layout = BufferLayout.of(abi);
         this.type = callingSequence.methodType();
-        this.function = callingSequence.functionDesc();
         this.callingSequence = callingSequence;
         this.mh = target.asSpreader(Object[].class, callingSequence.methodType().parameterCount());
         this.entryPoint = allocateUpcallStub(abi, layout);

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/SharedUtils.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/SharedUtils.java
@@ -77,10 +77,6 @@ public class SharedUtils {
         return ((addr - 1) | (alignment - 1)) + 1;
     }
 
-    public static long alignDown(long addr, long alignment) {
-        return addr & ~(alignment - 1);
-    }
-
     /**
      * The alignment requirement for a given type
      * @param isVar indicate if the type is a standalone variable. This change how
@@ -106,7 +102,7 @@ public class SharedUtils {
     }
 
     private static long alignmentOfArray(SequenceLayout ar, boolean isVar) {
-        if (ar.elementCount().getAsLong() == 0) {
+        if (ar.elementCount().orElseThrow() == 0) {
             // VLA or incomplete
             return 16;
         } else if ((ar.byteSize()) >= 16 && isVar) {

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/UpcallStubs.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/UpcallStubs.java
@@ -26,8 +26,6 @@ package jdk.internal.foreign.abi;
 
 import jdk.incubator.foreign.MemoryAddress;
 import jdk.internal.foreign.MemoryAddressImpl;
-import jdk.internal.foreign.MemoryScope;
-import jdk.internal.foreign.MemorySegmentImpl;
 
 public class UpcallStubs {
 

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/aarch64/AArch64ABI.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/aarch64/AArch64ABI.java
@@ -28,23 +28,15 @@ package jdk.internal.foreign.abi.aarch64;
 import jdk.incubator.foreign.FunctionDescriptor;
 import jdk.incubator.foreign.MemoryAddress;
 import jdk.incubator.foreign.MemoryLayout;
-import jdk.incubator.foreign.MemoryHandles;
-import jdk.incubator.foreign.MemorySegment;
 import jdk.incubator.foreign.SystemABI;
 import jdk.internal.foreign.MemoryAddressImpl;
 import jdk.internal.foreign.abi.*;
 
-import jdk.incubator.foreign.GroupLayout;
-import jdk.incubator.foreign.MemoryLayout;
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodType;
-import java.lang.invoke.VarHandle;
-import java.util.function.Function;
-import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 
-import static sun.security.action.GetPropertyAction.privilegedGetProperty;
 import static jdk.incubator.foreign.MemoryLayouts.AArch64ABI.*;
 
 /**

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/aarch64/AArch64Architecture.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/aarch64/AArch64Architecture.java
@@ -27,8 +27,6 @@ import jdk.internal.foreign.abi.ABIDescriptor;
 import jdk.internal.foreign.abi.Architecture;
 import jdk.internal.foreign.abi.VMStorage;
 
-import java.util.stream.IntStream;
-
 public class AArch64Architecture implements Architecture {
     public static final Architecture INSTANCE = new AArch64Architecture();
 

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/aarch64/CallArranger.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/aarch64/CallArranger.java
@@ -243,7 +243,7 @@ public class CallArranger {
     static class StorageCalculator {
         private final boolean forArguments;
 
-        private int nRegs[] = new int[] { 0, 0 };
+        private final int[] nRegs = new int[] { 0, 0 };
         private long stackOffset = 0;
 
         public StorageCalculator(boolean forArguments) {
@@ -461,7 +461,6 @@ public class CallArranger {
                 .build();
         }
 
-        @SuppressWarnings("fallthrough")
         @Override
         List<Binding> getBindings(Class<?> carrier, MemoryLayout layout) {
             TypeClass argumentClass = classifyType(layout);

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/x64/sysv/CallArranger.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/x64/sysv/CallArranger.java
@@ -357,7 +357,6 @@ public class CallArranger {
             super(forArguments);
         }
 
-        @SuppressWarnings("fallthrough")
         @Override
         List<Binding> getBindings(Class<?> carrier, MemoryLayout layout) {
             TypeClass argumentClass = classifyLayout(layout);
@@ -437,9 +436,6 @@ public class CallArranger {
             //padding not allowed here
             throw new IllegalStateException("Unexpected value layout: could not determine ABI class");
         }
-        if (clazz == ArgumentClassImpl.POINTER) {
-            clazz = ArgumentClassImpl.POINTER;
-        }
         classes.add(clazz);
         if (clazz == ArgumentClassImpl.INTEGER) {
             // int128
@@ -469,7 +465,7 @@ public class CallArranger {
         }
 
         long offset = 0;
-        final long count = type.elementCount().getAsLong();
+        final long count = type.elementCount().orElseThrow();
         for (long idx = 0; idx < count; idx++) {
             MemoryLayout t = type.elementLayout();
             offset = SharedUtils.align(t, false, offset);
@@ -550,7 +546,7 @@ public class CallArranger {
             // ignore zero-length array for now
             // TODO: handle zero length arrays here
             if (t instanceof SequenceLayout) {
-                if (((SequenceLayout) t).elementCount().getAsLong() == 0) {
+                if (((SequenceLayout) t).elementCount().orElseThrow() == 0) {
                     continue;
                 }
             }

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/x64/sysv/SysVx64ABI.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/x64/sysv/SysVx64ABI.java
@@ -25,24 +25,17 @@
 package jdk.internal.foreign.abi.x64.sysv;
 
 import jdk.incubator.foreign.FunctionDescriptor;
-import jdk.incubator.foreign.GroupLayout;
 import jdk.incubator.foreign.MemoryAddress;
 import jdk.incubator.foreign.MemoryLayout;
-import jdk.incubator.foreign.MemoryHandles;
-import jdk.incubator.foreign.MemoryLayout;
-import jdk.incubator.foreign.MemorySegment;
 import jdk.incubator.foreign.SystemABI;
 import jdk.internal.foreign.MemoryAddressImpl;
-import jdk.internal.foreign.Utils;
 import jdk.internal.foreign.abi.*;
 import jdk.internal.foreign.abi.x64.ArgumentClassImpl;
 
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodType;
-import java.lang.invoke.VarHandle;
 import java.util.*;
 
-import static sun.security.action.GetPropertyAction.privilegedGetProperty;
 import static jdk.incubator.foreign.MemoryLayouts.SysV.*;
 
 /**

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/x64/windows/CallArranger.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/x64/windows/CallArranger.java
@@ -326,7 +326,6 @@ public class CallArranger {
             this.storageCalculator = new StorageCalculator(forArguments);
         }
 
-        @SuppressWarnings("fallthrough")
         @Override
         public List<Binding> getBindings(Class<?> carrier, MemoryLayout layout) {
             TypeClass argumentClass = classifyType(layout);

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/x64/windows/Windowsx64ABI.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/x64/windows/Windowsx64ABI.java
@@ -37,7 +37,6 @@ import java.lang.invoke.MethodType;
 import java.util.Objects;
 import java.util.Optional;
 
-import static sun.security.action.GetPropertyAction.privilegedGetProperty;
 import static jdk.incubator.foreign.MemoryLayouts.WinABI.*;
 
 /**


### PR DESCRIPTION
Hi,

This patch applies some general cleanups suggested by IntelliJ, such as:
- Removing unused imports
- Fixing typos
- Applying `final` when possible
- Using Optional::orElseThrow instead of Optional::get where it's uncertain if the optional contains a value
- Using StringBuilder::append instead of `+` in some places (to avoid indy concat).
- Changing indexed to for-each loop
- Fixing a link in javadoc
- Removing a spurious semicolon
- Removing an unused method

Jorn
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * Henry Jen ([henryjen](@slowhog) - Committer)

### Download
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/59/head:pull/59`
`$ git checkout pull/59`
