### PR TITLE
JDK-8241998: Revisit Foreign::ofNativeUnchecked

### DIFF
--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/Foreign.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/Foreign.java
@@ -97,34 +97,6 @@ public interface Foreign {
     MemoryAddress withSize(MemoryAddress base, long byteSize);
 
     /**
-     * Returns a new memory address attached to a native memory segment with given base address and size,
-     * obtained by the provided layout. Calling this method is equivalent to the following:
-     *
-     * <blockquote><pre>{@code
-    withSize(base, layout.byteSize());
-     * }</pre></blockquote>
-     *
-     * The segment attached to the returned address has <em>no temporal bounds</em> and cannot be closed; as such,
-     * the returned address is assumed to always be <em>alive</em>. Also, the segment attached to the returned address
-     * has <em>no confinement thread</em>; this means that the returned address can be used by multiple threads.
-     * <p>
-     * This method is <em>restricted</em>. Restricted method are unsafe, and, if used incorrectly, their use might crash
-     * the JVM crash or, worse, silently result in memory corruption. Thus, clients should refrain from depending on
-     * restricted methods, and use safe and supported functionalities, where possible.
-     *
-     * @param base the desired base address
-     * @param layout the desired layout.
-     * @return a new memory address attached to a native memory segment with given base address and size, where
-     * the size is identical to {@code layout.byteSize()}.
-     * @throws IllegalArgumentException if {@code base} does not encapsulate a native memory address,
-     * or if the segment associated with {@code base} is not the <em>primordial</em> segment.
-     * @throws IllegalAccessError if the permission jkd.incubator.foreign.restrictedMethods is set to 'deny'
-     */
-    default MemoryAddress withSize(MemoryAddress base, MemoryLayout layout) {
-        return withSize(base, layout.byteSize());
-    }
-
-    /**
      * Returns a new native memory segment with given base address and size; the returned segment has its own temporal
      * bounds, and can therefore be closed; closing such a segment results in releasing the native memory by calling
      * <em>free</em> on the base address of the returned memory segment. As for other ordinary memory segments,
@@ -142,35 +114,6 @@ public interface Foreign {
      * @throws IllegalAccessError if the permission jkd.incubator.foreign.restrictedMethods is set to 'deny'
      */
     MemorySegment asMallocSegment(MemoryAddress base, long byteSize);
-
-    /**
-     * Returns a new native memory segment with given base address and size, obtained by the provided layout.
-     * Calling this method is equivalent to the following:
-     *
-     * <blockquote><pre>{@code
-    asMallocSegment(base, layout.byteSize());
-     * }</pre></blockquote>
-     *
-     * The returned segment has its own temporal bounds, and can therefore be closed; closing such a segment results
-     * in releasing the native memory by calling <em>free</em> on the base address of the returned memory segment.
-     * As for other ordinary memory segments, the returned segment will also be confined on the current thread
-     * (see {@link Thread#currentThread()}).
-     * <p>
-     * This method is <em>restricted</em>. Restricted method are unsafe, and, if used incorrectly, their use might crash
-     * the JVM crash or, worse, silently result in memory corruption. Thus, clients should refrain from depending on
-     * restricted methods, and use safe and supported functionalities, where possible.
-     *
-     * @param base the desired base address
-     * @param layout the desired layout.
-     * @return a new native memory segment with given base address and size, where the size is identical to
-     * {@code layout.byteSize()}.
-     * @throws IllegalArgumentException if {@code base} does not encapsulate a native memory address,
-     * or if the segment associated with {@code base} is not the <em>primordial</em> segment.
-     * @throws IllegalAccessError if the permission jkd.incubator.foreign.restrictedMethods is set to 'deny'
-     */
-    default MemoryAddress asMallocSegment(MemoryAddress base, MemoryLayout layout) {
-        return withSize(base, layout.byteSize());
-    }
 
     /**
      * Returns a non-confined memory segment that has the same spatial and temporal bounds as the provided segment.

--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/Foreign.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/Foreign.java
@@ -78,33 +78,96 @@ public interface Foreign {
     long asLong(MemoryAddress address) throws IllegalAccessError;
 
     /**
-     * Returns a new native memory segment with given base address and size. The returned segment has its own temporal
-     * bounds, and can therefore be closed; closing such a segment does <em>not</em> result in any resource being
-     * deallocated.
+     * Returns a new memory address attached to a native memory segment with given base address and size. The segment
+     * attached to the returned address has <em>no temporal bounds</em> and cannot be closed; as such,
+     * the returned address is assumed to always be <em>alive</em>. Also, the segment attached to the returned address
+     * has <em>no confinement thread</em>; this means that the returned address can be used by multiple threads.
      * <p>
      * This method is <em>restricted</em>. Restricted method are unsafe, and, if used incorrectly, their use might crash
      * the JVM crash or, worse, silently result in memory corruption. Thus, clients should refrain from depending on
      * restricted methods, and use safe and supported functionalities, where possible.
-     * <p>
-     * This method allows for making an otherwise in-accessible memory region accessible. However, there
-     * is no guarantee that this memory is safe to access, or that the given size for the new segment is not too large,
-     * potentially resulting in out-of-bounds accesses. The developer is trusted to make the judgement that the use of the
-     * returned memory segment is safe.
      *
      * @param base the desired base address
-     * @param byteSize the desired size.
-     * @return a new native memory segment with given base address and size.
-     * @throws IllegalArgumentException if {@code base} does not encapsulate a native memory address.
+     * @param byteSize the desired size (in bytes).
+     * @return a new memory address attached to a native memory segment with given base address and size.
+     * @throws IllegalArgumentException if {@code base} does not encapsulate a native memory address,
+     * or if the segment associated with {@code base} is not the <em>primordial</em> segment.
      * @throws IllegalAccessError if the permission jkd.incubator.foreign.restrictedMethods is set to 'deny'
      */
     MemoryAddress withSize(MemoryAddress base, long byteSize);
 
+    /**
+     * Returns a new memory address attached to a native memory segment with given base address and size,
+     * obtained by the provided layout. Calling this method is equivalent to the following:
+     *
+     * <blockquote><pre>{@code
+    withSize(base, layout.byteSize());
+     * }</pre></blockquote>
+     *
+     * The segment attached to the returned address has <em>no temporal bounds</em> and cannot be closed; as such,
+     * the returned address is assumed to always be <em>alive</em>. Also, the segment attached to the returned address
+     * has <em>no confinement thread</em>; this means that the returned address can be used by multiple threads.
+     * <p>
+     * This method is <em>restricted</em>. Restricted method are unsafe, and, if used incorrectly, their use might crash
+     * the JVM crash or, worse, silently result in memory corruption. Thus, clients should refrain from depending on
+     * restricted methods, and use safe and supported functionalities, where possible.
+     *
+     * @param base the desired base address
+     * @param layout the desired layout.
+     * @return a new memory address attached to a native memory segment with given base address and size, where
+     * the size is identical to {@code layout.byteSize()}.
+     * @throws IllegalArgumentException if {@code base} does not encapsulate a native memory address,
+     * or if the segment associated with {@code base} is not the <em>primordial</em> segment.
+     * @throws IllegalAccessError if the permission jkd.incubator.foreign.restrictedMethods is set to 'deny'
+     */
     default MemoryAddress withSize(MemoryAddress base, MemoryLayout layout) {
         return withSize(base, layout.byteSize());
     }
 
+    /**
+     * Returns a new native memory segment with given base address and size; the returned segment has its own temporal
+     * bounds, and can therefore be closed; closing such a segment results in releasing the native memory by calling
+     * <em>free</em> on the base address of the returned memory segment. As for other ordinary memory segments,
+     * the returned segment will also be confined on the current thread (see {@link Thread#currentThread()}).
+     * <p>
+     * This method is <em>restricted</em>. Restricted method are unsafe, and, if used incorrectly, their use might crash
+     * the JVM crash or, worse, silently result in memory corruption. Thus, clients should refrain from depending on
+     * restricted methods, and use safe and supported functionalities, where possible.
+     *
+     * @param base the desired base address
+     * @param byteSize the desired size.
+     * @return a new native memory segment with given base address and size.
+     * @throws IllegalArgumentException if {@code base} does not encapsulate a native memory address,
+     * or if the segment associated with {@code base} is not the <em>primordial</em> segment.
+     * @throws IllegalAccessError if the permission jkd.incubator.foreign.restrictedMethods is set to 'deny'
+     */
     MemorySegment asMallocSegment(MemoryAddress base, long byteSize);
 
+    /**
+     * Returns a new native memory segment with given base address and size, obtained by the provided layout.
+     * Calling this method is equivalent to the following:
+     *
+     * <blockquote><pre>{@code
+    asMallocSegment(base, layout.byteSize());
+     * }</pre></blockquote>
+     *
+     * The returned segment has its own temporal bounds, and can therefore be closed; closing such a segment results
+     * in releasing the native memory by calling <em>free</em> on the base address of the returned memory segment.
+     * As for other ordinary memory segments, the returned segment will also be confined on the current thread
+     * (see {@link Thread#currentThread()}).
+     * <p>
+     * This method is <em>restricted</em>. Restricted method are unsafe, and, if used incorrectly, their use might crash
+     * the JVM crash or, worse, silently result in memory corruption. Thus, clients should refrain from depending on
+     * restricted methods, and use safe and supported functionalities, where possible.
+     *
+     * @param base the desired base address
+     * @param layout the desired layout.
+     * @return a new native memory segment with given base address and size, where the size is identical to
+     * {@code layout.byteSize()}.
+     * @throws IllegalArgumentException if {@code base} does not encapsulate a native memory address,
+     * or if the segment associated with {@code base} is not the <em>primordial</em> segment.
+     * @throws IllegalAccessError if the permission jkd.incubator.foreign.restrictedMethods is set to 'deny'
+     */
     default MemoryAddress asMallocSegment(MemoryAddress base, MemoryLayout layout) {
         return withSize(base, layout.byteSize());
     }

--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/Foreign.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/Foreign.java
@@ -97,7 +97,17 @@ public interface Foreign {
      * @throws IllegalArgumentException if {@code base} does not encapsulate a native memory address.
      * @throws IllegalAccessError if the permission jkd.incubator.foreign.restrictedMethods is set to 'deny'
      */
-    MemorySegment ofNativeUnchecked(MemoryAddress base, long byteSize) throws IllegalAccessError;
+    MemoryAddress withSize(MemoryAddress base, long byteSize);
+
+    default MemoryAddress withSize(MemoryAddress base, MemoryLayout layout) {
+        return withSize(base, layout.byteSize());
+    }
+
+    MemorySegment asMallocSegment(MemoryAddress base, long byteSize);
+
+    default MemoryAddress asMallocSegment(MemoryAddress base, MemoryLayout layout) {
+        return withSize(base, layout.byteSize());
+    }
 
     /**
      * Returns a non-confined memory segment that has the same spatial and temporal bounds as the provided segment.

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/InternalForeign.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/InternalForeign.java
@@ -63,8 +63,15 @@ public class InternalForeign implements Foreign {
     }
 
     @Override
-    public MemorySegment ofNativeUnchecked(MemoryAddress base, long byteSize) throws IllegalAccessError {
-        return Utils.makeNativeSegmentUnchecked(base, byteSize);
+    public MemoryAddress withSize(MemoryAddress base, long byteSize) throws IllegalAccessError {
+        return Utils.makeNativeSegmentUnchecked(asLong(base), byteSize, null, false)
+                .baseAddress();
+    }
+
+    @Override
+    public MemorySegment asMallocSegment(MemoryAddress base, long byteSize) throws IllegalAccessError {
+        long addr = asLong(base);
+        return Utils.makeNativeSegmentUnchecked(addr, byteSize, Thread.currentThread(), true);
     }
 
     @Override
@@ -141,14 +148,12 @@ public class InternalForeign implements Foreign {
     @Override
     public String toJavaString(MemoryAddress addr) {
         StringBuilder buf = new StringBuilder();
-        try (MemorySegment seg = ofNativeUnchecked(addr, Long.MAX_VALUE)) {
-            MemoryAddress baseAddr = seg.baseAddress();
-            byte curr = (byte) Lazy.byteArrHandle.get(baseAddr, 0);
-            long offset = 0;
-            while (curr != 0) {
-                buf.append((char) curr);
-                curr = (byte) Lazy.byteArrHandle.get(baseAddr, ++offset);
-            }
+        MemoryAddress baseAddr = withSize(addr, Long.MAX_VALUE);
+        byte curr = (byte) Lazy.byteArrHandle.get(baseAddr, 0);
+        long offset = 0;
+        while (curr != 0) {
+            buf.append((char) curr);
+            curr = (byte) Lazy.byteArrHandle.get(baseAddr, ++offset);
         }
         return buf.toString();
     }

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/MemoryAddressImpl.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/MemoryAddressImpl.java
@@ -25,6 +25,7 @@
  */
 package jdk.internal.foreign;
 
+import jdk.incubator.foreign.Foreign;
 import jdk.internal.access.foreign.MemoryAddressProxy;
 import jdk.internal.misc.Unsafe;
 
@@ -40,6 +41,7 @@ import java.util.Objects;
 public final class MemoryAddressImpl implements MemoryAddress, MemoryAddressProxy {
 
     private static final Unsafe UNSAFE = Unsafe.getUnsafe();
+    private static final InternalForeign foreign = InternalForeign.getInstancePrivileged();
 
     private final MemorySegmentImpl segment;
     private final long offset;
@@ -148,6 +150,6 @@ public final class MemoryAddressImpl implements MemoryAddress, MemoryAddressProx
     }
 
     public static MemoryAddress ofLongUnchecked(long value, long byteSize) {
-        return new MemoryAddressImpl((MemorySegmentImpl)Utils.makeNativeSegmentUnchecked(value, byteSize), 0);
+        return foreign.withSize(MemoryAddress.ofLong(value), byteSize);
     }
 }

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/MemorySegmentImpl.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/MemorySegmentImpl.java
@@ -86,7 +86,7 @@ public final class MemorySegmentImpl implements MemorySegment, MemorySegmentProx
     }
 
     @ForceInline
