### PR TITLE
Backport Foreign methods from foreign-abi back to foreign-memaccess

### DIFF
--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/Foreign.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/Foreign.java
@@ -27,7 +27,6 @@
 package jdk.incubator.foreign;
 
 import jdk.internal.foreign.InternalForeign;
-import jdk.internal.foreign.MemorySegmentImpl;
 
 /**
  * A class containing various methods relating to native interop.
@@ -62,26 +61,42 @@ public interface Foreign {
     }
 
     /**
-     * Returns a new native memory segment with given base address and size. The returned segment has its own temporal
-     * bounds, and can therefore be closed; closing such a segment does <em>not</em> result in any resource being
-     * deallocated.
+     * Returns a new memory address attached to a native memory segment with given base address and size. The segment
+     * attached to the returned address has <em>no temporal bounds</em> and cannot be closed; as such,
+     * the returned address is assumed to always be <em>alive</em>. Also, the segment attached to the returned address
+     * has <em>no confinement thread</em>; this means that the returned address can be used by multiple threads.
      * <p>
      * This method is <em>restricted</em>. Restricted method are unsafe, and, if used incorrectly, their use might crash
      * the JVM crash or, worse, silently result in memory corruption. Thus, clients should refrain from depending on
      * restricted methods, and use safe and supported functionalities, where possible.
+     *
+     * @param base the desired base address
+     * @param byteSize the desired size (in bytes).
+     * @return a new memory address attached to a native memory segment with given base address and size.
+     * @throws IllegalArgumentException if {@code base} does not encapsulate a native memory address,
+     * or if the segment associated with {@code base} is not the <em>primordial</em> segment.
+     * @throws IllegalAccessError if the permission jkd.incubator.foreign.restrictedMethods is set to 'deny'
+     */
+    MemoryAddress withSize(MemoryAddress base, long byteSize);
+
+    /**
+     * Returns a new native memory segment with given base address and size; the returned segment has its own temporal
+     * bounds, and can therefore be closed; closing such a segment results in releasing the native memory by calling
+     * <em>free</em> on the base address of the returned memory segment. As for other ordinary memory segments,
+     * the returned segment will also be confined on the current thread (see {@link Thread#currentThread()}).
      * <p>
-     * This method allows for making an otherwise in-accessible memory region accessible. However, there
-     * is no guarantee that this memory is safe to access, or that the given size for the new segment is not too large,
-     * potentially resulting in out-of-bounds accesses. The developer is trusted to make the judgement that the use of the
-     * returned memory segment is safe.
+     * This method is <em>restricted</em>. Restricted method are unsafe, and, if used incorrectly, their use might crash
+     * the JVM crash or, worse, silently result in memory corruption. Thus, clients should refrain from depending on
+     * restricted methods, and use safe and supported functionalities, where possible.
      *
      * @param base the desired base address
      * @param byteSize the desired size.
      * @return a new native memory segment with given base address and size.
-     * @throws IllegalArgumentException if {@code base} does not encapsulate a native memory address.
+     * @throws IllegalArgumentException if {@code base} does not encapsulate a native memory address,
+     * or if the segment associated with {@code base} is not the <em>primordial</em> segment.
      * @throws IllegalAccessError if the permission jkd.incubator.foreign.restrictedMethods is set to 'deny'
      */
-    MemorySegment ofNativeUnchecked(MemoryAddress base, long byteSize) throws IllegalAccessError;
+    MemorySegment asMallocSegment(MemoryAddress base, long byteSize);
 
     /**
      * Returns a non-confined memory segment that has the same spatial and temporal bounds as the provided segment.

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/InternalForeign.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/InternalForeign.java
@@ -48,8 +48,14 @@ public class InternalForeign implements Foreign {
     }
 
     @Override
-    public MemorySegment ofNativeUnchecked(MemoryAddress base, long byteSize) throws IllegalAccessError {
-        return Utils.makeNativeSegmentUnchecked(base, byteSize);
+    public MemoryAddress withSize(MemoryAddress base, long byteSize) throws IllegalAccessError {
+        return Utils.makeNativeSegmentUnchecked(base.toRawLongValue(), byteSize, null, false)
+                .baseAddress();
+    }
+
+    @Override
+    public MemorySegment asMallocSegment(MemoryAddress base, long byteSize) throws IllegalAccessError {
+        return Utils.makeNativeSegmentUnchecked(base.toRawLongValue(), byteSize, Thread.currentThread(), true);
     }
 
     @Override

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/MemorySegmentImpl.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/MemorySegmentImpl.java
@@ -86,7 +86,7 @@ public final class MemorySegmentImpl implements MemorySegment, MemorySegmentProx
     }
 
     @ForceInline
-    private MemorySegmentImpl(long min, Object base, long length, int mask, Thread owner, MemoryScope scope) {
+    MemorySegmentImpl(long min, Object base, long length, int mask, Thread owner, MemoryScope scope) {
         this.length = length;
         this.mask = length > Integer.MAX_VALUE ? mask : (mask | SMALL);
         this.min = min;

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/Utils.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/Utils.java
@@ -109,16 +109,13 @@ public final class Utils {
         return segment;
     }
 
-    public static MemorySegment makeNativeSegmentUnchecked(MemoryAddress base, long bytesSize) {
-        if (((MemorySegmentImpl)base.segment()).base != null) {
-            throw new IllegalArgumentException("Not a native address: " + base);
+    public static MemorySegment makeNativeSegmentUnchecked(long min, long bytesSize, Thread owner, boolean allowClose) {
+        MemoryScope scope = new MemoryScope(null, allowClose ? () -> unsafe.freeMemory(min) : null);
+        int mask = MemorySegmentImpl.DEFAULT_MASK;
+        if (!allowClose) {
+            mask &= ~MemorySegment.CLOSE;
         }
-        return makeNativeSegmentUnchecked(((MemoryAddressImpl)base).unsafeGetOffset(), bytesSize);
-    }
-
-    public static MemorySegment makeNativeSegmentUnchecked(long min, long bytesSize) {
-        MemoryScope scope = new MemoryScope(null, null);
-        return new MemorySegmentImpl(min, null, bytesSize, Thread.currentThread(), scope);
+        return new MemorySegmentImpl(min, null, bytesSize, mask, owner, scope);
     }
 
     public static MemorySegment makeArraySegment(byte[] arr) {

--- a/test/jdk/java/foreign/TestByteBuffer.java
+++ b/test/jdk/java/foreign/TestByteBuffer.java
@@ -397,7 +397,9 @@ public class TestByteBuffer {
     @Test(expectedExceptions = { UnsupportedOperationException.class,
                                  IllegalArgumentException.class })
     public void testTooBigForByteBuffer() {
-        MemorySegment.allocateNative((long) Integer.MAX_VALUE * 2).asByteBuffer();
+        try (MemorySegment segment = MemorySegment.allocateNative((long)Integer.MAX_VALUE + 10L)) {
+            segment.asByteBuffer();
+        }
     }
 
     @Test(dataProvider="resizeOps")


### PR DESCRIPTION
This is a straight backport for

https://git.openjdk.java.net/panama-foreign/pull/81

The only other thing I've fixed is a byte buffer test that was intermittently causing OOME. I realized that:

* the test was allocating an absurd amount of native memory (max int * 2)
* the test was not closing the native segment afterwards

Both issues are now addressed.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * Henry Jen ([henryjen](@slowhog) - Committer)

### Download
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/91/head:pull/91`
`$ git checkout pull/91`
