### PR TITLE
JDK-8241849: Add unsafe way to create unconfined memory segment view

### DIFF
--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/unsafe/ForeignUnsafe.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/unsafe/ForeignUnsafe.java
@@ -27,7 +27,9 @@
 package jdk.incubator.foreign.unsafe;
 
 import jdk.incubator.foreign.MemoryAddress;
+import jdk.incubator.foreign.MemorySegment;
 import jdk.internal.foreign.MemoryAddressImpl;
+import jdk.internal.foreign.MemorySegmentImpl;
 
 /**
  * Unsafe methods to allow interop between sun.misc.unsafe and memory access API.
@@ -64,5 +66,17 @@ public final class ForeignUnsafe {
      */
     public static long getUnsafeOffset(MemoryAddress address) {
         return ((MemoryAddressImpl)address).unsafeGetOffset();
+    }
+
+    /**
+     * Returns a non-confined memory segment that has the same spatial and temporal bounds as the provided segment.
+     * Since the returned segment can be effectively accessed by multiple threads in an unconstrained fashion,
+     * this method should be used with care, as it might lead to JVM crashes - e.g. in the case where a thread {@code A}
+     * closes a segment while another thread {@code B} is accessing it.
+     * @param segment the segment from which an unconfined view is to be created.
+     * @return a non-confined memory segment that has the same spatial and temporal bounds as the provided segment.
+     */
+    public static MemorySegment asUnconfined(MemorySegment segment) {
+        return ((MemorySegmentImpl)segment).asUnconfined();
     }
 }

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/MemorySegmentImpl.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/MemorySegmentImpl.java
@@ -204,7 +204,7 @@ public final class MemorySegmentImpl implements MemorySegment, MemorySegmentProx
 
     @Override
     public final void checkValidState() {
-        if (owner != Thread.currentThread()) {
+        if (owner != null && owner != Thread.currentThread()) {
             throw new IllegalStateException("Attempt to access segment outside owning thread");
         }
         scope.checkAliveConfined();
@@ -228,6 +228,11 @@ public final class MemorySegmentImpl implements MemorySegment, MemorySegmentProx
             throw unsupportedAccessMode(ACQUIRE);
         }
         return new MemorySegmentImpl(min, base, length, mask, Thread.currentThread(), scope.acquire());
+    }
+
+    public MemorySegment asUnconfined() {
+        checkValidState();
+        return new MemorySegmentImpl(min, base, length, mask, null, scope);
     }
 
     void checkRange(long offset, long length, boolean writeAccess) {


### PR DESCRIPTION
This patch adds an extra foreign unsafe static method to create an unconfined view of an existing segment. Following JDK-8241772, the acquire() entry point has been removed; while the common divide and conquer use cases are still supported (via spliterator), it might be the case that some of the clients want a truly unconfined (and unsafe) segment. This patch adds that. The new API is more powerful than just acquire() and more in sync with what existing clients might already doing in certain cases, by calling Unsafe::invokeCleaner when working with direct buffers.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [JDK-8241849](https://bugs.openjdk.java.net/browse/JDK-8241849): Add unsafe way to create unconfined memory segment view


### Reviewers
 * Athijegannathan Sundararajan ([sundar](@sundararajana) - Committer)

### Download
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/73/head:pull/73`
`$ git checkout pull/73`
