### PR TITLE
JDK-8242011: Add support for memory address combinator

### DIFF
--- a/make/gensrc/GensrcVarHandles.gmk
+++ b/make/gensrc/GensrcVarHandles.gmk
@@ -160,14 +160,14 @@ endef
 ################################################################################
 
 ################################################################################
-# Setup a rule for generating a VarHandleMemoryAddress java class
+# Setup a rule for generating a memory access var handle helper classes
 # Param 1 - Variable declaration prefix
 # Param 2 - Type with first letter capitalized
-define GenerateVarHandleMemoryAddress
+define GenerateVarHandleMemoryAccess
 
   $1_Type := $2
 
-  $1_FILENAME := $(VARHANDLES_GENSRC_DIR)/VarHandleMemoryAddressAs$$($1_Type)s.java
+  $1_FILENAME := $(VARHANDLES_GENSRC_DIR)/MemoryAccessVarHandle$$($1_Type)Helper.java
 
   ifeq ($$($1_Type), Byte)
     $1_type := byte
@@ -248,7 +248,7 @@ define GenerateVarHandleMemoryAddress
     $1_ARGS += -KfloatingPoint
   endif
 
-  $$($1_FILENAME): $(VARHANDLES_SRC_DIR)/X-VarHandleMemoryAddressView.java.template $(BUILD_TOOLS_JDK)
+  $$($1_FILENAME): $(VARHANDLES_SRC_DIR)/X-VarHandleMemoryAccess.java.template $(BUILD_TOOLS_JDK)
 	$$(call MakeDir, $$(@D))
 	$(RM) $$@
 	$(TOOL_SPP) -nel -K$$($1_type) \
@@ -274,7 +274,7 @@ $(foreach t, $(VARHANDLES_BYTE_ARRAY_TYPES), \
 # List the types to generate source for, with capitalized first letter
 VARHANDLES_MEMORY_ADDRESS_TYPES := Byte Short Char Int Long Float Double
 $(foreach t, $(VARHANDLES_MEMORY_ADDRESS_TYPES), \
-  $(eval $(call GenerateVarHandleMemoryAddress,VAR_HANDLE_MEMORY_ADDRESS_$t,$t)))
+  $(eval $(call GenerateVarHandleMemoryAccess,VAR_HANDLE_MEMORY_ADDRESS_$t,$t)))
 
 GENSRC_JAVA_BASE += $(GENSRC_VARHANDLES)
 

--- a/src/java.base/share/classes/java/lang/invoke/IndirectVarHandle.java
+++ b/src/java.base/share/classes/java/lang/invoke/IndirectVarHandle.java
@@ -86,6 +86,10 @@ import java.util.function.BiFunction;
         return directTarget;
     }
 
