### PR TITLE
8241504: Expose MemoryLayout annotations/attributes in the public API

### DIFF
--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/AbstractLayout.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/AbstractLayout.java
@@ -150,7 +150,7 @@ abstract class AbstractLayout implements MemoryLayout {
         }
         return s;
     }
-    
+
     <T> DynamicConstantDesc<T> decorateLayoutConstant(DynamicConstantDesc<T> desc) {
         if (!hasNaturalAlignment()) {
             desc = DynamicConstantDesc.ofNamed(BSM_INVOKE, "withBitAlignment", desc.constantType(), MH_WITH_BIT_ALIGNMENT,

--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/AbstractLayout.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/AbstractLayout.java
@@ -67,6 +67,11 @@ abstract class AbstractLayout implements MemoryLayout {
     }
 
     @Override
+    public final Optional<String> name() {
+        return attribute(NAME).map(String.class::cast);
+    }
+
+    @Override
     public Optional<Constable> attribute(String name) {
         return Optional.ofNullable(attributes.get(name));
     }
@@ -81,11 +86,6 @@ abstract class AbstractLayout implements MemoryLayout {
         Map<String, Constable> newAttributes = new HashMap<>(attributes);
         newAttributes.put(name, value);
         return dup(alignment, newAttributes);
-    }
-
-    @Override
-    public final Optional<String> name() {
-        return attribute(NAME).map(String.class::cast);
     }
 
     abstract AbstractLayout dup(long alignment, Map<String, Constable> annos);

--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/AbstractLayout.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/AbstractLayout.java
@@ -40,49 +40,59 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.OptionalLong;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static java.lang.constant.ConstantDescs.BSM_INVOKE;
+import static java.lang.constant.ConstantDescs.CD_String;
+import static java.lang.constant.ConstantDescs.CD_long;
 
 abstract class AbstractLayout implements MemoryLayout {
-    private final OptionalLong size;
-    final long alignment;
-    protected final Map<String, Constable> annotations;
-
-    public AbstractLayout(OptionalLong size, long alignment, Map<String, Constable> annotations) {
-        this.size = size;
-        this.alignment = alignment;
-        this.annotations = Collections.unmodifiableMap(annotations);
-    }
-
-    Optional<String> optName() {
-        return Optional.ofNullable((String)annotations.get(NAME));
-    }
-
-    // memory layout annotation key for abi native type
+    // memory layout attribute key for layout name
+    static final String NAME = "name";
+    // memory layout attribute key for abi native type
     static final String NATIVE_TYPE = "abi/native-type";
 
-    Optional<SystemABI.Type> optABIType() {
-        return Optional.ofNullable((SystemABI.Type)annotations.get(NATIVE_TYPE));
+    private final OptionalLong size;
+    final long alignment;
+    protected final Map<String, Constable> attributes;
+
+    public AbstractLayout(OptionalLong size, long alignment, Map<String, Constable> attributes) {
+        this.size = size;
+        this.alignment = alignment;
+        this.attributes = Collections.unmodifiableMap(attributes);
     }
 
     @Override
     public AbstractLayout withName(String name) {
-        return withAnnotation(NAME, name);
+        return withAttribute(NAME, name);
     }
 
-    @SuppressWarnings("unchecked")
-    public <Z extends AbstractLayout> Z withAnnotation(String name, Constable value) {
-        Map<String, Constable> new_annos = new HashMap<>(annotations);
-        new_annos.put(name, value);
-        return (Z)dup(alignment, new_annos);
+    @Override
+    public Optional<Constable> attribute(String name) {
+        return Optional.ofNullable(attributes.get(name));
+    }
+
+    @Override
+    public Stream<String> attributes() {
+        return attributes.keySet().stream();
+    }
+
+    @Override
+    public AbstractLayout withAttribute(String name, Constable value) {
+        Map<String, Constable> newAttributes = new HashMap<>(attributes);
+        newAttributes.put(name, value);
+        return dup(alignment, newAttributes);
     }
 
     @Override
     public final Optional<String> name() {
-        return optName();
+        return attribute(NAME).map(String.class::cast);
     }
 
     @Override
     public final Optional<SystemABI.Type> abiType() {
-        return optABIType();
+        return attribute(NATIVE_TYPE).map(SystemABI.Type.class::cast);
     }
 
     abstract AbstractLayout dup(long alignment, Map<String, Constable> annos);
@@ -90,7 +100,7 @@ abstract class AbstractLayout implements MemoryLayout {
     @Override
     public AbstractLayout withBitAlignment(long alignmentBits) {
         checkAlignment(alignmentBits);
-        return dup(alignmentBits, annotations);
+        return dup(alignmentBits, attributes);
     }
 
     void checkAlignment(long alignmentBitCount) {
@@ -134,13 +144,31 @@ abstract class AbstractLayout implements MemoryLayout {
     }
 
     String decorateLayoutString(String s) {
-        if (optName().isPresent()) {
-            s = String.format("%s(%s)", s, optName().get());
+        if (name().isPresent()) {
+            s = String.format("%s(%s)", s, name().get());
         }
         if (!hasNaturalAlignment()) {
             s = alignment + "%" + s;
         }
+        if (!attributes.isEmpty()) {
+            s += attributes.entrySet().stream()
+                                      .map(e -> e.getKey() + "=" + e.getValue())
+                                      .collect(Collectors.joining(",", "[", "]"));
+        }
         return s;
+    }
+    
+    <T> DynamicConstantDesc<T> decorateLayoutConstant(DynamicConstantDesc<T> desc) {
+        if (!hasNaturalAlignment()) {
+            desc = DynamicConstantDesc.ofNamed(BSM_INVOKE, "withBitAlignment", desc.constantType(), MH_WITH_BIT_ALIGNMENT,
+                    desc, bitAlignment());
+        }
+        for (var e : attributes.entrySet()) {
+            desc = DynamicConstantDesc.ofNamed(BSM_INVOKE, "withAttribute", desc.constantType(), MH_WITH_ATTRIBUTE,
+                    desc, e.getKey(), e.getValue().describeConstable().orElseThrow());
+        }
+
+        return desc;
     }
 
     boolean hasNaturalAlignment() {
@@ -149,7 +177,7 @@ abstract class AbstractLayout implements MemoryLayout {
 
     @Override
     public int hashCode() {
-        return annotations.hashCode() << Long.hashCode(alignment);
+        return attributes.hashCode() << Long.hashCode(alignment);
     }
 
     @Override
@@ -162,11 +190,9 @@ abstract class AbstractLayout implements MemoryLayout {
             return false;
         }
 
-        return Objects.equals(annotations, ((AbstractLayout)other).annotations) &&
-                Objects.equals(alignment, ((AbstractLayout)other).alignment);
+        return Objects.equals(attributes, ((AbstractLayout) other).attributes) &&
+                Objects.equals(alignment, ((AbstractLayout) other).alignment);
     }
-
-    static final String NAME = "name";
 
     /*** Helper constants for implementing Layout::describeConstable ***/
 
@@ -174,7 +200,7 @@ abstract class AbstractLayout implements MemoryLayout {
             = ConstantDescs.ofConstantBootstrap(ConstantDescs.CD_ConstantBootstraps, "getStaticFinal",
             ConstantDescs.CD_Object, ConstantDescs.CD_Class);
 
-    static final ClassDesc CD_LAYOUT = MemoryLayout.class.describeConstable().get();
+    static final ClassDesc CD_MEMORY_LAYOUT = MemoryLayout.class.describeConstable().get();
 
     static final ClassDesc CD_VALUE_LAYOUT = ValueLayout.class.describeConstable().get();
 
@@ -186,6 +212,8 @@ abstract class AbstractLayout implements MemoryLayout {
 
     static final ClassDesc CD_FUNCTION_DESC = FunctionDescriptor.class.describeConstable().get();
 
+    static final ClassDesc CD_Constable = Constable.class.describeConstable().get();
+
     static final ConstantDesc BIG_ENDIAN = DynamicConstantDesc.ofNamed(BSM_GET_STATIC_FINAL, "BIG_ENDIAN", CD_BYTEORDER, CD_BYTEORDER);
 
     static final ConstantDesc LITTLE_ENDIAN = DynamicConstantDesc.ofNamed(BSM_GET_STATIC_FINAL, "LITTLE_ENDIAN", CD_BYTEORDER, CD_BYTEORDER);
@@ -194,27 +222,33 @@ abstract class AbstractLayout implements MemoryLayout {
 
     static final ConstantDesc FALSE = DynamicConstantDesc.ofNamed(BSM_GET_STATIC_FINAL, "FALSE", ConstantDescs.CD_Boolean, ConstantDescs.CD_Boolean);
 
-    static final MethodHandleDesc MH_PADDING = MethodHandleDesc.ofMethod(DirectMethodHandleDesc.Kind.INTERFACE_STATIC, CD_LAYOUT, "ofPaddingBits",
-                MethodTypeDesc.of(CD_LAYOUT, ConstantDescs.CD_long));
+    static final MethodHandleDesc MH_PADDING = MethodHandleDesc.ofMethod(DirectMethodHandleDesc.Kind.INTERFACE_STATIC, CD_MEMORY_LAYOUT, "ofPaddingBits",
+                MethodTypeDesc.of(CD_MEMORY_LAYOUT, CD_long));
 
-    static final MethodHandleDesc MH_VALUE = MethodHandleDesc.ofMethod(DirectMethodHandleDesc.Kind.INTERFACE_STATIC, CD_LAYOUT, "ofValueBits",
-                MethodTypeDesc.of(CD_VALUE_LAYOUT, ConstantDescs.CD_long, CD_BYTEORDER));
+    static final MethodHandleDesc MH_VALUE = MethodHandleDesc.ofMethod(DirectMethodHandleDesc.Kind.INTERFACE_STATIC, CD_MEMORY_LAYOUT, "ofValueBits",
+                MethodTypeDesc.of(CD_VALUE_LAYOUT, CD_long, CD_BYTEORDER));
 
-    static final MethodHandleDesc MH_SIZED_SEQUENCE = MethodHandleDesc.ofMethod(DirectMethodHandleDesc.Kind.INTERFACE_STATIC, CD_LAYOUT, "ofSequence",
-                MethodTypeDesc.of(CD_SEQUENCE_LAYOUT, ConstantDescs.CD_long, CD_LAYOUT));
+    static final MethodHandleDesc MH_SIZED_SEQUENCE = MethodHandleDesc.ofMethod(DirectMethodHandleDesc.Kind.INTERFACE_STATIC, CD_MEMORY_LAYOUT, "ofSequence",
+                MethodTypeDesc.of(CD_SEQUENCE_LAYOUT, CD_long, CD_MEMORY_LAYOUT));
 
-    static final MethodHandleDesc MH_UNSIZED_SEQUENCE = MethodHandleDesc.ofMethod(DirectMethodHandleDesc.Kind.INTERFACE_STATIC, CD_LAYOUT, "ofSequence",
-                MethodTypeDesc.of(CD_SEQUENCE_LAYOUT, CD_LAYOUT));
+    static final MethodHandleDesc MH_UNSIZED_SEQUENCE = MethodHandleDesc.ofMethod(DirectMethodHandleDesc.Kind.INTERFACE_STATIC, CD_MEMORY_LAYOUT, "ofSequence",
+                MethodTypeDesc.of(CD_SEQUENCE_LAYOUT, CD_MEMORY_LAYOUT));
 
-    static final MethodHandleDesc MH_STRUCT = MethodHandleDesc.ofMethod(DirectMethodHandleDesc.Kind.INTERFACE_STATIC, CD_LAYOUT, "ofStruct",
-                MethodTypeDesc.of(CD_GROUP_LAYOUT, CD_LAYOUT.arrayType()));
+    static final MethodHandleDesc MH_STRUCT = MethodHandleDesc.ofMethod(DirectMethodHandleDesc.Kind.INTERFACE_STATIC, CD_MEMORY_LAYOUT, "ofStruct",
+                MethodTypeDesc.of(CD_GROUP_LAYOUT, CD_MEMORY_LAYOUT.arrayType()));
 
-    static final MethodHandleDesc MH_UNION = MethodHandleDesc.ofMethod(DirectMethodHandleDesc.Kind.INTERFACE_STATIC, CD_LAYOUT, "ofUnion",
-                MethodTypeDesc.of(CD_GROUP_LAYOUT, CD_LAYOUT.arrayType()));
+    static final MethodHandleDesc MH_UNION = MethodHandleDesc.ofMethod(DirectMethodHandleDesc.Kind.INTERFACE_STATIC, CD_MEMORY_LAYOUT, "ofUnion",
+                MethodTypeDesc.of(CD_GROUP_LAYOUT, CD_MEMORY_LAYOUT.arrayType()));
 
-    static final MethodHandleDesc MH_VOID_FUNCTION = MethodHandleDesc.ofMethod(DirectMethodHandleDesc.Kind.INTERFACE_STATIC, CD_FUNCTION_DESC, "ofVoid",
-                MethodTypeDesc.of(CD_FUNCTION_DESC, CD_LAYOUT.arrayType()));
+    static final MethodHandleDesc MH_VOID_FUNCTION = MethodHandleDesc.ofMethod(DirectMethodHandleDesc.Kind.STATIC, CD_FUNCTION_DESC, "ofVoid",
+                MethodTypeDesc.of(CD_FUNCTION_DESC, CD_MEMORY_LAYOUT.arrayType()));
 
-    static final MethodHandleDesc MH_FUNCTION = MethodHandleDesc.ofMethod(DirectMethodHandleDesc.Kind.INTERFACE_STATIC, CD_FUNCTION_DESC, "of",
-                MethodTypeDesc.of(CD_FUNCTION_DESC, CD_LAYOUT, CD_LAYOUT.arrayType()));
+    static final MethodHandleDesc MH_FUNCTION = MethodHandleDesc.ofMethod(DirectMethodHandleDesc.Kind.STATIC, CD_FUNCTION_DESC, "of",
+                MethodTypeDesc.of(CD_FUNCTION_DESC, CD_MEMORY_LAYOUT, CD_MEMORY_LAYOUT.arrayType()));
+
+    static final MethodHandleDesc MH_WITH_BIT_ALIGNMENT = MethodHandleDesc.ofMethod(DirectMethodHandleDesc.Kind.INTERFACE_VIRTUAL, CD_MEMORY_LAYOUT, "withBitAlignment",
+                MethodTypeDesc.of(CD_MEMORY_LAYOUT, CD_long));
+
+    static final MethodHandleDesc MH_WITH_ATTRIBUTE = MethodHandleDesc.ofMethod(DirectMethodHandleDesc.Kind.INTERFACE_VIRTUAL, CD_MEMORY_LAYOUT, "withAttribute",
+                MethodTypeDesc.of(CD_MEMORY_LAYOUT, CD_String, CD_Constable));
 }

--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/AbstractLayout.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/AbstractLayout.java
@@ -50,8 +50,6 @@ import static java.lang.constant.ConstantDescs.CD_long;
 abstract class AbstractLayout implements MemoryLayout {
     // memory layout attribute key for layout name
     static final String NAME = "name";
-    // memory layout attribute key for abi native type
-    static final String NATIVE_TYPE = "abi/native-type";
 
     private final OptionalLong size;
     final long alignment;
@@ -88,11 +86,6 @@ abstract class AbstractLayout implements MemoryLayout {
     @Override
     public final Optional<String> name() {
         return attribute(NAME).map(String.class::cast);
-    }
-
-    @Override
-    public final Optional<SystemABI.Type> abiType() {
-        return attribute(NATIVE_TYPE).map(SystemABI.Type.class::cast);
     }
 
     abstract AbstractLayout dup(long alignment, Map<String, Constable> annos);

--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/GroupLayout.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/GroupLayout.java
@@ -31,6 +31,7 @@ import java.lang.constant.ConstantDescs;
 import java.lang.constant.DynamicConstantDesc;
 import java.lang.constant.MethodHandleDesc;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -105,8 +106,8 @@ public final class GroupLayout extends AbstractLayout {
         this(kind, elements, kind.alignof(elements), Map.of());
     }
 
-    GroupLayout(Kind kind, List<MemoryLayout> elements, long alignment, Map<String, Constable> annotations) {
-        super(kind.sizeof(elements), alignment, annotations);
+    GroupLayout(Kind kind, List<MemoryLayout> elements, long alignment, Map<String, Constable> attributes) {
+        super(kind.sizeof(elements), alignment, attributes);
         this.kind = kind;
         this.elements = elements;
     }
@@ -170,8 +171,8 @@ public final class GroupLayout extends AbstractLayout {
     }
 
     @Override
-    GroupLayout dup(long alignment, Map<String, Constable> annotations) {
-        return new GroupLayout(kind, elements, alignment, annotations);
+    GroupLayout dup(long alignment, Map<String, Constable> attributes) {
+        return new GroupLayout(kind, elements, alignment, attributes);
     }
 
     @Override
@@ -186,9 +187,9 @@ public final class GroupLayout extends AbstractLayout {
         for (int i = 0 ; i < elements.size() ; i++) {
             constants[i + 1] = elements.get(i).describeConstable().get();
         }
-        return Optional.of(DynamicConstantDesc.ofNamed(
+        return Optional.of(decorateLayoutConstant(DynamicConstantDesc.ofNamed(
                     ConstantDescs.BSM_INVOKE, kind.name().toLowerCase(),
-                CD_GROUP_LAYOUT, constants));
+                CD_GROUP_LAYOUT, constants)));
     }
 
     //hack: the declarations below are to make javadoc happy; we could have used generics in AbstractLayout
@@ -208,5 +209,13 @@ public final class GroupLayout extends AbstractLayout {
     @Override
     public GroupLayout withBitAlignment(long alignmentBits) {
         return (GroupLayout)super.withBitAlignment(alignmentBits);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public GroupLayout withAttribute(String name, Constable value) {
+        return (GroupLayout)super.withAttribute(name, value);
     }
 }

--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/MemoryLayout.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/MemoryLayout.java
@@ -305,7 +305,7 @@ public interface MemoryLayout extends Constable {
     }
 
     /**
-     * Returns a new MemoryLayout with the given addtional attribute
+     * Returns a new MemoryLayout with the given additional attribute
      *
      * @param name the name of the attribute
      * @param value the value of the attribute

--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/MemoryLayout.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/MemoryLayout.java
@@ -41,6 +41,7 @@ import java.util.OptionalLong;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.function.UnaryOperator;
+import java.util.stream.Stream;
 
 /**
  * A memory layout can be used to describe the contents of a memory segment in a <em>language neutral</em> fashion.
@@ -290,6 +291,30 @@ public interface MemoryLayout extends Constable {
      * @throws IllegalArgumentException if {@code bitAlignment} is not a power of two, or if it's less than than 8.
      */
     MemoryLayout withBitAlignment(long bitAlignment);
+
+    /**
+     * Returns the attribute with the given name if it exists, or an empty optional
+     *
+     * @param name the name of the attribute
+     * @return the optional attribute
+     */
+    Optional<Constable> attribute(String name);
+
+    /**
+     * Returns a new MemoryLayout with the given addtional attribute
+     *
+     * @param name the name of the attribute
+     * @param value the value of the attribute
+     * @return the new MemoryLayout
+     */
+    MemoryLayout withAttribute(String name, Constable value);
+
+    /**
+     * Returns a stream of the names of the attributes of this layout
+     *
+     * @return the stream of names
+     */
+    Stream<String> attributes();
 
     /**
      * Computes the offset, in bits, of the layout selected by a given layout path, where the path is considered rooted in this

--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/MemoryLayout.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/MemoryLayout.java
@@ -228,13 +228,6 @@ public interface MemoryLayout extends Constable {
     Optional<String> name();
 
     /**
-     * Return the ABI <em>type</em> (if any) associated with this layout.
-     *
-     * @return the layout ABI <em>type</em> (if any).
-     */
-    Optional<SystemABI.Type> abiType();
-
-    /**
      * Creates a new layout which features the desired layout <em>name</em>.
      *
      * @param name the layout name.
@@ -299,6 +292,17 @@ public interface MemoryLayout extends Constable {
      * @return the optional attribute
      */
     Optional<Constable> attribute(String name);
+
+    /**
+     * Returns the attribute with the given name and the given type if it exists, or an empty optional
+     *
+     * @param name the name of the attribute
+     * @param type the type to filter by
+     * @return the optional attribute
+     */
+    default <T extends Constable> Optional<T> attribute(String name, Class<T> type) {
+        return attribute(name).filter(type::isInstance).map(type::cast);
+    }
 
     /**
      * Returns a new MemoryLayout with the given addtional attribute

--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/MemoryLayout.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/MemoryLayout.java
@@ -294,17 +294,6 @@ public interface MemoryLayout extends Constable {
     Optional<Constable> attribute(String name);
 
     /**
-     * Returns the attribute with the given name and the given type if it exists, or an empty optional
-     *
-     * @param name the name of the attribute
-     * @param type the type to filter by
-     * @return the optional attribute
-     */
-    default <T extends Constable> Optional<T> attribute(String name, Class<T> type) {
-        return attribute(name).filter(type::isInstance).map(type::cast);
-    }
-
-    /**
      * Returns a new MemoryLayout with the given additional attribute
      *
      * @param name the name of the attribute

--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/MemoryLayouts.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/MemoryLayouts.java
@@ -288,107 +288,107 @@ public final class MemoryLayouts {
          * The {@code _Bool} native type.
          */
         public static final ValueLayout C_BOOL = SharedLayouts.BITS_8_LE
-                .withAnnotation(AbstractLayout.NATIVE_TYPE, SystemABI.Type.BOOL);
+                .withAttribute(AbstractLayout.NATIVE_TYPE, SystemABI.Type.BOOL);
 
 
         /**
          * The {@code unsigned char} native type.
          */
         public static final ValueLayout C_UCHAR = SharedLayouts.BITS_8_LE
-                .withAnnotation(AbstractLayout.NATIVE_TYPE, SystemABI.Type.UNSIGNED_CHAR);
+                .withAttribute(AbstractLayout.NATIVE_TYPE, SystemABI.Type.UNSIGNED_CHAR);
 
 
         /**
          * The {@code signed char} native type.
          */
         public static final ValueLayout C_SCHAR = SharedLayouts.BITS_8_LE
-                .withAnnotation(AbstractLayout.NATIVE_TYPE, SystemABI.Type.SIGNED_CHAR);
+                .withAttribute(AbstractLayout.NATIVE_TYPE, SystemABI.Type.SIGNED_CHAR);
 
 
         /**
          * The {@code char} native type.
          */
         public static final ValueLayout C_CHAR = SharedLayouts.BITS_8_LE
-                .withAnnotation(AbstractLayout.NATIVE_TYPE, SystemABI.Type.CHAR);
+                .withAttribute(AbstractLayout.NATIVE_TYPE, SystemABI.Type.CHAR);
 
         /**
          * The {@code short} native type.
          */
         public static final ValueLayout C_SHORT = SharedLayouts.BITS_16_LE
-                .withAnnotation(AbstractLayout.NATIVE_TYPE, SystemABI.Type.SHORT);
+                .withAttribute(AbstractLayout.NATIVE_TYPE, SystemABI.Type.SHORT);
 
         /**
          * The {@code unsigned short} native type.
          */
         public static final ValueLayout C_USHORT = SharedLayouts.BITS_16_LE
-                .withAnnotation(AbstractLayout.NATIVE_TYPE, SystemABI.Type.UNSIGNED_SHORT);
+                .withAttribute(AbstractLayout.NATIVE_TYPE, SystemABI.Type.UNSIGNED_SHORT);
 
         /**
          * The {@code int} native type.
          */
         public static final ValueLayout C_INT = SharedLayouts.BITS_32_LE
-                .withAnnotation(AbstractLayout.NATIVE_TYPE, SystemABI.Type.INT);
+                .withAttribute(AbstractLayout.NATIVE_TYPE, SystemABI.Type.INT);
 
         /**
          * The {@code unsigned int} native type.
          */
         public static final ValueLayout C_UINT = SharedLayouts.BITS_32_LE
-                .withAnnotation(AbstractLayout.NATIVE_TYPE, SystemABI.Type.UNSIGNED_INT);
+                .withAttribute(AbstractLayout.NATIVE_TYPE, SystemABI.Type.UNSIGNED_INT);
 
         /**
          * The {@code long} native type.
          */
         public static final ValueLayout C_LONG = SharedLayouts.BITS_64_LE
-                .withAnnotation(AbstractLayout.NATIVE_TYPE, SystemABI.Type.LONG);
+                .withAttribute(AbstractLayout.NATIVE_TYPE, SystemABI.Type.LONG);
 
         /**
          * The {@code unsigned long} native type.
          */
         public static final ValueLayout C_ULONG = SharedLayouts.BITS_64_LE
-                .withAnnotation(AbstractLayout.NATIVE_TYPE, SystemABI.Type.UNSIGNED_LONG);
+                .withAttribute(AbstractLayout.NATIVE_TYPE, SystemABI.Type.UNSIGNED_LONG);
 
 
         /**
          * The {@code long long} native type.
          */
         public static final ValueLayout C_LONGLONG = SharedLayouts.BITS_64_LE
-                .withAnnotation(AbstractLayout.NATIVE_TYPE, SystemABI.Type.LONG_LONG);
+                .withAttribute(AbstractLayout.NATIVE_TYPE, SystemABI.Type.LONG_LONG);
 
         /**
          * The {@code unsigned long long} native type.
          */
         public static final ValueLayout C_ULONGLONG = SharedLayouts.BITS_64_LE
-                .withAnnotation(AbstractLayout.NATIVE_TYPE, SystemABI.Type.UNSIGNED_LONG_LONG);
+                .withAttribute(AbstractLayout.NATIVE_TYPE, SystemABI.Type.UNSIGNED_LONG_LONG);
 
         /**
          * The {@code float} native type.
          */
         public static final ValueLayout C_FLOAT = SharedLayouts.BITS_32_LE
-                .withAnnotation(AbstractLayout.NATIVE_TYPE, SystemABI.Type.FLOAT);
+                .withAttribute(AbstractLayout.NATIVE_TYPE, SystemABI.Type.FLOAT);
 
         /**
          * The {@code double} native type.
          */
         public static final ValueLayout C_DOUBLE = SharedLayouts.BITS_64_LE
-                .withAnnotation(AbstractLayout.NATIVE_TYPE, SystemABI.Type.DOUBLE);
+                .withAttribute(AbstractLayout.NATIVE_TYPE, SystemABI.Type.DOUBLE);
 
         /**
          * The {@code long double} native type.
          */
         public static final ValueLayout C_LONGDOUBLE = MemoryLayout.ofValueBits(128, ByteOrder.LITTLE_ENDIAN)
-                .withAnnotation(AbstractLayout.NATIVE_TYPE, SystemABI.Type.LONG_DOUBLE);
+                .withAttribute(AbstractLayout.NATIVE_TYPE, SystemABI.Type.LONG_DOUBLE);
 
         /**
          * The {@code complex long double} native type.
          */
         public static final GroupLayout C_COMPLEX_LONGDOUBLE = MemoryLayout.ofStruct(C_LONGDOUBLE, C_LONGDOUBLE)
-                .withAnnotation(AbstractLayout.NATIVE_TYPE, SystemABI.Type.COMPLEX_LONG_DOUBLE);
+                .withAttribute(AbstractLayout.NATIVE_TYPE, SystemABI.Type.COMPLEX_LONG_DOUBLE);
 
         /**
          * The {@code T*} native type.
          */
         public static final ValueLayout C_POINTER = SharedLayouts.BITS_64_LE
-                .withAnnotation(AbstractLayout.NATIVE_TYPE, SystemABI.Type.POINTER);
+                .withAttribute(AbstractLayout.NATIVE_TYPE, SystemABI.Type.POINTER);
     }
 
     /**
@@ -399,100 +399,100 @@ public final class MemoryLayouts {
          * The {@code _Bool} native type.
          */
         public static final ValueLayout C_BOOL = SharedLayouts.BITS_8_LE
-                .withAnnotation(AbstractLayout.NATIVE_TYPE, SystemABI.Type.BOOL);
+                .withAttribute(AbstractLayout.NATIVE_TYPE, SystemABI.Type.BOOL);
 
         /**
          * The {@code unsigned char} native type.
          */
         public static final ValueLayout C_UCHAR = SharedLayouts.BITS_8_LE
-                .withAnnotation(AbstractLayout.NATIVE_TYPE, SystemABI.Type.UNSIGNED_CHAR);
+                .withAttribute(AbstractLayout.NATIVE_TYPE, SystemABI.Type.UNSIGNED_CHAR);
 
         /**
          * The {@code signed char} native type.
          */
         public static final ValueLayout C_SCHAR = SharedLayouts.BITS_8_LE
-                .withAnnotation(AbstractLayout.NATIVE_TYPE, SystemABI.Type.SIGNED_CHAR);
+                .withAttribute(AbstractLayout.NATIVE_TYPE, SystemABI.Type.SIGNED_CHAR);
 
         /**
          * The {@code char} native type.
          */
         public static final ValueLayout C_CHAR = SharedLayouts.BITS_8_LE
-                .withAnnotation(AbstractLayout.NATIVE_TYPE, SystemABI.Type.CHAR);
+                .withAttribute(AbstractLayout.NATIVE_TYPE, SystemABI.Type.CHAR);
 
         /**
          * The {@code short} native type.
          */
         public static final ValueLayout C_SHORT = SharedLayouts.BITS_16_LE
-                .withAnnotation(AbstractLayout.NATIVE_TYPE, SystemABI.Type.SHORT);
+                .withAttribute(AbstractLayout.NATIVE_TYPE, SystemABI.Type.SHORT);
 
         /**
          * The {@code unsigned short} native type.
          */
         public static final ValueLayout C_USHORT = SharedLayouts.BITS_16_LE
-                .withAnnotation(AbstractLayout.NATIVE_TYPE, SystemABI.Type.UNSIGNED_SHORT);
+                .withAttribute(AbstractLayout.NATIVE_TYPE, SystemABI.Type.UNSIGNED_SHORT);
 
         /**
          * The {@code int} native type.
          */
         public static final ValueLayout C_INT = SharedLayouts.BITS_32_LE
-                .withAnnotation(AbstractLayout.NATIVE_TYPE, SystemABI.Type.INT);
+                .withAttribute(AbstractLayout.NATIVE_TYPE, SystemABI.Type.INT);
 
         /**
          * The {@code unsigned int} native type.
          */
         public static final ValueLayout C_UINT = SharedLayouts.BITS_32_LE
-                .withAnnotation(AbstractLayout.NATIVE_TYPE, SystemABI.Type.UNSIGNED_INT);
+                .withAttribute(AbstractLayout.NATIVE_TYPE, SystemABI.Type.UNSIGNED_INT);
 
         /**
          * The {@code long} native type.
          */
         public static final ValueLayout C_LONG = SharedLayouts.BITS_32_LE
-                .withAnnotation(AbstractLayout.NATIVE_TYPE, SystemABI.Type.LONG);
+                .withAttribute(AbstractLayout.NATIVE_TYPE, SystemABI.Type.LONG);
 
         /**
          * The {@code unsigned long} native type.
          */
         public static final ValueLayout C_ULONG = SharedLayouts.BITS_32_LE
-                .withAnnotation(AbstractLayout.NATIVE_TYPE, SystemABI.Type.UNSIGNED_LONG);
+                .withAttribute(AbstractLayout.NATIVE_TYPE, SystemABI.Type.UNSIGNED_LONG);
 
         /**
          * The {@code long long} native type.
          */
         public static final ValueLayout C_LONGLONG = SharedLayouts.BITS_64_LE
-                .withAnnotation(AbstractLayout.NATIVE_TYPE, SystemABI.Type.LONG_LONG);
+                .withAttribute(AbstractLayout.NATIVE_TYPE, SystemABI.Type.LONG_LONG);
 
         /**
          * The {@code unsigned long long} native type.
          */
         public static final ValueLayout C_ULONGLONG = SharedLayouts.BITS_64_LE
-                .withAnnotation(AbstractLayout.NATIVE_TYPE, SystemABI.Type.UNSIGNED_LONG_LONG);
+                .withAttribute(AbstractLayout.NATIVE_TYPE, SystemABI.Type.UNSIGNED_LONG_LONG);
 
         /**
          * The {@code float} native type.
          */
         public static final ValueLayout C_FLOAT = SharedLayouts.BITS_32_LE
-                .withAnnotation(AbstractLayout.NATIVE_TYPE, SystemABI.Type.FLOAT);
+                .withAttribute(AbstractLayout.NATIVE_TYPE, SystemABI.Type.FLOAT);
 
         /**
          * The {@code double} native type.
          */
         public static final ValueLayout C_DOUBLE = SharedLayouts.BITS_64_LE
-                .withAnnotation(AbstractLayout.NATIVE_TYPE, SystemABI.Type.DOUBLE);
+                .withAttribute(AbstractLayout.NATIVE_TYPE, SystemABI.Type.DOUBLE);
 
         /**
          * The {@code long double} native type.
          */
         public static final ValueLayout C_LONGDOUBLE = SharedLayouts.BITS_64_LE
-                .withAnnotation(AbstractLayout.NATIVE_TYPE, SystemABI.Type.LONG_DOUBLE);
+                .withAttribute(AbstractLayout.NATIVE_TYPE, SystemABI.Type.LONG_DOUBLE);
 
         /**
          * The {@code T*} native type.
          */
         public static final ValueLayout C_POINTER = SharedLayouts.BITS_64_LE
-                .withAnnotation(AbstractLayout.NATIVE_TYPE, SystemABI.Type.POINTER);
+                .withAttribute(AbstractLayout.NATIVE_TYPE, SystemABI.Type.POINTER);
 
         public static ValueLayout asVarArg(ValueLayout l) {
-           return l.withAnnotation(Windowsx64ABI.VARARGS_ANNOTATION_NAME, "true");
+           return l.withAttribute(Windowsx64ABI.VARARGS_ATTRIBUTE_NAME, "true");
         }
     }
 
@@ -504,97 +504,97 @@ public final class MemoryLayouts {
          * The {@code _Bool} native type.
          */
         public static final ValueLayout C_BOOL = SharedLayouts.BITS_8_LE
-                .withAnnotation(AbstractLayout.NATIVE_TYPE, SystemABI.Type.BOOL);
+                .withAttribute(AbstractLayout.NATIVE_TYPE, SystemABI.Type.BOOL);
 
         /**
          * The {@code unsigned char} native type.
          */
         public static final ValueLayout C_UCHAR = SharedLayouts.BITS_8_LE
-                .withAnnotation(AbstractLayout.NATIVE_TYPE, SystemABI.Type.UNSIGNED_CHAR);
+                .withAttribute(AbstractLayout.NATIVE_TYPE, SystemABI.Type.UNSIGNED_CHAR);
 
         /**
          * The {@code signed char} native type.
          */
         public static final ValueLayout C_SCHAR = SharedLayouts.BITS_8_LE
-                .withAnnotation(AbstractLayout.NATIVE_TYPE, SystemABI.Type.SIGNED_CHAR);
+                .withAttribute(AbstractLayout.NATIVE_TYPE, SystemABI.Type.SIGNED_CHAR);
 
         /**
          * The {@code char} native type.
          */
         public static final ValueLayout C_CHAR = SharedLayouts.BITS_8_LE
-                .withAnnotation(AbstractLayout.NATIVE_TYPE, SystemABI.Type.CHAR);
+                .withAttribute(AbstractLayout.NATIVE_TYPE, SystemABI.Type.CHAR);
 
         /**
          * The {@code short} native type.
          */
         public static final ValueLayout C_SHORT = SharedLayouts.BITS_16_LE
-                .withAnnotation(AbstractLayout.NATIVE_TYPE, SystemABI.Type.SHORT);
+                .withAttribute(AbstractLayout.NATIVE_TYPE, SystemABI.Type.SHORT);
 
         /**
          * The {@code unsigned short} native type.
          */
         public static final ValueLayout C_USHORT = SharedLayouts.BITS_16_LE
-                .withAnnotation(AbstractLayout.NATIVE_TYPE, SystemABI.Type.UNSIGNED_SHORT);
+                .withAttribute(AbstractLayout.NATIVE_TYPE, SystemABI.Type.UNSIGNED_SHORT);
 
         /**
          * The {@code int} native type.
          */
         public static final ValueLayout C_INT = SharedLayouts.BITS_32_LE
-                .withAnnotation(AbstractLayout.NATIVE_TYPE, SystemABI.Type.INT);
+                .withAttribute(AbstractLayout.NATIVE_TYPE, SystemABI.Type.INT);
 
         /**
          * The {@code unsigned int} native type.
          */
         public static final ValueLayout C_UINT = SharedLayouts.BITS_32_LE
-                .withAnnotation(AbstractLayout.NATIVE_TYPE, SystemABI.Type.UNSIGNED_INT);
+                .withAttribute(AbstractLayout.NATIVE_TYPE, SystemABI.Type.UNSIGNED_INT);
 
         /**
          * The {@code long} native type.
          */
         public static final ValueLayout C_LONG = SharedLayouts.BITS_64_LE
-                .withAnnotation(AbstractLayout.NATIVE_TYPE, SystemABI.Type.LONG);
+                .withAttribute(AbstractLayout.NATIVE_TYPE, SystemABI.Type.LONG);
 
         /**
          * The {@code unsigned long} native type.
          */
         public static final ValueLayout C_ULONG = SharedLayouts.BITS_64_LE
-                .withAnnotation(AbstractLayout.NATIVE_TYPE, SystemABI.Type.UNSIGNED_LONG);
+                .withAttribute(AbstractLayout.NATIVE_TYPE, SystemABI.Type.UNSIGNED_LONG);
 
         /**
          * The {@code long long} native type.
          */
         public static final ValueLayout C_LONGLONG = SharedLayouts.BITS_64_LE
-                .withAnnotation(AbstractLayout.NATIVE_TYPE, SystemABI.Type.LONG_LONG);
+                .withAttribute(AbstractLayout.NATIVE_TYPE, SystemABI.Type.LONG_LONG);
 
         /**
          * The {@code unsigned long long} native type.
          */
         public static final ValueLayout C_ULONGLONG = SharedLayouts.BITS_64_LE
-                .withAnnotation(AbstractLayout.NATIVE_TYPE, SystemABI.Type.UNSIGNED_LONG_LONG);
+                .withAttribute(AbstractLayout.NATIVE_TYPE, SystemABI.Type.UNSIGNED_LONG_LONG);
 
         /**
          * The {@code float} native type.
          */
         public static final ValueLayout C_FLOAT = SharedLayouts.BITS_32_LE
-                .withAnnotation(AbstractLayout.NATIVE_TYPE, SystemABI.Type.FLOAT);
+                .withAttribute(AbstractLayout.NATIVE_TYPE, SystemABI.Type.FLOAT);
 
         /**
          * The {@code double} native type.
          */
         public static final ValueLayout C_DOUBLE = SharedLayouts.BITS_64_LE
-                .withAnnotation(AbstractLayout.NATIVE_TYPE, SystemABI.Type.DOUBLE);
+                .withAttribute(AbstractLayout.NATIVE_TYPE, SystemABI.Type.DOUBLE);
 
         /**
          * The {@code long double} native type.
          */
         public static final ValueLayout C_LONGDOUBLE = MemoryLayout.ofValueBits(128, ByteOrder.LITTLE_ENDIAN)
-                .withAnnotation(AbstractLayout.NATIVE_TYPE, SystemABI.Type.LONG_DOUBLE);
+                .withAttribute(AbstractLayout.NATIVE_TYPE, SystemABI.Type.LONG_DOUBLE);
 
         /**
          * The {@code T*} native type.
          */
         public static final ValueLayout C_POINTER = SharedLayouts.BITS_64_LE
-                .withAnnotation(AbstractLayout.NATIVE_TYPE, SystemABI.Type.POINTER);
+                .withAttribute(AbstractLayout.NATIVE_TYPE, SystemABI.Type.POINTER);
     }
 
     private static class SharedLayouts { // Separate class to prevent circular clinit references

--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/MemoryLayouts.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/MemoryLayouts.java
@@ -288,107 +288,107 @@ public final class MemoryLayouts {
          * The {@code _Bool} native type.
          */
         public static final ValueLayout C_BOOL = SharedLayouts.BITS_8_LE
-                .withAttribute(AbstractLayout.NATIVE_TYPE, SystemABI.Type.BOOL);
+                .withAttribute(SystemABI.NATIVE_TYPE, SystemABI.Type.BOOL);
 
 
         /**
          * The {@code unsigned char} native type.
          */
         public static final ValueLayout C_UCHAR = SharedLayouts.BITS_8_LE
-                .withAttribute(AbstractLayout.NATIVE_TYPE, SystemABI.Type.UNSIGNED_CHAR);
+                .withAttribute(SystemABI.NATIVE_TYPE, SystemABI.Type.UNSIGNED_CHAR);
 
 
         /**
          * The {@code signed char} native type.
          */
         public static final ValueLayout C_SCHAR = SharedLayouts.BITS_8_LE
-                .withAttribute(AbstractLayout.NATIVE_TYPE, SystemABI.Type.SIGNED_CHAR);
+                .withAttribute(SystemABI.NATIVE_TYPE, SystemABI.Type.SIGNED_CHAR);
 
 
         /**
          * The {@code char} native type.
          */
         public static final ValueLayout C_CHAR = SharedLayouts.BITS_8_LE
-                .withAttribute(AbstractLayout.NATIVE_TYPE, SystemABI.Type.CHAR);
+                .withAttribute(SystemABI.NATIVE_TYPE, SystemABI.Type.CHAR);
 
         /**
          * The {@code short} native type.
          */
         public static final ValueLayout C_SHORT = SharedLayouts.BITS_16_LE
-                .withAttribute(AbstractLayout.NATIVE_TYPE, SystemABI.Type.SHORT);
+                .withAttribute(SystemABI.NATIVE_TYPE, SystemABI.Type.SHORT);
 
         /**
          * The {@code unsigned short} native type.
          */
         public static final ValueLayout C_USHORT = SharedLayouts.BITS_16_LE
-                .withAttribute(AbstractLayout.NATIVE_TYPE, SystemABI.Type.UNSIGNED_SHORT);
+                .withAttribute(SystemABI.NATIVE_TYPE, SystemABI.Type.UNSIGNED_SHORT);
 
         /**
          * The {@code int} native type.
          */
         public static final ValueLayout C_INT = SharedLayouts.BITS_32_LE
-                .withAttribute(AbstractLayout.NATIVE_TYPE, SystemABI.Type.INT);
+                .withAttribute(SystemABI.NATIVE_TYPE, SystemABI.Type.INT);
 
         /**
          * The {@code unsigned int} native type.
          */
         public static final ValueLayout C_UINT = SharedLayouts.BITS_32_LE
-                .withAttribute(AbstractLayout.NATIVE_TYPE, SystemABI.Type.UNSIGNED_INT);
+                .withAttribute(SystemABI.NATIVE_TYPE, SystemABI.Type.UNSIGNED_INT);
 
         /**
          * The {@code long} native type.
          */
         public static final ValueLayout C_LONG = SharedLayouts.BITS_64_LE
-                .withAttribute(AbstractLayout.NATIVE_TYPE, SystemABI.Type.LONG);
+                .withAttribute(SystemABI.NATIVE_TYPE, SystemABI.Type.LONG);
 
         /**
          * The {@code unsigned long} native type.
          */
         public static final ValueLayout C_ULONG = SharedLayouts.BITS_64_LE
-                .withAttribute(AbstractLayout.NATIVE_TYPE, SystemABI.Type.UNSIGNED_LONG);
+                .withAttribute(SystemABI.NATIVE_TYPE, SystemABI.Type.UNSIGNED_LONG);
 
 
         /**
          * The {@code long long} native type.
          */
         public static final ValueLayout C_LONGLONG = SharedLayouts.BITS_64_LE
-                .withAttribute(AbstractLayout.NATIVE_TYPE, SystemABI.Type.LONG_LONG);
+                .withAttribute(SystemABI.NATIVE_TYPE, SystemABI.Type.LONG_LONG);
 
         /**
          * The {@code unsigned long long} native type.
          */
         public static final ValueLayout C_ULONGLONG = SharedLayouts.BITS_64_LE
-                .withAttribute(AbstractLayout.NATIVE_TYPE, SystemABI.Type.UNSIGNED_LONG_LONG);
+                .withAttribute(SystemABI.NATIVE_TYPE, SystemABI.Type.UNSIGNED_LONG_LONG);
 
         /**
          * The {@code float} native type.
          */
         public static final ValueLayout C_FLOAT = SharedLayouts.BITS_32_LE
-                .withAttribute(AbstractLayout.NATIVE_TYPE, SystemABI.Type.FLOAT);
+                .withAttribute(SystemABI.NATIVE_TYPE, SystemABI.Type.FLOAT);
 
         /**
          * The {@code double} native type.
          */
         public static final ValueLayout C_DOUBLE = SharedLayouts.BITS_64_LE
-                .withAttribute(AbstractLayout.NATIVE_TYPE, SystemABI.Type.DOUBLE);
+                .withAttribute(SystemABI.NATIVE_TYPE, SystemABI.Type.DOUBLE);
 
         /**
          * The {@code long double} native type.
          */
         public static final ValueLayout C_LONGDOUBLE = MemoryLayout.ofValueBits(128, ByteOrder.LITTLE_ENDIAN)
-                .withAttribute(AbstractLayout.NATIVE_TYPE, SystemABI.Type.LONG_DOUBLE);
+                .withAttribute(SystemABI.NATIVE_TYPE, SystemABI.Type.LONG_DOUBLE);
 
         /**
          * The {@code complex long double} native type.
          */
         public static final GroupLayout C_COMPLEX_LONGDOUBLE = MemoryLayout.ofStruct(C_LONGDOUBLE, C_LONGDOUBLE)
-                .withAttribute(AbstractLayout.NATIVE_TYPE, SystemABI.Type.COMPLEX_LONG_DOUBLE);
+                .withAttribute(SystemABI.NATIVE_TYPE, SystemABI.Type.COMPLEX_LONG_DOUBLE);
 
         /**
          * The {@code T*} native type.
          */
         public static final ValueLayout C_POINTER = SharedLayouts.BITS_64_LE
-                .withAttribute(AbstractLayout.NATIVE_TYPE, SystemABI.Type.POINTER);
+                .withAttribute(SystemABI.NATIVE_TYPE, SystemABI.Type.POINTER);
     }
 
     /**
@@ -399,97 +399,97 @@ public final class MemoryLayouts {
          * The {@code _Bool} native type.
          */
         public static final ValueLayout C_BOOL = SharedLayouts.BITS_8_LE
-                .withAttribute(AbstractLayout.NATIVE_TYPE, SystemABI.Type.BOOL);
+                .withAttribute(SystemABI.NATIVE_TYPE, SystemABI.Type.BOOL);
 
         /**
          * The {@code unsigned char} native type.
          */
         public static final ValueLayout C_UCHAR = SharedLayouts.BITS_8_LE
-                .withAttribute(AbstractLayout.NATIVE_TYPE, SystemABI.Type.UNSIGNED_CHAR);
+                .withAttribute(SystemABI.NATIVE_TYPE, SystemABI.Type.UNSIGNED_CHAR);
 
         /**
          * The {@code signed char} native type.
          */
         public static final ValueLayout C_SCHAR = SharedLayouts.BITS_8_LE
-                .withAttribute(AbstractLayout.NATIVE_TYPE, SystemABI.Type.SIGNED_CHAR);
+                .withAttribute(SystemABI.NATIVE_TYPE, SystemABI.Type.SIGNED_CHAR);
 
         /**
          * The {@code char} native type.
          */
         public static final ValueLayout C_CHAR = SharedLayouts.BITS_8_LE
-                .withAttribute(AbstractLayout.NATIVE_TYPE, SystemABI.Type.CHAR);
+                .withAttribute(SystemABI.NATIVE_TYPE, SystemABI.Type.CHAR);
 
         /**
          * The {@code short} native type.
          */
         public static final ValueLayout C_SHORT = SharedLayouts.BITS_16_LE
-                .withAttribute(AbstractLayout.NATIVE_TYPE, SystemABI.Type.SHORT);
+                .withAttribute(SystemABI.NATIVE_TYPE, SystemABI.Type.SHORT);
 
         /**
          * The {@code unsigned short} native type.
          */
         public static final ValueLayout C_USHORT = SharedLayouts.BITS_16_LE
-                .withAttribute(AbstractLayout.NATIVE_TYPE, SystemABI.Type.UNSIGNED_SHORT);
+                .withAttribute(SystemABI.NATIVE_TYPE, SystemABI.Type.UNSIGNED_SHORT);
 
         /**
          * The {@code int} native type.
          */
         public static final ValueLayout C_INT = SharedLayouts.BITS_32_LE
-                .withAttribute(AbstractLayout.NATIVE_TYPE, SystemABI.Type.INT);
+                .withAttribute(SystemABI.NATIVE_TYPE, SystemABI.Type.INT);
 
         /**
          * The {@code unsigned int} native type.
          */
         public static final ValueLayout C_UINT = SharedLayouts.BITS_32_LE
-                .withAttribute(AbstractLayout.NATIVE_TYPE, SystemABI.Type.UNSIGNED_INT);
+                .withAttribute(SystemABI.NATIVE_TYPE, SystemABI.Type.UNSIGNED_INT);
 
         /**
          * The {@code long} native type.
          */
         public static final ValueLayout C_LONG = SharedLayouts.BITS_32_LE
-                .withAttribute(AbstractLayout.NATIVE_TYPE, SystemABI.Type.LONG);
+                .withAttribute(SystemABI.NATIVE_TYPE, SystemABI.Type.LONG);
 
         /**
          * The {@code unsigned long} native type.
          */
         public static final ValueLayout C_ULONG = SharedLayouts.BITS_32_LE
-                .withAttribute(AbstractLayout.NATIVE_TYPE, SystemABI.Type.UNSIGNED_LONG);
+                .withAttribute(SystemABI.NATIVE_TYPE, SystemABI.Type.UNSIGNED_LONG);
 
         /**
          * The {@code long long} native type.
          */
         public static final ValueLayout C_LONGLONG = SharedLayouts.BITS_64_LE
-                .withAttribute(AbstractLayout.NATIVE_TYPE, SystemABI.Type.LONG_LONG);
+                .withAttribute(SystemABI.NATIVE_TYPE, SystemABI.Type.LONG_LONG);
 
         /**
          * The {@code unsigned long long} native type.
          */
         public static final ValueLayout C_ULONGLONG = SharedLayouts.BITS_64_LE
-                .withAttribute(AbstractLayout.NATIVE_TYPE, SystemABI.Type.UNSIGNED_LONG_LONG);
+                .withAttribute(SystemABI.NATIVE_TYPE, SystemABI.Type.UNSIGNED_LONG_LONG);
 
         /**
          * The {@code float} native type.
          */
         public static final ValueLayout C_FLOAT = SharedLayouts.BITS_32_LE
-                .withAttribute(AbstractLayout.NATIVE_TYPE, SystemABI.Type.FLOAT);
+                .withAttribute(SystemABI.NATIVE_TYPE, SystemABI.Type.FLOAT);
 
         /**
          * The {@code double} native type.
          */
         public static final ValueLayout C_DOUBLE = SharedLayouts.BITS_64_LE
-                .withAttribute(AbstractLayout.NATIVE_TYPE, SystemABI.Type.DOUBLE);
+                .withAttribute(SystemABI.NATIVE_TYPE, SystemABI.Type.DOUBLE);
 
         /**
          * The {@code long double} native type.
          */
         public static final ValueLayout C_LONGDOUBLE = SharedLayouts.BITS_64_LE
-                .withAttribute(AbstractLayout.NATIVE_TYPE, SystemABI.Type.LONG_DOUBLE);
+                .withAttribute(SystemABI.NATIVE_TYPE, SystemABI.Type.LONG_DOUBLE);
 
         /**
          * The {@code T*} native type.
          */
         public static final ValueLayout C_POINTER = SharedLayouts.BITS_64_LE
-                .withAttribute(AbstractLayout.NATIVE_TYPE, SystemABI.Type.POINTER);
+                .withAttribute(SystemABI.NATIVE_TYPE, SystemABI.Type.POINTER);
 
         public static ValueLayout asVarArg(ValueLayout l) {
            return l.withAttribute(Windowsx64ABI.VARARGS_ATTRIBUTE_NAME, "true");
@@ -504,97 +504,97 @@ public final class MemoryLayouts {
          * The {@code _Bool} native type.
          */
         public static final ValueLayout C_BOOL = SharedLayouts.BITS_8_LE
-                .withAttribute(AbstractLayout.NATIVE_TYPE, SystemABI.Type.BOOL);
+                .withAttribute(SystemABI.NATIVE_TYPE, SystemABI.Type.BOOL);
 
         /**
          * The {@code unsigned char} native type.
          */
         public static final ValueLayout C_UCHAR = SharedLayouts.BITS_8_LE
-                .withAttribute(AbstractLayout.NATIVE_TYPE, SystemABI.Type.UNSIGNED_CHAR);
+                .withAttribute(SystemABI.NATIVE_TYPE, SystemABI.Type.UNSIGNED_CHAR);
 
         /**
          * The {@code signed char} native type.
          */
         public static final ValueLayout C_SCHAR = SharedLayouts.BITS_8_LE
-                .withAttribute(AbstractLayout.NATIVE_TYPE, SystemABI.Type.SIGNED_CHAR);
+                .withAttribute(SystemABI.NATIVE_TYPE, SystemABI.Type.SIGNED_CHAR);
 
         /**
          * The {@code char} native type.
          */
         public static final ValueLayout C_CHAR = SharedLayouts.BITS_8_LE
-                .withAttribute(AbstractLayout.NATIVE_TYPE, SystemABI.Type.CHAR);
+                .withAttribute(SystemABI.NATIVE_TYPE, SystemABI.Type.CHAR);
 
         /**
          * The {@code short} native type.
          */
         public static final ValueLayout C_SHORT = SharedLayouts.BITS_16_LE
-                .withAttribute(AbstractLayout.NATIVE_TYPE, SystemABI.Type.SHORT);
+                .withAttribute(SystemABI.NATIVE_TYPE, SystemABI.Type.SHORT);
 
         /**
          * The {@code unsigned short} native type.
          */
         public static final ValueLayout C_USHORT = SharedLayouts.BITS_16_LE
-                .withAttribute(AbstractLayout.NATIVE_TYPE, SystemABI.Type.UNSIGNED_SHORT);
+                .withAttribute(SystemABI.NATIVE_TYPE, SystemABI.Type.UNSIGNED_SHORT);
 
         /**
          * The {@code int} native type.
          */
         public static final ValueLayout C_INT = SharedLayouts.BITS_32_LE
-                .withAttribute(AbstractLayout.NATIVE_TYPE, SystemABI.Type.INT);
+                .withAttribute(SystemABI.NATIVE_TYPE, SystemABI.Type.INT);
 
         /**
          * The {@code unsigned int} native type.
          */
         public static final ValueLayout C_UINT = SharedLayouts.BITS_32_LE
-                .withAttribute(AbstractLayout.NATIVE_TYPE, SystemABI.Type.UNSIGNED_INT);
+                .withAttribute(SystemABI.NATIVE_TYPE, SystemABI.Type.UNSIGNED_INT);
 
         /**
          * The {@code long} native type.
          */
         public static final ValueLayout C_LONG = SharedLayouts.BITS_64_LE
-                .withAttribute(AbstractLayout.NATIVE_TYPE, SystemABI.Type.LONG);
+                .withAttribute(SystemABI.NATIVE_TYPE, SystemABI.Type.LONG);
 
         /**
          * The {@code unsigned long} native type.
          */
         public static final ValueLayout C_ULONG = SharedLayouts.BITS_64_LE
-                .withAttribute(AbstractLayout.NATIVE_TYPE, SystemABI.Type.UNSIGNED_LONG);
+                .withAttribute(SystemABI.NATIVE_TYPE, SystemABI.Type.UNSIGNED_LONG);
 
         /**
          * The {@code long long} native type.
          */
         public static final ValueLayout C_LONGLONG = SharedLayouts.BITS_64_LE
-                .withAttribute(AbstractLayout.NATIVE_TYPE, SystemABI.Type.LONG_LONG);
+                .withAttribute(SystemABI.NATIVE_TYPE, SystemABI.Type.LONG_LONG);
 
         /**
          * The {@code unsigned long long} native type.
          */
         public static final ValueLayout C_ULONGLONG = SharedLayouts.BITS_64_LE
-                .withAttribute(AbstractLayout.NATIVE_TYPE, SystemABI.Type.UNSIGNED_LONG_LONG);
+                .withAttribute(SystemABI.NATIVE_TYPE, SystemABI.Type.UNSIGNED_LONG_LONG);
 
         /**
          * The {@code float} native type.
          */
         public static final ValueLayout C_FLOAT = SharedLayouts.BITS_32_LE
-                .withAttribute(AbstractLayout.NATIVE_TYPE, SystemABI.Type.FLOAT);
+                .withAttribute(SystemABI.NATIVE_TYPE, SystemABI.Type.FLOAT);
 
         /**
          * The {@code double} native type.
          */
         public static final ValueLayout C_DOUBLE = SharedLayouts.BITS_64_LE
-                .withAttribute(AbstractLayout.NATIVE_TYPE, SystemABI.Type.DOUBLE);
+                .withAttribute(SystemABI.NATIVE_TYPE, SystemABI.Type.DOUBLE);
 
         /**
          * The {@code long double} native type.
          */
         public static final ValueLayout C_LONGDOUBLE = MemoryLayout.ofValueBits(128, ByteOrder.LITTLE_ENDIAN)
-                .withAttribute(AbstractLayout.NATIVE_TYPE, SystemABI.Type.LONG_DOUBLE);
+                .withAttribute(SystemABI.NATIVE_TYPE, SystemABI.Type.LONG_DOUBLE);
 
         /**
          * The {@code T*} native type.
          */
         public static final ValueLayout C_POINTER = SharedLayouts.BITS_64_LE
-                .withAttribute(AbstractLayout.NATIVE_TYPE, SystemABI.Type.POINTER);
+                .withAttribute(SystemABI.NATIVE_TYPE, SystemABI.Type.POINTER);
     }
 
     private static class SharedLayouts { // Separate class to prevent circular clinit references

--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/PaddingLayout.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/PaddingLayout.java
@@ -52,8 +52,8 @@ import java.util.OptionalLong;
         this(size, 1, Map.of());
     }
 
-    PaddingLayout(long size, long alignment, Map<String, Constable> annotations) {
-        super(OptionalLong.of(size), alignment, annotations);
+    PaddingLayout(long size, long alignment, Map<String, Constable> attributes) {
+        super(OptionalLong.of(size), alignment, attributes);
     }
 
     @Override
@@ -82,14 +82,19 @@ import java.util.OptionalLong;
     }
 
     @Override
-    PaddingLayout dup(long alignment, Map<String, Constable> annotations) {
-        return new PaddingLayout(bitSize(), alignment, annotations);
+    PaddingLayout dup(long alignment, Map<String, Constable> attributes) {
+        return new PaddingLayout(bitSize(), alignment, attributes);
+    }
+
+    @Override
+    public boolean hasNaturalAlignment() {
+        return true;
     }
 
     @Override
     public Optional<DynamicConstantDesc<MemoryLayout>> describeConstable() {
-        return Optional.of(DynamicConstantDesc.ofNamed(ConstantDescs.BSM_INVOKE, "padding",
-                CD_LAYOUT, MH_PADDING, bitSize()));
+        return Optional.of(decorateLayoutConstant(DynamicConstantDesc.ofNamed(ConstantDescs.BSM_INVOKE, "padding",
+                CD_MEMORY_LAYOUT, MH_PADDING, bitSize())));
     }
 
     //hack: the declarations below are to make javadoc happy; we could have used generics in AbstractLayout
@@ -109,5 +114,13 @@ import java.util.OptionalLong;
     @Override
     public PaddingLayout withBitAlignment(long alignmentBits) {
         return (PaddingLayout)super.withBitAlignment(alignmentBits);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public PaddingLayout withAttribute(String name, Constable value) {
+        return (PaddingLayout)super.withAttribute(name, value);
     }
 }

--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/SequenceLayout.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/SequenceLayout.java
@@ -71,10 +71,10 @@ public final class SequenceLayout extends AbstractLayout {
         this(elemCount, elementLayout, elementLayout.bitAlignment(), Map.of());
     }
 
-    SequenceLayout(OptionalLong elemCount, MemoryLayout elementLayout, long alignment, Map<String, Constable> annotations) {
+    SequenceLayout(OptionalLong elemCount, MemoryLayout elementLayout, long alignment, Map<String, Constable> attributes) {
         super(elemCount.isPresent() && AbstractLayout.optSize(elementLayout).isPresent() ?
                 OptionalLong.of(elemCount.getAsLong() * elementLayout.bitSize()) :
-                OptionalLong.empty(), alignment, annotations);
+                OptionalLong.empty(), alignment, attributes);
         this.elemCount = elemCount;
         this.elementLayout = elementLayout;
     }
@@ -106,7 +106,7 @@ public final class SequenceLayout extends AbstractLayout {
      */
     public SequenceLayout withElementCount(long elementCount) {
         AbstractLayout.checkSize(elementCount, true);
-        return new SequenceLayout(OptionalLong.of(elementCount), elementLayout, alignment, annotations);
+        return new SequenceLayout(OptionalLong.of(elementCount), elementLayout, alignment, attributes);
     }
 
     @Override
@@ -136,8 +136,8 @@ public final class SequenceLayout extends AbstractLayout {
     }
 
     @Override
-    SequenceLayout dup(long alignment, Map<String, Constable> annotations) {
-        return new SequenceLayout(elementCount(), elementLayout, alignment, annotations);
+    SequenceLayout dup(long alignment, Map<String, Constable> attributes) {
+        return new SequenceLayout(elementCount(), elementLayout, alignment, attributes);
     }
 
     @Override
@@ -147,11 +147,11 @@ public final class SequenceLayout extends AbstractLayout {
 
     @Override
     public Optional<DynamicConstantDesc<SequenceLayout>> describeConstable() {
-        return elemCount.isPresent() ?
-                Optional.of(DynamicConstantDesc.ofNamed(ConstantDescs.BSM_INVOKE, "value",
-                        CD_SEQUENCE_LAYOUT, MH_SIZED_SEQUENCE, elemCount.getAsLong(), elementLayout.describeConstable().get())) :
-                Optional.of(DynamicConstantDesc.ofNamed(ConstantDescs.BSM_INVOKE, "value",
-                        CD_SEQUENCE_LAYOUT, MH_UNSIZED_SEQUENCE, elementLayout.describeConstable().get()));
+        return Optional.of(decorateLayoutConstant(elemCount.isPresent() ?
+                DynamicConstantDesc.ofNamed(ConstantDescs.BSM_INVOKE, "value",
+                        CD_SEQUENCE_LAYOUT, MH_SIZED_SEQUENCE, elemCount.getAsLong(), elementLayout.describeConstable().get()) :
+                DynamicConstantDesc.ofNamed(ConstantDescs.BSM_INVOKE, "value",
+                        CD_SEQUENCE_LAYOUT, MH_UNSIZED_SEQUENCE, elementLayout.describeConstable().get())));
     }
 
     //hack: the declarations below are to make javadoc happy; we could have used generics in AbstractLayout
@@ -171,5 +171,13 @@ public final class SequenceLayout extends AbstractLayout {
     @Override
     public SequenceLayout withBitAlignment(long alignmentBits) {
         return (SequenceLayout)super.withBitAlignment(alignmentBits);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public SequenceLayout withAttribute(String name, Constable value) {
+        return (SequenceLayout)super.withAttribute(name, value);
     }
 }

--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/SystemABI.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/SystemABI.java
@@ -191,7 +191,6 @@ public interface SystemABI {
          */
         public static Type fromLayout(MemoryLayout ml) throws IllegalArgumentException {
             return ml.attribute(NATIVE_TYPE)
-                     .filter(SystemABI.Type.class::isInstance)
                      .map(SystemABI.Type.class::cast)
                      .orElseThrow(() -> new IllegalArgumentException("No ABI attribute present"));
         }

--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/SystemABI.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/SystemABI.java
@@ -179,7 +179,20 @@ public interface SystemABI {
         /**
          * The {@code T*} native type.
          */
-        POINTER
+        POINTER;
+
+        /**
+         * Retrieve the ABI type attached to the given layout,
+         * or throw an {@code IllegalArgumentException} if there is none
+         *
+         * @param ml the layout to retrieve the ABI type of
+         * @return the retrieved ABI type
+         * @throws IllegalArgumentException if the given layout does not have an ABI type annotation
+         */
+        public static Type fromLayout(MemoryLayout ml) throws IllegalArgumentException {
+            return ml.attribute(NATIVE_TYPE, SystemABI.Type.class)
+                     .orElseThrow(() -> new IllegalArgumentException("No ABI attribute present"));
+        }
     }
 
     /**

--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/SystemABI.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/SystemABI.java
@@ -187,7 +187,7 @@ public interface SystemABI {
          *
          * @param ml the layout to retrieve the ABI type of
          * @return the retrieved ABI type
-         * @throws IllegalArgumentException if the given layout does not have an ABI type annotation
+         * @throws IllegalArgumentException if the given layout does not have an ABI type attribute
          */
         public static Type fromLayout(MemoryLayout ml) throws IllegalArgumentException {
             return ml.attribute(NATIVE_TYPE)

--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/SystemABI.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/SystemABI.java
@@ -53,6 +53,11 @@ public interface SystemABI {
     String ABI_AARCH64 = "AArch64";
 
     /**
+     * memory layout attribute key for abi native type
+     */
+    String NATIVE_TYPE = "abi/native-type";
+
+    /**
      * Obtain a method handle which can be used to call a given native function.
      *
      * @param symbol downcall symbol.

--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/SystemABI.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/SystemABI.java
@@ -190,7 +190,9 @@ public interface SystemABI {
          * @throws IllegalArgumentException if the given layout does not have an ABI type annotation
          */
         public static Type fromLayout(MemoryLayout ml) throws IllegalArgumentException {
-            return ml.attribute(NATIVE_TYPE, SystemABI.Type.class)
+            return ml.attribute(NATIVE_TYPE)
+                     .filter(SystemABI.Type.class::isInstance)
+                     .map(SystemABI.Type.class::cast)
                      .orElseThrow(() -> new IllegalArgumentException("No ABI attribute present"));
         }
     }

--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/ValueLayout.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/ValueLayout.java
@@ -56,8 +56,8 @@ public final class ValueLayout extends AbstractLayout implements MemoryLayout {
         this(order, size, size, Map.of());
     }
 
-    ValueLayout(ByteOrder order, long size, long alignment, Map<String, Constable> annotations) {
-        super(OptionalLong.of(size), alignment, annotations);
+    ValueLayout(ByteOrder order, long size, long alignment, Map<String, Constable> attributes) {
+        super(OptionalLong.of(size), alignment, attributes);
         this.order = order;
     }
 
@@ -77,7 +77,7 @@ public final class ValueLayout extends AbstractLayout implements MemoryLayout {
      * @return a new value layout with given byte order.
      */
     public ValueLayout withOrder(ByteOrder order) {
-        return new ValueLayout(order, bitSize(), alignment, annotations);
+        return new ValueLayout(order, bitSize(), alignment, attributes);
     }
 
     @Override
@@ -110,14 +110,14 @@ public final class ValueLayout extends AbstractLayout implements MemoryLayout {
     }
 
     @Override
-    ValueLayout dup(long alignment, Map<String, Constable> annotations) {
-        return new ValueLayout(order, bitSize(), alignment, annotations);
+    ValueLayout dup(long alignment, Map<String, Constable> attributes) {
+        return new ValueLayout(order, bitSize(), alignment, attributes);
     }
 
     @Override
     public Optional<DynamicConstantDesc<ValueLayout>> describeConstable() {
-        return Optional.of(DynamicConstantDesc.ofNamed(ConstantDescs.BSM_INVOKE, "value",
-                CD_VALUE_LAYOUT, MH_VALUE, bitSize(), order == ByteOrder.BIG_ENDIAN ? BIG_ENDIAN : LITTLE_ENDIAN));
+        return Optional.of(decorateLayoutConstant(DynamicConstantDesc.ofNamed(ConstantDescs.BSM_INVOKE, "value",
+                CD_VALUE_LAYOUT, MH_VALUE, bitSize(), order == ByteOrder.BIG_ENDIAN ? BIG_ENDIAN : LITTLE_ENDIAN)));
     }
 
     //hack: the declarations below are to make javadoc happy; we could have used generics in AbstractLayout
@@ -137,5 +137,13 @@ public final class ValueLayout extends AbstractLayout implements MemoryLayout {
     @Override
     public ValueLayout withBitAlignment(long alignmentBits) {
         return (ValueLayout)super.withBitAlignment(alignmentBits);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public ValueLayout withAttribute(String name, Constable value) {
+        return (ValueLayout)super.withAttribute(name, value);
     }
 }

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/Utils.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/Utils.java
@@ -117,21 +117,6 @@ public final class Utils {
         return layout.getClass() == PADDING_CLASS;
     }
 
-    @SuppressWarnings("unchecked")
-    public static Map<String, Constable> getAnnotations(MemoryLayout layout) {
-        try {
-            Field f = ValueLayout.class.getSuperclass().getDeclaredField("annotations");
-            f.setAccessible(true);
-            return (Map<String, Constable>) f.get(layout);
-        } catch (ReflectiveOperationException ex) {
-            throw new IllegalStateException(ex);
-        }
-    }
-
-    public static Constable getAnnotation(MemoryLayout layout, String name) {
-        return getAnnotations(layout).get(name);
-    }
-
     public static MemoryAddress resizeNativeAddress(MemoryAddress base, long byteSize) {
         return new MemoryAddressImpl((MemorySegmentImpl)Utils.makeNativeSegmentUnchecked(base, byteSize), 0);
     }

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/aarch64/CallArranger.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/aarch64/CallArranger.java
@@ -30,6 +30,7 @@ import jdk.incubator.foreign.MemoryLayout;
 import jdk.incubator.foreign.MemoryLayouts;
 import jdk.incubator.foreign.MemorySegment;
 import jdk.incubator.foreign.SequenceLayout;
+import jdk.incubator.foreign.SystemABI;
 import jdk.incubator.foreign.ValueLayout;
 import jdk.internal.foreign.Utils;
 import jdk.internal.foreign.abi.CallingSequenceBuilder;
@@ -162,7 +163,7 @@ public class CallArranger {
     }
 
     private static TypeClass classifyValueType(ValueLayout type) {
-        var optAbiType = type.abiType();
+        var optAbiType = type.attribute(SystemABI.NATIVE_TYPE, SystemABI.Type.class);
         //padding not allowed here
         ArgumentClassImpl clazz = optAbiType.map(AArch64ABI::argumentClassFor).
             orElseThrow(()->new IllegalStateException("Unexpected value layout: could not determine ABI class"));
@@ -200,13 +201,13 @@ public class CallArranger {
         if (!(baseType instanceof ValueLayout))
             return false;
 
-        var optAbiType = baseType.abiType();
+        var optAbiType = baseType.attribute(SystemABI.NATIVE_TYPE, SystemABI.Type.class);
         ArgumentClassImpl baseArgClass = optAbiType.map(AArch64ABI::argumentClassFor).orElse(null);
         if (baseArgClass != ArgumentClassImpl.VECTOR)
            return false;
 
         for (MemoryLayout elem : groupLayout.memberLayouts()) {
-            optAbiType = elem.abiType();
+            optAbiType = elem.attribute(SystemABI.NATIVE_TYPE, SystemABI.Type.class);
             ArgumentClassImpl argClass = optAbiType.map(AArch64ABI::argumentClassFor).orElse(null);
             if (!(elem instanceof ValueLayout) ||
                     elem.bitSize() != baseType.bitSize() ||

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/aarch64/CallArranger.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/aarch64/CallArranger.java
@@ -163,10 +163,7 @@ public class CallArranger {
     }
 
     private static TypeClass classifyValueType(ValueLayout type) {
-        var optAbiType = type.attribute(SystemABI.NATIVE_TYPE, SystemABI.Type.class);
-        //padding not allowed here
-        ArgumentClassImpl clazz = optAbiType.map(AArch64ABI::argumentClassFor).
-            orElseThrow(()->new IllegalStateException("Unexpected value layout: could not determine ABI class"));
+        ArgumentClassImpl clazz = AArch64ABI.argumentClassFor(SystemABI.Type.fromLayout(type));
         if (clazz == null) {
             //padding not allowed here
             throw new IllegalStateException("Unexpected value layout: could not determine ABI class");
@@ -201,14 +198,12 @@ public class CallArranger {
         if (!(baseType instanceof ValueLayout))
             return false;
 
-        var optAbiType = baseType.attribute(SystemABI.NATIVE_TYPE, SystemABI.Type.class);
-        ArgumentClassImpl baseArgClass = optAbiType.map(AArch64ABI::argumentClassFor).orElse(null);
+        ArgumentClassImpl baseArgClass = AArch64ABI.argumentClassFor(SystemABI.Type.fromLayout(baseType));
         if (baseArgClass != ArgumentClassImpl.VECTOR)
            return false;
 
         for (MemoryLayout elem : groupLayout.memberLayouts()) {
-            optAbiType = elem.attribute(SystemABI.NATIVE_TYPE, SystemABI.Type.class);
-            ArgumentClassImpl argClass = optAbiType.map(AArch64ABI::argumentClassFor).orElse(null);
+            ArgumentClassImpl argClass = AArch64ABI.argumentClassFor(SystemABI.Type.fromLayout(elem));
             if (!(elem instanceof ValueLayout) ||
                     elem.bitSize() != baseType.bitSize() ||
                     elem.bitAlignment() != baseType.bitAlignment() ||

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/x64/sysv/CallArranger.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/x64/sysv/CallArranger.java
@@ -517,7 +517,9 @@ public class CallArranger {
     // TODO: handle zero length arrays
     // TODO: Handle nested structs (and primitives)
     private static List<ArgumentClassImpl> classifyStructType(GroupLayout type) {
-        if (type.attribute(SystemABI.NATIVE_TYPE, SystemABI.Type.class)
+        if (type.attribute(SystemABI.NATIVE_TYPE)
+                .filter(SystemABI.Type.class::isInstance)
+                .map(SystemABI.Type.class::cast)
                 .map(SysVx64ABI::argumentClassFor)
                 .filter(ArgumentClassImpl.COMPLEX_X87::equals)
                 .isPresent()) {

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/x64/sysv/CallArranger.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/x64/sysv/CallArranger.java
@@ -518,7 +518,6 @@ public class CallArranger {
     // TODO: Handle nested structs (and primitives)
     private static List<ArgumentClassImpl> classifyStructType(GroupLayout type) {
         if (type.attribute(SystemABI.NATIVE_TYPE)
-                .filter(SystemABI.Type.class::isInstance)
                 .map(SystemABI.Type.class::cast)
                 .map(SysVx64ABI::argumentClassFor)
                 .filter(ArgumentClassImpl.COMPLEX_X87::equals)

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/x64/sysv/CallArranger.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/x64/sysv/CallArranger.java
@@ -429,10 +429,7 @@ public class CallArranger {
 
     private static List<ArgumentClassImpl> classifyValueType(ValueLayout type) {
         ArrayList<ArgumentClassImpl> classes = new ArrayList<>();
-        var optAbiType = type.attribute(SystemABI.NATIVE_TYPE, SystemABI.Type.class);
-        //padding not allowed here
-        ArgumentClassImpl clazz = optAbiType.map(SysVx64ABI::argumentClassFor).
-            orElseThrow(()->new IllegalStateException("Unexpected value layout: could not determine ABI class"));
+        ArgumentClassImpl clazz = SysVx64ABI.argumentClassFor(SystemABI.Type.fromLayout(type));
         if (clazz == null) {
             //padding not allowed here
             throw new IllegalStateException("Unexpected value layout: could not determine ABI class");
@@ -520,9 +517,10 @@ public class CallArranger {
     // TODO: handle zero length arrays
     // TODO: Handle nested structs (and primitives)
     private static List<ArgumentClassImpl> classifyStructType(GroupLayout type) {
-        var optAbiType = type.attribute(SystemABI.NATIVE_TYPE, SystemABI.Type.class);
-        var clazz = optAbiType.map(SysVx64ABI::argumentClassFor).orElse(null);
-        if (clazz == ArgumentClassImpl.COMPLEX_X87) {
+        if (type.attribute(SystemABI.NATIVE_TYPE, SystemABI.Type.class)
+                .map(SysVx64ABI::argumentClassFor)
+                .filter(ArgumentClassImpl.COMPLEX_X87::equals)
+                .isPresent()) {
             return COMPLEX_X87_CLASSES;
         }
 

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/x64/sysv/CallArranger.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/x64/sysv/CallArranger.java
@@ -32,6 +32,7 @@ import jdk.incubator.foreign.MemoryLayout;
 import jdk.incubator.foreign.MemoryLayouts;
 import jdk.incubator.foreign.MemorySegment;
 import jdk.incubator.foreign.SequenceLayout;
+import jdk.incubator.foreign.SystemABI;
 import jdk.incubator.foreign.ValueLayout;
 import jdk.internal.foreign.Utils;
 import jdk.internal.foreign.abi.CallingSequenceBuilder;
@@ -428,7 +429,7 @@ public class CallArranger {
 
     private static List<ArgumentClassImpl> classifyValueType(ValueLayout type) {
         ArrayList<ArgumentClassImpl> classes = new ArrayList<>();
-        var optAbiType = type.abiType();
+        var optAbiType = type.attribute(SystemABI.NATIVE_TYPE, SystemABI.Type.class);
         //padding not allowed here
         ArgumentClassImpl clazz = optAbiType.map(SysVx64ABI::argumentClassFor).
             orElseThrow(()->new IllegalStateException("Unexpected value layout: could not determine ABI class"));
@@ -519,7 +520,7 @@ public class CallArranger {
     // TODO: handle zero length arrays
     // TODO: Handle nested structs (and primitives)
     private static List<ArgumentClassImpl> classifyStructType(GroupLayout type) {
-        var optAbiType = type.abiType();
+        var optAbiType = type.attribute(SystemABI.NATIVE_TYPE, SystemABI.Type.class);
         var clazz = optAbiType.map(SysVx64ABI::argumentClassFor).orElse(null);
         if (clazz == ArgumentClassImpl.COMPLEX_X87) {
             return COMPLEX_X87_CLASSES;

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/x64/windows/CallArranger.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/x64/windows/CallArranger.java
@@ -183,7 +183,10 @@ public class CallArranger {
         } else if(clazz == ArgumentClassImpl.POINTER) {
             return TypeClass.POINTER;
         } else if (clazz == ArgumentClassImpl.SSE) {
-            if (type.attribute(VARARGS_ATTRIBUTE_NAME, String.class).map(Boolean::parseBoolean).orElse(false)) {
+            if (type.attribute(VARARGS_ATTRIBUTE_NAME)
+                    .filter(String.class::isInstance)
+                    .map(String.class::cast)
+                    .map(Boolean::parseBoolean).orElse(false)) {
                 return TypeClass.VARARG_FLOAT;
             }
             return TypeClass.FLOAT;

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/x64/windows/CallArranger.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/x64/windows/CallArranger.java
@@ -184,7 +184,6 @@ public class CallArranger {
             return TypeClass.POINTER;
         } else if (clazz == ArgumentClassImpl.SSE) {
             if (type.attribute(VARARGS_ATTRIBUTE_NAME)
-                    .filter(String.class::isInstance)
                     .map(String.class::cast)
                     .map(Boolean::parseBoolean).orElse(false)) {
                 return TypeClass.VARARG_FLOAT;

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/x64/windows/CallArranger.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/x64/windows/CallArranger.java
@@ -43,6 +43,7 @@ import jdk.internal.foreign.abi.VMStorage;
 import jdk.internal.foreign.abi.x64.X86_64Architecture;
 import jdk.internal.foreign.abi.x64.ArgumentClassImpl;
 import jdk.internal.foreign.abi.SharedUtils;
+import jdk.internal.foreign.abi.x64.sysv.SysVx64ABI;
 
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodType;
@@ -162,10 +163,7 @@ public class CallArranger {
     }
 
     private static TypeClass classifyValueType(ValueLayout type) {
-        var optAbiType = type.attribute(SystemABI.NATIVE_TYPE, SystemABI.Type.class);
-        //padding not allowed here
-        ArgumentClassImpl clazz = optAbiType.map(Windowsx64ABI::argumentClassFor).
-            orElseThrow(()->new IllegalStateException("Unexpected value layout: could not determine ABI class"));
+        ArgumentClassImpl clazz = Windowsx64ABI.argumentClassFor(SystemABI.Type.fromLayout(type));
         if (clazz == null) {
             //padding not allowed here
             throw new IllegalStateException("Unexpected value layout: could not determine ABI class");

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/x64/windows/CallArranger.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/x64/windows/CallArranger.java
@@ -29,6 +29,7 @@ import jdk.incubator.foreign.MemoryLayout;
 import jdk.incubator.foreign.MemoryLayouts;
 import jdk.incubator.foreign.MemorySegment;
 import jdk.incubator.foreign.SequenceLayout;
+import jdk.incubator.foreign.SystemABI;
 import jdk.incubator.foreign.ValueLayout;
 import jdk.internal.foreign.Utils;
 import jdk.internal.foreign.abi.CallingSequenceBuilder;
@@ -161,7 +162,7 @@ public class CallArranger {
     }
 
     private static TypeClass classifyValueType(ValueLayout type) {
-        var optAbiType = type.abiType();
+        var optAbiType = type.attribute(SystemABI.NATIVE_TYPE, SystemABI.Type.class);
         //padding not allowed here
         ArgumentClassImpl clazz = optAbiType.map(Windowsx64ABI::argumentClassFor).
             orElseThrow(()->new IllegalStateException("Unexpected value layout: could not determine ABI class"));

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/x64/windows/CallArranger.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/x64/windows/CallArranger.java
@@ -185,7 +185,7 @@ public class CallArranger {
         } else if(clazz == ArgumentClassImpl.POINTER) {
             return TypeClass.POINTER;
         } else if (clazz == ArgumentClassImpl.SSE) {
-            if (type.attribute(VARARGS_ATTRIBUTE_NAME).map(String.class::cast).map(Boolean::parseBoolean).orElse(false)) {
+            if (type.attribute(VARARGS_ATTRIBUTE_NAME, String.class).map(Boolean::parseBoolean).orElse(false)) {
                 return TypeClass.VARARG_FLOAT;
             }
             return TypeClass.FLOAT;

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/x64/windows/CallArranger.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/x64/windows/CallArranger.java
@@ -49,7 +49,7 @@ import java.util.List;
 import java.util.Optional;
 
 import static jdk.internal.foreign.abi.x64.X86_64Architecture.*;
-import static jdk.internal.foreign.abi.x64.windows.Windowsx64ABI.VARARGS_ANNOTATION_NAME;
+import static jdk.internal.foreign.abi.x64.windows.Windowsx64ABI.VARARGS_ATTRIBUTE_NAME;
 
 /**
  * For the Windowx x64 C ABI specifically, this class uses the ProgrammableInvoker API, namely CallingSequenceBuilder2
@@ -184,7 +184,7 @@ public class CallArranger {
         } else if(clazz == ArgumentClassImpl.POINTER) {
             return TypeClass.POINTER;
         } else if (clazz == ArgumentClassImpl.SSE) {
-            if (Boolean.parseBoolean((String) Utils.getAnnotation(type, VARARGS_ANNOTATION_NAME))) {
+            if (type.attribute(VARARGS_ATTRIBUTE_NAME).map(String.class::cast).map(Boolean::parseBoolean).orElse(false)) {
                 return TypeClass.VARARG_FLOAT;
             }
             return TypeClass.FLOAT;

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/x64/windows/Windowsx64ABI.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/x64/windows/Windowsx64ABI.java
@@ -51,7 +51,7 @@ public class Windowsx64ABI implements SystemABI {
     public static final int MAX_REGISTER_ARGUMENTS = 4;
     public static final int MAX_REGISTER_RETURNS = 1;
 
-    public static final String VARARGS_ANNOTATION_NAME = "abi/windows/varargs";
+    public static final String VARARGS_ATTRIBUTE_NAME = "abi/windows/varargs";
 
     private static Windowsx64ABI instance;
 

--- a/test/jdk/java/foreign/NativeTestHelper.java
+++ b/test/jdk/java/foreign/NativeTestHelper.java
@@ -38,11 +38,7 @@ public class NativeTestHelper {
     public static final SystemABI ABI = Foreign.getInstance().getSystemABI();
 
     public static boolean isIntegral(MemoryLayout layout) {
-        var optAbiType = layout.attribute(SystemABI.NATIVE_TYPE, SystemABI.Type.class);
-        if (!optAbiType.isPresent()) {
-            return false;
-        }
-        return switch(optAbiType.get()) {
+        return switch(SystemABI.Type.fromLayout(layout)) {
             case BOOL, UNSIGNED_CHAR, SIGNED_CHAR, CHAR, SHORT, UNSIGNED_SHORT,
                 INT, UNSIGNED_INT, LONG, UNSIGNED_LONG, LONG_LONG, UNSIGNED_LONG_LONG -> true;
             default -> false;
@@ -50,8 +46,7 @@ public class NativeTestHelper {
     }
 
     public static boolean isPointer(MemoryLayout layout) {
-        return layout.attribute(SystemABI.NATIVE_TYPE, SystemABI.Type.class)
-                     .filter(Predicate.isEqual(Type.POINTER)).isPresent();
+        return SystemABI.Type.fromLayout(layout) == Type.POINTER;
     }
 
     public static ValueLayout asVarArg(ValueLayout layout) {

--- a/test/jdk/java/foreign/NativeTestHelper.java
+++ b/test/jdk/java/foreign/NativeTestHelper.java
@@ -38,7 +38,7 @@ public class NativeTestHelper {
     public static final SystemABI ABI = Foreign.getInstance().getSystemABI();
 
     public static boolean isIntegral(MemoryLayout layout) {
-        var optAbiType = layout.abiType();
+        var optAbiType = layout.attribute(SystemABI.NATIVE_TYPE, SystemABI.Type.class);
         if (!optAbiType.isPresent()) {
             return false;
         }
@@ -50,7 +50,8 @@ public class NativeTestHelper {
     }
 
     public static boolean isPointer(MemoryLayout layout) {
-        return layout.abiType().filter(Predicate.isEqual(Type.POINTER)).isPresent();
+        return layout.attribute(SystemABI.NATIVE_TYPE, SystemABI.Type.class)
+                     .filter(Predicate.isEqual(Type.POINTER)).isPresent();
     }
 
     public static ValueLayout asVarArg(ValueLayout layout) {

--- a/test/jdk/java/foreign/TestLayoutAttributes.java
+++ b/test/jdk/java/foreign/TestLayoutAttributes.java
@@ -1,0 +1,81 @@
+/*
+ *  Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ *  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ *  This code is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License version 2 only, as
+ *  published by the Free Software Foundation.
+ *
+ *  This code is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ *  version 2 for more details (a copy is included in the LICENSE file that
+ *  accompanied this code).
+ *
+ *  You should have received a copy of the GNU General Public License version
+ *  2 along with this work; if not, write to the Free Software Foundation,
+ *  Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ *  Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ *  or visit www.oracle.com if you need additional information or have any
+ *  questions.
+ */
+
+/*
+ * @test
+ * @run testng TestLayoutAttributes
+ */
+
+import jdk.incubator.foreign.MemoryLayout;
+import jdk.incubator.foreign.MemoryLayouts;
+import org.testng.annotations.Test;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+public class TestLayoutAttributes {
+
+    @Test
+    public void testAttribute() {
+        MemoryLayout ml = MemoryLayouts.BITS_32_LE
+                .withAttribute("MyAttribute", 10L);
+        assertEquals((long) ml.attribute("MyAttribute", Long.class).orElseThrow(), 10L);
+    }
+
+    @Test
+    public void testAttributeNonExistent() {
+        MemoryLayout ml = MemoryLayouts.BITS_32_LE
+                .withAttribute("MyAttribute", 10L);
+        assertTrue(ml.attribute("Foo").isEmpty());
+    }
+
+    @Test
+    public void testAttributeTypeFilter() {
+        MemoryLayout ml = MemoryLayouts.BITS_32_LE
+                .withAttribute("MyAttribute", 10L);
+        assertTrue(ml.attribute("MyAttribute", Integer.class).isEmpty());
+        assertTrue(ml.attribute("MyAttribute", Long.class).isPresent());
+        assertTrue(ml.attribute("MyAttribute").isPresent());
+    }
+
+    @Test
+    public void testNameAttribute() {
+        MemoryLayout ml = MemoryLayouts.BITS_32_LE
+                .withName("foo");
+        assertEquals(ml.name().orElseThrow(), "foo");
+        assertEquals(ml.attribute("name", String.class).orElseThrow(), "foo");
+    }
+
+    @Test
+    public void testAttributesStream() {
+        MemoryLayout ml = MemoryLayouts.BITS_32_LE
+                .withName("foo")
+                .withAttribute("MyAttribute", 10L);
+        List<String> attribs = ml.attributes().collect(Collectors.toList());
+        assertEquals(attribs, List.of("name", "MyAttribute"));
+    }
+
+}

--- a/test/jdk/java/foreign/TestLayoutAttributes.java
+++ b/test/jdk/java/foreign/TestLayoutAttributes.java
@@ -42,7 +42,7 @@ public class TestLayoutAttributes {
     public void testAttribute() {
         MemoryLayout ml = MemoryLayouts.BITS_32_LE
                 .withAttribute("MyAttribute", 10L);
-        assertEquals((long) ml.attribute("MyAttribute", Long.class).orElseThrow(), 10L);
+        assertEquals((long) ml.attribute("MyAttribute").orElseThrow(), 10L);
     }
 
     @Test
@@ -53,20 +53,11 @@ public class TestLayoutAttributes {
     }
 
     @Test
-    public void testAttributeTypeFilter() {
-        MemoryLayout ml = MemoryLayouts.BITS_32_LE
-                .withAttribute("MyAttribute", 10L);
-        assertTrue(ml.attribute("MyAttribute", Integer.class).isEmpty());
-        assertTrue(ml.attribute("MyAttribute", Long.class).isPresent());
-        assertTrue(ml.attribute("MyAttribute").isPresent());
-    }
-
-    @Test
     public void testNameAttribute() {
         MemoryLayout ml = MemoryLayouts.BITS_32_LE
                 .withName("foo");
         assertEquals(ml.name().orElseThrow(), "foo");
-        assertEquals(ml.attribute("name", String.class).orElseThrow(), "foo");
+        assertEquals(ml.attribute("name").orElseThrow(), "foo");
     }
 
     @Test

--- a/test/jdk/java/foreign/TestLayoutConstants.java
+++ b/test/jdk/java/foreign/TestLayoutConstants.java
@@ -108,7 +108,7 @@ public class TestLayoutConstants {
                                 MemoryLayouts.BITS_32_BE)) },
                 { MemoryLayouts.BITS_32_LE.withName("myInt") },
                 { MemoryLayouts.BITS_32_LE.withBitAlignment(8) },
-                { MemoryLayouts.BITS_32_LE.withAttribute("xyz", "xyz") },
+                { MemoryLayouts.BITS_32_LE.withAttribute("xyz", "abc") },
         };
     }
 

--- a/test/jdk/java/foreign/TestLayoutConstants.java
+++ b/test/jdk/java/foreign/TestLayoutConstants.java
@@ -106,6 +106,9 @@ public class TestLayoutConstants {
                         MemoryLayout.ofStruct(
                                 MemoryLayouts.PAD_8,
                                 MemoryLayouts.BITS_32_BE)) },
+                { MemoryLayouts.BITS_32_LE.withName("myInt") },
+                { MemoryLayouts.BITS_32_LE.withBitAlignment(8) },
+                { MemoryLayouts.BITS_32_LE.withAttribute("xyz", "xyz") },
         };
     }
 

--- a/test/micro/org/openjdk/bench/jdk/incubator/foreign/CallOverhead.java
+++ b/test/micro/org/openjdk/bench/jdk/incubator/foreign/CallOverhead.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2020 Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.bench.jdk.incubator.foreign;
+
+import jdk.incubator.foreign.Foreign;
+import jdk.incubator.foreign.FunctionDescriptor;
+import jdk.incubator.foreign.LibraryLookup;
+import jdk.incubator.foreign.SystemABI;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+import java.util.concurrent.TimeUnit;
+
+import static jdk.incubator.foreign.MemoryLayouts.C_INT;
+
+@BenchmarkMode(Mode.AverageTime)
+@Warmup(iterations = 5, time = 500, timeUnit = TimeUnit.MILLISECONDS)
+@Measurement(iterations = 10, time = 500, timeUnit = TimeUnit.MILLISECONDS)
+@State(org.openjdk.jmh.annotations.Scope.Thread)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Fork(3)
+public class CallOverhead {
+
+    static final SystemABI abi = Foreign.getInstance().getSystemABI();
+    static final MethodHandle func;
+    static final MethodHandle identity;
+
+    static {
+        System.loadLibrary("CallOverheadJNI");
+
+        try {
+            LibraryLookup ll = LibraryLookup.ofLibrary(MethodHandles.lookup(), "CallOverhead");
+            func = abi.downcallHandle(ll.lookup("func"),
+                    MethodType.methodType(void.class),
+                    FunctionDescriptor.ofVoid());
+            identity = abi.downcallHandle(ll.lookup("identity"),
+                    MethodType.methodType(int.class, int.class),
+                    FunctionDescriptor.of(C_INT, C_INT));
+        } catch (NoSuchMethodException e) {
+            throw new BootstrapMethodError(e);
+        }
+    }
+
+    static native void blank();
+    static native int identity(int x);
+
+    @Benchmark
+    public void jni_blank() throws Throwable {
+        blank();
+    }
+
+    @Benchmark
+    public void panama_blank() throws Throwable {
+        func.invokeExact();
+    }
+
+    @Benchmark
+    public int jni_identity() throws Throwable {
+        return identity(10);
+    }
+
+    @Benchmark
+    public int panama_identity() throws Throwable {
+        return (int) identity.invokeExact(10);
+    }
+}

--- a/test/micro/org/openjdk/bench/jdk/incubator/foreign/libCallOverhead.c
+++ b/test/micro/org/openjdk/bench/jdk/incubator/foreign/libCallOverhead.c
@@ -20,44 +20,15 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
-package org.openjdk.bench.jdk.incubator.foreign.points.support;
 
-import java.nio.ByteBuffer;
-import java.nio.ByteOrder;
+#ifdef _WIN64
+#define EXPORT __declspec(dllexport)
+#else
+#define EXPORT
+#endif
 
-public class BBPoint {
+EXPORT void func() {}
 
-    static {
-        System.loadLibrary("JNIPoint");
-    }
-
-    private final ByteBuffer buff;
-
-    public BBPoint(int x, int y) {
-        this.buff = ByteBuffer.allocateDirect(4 * 2).order(ByteOrder.nativeOrder());
-        setX(x);
-        setY(y);
-    }
-
-    public void setX(int x) {
-        buff.putInt(0, x);
-    }
-
-    public int getX() {
-        return buff.getInt(0);
-    }
-
-    public int getY() {
-        return buff.getInt(1);
-    }
-
-    public void setY(int y) {
-        buff.putInt(0, y);
-    }
-
-    public double distanceTo(BBPoint other) {
-        return distance(buff, other.buff);
-    }
-
-    private static native double distance(ByteBuffer p1, ByteBuffer p2);
+EXPORT int identity(int x) {
+  return x;
 }

--- a/test/micro/org/openjdk/bench/jdk/incubator/foreign/libCallOverheadJNI.c
+++ b/test/micro/org/openjdk/bench/jdk/incubator/foreign/libCallOverheadJNI.c
@@ -20,44 +20,20 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
-package org.openjdk.bench.jdk.incubator.foreign.points.support;
+#include <jni.h>
 
-import java.nio.ByteBuffer;
-import java.nio.ByteOrder;
+void func() {}
 
-public class BBPoint {
+int identity(int x) {
+  return x;
+}
 
-    static {
-        System.loadLibrary("JNIPoint");
-    }
+JNIEXPORT void JNICALL Java_org_openjdk_bench_jdk_incubator_foreign_CallOverhead_blank
+  (JNIEnv *env, jclass cls) {
+    func();
+}
 
-    private final ByteBuffer buff;
-
-    public BBPoint(int x, int y) {
-        this.buff = ByteBuffer.allocateDirect(4 * 2).order(ByteOrder.nativeOrder());
-        setX(x);
-        setY(y);
-    }
-
-    public void setX(int x) {
-        buff.putInt(0, x);
-    }
-
-    public int getX() {
-        return buff.getInt(0);
-    }
-
-    public int getY() {
-        return buff.getInt(1);
-    }
-
-    public void setY(int y) {
-        buff.putInt(0, y);
-    }
-
-    public double distanceTo(BBPoint other) {
-        return distance(buff, other.buff);
-    }
-
-    private static native double distance(ByteBuffer p1, ByteBuffer p2);
+JNIEXPORT jint JNICALL Java_org_openjdk_bench_jdk_incubator_foreign_CallOverhead_identity
+  (JNIEnv *env, jclass cls, jint x) {
+    return identity(x);
 }

--- a/test/micro/org/openjdk/bench/jdk/incubator/foreign/points/PointsDistance.java
+++ b/test/micro/org/openjdk/bench/jdk/incubator/foreign/points/PointsDistance.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2020 Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.bench.jdk.incubator.foreign.points;
+
+import org.openjdk.bench.jdk.incubator.foreign.points.support.BBPoint;
+import org.openjdk.bench.jdk.incubator.foreign.points.support.JNIPoint;
+import org.openjdk.bench.jdk.incubator.foreign.points.support.PanamaPoint;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Warmup;
+
+import java.util.concurrent.TimeUnit;
+
+@BenchmarkMode(Mode.AverageTime)
+@Warmup(iterations = 5, time = 500, timeUnit = TimeUnit.MILLISECONDS)
+@Measurement(iterations = 10, time = 500, timeUnit = TimeUnit.MILLISECONDS)
+@State(org.openjdk.jmh.annotations.Scope.Thread)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Fork(3)
+public class PointsDistance {
+
+    BBPoint jniP1;
+    BBPoint jniP2;
+
+    JNIPoint nativeP1;
+    JNIPoint nativeP2;
+
+    PanamaPoint panamaPointP1;
+    PanamaPoint panamaPointP2;
+
+    @Setup
+    public void setup() {
+        jniP1 = new BBPoint(0, 0);
+        jniP2 = new BBPoint(1, 1);
+
+        nativeP1 = new JNIPoint(0, 0);
+        nativeP2 = new JNIPoint(1, 1);
+
+        panamaPointP1 = new PanamaPoint(0, 0);
+        panamaPointP2 = new PanamaPoint(1, 1);
+    }
+
+    @TearDown
+    public void tearDown() {
+        nativeP1.free();
+        nativeP2.free();
+
+        panamaPointP1.close();
+        panamaPointP2.close();
+    }
+
+    @Benchmark
+    public double jni_ByteBuffer() throws Throwable {
+        return jniP1.distanceTo(jniP2);
+    }
+
+    @Benchmark
+    public double jni_long() throws Throwable {
+        return nativeP1.distanceTo(nativeP2);
+    }
+
+    @Benchmark
+    public double panama_MemorySegment() throws Throwable {
+        return panamaPointP1.distanceTo(panamaPointP2);
+    }
+
+    @Benchmark
+    public double panama_MemoryAddress() throws Throwable {
+        return panamaPointP1.distanceToPtrs(panamaPointP2);
+    }
+
+}

--- a/test/micro/org/openjdk/bench/jdk/incubator/foreign/points/support/JNIPoint.java
+++ b/test/micro/org/openjdk/bench/jdk/incubator/foreign/points/support/JNIPoint.java
@@ -56,6 +56,10 @@ public class JNIPoint implements AutoCloseable {
         setY(peer, value);
     }
 
+    public double distanceTo(JNIPoint other) {
+        return distance(peer, other.peer);
+    }
+
     private static native long allocate();
     private static native void free(long ptr);
 
@@ -64,6 +68,8 @@ public class JNIPoint implements AutoCloseable {
 
     private static native int getY(long ptr);
     private static native void setY(long ptr, int y);
+
+    private static native double distance(long p1, long p2);
 
     @Override
     public void close() {

--- a/test/micro/org/openjdk/bench/jdk/incubator/foreign/points/support/PanamaPoint.java
+++ b/test/micro/org/openjdk/bench/jdk/incubator/foreign/points/support/PanamaPoint.java
@@ -22,26 +22,55 @@
  */
 package org.openjdk.bench.jdk.incubator.foreign.points.support;
 
+import jdk.incubator.foreign.Foreign;
+import jdk.incubator.foreign.FunctionDescriptor;
+import jdk.incubator.foreign.LibraryLookup;
+import jdk.incubator.foreign.MemoryAddress;
 import jdk.incubator.foreign.MemoryLayout;
 import jdk.incubator.foreign.MemoryLayouts;
 import jdk.incubator.foreign.MemorySegment;
+import jdk.incubator.foreign.SystemABI;
 
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
 import java.lang.invoke.VarHandle;
-import java.nio.ByteOrder;
 
+import static java.lang.invoke.MethodType.methodType;
 import static jdk.incubator.foreign.MemoryLayout.PathElement.groupElement;
+import static jdk.incubator.foreign.MemoryLayouts.*;
 
 public class PanamaPoint implements AutoCloseable {
 
     public static final MemoryLayout LAYOUT = MemoryLayout.ofStruct(
-        MemoryLayouts.JAVA_INT.withOrder(ByteOrder.nativeOrder()).withName("x"),
-        MemoryLayouts.JAVA_INT.withOrder(ByteOrder.nativeOrder()).withName("y")
+        MemoryLayouts.C_INT.withName("x"),
+        MemoryLayouts.C_INT.withName("y")
     );
 
     private static final VarHandle VH_x = LAYOUT.varHandle(int.class, groupElement("x"));
     private static final VarHandle VH_y = LAYOUT.varHandle(int.class, groupElement("y"));
+    private static final MethodHandle MH_distance;
+    private static final MethodHandle MH_distance_ptrs;
 
-    private final MemorySegment segment;
+    static {
+        try {
+            SystemABI abi = Foreign.getInstance().getSystemABI();
+            LibraryLookup lookup = LibraryLookup.ofLibrary(MethodHandles.lookup(), "Point");
+            MH_distance = abi.downcallHandle(
+                lookup.lookup("distance"),
+                methodType(double.class, MemorySegment.class, MemorySegment.class),
+                FunctionDescriptor.of(C_DOUBLE, LAYOUT, LAYOUT)
+            );
+            MH_distance_ptrs = abi.downcallHandle(
+                lookup.lookup("distance_ptrs"),
+                methodType(double.class, MemoryAddress.class, MemoryAddress.class),
+                FunctionDescriptor.of(C_DOUBLE, C_POINTER, C_POINTER)
+            );
+        } catch (NoSuchMethodException e) {
+            throw new BootstrapMethodError(e);
+        }
+    }
+
+    private final MemoryAddress address;
 
     public PanamaPoint(int x, int y) {
         this(MemorySegment.allocateNative(LAYOUT), x, y);
@@ -54,27 +83,43 @@ public class PanamaPoint implements AutoCloseable {
     }
 
     public PanamaPoint(MemorySegment segment) {
-        this.segment = segment;
+        this.address = segment.baseAddress();
     }
 
     public void setX(int x) {
-        VH_x.set(segment.baseAddress(), x);
+        VH_x.set(address, x);
     }
 
     public int getX() {
-        return (int) VH_x.get(segment.baseAddress());
+        return (int) VH_x.get(address);
     }
 
     public void setY(int y) {
-        VH_y.set(segment.baseAddress(), y);
+        VH_y.set(address, y);
     }
 
     public int getY() {
-        return (int) VH_y.get(segment.baseAddress());
+        return (int) VH_y.get(address);
+    }
+
+    public double distanceTo(PanamaPoint other) {
+        try {
+            return (double) MH_distance.invokeExact(address.segment(), other.address.segment());
+        } catch (Throwable throwable) {
+            throw new InternalError(throwable);
+        }
+    }
+
+    public double distanceToPtrs(PanamaPoint other) {
+        try {
+            return (double) MH_distance_ptrs.invokeExact(address, other.address);
+        } catch (Throwable throwable) {
+            throw new InternalError(throwable);
+        }
     }
 
     @Override
     public void close() {
-        segment.close();
+        address.segment().close();
     }
 }

--- a/test/micro/org/openjdk/bench/jdk/incubator/foreign/points/support/libJNIPoint.c
+++ b/test/micro/org/openjdk/bench/jdk/incubator/foreign/points/support/libJNIPoint.c
@@ -22,8 +22,15 @@
  */
 #include <jni.h>
 #include <stdlib.h>
+#include <math.h>
 
 #include "points.h"
+
+double distance(Point p1, Point p2) {
+    int xDist = abs(p1.x - p2.x);
+    int yDist = abs(p1.y - p2.y);
+    return sqrt((xDist * xDist) + (yDist * yDist));
+}
 
 JNIEXPORT jlong JNICALL Java_org_openjdk_bench_jdk_incubator_foreign_points_support_JNIPoint_allocate
   (JNIEnv *env, jclass nativePointClass) {
@@ -58,4 +65,18 @@ JNIEXPORT void JNICALL Java_org_openjdk_bench_jdk_incubator_foreign_points_suppo
   (JNIEnv *env, jclass cls, jlong thisPoint, jint value) {
     Point* point = (Point*) thisPoint;
     point->y = value;
+}
+
+JNIEXPORT jdouble JNICALL Java_org_openjdk_bench_jdk_incubator_foreign_points_support_JNIPoint_distance
+  (JNIEnv *env, jclass cls, jlong thisPoint, jlong other) {
+    Point* p1 = (Point*) thisPoint;
+    Point* p2 = (Point*) other;
+    return distance(*p1, *p2);
+}
+
+JNIEXPORT jdouble JNICALL Java_org_openjdk_bench_jdk_incubator_foreign_points_support_BBPoint_distance
+  (JNIEnv *env, jclass ignored, jobject buffP1, jobject buffP2) {
+    Point* p1 = (Point*) (*env)->GetDirectBufferAddress(env, buffP1);
+    Point* p2 = (Point*) (*env)->GetDirectBufferAddress(env, buffP2);
+    return distance(*p1, *p2);
 }

--- a/test/micro/org/openjdk/bench/jdk/incubator/foreign/points/support/libPoint.c
+++ b/test/micro/org/openjdk/bench/jdk/incubator/foreign/points/support/libPoint.c
@@ -20,44 +20,23 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
-package org.openjdk.bench.jdk.incubator.foreign.points.support;
+#include <stdlib.h>
+#include <math.h>
 
-import java.nio.ByteBuffer;
-import java.nio.ByteOrder;
+#include "points.h"
 
-public class BBPoint {
+#ifdef _WIN64
+#define EXPORT __declspec(dllexport)
+#else
+#define EXPORT
+#endif
 
-    static {
-        System.loadLibrary("JNIPoint");
-    }
+EXPORT double distance(Point p1, Point p2) {
+    int xDist = abs(p1.x - p2.x);
+    int yDist = abs(p1.y - p2.y);
+    return sqrt((xDist * xDist) + (yDist * yDist));
+}
 
-    private final ByteBuffer buff;
-
-    public BBPoint(int x, int y) {
-        this.buff = ByteBuffer.allocateDirect(4 * 2).order(ByteOrder.nativeOrder());
-        setX(x);
-        setY(y);
-    }
-
-    public void setX(int x) {
-        buff.putInt(0, x);
-    }
-
-    public int getX() {
-        return buff.getInt(0);
-    }
-
-    public int getY() {
-        return buff.getInt(1);
-    }
-
-    public void setY(int y) {
-        buff.putInt(0, y);
-    }
-
-    public double distanceTo(BBPoint other) {
-        return distance(buff, other.buff);
-    }
-
-    private static native double distance(ByteBuffer p1, ByteBuffer p2);
+EXPORT double distance_ptrs(Point* p1, Point* p2) {
+    return distance(*p1, *p2);
 }


### PR DESCRIPTION
Hi,

This PR exposed MemoryLayout attributes in the public API.

A summary of the changes:
- Renamed annotation -> attribute everywhere to avoid confusion with Java language annotations
- Made sure that annotations were being serialized as part of a MemoryLayout's ConstantDesc, as well as the alignment which was previously left out. (The latter also meant changing PaddingLayout::hasNaturalAlignment to always return `true`, so serializing alignment is skipped for padding).
- Removed special casing for the abiType attribute. This can now instead be handled through the generic attribute mechanism.

Thanks,
Jorn
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * ⚠️ Temporary failure when trying to retrieve information on issue `8241504`.


### Reviewers
 * Maurizio Cimadamore ([mcimadamore](@mcimadamore) - Committer)

### Download
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/64/head:pull/64`
`$ git checkout pull/64`
