### PR TITLE
Fix javadoc in jdk.incubator.foreign.Foreign

### DIFF
--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/Foreign.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/Foreign.java
@@ -73,8 +73,8 @@ public interface Foreign {
      * @param base the desired base address
      * @param byteSize the desired size (in bytes).
      * @return a new memory address attached to a native memory segment with given base address and size.
-     * @throws IllegalArgumentException if {@code base} does not encapsulate a native memory address,
-     * or if the segment associated with {@code base} is not the <em>primordial</em> segment.
+     * @throws IllegalArgumentException if {@code base} does not encapsulate an <em>unchecked</em> native memory address,
+     * e.g. if {@code base.segment() != null}.
      * @throws IllegalAccessError if the permission jkd.incubator.foreign.restrictedMethods is set to 'deny'
      */
     MemoryAddress withSize(MemoryAddress base, long byteSize);
@@ -92,8 +92,8 @@ public interface Foreign {
      * @param base the desired base address
      * @param byteSize the desired size.
      * @return a new native memory segment with given base address and size.
-     * @throws IllegalArgumentException if {@code base} does not encapsulate a native memory address,
-     * or if the segment associated with {@code base} is not the <em>primordial</em> segment.
+     * @throws IllegalArgumentException if {@code base} does not encapsulate an <em>unchecked</em> native memory address,
+      * e.g. if {@code base.segment() != null}.
      * @throws IllegalAccessError if the permission jkd.incubator.foreign.restrictedMethods is set to 'deny'
      */
     MemorySegment asMallocSegment(MemoryAddress base, long byteSize);


### PR DESCRIPTION
This simple patch fixes an issue in the Foreign javadoc which was referring to the concept of "primordial" segment (a synonim of Nothing segment). As per recent changes, now we can speak of address that do _not_ have a segment (e.g. address.segment() == null), so javadoc should be rectified to reflect that.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * Jorn Vernee ([jvernee](@JornVernee) - Committer)

### Download
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/98/head:pull/98`
`$ git checkout pull/98`