+    VarHandle target() {
+        return target;
+    }
+
     @Override
     @ForceInline
     MethodHandle getMethodHandle(int mode) {

--- a/src/java.base/share/classes/java/lang/invoke/MemoryAccessVarHandleBase.java
+++ b/src/java.base/share/classes/java/lang/invoke/MemoryAccessVarHandleBase.java
@@ -28,7 +28,7 @@ package java.lang.invoke;
 /**
  * Base class for memory access var handle implementations.
  */
-abstract class VarHandleMemoryAddressBase extends VarHandle {
+abstract class MemoryAccessVarHandleBase extends VarHandle {
 
     /** endianness **/
     final boolean be;
@@ -42,7 +42,7 @@ abstract class VarHandleMemoryAddressBase extends VarHandle {
     /** alignment constraint (in bytes, expressed as a bit mask) **/
     final long alignmentMask;
 
-    VarHandleMemoryAddressBase(VarForm form, boolean be, long length, long offset, long alignmentMask) {
+    MemoryAccessVarHandleBase(VarForm form, boolean be, long length, long offset, long alignmentMask) {
         super(form);
         this.be = be;
         this.length = length;

--- a/src/java.base/share/classes/java/lang/invoke/MemoryAccessVarHandleGenerator.java
+++ b/src/java.base/share/classes/java/lang/invoke/MemoryAccessVarHandleGenerator.java
@@ -71,13 +71,13 @@ import static jdk.internal.org.objectweb.asm.Opcodes.DUP;
 import static jdk.internal.org.objectweb.asm.Opcodes.SIPUSH;
 import static jdk.internal.org.objectweb.asm.Opcodes.T_LONG;
 
-class AddressVarHandleGenerator {
+class MemoryAccessVarHandleGenerator {
     private static final String DEBUG_DUMP_CLASSES_DIR_PROPERTY = "jdk.internal.foreign.ClassGenerator.DEBUG_DUMP_CLASSES_DIR";
 
     private static final boolean DEBUG =
         GetBooleanAction.privilegedGetProperty("jdk.internal.foreign.ClassGenerator.DEBUG");
 
-    private static final Class<?> BASE_CLASS = VarHandleMemoryAddressBase.class;
+    private static final Class<?> BASE_CLASS = MemoryAccessVarHandleBase.class;
 
     private static final HashMap<Class<?>, Class<?>> helperClassCache;
 
@@ -88,13 +88,13 @@ class AddressVarHandleGenerator {
 
     static {
         helperClassCache = new HashMap<>();
-        helperClassCache.put(byte.class, VarHandleMemoryAddressAsBytes.class);
-        helperClassCache.put(short.class, VarHandleMemoryAddressAsShorts.class);
-        helperClassCache.put(char.class, VarHandleMemoryAddressAsChars.class);
-        helperClassCache.put(int.class, VarHandleMemoryAddressAsInts.class);
-        helperClassCache.put(long.class, VarHandleMemoryAddressAsLongs.class);
-        helperClassCache.put(float.class, VarHandleMemoryAddressAsFloats.class);
-        helperClassCache.put(double.class, VarHandleMemoryAddressAsDoubles.class);
+        helperClassCache.put(byte.class, MemoryAccessVarHandleByteHelper.class);
+        helperClassCache.put(short.class, MemoryAccessVarHandleShortHelper.class);
+        helperClassCache.put(char.class, MemoryAccessVarHandleCharHelper.class);
+        helperClassCache.put(int.class, MemoryAccessVarHandleIntHelper.class);
+        helperClassCache.put(long.class, MemoryAccessVarHandleLongHelper.class);
+        helperClassCache.put(float.class, MemoryAccessVarHandleFloatHelper.class);
+        helperClassCache.put(double.class, MemoryAccessVarHandleDoubleHelper.class);
 
         OFFSET_OP_TYPE = MethodType.methodType(long.class, long.class, long.class, MemoryAddressProxy.class);
 
@@ -125,7 +125,7 @@ class AddressVarHandleGenerator {
     private final Class<?> helperClass;
     private final VarForm form;
 
-    AddressVarHandleGenerator(Class<?> carrier, int dims) {
+    MemoryAccessVarHandleGenerator(Class<?> carrier, int dims) {
         this.dimensions = dims;
         this.carrier = carrier;
         Class<?>[] components = new Class<?>[dimensions];

--- a/src/java.base/share/classes/java/lang/invoke/MethodHandleImpl.java
+++ b/src/java.base/share/classes/java/lang/invoke/MethodHandleImpl.java
@@ -1792,42 +1792,59 @@ abstract class MethodHandleImpl {
             }
 
             @Override
-            public VarHandle memoryAddressViewVarHandle(Class<?> carrier, long alignmentMask,
-                                                        ByteOrder order, long offset, long[] strides) {
+            public VarHandle memoryAccessVarHandle(Class<?> carrier, long alignmentMask,
+                                                   ByteOrder order, long offset, long[] strides) {
                 return VarHandles.makeMemoryAddressViewHandle(carrier, alignmentMask, order, offset, strides);
             }
 
             @Override
             public Class<?> memoryAddressCarrier(VarHandle handle) {
-                return checkMemAccessHandle(handle).carrier();
+                return checkMemoryAccessHandle(handle).carrier();
             }
 
             @Override
             public long memoryAddressAlignmentMask(VarHandle handle) {
-                return checkMemAccessHandle(handle).alignmentMask;
+                return checkMemoryAccessHandle(handle).alignmentMask;
             }
 
             @Override
             public ByteOrder memoryAddressByteOrder(VarHandle handle) {
-                return checkMemAccessHandle(handle).be ?
+                return checkMemoryAccessHandle(handle).be ?
                         ByteOrder.BIG_ENDIAN : ByteOrder.LITTLE_ENDIAN;
             }
 
             @Override
             public long memoryAddressOffset(VarHandle handle) {
-                return checkMemAccessHandle(handle).offset;
+                return checkMemoryAccessHandle(handle).offset;
             }
 
             @Override
             public long[] memoryAddressStrides(VarHandle handle) {
-                return checkMemAccessHandle(handle).strides();
+                return checkMemoryAccessHandle(handle).strides();
             }
 
-            private VarHandleMemoryAddressBase checkMemAccessHandle(VarHandle handle) {
-                if (!(handle.asDirect() instanceof VarHandleMemoryAddressBase)) {
+            @Override
+            public boolean isMemoryAccessVarHandle(VarHandle handle) {
+                return asMemoryAccessVarHandle(handle) != null;
+            }
+
+            private MemoryAccessVarHandleBase asMemoryAccessVarHandle(VarHandle handle) {
+                if (handle instanceof MemoryAccessVarHandleBase) {
+                    return (MemoryAccessVarHandleBase)handle;
+                } else if (handle.target() instanceof MemoryAccessVarHandleBase) {
+                    // skip first adaptation, since we have to step over MemoryAddressProxy
+                    return (MemoryAccessVarHandleBase)handle.target();
+                } else {
+                    return null;
+                }
+            }
+
+            private MemoryAccessVarHandleBase checkMemoryAccessHandle(VarHandle handle) {
+                MemoryAccessVarHandleBase base = asMemoryAccessVarHandle(handle);
+                if (base == null) {
                     throw new IllegalArgumentException("Not a memory access varhandle: " + handle);
                 }
-                return (VarHandleMemoryAddressBase) handle.asDirect();
+                return base;
             }
         });
     }

--- a/src/java.base/share/classes/java/lang/invoke/MethodHandleImpl.java
+++ b/src/java.base/share/classes/java/lang/invoke/MethodHandleImpl.java
@@ -1833,6 +1833,7 @@ abstract class MethodHandleImpl {
                     return (MemoryAccessVarHandleBase)handle;
                 } else if (handle.target() instanceof MemoryAccessVarHandleBase) {
                     // skip first adaptation, since we have to step over MemoryAddressProxy
+                    // see JDK-8237349
                     return (MemoryAccessVarHandleBase)handle.target();
                 } else {
                     return null;

--- a/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
+++ b/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
@@ -5256,9 +5256,8 @@ System.out.println((int) f0.invokeExact("x", "y")); // 2
         }
 
         List<Class<?>> newCoordinates = new ArrayList<>(targetCoordinates);
-        for (Class<?> arg : filter.type().parameterList()) {
-            newCoordinates.add(pos, arg);
-        }
+        newCoordinates.remove(pos);
+        newCoordinates.addAll(pos, filter.type().parameterList());
 
         return new IndirectVarHandle(target, target.varType(), newCoordinates.toArray(new Class<?>[0]),
                 (mode, modeHandle) -> MethodHandles.collectArguments(modeHandle, 1 + pos, filter));

--- a/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
+++ b/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
@@ -5041,7 +5041,6 @@ System.out.println((int) f0.invokeExact("x", "y")); // 2
     public static VarHandle filterCoordinates(VarHandle target, int pos, MethodHandle... filters) {
         Objects.nonNull(target);
         Objects.nonNull(filters);
-        if (filters.length == 0) return target;
 
         List<Class<?>> targetCoordinates = target.coordinateTypes();
         if (pos < 0 || pos >= targetCoordinates.size()) {
@@ -5049,6 +5048,8 @@ System.out.println((int) f0.invokeExact("x", "y")); // 2
         } else if (pos + filters.length > targetCoordinates.size()) {
             throw new IllegalArgumentException("Too many filters");
         }
+
+        if (filters.length == 0) return target;
 
         List<Class<?>> newCoordinates = new ArrayList<>(targetCoordinates);
         for (int i = 0 ; i < filters.length ; i++) {
@@ -5095,7 +5096,6 @@ System.out.println((int) f0.invokeExact("x", "y")); // 2
     public static VarHandle insertCoordinates(VarHandle target, int pos, Object... values) {
         Objects.nonNull(target);
         Objects.nonNull(values);
-        if (values.length == 0) return target;
 
         List<Class<?>> targetCoordinates = target.coordinateTypes();
         if (pos < 0 || pos >= targetCoordinates.size()) {
@@ -5103,6 +5103,8 @@ System.out.println((int) f0.invokeExact("x", "y")); // 2
         } else if (pos + values.length > targetCoordinates.size()) {
             throw new IllegalArgumentException("Too many values");
         }
+
+        if (values.length == 0) return target;
 
         List<Class<?>> newCoordinates = new ArrayList<>(targetCoordinates);
         for (int i = 0 ; i < values.length ; i++) {
@@ -5261,6 +5263,44 @@ System.out.println((int) f0.invokeExact("x", "y")); // 2
 
         return new IndirectVarHandle(target, target.varType(), newCoordinates.toArray(new Class<?>[0]),
                 (mode, modeHandle) -> MethodHandles.collectArguments(modeHandle, 1 + pos, filter));
+    }
+
+    /**
+     * Returns a var handle which will discard some dummy coordinates before delegating to the
+     * target var handle. As a consequence, the resulting var handle will feature more
+     * coordinate types than the target var handle.
+     * <p>
+     * The {@code pos} argument may range between zero and <i>N</i>, where <i>N</i> is the arity of the
+     * target var handle's coordinate types. If {@code pos} is zero, the dummy coordinates will precede
+     * the target's real arguments; if {@code pos} is <i>N</i> they will come after.
+     * <p>
+     * The resulting var handle will feature the same access modes (see {@link java.lang.invoke.VarHandle.AccessMode} and
+     * atomic access guarantees as those featured by the target var handle.
+     *
+     * @param target the var handle to invoke after the dummy coordinates are dropped
+     * @param pos position of first coordinate to drop (zero for the leftmost)
+     * @param valueTypes the type(s) of the coordinate(s) to drop
+     * @return an adapter var handle which drops some dummy coordinates,
+     *         before calling the target var handle
+     * @throws NullPointerException if either {@code target}, {@code valueTypes} are {@code == null}.
+     * @throws IllegalArgumentException if {@code pos} is not between 0 and the target var handle coordinate arity, inclusive.
+     */
+    public static VarHandle dropCoordinates(VarHandle target, int pos, Class<?>... valueTypes) {
+        Objects.nonNull(target);
+        Objects.nonNull(valueTypes);
+
+        List<Class<?>> targetCoordinates = target.coordinateTypes();
+        if (pos < 0 || pos > targetCoordinates.size()) {
+            throw newIllegalArgumentException("Invalid position " + pos + " for coordinate types", targetCoordinates);
+        }
+
+        if (valueTypes.length == 0) return target;
+
+        List<Class<?>> newCoordinates = new ArrayList<>(targetCoordinates);
+        newCoordinates.addAll(pos, List.of(valueTypes));
+
+        return new IndirectVarHandle(target, target.varType(), newCoordinates.toArray(new Class<?>[0]),
+                (mode, modeHandle) -> MethodHandles.dropArguments(modeHandle, 1 + pos, valueTypes));
     }
 
     private static void noCheckedExceptions(MethodHandle handle) {

--- a/src/java.base/share/classes/java/lang/invoke/VarHandle.java
+++ b/src/java.base/share/classes/java/lang/invoke/VarHandle.java
@@ -463,6 +463,8 @@ public abstract class VarHandle implements Constable {
         return this;
     }
 
+    VarHandle target() { return null; }
+
     // Plain accessors
 
     /**

--- a/src/java.base/share/classes/java/lang/invoke/VarHandles.java
+++ b/src/java.base/share/classes/java/lang/invoke/VarHandles.java
@@ -320,7 +320,7 @@ final class VarHandles {
 
         Map<Integer, MethodHandle> carrierFactory = ADDRESS_FACTORIES.get(carrier);
         MethodHandle fac = carrierFactory.computeIfAbsent(strides.length,
-                dims -> new AddressVarHandleGenerator(carrier, dims)
+                dims -> new MemoryAccessVarHandleGenerator(carrier, dims)
                             .generateHandleFactory());
 
         try {

--- a/src/java.base/share/classes/java/lang/invoke/X-VarHandleMemoryAccess.java.template
+++ b/src/java.base/share/classes/java/lang/invoke/X-VarHandleMemoryAccess.java.template
@@ -33,7 +33,7 @@ import static java.lang.invoke.MethodHandleStatics.UNSAFE;
 
 #warn
 
-final class VarHandleMemoryAddressAs$Type$s {
+final class MemoryAccessVarHandle$Type$Helper {
 
     static final boolean BE = UNSAFE.isBigEndian();
 
@@ -76,7 +76,7 @@ final class VarHandleMemoryAddressAs$Type$s {
     static long offset(MemoryAddressProxy bb, long offset, long alignmentMask) {
         long address = offsetNoVMAlignCheck(bb, offset, alignmentMask);
         if ((address & VM_ALIGN) != 0) {
-            throw VarHandleMemoryAddressBase.newIllegalStateExceptionForMisalignedAccess(address);
+            throw MemoryAccessVarHandleBase.newIllegalStateExceptionForMisalignedAccess(address);
         }
         return address;
     }
@@ -87,14 +87,14 @@ final class VarHandleMemoryAddressAs$Type$s {
         long address = base + offset;
         //note: the offset portion has already been aligned-checked, by construction
         if ((base & alignmentMask) != 0) {
-            throw VarHandleMemoryAddressBase.newIllegalStateExceptionForMisalignedAccess(address);
+            throw MemoryAccessVarHandleBase.newIllegalStateExceptionForMisalignedAccess(address);
         }
         return address;
     }
     
     @ForceInline
     static $type$ get0(VarHandle ob, Object obb, long base) {
-        VarHandleMemoryAddressBase handle = (VarHandleMemoryAddressBase)ob;
+        MemoryAccessVarHandleBase handle = (MemoryAccessVarHandleBase)ob;
         MemoryAddressProxy bb = checkAddress(obb, base, handle.length, true);
 #if[floatingPoint]
         $rawType$ rawValue = UNSAFE.get$RawType$Unaligned(
@@ -118,7 +118,7 @@ final class VarHandleMemoryAddressAs$Type$s {
 
     @ForceInline
     static void set0(VarHandle ob, Object obb, long base, $type$ value) {
-        VarHandleMemoryAddressBase handle = (VarHandleMemoryAddressBase)ob;
+        MemoryAccessVarHandleBase handle = (MemoryAccessVarHandleBase)ob;
         MemoryAddressProxy bb = checkAddress(obb, base, handle.length, false);
 #if[floatingPoint]
         UNSAFE.put$RawType$Unaligned(
@@ -144,7 +144,7 @@ final class VarHandleMemoryAddressAs$Type$s {
 
     @ForceInline
     static $type$ getVolatile0(VarHandle ob, Object obb, long base) {
-        VarHandleMemoryAddressBase handle = (VarHandleMemoryAddressBase)ob;
+        MemoryAccessVarHandleBase handle = (MemoryAccessVarHandleBase)ob;
         MemoryAddressProxy bb = checkAddress(obb, base, handle.length, true);
         return convEndian(handle.be,
                           UNSAFE.get$RawType$Volatile(
@@ -154,7 +154,7 @@ final class VarHandleMemoryAddressAs$Type$s {
 
     @ForceInline
     static void setVolatile0(VarHandle ob, Object obb, long base, $type$ value) {
-        VarHandleMemoryAddressBase handle = (VarHandleMemoryAddressBase)ob;
+        MemoryAccessVarHandleBase handle = (MemoryAccessVarHandleBase)ob;
         MemoryAddressProxy bb = checkAddress(obb, base, handle.length, false);
         UNSAFE.put$RawType$Volatile(
                 bb.unsafeGetBase(),
@@ -164,7 +164,7 @@ final class VarHandleMemoryAddressAs$Type$s {
 
     @ForceInline
     static $type$ getAcquire0(VarHandle ob, Object obb, long base) {
-        VarHandleMemoryAddressBase handle = (VarHandleMemoryAddressBase)ob;
+        MemoryAccessVarHandleBase handle = (MemoryAccessVarHandleBase)ob;
         MemoryAddressProxy bb = checkAddress(obb, base, handle.length, true);
         return convEndian(handle.be,
                           UNSAFE.get$RawType$Acquire(
@@ -174,7 +174,7 @@ final class VarHandleMemoryAddressAs$Type$s {
 
     @ForceInline
     static void setRelease0(VarHandle ob, Object obb, long base, $type$ value) {
-        VarHandleMemoryAddressBase handle = (VarHandleMemoryAddressBase)ob;
+        MemoryAccessVarHandleBase handle = (MemoryAccessVarHandleBase)ob;
         MemoryAddressProxy bb = checkAddress(obb, base, handle.length, false);
         UNSAFE.put$RawType$Release(
                 bb.unsafeGetBase(),
@@ -184,7 +184,7 @@ final class VarHandleMemoryAddressAs$Type$s {
 
     @ForceInline
     static $type$ getOpaque0(VarHandle ob, Object obb, long base) {
-        VarHandleMemoryAddressBase handle = (VarHandleMemoryAddressBase)ob;
+        MemoryAccessVarHandleBase handle = (MemoryAccessVarHandleBase)ob;
         MemoryAddressProxy bb = checkAddress(obb, base, handle.length, true);
         return convEndian(handle.be,
                           UNSAFE.get$RawType$Opaque(
@@ -194,7 +194,7 @@ final class VarHandleMemoryAddressAs$Type$s {
 
     @ForceInline
     static void setOpaque0(VarHandle ob, Object obb, long base, $type$ value) {
-        VarHandleMemoryAddressBase handle = (VarHandleMemoryAddressBase)ob;
+        MemoryAccessVarHandleBase handle = (MemoryAccessVarHandleBase)ob;
         MemoryAddressProxy bb = checkAddress(obb, base, handle.length, false);
         UNSAFE.put$RawType$Opaque(
                 bb.unsafeGetBase(),
@@ -205,7 +205,7 @@ final class VarHandleMemoryAddressAs$Type$s {
 
     @ForceInline
     static boolean compareAndSet0(VarHandle ob, Object obb, long base, $type$ expected, $type$ value) {
-        VarHandleMemoryAddressBase handle = (VarHandleMemoryAddressBase)ob;
+        MemoryAccessVarHandleBase handle = (MemoryAccessVarHandleBase)ob;
         MemoryAddressProxy bb = checkAddress(obb, base, handle.length, false);
         return UNSAFE.compareAndSet$RawType$(
                 bb.unsafeGetBase(),
@@ -215,7 +215,7 @@ final class VarHandleMemoryAddressAs$Type$s {
 
     @ForceInline
     static $type$ compareAndExchange0(VarHandle ob, Object obb, long base, $type$ expected, $type$ value) {
-        VarHandleMemoryAddressBase handle = (VarHandleMemoryAddressBase)ob;
+        MemoryAccessVarHandleBase handle = (MemoryAccessVarHandleBase)ob;
         MemoryAddressProxy bb = checkAddress(obb, base, handle.length, false);
         return convEndian(handle.be,
                           UNSAFE.compareAndExchange$RawType$(
@@ -226,7 +226,7 @@ final class VarHandleMemoryAddressAs$Type$s {
 
     @ForceInline
     static $type$ compareAndExchangeAcquire0(VarHandle ob, Object obb, long base, $type$ expected, $type$ value) {
-        VarHandleMemoryAddressBase handle = (VarHandleMemoryAddressBase)ob;
+        MemoryAccessVarHandleBase handle = (MemoryAccessVarHandleBase)ob;
         MemoryAddressProxy bb = checkAddress(obb, base, handle.length, false);
         return convEndian(handle.be,
                           UNSAFE.compareAndExchange$RawType$Acquire(
@@ -237,7 +237,7 @@ final class VarHandleMemoryAddressAs$Type$s {
 
     @ForceInline
     static $type$ compareAndExchangeRelease0(VarHandle ob, Object obb, long base, $type$ expected, $type$ value) {
-        VarHandleMemoryAddressBase handle = (VarHandleMemoryAddressBase)ob;
+        MemoryAccessVarHandleBase handle = (MemoryAccessVarHandleBase)ob;
         MemoryAddressProxy bb = checkAddress(obb, base, handle.length, false);
         return convEndian(handle.be,
                           UNSAFE.compareAndExchange$RawType$Release(
@@ -248,7 +248,7 @@ final class VarHandleMemoryAddressAs$Type$s {
 
     @ForceInline
     static boolean weakCompareAndSetPlain0(VarHandle ob, Object obb, long base, $type$ expected, $type$ value) {
-        VarHandleMemoryAddressBase handle = (VarHandleMemoryAddressBase)ob;
+        MemoryAccessVarHandleBase handle = (MemoryAccessVarHandleBase)ob;
         MemoryAddressProxy bb = checkAddress(obb, base, handle.length, false);
         return UNSAFE.weakCompareAndSet$RawType$Plain(
                 bb.unsafeGetBase(),
@@ -258,7 +258,7 @@ final class VarHandleMemoryAddressAs$Type$s {
 
     @ForceInline
     static boolean weakCompareAndSet0(VarHandle ob, Object obb, long base, $type$ expected, $type$ value) {
-        VarHandleMemoryAddressBase handle = (VarHandleMemoryAddressBase)ob;
+        MemoryAccessVarHandleBase handle = (MemoryAccessVarHandleBase)ob;
         MemoryAddressProxy bb = checkAddress(obb, base, handle.length, false);
         return UNSAFE.weakCompareAndSet$RawType$(
                 bb.unsafeGetBase(),
@@ -268,7 +268,7 @@ final class VarHandleMemoryAddressAs$Type$s {
 
     @ForceInline
     static boolean weakCompareAndSetAcquire0(VarHandle ob, Object obb, long base, $type$ expected, $type$ value) {
-        VarHandleMemoryAddressBase handle = (VarHandleMemoryAddressBase)ob;
+        MemoryAccessVarHandleBase handle = (MemoryAccessVarHandleBase)ob;
         MemoryAddressProxy bb = checkAddress(obb, base, handle.length, false);
         return UNSAFE.weakCompareAndSet$RawType$Acquire(
                 bb.unsafeGetBase(),
@@ -278,7 +278,7 @@ final class VarHandleMemoryAddressAs$Type$s {
 
     @ForceInline
     static boolean weakCompareAndSetRelease0(VarHandle ob, Object obb, long base, $type$ expected, $type$ value) {
-        VarHandleMemoryAddressBase handle = (VarHandleMemoryAddressBase)ob;
+        MemoryAccessVarHandleBase handle = (MemoryAccessVarHandleBase)ob;
         MemoryAddressProxy bb = checkAddress(obb, base, handle.length, false);
         return UNSAFE.weakCompareAndSet$RawType$Release(
                 bb.unsafeGetBase(),
@@ -288,7 +288,7 @@ final class VarHandleMemoryAddressAs$Type$s {
 
     @ForceInline
     static $type$ getAndSet0(VarHandle ob, Object obb, long base, $type$ value) {
-        VarHandleMemoryAddressBase handle = (VarHandleMemoryAddressBase)ob;
+        MemoryAccessVarHandleBase handle = (MemoryAccessVarHandleBase)ob;
         MemoryAddressProxy bb = checkAddress(obb, base, handle.length, false);
         return convEndian(handle.be,
                           UNSAFE.getAndSet$RawType$(
@@ -299,7 +299,7 @@ final class VarHandleMemoryAddressAs$Type$s {
 
     @ForceInline
     static $type$ getAndSetAcquire0(VarHandle ob, Object obb, long base, $type$ value) {
-        VarHandleMemoryAddressBase handle = (VarHandleMemoryAddressBase)ob;
+        MemoryAccessVarHandleBase handle = (MemoryAccessVarHandleBase)ob;
         MemoryAddressProxy bb = checkAddress(obb, base, handle.length, false);
         return convEndian(handle.be,
                           UNSAFE.getAndSet$RawType$Acquire(
@@ -310,7 +310,7 @@ final class VarHandleMemoryAddressAs$Type$s {
 
     @ForceInline
     static $type$ getAndSetRelease0(VarHandle ob, Object obb, long base, $type$ value) {
-        VarHandleMemoryAddressBase handle = (VarHandleMemoryAddressBase)ob;
+        MemoryAccessVarHandleBase handle = (MemoryAccessVarHandleBase)ob;
         MemoryAddressProxy bb = checkAddress(obb, base, handle.length, false);
         return convEndian(handle.be,
                           UNSAFE.getAndSet$RawType$Release(
@@ -323,7 +323,7 @@ final class VarHandleMemoryAddressAs$Type$s {
 
     @ForceInline
     static $type$ getAndAdd0(VarHandle ob, Object obb, long base, $type$ delta) {
-        VarHandleMemoryAddressBase handle = (VarHandleMemoryAddressBase)ob;
+        MemoryAccessVarHandleBase handle = (MemoryAccessVarHandleBase)ob;
         MemoryAddressProxy bb = checkAddress(obb, base, handle.length, false);
         if (handle.be == BE) {
             return UNSAFE.getAndAdd$RawType$(
@@ -337,7 +337,7 @@ final class VarHandleMemoryAddressAs$Type$s {
 
     @ForceInline
     static $type$ getAndAddAcquire0(VarHandle ob, Object obb, long base, $type$ delta) {
-        VarHandleMemoryAddressBase handle = (VarHandleMemoryAddressBase)ob;
+        MemoryAccessVarHandleBase handle = (MemoryAccessVarHandleBase)ob;
         MemoryAddressProxy bb = checkAddress(obb, base, handle.length, false);
         if (handle.be == BE) {
             return UNSAFE.getAndAdd$RawType$Acquire(
@@ -351,7 +351,7 @@ final class VarHandleMemoryAddressAs$Type$s {
 
     @ForceInline
     static $type$ getAndAddRelease0(VarHandle ob, Object obb, long base, $type$ delta) {
-        VarHandleMemoryAddressBase handle = (VarHandleMemoryAddressBase)ob;
+        MemoryAccessVarHandleBase handle = (MemoryAccessVarHandleBase)ob;
         MemoryAddressProxy bb = checkAddress(obb, base, handle.length, false);
         if (handle.be == BE) {
             return UNSAFE.getAndAdd$RawType$Release(
@@ -379,7 +379,7 @@ final class VarHandleMemoryAddressAs$Type$s {
 
     @ForceInline
     static $type$ getAndBitwiseOr0(VarHandle ob, Object obb, long base, $type$ value) {
-        VarHandleMemoryAddressBase handle = (VarHandleMemoryAddressBase)ob;
+        MemoryAccessVarHandleBase handle = (MemoryAccessVarHandleBase)ob;
         MemoryAddressProxy bb = checkAddress(obb, base, handle.length, false);
         if (handle.be == BE) {
             return UNSAFE.getAndBitwiseOr$RawType$(
@@ -393,7 +393,7 @@ final class VarHandleMemoryAddressAs$Type$s {
 
     @ForceInline
     static $type$ getAndBitwiseOrRelease0(VarHandle ob, Object obb, long base, $type$ value) {
-        VarHandleMemoryAddressBase handle = (VarHandleMemoryAddressBase)ob;
+        MemoryAccessVarHandleBase handle = (MemoryAccessVarHandleBase)ob;
         MemoryAddressProxy bb = checkAddress(obb, base, handle.length, false);
         if (handle.be == BE) {
             return UNSAFE.getAndBitwiseOr$RawType$Release(
@@ -407,7 +407,7 @@ final class VarHandleMemoryAddressAs$Type$s {
 
     @ForceInline
     static $type$ getAndBitwiseOrAcquire0(VarHandle ob, Object obb, long base, $type$ value) {
-        VarHandleMemoryAddressBase handle = (VarHandleMemoryAddressBase)ob;
+        MemoryAccessVarHandleBase handle = (MemoryAccessVarHandleBase)ob;
         MemoryAddressProxy bb = checkAddress(obb, base, handle.length, false);
         if (handle.be == BE) {
             return UNSAFE.getAndBitwiseOr$RawType$Acquire(
@@ -433,7 +433,7 @@ final class VarHandleMemoryAddressAs$Type$s {
 
     @ForceInline
     static $type$ getAndBitwiseAnd0(VarHandle ob, Object obb, long base, $type$ value) {
-        VarHandleMemoryAddressBase handle = (VarHandleMemoryAddressBase)ob;
+        MemoryAccessVarHandleBase handle = (MemoryAccessVarHandleBase)ob;
         MemoryAddressProxy bb = checkAddress(obb, base, handle.length, false);
         if (handle.be == BE) {
             return UNSAFE.getAndBitwiseAnd$RawType$(
@@ -447,7 +447,7 @@ final class VarHandleMemoryAddressAs$Type$s {
 
     @ForceInline
     static $type$ getAndBitwiseAndRelease0(VarHandle ob, Object obb, long base, $type$ value) {
-        VarHandleMemoryAddressBase handle = (VarHandleMemoryAddressBase)ob;
+        MemoryAccessVarHandleBase handle = (MemoryAccessVarHandleBase)ob;
         MemoryAddressProxy bb = checkAddress(obb, base, handle.length, false);
         if (handle.be == BE) {
             return UNSAFE.getAndBitwiseAnd$RawType$Release(
@@ -461,7 +461,7 @@ final class VarHandleMemoryAddressAs$Type$s {
 
     @ForceInline
     static $type$ getAndBitwiseAndAcquire0(VarHandle ob, Object obb, long base, $type$ value) {
-        VarHandleMemoryAddressBase handle = (VarHandleMemoryAddressBase)ob;
+        MemoryAccessVarHandleBase handle = (MemoryAccessVarHandleBase)ob;
         MemoryAddressProxy bb = checkAddress(obb, base, handle.length, false);
         if (handle.be == BE) {
             return UNSAFE.getAndBitwiseAnd$RawType$Acquire(
@@ -488,7 +488,7 @@ final class VarHandleMemoryAddressAs$Type$s {
 
     @ForceInline
     static $type$ getAndBitwiseXor0(VarHandle ob, Object obb, long base, $type$ value) {
-        VarHandleMemoryAddressBase handle = (VarHandleMemoryAddressBase)ob;
+        MemoryAccessVarHandleBase handle = (MemoryAccessVarHandleBase)ob;
         MemoryAddressProxy bb = checkAddress(obb, base, handle.length, false);
         if (handle.be == BE) {
             return UNSAFE.getAndBitwiseXor$RawType$(
@@ -502,7 +502,7 @@ final class VarHandleMemoryAddressAs$Type$s {
 
     @ForceInline
     static $type$ getAndBitwiseXorRelease0(VarHandle ob, Object obb, long base, $type$ value) {
-        VarHandleMemoryAddressBase handle = (VarHandleMemoryAddressBase)ob;
+        MemoryAccessVarHandleBase handle = (MemoryAccessVarHandleBase)ob;
         MemoryAddressProxy bb = checkAddress(obb, base, handle.length, false);
         if (handle.be == BE) {
             return UNSAFE.getAndBitwiseXor$RawType$Release(
@@ -516,7 +516,7 @@ final class VarHandleMemoryAddressAs$Type$s {
 
     @ForceInline
     static $type$ getAndBitwiseXorAcquire0(VarHandle ob, Object obb, long base, $type$ value) {
-        VarHandleMemoryAddressBase handle = (VarHandleMemoryAddressBase)ob;
+        MemoryAccessVarHandleBase handle = (MemoryAccessVarHandleBase)ob;
         MemoryAddressProxy bb = checkAddress(obb, base, handle.length, false);
         if (handle.be == BE) {
             return UNSAFE.getAndBitwiseXor$RawType$Acquire(

--- a/src/java.base/share/classes/jdk/internal/access/JavaLangInvokeAccess.java
+++ b/src/java.base/share/classes/jdk/internal/access/JavaLangInvokeAccess.java
@@ -113,8 +113,14 @@ public interface JavaLangInvokeAccess {
      * Used by {@code jdk.internal.foreign.LayoutPath} and
      * {@code jdk.incubator.foreign.MemoryHandles}.
      */
-    VarHandle memoryAddressViewVarHandle(Class<?> carrier, long alignmentMask,
-                                         ByteOrder order, long offset, long[] strides);
+    VarHandle memoryAccessVarHandle(Class<?> carrier, long alignmentMask,
+                                    ByteOrder order, long offset, long[] strides);
+
+    /**
+     * Is {@code handle} a memory access varhandle?
+     * Used by {@code jdk.incubator.foreign.MemoryHandles}.
+     */
+    boolean isMemoryAccessVarHandle(VarHandle handle);
 
     /**
      * Returns the carrier associated with a memory access var handle.

--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/MemoryAddress.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/MemoryAddress.java
@@ -127,13 +127,21 @@ public interface MemoryAddress {
     }
 
     /**
+     * A native memory address instance modelling the {@code NULL} pointer. This address is backed by a memory segment
+     * which can be neither closed, nor dereferenced.
+     */
+    MemoryAddress NULL = MemorySegmentImpl.NOTHING.baseAddress();
+
+    /**
      * Obtain a new memory address instance from given long address. The returned address is backed by a memory segment
      * which can be neither closed, nor dereferenced.
      * @param value the long address.
      * @return the new memory address instance.
      */
     static MemoryAddress ofLong(long value) {
-        return MemorySegmentImpl.NOTHING.baseAddress().addOffset(value);
+        return value == 0 ?
+                NULL :
+                MemorySegmentImpl.NOTHING.baseAddress().addOffset(value);
     }
 
 }

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/LayoutPath.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/LayoutPath.java
@@ -141,7 +141,7 @@ public class LayoutPath {
 
         checkAlignment(this);
 
-        return Utils.fixUpVarHandle(JLI.memoryAddressViewVarHandle(
+        return Utils.fixUpVarHandle(JLI.memoryAccessVarHandle(
                 carrier,
                 layout.byteAlignment() - 1, //mask
                 ((ValueLayout) layout).order(),

--- a/test/jdk/java/foreign/TestAdaptVarHandles.java
+++ b/test/jdk/java/foreign/TestAdaptVarHandles.java
@@ -394,6 +394,48 @@ public class TestAdaptVarHandles {
         MethodHandles.collectCoordinates(intHandle, 0, S2L_EX);
     }
 
+    @Test
+    public void testDropCoordinates() throws Throwable {
+        ValueLayout layout = MemoryLayouts.JAVA_INT;
+        MemorySegment segment = MemorySegment.allocateNative(layout);
+        VarHandle intHandle = MemoryHandles.withStride(layout.varHandle(int.class), 4);
+        VarHandle intHandle_dummy = MethodHandles.dropCoordinates(intHandle, 1, float.class, String.class);
+        intHandle_dummy.set(segment.baseAddress(), 1f, "hello", 0L, 1);
+        int oldValue = (int)intHandle_dummy.getAndAdd(segment.baseAddress(), 1f, "hello", 0L, 42);
+        assertEquals(oldValue, 1);
+        int value = (int)intHandle_dummy.get(segment.baseAddress(), 1f, "hello", 0L);
+        assertEquals(value, 43);
+        boolean swapped = (boolean)intHandle_dummy.compareAndSet(segment.baseAddress(), 1f, "hello", 0L, 43, 12);
+        assertTrue(swapped);
+        oldValue = (int)intHandle_dummy.compareAndExchange(segment.baseAddress(), 1f, "hello", 0L, 12, 42);
+        assertEquals(oldValue, 12);
+        value = (int)intHandle_dummy.toMethodHandle(VarHandle.AccessMode.GET).invokeExact(segment.baseAddress(), 1f, "hello", 0L);
+        assertEquals(value, 42);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testBadDropCoordinatesNegativePos() {
+        VarHandle intHandle = MemoryLayouts.JAVA_INT.varHandle(int.class);
+        MethodHandles.dropCoordinates(intHandle, -1);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testBadDropCoordinatesPosTooBig() {
+        VarHandle intHandle = MemoryLayouts.JAVA_INT.varHandle(int.class);
+        MethodHandles.dropCoordinates(intHandle, 2);
+    }
+
+    @Test(expectedExceptions = NullPointerException.class)
+    public void testBadDropCoordinatesNullValueTypes() {
+        VarHandle intHandle = MemoryLayouts.JAVA_INT.varHandle(int.class);
+        MethodHandles.dropCoordinates(intHandle, 1, null);
+    }
+
+    @Test(expectedExceptions = NullPointerException.class)
+    public void testBadDropCoordinatesNullTarget() {
+        MethodHandles.dropCoordinates(null, 1);
+    }
+
     //helper methods
 
     static int stringToInt(String s) {

--- a/test/jdk/java/foreign/TestAddressHandle.java
+++ b/test/jdk/java/foreign/TestAddressHandle.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ *  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ *  This code is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License version 2 only, as
+ *  published by the Free Software Foundation.
+ *
+ *  This code is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ *  version 2 for more details (a copy is included in the LICENSE file that
+ *  accompanied this code).
+ *
+ *  You should have received a copy of the GNU General Public License version
+ *  2 along with this work; if not, write to the Free Software Foundation,
+ *  Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ *   Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ *  or visit www.oracle.com if you need additional information or have any
+ *  questions.
+ *
+ */
+
+/*
+ * @test
+ * @run testng/othervm -Djava.lang.invoke.VarHandle.VAR_HANDLE_GUARDS=true -Djava.lang.invoke.VarHandle.VAR_HANDLE_IDENTITY_ADAPT=false -Xverify:all TestAddressHandle
+ * @run testng/othervm -Djava.lang.invoke.VarHandle.VAR_HANDLE_GUARDS=true -Djava.lang.invoke.VarHandle.VAR_HANDLE_IDENTITY_ADAPT=true -Xverify:all TestAddressHandle
+ * @run testng/othervm -Djava.lang.invoke.VarHandle.VAR_HANDLE_GUARDS=false -Djava.lang.invoke.VarHandle.VAR_HANDLE_IDENTITY_ADAPT=false -Xverify:all TestAddressHandle
+ * @run testng/othervm -Djava.lang.invoke.VarHandle.VAR_HANDLE_GUARDS=false -Djava.lang.invoke.VarHandle.VAR_HANDLE_IDENTITY_ADAPT=true -Xverify:all TestAddressHandle
+ */
+
+import java.lang.invoke.*;
+import java.nio.ByteOrder;
+import jdk.incubator.foreign.*;
+
+import org.testng.annotations.*;
+import static org.testng.Assert.*;
+
+public class TestAddressHandle {
+    @Test(dataProvider = "addressHandles")
+    public void testAddressHandle(VarHandle addrHandle) {
+        VarHandle longHandle = MemoryHandles.varHandle(long.class, ByteOrder.nativeOrder());
+        try (MemorySegment segment = MemorySegment.allocateNative(8)) {
+            longHandle.set(segment.baseAddress(), 42L);
+            MemoryAddress address = (MemoryAddress)addrHandle.get(segment.baseAddress());
+            assertEquals(address.offset(), 42L);
+            try {
+                longHandle.get(address); // check OOB
+                fail();
+            } catch (UnsupportedOperationException ex) {
+                assertTrue(true);
+            }
+            addrHandle.set(segment.baseAddress(), address.addOffset(1));
+            long result = (long)longHandle.get(segment.baseAddress());
+            assertEquals(43L, result);
+        }
+    }
+
+    @Test(dataProvider = "addressHandles")
+    public void testNull(VarHandle addrHandle) {
+        VarHandle longHandle = MemoryHandles.varHandle(long.class, ByteOrder.nativeOrder());
+        try (MemorySegment segment = MemorySegment.allocateNative(8)) {
+            longHandle.set(segment.baseAddress(), 0L);
+            MemoryAddress address = (MemoryAddress)addrHandle.get(segment.baseAddress());
+            assertTrue(address == MemoryAddress.NULL);
+        }
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testBadAdaptFloat() {
+        VarHandle floatHandle = MemoryHandles.varHandle(float.class, ByteOrder.nativeOrder());
+        MemoryHandles.asAddressVarHandle(floatHandle);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testBadAdaptDouble() {
+        VarHandle doubleHandle = MemoryHandles.varHandle(double.class, ByteOrder.nativeOrder());
+        MemoryHandles.asAddressVarHandle(doubleHandle);
+    }
+
+    @DataProvider(name = "addressHandles")
+    static Object[][] addressHandles() {
+        return new Object[][] {
+                // long
+                { MemoryHandles.asAddressVarHandle(MemoryHandles.varHandle(long.class, ByteOrder.nativeOrder())) },
+                { MemoryHandles.asAddressVarHandle(MemoryHandles.withOffset(MemoryHandles.varHandle(long.class, ByteOrder.nativeOrder()), 0)) },
+                { MemoryHandles.asAddressVarHandle(MemoryLayouts.JAVA_LONG.varHandle(long.class)) },
+
+                // int
+                { MemoryHandles.asAddressVarHandle(MemoryHandles.varHandle(int.class, ByteOrder.nativeOrder())) },
+                { MemoryHandles.asAddressVarHandle(MemoryHandles.withOffset(MemoryHandles.varHandle(int.class, ByteOrder.nativeOrder()), 0)) },
+                { MemoryHandles.asAddressVarHandle(MemoryLayouts.JAVA_INT.varHandle(int.class)) },
+
+                // short
+                { MemoryHandles.asAddressVarHandle(MemoryHandles.varHandle(short.class, ByteOrder.nativeOrder())) },
+                { MemoryHandles.asAddressVarHandle(MemoryHandles.withOffset(MemoryHandles.varHandle(short.class, ByteOrder.nativeOrder()), 0)) },
+                { MemoryHandles.asAddressVarHandle(MemoryLayouts.JAVA_SHORT.varHandle(short.class)) },
+
+                // char
+                { MemoryHandles.asAddressVarHandle(MemoryHandles.varHandle(char.class, ByteOrder.nativeOrder())) },
+                { MemoryHandles.asAddressVarHandle(MemoryHandles.withOffset(MemoryHandles.varHandle(char.class, ByteOrder.nativeOrder()), 0)) },
+                { MemoryHandles.asAddressVarHandle(MemoryLayouts.JAVA_CHAR.varHandle(char.class)) },
+
+                // byte
+                { MemoryHandles.asAddressVarHandle(MemoryHandles.varHandle(byte.class, ByteOrder.nativeOrder())) },
+                { MemoryHandles.asAddressVarHandle(MemoryHandles.withOffset(MemoryHandles.varHandle(byte.class, ByteOrder.nativeOrder()), 0)) },
+                { MemoryHandles.asAddressVarHandle(MemoryLayouts.JAVA_BYTE.varHandle(byte.class)) }
+        };
+    }
+}

--- a/test/jdk/java/foreign/TestVarHandleCombinators.java
+++ b/test/jdk/java/foreign/TestVarHandleCombinators.java
@@ -34,6 +34,7 @@ import org.testng.annotations.Test;
 import jdk.incubator.foreign.MemoryAddress;
 import jdk.incubator.foreign.MemorySegment;
 
+import java.lang.invoke.MethodHandles;
 import java.lang.invoke.VarHandle;
 import java.nio.ByteOrder;
 
@@ -65,6 +66,12 @@ public class TestVarHandleCombinators {
     public void testBadStrideElement() {
         VarHandle vh = MemoryHandles.varHandle(int.class, ByteOrder.nativeOrder());
         MemoryHandles.withStride(vh, 0); //scale factor cant be zero
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testStrideWrongHandle() {
+        VarHandle vh = MethodHandles.byteArrayViewVarHandle(int[].class, ByteOrder.nativeOrder());
+        MemoryHandles.withStride(vh, 10);
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class)
@@ -103,6 +110,12 @@ public class TestVarHandleCombinators {
     public void testOffsetNegative() {
         VarHandle vh = MemoryHandles.varHandle(byte.class, ByteOrder.nativeOrder());
         MemoryHandles.withOffset(vh, -1);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testOffsetWrongHandle() {
+        VarHandle vh = MethodHandles.byteArrayViewVarHandle(int[].class, ByteOrder.nativeOrder());
+        MemoryHandles.withOffset(vh, 1);
     }
 
     @Test(expectedExceptions = IllegalStateException.class)

--- a/test/jdk/java/foreign/TestVarHandleCombinators.java
+++ b/test/jdk/java/foreign/TestVarHandleCombinators.java
@@ -53,10 +53,12 @@ public class TestVarHandleCombinators {
         assertEquals((byte) vh.get(addr, 2), (byte) -1);
     }
 
-    @Test(expectedExceptions = IllegalArgumentException.class)
+    @Test(expectedExceptions = IllegalStateException.class)
     public void testUnalignedElement() {
         VarHandle vh = MemoryHandles.varHandle(byte.class, 4, ByteOrder.nativeOrder());
-        MemoryHandles.withStride(vh, 2);
+        vh = MemoryHandles.withStride(vh, 2);
+        MemorySegment segment = MemorySegment.ofArray(new byte[4]);
+        vh.get(segment.baseAddress(), 1L); //should throw
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class)
@@ -86,7 +88,7 @@ public class TestVarHandleCombinators {
         assertEquals((byte) vh.get(address), (byte) 10);
     }
 
-    @Test(expectedExceptions = IllegalArgumentException.class)
+    @Test(expectedExceptions = IllegalStateException.class)
     public void testAlignBadAccess() {
         VarHandle vh = MemoryHandles.varHandle(byte.class, 2, ByteOrder.nativeOrder());
         vh = MemoryHandles.withOffset(vh, 1); // offset by 1 byte
@@ -103,10 +105,12 @@ public class TestVarHandleCombinators {
         MemoryHandles.withOffset(vh, -1);
     }
 
-    @Test(expectedExceptions = IllegalArgumentException.class)
+    @Test(expectedExceptions = IllegalStateException.class)
     public void testUnalignedOffset() {
         VarHandle vh = MemoryHandles.varHandle(byte.class, 4, ByteOrder.nativeOrder());
-        MemoryHandles.withOffset(vh, 2);
+        vh = MemoryHandles.withOffset(vh, 2);
+        MemorySegment segment = MemorySegment.ofArray(new byte[4]);
+        vh.get(segment.baseAddress()); //should throw
     }
 
     @Test

--- a/test/jdk/java/foreign/TestVarHandleCombinators.java
+++ b/test/jdk/java/foreign/TestVarHandleCombinators.java
@@ -62,10 +62,13 @@ public class TestVarHandleCombinators {
         vh.get(segment.baseAddress(), 1L); //should throw
     }
 
-    @Test(expectedExceptions = IllegalArgumentException.class)
-    public void testBadStrideElement() {
+    public void testZeroStrideElement() {
         VarHandle vh = MemoryHandles.varHandle(int.class, ByteOrder.nativeOrder());
-        MemoryHandles.withStride(vh, 0); //scale factor cant be zero
+        VarHandle strided_vh = MemoryHandles.withStride(vh, 0);
+        MemorySegment segment = MemorySegment.ofArray(new int[] { 42 });
+        for (int i = 0 ; i < 100 ; i++) {
+            assertEquals((int)vh.get(segment.baseAddress()), strided_vh.get(segment.baseAddress(), (long)i));
+        }
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class)
@@ -106,10 +109,13 @@ public class TestVarHandleCombinators {
         vh.set(address, (byte) 10); // should be bad align
     }
 
-    @Test(expectedExceptions = IllegalArgumentException.class)
-    public void testOffsetNegative() {
-        VarHandle vh = MemoryHandles.varHandle(byte.class, ByteOrder.nativeOrder());
-        MemoryHandles.withOffset(vh, -1);
+    public void testZeroOffsetElement() {
+        VarHandle vh = MemoryHandles.varHandle(int.class, ByteOrder.nativeOrder());
+        VarHandle offset_vh = MemoryHandles.withOffset(vh, 0);
+        MemorySegment segment = MemorySegment.ofArray(new int[] { 42 });
+        for (int i = 0 ; i < 100 ; i++) {
+            assertEquals((int)vh.get(segment.baseAddress()), offset_vh.get(segment.baseAddress(), (long)i));
+        }
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class)


### PR DESCRIPTION
Following recent changes (see https://github.com/openjdk/panama-foreign/pull/77)which backport some of the goodies in foreign-abi into foreign-memaccess,
this patch brings support for a VarHandle combinator which turns a regular memory access var handle into a var handle which gets/sets a MemoryAddress (e.g. instead of a long).

This patch also addresses the general problem of the co-existence between combinators in MemoryHandles and the general var handle combinators in MethodHandles.

This coexistence has always been tricky, because the combinators in MemoryHandles like to create a new 'flattened' memory access var handle, which provides best possible performances, and also performs certain alignment checks upfront.

However, if a memory access handle is adapted (e.g. the carrier type is changed) this simplistic approach no longer works, as, by reconstructing the memory access var handle from scratch we will also lose all the adaptations.

The solution is to detect as to wheter the target handle is a "direct" memory access var handle or not (special provisions are made for the ubiquitous adaptation added on all memory access var handle creation as a workaround for JDK-8237349). If that's the case, and, if the stride or the offset matches the alignment constraint, then we go the fast/flattened path and we can adapt by reconstructing the handle from scratch. If any of these two conditions are not met (there's complex adaption that would be dropped on the floor, or the offset/stride parameter doesn't match with alignment constraint), then the slow path is taken - the target var handle is kept around and is adapted using the standard combinator API. This leads to a less performant VarHandle (because, unfortunately, calling addOffset() currently breaks C2 optimizations), but also guarantees that alignment constraints will be checked in full (this is because the memory access var handle implementation always checks the alignment of the base address passed to it - only for the offset part is the alignment check skipped - on the basis that this has already been verified by construction).

The result is that we can lift a lot of the restrictions surrounding the combinators in MemoryHandles; such combinators can now work on _any_ var handle (provided the var handle has a first coordinate type of type MemoryAddress). Also, I've lifted the alignment restrictions, since these will either be enforced dynamically (by taking the slow path), or they won't be enforced because we have already statically proven that the constraints are satisfied (fast path).

I've also took the chance to rename some of the classes surrounding memory access var handles to use the "memory access var handle" terminology, which is the one that stuck (currently, some classes use the word "address var hande" which is ambiguous).
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [JDK-8242011](https://bugs.openjdk.java.net/browse/JDK-8242011): Add support for memory address combinator


### Reviewers
 * Jorn Vernee ([jvernee](@JornVernee) - Committer)

### Download
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/84/head:pull/84`
`$ git checkout pull/84`
