### PR TITLE
8241712: AArch64: TestDowncall fails with IllegalArgumentException: No ABI attribute present

### DIFF
--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/aarch64/CallArranger.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/aarch64/CallArranger.java
@@ -203,9 +203,11 @@ public class CallArranger {
            return false;
 
         for (MemoryLayout elem : groupLayout.memberLayouts()) {
+            if (!(elem instanceof ValueLayout))
+                return false;
+
             ArgumentClassImpl argClass = AArch64ABI.argumentClassFor(SystemABI.Type.fromLayout(elem));
-            if (!(elem instanceof ValueLayout) ||
-                    elem.bitSize() != baseType.bitSize() ||
+            if (elem.bitSize() != baseType.bitSize() ||
                     elem.bitAlignment() != baseType.bitAlignment() ||
                     baseArgClass != argClass) {
                 return false;

--- a/test/jdk/java/foreign/callarranger/TestAarch64CallArranger.java
+++ b/test/jdk/java/foreign/callarranger/TestAarch64CallArranger.java
@@ -170,8 +170,8 @@ public class TestAarch64CallArranger extends CallArrangerTestBase {
                     // s.b[0] & s.b[1]
                     dereference(8, long.class), move(r1, long.class),
             }},
-            // struct s { int32_t a; /* padding */ double b };
-            { MemoryLayout.ofStruct(C_INT, MemoryLayout.ofPaddingBits(32), C_DOUBLE),
+            // struct s { float a; /* padding */ double b };
+            { MemoryLayout.ofStruct(C_FLOAT, MemoryLayout.ofPaddingBits(32), C_DOUBLE),
               new Binding[] {
                 dup(),
                 // s.a

--- a/test/jdk/java/foreign/callarranger/TestAarch64CallArranger.java
+++ b/test/jdk/java/foreign/callarranger/TestAarch64CallArranger.java
@@ -170,6 +170,15 @@ public class TestAarch64CallArranger extends CallArrangerTestBase {
                     // s.b[0] & s.b[1]
                     dereference(8, long.class), move(r1, long.class),
             }},
+            // struct s { int32_t a; /* padding */ double b };
+            { MemoryLayout.ofStruct(C_INT, MemoryLayout.ofPaddingBits(32), C_DOUBLE),
+              new Binding[] {
+                dup(),
+                // s.a
+                dereference(0, long.class), move(r0, long.class),
+                // s.b
+                dereference(8, long.class), move(r1, long.class),
+            }},
         };
     }
 


### PR DESCRIPTION
Tests cases where the structure has an initial floating point element followed by padding fail with this exception. The padding element doesn't have the NATIVE_TYPE attribute.

```
  test TestDowncall.testDowncall("f0_V_S_FD", VOID, [STRUCT], [FLOAT, DOUBLE]): failure
  java.lang.IllegalArgumentException: No ABI attribute present
          at jdk.incubator.foreign/jdk.incubator.foreign.SystemABI$Type.lambda$fromLayout$0(SystemABI.java:195)
          at java.base/java.util.Optional.orElseThrow(Optional.java:401)
          at jdk.incubator.foreign/jdk.incubator.foreign.SystemABI$Type.fromLayout(SystemABI.java:195)
          at jdk.incubator.foreign/jdk.internal.foreign.abi.aarch64.CallArranger.isHomogeneousFloatAggregate(CallArranger.java:207)
          at jdk.incubator.foreign/jdk.internal.foreign.abi.aarch64.CallArranger.classifyStructType(CallArranger.java:220)
```
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [JDK-8241712](https://bugs.openjdk.java.net/browse/JDK-8241712): AArch64: TestDowncall fails with IllegalArgumentException: No ABI attribute present


### Reviewers
 * Jorn Vernee ([jvernee](@JornVernee) - Committer) ⚠️ Review applies to aee157e793ae7ef0a52093be4a3990c010c3ab44

### Download
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/70/head:pull/70`
`$ git checkout pull/70`
