### PR TITLE
JDK-8241866:Add API to reshape sequence layouts

### DIFF
--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/SequenceLayout.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/SequenceLayout.java
@@ -202,19 +202,25 @@ public final class SequenceLayout extends AbstractLayout {
      * }</pre>
      * @return a new sequence layout with the same size as this layout (but, possibly, with different
      * element count), whose element layout is not a sequence layout.
-     * @throws UnsupportedOperationException if this sequence layout does not have an element count.
+     * @throws UnsupportedOperationException if this sequence layout, or one of the nested sequence layouts being
+     * flattened, does not have an element count.
      */
     public SequenceLayout flatten() {
         if (!elementCount().isPresent()) {
-            throw new UnsupportedOperationException("Cannot flatten a sequence layout whose element count is unspecified");
+            throw badUnboundSequenceLayout();
         }
         long count = elementCount().getAsLong();
         MemoryLayout elemLayout = elementLayout();
         while (elemLayout instanceof SequenceLayout) {
-            count = count * ((SequenceLayout)elemLayout).elementCount().getAsLong();
-            elemLayout = ((SequenceLayout)elemLayout).elementLayout();
+            SequenceLayout elemSeq = (SequenceLayout)elemLayout;
+            count = count * elemSeq.elementCount().orElseThrow(this::badUnboundSequenceLayout);
+            elemLayout = elemSeq.elementLayout();
         }
         return MemoryLayout.ofSequence(count, elemLayout);
+    }
+
+    private UnsupportedOperationException badUnboundSequenceLayout() {
+        return new UnsupportedOperationException("Cannot flatten a sequence layout whose element count is unspecified");
     }
 
     @Override

