### PR TITLE
JDK-8242102: foreign-abi build is broken

### DIFF
--- a/src/hotspot/cpu/x86/assembler_x86.cpp
+++ b/src/hotspot/cpu/x86/assembler_x86.cpp
@@ -6889,13 +6889,6 @@ void Assembler::decl(Register dst) {
 
 // 64bit doesn't use the x87
 
-void Assembler::emit_operand32(Register reg, Address adr) {
-  assert(reg->encoding() < 8, "no extended registers");
-  assert(!adr.base_needs_rex() && !adr.index_needs_rex(), "no extended registers");
-  emit_operand(reg, adr._base, adr._index, adr._scale, adr._disp,
-               adr._rspec);
-}
-
 void Assembler::emit_farith(int b1, int b2, int i) {
   assert(isByte(b1) && isByte(b2), "wrong opcode");
   assert(0 <= i &&  i < 8, "illegal stack offset");
@@ -8364,6 +8357,13 @@ void Assembler::fstp_x(Address adr) {
   InstructionMark im(this);
   emit_int8((unsigned char)0xDB);
   emit_operand32(rdi, adr);
+}
+
+void Assembler::emit_operand32(Register reg, Address adr) {
+  assert(reg->encoding() < 8, "no extended registers");
+  assert(!adr.base_needs_rex() && !adr.index_needs_rex(), "no extended registers");
+  emit_operand(reg, adr._base, adr._index, adr._scale, adr._disp,
+               adr._rspec);
 }
 
 void Assembler::fxrstor(Address src) {

--- a/src/hotspot/cpu/x86/assembler_x86.hpp
+++ b/src/hotspot/cpu/x86/assembler_x86.hpp
@@ -1169,8 +1169,6 @@ private:
 
 #ifndef _LP64
  private:
-  // operands that only take the original 32bit registers
-  void emit_operand32(Register reg, Address adr);
 
   void emit_farith(int b1, int b2, int i);
 
@@ -1313,6 +1311,9 @@ private:
   void f2xm1();
   void fldl2e();
 #endif // !_LP64
+
+  // operands that only take the original 32bit registers
+  void emit_operand32(Register reg, Address adr);
 
   void fld_x(Address adr);  // extended-precision (80-bit) format
   void fstp_x(Address adr); // extended-precision (80-bit) format


### PR DESCRIPTION
This moves back some functions that were moved upstream under the !_LP64 flag.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [JDK-8242102](https://bugs.openjdk.java.net/browse/JDK-8242102): foreign-abi build is broken


### Reviewers
 * Athijegannathan Sundararajan ([sundar](@sundararajana) - Committer)

### Download
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/96/head:pull/96`
`$ git checkout pull/96`
