### PR TITLE
Backport 8237573 to foreign-abi

### DIFF
--- a/test/micro/org/openjdk/bench/jdk/incubator/foreign/CallOverhead.java
+++ b/test/micro/org/openjdk/bench/jdk/incubator/foreign/CallOverhead.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2020 Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.bench.jdk.incubator.foreign;
+
+import jdk.incubator.foreign.Foreign;
+import jdk.incubator.foreign.FunctionDescriptor;
+import jdk.incubator.foreign.LibraryLookup;
+import jdk.incubator.foreign.SystemABI;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+import java.util.concurrent.TimeUnit;
+
+import static jdk.incubator.foreign.MemoryLayouts.C_INT;
+
+@BenchmarkMode(Mode.AverageTime)
+@Warmup(iterations = 5, time = 500, timeUnit = TimeUnit.MILLISECONDS)
+@Measurement(iterations = 10, time = 500, timeUnit = TimeUnit.MILLISECONDS)
+@State(org.openjdk.jmh.annotations.Scope.Thread)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Fork(3)
+public class CallOverhead {
+
+    static final SystemABI abi = Foreign.getInstance().getSystemABI();
+    static final MethodHandle func;
+    static final MethodHandle identity;
+
+    static {
+        System.loadLibrary("CallOverheadJNI");
+
+        try {
+            LibraryLookup ll = LibraryLookup.ofLibrary(MethodHandles.lookup(), "CallOverhead");
+            func = abi.downcallHandle(ll.lookup("func"),
+                    MethodType.methodType(void.class),
+                    FunctionDescriptor.ofVoid());
+            identity = abi.downcallHandle(ll.lookup("identity"),
+                    MethodType.methodType(int.class, int.class),
+                    FunctionDescriptor.of(C_INT, C_INT));
+        } catch (NoSuchMethodException e) {
+            throw new BootstrapMethodError(e);
+        }
+    }
+
+    static native void blank();
+    static native int identity(int x);
+
+    @Benchmark
+    public void jni_blank() throws Throwable {
+        blank();
+    }
+
+    @Benchmark
+    public void panama_blank() throws Throwable {
+        func.invokeExact();
+    }
+
+    @Benchmark
+    public int jni_identity() throws Throwable {
+        return identity(10);
+    }
+
+    @Benchmark
+    public int panama_identity() throws Throwable {
+        return (int) identity.invokeExact(10);
+    }
+}

--- a/test/micro/org/openjdk/bench/jdk/incubator/foreign/libCallOverhead.c
+++ b/test/micro/org/openjdk/bench/jdk/incubator/foreign/libCallOverhead.c
@@ -20,44 +20,15 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
-package org.openjdk.bench.jdk.incubator.foreign.points.support;
 
-import java.nio.ByteBuffer;
-import java.nio.ByteOrder;
+#ifdef _WIN64
+#define EXPORT __declspec(dllexport)
+#else
+#define EXPORT
+#endif
 
