### PR TITLE
8241504: Expose MemoryLayout annotations/attributes in the public API (foreign-jextract part)

### DIFF
--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/AbstractLayout.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/AbstractLayout.java
@@ -40,49 +40,52 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.OptionalLong;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static java.lang.constant.ConstantDescs.BSM_INVOKE;
+import static java.lang.constant.ConstantDescs.CD_String;
+import static java.lang.constant.ConstantDescs.CD_long;
 
 abstract class AbstractLayout implements MemoryLayout {
+    // memory layout attribute key for layout name
+    static final String NAME = "name";
+
     private final OptionalLong size;
     final long alignment;
-    protected final Map<String, Constable> annotations;
+    protected final Map<String, Constable> attributes;
 
-    public AbstractLayout(OptionalLong size, long alignment, Map<String, Constable> annotations) {
+    public AbstractLayout(OptionalLong size, long alignment, Map<String, Constable> attributes) {
         this.size = size;
         this.alignment = alignment;
-        this.annotations = Collections.unmodifiableMap(annotations);
-    }
-
-    Optional<String> optName() {
-        return Optional.ofNullable((String)annotations.get(NAME));
-    }
-
-    // memory layout annotation key for abi native type
-    static final String NATIVE_TYPE = "abi/native-type";
-
-    Optional<SystemABI.Type> optABIType() {
-        return Optional.ofNullable((SystemABI.Type)annotations.get(NATIVE_TYPE));
+        this.attributes = Collections.unmodifiableMap(attributes);
     }
 
     @Override
     public AbstractLayout withName(String name) {
-        return withAnnotation(NAME, name);
-    }
-
-    @SuppressWarnings("unchecked")
-    public <Z extends AbstractLayout> Z withAnnotation(String name, Constable value) {
-        Map<String, Constable> new_annos = new HashMap<>(annotations);
-        new_annos.put(name, value);
-        return (Z)dup(alignment, new_annos);
+        return withAttribute(NAME, name);
     }
 
     @Override
     public final Optional<String> name() {
-        return optName();
+        return attribute(NAME).map(String.class::cast);
     }
 
     @Override
-    public final Optional<SystemABI.Type> abiType() {
-        return optABIType();
+    public Optional<Constable> attribute(String name) {
+        return Optional.ofNullable(attributes.get(name));
+    }
+
+    @Override
+    public Stream<String> attributes() {
+        return attributes.keySet().stream();
+    }
+
+    @Override
+    public AbstractLayout withAttribute(String name, Constable value) {
+        Map<String, Constable> newAttributes = new HashMap<>(attributes);
+        newAttributes.put(name, value);
+        return dup(alignment, newAttributes);
     }
 
     abstract AbstractLayout dup(long alignment, Map<String, Constable> annos);
@@ -90,7 +93,7 @@ abstract class AbstractLayout implements MemoryLayout {
     @Override
     public AbstractLayout withBitAlignment(long alignmentBits) {
         checkAlignment(alignmentBits);
-        return dup(alignmentBits, annotations);
+        return dup(alignmentBits, attributes);
     }
 
     void checkAlignment(long alignmentBitCount) {
@@ -134,13 +137,31 @@ abstract class AbstractLayout implements MemoryLayout {
     }
 
     String decorateLayoutString(String s) {
-        if (optName().isPresent()) {
-            s = String.format("%s(%s)", s, optName().get());
+        if (name().isPresent()) {
+            s = String.format("%s(%s)", s, name().get());
         }
         if (!hasNaturalAlignment()) {
             s = alignment + "%" + s;
         }
+        if (!attributes.isEmpty()) {
+            s += attributes.entrySet().stream()
+                                      .map(e -> e.getKey() + "=" + e.getValue())
+                                      .collect(Collectors.joining(",", "[", "]"));
+        }
         return s;
+    }
+
+    <T> DynamicConstantDesc<T> decorateLayoutConstant(DynamicConstantDesc<T> desc) {
+        if (!hasNaturalAlignment()) {
+            desc = DynamicConstantDesc.ofNamed(BSM_INVOKE, "withBitAlignment", desc.constantType(), MH_WITH_BIT_ALIGNMENT,
+                    desc, bitAlignment());
+        }
+        for (var e : attributes.entrySet()) {
+            desc = DynamicConstantDesc.ofNamed(BSM_INVOKE, "withAttribute", desc.constantType(), MH_WITH_ATTRIBUTE,
+                    desc, e.getKey(), e.getValue().describeConstable().orElseThrow());
+        }
+
+        return desc;
     }
 
     boolean hasNaturalAlignment() {
@@ -149,7 +170,7 @@ abstract class AbstractLayout implements MemoryLayout {
 
     @Override
     public int hashCode() {
-        return annotations.hashCode() << Long.hashCode(alignment);
+        return attributes.hashCode() << Long.hashCode(alignment);
     }
 
     @Override
@@ -162,11 +183,9 @@ abstract class AbstractLayout implements MemoryLayout {
             return false;
         }
 
-        return Objects.equals(annotations, ((AbstractLayout)other).annotations) &&
-                Objects.equals(alignment, ((AbstractLayout)other).alignment);
+        return Objects.equals(attributes, ((AbstractLayout) other).attributes) &&
+                Objects.equals(alignment, ((AbstractLayout) other).alignment);
     }
-
-    static final String NAME = "name";
 
     /*** Helper constants for implementing Layout::describeConstable ***/
 
@@ -174,7 +193,7 @@ abstract class AbstractLayout implements MemoryLayout {
             = ConstantDescs.ofConstantBootstrap(ConstantDescs.CD_ConstantBootstraps, "getStaticFinal",
             ConstantDescs.CD_Object, ConstantDescs.CD_Class);
 
-    static final ClassDesc CD_LAYOUT = MemoryLayout.class.describeConstable().get();
+    static final ClassDesc CD_MEMORY_LAYOUT = MemoryLayout.class.describeConstable().get();
 
     static final ClassDesc CD_VALUE_LAYOUT = ValueLayout.class.describeConstable().get();
 
@@ -186,6 +205,8 @@ abstract class AbstractLayout implements MemoryLayout {
 
     static final ClassDesc CD_FUNCTION_DESC = FunctionDescriptor.class.describeConstable().get();
 
+    static final ClassDesc CD_Constable = Constable.class.describeConstable().get();
+
     static final ConstantDesc BIG_ENDIAN = DynamicConstantDesc.ofNamed(BSM_GET_STATIC_FINAL, "BIG_ENDIAN", CD_BYTEORDER, CD_BYTEORDER);
 
     static final ConstantDesc LITTLE_ENDIAN = DynamicConstantDesc.ofNamed(BSM_GET_STATIC_FINAL, "LITTLE_ENDIAN", CD_BYTEORDER, CD_BYTEORDER);
@@ -194,27 +215,33 @@ abstract class AbstractLayout implements MemoryLayout {
 
     static final ConstantDesc FALSE = DynamicConstantDesc.ofNamed(BSM_GET_STATIC_FINAL, "FALSE", ConstantDescs.CD_Boolean, ConstantDescs.CD_Boolean);
 
-    static final MethodHandleDesc MH_PADDING = MethodHandleDesc.ofMethod(DirectMethodHandleDesc.Kind.INTERFACE_STATIC, CD_LAYOUT, "ofPaddingBits",
-                MethodTypeDesc.of(CD_LAYOUT, ConstantDescs.CD_long));
+    static final MethodHandleDesc MH_PADDING = MethodHandleDesc.ofMethod(DirectMethodHandleDesc.Kind.INTERFACE_STATIC, CD_MEMORY_LAYOUT, "ofPaddingBits",
+                MethodTypeDesc.of(CD_MEMORY_LAYOUT, CD_long));
 
-    static final MethodHandleDesc MH_VALUE = MethodHandleDesc.ofMethod(DirectMethodHandleDesc.Kind.INTERFACE_STATIC, CD_LAYOUT, "ofValueBits",
-                MethodTypeDesc.of(CD_VALUE_LAYOUT, ConstantDescs.CD_long, CD_BYTEORDER));
+    static final MethodHandleDesc MH_VALUE = MethodHandleDesc.ofMethod(DirectMethodHandleDesc.Kind.INTERFACE_STATIC, CD_MEMORY_LAYOUT, "ofValueBits",
+                MethodTypeDesc.of(CD_VALUE_LAYOUT, CD_long, CD_BYTEORDER));
 
-    static final MethodHandleDesc MH_SIZED_SEQUENCE = MethodHandleDesc.ofMethod(DirectMethodHandleDesc.Kind.INTERFACE_STATIC, CD_LAYOUT, "ofSequence",
-                MethodTypeDesc.of(CD_SEQUENCE_LAYOUT, ConstantDescs.CD_long, CD_LAYOUT));
+    static final MethodHandleDesc MH_SIZED_SEQUENCE = MethodHandleDesc.ofMethod(DirectMethodHandleDesc.Kind.INTERFACE_STATIC, CD_MEMORY_LAYOUT, "ofSequence",
+                MethodTypeDesc.of(CD_SEQUENCE_LAYOUT, CD_long, CD_MEMORY_LAYOUT));
 
-    static final MethodHandleDesc MH_UNSIZED_SEQUENCE = MethodHandleDesc.ofMethod(DirectMethodHandleDesc.Kind.INTERFACE_STATIC, CD_LAYOUT, "ofSequence",
-                MethodTypeDesc.of(CD_SEQUENCE_LAYOUT, CD_LAYOUT));
+    static final MethodHandleDesc MH_UNSIZED_SEQUENCE = MethodHandleDesc.ofMethod(DirectMethodHandleDesc.Kind.INTERFACE_STATIC, CD_MEMORY_LAYOUT, "ofSequence",
+                MethodTypeDesc.of(CD_SEQUENCE_LAYOUT, CD_MEMORY_LAYOUT));
 
-    static final MethodHandleDesc MH_STRUCT = MethodHandleDesc.ofMethod(DirectMethodHandleDesc.Kind.INTERFACE_STATIC, CD_LAYOUT, "ofStruct",
-                MethodTypeDesc.of(CD_GROUP_LAYOUT, CD_LAYOUT.arrayType()));
+    static final MethodHandleDesc MH_STRUCT = MethodHandleDesc.ofMethod(DirectMethodHandleDesc.Kind.INTERFACE_STATIC, CD_MEMORY_LAYOUT, "ofStruct",
+                MethodTypeDesc.of(CD_GROUP_LAYOUT, CD_MEMORY_LAYOUT.arrayType()));
 
-    static final MethodHandleDesc MH_UNION = MethodHandleDesc.ofMethod(DirectMethodHandleDesc.Kind.INTERFACE_STATIC, CD_LAYOUT, "ofUnion",
-                MethodTypeDesc.of(CD_GROUP_LAYOUT, CD_LAYOUT.arrayType()));
+    static final MethodHandleDesc MH_UNION = MethodHandleDesc.ofMethod(DirectMethodHandleDesc.Kind.INTERFACE_STATIC, CD_MEMORY_LAYOUT, "ofUnion",
+                MethodTypeDesc.of(CD_GROUP_LAYOUT, CD_MEMORY_LAYOUT.arrayType()));
 
-    static final MethodHandleDesc MH_VOID_FUNCTION = MethodHandleDesc.ofMethod(DirectMethodHandleDesc.Kind.INTERFACE_STATIC, CD_FUNCTION_DESC, "ofVoid",
-                MethodTypeDesc.of(CD_FUNCTION_DESC, CD_LAYOUT.arrayType()));
+    static final MethodHandleDesc MH_VOID_FUNCTION = MethodHandleDesc.ofMethod(DirectMethodHandleDesc.Kind.STATIC, CD_FUNCTION_DESC, "ofVoid",
+                MethodTypeDesc.of(CD_FUNCTION_DESC, CD_MEMORY_LAYOUT.arrayType()));
 
-    static final MethodHandleDesc MH_FUNCTION = MethodHandleDesc.ofMethod(DirectMethodHandleDesc.Kind.INTERFACE_STATIC, CD_FUNCTION_DESC, "of",
-                MethodTypeDesc.of(CD_FUNCTION_DESC, CD_LAYOUT, CD_LAYOUT.arrayType()));
+    static final MethodHandleDesc MH_FUNCTION = MethodHandleDesc.ofMethod(DirectMethodHandleDesc.Kind.STATIC, CD_FUNCTION_DESC, "of",
+                MethodTypeDesc.of(CD_FUNCTION_DESC, CD_MEMORY_LAYOUT, CD_MEMORY_LAYOUT.arrayType()));
+
+    static final MethodHandleDesc MH_WITH_BIT_ALIGNMENT = MethodHandleDesc.ofMethod(DirectMethodHandleDesc.Kind.INTERFACE_VIRTUAL, CD_MEMORY_LAYOUT, "withBitAlignment",
+                MethodTypeDesc.of(CD_MEMORY_LAYOUT, CD_long));
+
+    static final MethodHandleDesc MH_WITH_ATTRIBUTE = MethodHandleDesc.ofMethod(DirectMethodHandleDesc.Kind.INTERFACE_VIRTUAL, CD_MEMORY_LAYOUT, "withAttribute",
+                MethodTypeDesc.of(CD_MEMORY_LAYOUT, CD_String, CD_Constable));
 }

--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/GroupLayout.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/GroupLayout.java
@@ -31,6 +31,7 @@ import java.lang.constant.ConstantDescs;
 import java.lang.constant.DynamicConstantDesc;
 import java.lang.constant.MethodHandleDesc;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -105,8 +106,8 @@ public final class GroupLayout extends AbstractLayout {
         this(kind, elements, kind.alignof(elements), Map.of());
     }
 
-    GroupLayout(Kind kind, List<MemoryLayout> elements, long alignment, Map<String, Constable> annotations) {
-        super(kind.sizeof(elements), alignment, annotations);
+    GroupLayout(Kind kind, List<MemoryLayout> elements, long alignment, Map<String, Constable> attributes) {
+        super(kind.sizeof(elements), alignment, attributes);
         this.kind = kind;
         this.elements = elements;
     }
@@ -170,8 +171,8 @@ public final class GroupLayout extends AbstractLayout {
     }
 
     @Override
-    GroupLayout dup(long alignment, Map<String, Constable> annotations) {
-        return new GroupLayout(kind, elements, alignment, annotations);
+    GroupLayout dup(long alignment, Map<String, Constable> attributes) {
+        return new GroupLayout(kind, elements, alignment, attributes);
     }
 
     @Override
@@ -186,9 +187,9 @@ public final class GroupLayout extends AbstractLayout {
         for (int i = 0 ; i < elements.size() ; i++) {
             constants[i + 1] = elements.get(i).describeConstable().get();
         }
-        return Optional.of(DynamicConstantDesc.ofNamed(
+        return Optional.of(decorateLayoutConstant(DynamicConstantDesc.ofNamed(
                     ConstantDescs.BSM_INVOKE, kind.name().toLowerCase(),
-                CD_GROUP_LAYOUT, constants));
+                CD_GROUP_LAYOUT, constants)));
     }
 
     //hack: the declarations below are to make javadoc happy; we could have used generics in AbstractLayout
@@ -208,5 +209,13 @@ public final class GroupLayout extends AbstractLayout {
     @Override
     public GroupLayout withBitAlignment(long alignmentBits) {
         return (GroupLayout)super.withBitAlignment(alignmentBits);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public GroupLayout withAttribute(String name, Constable value) {
+        return (GroupLayout)super.withAttribute(name, value);
     }
 }

--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/MemoryLayout.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/MemoryLayout.java
@@ -41,6 +41,7 @@ import java.util.OptionalLong;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.function.UnaryOperator;
+import java.util.stream.Stream;
 
 /**
  * A memory layout can be used to describe the contents of a memory segment in a <em>language neutral</em> fashion.
@@ -227,13 +228,6 @@ public interface MemoryLayout extends Constable {
     Optional<String> name();
 
     /**
-     * Return the ABI <em>type</em> (if any) associated with this layout.
-     *
-     * @return the layout ABI <em>type</em> (if any).
-     */
-    Optional<SystemABI.Type> abiType();
-
-    /**
      * Creates a new layout which features the desired layout <em>name</em>.
      *
      * @param name the layout name.
@@ -290,6 +284,30 @@ public interface MemoryLayout extends Constable {
      * @throws IllegalArgumentException if {@code bitAlignment} is not a power of two, or if it's less than than 8.
      */
     MemoryLayout withBitAlignment(long bitAlignment);
+
+    /**
+     * Returns the attribute with the given name if it exists, or an empty optional
+     *
+     * @param name the name of the attribute
+     * @return the optional attribute
+     */
+    Optional<Constable> attribute(String name);
+
+    /**
+     * Returns a new MemoryLayout with the given additional attribute
+     *
+     * @param name the name of the attribute
+     * @param value the value of the attribute
+     * @return the new MemoryLayout
+     */
+    MemoryLayout withAttribute(String name, Constable value);
+
+    /**
+     * Returns a stream of the names of the attributes of this layout
+     *
+     * @return the stream of names
+     */
+    Stream<String> attributes();
 
     /**
      * Computes the offset, in bits, of the layout selected by a given layout path, where the path is considered rooted in this

--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/MemoryLayouts.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/MemoryLayouts.java
@@ -288,107 +288,107 @@ public final class MemoryLayouts {
          * The {@code _Bool} native type.
          */
         public static final ValueLayout C_BOOL = SharedLayouts.BITS_8_LE
-                .withAnnotation(AbstractLayout.NATIVE_TYPE, SystemABI.Type.BOOL);
+                .withAttribute(SystemABI.NATIVE_TYPE, SystemABI.Type.BOOL);
 
 
         /**
          * The {@code unsigned char} native type.
          */
         public static final ValueLayout C_UCHAR = SharedLayouts.BITS_8_LE
-                .withAnnotation(AbstractLayout.NATIVE_TYPE, SystemABI.Type.UNSIGNED_CHAR);
+                .withAttribute(SystemABI.NATIVE_TYPE, SystemABI.Type.UNSIGNED_CHAR);
 
 
         /**
          * The {@code signed char} native type.
          */
         public static final ValueLayout C_SCHAR = SharedLayouts.BITS_8_LE
-                .withAnnotation(AbstractLayout.NATIVE_TYPE, SystemABI.Type.SIGNED_CHAR);
+                .withAttribute(SystemABI.NATIVE_TYPE, SystemABI.Type.SIGNED_CHAR);
 
 
         /**
          * The {@code char} native type.
          */
         public static final ValueLayout C_CHAR = SharedLayouts.BITS_8_LE
-                .withAnnotation(AbstractLayout.NATIVE_TYPE, SystemABI.Type.CHAR);
+                .withAttribute(SystemABI.NATIVE_TYPE, SystemABI.Type.CHAR);
 
         /**
          * The {@code short} native type.
          */
         public static final ValueLayout C_SHORT = SharedLayouts.BITS_16_LE
-                .withAnnotation(AbstractLayout.NATIVE_TYPE, SystemABI.Type.SHORT);
+                .withAttribute(SystemABI.NATIVE_TYPE, SystemABI.Type.SHORT);
 
         /**
          * The {@code unsigned short} native type.
          */
         public static final ValueLayout C_USHORT = SharedLayouts.BITS_16_LE
-                .withAnnotation(AbstractLayout.NATIVE_TYPE, SystemABI.Type.UNSIGNED_SHORT);
+                .withAttribute(SystemABI.NATIVE_TYPE, SystemABI.Type.UNSIGNED_SHORT);
 
         /**
          * The {@code int} native type.
          */
         public static final ValueLayout C_INT = SharedLayouts.BITS_32_LE
-                .withAnnotation(AbstractLayout.NATIVE_TYPE, SystemABI.Type.INT);
+                .withAttribute(SystemABI.NATIVE_TYPE, SystemABI.Type.INT);
 
         /**
          * The {@code unsigned int} native type.
          */
         public static final ValueLayout C_UINT = SharedLayouts.BITS_32_LE
-                .withAnnotation(AbstractLayout.NATIVE_TYPE, SystemABI.Type.UNSIGNED_INT);
+                .withAttribute(SystemABI.NATIVE_TYPE, SystemABI.Type.UNSIGNED_INT);
 
         /**
          * The {@code long} native type.
          */
         public static final ValueLayout C_LONG = SharedLayouts.BITS_64_LE
-                .withAnnotation(AbstractLayout.NATIVE_TYPE, SystemABI.Type.LONG);
+                .withAttribute(SystemABI.NATIVE_TYPE, SystemABI.Type.LONG);
 
         /**
          * The {@code unsigned long} native type.
          */
         public static final ValueLayout C_ULONG = SharedLayouts.BITS_64_LE
-                .withAnnotation(AbstractLayout.NATIVE_TYPE, SystemABI.Type.UNSIGNED_LONG);
+                .withAttribute(SystemABI.NATIVE_TYPE, SystemABI.Type.UNSIGNED_LONG);
 
 
         /**
          * The {@code long long} native type.
          */
         public static final ValueLayout C_LONGLONG = SharedLayouts.BITS_64_LE
-                .withAnnotation(AbstractLayout.NATIVE_TYPE, SystemABI.Type.LONG_LONG);
+                .withAttribute(SystemABI.NATIVE_TYPE, SystemABI.Type.LONG_LONG);
 
         /**
          * The {@code unsigned long long} native type.
          */
         public static final ValueLayout C_ULONGLONG = SharedLayouts.BITS_64_LE
-                .withAnnotation(AbstractLayout.NATIVE_TYPE, SystemABI.Type.UNSIGNED_LONG_LONG);
+                .withAttribute(SystemABI.NATIVE_TYPE, SystemABI.Type.UNSIGNED_LONG_LONG);
 
         /**
          * The {@code float} native type.
          */
         public static final ValueLayout C_FLOAT = SharedLayouts.BITS_32_LE
-                .withAnnotation(AbstractLayout.NATIVE_TYPE, SystemABI.Type.FLOAT);
+                .withAttribute(SystemABI.NATIVE_TYPE, SystemABI.Type.FLOAT);
 
         /**
          * The {@code double} native type.
          */
         public static final ValueLayout C_DOUBLE = SharedLayouts.BITS_64_LE
-                .withAnnotation(AbstractLayout.NATIVE_TYPE, SystemABI.Type.DOUBLE);
+                .withAttribute(SystemABI.NATIVE_TYPE, SystemABI.Type.DOUBLE);
 
         /**
          * The {@code long double} native type.
          */
         public static final ValueLayout C_LONGDOUBLE = MemoryLayout.ofValueBits(128, ByteOrder.LITTLE_ENDIAN)
-                .withAnnotation(AbstractLayout.NATIVE_TYPE, SystemABI.Type.LONG_DOUBLE);
+                .withAttribute(SystemABI.NATIVE_TYPE, SystemABI.Type.LONG_DOUBLE);
 
         /**
          * The {@code complex long double} native type.
          */
         public static final GroupLayout C_COMPLEX_LONGDOUBLE = MemoryLayout.ofStruct(C_LONGDOUBLE, C_LONGDOUBLE)
-                .withAnnotation(AbstractLayout.NATIVE_TYPE, SystemABI.Type.COMPLEX_LONG_DOUBLE);
+                .withAttribute(SystemABI.NATIVE_TYPE, SystemABI.Type.COMPLEX_LONG_DOUBLE);
 
         /**
          * The {@code T*} native type.
          */
         public static final ValueLayout C_POINTER = SharedLayouts.BITS_64_LE
-                .withAnnotation(AbstractLayout.NATIVE_TYPE, SystemABI.Type.POINTER);
+                .withAttribute(SystemABI.NATIVE_TYPE, SystemABI.Type.POINTER);
     }
 
     /**
@@ -399,100 +399,100 @@ public final class MemoryLayouts {
          * The {@code _Bool} native type.
          */
         public static final ValueLayout C_BOOL = SharedLayouts.BITS_8_LE
-                .withAnnotation(AbstractLayout.NATIVE_TYPE, SystemABI.Type.BOOL);
+                .withAttribute(SystemABI.NATIVE_TYPE, SystemABI.Type.BOOL);
 
         /**
          * The {@code unsigned char} native type.
          */
         public static final ValueLayout C_UCHAR = SharedLayouts.BITS_8_LE
-                .withAnnotation(AbstractLayout.NATIVE_TYPE, SystemABI.Type.UNSIGNED_CHAR);
+                .withAttribute(SystemABI.NATIVE_TYPE, SystemABI.Type.UNSIGNED_CHAR);
 
         /**
          * The {@code signed char} native type.
          */
         public static final ValueLayout C_SCHAR = SharedLayouts.BITS_8_LE
-                .withAnnotation(AbstractLayout.NATIVE_TYPE, SystemABI.Type.SIGNED_CHAR);
+                .withAttribute(SystemABI.NATIVE_TYPE, SystemABI.Type.SIGNED_CHAR);
 
         /**
          * The {@code char} native type.
          */
         public static final ValueLayout C_CHAR = SharedLayouts.BITS_8_LE
-                .withAnnotation(AbstractLayout.NATIVE_TYPE, SystemABI.Type.CHAR);
+                .withAttribute(SystemABI.NATIVE_TYPE, SystemABI.Type.CHAR);
 
         /**
          * The {@code short} native type.
          */
         public static final ValueLayout C_SHORT = SharedLayouts.BITS_16_LE
-                .withAnnotation(AbstractLayout.NATIVE_TYPE, SystemABI.Type.SHORT);
+                .withAttribute(SystemABI.NATIVE_TYPE, SystemABI.Type.SHORT);
 
         /**
          * The {@code unsigned short} native type.
          */
         public static final ValueLayout C_USHORT = SharedLayouts.BITS_16_LE
-                .withAnnotation(AbstractLayout.NATIVE_TYPE, SystemABI.Type.UNSIGNED_SHORT);
+                .withAttribute(SystemABI.NATIVE_TYPE, SystemABI.Type.UNSIGNED_SHORT);
 
         /**
          * The {@code int} native type.
          */
         public static final ValueLayout C_INT = SharedLayouts.BITS_32_LE
-                .withAnnotation(AbstractLayout.NATIVE_TYPE, SystemABI.Type.INT);
+                .withAttribute(SystemABI.NATIVE_TYPE, SystemABI.Type.INT);
 
         /**
          * The {@code unsigned int} native type.
          */
         public static final ValueLayout C_UINT = SharedLayouts.BITS_32_LE
-                .withAnnotation(AbstractLayout.NATIVE_TYPE, SystemABI.Type.UNSIGNED_INT);
+                .withAttribute(SystemABI.NATIVE_TYPE, SystemABI.Type.UNSIGNED_INT);
 
         /**
          * The {@code long} native type.
          */
         public static final ValueLayout C_LONG = SharedLayouts.BITS_32_LE
-                .withAnnotation(AbstractLayout.NATIVE_TYPE, SystemABI.Type.LONG);
+                .withAttribute(SystemABI.NATIVE_TYPE, SystemABI.Type.LONG);
 
         /**
          * The {@code unsigned long} native type.
          */
         public static final ValueLayout C_ULONG = SharedLayouts.BITS_32_LE
-                .withAnnotation(AbstractLayout.NATIVE_TYPE, SystemABI.Type.UNSIGNED_LONG);
+                .withAttribute(SystemABI.NATIVE_TYPE, SystemABI.Type.UNSIGNED_LONG);
 
         /**
          * The {@code long long} native type.
          */
         public static final ValueLayout C_LONGLONG = SharedLayouts.BITS_64_LE
-                .withAnnotation(AbstractLayout.NATIVE_TYPE, SystemABI.Type.LONG_LONG);
+                .withAttribute(SystemABI.NATIVE_TYPE, SystemABI.Type.LONG_LONG);
 
         /**
          * The {@code unsigned long long} native type.
          */
         public static final ValueLayout C_ULONGLONG = SharedLayouts.BITS_64_LE
-                .withAnnotation(AbstractLayout.NATIVE_TYPE, SystemABI.Type.UNSIGNED_LONG_LONG);
+                .withAttribute(SystemABI.NATIVE_TYPE, SystemABI.Type.UNSIGNED_LONG_LONG);
 
         /**
          * The {@code float} native type.
          */
         public static final ValueLayout C_FLOAT = SharedLayouts.BITS_32_LE
-                .withAnnotation(AbstractLayout.NATIVE_TYPE, SystemABI.Type.FLOAT);
+                .withAttribute(SystemABI.NATIVE_TYPE, SystemABI.Type.FLOAT);
 
         /**
          * The {@code double} native type.
          */
         public static final ValueLayout C_DOUBLE = SharedLayouts.BITS_64_LE
-                .withAnnotation(AbstractLayout.NATIVE_TYPE, SystemABI.Type.DOUBLE);
+                .withAttribute(SystemABI.NATIVE_TYPE, SystemABI.Type.DOUBLE);
 
         /**
          * The {@code long double} native type.
          */
         public static final ValueLayout C_LONGDOUBLE = SharedLayouts.BITS_64_LE
-                .withAnnotation(AbstractLayout.NATIVE_TYPE, SystemABI.Type.LONG_DOUBLE);
+                .withAttribute(SystemABI.NATIVE_TYPE, SystemABI.Type.LONG_DOUBLE);
 
         /**
          * The {@code T*} native type.
          */
         public static final ValueLayout C_POINTER = SharedLayouts.BITS_64_LE
-                .withAnnotation(AbstractLayout.NATIVE_TYPE, SystemABI.Type.POINTER);
+                .withAttribute(SystemABI.NATIVE_TYPE, SystemABI.Type.POINTER);
 
         public static ValueLayout asVarArg(ValueLayout l) {
-           return l.withAnnotation(Windowsx64ABI.VARARGS_ANNOTATION_NAME, "true");
+           return l.withAttribute(Windowsx64ABI.VARARGS_ATTRIBUTE_NAME, "true");
         }
     }
 
@@ -504,97 +504,97 @@ public final class MemoryLayouts {
          * The {@code _Bool} native type.
          */
         public static final ValueLayout C_BOOL = SharedLayouts.BITS_8_LE
-                .withAnnotation(AbstractLayout.NATIVE_TYPE, SystemABI.Type.BOOL);
+                .withAttribute(SystemABI.NATIVE_TYPE, SystemABI.Type.BOOL);
 
         /**
          * The {@code unsigned char} native type.
          */
         public static final ValueLayout C_UCHAR = SharedLayouts.BITS_8_LE
-                .withAnnotation(AbstractLayout.NATIVE_TYPE, SystemABI.Type.UNSIGNED_CHAR);
+                .withAttribute(SystemABI.NATIVE_TYPE, SystemABI.Type.UNSIGNED_CHAR);
 
         /**
          * The {@code signed char} native type.
          */
         public static final ValueLayout C_SCHAR = SharedLayouts.BITS_8_LE
-                .withAnnotation(AbstractLayout.NATIVE_TYPE, SystemABI.Type.SIGNED_CHAR);
+                .withAttribute(SystemABI.NATIVE_TYPE, SystemABI.Type.SIGNED_CHAR);
 
         /**
          * The {@code char} native type.
          */
         public static final ValueLayout C_CHAR = SharedLayouts.BITS_8_LE
-                .withAnnotation(AbstractLayout.NATIVE_TYPE, SystemABI.Type.CHAR);
+                .withAttribute(SystemABI.NATIVE_TYPE, SystemABI.Type.CHAR);
 
         /**
          * The {@code short} native type.
          */
         public static final ValueLayout C_SHORT = SharedLayouts.BITS_16_LE
-                .withAnnotation(AbstractLayout.NATIVE_TYPE, SystemABI.Type.SHORT);
+                .withAttribute(SystemABI.NATIVE_TYPE, SystemABI.Type.SHORT);
 
         /**
          * The {@code unsigned short} native type.
          */
         public static final ValueLayout C_USHORT = SharedLayouts.BITS_16_LE
-                .withAnnotation(AbstractLayout.NATIVE_TYPE, SystemABI.Type.UNSIGNED_SHORT);
+                .withAttribute(SystemABI.NATIVE_TYPE, SystemABI.Type.UNSIGNED_SHORT);
 
         /**
          * The {@code int} native type.
          */
         public static final ValueLayout C_INT = SharedLayouts.BITS_32_LE
-                .withAnnotation(AbstractLayout.NATIVE_TYPE, SystemABI.Type.INT);
+                .withAttribute(SystemABI.NATIVE_TYPE, SystemABI.Type.INT);
 
         /**
          * The {@code unsigned int} native type.
          */
         public static final ValueLayout C_UINT = SharedLayouts.BITS_32_LE
-                .withAnnotation(AbstractLayout.NATIVE_TYPE, SystemABI.Type.UNSIGNED_INT);
+                .withAttribute(SystemABI.NATIVE_TYPE, SystemABI.Type.UNSIGNED_INT);
 
         /**
          * The {@code long} native type.
          */
         public static final ValueLayout C_LONG = SharedLayouts.BITS_64_LE
-                .withAnnotation(AbstractLayout.NATIVE_TYPE, SystemABI.Type.LONG);
+                .withAttribute(SystemABI.NATIVE_TYPE, SystemABI.Type.LONG);
 
         /**
          * The {@code unsigned long} native type.
          */
         public static final ValueLayout C_ULONG = SharedLayouts.BITS_64_LE
-                .withAnnotation(AbstractLayout.NATIVE_TYPE, SystemABI.Type.UNSIGNED_LONG);
+                .withAttribute(SystemABI.NATIVE_TYPE, SystemABI.Type.UNSIGNED_LONG);
 
         /**
          * The {@code long long} native type.
          */
         public static final ValueLayout C_LONGLONG = SharedLayouts.BITS_64_LE
-                .withAnnotation(AbstractLayout.NATIVE_TYPE, SystemABI.Type.LONG_LONG);
+                .withAttribute(SystemABI.NATIVE_TYPE, SystemABI.Type.LONG_LONG);
 
         /**
          * The {@code unsigned long long} native type.
          */
         public static final ValueLayout C_ULONGLONG = SharedLayouts.BITS_64_LE
-                .withAnnotation(AbstractLayout.NATIVE_TYPE, SystemABI.Type.UNSIGNED_LONG_LONG);
+                .withAttribute(SystemABI.NATIVE_TYPE, SystemABI.Type.UNSIGNED_LONG_LONG);
 
         /**
          * The {@code float} native type.
          */
         public static final ValueLayout C_FLOAT = SharedLayouts.BITS_32_LE
-                .withAnnotation(AbstractLayout.NATIVE_TYPE, SystemABI.Type.FLOAT);
+                .withAttribute(SystemABI.NATIVE_TYPE, SystemABI.Type.FLOAT);
 
         /**
          * The {@code double} native type.
          */
         public static final ValueLayout C_DOUBLE = SharedLayouts.BITS_64_LE
-                .withAnnotation(AbstractLayout.NATIVE_TYPE, SystemABI.Type.DOUBLE);
+                .withAttribute(SystemABI.NATIVE_TYPE, SystemABI.Type.DOUBLE);
 
         /**
          * The {@code long double} native type.
          */
         public static final ValueLayout C_LONGDOUBLE = MemoryLayout.ofValueBits(128, ByteOrder.LITTLE_ENDIAN)
-                .withAnnotation(AbstractLayout.NATIVE_TYPE, SystemABI.Type.LONG_DOUBLE);
+                .withAttribute(SystemABI.NATIVE_TYPE, SystemABI.Type.LONG_DOUBLE);
 
         /**
          * The {@code T*} native type.
          */
         public static final ValueLayout C_POINTER = SharedLayouts.BITS_64_LE
-                .withAnnotation(AbstractLayout.NATIVE_TYPE, SystemABI.Type.POINTER);
+                .withAttribute(SystemABI.NATIVE_TYPE, SystemABI.Type.POINTER);
     }
 
     private static class SharedLayouts { // Separate class to prevent circular clinit references

--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/PaddingLayout.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/PaddingLayout.java
@@ -52,8 +52,8 @@ import java.util.OptionalLong;
         this(size, 1, Map.of());
     }
 
-    PaddingLayout(long size, long alignment, Map<String, Constable> annotations) {
-        super(OptionalLong.of(size), alignment, annotations);
+    PaddingLayout(long size, long alignment, Map<String, Constable> attributes) {
+        super(OptionalLong.of(size), alignment, attributes);
     }
 
     @Override
@@ -82,14 +82,19 @@ import java.util.OptionalLong;
     }
 
     @Override
-    PaddingLayout dup(long alignment, Map<String, Constable> annotations) {
-        return new PaddingLayout(bitSize(), alignment, annotations);
+    PaddingLayout dup(long alignment, Map<String, Constable> attributes) {
+        return new PaddingLayout(bitSize(), alignment, attributes);
+    }
+
+    @Override
+    public boolean hasNaturalAlignment() {
+        return true;
     }
 
     @Override
     public Optional<DynamicConstantDesc<MemoryLayout>> describeConstable() {
-        return Optional.of(DynamicConstantDesc.ofNamed(ConstantDescs.BSM_INVOKE, "padding",
-                CD_LAYOUT, MH_PADDING, bitSize()));
+        return Optional.of(decorateLayoutConstant(DynamicConstantDesc.ofNamed(ConstantDescs.BSM_INVOKE, "padding",
+                CD_MEMORY_LAYOUT, MH_PADDING, bitSize())));
     }
 
     //hack: the declarations below are to make javadoc happy; we could have used generics in AbstractLayout
@@ -109,5 +114,13 @@ import java.util.OptionalLong;
     @Override
     public PaddingLayout withBitAlignment(long alignmentBits) {
         return (PaddingLayout)super.withBitAlignment(alignmentBits);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public PaddingLayout withAttribute(String name, Constable value) {
+        return (PaddingLayout)super.withAttribute(name, value);
     }
 }

--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/SequenceLayout.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/SequenceLayout.java
@@ -71,10 +71,10 @@ public final class SequenceLayout extends AbstractLayout {
         this(elemCount, elementLayout, elementLayout.bitAlignment(), Map.of());
     }
 
-    SequenceLayout(OptionalLong elemCount, MemoryLayout elementLayout, long alignment, Map<String, Constable> annotations) {
+    SequenceLayout(OptionalLong elemCount, MemoryLayout elementLayout, long alignment, Map<String, Constable> attributes) {
         super(elemCount.isPresent() && AbstractLayout.optSize(elementLayout).isPresent() ?
                 OptionalLong.of(elemCount.getAsLong() * elementLayout.bitSize()) :
-                OptionalLong.empty(), alignment, annotations);
+                OptionalLong.empty(), alignment, attributes);
         this.elemCount = elemCount;
         this.elementLayout = elementLayout;
     }
@@ -106,7 +106,7 @@ public final class SequenceLayout extends AbstractLayout {
      */
     public SequenceLayout withElementCount(long elementCount) {
         AbstractLayout.checkSize(elementCount, true);
-        return new SequenceLayout(OptionalLong.of(elementCount), elementLayout, alignment, annotations);
+        return new SequenceLayout(OptionalLong.of(elementCount), elementLayout, alignment, attributes);
     }
 
     @Override
@@ -136,8 +136,8 @@ public final class SequenceLayout extends AbstractLayout {
     }
 
     @Override
-    SequenceLayout dup(long alignment, Map<String, Constable> annotations) {
-        return new SequenceLayout(elementCount(), elementLayout, alignment, annotations);
+    SequenceLayout dup(long alignment, Map<String, Constable> attributes) {
+        return new SequenceLayout(elementCount(), elementLayout, alignment, attributes);
     }
 
     @Override
@@ -147,11 +147,11 @@ public final class SequenceLayout extends AbstractLayout {
 
     @Override
     public Optional<DynamicConstantDesc<SequenceLayout>> describeConstable() {
-        return elemCount.isPresent() ?
-                Optional.of(DynamicConstantDesc.ofNamed(ConstantDescs.BSM_INVOKE, "value",
-                        CD_SEQUENCE_LAYOUT, MH_SIZED_SEQUENCE, elemCount.getAsLong(), elementLayout.describeConstable().get())) :
-                Optional.of(DynamicConstantDesc.ofNamed(ConstantDescs.BSM_INVOKE, "value",
-                        CD_SEQUENCE_LAYOUT, MH_UNSIZED_SEQUENCE, elementLayout.describeConstable().get()));
+        return Optional.of(decorateLayoutConstant(elemCount.isPresent() ?
+                DynamicConstantDesc.ofNamed(ConstantDescs.BSM_INVOKE, "value",
+                        CD_SEQUENCE_LAYOUT, MH_SIZED_SEQUENCE, elemCount.getAsLong(), elementLayout.describeConstable().get()) :
+                DynamicConstantDesc.ofNamed(ConstantDescs.BSM_INVOKE, "value",
+                        CD_SEQUENCE_LAYOUT, MH_UNSIZED_SEQUENCE, elementLayout.describeConstable().get())));
     }
 
     //hack: the declarations below are to make javadoc happy; we could have used generics in AbstractLayout
@@ -171,5 +171,13 @@ public final class SequenceLayout extends AbstractLayout {
     @Override
     public SequenceLayout withBitAlignment(long alignmentBits) {
         return (SequenceLayout)super.withBitAlignment(alignmentBits);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public SequenceLayout withAttribute(String name, Constable value) {
+        return (SequenceLayout)super.withAttribute(name, value);
     }
 }

--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/SystemABI.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/SystemABI.java
@@ -53,6 +53,11 @@ public interface SystemABI {
     String ABI_AARCH64 = "AArch64";
 
     /**
+     * memory layout attribute key for abi native type
+     */
+    String NATIVE_TYPE = "abi/native-type";
+
+    /**
      * Obtain a method handle which can be used to call a given native function.
      *
      * @param symbol downcall symbol.
@@ -174,7 +179,21 @@ public interface SystemABI {
         /**
          * The {@code T*} native type.
          */
-        POINTER
+        POINTER;
+
+        /**
+         * Retrieve the ABI type attached to the given layout,
+         * or throw an {@code IllegalArgumentException} if there is none
+         *
+         * @param ml the layout to retrieve the ABI type of
+         * @return the retrieved ABI type
+         * @throws IllegalArgumentException if the given layout does not have an ABI type attribute
+         */
+        public static Type fromLayout(MemoryLayout ml) throws IllegalArgumentException {
+            return ml.attribute(NATIVE_TYPE)
+                     .map(SystemABI.Type.class::cast)
+                     .orElseThrow(() -> new IllegalArgumentException("No ABI attribute present"));
+        }
     }
 
     /**

--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/ValueLayout.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/ValueLayout.java
@@ -56,8 +56,8 @@ public final class ValueLayout extends AbstractLayout implements MemoryLayout {
         this(order, size, size, Map.of());
     }
 
-    ValueLayout(ByteOrder order, long size, long alignment, Map<String, Constable> annotations) {
-        super(OptionalLong.of(size), alignment, annotations);
+    ValueLayout(ByteOrder order, long size, long alignment, Map<String, Constable> attributes) {
+        super(OptionalLong.of(size), alignment, attributes);
         this.order = order;
     }
 
@@ -77,7 +77,7 @@ public final class ValueLayout extends AbstractLayout implements MemoryLayout {
      * @return a new value layout with given byte order.
      */
     public ValueLayout withOrder(ByteOrder order) {
-        return new ValueLayout(order, bitSize(), alignment, annotations);
+        return new ValueLayout(order, bitSize(), alignment, attributes);
     }
 
     @Override
@@ -110,14 +110,14 @@ public final class ValueLayout extends AbstractLayout implements MemoryLayout {
     }
 
     @Override
-    ValueLayout dup(long alignment, Map<String, Constable> annotations) {
-        return new ValueLayout(order, bitSize(), alignment, annotations);
+    ValueLayout dup(long alignment, Map<String, Constable> attributes) {
+        return new ValueLayout(order, bitSize(), alignment, attributes);
     }
 
     @Override
     public Optional<DynamicConstantDesc<ValueLayout>> describeConstable() {
-        return Optional.of(DynamicConstantDesc.ofNamed(ConstantDescs.BSM_INVOKE, "value",
-                CD_VALUE_LAYOUT, MH_VALUE, bitSize(), order == ByteOrder.BIG_ENDIAN ? BIG_ENDIAN : LITTLE_ENDIAN));
+        return Optional.of(decorateLayoutConstant(DynamicConstantDesc.ofNamed(ConstantDescs.BSM_INVOKE, "value",
+                CD_VALUE_LAYOUT, MH_VALUE, bitSize(), order == ByteOrder.BIG_ENDIAN ? BIG_ENDIAN : LITTLE_ENDIAN)));
     }
 
     //hack: the declarations below are to make javadoc happy; we could have used generics in AbstractLayout
@@ -137,5 +137,13 @@ public final class ValueLayout extends AbstractLayout implements MemoryLayout {
     @Override
     public ValueLayout withBitAlignment(long alignmentBits) {
         return (ValueLayout)super.withBitAlignment(alignmentBits);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public ValueLayout withAttribute(String name, Constable value) {
+        return (ValueLayout)super.withAttribute(name, value);
     }
 }

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/Utils.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/Utils.java
@@ -118,31 +118,6 @@ public final class Utils {
         return layout.getClass() == PADDING_CLASS;
     }
 
-    @SuppressWarnings("unchecked")
-    public static Map<String, Constable> getAnnotations(MemoryLayout layout) {
-        try {
-            Field f = ValueLayout.class.getSuperclass().getDeclaredField("annotations");
-            f.setAccessible(true);
-            return (Map<String, Constable>) f.get(layout);
-        } catch (ReflectiveOperationException ex) {
-            throw new IllegalStateException(ex);
-        }
-    }
-
-    public static Constable getAnnotation(MemoryLayout layout, String name) {
-        return getAnnotations(layout).get(name);
-    }
-
-    public static MemoryLayout withAnnotation(MemoryLayout layout, String name, Constable value) {
-        try {
-            Method m = ValueLayout.class.getSuperclass().getDeclaredMethod("withAnnotation", String.class, Constable.class);
-            m.setAccessible(true);
-            return (MemoryLayout)m.invoke(layout, name, value);
-        } catch (ReflectiveOperationException ex) {
-            throw new IllegalStateException(ex);
-        }
-    }
-
     public static MemoryAddress resizeNativeAddress(MemoryAddress base, long byteSize) {
         return new MemoryAddressImpl((MemorySegmentImpl)Utils.makeNativeSegmentUnchecked(base, byteSize), 0);
     }

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/x64/windows/Windowsx64ABI.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/x64/windows/Windowsx64ABI.java
@@ -51,7 +51,7 @@ public class Windowsx64ABI implements SystemABI {
     public static final int MAX_REGISTER_ARGUMENTS = 4;
     public static final int MAX_REGISTER_RETURNS = 1;
 
-    public static final String VARARGS_ANNOTATION_NAME = "abi/windows/varargs";
+    public static final String VARARGS_ATTRIBUTE_NAME = "abi/windows/varargs";
 
     private static Windowsx64ABI instance;
 

--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/Utils.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/Utils.java
@@ -281,11 +281,11 @@ class Utils {
     }
 
     public static Optional<GroupLayout> getContents(MemoryLayout layout) {
-        return Optional.ofNullable((GroupLayout)jdk.internal.foreign.Utils.getAnnotation(layout, "contents"));
+        return layout.attribute("contents").map(GroupLayout.class::cast);
     }
 
     @SuppressWarnings("unchecked")
     public static <Z extends MemoryLayout> Z addContents(Z layout, GroupLayout contents) {
-        return (Z)jdk.internal.foreign.Utils.withAnnotation(layout, "contents", contents);
+        return (Z) layout.withAttribute("contents", contents);
     }
 }

--- a/test/jdk/java/foreign/NativeTestHelper.java
+++ b/test/jdk/java/foreign/NativeTestHelper.java
@@ -38,11 +38,7 @@ public class NativeTestHelper {
     public static final SystemABI ABI = Foreign.getInstance().getSystemABI();
 
     public static boolean isIntegral(MemoryLayout layout) {
-        var optAbiType = layout.abiType();
-        if (!optAbiType.isPresent()) {
-            return false;
-        }
-        return switch(optAbiType.get()) {
+        return switch(SystemABI.Type.fromLayout(layout)) {
             case BOOL, UNSIGNED_CHAR, SIGNED_CHAR, CHAR, SHORT, UNSIGNED_SHORT,
                 INT, UNSIGNED_INT, LONG, UNSIGNED_LONG, LONG_LONG, UNSIGNED_LONG_LONG -> true;
             default -> false;
@@ -50,7 +46,7 @@ public class NativeTestHelper {
     }
 
     public static boolean isPointer(MemoryLayout layout) {
-        return layout.abiType().filter(Predicate.isEqual(Type.POINTER)).isPresent();
+        return SystemABI.Type.fromLayout(layout) == Type.POINTER;
     }
 
     public static ValueLayout asVarArg(ValueLayout layout) {

--- a/test/jdk/java/foreign/TestLayoutAttributes.java
+++ b/test/jdk/java/foreign/TestLayoutAttributes.java
@@ -1,0 +1,72 @@
+/*
+ *  Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ *  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ *  This code is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License version 2 only, as
+ *  published by the Free Software Foundation.
+ *
+ *  This code is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ *  version 2 for more details (a copy is included in the LICENSE file that
+ *  accompanied this code).
+ *
+ *  You should have received a copy of the GNU General Public License version
+ *  2 along with this work; if not, write to the Free Software Foundation,
+ *  Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ *  Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ *  or visit www.oracle.com if you need additional information or have any
+ *  questions.
+ */
+
+/*
+ * @test
+ * @run testng TestLayoutAttributes
+ */
+
+import jdk.incubator.foreign.MemoryLayout;
+import jdk.incubator.foreign.MemoryLayouts;
+import org.testng.annotations.Test;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+public class TestLayoutAttributes {
+
+    @Test
+    public void testAttribute() {
+        MemoryLayout ml = MemoryLayouts.BITS_32_LE
+                .withAttribute("MyAttribute", 10L);
+        assertEquals((long) ml.attribute("MyAttribute").orElseThrow(), 10L);
+    }
+
+    @Test
+    public void testAttributeNonExistent() {
+        MemoryLayout ml = MemoryLayouts.BITS_32_LE
+                .withAttribute("MyAttribute", 10L);
+        assertTrue(ml.attribute("Foo").isEmpty());
+    }
+
+    @Test
+    public void testNameAttribute() {
+        MemoryLayout ml = MemoryLayouts.BITS_32_LE
+                .withName("foo");
+        assertEquals(ml.name().orElseThrow(), "foo");
+        assertEquals(ml.attribute("name").orElseThrow(), "foo");
+    }
+
+    @Test
+    public void testAttributesStream() {
+        MemoryLayout ml = MemoryLayouts.BITS_32_LE
+                .withName("foo")
+                .withAttribute("MyAttribute", 10L);
+        List<String> attribs = ml.attributes().collect(Collectors.toList());
+        assertEquals(attribs, List.of("name", "MyAttribute"));
+    }
+
+}

--- a/test/jdk/java/foreign/TestLayoutConstants.java
+++ b/test/jdk/java/foreign/TestLayoutConstants.java
@@ -106,6 +106,9 @@ public class TestLayoutConstants {
                         MemoryLayout.ofStruct(
                                 MemoryLayouts.PAD_8,
                                 MemoryLayouts.BITS_32_BE)) },
+                { MemoryLayouts.BITS_32_LE.withName("myInt") },
+                { MemoryLayouts.BITS_32_LE.withBitAlignment(8) },
+                { MemoryLayouts.BITS_32_LE.withAttribute("xyz", "abc") },
         };
     }
 

--- a/test/jdk/tools/jextract/JextractToolRunner.java
+++ b/test/jdk/tools/jextract/JextractToolRunner.java
@@ -38,8 +38,10 @@ import java.util.Objects;
 import java.util.spi.ToolProvider;
 import jdk.incubator.foreign.MemoryLayout;
 import jdk.incubator.foreign.MemoryLayout.PathElement;
+import jdk.incubator.foreign.SystemABI;
 import jdk.incubator.foreign.SystemABI.Type;
 
+import static jdk.incubator.foreign.SystemABI.NATIVE_TYPE;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotEquals;
 import static org.testng.Assert.assertNotNull;
@@ -243,7 +245,9 @@ public class JextractToolRunner {
     }
 
     protected static void checkFieldABIType(MemoryLayout layout, String fieldName, Type expected) {
-        assertEquals(layout.select(PathElement.groupElement(fieldName)).abiType().orElseThrow(), expected);
+        assertEquals(layout.select(PathElement.groupElement(fieldName)).attribute(NATIVE_TYPE)
+                                                                       .map(SystemABI.Type.class::cast)
+                                                                       .orElseThrow(), expected);
     }
 
     protected static class Loader implements AutoCloseable {

--- a/test/jdk/tools/jextract/testStruct/LibStructTest.java
+++ b/test/jdk/tools/jextract/testStruct/LibStructTest.java
@@ -23,8 +23,11 @@
 
 import jdk.incubator.foreign.MemoryLayout.PathElement;
 import jdk.incubator.foreign.GroupLayout;
+import jdk.incubator.foreign.SystemABI;
 import jdk.incubator.foreign.SystemABI.Type;
 import org.testng.annotations.Test;
+
+import static jdk.incubator.foreign.SystemABI.NATIVE_TYPE;
 import static org.testng.Assert.assertEquals;
 import static test.jextract.struct.struct_h.*;
 
@@ -45,7 +48,9 @@ public class LibStructTest {
     }
 
     private static void checkFieldABIType(GroupLayout group, String fieldName, Type expected) {
-        assertEquals(group.select(PathElement.groupElement(fieldName)).abiType().orElseThrow(), expected);
+        assertEquals(group.select(PathElement.groupElement(fieldName)).attribute(NATIVE_TYPE)
+                                                                      .map(SystemABI.Type.class::cast)
+                                                                      .orElseThrow(), expected);
     }
 
     @Test


### PR DESCRIPTION
Hi,

These are the jextract changes needed after exposing layout attributes in the public API. This also fixes the pending merge conflict, which was closely related to the needed changes.

Jorn
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [JDK-8241504](https://bugs.openjdk.java.net/browse/JDK-8241504): Expose MemoryLayout annotations/attributes in the public API


### Reviewers
 * Maurizio Cimadamore ([mcimadamore](@mcimadamore) - Committer)

### Download
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/69/head:pull/69`
`$ git checkout pull/69`
