### PR TITLE
8241334: panama foreign-jextract branch fails to build

### DIFF
--- a/src/jdk.incubator.jextract/share/classes/jdk/incubator/jextract/tool/HandleSourceFactory.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/incubator/jextract/tool/HandleSourceFactory.java
@@ -127,7 +127,7 @@ public class HandleSourceFactory implements Declaration.Visitor<Void, Declaratio
 
     private static String getCLangConstantsHolder() {
         String prefix = "jdk.incubator.foreign.MemoryLayouts.";
-        String abi = InternalForeign.getInstancePriviledged().getSystemABI().name();
+        String abi = InternalForeign.getInstancePrivileged().getSystemABI().name();
         switch (abi) {
             case SystemABI.ABI_SYSV:
                 return prefix + "SysV";

--- a/src/jdk.incubator.jextract/share/classes/jdk/incubator/jextract/tool/JavaSourceBuilder.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/incubator/jextract/tool/JavaSourceBuilder.java
@@ -51,7 +51,7 @@ import javax.lang.model.SourceVersion;
  * method is called to get overall generated source string.
  */
 class JavaSourceBuilder {
-    private static final String ABI = InternalForeign.getInstancePriviledged().getSystemABI().name();
+    private static final String ABI = InternalForeign.getInstancePrivileged().getSystemABI().name();
     // buffer
     protected StringBuffer sb;
     // current line alignment (number of 4-spaces)

--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/clang/TranslationUnit.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/clang/TranslationUnit.java
@@ -40,7 +40,7 @@ import java.util.Objects;
 import java.util.function.Consumer;
 
 public class TranslationUnit implements AutoCloseable {
-    private static final Foreign FOREIGN = InternalForeign.getInstancePriviledged();
+    private static final Foreign FOREIGN = InternalForeign.getInstancePrivileged();
 
     private MemoryAddress tu;
 

--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/clang/Utils.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/clang/Utils.java
@@ -53,12 +53,12 @@ public class Utils {
 
     static {
         try {
-            STRLEN = InternalForeign.getInstancePriviledged().getSystemABI().downcallHandle(
+            STRLEN = InternalForeign.getInstancePrivileged().getSystemABI().downcallHandle(
                     LibraryLookup.ofDefault().lookup("strlen"),
                     MethodType.methodType(int.class, MemoryAddress.class),
                     FunctionDescriptor.of(LayoutUtils.C_INT, LayoutUtils.C_POINTER));
 
-            STRCPY = InternalForeign.getInstancePriviledged().getSystemABI().downcallHandle(
+            STRCPY = InternalForeign.getInstancePrivileged().getSystemABI().downcallHandle(
                     LibraryLookup.ofDefault().lookup("strcpy"),
                     MethodType.methodType(MemoryAddress.class, MemoryAddress.class, MemoryAddress.class),
                     FunctionDescriptor.of(LayoutUtils.C_POINTER, LayoutUtils.C_POINTER, LayoutUtils.C_POINTER));

--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/clang/libclang/RuntimeHelper.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/clang/libclang/RuntimeHelper.java
@@ -44,7 +44,7 @@ import java.util.Optional;
 
 public class RuntimeHelper {
 
-    private final static SystemABI ABI = InternalForeign.getInstancePriviledged().getSystemABI();
+    private final static SystemABI ABI = InternalForeign.getInstancePrivileged().getSystemABI();
 
     private final static ClassLoader LOADER = RuntimeHelper.class.getClassLoader();
 

--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/LayoutUtils.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/LayoutUtils.java
@@ -47,7 +47,7 @@ import java.util.Optional;
  * General Layout utility functions
  */
 public final class LayoutUtils {
-    private static SystemABI abi = InternalForeign.getInstancePriviledged().getSystemABI();
+    private static SystemABI abi = InternalForeign.getInstancePrivileged().getSystemABI();
     private LayoutUtils() {}
 
     public static String getName(Type type) {


### PR DESCRIPTION
Renamed usage as Foreign.getInstancePrivileged
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [JDK-8241334](https://bugs.openjdk.java.net/browse/JDK-8241334): panama foreign-jextract branch fails to build


### Reviewers
 * Henry Jen ([henryjen](@slowhog) - Committer)

### Download
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/60/head:pull/60`
`$ git checkout pull/60`
