### PR TITLE
8241442: jextract spuriously crashes

### DIFF
--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/clang/LibClang.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/clang/LibClang.java
@@ -25,17 +25,46 @@
  */
 package jdk.internal.clang;
 
+import jdk.incubator.foreign.FunctionDescriptor;
+import jdk.incubator.foreign.LibraryLookup;
 import jdk.incubator.foreign.MemoryAddress;
 import jdk.incubator.foreign.MemorySegment;
+import jdk.incubator.foreign.SystemABI;
 import jdk.internal.clang.libclang.Index_h;
+import jdk.internal.foreign.InternalForeign;
+import jdk.internal.jextract.impl.LayoutUtils;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodType;
 
 public class LibClang {
     private static final boolean DEBUG = Boolean.getBoolean("libclang.debug");
     private static final boolean CRASH_RECOVERY = Boolean.getBoolean("libclang.crash_recovery");
 
+    private final static MemorySegment disableCrashRecovery =
+            Utils.toNativeString("LIBCLANG_DISABLE_CRASH_RECOVERY=" + CRASH_RECOVERY)
+                .withAccessModes(MemorySegment.READ);
+
+    static {
+        if (!CRASH_RECOVERY) {
+            //this is an hack - needed because clang_toggleCrashRecovery only takes effect _after_ the
+            //first call to createIndex.
+            try {
+                SystemABI abi = InternalForeign.getInstancePrivileged().getSystemABI();
+                String putenv = abi.name().equals(SystemABI.ABI_WINDOWS) ?
+                        "_putenv" : "putenv";
+                MethodHandle PUT_ENV = abi.downcallHandle(LibraryLookup.ofDefault().lookup(putenv),
+                                MethodType.methodType(int.class, MemoryAddress.class),
+                                FunctionDescriptor.of(LayoutUtils.C_INT, LayoutUtils.C_POINTER));
+                int res = (int) PUT_ENV.invokeExact(disableCrashRecovery.baseAddress());
+            } catch (Throwable ex) {
+                throw new ExceptionInInitializerError(ex);
+            }
+        }
+    }
+
     public static Index createIndex(boolean local) {
         Index index = new Index(Index_h.clang_createIndex(local ? 1 : 0, 0));
-        Index_h.clang_toggleCrashRecovery(CRASH_RECOVERY ? 1 : 0);
         if (DEBUG) {
             System.err.println("LibClang crash recovery " + (CRASH_RECOVERY ? "enabled" : "disabled"));
         }


### PR DESCRIPTION
This patch fixes a spurious crash when running jextract; the problem is, again, related to the signal handlers installed by libclang. While we disable those by calling clang_toggleCrashRecovery soon after index creation, this leaves us exposed for the call to clang_createIndex itself, which set up the alternate handlers soon after function enter. This means that, during that call, a bad interaction between hotspot generated signals and libclang signal handlers can result in spurious VM crashes. This behavior started to become more apparent after this change:

https://github.com/openjdk/panama-foreign/pull/40

Although there's nothing wrong with these changes (but they probably trigger different optimizations to kick in).

The fix is to set an environment variable `LIBCLANG_DISABLE_CRASH_RECOVERY` which is used to gate the signal override behavior, see:

https://github.com/llvm-mirror/clang/blob/master/tools/libclang/CIndex.cpp#L3281

We do this using `putenv` on Linux/Mac and `_putenv` on Windows.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [JDK-8241442](https://bugs.openjdk.java.net/browse/JDK-8241442): jextract spuriously crashes


### Reviewers
 * Athijegannathan Sundararajan ([sundar](@sundararajana) - Committer)

### Download
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/62/head:pull/62`
`$ git checkout pull/62`
