### PR TITLE
JDK-8242051: Clarify difference between checked and unchecked addresses

### DIFF
--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/MemoryAddress.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/MemoryAddress.java
@@ -37,7 +37,7 @@ import jdk.internal.foreign.MemorySegmentImpl;
  * dereferenced using a memory access var handle (see {@link MemoryHandles}).
  * <p>
  * If an address does not have any associated segment, it is said to be <em>unchecked</em>. Unchecked memory
- * address do not feature known spatial or temporal bounds; as such, attempting a memory dereference operation
+ * addresses do not feature known spatial or temporal bounds; as such, attempting a memory dereference operation
  * using an unchecked memory address will result in a runtime exception. Unchecked addresses can be obtained
  * e.g. by calling the {@link #ofLong(long)} method.
  * <p>

--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/MemoryAddress.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/MemoryAddress.java
@@ -30,13 +30,16 @@ import jdk.internal.foreign.MemoryAddressImpl;
 import jdk.internal.foreign.MemorySegmentImpl;
 
 /**
- * A memory address encodes an offset within a given {@link MemorySegment}. Memory addresses are typically obtained
- * using the {@link MemorySegment#baseAddress()} method; such addresses can then be adjusted as required,
- * using {@link MemoryAddress#addOffset(long)}.
+ * A memory address models a reference into a memory location. Memory addresses are typically obtained using the
+ * {@link MemorySegment#baseAddress()} method; such addresses are said to be <em>checked</em>, and can be expressed
+ * as <em>offsets</em> into some underlying memory segment (see {@link #segment()} and {@link #segmentOffset()}).
+ * Since checked memory addresses feature both spatial and temporal bounds, these addresses can <em>safely</em> be
+ * dereferenced using a memory access var handle (see {@link MemoryHandles}).
  * <p>
- * A memory address is typically used as the first argument in a memory access var handle call, to perform some operation
- * on the underlying memory backing a given memory segment. Since a memory address is always associated with a memory segment,
- * such access operations are always subject to spatial and temporal checks as enforced by the address' owning memory region.
+ * If an address does not have any associated segment, it is said to be <em>unchecked</em>. Unchecked memory
+ * address do not feature known spatial or temporal bounds; as such, attempting a memory dereference operation
+ * using an unchecked memory address will result in a runtime exception. Unchecked addresses can be obtained
+ * e.g. by calling the {@link #ofLong(long)} method.
  * <p>
  * All implementations of this interface must be <a href="{@docRoot}/java.base/java/lang/doc-files/ValueBased.html">value-based</a>;
  * use of identity-sensitive operations (including reference equality ({@code ==}), identity hash code, or synchronization) on
@@ -61,10 +64,12 @@ public interface MemoryAddress {
     MemoryAddress addOffset(long offset);
 
     /**
-     * Returns the offset of this memory address into the underlying segment.
-     * @return the offset of this memory address into the underlying segment.
+     * Returns the offset of this memory address into the underlying segment (if any).
+     * @return the offset of this memory address into the underlying segment (if any).
+     * @throws UnsupportedOperationException if no segment is associated with this memory address,
+     * e.g. if {@code segment() == null}.
      */
-    long offset();
+    long segmentOffset();
 
     /**
      * Returns the raw long value associated to this memory address.
@@ -74,8 +79,8 @@ public interface MemoryAddress {
     long toRawLongValue();
 
     /**
-     * Returns the memory segment this address belongs to.
-     * @return The memory segment this address belongs to.
+     * Returns the memory segment (if any) this address belongs to.
+     * @return The memory segment this address belongs to, or {@code null} if no such segment exists.
      */
     MemorySegment segment();
 
@@ -133,21 +138,21 @@ public interface MemoryAddress {
     }
 
     /**
-     * A native memory address instance modelling the {@code NULL} pointer. This address is backed by a memory segment
-     * which can be neither closed, nor dereferenced.
+     * The <em>unchecked</em> memory address instance modelling the {@code NULL} address. This address is <em>not</em> backed by
+     * a memory segment and hence it cannot be dereferenced.
      */
-    MemoryAddress NULL = MemorySegmentImpl.NOTHING.baseAddress();
+    MemoryAddress NULL = new MemoryAddressImpl( 0L);
 
     /**
-     * Obtain a new memory address instance from given long address. The returned address is backed by a memory segment
-     * which can be neither closed, nor dereferenced.
+     * Obtain a new <em>unchecked</em> memory address instance from given long address. The returned address is <em>not</em> backed by
+     * a memory segment and hence it cannot be dereferenced.
      * @param value the long address.
      * @return the new memory address instance.
      */
     static MemoryAddress ofLong(long value) {
         return value == 0 ?
                 NULL :
-                MemorySegmentImpl.NOTHING.baseAddress().addOffset(value);
+                new MemoryAddressImpl(value);
     }
 
 }