-    private MemorySegmentImpl(long min, Object base, long length, int mask, Thread owner, MemoryScope scope) {
+    MemorySegmentImpl(long min, Object base, long length, int mask, Thread owner, MemoryScope scope) {
         this.length = length;
         this.mask = length > Integer.MAX_VALUE ? mask : (mask | SMALL);
         this.min = min;

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/Utils.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/Utils.java
@@ -117,10 +117,6 @@ public final class Utils {
         return layout.getClass() == PADDING_CLASS;
     }
 
-    public static MemoryAddress resizeNativeAddress(MemoryAddress base, long byteSize) {
-        return new MemoryAddressImpl((MemorySegmentImpl)Utils.makeNativeSegmentUnchecked(base, byteSize), 0);
-    }
-
     public static void checkCarrier(Class<?> carrier) {
         if (carrier == void.class || carrier == boolean.class ||
                 (!carrier.isPrimitive() && !isAddress(carrier))) {
@@ -169,16 +165,13 @@ public final class Utils {
         return segment;
     }
 
-    public static MemorySegment makeNativeSegmentUnchecked(MemoryAddress base, long bytesSize) {
-        if (((MemorySegmentImpl)base.segment()).base != null) {
-            throw new IllegalArgumentException("Not a native address: " + base);
+    public static MemorySegment makeNativeSegmentUnchecked(long min, long bytesSize, Thread owner, boolean allowClose) {
+        MemoryScope scope = new MemoryScope(null, allowClose ? () -> unsafe.freeMemory(min) : null);
+        int mask = MemorySegmentImpl.DEFAULT_MASK;
+        if (!allowClose) {
+            mask &= ~MemorySegment.CLOSE;
         }
-        return makeNativeSegmentUnchecked(((MemoryAddressImpl)base).unsafeGetOffset(), bytesSize);
-    }
-
-    public static MemorySegment makeNativeSegmentUnchecked(long min, long bytesSize) {
-        MemoryScope scope = new MemoryScope(null, null);
-        return new MemorySegmentImpl(min, null, bytesSize, Thread.currentThread(), scope);
+        return new MemorySegmentImpl(min, null, bytesSize, mask, owner, scope);
     }
 
     public static MemorySegment makeArraySegment(byte[] arr) {

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/BindingInterpreter.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/BindingInterpreter.java
@@ -25,6 +25,7 @@ package jdk.internal.foreign.abi;
 import jdk.incubator.foreign.MemoryAddress;
 import jdk.incubator.foreign.MemoryHandles;
 import jdk.incubator.foreign.MemorySegment;
+import jdk.internal.foreign.InternalForeign;
 import jdk.internal.foreign.MemoryAddressImpl;
 import jdk.internal.foreign.Utils;
 
@@ -43,6 +44,8 @@ public class BindingInterpreter {
     private static final VarHandle VH_LONG = MemoryHandles.varHandle(long.class, ByteOrder.nativeOrder());
     private static final VarHandle VH_FLOAT = MemoryHandles.varHandle(float.class, ByteOrder.nativeOrder());
     private static final VarHandle VH_DOUBLE = MemoryHandles.varHandle(double.class, ByteOrder.nativeOrder());
+
+    private static InternalForeign foreign = InternalForeign.getInstancePrivileged();
 
     static void unbox(Object arg, List<Binding> bindings, Function<VMStorage,
             MemoryAddress> ptrFunction, List<? super MemorySegment> buffers) {
@@ -104,7 +107,7 @@ public class BindingInterpreter {
                 case COPY_BUFFER -> {
                     Binding.Copy binding = (Binding.Copy) b;
                     MemoryAddress operand = (MemoryAddress) stack.pop();
-                    operand = Utils.resizeNativeAddress(operand, binding.size());
+                    operand = foreign.withSize(operand, binding.size());
                     MemorySegment copy = MemorySegment.allocateNative(binding.size(), binding.alignment());
                     MemoryAddress.copy(operand, copy.baseAddress(), binding.size());
                     stack.push(copy); // leaked

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/ProgrammableUpcallHandler.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/ProgrammableUpcallHandler.java
@@ -25,6 +25,7 @@ package jdk.internal.foreign.abi;
 
 import jdk.incubator.foreign.MemoryAddress;
 import jdk.incubator.foreign.MemoryHandles;
+import jdk.internal.foreign.InternalForeign;
 import jdk.internal.foreign.MemoryAddressImpl;
 import jdk.internal.foreign.Utils;
 import jdk.internal.vm.annotation.Stable;
@@ -50,6 +51,8 @@ public class ProgrammableUpcallHandler implements UpcallHandler {
         privilegedGetProperty("jdk.internal.foreign.ProgrammableUpcallHandler.DEBUG");
 
     private static final VarHandle VH_LONG = MemoryHandles.varHandle(long.class, ByteOrder.nativeOrder());
+
+    private static InternalForeign foreign = InternalForeign.getInstancePrivileged();
 
     @Stable
     private final MethodHandle mh;
@@ -85,7 +88,7 @@ public class ProgrammableUpcallHandler implements UpcallHandler {
                 layout.dump(abi.arch, buffer, System.err);
             }
 
-            MemoryAddress bufferBase = Utils.resizeNativeAddress(buffer, layout.size);
+            MemoryAddress bufferBase = foreign.withSize(buffer, layout.size);
             MemoryAddress stackArgsBase = MemoryAddressImpl.ofLongUnchecked((long)VH_LONG.get(buffer.rebase(bufferBase.segment()).addOffset(layout.stack_args)));
             Object[] args = new Object[type.parameterCount()];
             for (int i = 0 ; i < type.parameterCount() ; i++) {

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/SharedUtils.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/SharedUtils.java
@@ -27,6 +27,7 @@ package jdk.internal.foreign.abi;
 import jdk.incubator.foreign.FunctionDescriptor;
 import jdk.incubator.foreign.MemoryAddress;
 import jdk.incubator.foreign.MemorySegment;
+import jdk.internal.foreign.InternalForeign;
 import jdk.internal.foreign.Utils;
 
 import jdk.incubator.foreign.GroupLayout;
@@ -50,6 +51,8 @@ public class SharedUtils {
     private static final MethodHandle MH_ALLOC_BUFFER;
     private static final MethodHandle MH_BASEADDRESS;
     private static final MethodHandle MH_BUFFER_COPY;
+
+    private static InternalForeign foreign = InternalForeign.getInstancePrivileged();
 
     static {
         try {
@@ -170,7 +173,7 @@ public class SharedUtils {
     }
 
     private static MemoryAddress bufferCopy(MemoryAddress dest, MemorySegment buffer) {
-        MemoryAddress.copy(buffer.baseAddress(), Utils.resizeNativeAddress(dest, buffer.byteSize()), buffer.byteSize());
+        MemoryAddress.copy(buffer.baseAddress(), foreign.withSize(dest, buffer.byteSize()), buffer.byteSize());
         return dest;
     }
 

--- a/test/jdk/java/foreign/StdLibTest.java
+++ b/test/jdk/java/foreign/StdLibTest.java
@@ -108,21 +108,20 @@ public class StdLibTest extends NativeTestHelper {
 
     @Test(dataProvider = "instants")
     void test_time(Instant instant) throws Throwable {
-        try (StdLibHelper.Tm tm = stdLibHelper.gmtime(instant.getEpochSecond())) {
-            LocalDateTime localTime = LocalDateTime.ofInstant(instant, ZoneOffset.UTC);
-            assertEquals(tm.sec(), localTime.getSecond());
-            assertEquals(tm.min(), localTime.getMinute());
-            assertEquals(tm.hour(), localTime.getHour());
-            //day pf year in Java has 1-offset
-            assertEquals(tm.yday(), localTime.getDayOfYear() - 1);
-            assertEquals(tm.mday(), localTime.getDayOfMonth());
-            //days of week starts from Sunday in C, but on Monday in Java, also account for 1-offset
-            assertEquals((tm.wday() + 6) % 7, localTime.getDayOfWeek().getValue() - 1);
-            //month in Java has 1-offset
-            assertEquals(tm.mon(), localTime.getMonth().getValue() - 1);
-            assertEquals(tm.isdst(), ZoneOffset.UTC.getRules()
-                    .isDaylightSavings(Instant.ofEpochMilli(instant.getEpochSecond() * 1000)));
-        }
+        StdLibHelper.Tm tm = stdLibHelper.gmtime(instant.getEpochSecond());
+        LocalDateTime localTime = LocalDateTime.ofInstant(instant, ZoneOffset.UTC);
+        assertEquals(tm.sec(), localTime.getSecond());
+        assertEquals(tm.min(), localTime.getMinute());
+        assertEquals(tm.hour(), localTime.getHour());
+        //day pf year in Java has 1-offset
+        assertEquals(tm.yday(), localTime.getDayOfYear() - 1);
+        assertEquals(tm.mday(), localTime.getDayOfMonth());
+        //days of week starts from Sunday in C, but on Monday in Java, also account for 1-offset
+        assertEquals((tm.wday() + 6) % 7, localTime.getDayOfWeek().getValue() - 1);
+        //month in Java has 1-offset
+        assertEquals(tm.mon(), localTime.getMonth().getValue() - 1);
+        assertEquals(tm.isdst(), ZoneOffset.UTC.getRules()
+                .isDaylightSavings(Instant.ofEpochMilli(instant.getEpochSecond() * 1000)));
     }
 
     @Test(dataProvider = "ints")
@@ -261,7 +260,7 @@ public class StdLibTest extends NativeTestHelper {
             }
         }
 
-        static class Tm implements AutoCloseable {
+        static class Tm {
 
             //Tm pointer should never be freed directly, as it points to shared memory
             private MemoryAddress base;
@@ -269,7 +268,7 @@ public class StdLibTest extends NativeTestHelper {
             static final long SIZE = 56;
 
             Tm(MemoryAddress base) {
-                this.base = base.rebase(FOREIGN.ofNativeUnchecked(base, SIZE));
+                this.base = FOREIGN.withSize(base, SIZE);
             }
 
             int sec() {
@@ -299,11 +298,6 @@ public class StdLibTest extends NativeTestHelper {
             boolean isdst() {
                 byte b = (byte)byteHandle.get(base.addOffset(32));
                 return b == 0 ? false : true;
-            }
-
-            @Override
-            public void close() throws Exception {
-                base.segment().close();
             }
         }
 


### PR DESCRIPTION
The current Foreign::ofNativeUnchecked can be a bit clunky too use in idiomatic native interop code. So far we have isolated two common use cases:

* attach a size to an otherwise unchecked address
* create a segment from an address that comes from a malloc - in cases where user is responsible for cleanup

The current ofNativeUnchecked is too clunky for the first use case, and not powerful enough for the latter. Rather than exposing a very complex, builder-like factory to create any kind of segment, let's add ad-hoc capabilities to create segments that native interop actually needs. 

This patch replaces Foreign::ofNativeUnchecked with two routines:

* withSize, which takes a MemoryAddress and returns a MemoryAddress (with a sized segment attached)
* asMallocSegment, which takes a MemoryAddress and create a closeable, confined segment of given size; calling close will free the address
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [JDK-8241998](https://bugs.openjdk.java.net/browse/JDK-8241998): Revisit Foreign::ofNativeUnchecked


### Reviewers
 * Athijegannathan Sundararajan ([sundar](@sundararajana) - Committer)

### Download
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/81/head:pull/81`
`$ git checkout pull/81`
