### PR TITLE
Add missing libclang dependencies to jib-profiles

### DIFF
--- a/make/conf/jib-profiles.js
+++ b/make/conf/jib-profiles.js
@@ -404,7 +404,7 @@ var getJibProfilesProfiles = function (input, common, data) {
         "linux-x64": {
             target_os: "linux",
             target_cpu: "x64",
-            dependencies: ["devkit", "graphviz", "pandoc", "graalunit_lib"],
+            dependencies: ["devkit", "graphviz", "pandoc", "graalunit_lib", "libclang"],
             configure_args: concat(common.configure_args_64bit,
                 "--enable-full-docs", "--with-zlib=system",
                 (isWsl(input) ? [ "--host=x86_64-unknown-linux-gnu",
@@ -424,7 +424,7 @@ var getJibProfilesProfiles = function (input, common, data) {
         "macosx-x64": {
             target_os: "macosx",
             target_cpu: "x64",
-            dependencies: ["devkit", "pandoc", "graalunit_lib"],
+            dependencies: ["devkit", "pandoc", "graalunit_lib", "libclang"],
             configure_args: concat(common.configure_args_64bit, "--with-zlib=system",
                 "--with-macosx-version-max=10.9.0"),
         },
@@ -448,7 +448,7 @@ var getJibProfilesProfiles = function (input, common, data) {
         "windows-x64": {
             target_os: "windows",
             target_cpu: "x64",
-            dependencies: ["devkit", "pandoc", "graalunit_lib"],
+            dependencies: ["devkit", "pandoc", "graalunit_lib", "libclang"],
             configure_args: concat(common.configure_args_64bit),
         },
 
@@ -1053,6 +1053,13 @@ var getJibProfilesDependencies = function (input, common) {
             organization: common.organization,
             ext: "tar.gz",
             revision: "1.0118+1.0"
+        },
+
+        libclang: {
+            organization: common.organization,
+            module: "libclang-" + input.build_platform,
+            ext: "tar.gz",
+            revision: "9.0.0+1.0"
         },
 
         jtreg: {


### PR DESCRIPTION
Hi,

Our CI is currently failing because the jib-profiles file does not record the libclang dependency.

This patch adds it.

Testing: running a local jib-bases build, verifying that libclang dll is placed in generated jdk image, and that jdk_jextract tests are passing.

Thanks,
Jorn
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * Henry Jen ([henryjen](@slowhog) - Committer)

### Download
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/83/head:pull/83`
`$ git checkout pull/83`
