### PR TITLE
8241994: Missing SystemABI.layoutFor mappings for LONG_DOUBLE

### DIFF
--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/aarch64/AArch64ABI.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/aarch64/AArch64ABI.java
@@ -85,6 +85,7 @@ public class AArch64ABI implements SystemABI {
             case UNSIGNED_LONG_LONG -> Optional.of(C_ULONGLONG);
             case FLOAT -> Optional.of(C_FLOAT);
             case DOUBLE -> Optional.of(C_DOUBLE);
+            case LONG_DOUBLE -> Optional.of(C_LONGDOUBLE);
             case POINTER -> Optional.of(C_POINTER);
             default -> Optional.empty();
         };

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/x64/windows/Windowsx64ABI.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/x64/windows/Windowsx64ABI.java
@@ -94,6 +94,7 @@ public class Windowsx64ABI implements SystemABI {
             case UNSIGNED_LONG_LONG -> Optional.of(C_ULONGLONG);
             case FLOAT -> Optional.of(C_FLOAT);
             case DOUBLE -> Optional.of(C_DOUBLE);
+            case LONG_DOUBLE -> Optional.of(C_LONGDOUBLE);
             case POINTER -> Optional.of(C_POINTER);
             default -> Optional.empty();
         };


### PR DESCRIPTION
Hi,

This patch fixes some test failures I'm seeing on Windows when running the jdk_jextract tests. The Failure occurs in [HandleSourceFactory](https://github.com/openjdk/panama-foreign/blob/foreign-jextract/src/jdk.incubator.jextract/share/classes/jdk/incubator/jextract/tool/HandleSourceFactory.java#L215) when trying to get the MemorryLayout for SystemABI.Type.LONG_DOUBLE using SystemABI::layoutFor. It turns out that there is a missing mapping from LONG_DOUBLE to it's layout on Windows, and I noticed the mapping is also missing for AArach64. This patch adds the missing mappings.

Thanks,
Jorn
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [JDK-8241994](https://bugs.openjdk.java.net/browse/JDK-8241994): Missing SystemABI.layoutFor mappings for LONG_DOUBLE


### Reviewers
 * Athijegannathan Sundararajan ([sundar](@sundararajana) - Committer)
 * Maurizio Cimadamore ([mcimadamore](@mcimadamore) - Committer)

### Download
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/82/head:pull/82`
`$ git checkout pull/82`
