### PR TITLE
JDK-8242048: Add API point to get raw long value out of a MemoryAddress

### DIFF
--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/Foreign.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/Foreign.java
@@ -62,20 +62,6 @@ public interface Foreign {
     }
 
     /**
-     * Returns the absolute address represented by the given off-heap memory address as a {@code long}.
-     * <p>
-     * This method is <em>restricted</em>. Restricted method are unsafe, and, if used incorrectly, their use might crash
-     * the JVM crash or, worse, silently result in memory corruption. Thus, clients should refrain from depending on
-     * restricted methods, and use safe and supported functionalities, where possible.
-     *
-     * @param address the address to turn into a {@code long}
-     * @return the address as a {@code long}
-     * @throws IllegalAccessError if the permission jkd.incubator.foreign.restrictedMethods is set to 'deny'
-     * @throws IllegalStateException if the given address is not an off-heap address
-     */
-    long asLong(MemoryAddress address) throws IllegalAccessError;
-
-    /**
      * Returns a new native memory segment with given base address and size. The returned segment has its own temporal
      * bounds, and can therefore be closed; closing such a segment does <em>not</em> result in any resource being
      * deallocated.

--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/MemoryAddress.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/MemoryAddress.java
@@ -61,14 +61,20 @@ public interface MemoryAddress {
     MemoryAddress addOffset(long offset);
 
     /**
-     * The offset of this memory address into the underlying segment.
-     *
-     * @return the offset
+     * Returns the offset of this memory address into the underlying segment.
+     * @return the offset of this memory address into the underlying segment.
      */
     long offset();
 
     /**
-     * The memory segment this address belongs to.
+     * Returns the raw long value associated to this memory address.
+     * @return The raw long value associated to this memory address.
+     * @throws UnsupportedOperationException if this memory address is associated with an heap segment.
+     */
+    long toRawLongValue();
+
+    /**
+     * Returns the memory segment this address belongs to.
      * @return The memory segment this address belongs to.
      */
     MemorySegment segment();

--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/MemoryHandles.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/MemoryHandles.java
@@ -339,7 +339,7 @@ public final class MemoryHandles {
     }
 
     private static long addressToLong(MemoryAddress value) {
-        return MemoryAddressImpl.addressof(value);
+        return value.toRawLongValue();
     }
 
     private static MemoryAddress addOffset(MemoryAddress address, long offset) {

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/InternalForeign.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/InternalForeign.java
@@ -48,11 +48,6 @@ public class InternalForeign implements Foreign {
     }
 
     @Override
-    public long asLong(MemoryAddress address) throws IllegalAccessError {
-        return MemoryAddressImpl.addressof(address);
-    }
-
-    @Override
     public MemorySegment ofNativeUnchecked(MemoryAddress base, long byteSize) throws IllegalAccessError {
         return Utils.makeNativeSegmentUnchecked(base, byteSize);
     }

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/MemoryAddressImpl.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/MemoryAddressImpl.java
@@ -68,6 +68,14 @@ public final class MemoryAddressImpl implements MemoryAddress, MemoryAddressProx
     }
 
     @Override
+    public long toRawLongValue() {
+        if (unsafeGetBase() != null) {
+            throw new UnsupportedOperationException("Not a native address");
+        }
+        return unsafeGetOffset();
+    }
+
+    @Override
     public MemorySegment segment() {
         return segment;
     }
@@ -127,15 +135,5 @@ public final class MemoryAddressImpl implements MemoryAddress, MemoryAddressProx
     @Override
     public String toString() {
         return "MemoryAddress{ region: " + segment + " offset=0x" + Long.toHexString(offset) + " }";
-    }
-
-    // helper methods
-
-    public static long addressof(MemoryAddress address) {
-        MemoryAddressImpl addressImpl = (MemoryAddressImpl) address;
-        if (addressImpl.unsafeGetBase() != null) {
-            throw new IllegalStateException("Heap address!");
-        }
-        return addressImpl.unsafeGetOffset();
     }
 }

--- a/test/jdk/java/foreign/TestNative.java
+++ b/test/jdk/java/foreign/TestNative.java
@@ -25,11 +25,10 @@
 /*
  * @test
  * @modules java.base/jdk.internal.misc
- *          jdk.incubator.foreign/jdk.incubator.foreign.unsafe
- * @run testng/othervm -Djdk.incubator.foreign.Foreign=permit TestNative
+ *          jdk.incubator.foreign
+ * @run testng TestNative
  */
 
-import jdk.incubator.foreign.Foreign;
 import jdk.incubator.foreign.MemoryAddress;
 import jdk.incubator.foreign.MemoryLayout;
 import jdk.incubator.foreign.MemoryLayout.PathElement;
@@ -118,7 +117,7 @@ public class TestNative {
         for (long i = 0 ; i < nelems ; i++) {
             Object handleValue = handleExtractor.apply(base, i);
             Object bufferValue = nativeBufferExtractor.apply(z, (int)i);
-            Object rawValue = nativeRawExtractor.apply(Foreign.getInstance().asLong(base), (int)i);
+            Object rawValue = nativeRawExtractor.apply(base.toRawLongValue(), (int)i);
             if (handleValue instanceof Number) {
                 assertEquals(((Number)handleValue).longValue(), i);
                 assertEquals(((Number)bufferValue).longValue(), i);


### PR DESCRIPTION
This simple patch adds an extra API to retrieve the long value of an address; the method throws UOE if the address is heap-based. I have not added dedicated tests since this method is used pretty much everywhere (see MemoryHandles).
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [JDK-8242048](https://bugs.openjdk.java.net/browse/JDK-8242048): Add API point to get raw long value out of a MemoryAddress


### Reviewers
 * Athijegannathan Sundararajan ([sundar](@sundararajana) - Committer)
 * Paul Sandoz ([psandoz](@PaulSandoz) - Committer)

### Download
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/88/head:pull/88`
`$ git checkout pull/88`