-public class BBPoint {
+EXPORT void func() {}
 
-    static {
-        System.loadLibrary("JNIPoint");
-    }
-
-    private final ByteBuffer buff;
-
-    public BBPoint(int x, int y) {
-        this.buff = ByteBuffer.allocateDirect(4 * 2).order(ByteOrder.nativeOrder());
-        setX(x);
-        setY(y);
-    }
-
-    public void setX(int x) {
-        buff.putInt(0, x);
-    }
-
-    public int getX() {
-        return buff.getInt(0);
-    }
-
-    public int getY() {
-        return buff.getInt(1);
-    }
-
-    public void setY(int y) {
-        buff.putInt(0, y);
-    }
-
-    public double distanceTo(BBPoint other) {
-        return distance(buff, other.buff);
-    }
-
-    private static native double distance(ByteBuffer p1, ByteBuffer p2);
+EXPORT int identity(int x) {
+  return x;
 }

--- a/test/micro/org/openjdk/bench/jdk/incubator/foreign/libCallOverheadJNI.c
+++ b/test/micro/org/openjdk/bench/jdk/incubator/foreign/libCallOverheadJNI.c
@@ -20,44 +20,20 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
-package org.openjdk.bench.jdk.incubator.foreign.points.support;
+#include <jni.h>
 
-import java.nio.ByteBuffer;
-import java.nio.ByteOrder;
+void func() {}
 
-public class BBPoint {
+int identity(int x) {
+  return x;
+}
 
-    static {
-        System.loadLibrary("JNIPoint");
-    }
+JNIEXPORT void JNICALL Java_org_openjdk_bench_jdk_incubator_foreign_CallOverhead_blank
+  (JNIEnv *env, jclass cls) {
+    func();
+}
 
-    private final ByteBuffer buff;
-
-    public BBPoint(int x, int y) {
-        this.buff = ByteBuffer.allocateDirect(4 * 2).order(ByteOrder.nativeOrder());
-        setX(x);
-        setY(y);
-    }
-
-    public void setX(int x) {
-        buff.putInt(0, x);
-    }
-
-    public int getX() {
-        return buff.getInt(0);
-    }
-
-    public int getY() {
-        return buff.getInt(1);
-    }
-
-    public void setY(int y) {
-        buff.putInt(0, y);
-    }
-
-    public double distanceTo(BBPoint other) {
-        return distance(buff, other.buff);
-    }
-
-    private static native double distance(ByteBuffer p1, ByteBuffer p2);
+JNIEXPORT jint JNICALL Java_org_openjdk_bench_jdk_incubator_foreign_CallOverhead_identity
+  (JNIEnv *env, jclass cls, jint x) {
+    return identity(x);
 }

--- a/test/micro/org/openjdk/bench/jdk/incubator/foreign/points/PointsDistance.java
+++ b/test/micro/org/openjdk/bench/jdk/incubator/foreign/points/PointsDistance.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2020 Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.bench.jdk.incubator.foreign.points;
+
+import org.openjdk.bench.jdk.incubator.foreign.points.support.BBPoint;
+import org.openjdk.bench.jdk.incubator.foreign.points.support.JNIPoint;
+import org.openjdk.bench.jdk.incubator.foreign.points.support.PanamaPoint;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Warmup;
+
+import java.util.concurrent.TimeUnit;
+
+@BenchmarkMode(Mode.AverageTime)
+@Warmup(iterations = 5, time = 500, timeUnit = TimeUnit.MILLISECONDS)
+@Measurement(iterations = 10, time = 500, timeUnit = TimeUnit.MILLISECONDS)
+@State(org.openjdk.jmh.annotations.Scope.Thread)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Fork(3)
+public class PointsDistance {
+
+    BBPoint jniP1;
+    BBPoint jniP2;
+
+    JNIPoint nativeP1;
+    JNIPoint nativeP2;
+
+    PanamaPoint panamaPointP1;
+    PanamaPoint panamaPointP2;
+
+    @Setup
+    public void setup() {
+        jniP1 = new BBPoint(0, 0);
+        jniP2 = new BBPoint(1, 1);
+
+        nativeP1 = new JNIPoint(0, 0);
+        nativeP2 = new JNIPoint(1, 1);
+
+        panamaPointP1 = new PanamaPoint(0, 0);
+        panamaPointP2 = new PanamaPoint(1, 1);
+    }
+
+    @TearDown
+    public void tearDown() {
+        nativeP1.free();
+        nativeP2.free();
+
+        panamaPointP1.close();
+        panamaPointP2.close();
+    }
+
+    @Benchmark
+    public double jni_ByteBuffer() throws Throwable {
+        return jniP1.distanceTo(jniP2);
+    }
+
+    @Benchmark
+    public double jni_long() throws Throwable {
+        return nativeP1.distanceTo(nativeP2);
+    }
+
+    @Benchmark
+    public double panama_MemorySegment() throws Throwable {
+        return panamaPointP1.distanceTo(panamaPointP2);
+    }
+
+    @Benchmark
+    public double panama_MemoryAddress() throws Throwable {
+        return panamaPointP1.distanceToPtrs(panamaPointP2);
+    }
+
+}

--- a/test/micro/org/openjdk/bench/jdk/incubator/foreign/points/support/JNIPoint.java
+++ b/test/micro/org/openjdk/bench/jdk/incubator/foreign/points/support/JNIPoint.java
@@ -56,6 +56,10 @@ public class JNIPoint implements AutoCloseable {
         setY(peer, value);
     }
 
+    public double distanceTo(JNIPoint other) {
+        return distance(peer, other.peer);
+    }
+
     private static native long allocate();
     private static native void free(long ptr);
 
@@ -64,6 +68,8 @@ public class JNIPoint implements AutoCloseable {
 
     private static native int getY(long ptr);
     private static native void setY(long ptr, int y);
+
+    private static native double distance(long p1, long p2);
 
     @Override
     public void close() {

--- a/test/micro/org/openjdk/bench/jdk/incubator/foreign/points/support/PanamaPoint.java
+++ b/test/micro/org/openjdk/bench/jdk/incubator/foreign/points/support/PanamaPoint.java
@@ -22,26 +22,55 @@
  */
 package org.openjdk.bench.jdk.incubator.foreign.points.support;
 
+import jdk.incubator.foreign.Foreign;
+import jdk.incubator.foreign.FunctionDescriptor;
+import jdk.incubator.foreign.LibraryLookup;
+import jdk.incubator.foreign.MemoryAddress;
 import jdk.incubator.foreign.MemoryLayout;
 import jdk.incubator.foreign.MemoryLayouts;
 import jdk.incubator.foreign.MemorySegment;
+import jdk.incubator.foreign.SystemABI;
 
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
 import java.lang.invoke.VarHandle;
-import java.nio.ByteOrder;
 
+import static java.lang.invoke.MethodType.methodType;
 import static jdk.incubator.foreign.MemoryLayout.PathElement.groupElement;
+import static jdk.incubator.foreign.MemoryLayouts.*;
 
 public class PanamaPoint implements AutoCloseable {
 
     public static final MemoryLayout LAYOUT = MemoryLayout.ofStruct(
-        MemoryLayouts.JAVA_INT.withOrder(ByteOrder.nativeOrder()).withName("x"),
-        MemoryLayouts.JAVA_INT.withOrder(ByteOrder.nativeOrder()).withName("y")
+        MemoryLayouts.C_INT.withName("x"),
+        MemoryLayouts.C_INT.withName("y")
     );
 
     private static final VarHandle VH_x = LAYOUT.varHandle(int.class, groupElement("x"));
     private static final VarHandle VH_y = LAYOUT.varHandle(int.class, groupElement("y"));
+    private static final MethodHandle MH_distance;
+    private static final MethodHandle MH_distance_ptrs;
 
-    private final MemorySegment segment;
+    static {
+        try {
+            SystemABI abi = Foreign.getInstance().getSystemABI();
+            LibraryLookup lookup = LibraryLookup.ofLibrary(MethodHandles.lookup(), "Point");
+            MH_distance = abi.downcallHandle(
+                lookup.lookup("distance"),
+                methodType(double.class, MemorySegment.class, MemorySegment.class),
+                FunctionDescriptor.of(C_DOUBLE, LAYOUT, LAYOUT)
+            );
+            MH_distance_ptrs = abi.downcallHandle(
+                lookup.lookup("distance_ptrs"),
+                methodType(double.class, MemoryAddress.class, MemoryAddress.class),
+                FunctionDescriptor.of(C_DOUBLE, C_POINTER, C_POINTER)
+            );
+        } catch (NoSuchMethodException e) {
+            throw new BootstrapMethodError(e);
+        }
+    }
+
+    private final MemoryAddress address;
 
     public PanamaPoint(int x, int y) {
         this(MemorySegment.allocateNative(LAYOUT), x, y);
@@ -54,27 +83,43 @@ public class PanamaPoint implements AutoCloseable {
     }
 
     public PanamaPoint(MemorySegment segment) {
-        this.segment = segment;
+        this.address = segment.baseAddress();
     }
 
     public void setX(int x) {
-        VH_x.set(segment.baseAddress(), x);
+        VH_x.set(address, x);
     }
 
     public int getX() {
-        return (int) VH_x.get(segment.baseAddress());
+        return (int) VH_x.get(address);
     }
 
     public void setY(int y) {
-        VH_y.set(segment.baseAddress(), y);
+        VH_y.set(address, y);
     }
 
     public int getY() {
-        return (int) VH_y.get(segment.baseAddress());
+        return (int) VH_y.get(address);
+    }
+
+    public double distanceTo(PanamaPoint other) {
+        try {
+            return (double) MH_distance.invokeExact(address.segment(), other.address.segment());
+        } catch (Throwable throwable) {
+            throw new InternalError(throwable);
+        }
+    }
+
+    public double distanceToPtrs(PanamaPoint other) {
+        try {
+            return (double) MH_distance_ptrs.invokeExact(address, other.address);
+        } catch (Throwable throwable) {
+            throw new InternalError(throwable);
+        }
     }
 
     @Override
     public void close() {
-        segment.close();
+        address.segment().close();
     }
 }

--- a/test/micro/org/openjdk/bench/jdk/incubator/foreign/points/support/libJNIPoint.c
+++ b/test/micro/org/openjdk/bench/jdk/incubator/foreign/points/support/libJNIPoint.c
@@ -22,8 +22,15 @@
  */
 #include <jni.h>
 #include <stdlib.h>
+#include <math.h>
 
 #include "points.h"
+
+double distance(Point p1, Point p2) {
+    int xDist = abs(p1.x - p2.x);
+    int yDist = abs(p1.y - p2.y);
+    return sqrt((xDist * xDist) + (yDist * yDist));
+}
 
 JNIEXPORT jlong JNICALL Java_org_openjdk_bench_jdk_incubator_foreign_points_support_JNIPoint_allocate
   (JNIEnv *env, jclass nativePointClass) {
@@ -58,4 +65,18 @@ JNIEXPORT void JNICALL Java_org_openjdk_bench_jdk_incubator_foreign_points_suppo
   (JNIEnv *env, jclass cls, jlong thisPoint, jint value) {
     Point* point = (Point*) thisPoint;
     point->y = value;
+}
+
+JNIEXPORT jdouble JNICALL Java_org_openjdk_bench_jdk_incubator_foreign_points_support_JNIPoint_distance
+  (JNIEnv *env, jclass cls, jlong thisPoint, jlong other) {
+    Point* p1 = (Point*) thisPoint;
+    Point* p2 = (Point*) other;
+    return distance(*p1, *p2);
+}
+
+JNIEXPORT jdouble JNICALL Java_org_openjdk_bench_jdk_incubator_foreign_points_support_BBPoint_distance
+  (JNIEnv *env, jclass ignored, jobject buffP1, jobject buffP2) {
+    Point* p1 = (Point*) (*env)->GetDirectBufferAddress(env, buffP1);
+    Point* p2 = (Point*) (*env)->GetDirectBufferAddress(env, buffP2);
+    return distance(*p1, *p2);
 }

--- a/test/micro/org/openjdk/bench/jdk/incubator/foreign/points/support/libPoint.c
+++ b/test/micro/org/openjdk/bench/jdk/incubator/foreign/points/support/libPoint.c
@@ -20,44 +20,23 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
-package org.openjdk.bench.jdk.incubator.foreign.points.support;
+#include <stdlib.h>
+#include <math.h>
 
-import java.nio.ByteBuffer;
-import java.nio.ByteOrder;
+#include "points.h"
 
-public class BBPoint {
+#ifdef _WIN64
+#define EXPORT __declspec(dllexport)
+#else
+#define EXPORT
+#endif
 
-    static {
-        System.loadLibrary("JNIPoint");
-    }
+EXPORT double distance(Point p1, Point p2) {
+    int xDist = abs(p1.x - p2.x);
+    int yDist = abs(p1.y - p2.y);
+    return sqrt((xDist * xDist) + (yDist * yDist));
+}
 
-    private final ByteBuffer buff;
-
-    public BBPoint(int x, int y) {
-        this.buff = ByteBuffer.allocateDirect(4 * 2).order(ByteOrder.nativeOrder());
-        setX(x);
-        setY(y);
-    }
-
-    public void setX(int x) {
-        buff.putInt(0, x);
-    }
-
-    public int getX() {
-        return buff.getInt(0);
-    }
-
-    public int getY() {
-        return buff.getInt(1);
-    }
-
-    public void setY(int y) {
-        buff.putInt(0, y);
-    }
-
-    public double distanceTo(BBPoint other) {
-        return distance(buff, other.buff);
-    }
-
-    private static native double distance(ByteBuffer p1, ByteBuffer p2);
+EXPORT double distance_ptrs(Point* p1, Point* p2) {
+    return distance(*p1, *p2);
 }


### PR DESCRIPTION
Hi,

https://github.com/openjdk/panama-foreign/pull/65 went into the foreign-jextract branch by accident. It should be backported to the foreign-abi branch.

Thanks,
Jorn
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * Maurizio Cimadamore ([mcimadamore](@mcimadamore) - Committer)
 * Athijegannathan Sundararajan ([sundar](@sundararajana) - Committer)

### Download
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/67/head:pull/67`
`$ git checkout pull/67`
