### PR TITLE
8241816: foreign-abi and foreign-jextract panama branches fail to build and test

### DIFF
--- a/src/java.base/share/classes/jdk/internal/loader/NativeLibraries.java
+++ b/src/java.base/share/classes/jdk/internal/loader/NativeLibraries.java
@@ -384,7 +384,7 @@ public final class NativeLibraries {
         }
     }
 
-    public static NativeLibrary defaultLibrary = new NativeLibraryImpl(Object.class, "<default>", true) {
+    public static NativeLibrary defaultLibrary = new NativeLibraryImpl(Object.class, "<default>", true, true) {
 
         @Override
         boolean open() {

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/LibrariesHelper.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/LibrariesHelper.java
@@ -41,10 +41,11 @@ import java.util.Optional;
 public final class LibrariesHelper {
     private LibrariesHelper() {}
 
+    // FIXME - revisit this (refcount for unload)
     private final static ClassValue<NativeLibraries> nativeLibrary = new ClassValue<>() {
         @Override
         protected NativeLibraries computeValue(Class<?> type) {
-            return new NativeLibraries(type.getClassLoader());
+            return NativeLibraries.jniNativeLibraries(type.getClassLoader());
         }
     };
 


### PR DESCRIPTION
Temporary workaround for native library handling in foreign-abi.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [JDK-8241816](https://bugs.openjdk.java.net/browse/JDK-8241816): foreign-abi and foreign-jextract panama branches fail to build and test


### Reviewers
 * Maurizio Cimadamore ([mcimadamore](@mcimadamore) - Committer)

### Download
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/72/head:pull/72`
`$ git checkout pull/72`