--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/SequenceLayout.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/SequenceLayout.java
@@ -30,6 +30,7 @@ import java.lang.constant.DynamicConstantDesc;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.OptionalLong;
+import java.util.stream.LongStream;
 
 /**
  * A sequence layout. A sequence layout is used to denote a repetition of a given layout, also called the sequence layout's <em>element layout</em>.
@@ -105,6 +106,115 @@ public final class SequenceLayout extends AbstractLayout {
     public SequenceLayout withElementCount(long elementCount) {
         AbstractLayout.checkSize(elementCount, true);
         return new SequenceLayout(OptionalLong.of(elementCount), elementLayout, alignment, name());
+    }
+
+    /**
+     * Returns a new sequence layout where element layouts in the flattened projection of this
+     * sequence layout (see {@link #flatten()}) are re-arranged into one or more nested sequence layouts
+     * according to the provided element counts. This transformation preserves the layout size;
+     * that is, multiplying the provided element counts should yield the same element count
+     * as the flattened projection of this sequence layout.
+     * <p>
+     * For instance, given a sequence layout of the kind:
+     * <pre>{@code
+    var seq = MemoryLayout.ofSequence(4, MemoryLayout.ofSequence(3, MemoryLayouts.JAVA_INT));
+     * }</pre>
+     * calling {@code seq.reshape(2, 6)} will yield the following sequence layout:
+     * <pre>{@code
+    var reshapeSeq = MemoryLayout.ofSequence(2, MemoryLayout.ofSequence(6, MemoryLayouts.JAVA_INT));
+     * }</pre>
+     * <p>
+     * If one of the provided element count is the special value {@code -1}, then the element
+     * count in that position will be inferred from the remaining element counts and the
+     * element count of the flattened projection of this layout. For instance, a layout equivalent to
+     * the above {@code reshapeSeq} can also be computed in the following ways:
+     * <pre>{@code
+    var reshapeSeqImplicit1 = seq.reshape(-1, 6);
+    var reshapeSeqImplicit2 = seq.reshape(2, -1);
+     * }</pre>
+     * @param elementCounts an array of element counts, of which at most one can be {@code -1}.
+     * @return a new sequence layout where element element layouts in the flattened projection of this
+     * sequence layout (see {@link #flatten()}) are re-arranged into one or more nested sequence layouts.
+     * @throws NullPointerException if {@code elementCounts == null}.
+     * @throws UnsupportedOperationException if this sequence layout does not have an element count.
+     * @throws IllegalArgumentException if two or more element counts are set to {@code -1}, or if one
+     * or more element count is {@code <= 0} (but other than {@code -1}) or, if, after any required inference,
+     * multiplying the element counts does not yield the same element count as the flattened projection of this
+     * sequence layout.
+     */
+    public SequenceLayout reshape(long... elementCounts) {
+        Objects.requireNonNull(elementCounts);
+        if (elementCounts.length == 0) {
+            throw new IllegalArgumentException();
+        }
+        if (!elementCount().isPresent()) {
+            throw new UnsupportedOperationException("Cannot reshape a sequence layout whose element count is unspecified");
+        }
+        SequenceLayout flat = flatten();
+        long expectedCount = flat.elementCount().getAsLong();
+
+        long actualCount = 1;
+        int inferPosition = -1;
+        for (int i = 0 ; i < elementCounts.length ; i++) {
+            if (elementCounts[i] == -1) {
+                if (inferPosition == -1) {
+                    inferPosition = i;
+                } else {
+                    throw new IllegalArgumentException("Too many unspecified element counts");
+                }
+            } else if (elementCounts[i] <= 0) {
+                throw new IllegalArgumentException("Invalid element count: " + elementCounts[i]);
+            } else {
+                actualCount = elementCounts[i] * actualCount;
+            }
+        }
+
+        // infer an unspecified element count (if any)
+        if (inferPosition != -1) {
+            long inferredCount = expectedCount / actualCount;
+            elementCounts[inferPosition] = inferredCount;
+            actualCount = actualCount * inferredCount;
+        }
+
+        if (actualCount != expectedCount) {
+            throw new IllegalArgumentException("Element counts do not match expected size: " + expectedCount);
+        }
+
+        MemoryLayout res = flat.elementLayout();
+        for (int i = elementCounts.length - 1 ; i >= 0 ; i--) {
+            res = MemoryLayout.ofSequence(elementCounts[i], res);
+        }
+        return (SequenceLayout)res;
+    }
+
+    /**
+     * Returns a new, flattened sequence layout whose element layout is the first non-sequence
+     * element layout found by recursively traversing the element layouts of this sequence layout.
+     * This transformation preserves the layout size; nested sequence layout in this sequence layout will
+     * be dropped and their element counts will be incorporated into that of the returned sequence layout.
+     * For instance, given a sequence layout of the kind:
+     * <pre>{@code
+    var seq = MemoryLayout.ofSequence(4, MemoryLayout.ofSequence(3, MemoryLayouts.JAVA_INT));
+     * }</pre>
+     * calling {@code seq.flatten()} will yield the following sequence layout:
+     * <pre>{@code
+    var flattenedSeq = MemoryLayout.ofSequence(12, MemoryLayouts.JAVA_INT);
+     * }</pre>
+     * @return a new sequence layout with the same size as this layout (but, possibly, with different
+     * element count), whose element layout is not a sequence layout.
+     * @throws UnsupportedOperationException if this sequence layout does not have an element count.
+     */
+    public SequenceLayout flatten() {
+        if (!elementCount().isPresent()) {
+            throw new UnsupportedOperationException("Cannot flatten a sequence layout whose element count is unspecified");
+        }
+        long count = elementCount().getAsLong();
+        MemoryLayout elemLayout = elementLayout();
+        while (elemLayout instanceof SequenceLayout) {
+            count = count * ((SequenceLayout)elemLayout).elementCount().getAsLong();
+            elemLayout = ((SequenceLayout)elemLayout).elementLayout();
+        }
+        return MemoryLayout.ofSequence(count, elemLayout);
     }
 
     @Override

--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/SequenceLayout.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/SequenceLayout.java
@@ -133,7 +133,7 @@ public final class SequenceLayout extends AbstractLayout {
     var reshapeSeqImplicit2 = seq.reshape(2, -1);
      * }</pre>
      * @param elementCounts an array of element counts, of which at most one can be {@code -1}.
