### PR TITLE
8241650: jextract module should be mapped to application class loader

### DIFF
--- a/make/common/Modules.gmk
+++ b/make/common/Modules.gmk
@@ -117,7 +117,6 @@ PLATFORM_MODULES += \
     jdk.security.jgss \
     jdk.xml.dom \
     jdk.zipfs \
-    jdk.incubator.jextract \
     #
 
 ifeq ($(call isTargetOs, windows), true)
@@ -192,6 +191,7 @@ LANGTOOLS_MODULES := \
     jdk.javadoc \
     jdk.jdeps \
     jdk.jshell \
+    jdk.incubator.jextract \
     #
 
 HOTSPOT_MODULES := \

--- a/test/jdk/tools/jextract/Test8241650.java
+++ b/test/jdk/tools/jextract/Test8241650.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import jdk.incubator.jextract.Declaration;
+import org.testng.annotations.Test;
+import static org.testng.Assert.assertTrue;
+
+/*
+ * @test
+ * @modules jdk.incubator.jextract
+ * @bug 8241650
+ * @summary jextract module should be mapped to application class loader
+ * @run testng Test8241650
+ */
+public class Test8241650 {
+    @Test
+    public void testClassLoader() {
+        assertTrue(ClassLoader.getSystemClassLoader() == Declaration.class.getClassLoader());
+    }
+}


### PR DESCRIPTION
fixed makefile to map jextract module to application class loader
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [JDK-8241650](https://bugs.openjdk.java.net/browse/JDK-8241650): jextract module should be mapped to application class loader


### Reviewers
 * Maurizio Cimadamore ([mcimadamore](@mcimadamore) - Committer)

### Download
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/66/head:pull/66`
`$ git checkout pull/66`