--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/MemorySegment.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/MemorySegment.java
@@ -151,7 +151,9 @@ MemorySegment roSegment = segment.withAccessModes(segment.accessModes() & ~WRITE
 public interface MemorySegment extends AutoCloseable {
 
     /**
-     * The base memory address associated with this memory segment.
+     * The base memory address associated with this memory segment. The returned address is
+     * a <em>checked</em> memory address and can therefore be used in derefrence operations
+     * (see {@link MemoryAddress}).
      * @return The base memory address.
      */
     MemoryAddress baseAddress();

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/MemoryAddressImpl.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/MemoryAddressImpl.java
@@ -44,6 +44,11 @@ public final class MemoryAddressImpl implements MemoryAddress, MemoryAddressProx
     private final MemorySegmentImpl segment;
     private final long offset;
 
+    public MemoryAddressImpl(long offset) {
+        this.segment = MemorySegmentImpl.NOTHING;
+        this.offset = offset;
+    }
+
     public MemoryAddressImpl(MemorySegmentImpl segment, long offset) {
         this.segment = Objects.requireNonNull(segment);
         this.offset = offset;
@@ -63,7 +68,10 @@ public final class MemoryAddressImpl implements MemoryAddress, MemoryAddressProx
     // MemoryAddress methods
 
     @Override
-    public long offset() {
+    public long segmentOffset() {
+        if (segment() == null) {
+            throw new UnsupportedOperationException("Address does not have a segment");
+        }
         return offset;
     }
 
@@ -77,7 +85,8 @@ public final class MemoryAddressImpl implements MemoryAddress, MemoryAddressProx
 
     @Override
     public MemorySegment segment() {
-        return segment;
+        return segment != MemorySegmentImpl.NOTHING ?
+                segment : null;
     }
 
     @Override

--- a/test/jdk/java/foreign/TestAddressHandle.java
+++ b/test/jdk/java/foreign/TestAddressHandle.java
@@ -65,9 +65,9 @@ public class TestAddressHandle {
         try (MemorySegment segment = MemorySegment.allocateNative(8)) {
             longHandle.set(segment.baseAddress(), 42L);
             MemoryAddress address = (MemoryAddress)addrHandle.get(segment.baseAddress());
-            assertEquals(address.offset(), 42L);
+            assertEquals(address.toRawLongValue(), 42L);
             try {
-                longHandle.get(address); // check OOB
+                longHandle.get(address); // check that address cannot be de-referenced
                 fail();
             } catch (UnsupportedOperationException ex) {
                 assertTrue(true);

--- a/test/jdk/java/foreign/TestNative.java
+++ b/test/jdk/java/foreign/TestNative.java
@@ -112,7 +112,7 @@ public class TestNative {
                                               BiFunction<Z, Integer, Object> nativeBufferExtractor,
                                               BiFunction<Long, Integer, Object> nativeRawExtractor) {
         long nelems = layout.elementCount().getAsLong();
-        ByteBuffer bb = base.segment().asSlice(base.offset(), (int)layout.byteSize()).asByteBuffer();
+        ByteBuffer bb = base.segment().asSlice(base.segmentOffset(), (int)layout.byteSize()).asByteBuffer();
         Z z = bufferFactory.apply(bb);
         for (long i = 0 ; i < nelems ; i++) {
             Object handleValue = handleExtractor.apply(base, i);

--- a/test/jdk/java/foreign/TestSegments.java
+++ b/test/jdk/java/foreign/TestSegments.java
@@ -45,9 +45,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.LongFunction;
 import java.util.stream.Stream;
 
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertFalse;
-import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.*;
 
 public class TestSegments {
 
@@ -113,6 +111,13 @@ public class TestSegments {
         }
     }
 
+    @Test(expectedExceptions = UnsupportedOperationException.class)
+    public void testNothingSegmentOffset() {
+        MemoryAddress addr = MemoryAddress.ofLong(42);
+        assertNull(addr.segment());
+        addr.segmentOffset();
+    }
+
     @Test
     public void testSlices() {
         VarHandle byteHandle = MemoryLayout.ofSequence(MemoryLayouts.JAVA_BYTE)
@@ -126,7 +131,7 @@ public class TestSegments {
             MemoryAddress base = segment.baseAddress();
             MemoryAddress last = base.addOffset(10);
             while (!base.equals(last)) {
-                MemorySegment slice = segment.asSlice(base.offset(), 10 - start);
+                MemorySegment slice = segment.asSlice(base.segmentOffset(), 10 - start);
                 for (long i = start ; i < 10 ; i++) {
                     assertEquals(
                             byteHandle.get(segment.baseAddress(), i),


### PR DESCRIPTION
While most memory addresses are associated with a segment, addresses coming from native code, or those created from scratch (e.g. MemoryAddress::ofLong) do not have an associated segment.

This patch addresses this problem by having unchecked memory addresses returning`null` on MemoryAddress::segment(). Similarly, the MemoryAddress::offset method has been renamed to `segmentOffset` and now throws UOE if called on an unchecked address.

This makes the API cleaner: it is only possible to dereference those addresses which have an associated segment. I've tweaked the javadoc to convey that message more clearly.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [JDK-8242051](https://bugs.openjdk.java.net/browse/JDK-8242051): Clarify difference between checked and unchecked addresses


### Reviewers
 * Jorn Vernee ([jvernee](@JornVernee) - Committer) ⚠️ Review applies to bb98d9cefc1aa8fed9930d59f5a62d92672c14af

### Download
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/90/head:pull/90`
`$ git checkout pull/90`
