### PR TITLE
Merge foreign-memaccess

### DIFF
--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/Foreign.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/Foreign.java
@@ -104,6 +104,10 @@ public interface Foreign {
      * Since the returned segment can be effectively accessed by multiple threads in an unconstrained fashion,
      * this method should be used with care, as it might lead to JVM crashes - e.g. in the case where a thread {@code A}
      * closes a segment while another thread {@code B} is accessing it.
+     * <p>
+     * This method is <em>restricted</em>. Restricted method are unsafe, and, if used incorrectly, their use might crash
+     * the JVM crash or, worse, silently result in memory corruption. Thus, clients should refrain from depending on
+     * restricted methods, and use safe and supported functionalities, where possible.
      * @param segment the segment from which an unconfined view is to be created.
      * @return a non-confined memory segment that has the same spatial and temporal bounds as the provided segment.
      */

--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/Foreign.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/Foreign.java
@@ -27,6 +27,7 @@
 package jdk.incubator.foreign;
 
 import jdk.internal.foreign.InternalForeign;
+import jdk.internal.foreign.MemorySegmentImpl;
 
 import java.nio.charset.Charset;
 
@@ -97,6 +98,16 @@ public interface Foreign {
      * @throws IllegalAccessError if the permission jkd.incubator.foreign.restrictedMethods is set to 'deny'
      */
     MemorySegment ofNativeUnchecked(MemoryAddress base, long byteSize) throws IllegalAccessError;
+
+    /**
+     * Returns a non-confined memory segment that has the same spatial and temporal bounds as the provided segment.
+     * Since the returned segment can be effectively accessed by multiple threads in an unconstrained fashion,
+     * this method should be used with care, as it might lead to JVM crashes - e.g. in the case where a thread {@code A}
+     * closes a segment while another thread {@code B} is accessing it.
+     * @param segment the segment from which an unconfined view is to be created.
+     * @return a non-confined memory segment that has the same spatial and temporal bounds as the provided segment.
+     */
+    MemorySegment asUnconfined(MemorySegment segment);
 
     /**
      * Obtain an instance of the system ABI.

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/InternalForeign.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/InternalForeign.java
@@ -68,6 +68,11 @@ public class InternalForeign implements Foreign {
     }
 
     @Override
+    public MemorySegment asUnconfined(MemorySegment segment) {
+        return ((MemorySegmentImpl)segment).asUnconfined();
+    }
+
+    @Override
     public SystemABI getSystemABI() {
         String arch = System.getProperty("os.arch");
         String os = System.getProperty("os.name");

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/MemorySegmentImpl.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/MemorySegmentImpl.java
@@ -240,6 +240,11 @@ public final class MemorySegmentImpl implements MemorySegment, MemorySegmentProx
         return new MemorySegmentImpl(min, base, length, mask, Thread.currentThread(), scope.acquire());
     }
 
+    public MemorySegment asUnconfined() {
+        checkValidState();
+        return new MemorySegmentImpl(min, base, length, mask, null, scope);
+    }
+
     void checkRange(long offset, long length, boolean writeAccess) {
         checkValidState();
         if (writeAccess && !isSet(WRITE)) {


### PR DESCRIPTION
Just move the newly added ForeignUnsafe::asUnconfined to the new Foreign class.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * Athijegannathan Sundararajan ([sundar](@sundararajana) - Committer)
 * Jorn Vernee ([jvernee](@JornVernee) - Committer)

### Download
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/76/head:pull/76`
`$ git checkout pull/76`
