### PR TITLE
JDK-8242046: Add a predicate to determine if MemoryLayout is a padding layout

### DIFF
--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/AbstractLayout.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/AbstractLayout.java
@@ -169,6 +169,11 @@ abstract class AbstractLayout implements MemoryLayout {
     }
 
     @Override
+    public boolean isPadding() {
+        return this instanceof PaddingLayout;
+    }
+
+    @Override
     public int hashCode() {
         return attributes.hashCode() << Long.hashCode(alignment);
     }

--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/MemoryLayout.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/MemoryLayout.java
@@ -393,6 +393,12 @@ public interface MemoryLayout extends Constable {
     }
 
     /**
+     * Is this a padding layout (e.g. a layout created from {@link #ofPaddingBits(long)} ?
+     * @return true, if this layout is a padding layout.
+     */
+    boolean isPadding();
+
+    /**
      * Instances of this class are used to form <a href="MemoryLayout.html#layout-paths"><em>layout paths</em></a>. There
      * are two kinds of path elements: <em>group path elements</em> and <em>sequence path elements</em>. Group
      * path elements are used to select a given named member layout within a {@link GroupLayout}. Sequence

--- a/test/jdk/java/foreign/TestLayouts.java
+++ b/test/jdk/java/foreign/TestLayouts.java
@@ -208,6 +208,11 @@ public class TestLayouts {
         assertEquals(struct.byteAlignment(), 8);
     }
 
+    @Test(dataProvider = "layoutKinds")
+    public void testPadding(LayoutKind kind) {
+        assertEquals(kind == LayoutKind.PADDING, kind.layout.isPadding());
+    }
+
     @Test(dataProvider="layoutsAndAlignments")
     public void testAlignmentString(MemoryLayout layout, long bitAlign) {
         long[] alignments = { 8, 16, 32, 64, 128 };
@@ -254,6 +259,13 @@ public class TestLayouts {
             values[(i * 2) + 1] = new Object[] { layoutKinds[i].layout, 18 }; // not a power of 2
         }
         return values;
+    }
+
+    @DataProvider(name = "layoutKinds")
+    public Object[][] layoutsKinds() {
+        return Stream.of(LayoutKind.values())
+                .map(lk -> new Object[] { lk })
+                .toArray(Object[][]::new);
     }
 
     enum SizedLayoutFactory {


### PR DESCRIPTION
This simple patch adds a predicate to test if a memory layout is a padding layout.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [JDK-8242046](https://bugs.openjdk.java.net/browse/JDK-8242046): Add a predicate to determine if MemoryLayout is a padding layout


### Reviewers
 * Jorn Vernee ([jvernee](@JornVernee) - Committer)

### Download
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/86/head:pull/86`
`$ git checkout pull/86`