-     * @return a new sequence layout where element element layouts in the flattened projection of this
+     * @return a new sequence layout where element layouts in the flattened projection of this
      * sequence layout (see {@link #flatten()}) are re-arranged into one or more nested sequence layouts.
      * @throws NullPointerException if {@code elementCounts == null}.
      * @throws UnsupportedOperationException if this sequence layout does not have an element count.

--- a/test/jdk/java/foreign/TestReshape.java
+++ b/test/jdk/java/foreign/TestReshape.java
@@ -1,0 +1,183 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @run testng TestReshape
+ */
+
+import jdk.incubator.foreign.MemoryLayout;
+import jdk.incubator.foreign.MemoryLayouts;
+import jdk.incubator.foreign.MemorySegment;
+import jdk.incubator.foreign.SequenceLayout;
+import org.testng.annotations.*;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.stream.LongStream;
+
+import static org.testng.Assert.*;
+
+public class TestReshape {
+
+    @Test(dataProvider = "shapes")
+    public void testReshape(MemoryLayout layout, long[] expectedShape) {
+        long flattenedSize = LongStream.of(expectedShape).reduce(1L, Math::multiplyExact);
+        SequenceLayout seq_flattened = MemoryLayout.ofSequence(flattenedSize, layout);
+        assertDimensions(seq_flattened, flattenedSize);
+        for (long[] shape : new Shape(expectedShape)) {
+            SequenceLayout seq_shaped = seq_flattened.reshape(shape);
+            assertDimensions(seq_shaped, expectedShape);
+            assertEquals(seq_shaped.flatten(), seq_flattened);
+        }
+    }
+
+    @Test(expectedExceptions = NullPointerException.class)
+    public void testNullReshape() {
+        SequenceLayout seq = MemoryLayout.ofSequence(4, MemoryLayouts.JAVA_INT);
+        seq.reshape(null);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testInvalidReshape() {
+        SequenceLayout seq = MemoryLayout.ofSequence(4, MemoryLayouts.JAVA_INT);
+        seq.reshape(3, 2);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testBadReshapeInference() {
+        SequenceLayout seq = MemoryLayout.ofSequence(4, MemoryLayouts.JAVA_INT);
+        seq.reshape(-1, -1);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testBadReshapeParameterZero() {
+        SequenceLayout seq = MemoryLayout.ofSequence(4, MemoryLayouts.JAVA_INT);
+        seq.reshape(0, 4);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testBadReshapeParameterNegative() {
+        SequenceLayout seq = MemoryLayout.ofSequence(4, MemoryLayouts.JAVA_INT);
+        seq.reshape(-2, 2);
+    }
+
+    @Test(expectedExceptions = UnsupportedOperationException.class)
+    public void testReshapeOnUnboundSequence() {
+        SequenceLayout seq = MemoryLayout.ofSequence(MemoryLayouts.JAVA_INT);
+        seq.reshape(3, 2);
+    }
+
+    @Test(expectedExceptions = UnsupportedOperationException.class)
+    public void testFlattenOnUnboundSequence() {
+        SequenceLayout seq = MemoryLayout.ofSequence(MemoryLayouts.JAVA_INT);
+        seq.flatten();
+    }
+
+    static void assertDimensions(SequenceLayout layout, long... dims) {
+        SequenceLayout prev = null;
+        for (int i = 0 ; i < dims.length ; i++) {
+            if (prev != null) {
+                layout = (SequenceLayout)prev.elementLayout();
+            }
+            assertEquals(layout.elementCount().getAsLong(), dims[i]);
+            prev = layout;
+        }
+    }
+
+    static class Shape implements Iterable<long[]> {
+        long[] shape;
+
+        Shape(long... shape) {
+            this.shape = shape;
+        }
+
+        public Iterator<long[]> iterator() {
+            List<long[]> shapes = new ArrayList<>();
+            shapes.add(shape);
+            for (int i = 0 ; i < shape.length ; i++) {
+                long[] inferredShape = shape.clone();
+                inferredShape[i] = -1;
+                shapes.add(inferredShape);
+            }
+            return shapes.iterator();
+        }
+    }
+
+    @DataProvider(name = "shapes")
+    Object[][] shapes() {
+        return new Object[][] {
+                { MemoryLayouts.JAVA_BYTE, new long[] { 256 } },
+                { MemoryLayouts.JAVA_BYTE, new long[] { 16, 16 } },
+                { MemoryLayouts.JAVA_BYTE, new long[] { 4, 4, 4, 4 } },
+                { MemoryLayouts.JAVA_BYTE, new long[] { 2, 8, 16 } },
+                { MemoryLayouts.JAVA_BYTE, new long[] { 16, 8, 2 } },
+                { MemoryLayouts.JAVA_BYTE, new long[] { 8, 16, 2 } },
+
+                { MemoryLayouts.JAVA_SHORT, new long[] { 256 } },
+                { MemoryLayouts.JAVA_SHORT, new long[] { 16, 16 } },
+                { MemoryLayouts.JAVA_SHORT, new long[] { 4, 4, 4, 4 } },
+                { MemoryLayouts.JAVA_SHORT, new long[] { 2, 8, 16 } },
+                { MemoryLayouts.JAVA_SHORT, new long[] { 16, 8, 2 } },
+                { MemoryLayouts.JAVA_SHORT, new long[] { 8, 16, 2 } },
+
+                { MemoryLayouts.JAVA_CHAR, new long[] { 256 } },
+                { MemoryLayouts.JAVA_CHAR, new long[] { 16, 16 } },
+                { MemoryLayouts.JAVA_CHAR, new long[] { 4, 4, 4, 4 } },
+                { MemoryLayouts.JAVA_CHAR, new long[] { 2, 8, 16 } },
+                { MemoryLayouts.JAVA_CHAR, new long[] { 16, 8, 2 } },
+                { MemoryLayouts.JAVA_CHAR, new long[] { 8, 16, 2 } },
+
+                { MemoryLayouts.JAVA_INT, new long[] { 256 } },
+                { MemoryLayouts.JAVA_INT, new long[] { 16, 16 } },
+                { MemoryLayouts.JAVA_INT, new long[] { 4, 4, 4, 4 } },
+                { MemoryLayouts.JAVA_INT, new long[] { 2, 8, 16 } },
+                { MemoryLayouts.JAVA_INT, new long[] { 16, 8, 2 } },
+                { MemoryLayouts.JAVA_INT, new long[] { 8, 16, 2 } },
+
+                { MemoryLayouts.JAVA_LONG, new long[] { 256 } },
+                { MemoryLayouts.JAVA_LONG, new long[] { 16, 16 } },
+                { MemoryLayouts.JAVA_LONG, new long[] { 4, 4, 4, 4 } },
+                { MemoryLayouts.JAVA_LONG, new long[] { 2, 8, 16 } },
+                { MemoryLayouts.JAVA_LONG, new long[] { 16, 8, 2 } },
+                { MemoryLayouts.JAVA_LONG, new long[] { 8, 16, 2 } },
+
+                { MemoryLayouts.JAVA_FLOAT, new long[] { 256 } },
+                { MemoryLayouts.JAVA_FLOAT, new long[] { 16, 16 } },
+                { MemoryLayouts.JAVA_FLOAT, new long[] { 4, 4, 4, 4 } },
+                { MemoryLayouts.JAVA_FLOAT, new long[] { 2, 8, 16 } },
+                { MemoryLayouts.JAVA_FLOAT, new long[] { 16, 8, 2 } },
+                { MemoryLayouts.JAVA_FLOAT, new long[] { 8, 16, 2 } },
+
+                { MemoryLayouts.JAVA_DOUBLE, new long[] { 256 } },
+                { MemoryLayouts.JAVA_DOUBLE, new long[] { 16, 16 } },
+                { MemoryLayouts.JAVA_DOUBLE, new long[] { 4, 4, 4, 4 } },
+                { MemoryLayouts.JAVA_DOUBLE, new long[] { 2, 8, 16 } },
+                { MemoryLayouts.JAVA_DOUBLE, new long[] { 16, 8, 2 } },
+                { MemoryLayouts.JAVA_DOUBLE, new long[] { 8, 16, 2 } },
+        };
+    }
+}

--- a/test/jdk/java/foreign/TestReshape.java
+++ b/test/jdk/java/foreign/TestReshape.java
@@ -4,9 +4,7 @@
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 only, as
- * published by the Free Software Foundation.  Oracle designates this
- * particular file as subject to the "Classpath" exception as provided
- * by Oracle in the LICENSE file that accompanied this code.
+ * published by the Free Software Foundation.
  *
  * This code is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
@@ -93,6 +91,12 @@ public class TestReshape {
     @Test(expectedExceptions = UnsupportedOperationException.class)
     public void testFlattenOnUnboundSequence() {
         SequenceLayout seq = MemoryLayout.ofSequence(MemoryLayouts.JAVA_INT);
+        seq.flatten();
+    }
+
+    @Test(expectedExceptions = UnsupportedOperationException.class)
+    public void testFlattenOnUnboundNestedSequence() {
+        SequenceLayout seq = MemoryLayout.ofSequence(4, MemoryLayout.ofSequence(MemoryLayouts.JAVA_INT));
         seq.flatten();
     }
 

--- a/test/jdk/java/foreign/TestReshape.java
+++ b/test/jdk/java/foreign/TestReshape.java
@@ -125,7 +125,7 @@ public class TestReshape {
             return shapes.iterator();
         }
     }
-    
+
     static MemoryLayout POINT = MemoryLayout.ofStruct(
             MemoryLayouts.JAVA_INT,
             MemoryLayouts.JAVA_INT

--- a/test/jdk/java/foreign/TestReshape.java
+++ b/test/jdk/java/foreign/TestReshape.java
@@ -30,15 +30,14 @@
 
 import jdk.incubator.foreign.MemoryLayout;
 import jdk.incubator.foreign.MemoryLayouts;
-import jdk.incubator.foreign.MemorySegment;
 import jdk.incubator.foreign.SequenceLayout;
-import org.testng.annotations.*;
 
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 import java.util.stream.LongStream;
 
+import org.testng.annotations.*;
 import static org.testng.Assert.*;
 
 public class TestReshape {
@@ -126,6 +125,11 @@ public class TestReshape {
             return shapes.iterator();
         }
     }
+    
+    static MemoryLayout POINT = MemoryLayout.ofStruct(
+            MemoryLayouts.JAVA_INT,
+            MemoryLayouts.JAVA_INT
+    );
 
     @DataProvider(name = "shapes")
     Object[][] shapes() {
@@ -178,6 +182,13 @@ public class TestReshape {
                 { MemoryLayouts.JAVA_DOUBLE, new long[] { 2, 8, 16 } },
                 { MemoryLayouts.JAVA_DOUBLE, new long[] { 16, 8, 2 } },
                 { MemoryLayouts.JAVA_DOUBLE, new long[] { 8, 16, 2 } },
+
+                { POINT, new long[] { 256 } },
+                { POINT, new long[] { 16, 16 } },
+                { POINT, new long[] { 4, 4, 4, 4 } },
+                { POINT, new long[] { 2, 8, 16 } },
+                { POINT, new long[] { 16, 8, 2 } },
+                { POINT, new long[] { 8, 16, 2 } },
         };
     }
 }

--- a/test/micro/org/openjdk/bench/jdk/incubator/foreign/ParallelSum.java
+++ b/test/micro/org/openjdk/bench/jdk/incubator/foreign/ParallelSum.java
@@ -71,7 +71,7 @@ public class ParallelSum {
 
     final static SequenceLayout SEQUENCE_LAYOUT = MemoryLayout.ofSequence(ELEM_SIZE, MemoryLayouts.JAVA_INT);
     final static int BULK_FACTOR = 512;
-    final static SequenceLayout SEQUENCE_LAYOUT_BULK = MemoryLayout.ofSequence(ELEM_SIZE / BULK_FACTOR, MemoryLayout.ofSequence(BULK_FACTOR, MemoryLayouts.JAVA_INT));
+    final static SequenceLayout SEQUENCE_LAYOUT_BULK = SEQUENCE_LAYOUT.reshape(-1, BULK_FACTOR);
 
     static final Unsafe unsafe = Utils.unsafe;
 


### PR DESCRIPTION
https://docs.scipy.org/doc/numpy/reference/generated/numpy.reshape.html

As in Python, clients can use _at most_ one `-1` dimension value, and that dimension value will be inferred by remaining dimensions.

The changes also add the `flatten` method, which does the opposite - e.g. take a sequence layout, whose element layout could be other nested sequence layouts and flatten everything into an outermost sequence layout (where element count is adjusted as needed).

These routines are fairly general and helpful and I found myself in need for something similar when writing code doing parallel processing of memory segments, but there are many other possible use cases.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * Jorn Vernee ([jvernee](@JornVernee) - Committer)
 * Paul Sandoz ([psandoz](@PaulSandoz) - Committer) ⚠️ Review applies to 494bdd4e2fe2f4cada6ef7427479f8d96965c5fa

### Download
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/75/head:pull/75`
`$ git checkout pull/75`
