### PR TITLE
Revert "JDK-8242127: reorganize ABI-dependent layout constants"

### DIFF
--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/MemoryLayouts.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/MemoryLayouts.java
@@ -26,7 +26,14 @@
 
 package jdk.incubator.foreign;
 
+import jdk.internal.foreign.InternalForeign;
+import jdk.internal.foreign.abi.x64.windows.Windowsx64ABI;
+
 import java.nio.ByteOrder;
+
+import static jdk.incubator.foreign.SystemABI.ABI_AARCH64;
+import static jdk.incubator.foreign.SystemABI.ABI_SYSV;
+import static jdk.incubator.foreign.SystemABI.ABI_WINDOWS;
 
 /**
  * This class defines useful layout constants. Some of the constants defined in this class are explicit in both
@@ -44,22 +51,22 @@ public final class MemoryLayouts {
     /**
      * A value layout constant with size of one byte, and byte order set to {@link ByteOrder#LITTLE_ENDIAN}.
      */
-    public static final ValueLayout BITS_8_LE = MemoryLayout.ofValueBits(8, ByteOrder.LITTLE_ENDIAN);
+    public static final ValueLayout BITS_8_LE = SharedLayouts.BITS_8_LE;
 
     /**
      * A value layout constant with size of two bytes, and byte order set to {@link ByteOrder#LITTLE_ENDIAN}.
      */
-    public static final ValueLayout BITS_16_LE = MemoryLayout.ofValueBits(16, ByteOrder.LITTLE_ENDIAN);
+    public static final ValueLayout BITS_16_LE = SharedLayouts.BITS_16_LE;
 
     /**
      * A value layout constant with size of four bytes, and byte order set to {@link ByteOrder#LITTLE_ENDIAN}.
      */
-    public static final ValueLayout BITS_32_LE = MemoryLayout.ofValueBits(32, ByteOrder.LITTLE_ENDIAN);
+    public static final ValueLayout BITS_32_LE = SharedLayouts.BITS_32_LE;
 
     /**
      * A value layout constant with size of eight bytes, and byte order set to {@link ByteOrder#LITTLE_ENDIAN}.
      */
-    public static final ValueLayout BITS_64_LE = MemoryLayout.ofValueBits(64, ByteOrder.LITTLE_ENDIAN);
+    public static final ValueLayout BITS_64_LE = SharedLayouts.BITS_64_LE;
 
     /**
      * A value layout constant with size of one byte, and byte order set to {@link ByteOrder#BIG_ENDIAN}.
@@ -135,4 +142,465 @@ public final class MemoryLayouts {
      * A value layout constant whose size is the same as that of a Java {@code double}, and byte order set to {@link ByteOrder#nativeOrder()}.
      */
     public static final ValueLayout JAVA_DOUBLE = MemoryLayout.ofValueBits(64, ByteOrder.nativeOrder());
+
+    /**
+     * The {@code _Bool} native type.
+     */
+    public static final ValueLayout C_BOOL;
+
+    /**
+     * The {@code unsigned char} native type.
+     */
+    public static final ValueLayout C_UCHAR;
+
+    /**
+     * The {@code signed char} native type.
+     */
+    public static final ValueLayout C_SCHAR ;
+
+    /**
+     * The {@code char} native type.
+     */
+    public static final ValueLayout C_CHAR;
+
+    /**
+     * The {@code short} native type.
+     */
+    public static final ValueLayout C_SHORT;
+
+    /**
+     * The {@code unsigned short} native type.
+     */
+    public static final ValueLayout C_USHORT;
+
+    /**
+     * The {@code int} native type.
+     */
+    public static final ValueLayout C_INT;
+
+    /**
+     * The {@code unsigned int} native type.
+     */
+    public static final ValueLayout C_UINT;
+
+    /**
+     * The {@code long} native type.
+     */
+    public static final ValueLayout C_LONG;
+
+    /**
+     * The {@code unsigned long} native type.
+     */
+    public static final ValueLayout C_ULONG;
+
+    /**
+     * The {@code long long} native type.
+     */
+    public static final ValueLayout C_LONGLONG;
+
+    /**
+     * The {@code unsigned long long} native type.
+     */
+    public static final ValueLayout C_ULONGLONG;
+
+    /**
+     * The {@code float} native type.
+     */
+    public static final ValueLayout C_FLOAT;
+
+    /**
+     * The {@code double} native type.
+     */
+    public static final ValueLayout C_DOUBLE;
+
+    /**
+     * The {@code T*} native type.
+     */
+    public static final ValueLayout C_POINTER;
+
+    static {
+        SystemABI abi = InternalForeign.getInstancePrivileged().getSystemABI();
+        switch (abi.name()) {
+            case ABI_SYSV -> {
+                C_BOOL = SysV.C_BOOL;
+                C_UCHAR = SysV.C_UCHAR;
+                C_SCHAR = SysV.C_SCHAR;
+                C_CHAR = SysV.C_CHAR;
+                C_SHORT = SysV.C_SHORT;
+                C_USHORT = SysV.C_USHORT;
+                C_INT = SysV.C_INT;
+                C_UINT = SysV.C_UINT;
+                C_LONG = SysV.C_LONG;
+                C_ULONG = SysV.C_ULONG;
+                C_LONGLONG = SysV.C_LONGLONG;
+                C_ULONGLONG = SysV.C_ULONGLONG;
+                C_FLOAT = SysV.C_FLOAT;
+                C_DOUBLE = SysV.C_DOUBLE;
+                C_POINTER = SysV.C_POINTER;
+            }
+            case ABI_WINDOWS -> {
+                C_BOOL = WinABI.C_BOOL;
+                C_UCHAR = WinABI.C_UCHAR;
+                C_SCHAR = WinABI.C_SCHAR;
+                C_CHAR = WinABI.C_CHAR;
+                C_SHORT = WinABI.C_SHORT;
+                C_USHORT = WinABI.C_USHORT;
+                C_INT = WinABI.C_INT;
+                C_UINT = WinABI.C_UINT;
+                C_LONG = WinABI.C_LONG;
+                C_ULONG = WinABI.C_ULONG;
+                C_LONGLONG = WinABI.C_LONGLONG;
+                C_ULONGLONG = WinABI.C_ULONGLONG;
+                C_FLOAT = WinABI.C_FLOAT;
+                C_DOUBLE = WinABI.C_DOUBLE;
+                C_POINTER = WinABI.C_POINTER;
+            }
+            case ABI_AARCH64 -> {
+                C_BOOL = AArch64ABI.C_BOOL;
+                C_UCHAR = AArch64ABI.C_UCHAR;
+                C_SCHAR = AArch64ABI.C_SCHAR;
+                C_CHAR = AArch64ABI.C_CHAR;
+                C_SHORT = AArch64ABI.C_SHORT;
+                C_USHORT = AArch64ABI.C_USHORT;
+                C_INT = AArch64ABI.C_INT;
+                C_UINT = AArch64ABI.C_UINT;
+                C_LONG = AArch64ABI.C_LONG;
+                C_ULONG = AArch64ABI.C_ULONG;
+                C_LONGLONG = AArch64ABI.C_LONGLONG;
+                C_ULONGLONG = AArch64ABI.C_ULONGLONG;
+                C_FLOAT = AArch64ABI.C_FLOAT;
+                C_DOUBLE = AArch64ABI.C_DOUBLE;
+                C_POINTER = AArch64ABI.C_POINTER;
+            }
+            default -> throw new IllegalStateException("Unsupported ABI: " + abi.name());
+        }
+    }
+
+    /**
+     * This class defines layout constants modelling standard primitive types supported by the x64 SystemV ABI.
+     */
+    public static final class SysV {
+        private SysV() {
+            //just the one
+        }
+
+        /**
+         * The {@code _Bool} native type.
+         */
+        public static final ValueLayout C_BOOL = SharedLayouts.BITS_8_LE
+                .withAttribute(SystemABI.NATIVE_TYPE, SystemABI.Type.BOOL);
+
+
+        /**
+         * The {@code unsigned char} native type.
+         */
+        public static final ValueLayout C_UCHAR = SharedLayouts.BITS_8_LE
+                .withAttribute(SystemABI.NATIVE_TYPE, SystemABI.Type.UNSIGNED_CHAR);
+
+
+        /**
+         * The {@code signed char} native type.
+         */
+        public static final ValueLayout C_SCHAR = SharedLayouts.BITS_8_LE
+                .withAttribute(SystemABI.NATIVE_TYPE, SystemABI.Type.SIGNED_CHAR);
+
+
+        /**
+         * The {@code char} native type.
+         */
+        public static final ValueLayout C_CHAR = SharedLayouts.BITS_8_LE
+                .withAttribute(SystemABI.NATIVE_TYPE, SystemABI.Type.CHAR);
+
+        /**
+         * The {@code short} native type.
+         */
+        public static final ValueLayout C_SHORT = SharedLayouts.BITS_16_LE
+                .withAttribute(SystemABI.NATIVE_TYPE, SystemABI.Type.SHORT);
+
+        /**
+         * The {@code unsigned short} native type.
+         */
+        public static final ValueLayout C_USHORT = SharedLayouts.BITS_16_LE
+                .withAttribute(SystemABI.NATIVE_TYPE, SystemABI.Type.UNSIGNED_SHORT);
+
+        /**
+         * The {@code int} native type.
+         */
+        public static final ValueLayout C_INT = SharedLayouts.BITS_32_LE
+                .withAttribute(SystemABI.NATIVE_TYPE, SystemABI.Type.INT);
+
+        /**
+         * The {@code unsigned int} native type.
+         */
+        public static final ValueLayout C_UINT = SharedLayouts.BITS_32_LE
+                .withAttribute(SystemABI.NATIVE_TYPE, SystemABI.Type.UNSIGNED_INT);
+
+        /**
+         * The {@code long} native type.
+         */
+        public static final ValueLayout C_LONG = SharedLayouts.BITS_64_LE
+                .withAttribute(SystemABI.NATIVE_TYPE, SystemABI.Type.LONG);
+
+        /**
+         * The {@code unsigned long} native type.
+         */
+        public static final ValueLayout C_ULONG = SharedLayouts.BITS_64_LE
+                .withAttribute(SystemABI.NATIVE_TYPE, SystemABI.Type.UNSIGNED_LONG);
+
+
+        /**
+         * The {@code long long} native type.
+         */
+        public static final ValueLayout C_LONGLONG = SharedLayouts.BITS_64_LE
+                .withAttribute(SystemABI.NATIVE_TYPE, SystemABI.Type.LONG_LONG);
+
+        /**
+         * The {@code unsigned long long} native type.
+         */
+        public static final ValueLayout C_ULONGLONG = SharedLayouts.BITS_64_LE
+                .withAttribute(SystemABI.NATIVE_TYPE, SystemABI.Type.UNSIGNED_LONG_LONG);
+
+        /**
+         * The {@code float} native type.
+         */
+        public static final ValueLayout C_FLOAT = SharedLayouts.BITS_32_LE
+                .withAttribute(SystemABI.NATIVE_TYPE, SystemABI.Type.FLOAT);
+
+        /**
+         * The {@code double} native type.
+         */
+        public static final ValueLayout C_DOUBLE = SharedLayouts.BITS_64_LE
+                .withAttribute(SystemABI.NATIVE_TYPE, SystemABI.Type.DOUBLE);
+
+        /**
+         * The {@code long double} native type.
+         */
+        public static final ValueLayout C_LONGDOUBLE = MemoryLayout.ofValueBits(128, ByteOrder.LITTLE_ENDIAN)
+                .withAttribute(SystemABI.NATIVE_TYPE, SystemABI.Type.LONG_DOUBLE);
+
+        /**
+         * The {@code complex long double} native type.
+         */
+        public static final GroupLayout C_COMPLEX_LONGDOUBLE = MemoryLayout.ofStruct(C_LONGDOUBLE, C_LONGDOUBLE)
+                .withAttribute(SystemABI.NATIVE_TYPE, SystemABI.Type.COMPLEX_LONG_DOUBLE);
+
+        /**
+         * The {@code T*} native type.
+         */
+        public static final ValueLayout C_POINTER = SharedLayouts.BITS_64_LE
+                .withAttribute(SystemABI.NATIVE_TYPE, SystemABI.Type.POINTER);
+    }
+
+    /**
+     * This class defines layout constants modelling standard primitive types supported by the x64 Windows ABI.
+     */
+    public static final class WinABI {
+        /**
+         * The {@code _Bool} native type.
+         */
+        public static final ValueLayout C_BOOL = SharedLayouts.BITS_8_LE
+                .withAttribute(SystemABI.NATIVE_TYPE, SystemABI.Type.BOOL);
+
+        /**
+         * The {@code unsigned char} native type.
+         */
+        public static final ValueLayout C_UCHAR = SharedLayouts.BITS_8_LE
+                .withAttribute(SystemABI.NATIVE_TYPE, SystemABI.Type.UNSIGNED_CHAR);
+
+        /**
+         * The {@code signed char} native type.
+         */
+        public static final ValueLayout C_SCHAR = SharedLayouts.BITS_8_LE
+                .withAttribute(SystemABI.NATIVE_TYPE, SystemABI.Type.SIGNED_CHAR);
+
+        /**
+         * The {@code char} native type.
+         */
+        public static final ValueLayout C_CHAR = SharedLayouts.BITS_8_LE
+                .withAttribute(SystemABI.NATIVE_TYPE, SystemABI.Type.CHAR);
+
+        /**
+         * The {@code short} native type.
+         */
+        public static final ValueLayout C_SHORT = SharedLayouts.BITS_16_LE
+                .withAttribute(SystemABI.NATIVE_TYPE, SystemABI.Type.SHORT);
+
+        /**
+         * The {@code unsigned short} native type.
+         */
+        public static final ValueLayout C_USHORT = SharedLayouts.BITS_16_LE
+                .withAttribute(SystemABI.NATIVE_TYPE, SystemABI.Type.UNSIGNED_SHORT);
+
+        /**
+         * The {@code int} native type.
+         */
+        public static final ValueLayout C_INT = SharedLayouts.BITS_32_LE
+                .withAttribute(SystemABI.NATIVE_TYPE, SystemABI.Type.INT);
+
+        /**
+         * The {@code unsigned int} native type.
+         */
+        public static final ValueLayout C_UINT = SharedLayouts.BITS_32_LE
+                .withAttribute(SystemABI.NATIVE_TYPE, SystemABI.Type.UNSIGNED_INT);
+
+        /**
+         * The {@code long} native type.
+         */
+        public static final ValueLayout C_LONG = SharedLayouts.BITS_32_LE
+                .withAttribute(SystemABI.NATIVE_TYPE, SystemABI.Type.LONG);
+
+        /**
+         * The {@code unsigned long} native type.
+         */
+        public static final ValueLayout C_ULONG = SharedLayouts.BITS_32_LE
+                .withAttribute(SystemABI.NATIVE_TYPE, SystemABI.Type.UNSIGNED_LONG);
+
+        /**
+         * The {@code long long} native type.
+         */
+        public static final ValueLayout C_LONGLONG = SharedLayouts.BITS_64_LE
+                .withAttribute(SystemABI.NATIVE_TYPE, SystemABI.Type.LONG_LONG);
+
+        /**
+         * The {@code unsigned long long} native type.
+         */
+        public static final ValueLayout C_ULONGLONG = SharedLayouts.BITS_64_LE
+                .withAttribute(SystemABI.NATIVE_TYPE, SystemABI.Type.UNSIGNED_LONG_LONG);
+
+        /**
+         * The {@code float} native type.
+         */
+        public static final ValueLayout C_FLOAT = SharedLayouts.BITS_32_LE
+                .withAttribute(SystemABI.NATIVE_TYPE, SystemABI.Type.FLOAT);
+
+        /**
+         * The {@code double} native type.
+         */
+        public static final ValueLayout C_DOUBLE = SharedLayouts.BITS_64_LE
+                .withAttribute(SystemABI.NATIVE_TYPE, SystemABI.Type.DOUBLE);
+
+        /**
+         * The {@code long double} native type.
+         */
+        public static final ValueLayout C_LONGDOUBLE = SharedLayouts.BITS_64_LE
+                .withAttribute(SystemABI.NATIVE_TYPE, SystemABI.Type.LONG_DOUBLE);
+
+        /**
+         * The {@code T*} native type.
+         */
+        public static final ValueLayout C_POINTER = SharedLayouts.BITS_64_LE
+                .withAttribute(SystemABI.NATIVE_TYPE, SystemABI.Type.POINTER);
+
+        public static ValueLayout asVarArg(ValueLayout l) {
+           return l.withAttribute(Windowsx64ABI.VARARGS_ATTRIBUTE_NAME, "true");
+        }
+    }
+
+    /**
+     * This class defines layout constants modelling standard primitive types supported by the AArch64 ABI.
+     */
+    public static final class AArch64ABI {
+        /**
+         * The {@code _Bool} native type.
+         */
+        public static final ValueLayout C_BOOL = SharedLayouts.BITS_8_LE
+                .withAttribute(SystemABI.NATIVE_TYPE, SystemABI.Type.BOOL);
+
+        /**
+         * The {@code unsigned char} native type.
+         */
+        public static final ValueLayout C_UCHAR = SharedLayouts.BITS_8_LE
+                .withAttribute(SystemABI.NATIVE_TYPE, SystemABI.Type.UNSIGNED_CHAR);
+
+        /**
+         * The {@code signed char} native type.
+         */
+        public static final ValueLayout C_SCHAR = SharedLayouts.BITS_8_LE
+                .withAttribute(SystemABI.NATIVE_TYPE, SystemABI.Type.SIGNED_CHAR);
+
+        /**
+         * The {@code char} native type.
+         */
+        public static final ValueLayout C_CHAR = SharedLayouts.BITS_8_LE
+                .withAttribute(SystemABI.NATIVE_TYPE, SystemABI.Type.CHAR);
+
+        /**
+         * The {@code short} native type.
+         */
+        public static final ValueLayout C_SHORT = SharedLayouts.BITS_16_LE
+                .withAttribute(SystemABI.NATIVE_TYPE, SystemABI.Type.SHORT);
+
+        /**
+         * The {@code unsigned short} native type.
+         */
+        public static final ValueLayout C_USHORT = SharedLayouts.BITS_16_LE
+                .withAttribute(SystemABI.NATIVE_TYPE, SystemABI.Type.UNSIGNED_SHORT);
+
+        /**
+         * The {@code int} native type.
+         */
+        public static final ValueLayout C_INT = SharedLayouts.BITS_32_LE
+                .withAttribute(SystemABI.NATIVE_TYPE, SystemABI.Type.INT);
+
+        /**
+         * The {@code unsigned int} native type.
+         */
+        public static final ValueLayout C_UINT = SharedLayouts.BITS_32_LE
+                .withAttribute(SystemABI.NATIVE_TYPE, SystemABI.Type.UNSIGNED_INT);
+
+        /**
+         * The {@code long} native type.
+         */
+        public static final ValueLayout C_LONG = SharedLayouts.BITS_64_LE
+                .withAttribute(SystemABI.NATIVE_TYPE, SystemABI.Type.LONG);
+
+        /**
+         * The {@code unsigned long} native type.
+         */
+        public static final ValueLayout C_ULONG = SharedLayouts.BITS_64_LE
+                .withAttribute(SystemABI.NATIVE_TYPE, SystemABI.Type.UNSIGNED_LONG);
+
+        /**
+         * The {@code long long} native type.
+         */
+        public static final ValueLayout C_LONGLONG = SharedLayouts.BITS_64_LE
+                .withAttribute(SystemABI.NATIVE_TYPE, SystemABI.Type.LONG_LONG);
+
+        /**
+         * The {@code unsigned long long} native type.
+         */
+        public static final ValueLayout C_ULONGLONG = SharedLayouts.BITS_64_LE
+                .withAttribute(SystemABI.NATIVE_TYPE, SystemABI.Type.UNSIGNED_LONG_LONG);
+
+        /**
+         * The {@code float} native type.
+         */
+        public static final ValueLayout C_FLOAT = SharedLayouts.BITS_32_LE
+                .withAttribute(SystemABI.NATIVE_TYPE, SystemABI.Type.FLOAT);
+
+        /**
+         * The {@code double} native type.
+         */
+        public static final ValueLayout C_DOUBLE = SharedLayouts.BITS_64_LE
+                .withAttribute(SystemABI.NATIVE_TYPE, SystemABI.Type.DOUBLE);
+
+        /**
+         * The {@code long double} native type.
+         */
+        public static final ValueLayout C_LONGDOUBLE = MemoryLayout.ofValueBits(128, ByteOrder.LITTLE_ENDIAN)
+                .withAttribute(SystemABI.NATIVE_TYPE, SystemABI.Type.LONG_DOUBLE);
+
+        /**
+         * The {@code T*} native type.
+         */
+        public static final ValueLayout C_POINTER = SharedLayouts.BITS_64_LE
+                .withAttribute(SystemABI.NATIVE_TYPE, SystemABI.Type.POINTER);
+    }
+
+    private static class SharedLayouts { // Separate class to prevent circular clinit references
+        public static final ValueLayout BITS_8_LE = MemoryLayout.ofValueBits(8, ByteOrder.LITTLE_ENDIAN);
+        public static final ValueLayout BITS_16_LE = MemoryLayout.ofValueBits(16, ByteOrder.LITTLE_ENDIAN);
+        public static final ValueLayout BITS_32_LE = MemoryLayout.ofValueBits(32, ByteOrder.LITTLE_ENDIAN);
+        public static final ValueLayout BITS_64_LE = MemoryLayout.ofValueBits(64, ByteOrder.LITTLE_ENDIAN);
+    }
 }

--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/SystemABI.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/SystemABI.java
@@ -25,12 +25,11 @@
  */
 package jdk.incubator.foreign;
 
-import jdk.internal.foreign.Utils;
 import jdk.internal.foreign.abi.UpcallStubs;
 
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodType;
-import java.nio.ByteOrder;
+import java.util.Optional;
 
 /**
  * This class models a system application binary interface (ABI).
@@ -38,6 +37,25 @@ import java.nio.ByteOrder;
  * Instances of this class can be obtained by calling {@link Foreign#getSystemABI()}
  */
 public interface SystemABI {
+    /**
+     * The name of the SysV ABI
+     */
+    String ABI_SYSV = "SysV";
+
+    /**
+     * The name of the Windows ABI
+     */
+    String ABI_WINDOWS = "Windows";
+
+    /**
+     * The name of the AArch64 ABI
+     */
+    String ABI_AARCH64 = "AArch64";
+
+    /**
+     * memory layout attribute key for abi native type
+     */
+    String NATIVE_TYPE = "abi/native-type";
 
     /**
      * Obtain a method handle which can be used to call a given native function.
@@ -77,457 +95,111 @@ public interface SystemABI {
      */
     String name();
 
-    /**
-     * The {@code _Bool} native type.
-     */
-     ValueLayout C_BOOL = Utils.pick(SysV.C_BOOL, Win64.C_BOOL, AArch64.C_BOOL);
-
-    /**
-     * The {@code unsigned char} native type.
-     */
-     ValueLayout C_UCHAR = Utils.pick(SysV.C_UCHAR, Win64.C_UCHAR, AArch64.C_UCHAR);
-
-    /**
-     * The {@code signed char} native type.
-     */
-     ValueLayout C_SCHAR = Utils.pick(SysV.C_SCHAR, Win64.C_SCHAR, AArch64.C_SCHAR) ;
-
-    /**
-     * The {@code char} native type.
-     */
-     ValueLayout C_CHAR = Utils.pick(SysV.C_CHAR, Win64.C_CHAR, AArch64.C_CHAR);
-
-    /**
-     * The {@code short} native type.
-     */
-     ValueLayout C_SHORT = Utils.pick(SysV.C_SHORT, Win64.C_SHORT, AArch64.C_SHORT);
-
-    /**
-     * The {@code unsigned short} native type.
-     */
-     ValueLayout C_USHORT = Utils.pick(SysV.C_USHORT, Win64.C_USHORT, AArch64.C_USHORT);
-
-    /**
-     * The {@code int} native type.
-     */
-     ValueLayout C_INT = Utils.pick(SysV.C_INT, Win64.C_INT, AArch64.C_INT);
-
-    /**
-     * The {@code unsigned int} native type.
-     */
-     ValueLayout C_UINT = Utils.pick(SysV.C_UINT, Win64.C_UINT, AArch64.C_UINT);
-
-    /**
-     * The {@code long} native type.
-     */
-     ValueLayout C_LONG = Utils.pick(SysV.C_LONG, Win64.C_LONG, AArch64.C_LONG);
-
-    /**
-     * The {@code unsigned long} native type.
-     */
-     ValueLayout C_ULONG = Utils.pick(SysV.C_ULONG, Win64.C_ULONG, AArch64.C_ULONG);
-
-    /**
-     * The {@code long long} native type.
-     */
-     ValueLayout C_LONGLONG = Utils.pick(SysV.C_LONGLONG, Win64.C_LONGLONG, AArch64.C_LONGLONG);
-
-    /**
-     * The {@code unsigned long long} native type.
-     */
-     ValueLayout C_ULONGLONG = Utils.pick(SysV.C_ULONGLONG, Win64.C_ULONGLONG, AArch64.C_ULONGLONG);
-
-    /**
-     * The {@code float} native type.
-     */
-     ValueLayout C_FLOAT = Utils.pick(SysV.C_FLOAT, Win64.C_FLOAT, AArch64.C_FLOAT);
-
-    /**
-     * The {@code double} native type.
-     */
-     ValueLayout C_DOUBLE = Utils.pick(SysV.C_DOUBLE, Win64.C_DOUBLE, AArch64.C_DOUBLE);
-
-    /**
-     * The {@code long double} native type.
-     */
-    ValueLayout C_LONGDOUBLE = Utils.pick(SysV.C_LONGDOUBLE, Win64.C_LONGDOUBLE, AArch64.C_LONGDOUBLE);
-
-    /**
-     * The {@code T*} native type.
-     */
-     ValueLayout C_POINTER = Utils.pick(SysV.C_POINTER, Win64.C_POINTER, AArch64.C_POINTER);
-
-    /**
-     * This class defines layout constants modelling standard primitive types supported by the x64 SystemV ABI.
-     */
-    final class SysV {
-        private SysV() {
-            //just the one
-        }
-
-        /**
-         * The name of the SysV ABI
-         */
-        public static final String NAME = "SysV";
-
-        public final static String CLASS_ATTRIBUTE_NAME = "abi/sysv/class";
-
-        public enum ArgumentClass {
-            INTEGER,
-            SSE,
-            X87,
-            COMPLEX_87,
-            POINTER;
-        }
-
+    enum Type {
         /**
          * The {@code _Bool} native type.
          */
-        public static final ValueLayout C_BOOL = MemoryLayouts.BITS_8_LE
-                .withAttribute(CLASS_ATTRIBUTE_NAME, ArgumentClass.INTEGER);
-
+        BOOL,
 
         /**
          * The {@code unsigned char} native type.
          */
-        public static final ValueLayout C_UCHAR = MemoryLayouts.BITS_8_LE
-                .withAttribute(CLASS_ATTRIBUTE_NAME, ArgumentClass.INTEGER);
-
+        UNSIGNED_CHAR,
 
         /**
          * The {@code signed char} native type.
          */
-        public static final ValueLayout C_SCHAR = MemoryLayouts.BITS_8_LE
-                .withAttribute(CLASS_ATTRIBUTE_NAME, ArgumentClass.INTEGER);
-
+        SIGNED_CHAR,
 
         /**
          * The {@code char} native type.
          */
-        public static final ValueLayout C_CHAR = MemoryLayouts.BITS_8_LE
-                .withAttribute(CLASS_ATTRIBUTE_NAME, ArgumentClass.INTEGER);
+        CHAR,
 
         /**
          * The {@code short} native type.
          */
-        public static final ValueLayout C_SHORT = MemoryLayouts.BITS_16_LE
-                .withAttribute(CLASS_ATTRIBUTE_NAME, ArgumentClass.INTEGER);
+        SHORT,
 
         /**
          * The {@code unsigned short} native type.
          */
-        public static final ValueLayout C_USHORT = MemoryLayouts.BITS_16_LE
-                .withAttribute(CLASS_ATTRIBUTE_NAME, ArgumentClass.INTEGER);
+        UNSIGNED_SHORT,
 
         /**
          * The {@code int} native type.
          */
-        public static final ValueLayout C_INT = MemoryLayouts.BITS_32_LE
-                .withAttribute(CLASS_ATTRIBUTE_NAME, ArgumentClass.INTEGER);
+        INT,
 
         /**
          * The {@code unsigned int} native type.
          */
-        public static final ValueLayout C_UINT = MemoryLayouts.BITS_32_LE
-                .withAttribute(CLASS_ATTRIBUTE_NAME, ArgumentClass.INTEGER);
+        UNSIGNED_INT,
 
         /**
          * The {@code long} native type.
          */
-        public static final ValueLayout C_LONG = MemoryLayouts.BITS_64_LE
-                .withAttribute(CLASS_ATTRIBUTE_NAME, ArgumentClass.INTEGER);
+        LONG,
 
         /**
          * The {@code unsigned long} native type.
          */
-        public static final ValueLayout C_ULONG = MemoryLayouts.BITS_64_LE
-                .withAttribute(CLASS_ATTRIBUTE_NAME, ArgumentClass.INTEGER);
-
+        UNSIGNED_LONG,
 
         /**
          * The {@code long long} native type.
          */
-        public static final ValueLayout C_LONGLONG = MemoryLayouts.BITS_64_LE
-                .withAttribute(CLASS_ATTRIBUTE_NAME, ArgumentClass.INTEGER);
+        LONG_LONG,
 
         /**
          * The {@code unsigned long long} native type.
          */
-        public static final ValueLayout C_ULONGLONG = MemoryLayouts.BITS_64_LE
-                .withAttribute(CLASS_ATTRIBUTE_NAME, ArgumentClass.INTEGER);
+        UNSIGNED_LONG_LONG,
 
         /**
          * The {@code float} native type.
          */
-        public static final ValueLayout C_FLOAT = MemoryLayouts.BITS_32_LE
-                .withAttribute(CLASS_ATTRIBUTE_NAME, ArgumentClass.SSE);
+        FLOAT,
 
         /**
          * The {@code double} native type.
          */
-        public static final ValueLayout C_DOUBLE = MemoryLayouts.BITS_64_LE
-                .withAttribute(CLASS_ATTRIBUTE_NAME, ArgumentClass.SSE);
+        DOUBLE,
 
         /**
          * The {@code long double} native type.
          */
-        public static final ValueLayout C_LONGDOUBLE = MemoryLayout.ofValueBits(128, ByteOrder.LITTLE_ENDIAN)
-                .withAttribute(CLASS_ATTRIBUTE_NAME, ArgumentClass.X87);
+        LONG_DOUBLE,
 
         /**
          * The {@code complex long double} native type.
          */
-        public static final GroupLayout C_COMPLEX_LONGDOUBLE = MemoryLayout.ofStruct(C_LONGDOUBLE, C_LONGDOUBLE)
-                .withAttribute(CLASS_ATTRIBUTE_NAME, ArgumentClass.COMPLEX_87);
+        COMPLEX_LONG_DOUBLE,
 
         /**
          * The {@code T*} native type.
          */
-        public static final ValueLayout C_POINTER = MemoryLayouts.BITS_64_LE
-                .withAttribute(CLASS_ATTRIBUTE_NAME, ArgumentClass.POINTER);
-    }
-
-    /**
-     * This class defines layout constants modelling standard primitive types supported by the x64 Windows ABI.
-     */
-    final class Win64 {
-
-        private Win64() {
-            //just the one
-        }
+        POINTER;
 
         /**
-         * The name of the Windows ABI
+         * Retrieve the ABI type attached to the given layout,
+         * or throw an {@code IllegalArgumentException} if there is none
+         *
+         * @param ml the layout to retrieve the ABI type of
+         * @return the retrieved ABI type
+         * @throws IllegalArgumentException if the given layout does not have an ABI type attribute
          */
-        public final static String NAME = "Windows";
-
-        public final static String VARARGS_ATTRIBUTE_NAME = "abi/windows/varargs";
-
-        public final static String CLASS_ATTRIBUTE_NAME = "abi/windows/class";
-
-        public enum ArgumentClass {
-            INTEGER,
-            FLOAT,
-            POINTER;
-        }
-
-        /**
-         * The {@code _Bool} native type.
-         */
-        public static final ValueLayout C_BOOL = MemoryLayouts.BITS_8_LE
-                .withAttribute(CLASS_ATTRIBUTE_NAME, ArgumentClass.INTEGER);
-
-        /**
-         * The {@code unsigned char} native type.
-         */
-        public static final ValueLayout C_UCHAR = MemoryLayouts.BITS_8_LE
-                .withAttribute(CLASS_ATTRIBUTE_NAME, ArgumentClass.INTEGER);
-
-        /**
-         * The {@code signed char} native type.
-         */
-        public static final ValueLayout C_SCHAR = MemoryLayouts.BITS_8_LE
-                .withAttribute(CLASS_ATTRIBUTE_NAME, ArgumentClass.INTEGER);
-
-        /**
-         * The {@code char} native type.
-         */
-        public static final ValueLayout C_CHAR = MemoryLayouts.BITS_8_LE
-                .withAttribute(CLASS_ATTRIBUTE_NAME, ArgumentClass.INTEGER);
-
-        /**
-         * The {@code short} native type.
-         */
-        public static final ValueLayout C_SHORT = MemoryLayouts.BITS_16_LE
-                .withAttribute(CLASS_ATTRIBUTE_NAME, ArgumentClass.INTEGER);
-
-        /**
-         * The {@code unsigned short} native type.
-         */
-        public static final ValueLayout C_USHORT = MemoryLayouts.BITS_16_LE
-                .withAttribute(CLASS_ATTRIBUTE_NAME, ArgumentClass.INTEGER);
-
-        /**
-         * The {@code int} native type.
-         */
-        public static final ValueLayout C_INT = MemoryLayouts.BITS_32_LE
-                .withAttribute(CLASS_ATTRIBUTE_NAME, ArgumentClass.INTEGER);
-
-        /**
-         * The {@code unsigned int} native type.
-         */
-        public static final ValueLayout C_UINT = MemoryLayouts.BITS_32_LE
-                .withAttribute(CLASS_ATTRIBUTE_NAME, ArgumentClass.INTEGER);
-
-        /**
-         * The {@code long} native type.
-         */
-        public static final ValueLayout C_LONG = MemoryLayouts.BITS_32_LE
-                .withAttribute(CLASS_ATTRIBUTE_NAME, ArgumentClass.INTEGER);
-
-        /**
-         * The {@code unsigned long} native type.
-         */
-        public static final ValueLayout C_ULONG = MemoryLayouts.BITS_32_LE
-                .withAttribute(CLASS_ATTRIBUTE_NAME, ArgumentClass.INTEGER);
-
-        /**
-         * The {@code long long} native type.
-         */
-        public static final ValueLayout C_LONGLONG = MemoryLayouts.BITS_64_LE
-                .withAttribute(CLASS_ATTRIBUTE_NAME, ArgumentClass.INTEGER);
-
-        /**
-         * The {@code unsigned long long} native type.
-         */
-        public static final ValueLayout C_ULONGLONG = MemoryLayouts.BITS_64_LE
-                .withAttribute(CLASS_ATTRIBUTE_NAME, ArgumentClass.INTEGER);
-
-        /**
-         * The {@code float} native type.
-         */
-        public static final ValueLayout C_FLOAT = MemoryLayouts.BITS_32_LE
-                .withAttribute(CLASS_ATTRIBUTE_NAME, ArgumentClass.FLOAT);
-
-        /**
-         * The {@code double} native type.
-         */
-        public static final ValueLayout C_DOUBLE = MemoryLayouts.BITS_64_LE
-                .withAttribute(CLASS_ATTRIBUTE_NAME, ArgumentClass.FLOAT);
-
-        /**
-         * The {@code long double} native type.
-         */
-        public static final ValueLayout C_LONGDOUBLE = MemoryLayouts.BITS_64_LE
-                .withAttribute(CLASS_ATTRIBUTE_NAME, ArgumentClass.FLOAT);
-
-        /**
-         * The {@code T*} native type.
-         */
-        public static final ValueLayout C_POINTER = MemoryLayouts.BITS_64_LE
-                .withAttribute(CLASS_ATTRIBUTE_NAME, ArgumentClass.POINTER);
-
-        public static ValueLayout asVarArg(ValueLayout l) {
-            return l.withAttribute(VARARGS_ATTRIBUTE_NAME, "true");
+        public static Type fromLayout(MemoryLayout ml) throws IllegalArgumentException {
+            return ml.attribute(NATIVE_TYPE)
+                     .map(SystemABI.Type.class::cast)
+                     .orElseThrow(() -> new IllegalArgumentException("No ABI attribute present"));
         }
     }
 
     /**
-     * This class defines layout constants modelling standard primitive types supported by the AArch64 ABI.
+     * Returns memory layout for the given native type if supported by the platform ABI.
+     * @param type the native type for which the layout is to be retrieved.
+     * @return the layout (if any) associated with {@code type}
      */
-    final class AArch64 {
-
-        private AArch64() {
-            //just the one
-        }
-
-        /**
-         * The name of the AArch64 ABI
-         */
-        public final static String NAME = "AArch64";
-
-        public static final String CLASS_ATTRIBUTE_NAME = "abi/aarch64/class";
-
-        public enum ArgumentClass {
-            INTEGER,
-            VECTOR,
-            POINTER;
-        }
-
-        /**
-         * The {@code _Bool} native type.
-         */
-        public static final ValueLayout C_BOOL = MemoryLayouts.BITS_8_LE
-                .withAttribute(CLASS_ATTRIBUTE_NAME, ArgumentClass.INTEGER);
-
-        /**
-         * The {@code unsigned char} native type.
-         */
-        public static final ValueLayout C_UCHAR = MemoryLayouts.BITS_8_LE
-                .withAttribute(CLASS_ATTRIBUTE_NAME, ArgumentClass.INTEGER);
-
-        /**
-         * The {@code signed char} native type.
-         */
-        public static final ValueLayout C_SCHAR = MemoryLayouts.BITS_8_LE
-                .withAttribute(CLASS_ATTRIBUTE_NAME, ArgumentClass.INTEGER);
-
-        /**
-         * The {@code char} native type.
-         */
-        public static final ValueLayout C_CHAR = MemoryLayouts.BITS_8_LE
-                .withAttribute(CLASS_ATTRIBUTE_NAME, ArgumentClass.INTEGER);
-
-        /**
-         * The {@code short} native type.
-         */
-        public static final ValueLayout C_SHORT = MemoryLayouts.BITS_16_LE
-                .withAttribute(CLASS_ATTRIBUTE_NAME, ArgumentClass.INTEGER);
-
-        /**
-         * The {@code unsigned short} native type.
-         */
-        public static final ValueLayout C_USHORT = MemoryLayouts.BITS_16_LE
-                .withAttribute(CLASS_ATTRIBUTE_NAME, ArgumentClass.INTEGER);
-
-        /**
-         * The {@code int} native type.
-         */
-        public static final ValueLayout C_INT = MemoryLayouts.BITS_32_LE
-                .withAttribute(CLASS_ATTRIBUTE_NAME, ArgumentClass.INTEGER);
-
-        /**
-         * The {@code unsigned int} native type.
-         */
-        public static final ValueLayout C_UINT = MemoryLayouts.BITS_32_LE
-                .withAttribute(CLASS_ATTRIBUTE_NAME, ArgumentClass.INTEGER);
-
-        /**
-         * The {@code long} native type.
-         */
-        public static final ValueLayout C_LONG = MemoryLayouts.BITS_64_LE
-                .withAttribute(CLASS_ATTRIBUTE_NAME, ArgumentClass.INTEGER);
-
-        /**
-         * The {@code unsigned long} native type.
-         */
-        public static final ValueLayout C_ULONG = MemoryLayouts.BITS_64_LE
-                .withAttribute(CLASS_ATTRIBUTE_NAME, ArgumentClass.INTEGER);
-
-        /**
-         * The {@code long long} native type.
-         */
-        public static final ValueLayout C_LONGLONG = MemoryLayouts.BITS_64_LE
-                .withAttribute(CLASS_ATTRIBUTE_NAME, ArgumentClass.INTEGER);
-
-        /**
-         * The {@code unsigned long long} native type.
-         */
-        public static final ValueLayout C_ULONGLONG = MemoryLayouts.BITS_64_LE
-                .withAttribute(CLASS_ATTRIBUTE_NAME, ArgumentClass.INTEGER);
-
-        /**
-         * The {@code float} native type.
-         */
-        public static final ValueLayout C_FLOAT = MemoryLayouts.BITS_32_LE
-                .withAttribute(CLASS_ATTRIBUTE_NAME, ArgumentClass.VECTOR);
-
-        /**
-         * The {@code double} native type.
-         */
-        public static final ValueLayout C_DOUBLE = MemoryLayouts.BITS_64_LE
-                .withAttribute(CLASS_ATTRIBUTE_NAME, ArgumentClass.VECTOR);
-
-        /**
-         * The {@code long double} native type.
-         */
-        public static final ValueLayout C_LONGDOUBLE = MemoryLayout.ofValueBits(128, ByteOrder.LITTLE_ENDIAN)
-                .withAttribute(CLASS_ATTRIBUTE_NAME, ArgumentClass.VECTOR);
-
-        /**
-         * The {@code T*} native type.
-         */
-        public static final ValueLayout C_POINTER = MemoryLayouts.BITS_64_LE
-                .withAttribute(CLASS_ATTRIBUTE_NAME, ArgumentClass.POINTER);
-    }
+    Optional<MemoryLayout> layoutFor(Type type);
 }

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/Utils.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/Utils.java
@@ -27,9 +27,7 @@
 package jdk.internal.foreign;
 
 import jdk.incubator.foreign.MemoryAddress;
-import jdk.incubator.foreign.MemoryLayout;
 import jdk.incubator.foreign.MemorySegment;
-import jdk.incubator.foreign.SystemABI;
 import jdk.internal.access.JavaNioAccess;
 import jdk.internal.access.SharedSecrets;
 import jdk.internal.access.foreign.MemoryAddressProxy;
@@ -192,15 +190,5 @@ public final class Utils {
 
     private static MemoryAddressProxy filterAddress(MemoryAddress addr) {
         return (MemoryAddressImpl)addr;
-    }
-
-    public static <Z extends MemoryLayout> Z pick(Z sysv, Z win64, Z aarch64) {
-        SystemABI abi = InternalForeign.getInstancePrivileged().getSystemABI();
-        return switch (abi.name()) {
-            case SystemABI.SysV.NAME -> sysv;
-            case SystemABI.Win64.NAME -> win64;
-            case SystemABI.AArch64.NAME -> aarch64;
-            default -> throw new ExceptionInInitializerError("Unexpected ABI: " + abi.name());
-        };
     }
 }

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/aarch64/AArch64ABI.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/aarch64/AArch64ABI.java
@@ -29,10 +29,15 @@ import jdk.incubator.foreign.FunctionDescriptor;
 import jdk.incubator.foreign.MemoryAddress;
 import jdk.incubator.foreign.MemoryLayout;
 import jdk.incubator.foreign.SystemABI;
+import jdk.internal.foreign.MemoryAddressImpl;
 import jdk.internal.foreign.abi.*;
 
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodType;
+import java.util.Objects;
+import java.util.Optional;
+
+import static jdk.incubator.foreign.MemoryLayouts.AArch64ABI.*;
 
 /**
  * ABI implementation based on ARM document "Procedure Call Standard for
@@ -60,10 +65,40 @@ public class AArch64ABI implements SystemABI {
 
     @Override
     public String name() {
-        return AArch64.NAME;
+        return SystemABI.ABI_AARCH64;
     }
 
-    static AArch64.ArgumentClass argumentClassFor(MemoryLayout layout) {
-        return (AArch64.ArgumentClass)layout.attribute(AArch64.CLASS_ATTRIBUTE_NAME).get();
+    @Override
+    public Optional<MemoryLayout> layoutFor(Type type) {
+        return switch (Objects.requireNonNull(type)) {
+            case BOOL -> Optional.of(C_BOOL);
+            case UNSIGNED_CHAR -> Optional.of(C_UCHAR);
+            case SIGNED_CHAR -> Optional.of(C_SCHAR);
+            case CHAR -> Optional.of(C_CHAR);
+            case SHORT -> Optional.of(C_SHORT);
+            case UNSIGNED_SHORT -> Optional.of(C_USHORT);
+            case INT -> Optional.of(C_INT);
+            case UNSIGNED_INT -> Optional.of(C_UINT);
+            case LONG -> Optional.of(C_LONG);
+            case UNSIGNED_LONG -> Optional.of(C_ULONG);
+            case LONG_LONG -> Optional.of(C_LONGLONG);
+            case UNSIGNED_LONG_LONG -> Optional.of(C_ULONGLONG);
+            case FLOAT -> Optional.of(C_FLOAT);
+            case DOUBLE -> Optional.of(C_DOUBLE);
+            case LONG_DOUBLE -> Optional.of(C_LONGDOUBLE);
+            case POINTER -> Optional.of(C_POINTER);
+            default -> Optional.empty();
+        };
+    }
+
+    static ArgumentClassImpl argumentClassFor(Type type) {
+        return switch (Objects.requireNonNull(type)) {
+            case BOOL, UNSIGNED_CHAR, SIGNED_CHAR, CHAR, SHORT, UNSIGNED_SHORT,
+                INT, UNSIGNED_INT, LONG, UNSIGNED_LONG, LONG_LONG, UNSIGNED_LONG_LONG ->
+                    ArgumentClassImpl.INTEGER;
+            case FLOAT, DOUBLE -> ArgumentClassImpl.VECTOR;
+            case POINTER -> ArgumentClassImpl.POINTER;
+            default -> null;
+        };
     }
 }

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/aarch64/CallArranger.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/aarch64/CallArranger.java
@@ -107,7 +107,7 @@ public class CallArranger {
 
         boolean returnInMemory = isInMemoryReturn(cDesc.returnLayout());
         if (returnInMemory) {
-            csb.addArgumentBindings(MemoryAddress.class, SystemABI.AArch64.C_POINTER,
+            csb.addArgumentBindings(MemoryAddress.class, MemoryLayouts.AArch64ABI.C_POINTER,
                     argCalc.getIndirectBindings());
         } else if (cDesc.returnLayout().isPresent()) {
             Class<?> carrier = mt.returnType();
@@ -163,17 +163,17 @@ public class CallArranger {
     }
 
     private static TypeClass classifyValueType(ValueLayout type) {
-        SystemABI.AArch64.ArgumentClass clazz = AArch64ABI.argumentClassFor(type);
+        ArgumentClassImpl clazz = AArch64ABI.argumentClassFor(SystemABI.Type.fromLayout(type));
         if (clazz == null) {
             //padding not allowed here
             throw new IllegalStateException("Unexpected value layout: could not determine ABI class");
         }
 
-        if (clazz == SystemABI.AArch64.ArgumentClass.INTEGER) {
+        if (clazz == ArgumentClassImpl.INTEGER) {
             return TypeClass.INTEGER;
-        } else if(clazz == SystemABI.AArch64.ArgumentClass.POINTER) {
+        } else if(clazz == ArgumentClassImpl.POINTER) {
             return TypeClass.POINTER;
-        } else if (clazz == SystemABI.AArch64.ArgumentClass.VECTOR) {
+        } else if (clazz == ArgumentClassImpl.VECTOR) {
             return TypeClass.FLOAT;
         }
         throw new IllegalArgumentException("Unknown ABI class: " + clazz);
@@ -198,15 +198,15 @@ public class CallArranger {
         if (!(baseType instanceof ValueLayout))
             return false;
 
-        SystemABI.AArch64.ArgumentClass baseArgClass = AArch64ABI.argumentClassFor(baseType);
-        if (baseArgClass != SystemABI.AArch64.ArgumentClass.VECTOR)
+        ArgumentClassImpl baseArgClass = AArch64ABI.argumentClassFor(SystemABI.Type.fromLayout(baseType));
+        if (baseArgClass != ArgumentClassImpl.VECTOR)
            return false;
 
         for (MemoryLayout elem : groupLayout.memberLayouts()) {
             if (!(elem instanceof ValueLayout))
                 return false;
 
-            SystemABI.AArch64.ArgumentClass argClass = AArch64ABI.argumentClassFor(elem);
+            ArgumentClassImpl argClass = AArch64ABI.argumentClassFor(SystemABI.Type.fromLayout(elem));
             if (elem.bitSize() != baseType.bitSize() ||
                     elem.bitAlignment() != baseType.bitAlignment() ||
                     baseArgClass != argClass) {

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/x64/ArgumentClassImpl.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/x64/ArgumentClassImpl.java
@@ -1,12 +1,10 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 only, as
- * published by the Free Software Foundation.  Oracle designates this
- * particular file as subject to the "Classpath" exception as provided
- * by Oracle in the LICENSE file that accompanied this code.
+ * published by the Free Software Foundation.
  *
  * This code is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
@@ -22,7 +20,7 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
-package jdk.internal.foreign.abi.x64.sysv;
+package jdk.internal.foreign.abi.x64;
 
 public enum ArgumentClassImpl {
     POINTER, INTEGER, SSE, SSEUP, X87, X87UP, COMPLEX_X87, NO_CLASS, MEMORY;

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/x64/sysv/CallArranger.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/x64/sysv/CallArranger.java
@@ -29,6 +29,7 @@ import jdk.incubator.foreign.FunctionDescriptor;
 import jdk.incubator.foreign.GroupLayout;
 import jdk.incubator.foreign.MemoryAddress;
 import jdk.incubator.foreign.MemoryLayout;
+import jdk.incubator.foreign.MemoryLayouts;
 import jdk.incubator.foreign.MemorySegment;
 import jdk.incubator.foreign.SequenceLayout;
 import jdk.incubator.foreign.SystemABI;
@@ -43,6 +44,7 @@ import jdk.internal.foreign.abi.ProgrammableInvoker;
 import jdk.internal.foreign.abi.ProgrammableUpcallHandler;
 import jdk.internal.foreign.abi.VMStorage;
 import jdk.internal.foreign.abi.x64.X86_64Architecture;
+import jdk.internal.foreign.abi.x64.ArgumentClassImpl;
 import jdk.internal.foreign.abi.SharedUtils;
 
 import java.lang.invoke.MethodHandle;
@@ -58,7 +60,6 @@ import static jdk.internal.foreign.abi.Binding.*;
 import static jdk.internal.foreign.abi.x64.X86_64Architecture.*;
 import static jdk.internal.foreign.abi.x64.sysv.SysVx64ABI.MAX_INTEGER_ARGUMENT_REGISTERS;
 import static jdk.internal.foreign.abi.x64.sysv.SysVx64ABI.MAX_VECTOR_ARGUMENT_REGISTERS;
-import static jdk.internal.foreign.abi.x64.sysv.SysVx64ABI.argumentClassFor;
 
 /**
  * For the SysV x64 C ABI specifically, this class uses the ProgrammableInvoker API, namely CallingSequenceBuilder2
@@ -103,7 +104,7 @@ public class CallArranger {
         boolean returnInMemory = isInMemoryReturn(cDesc.returnLayout());
         if (returnInMemory) {
             Class<?> carrier = MemoryAddress.class;
-            MemoryLayout layout = SystemABI.SysV.C_POINTER;
+            MemoryLayout layout = MemoryLayouts.SysV.C_POINTER;
             csb.addArgumentBindings(carrier, layout, argCalc.getBindings(carrier, layout));
         } else if (cDesc.returnLayout().isPresent()) {
             Class<?> carrier = mt.returnType();
@@ -119,7 +120,7 @@ public class CallArranger {
 
         if (!forUpcall) {
             //add extra binding for number of used vector registers (used for variadic calls)
-            csb.addArgumentBindings(long.class, SystemABI.SysV.C_LONG,
+            csb.addArgumentBindings(long.class, MemoryLayouts.SysV.C_LONG,
                     List.of(move(rax, long.class)));
         }
 
@@ -428,8 +429,11 @@ public class CallArranger {
 
     private static List<ArgumentClassImpl> classifyValueType(ValueLayout type) {
         ArrayList<ArgumentClassImpl> classes = new ArrayList<>();
-        ArgumentClassImpl clazz = SysVx64ABI.argumentClassFor(type)
-                .orElseThrow(() -> new IllegalStateException("Unexpected value layout: could not determine ABI class"));
+        ArgumentClassImpl clazz = SysVx64ABI.argumentClassFor(SystemABI.Type.fromLayout(type));
+        if (clazz == null) {
+            //padding not allowed here
+            throw new IllegalStateException("Unexpected value layout: could not determine ABI class");
+        }
         classes.add(clazz);
         if (clazz == ArgumentClassImpl.INTEGER) {
             // int128
@@ -513,8 +517,10 @@ public class CallArranger {
     // TODO: handle zero length arrays
     // TODO: Handle nested structs (and primitives)
     private static List<ArgumentClassImpl> classifyStructType(GroupLayout type) {
-        if (argumentClassFor(type)
-                .filter(argClass -> argClass == ArgumentClassImpl.COMPLEX_X87)
+        if (type.attribute(SystemABI.NATIVE_TYPE)
+                .map(SystemABI.Type.class::cast)
+                .map(SysVx64ABI::argumentClassFor)
+                .filter(ArgumentClassImpl.COMPLEX_X87::equals)
                 .isPresent()) {
             return COMPLEX_X87_CLASSES;
         }

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/x64/sysv/SysVx64ABI.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/x64/sysv/SysVx64ABI.java
@@ -28,11 +28,15 @@ import jdk.incubator.foreign.FunctionDescriptor;
 import jdk.incubator.foreign.MemoryAddress;
 import jdk.incubator.foreign.MemoryLayout;
 import jdk.incubator.foreign.SystemABI;
+import jdk.internal.foreign.MemoryAddressImpl;
 import jdk.internal.foreign.abi.*;
+import jdk.internal.foreign.abi.x64.ArgumentClassImpl;
 
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodType;
-import java.util.Optional;
+import java.util.*;
+
+import static jdk.incubator.foreign.MemoryLayouts.SysV.*;
 
 /**
  * ABI implementation based on System V ABI AMD64 supplement v.0.99.6
@@ -65,20 +69,43 @@ public class SysVx64ABI implements SystemABI {
 
     @Override
     public String name() {
-        return SysV.NAME;
+        return SystemABI.ABI_SYSV;
     }
 
-    static Optional<ArgumentClassImpl> argumentClassFor(MemoryLayout layout) {
-        @SuppressWarnings({"unchecked", "rawtypes"})
-        Optional<SysV.ArgumentClass> argClassOpt =
-                (Optional<SysV.ArgumentClass>)(Optional)layout.attribute(SysV.CLASS_ATTRIBUTE_NAME);
-        return argClassOpt.map(argClass -> switch (argClass) {
-            case INTEGER -> ArgumentClassImpl.INTEGER;
-            case SSE -> ArgumentClassImpl.SSE;
-            case X87 -> ArgumentClassImpl.X87;
-            case COMPLEX_87 -> ArgumentClassImpl.COMPLEX_X87;
+    @Override
+    public Optional<MemoryLayout> layoutFor(Type type) {
+        return switch (Objects.requireNonNull(type)) {
+            case BOOL -> Optional.of(C_BOOL);
+            case UNSIGNED_CHAR -> Optional.of(C_UCHAR);
+            case SIGNED_CHAR -> Optional.of(C_SCHAR);
+            case CHAR -> Optional.of(C_CHAR);
+            case SHORT -> Optional.of(C_SHORT);
+            case UNSIGNED_SHORT -> Optional.of(C_USHORT);
+            case INT -> Optional.of(C_INT);
+            case UNSIGNED_INT -> Optional.of(C_UINT);
+            case LONG -> Optional.of(C_LONG);
+            case UNSIGNED_LONG -> Optional.of(C_ULONG);
+            case LONG_LONG -> Optional.of(C_LONGLONG);
+            case UNSIGNED_LONG_LONG -> Optional.of(C_ULONGLONG);
+            case FLOAT -> Optional.of(C_FLOAT);
+            case DOUBLE -> Optional.of(C_DOUBLE);
+            case LONG_DOUBLE -> Optional.of(C_LONGDOUBLE);
+            case COMPLEX_LONG_DOUBLE -> Optional.of(C_COMPLEX_LONGDOUBLE);
+            case POINTER -> Optional.of(C_POINTER);
+            default -> Optional.empty();
+        };
+    }
+
+    static ArgumentClassImpl argumentClassFor(Type type) {
+        return switch (Objects.requireNonNull(type)) {
+            case BOOL, UNSIGNED_CHAR, SIGNED_CHAR, CHAR, SHORT, UNSIGNED_SHORT,
+                INT, UNSIGNED_INT, LONG, UNSIGNED_LONG, LONG_LONG, UNSIGNED_LONG_LONG ->
+                    ArgumentClassImpl.INTEGER;
+            case FLOAT, DOUBLE -> ArgumentClassImpl.SSE;
+            case LONG_DOUBLE -> ArgumentClassImpl.X87;
+            case COMPLEX_LONG_DOUBLE -> ArgumentClassImpl.COMPLEX_X87;
             case POINTER -> ArgumentClassImpl.POINTER;
             default -> null;
-        });
+        };
     }
 }

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/x64/windows/CallArranger.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/x64/windows/CallArranger.java
@@ -26,6 +26,7 @@ import jdk.incubator.foreign.FunctionDescriptor;
 import jdk.incubator.foreign.GroupLayout;
 import jdk.incubator.foreign.MemoryAddress;
 import jdk.incubator.foreign.MemoryLayout;
+import jdk.incubator.foreign.MemoryLayouts;
 import jdk.incubator.foreign.MemorySegment;
 import jdk.incubator.foreign.SequenceLayout;
 import jdk.incubator.foreign.SystemABI;
@@ -40,15 +41,17 @@ import jdk.internal.foreign.abi.ProgrammableInvoker;
 import jdk.internal.foreign.abi.ProgrammableUpcallHandler;
 import jdk.internal.foreign.abi.VMStorage;
 import jdk.internal.foreign.abi.x64.X86_64Architecture;
+import jdk.internal.foreign.abi.x64.ArgumentClassImpl;
 import jdk.internal.foreign.abi.SharedUtils;
+import jdk.internal.foreign.abi.x64.sysv.SysVx64ABI;
 
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodType;
 import java.util.List;
 import java.util.Optional;
 
-import static jdk.incubator.foreign.SystemABI.Win64.VARARGS_ATTRIBUTE_NAME;
 import static jdk.internal.foreign.abi.x64.X86_64Architecture.*;
+import static jdk.internal.foreign.abi.x64.windows.Windowsx64ABI.VARARGS_ATTRIBUTE_NAME;
 
 /**
  * For the Windowx x64 C ABI specifically, this class uses the ProgrammableInvoker API, namely CallingSequenceBuilder2
@@ -105,7 +108,7 @@ public class CallArranger {
         boolean returnInMemory = isInMemoryReturn(cDesc.returnLayout());
         if (returnInMemory) {
             Class<?> carrier = MemoryAddress.class;
-            MemoryLayout layout = SystemABI.Win64.C_POINTER;
+            MemoryLayout layout = MemoryLayouts.WinABI.C_POINTER;
             csb.addArgumentBindings(carrier, layout);
             if (forUpcall) {
                 csb.setReturnBindings(carrier, layout);
@@ -160,7 +163,7 @@ public class CallArranger {
     }
 
     private static TypeClass classifyValueType(ValueLayout type) {
-        SystemABI.Win64.ArgumentClass clazz = Windowsx64ABI.argumentClassFor(type);
+        ArgumentClassImpl clazz = Windowsx64ABI.argumentClassFor(SystemABI.Type.fromLayout(type));
         if (clazz == null) {
             //padding not allowed here
             throw new IllegalStateException("Unexpected value layout: could not determine ABI class");
@@ -175,11 +178,11 @@ public class CallArranger {
         // but must be considered volatile across function calls."
         // https://docs.microsoft.com/en-us/cpp/build/x64-calling-convention?view=vs-2019
 
-        if (clazz == SystemABI.Win64.ArgumentClass.INTEGER) {
+        if (clazz == ArgumentClassImpl.INTEGER) {
             return TypeClass.INTEGER;
-        } else if(clazz == SystemABI.Win64.ArgumentClass.POINTER) {
+        } else if(clazz == ArgumentClassImpl.POINTER) {
             return TypeClass.POINTER;
-        } else if (clazz == SystemABI.Win64.ArgumentClass.FLOAT) {
+        } else if (clazz == ArgumentClassImpl.SSE) {
             if (type.attribute(VARARGS_ATTRIBUTE_NAME)
                     .map(String.class::cast)
                     .map(Boolean::parseBoolean).orElse(false)) {

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/x64/windows/Windowsx64ABI.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/x64/windows/Windowsx64ABI.java
@@ -28,11 +28,16 @@ import jdk.incubator.foreign.FunctionDescriptor;
 import jdk.incubator.foreign.MemoryAddress;
 import jdk.incubator.foreign.MemoryLayout;
 import jdk.incubator.foreign.SystemABI;
-import jdk.internal.foreign.abi.x64.sysv.ArgumentClassImpl;
+import jdk.internal.foreign.MemoryAddressImpl;
+import jdk.internal.foreign.abi.x64.ArgumentClassImpl;
 import jdk.internal.foreign.abi.*;
 
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodType;
+import java.util.Objects;
+import java.util.Optional;
+
+import static jdk.incubator.foreign.MemoryLayouts.WinABI.*;
 
 /**
  * ABI implementation based on Windows ABI AMD64 supplement v.0.99.6
@@ -45,6 +50,8 @@ public class Windowsx64ABI implements SystemABI {
     public static final int MAX_VECTOR_RETURN_REGISTERS = 1;
     public static final int MAX_REGISTER_ARGUMENTS = 4;
     public static final int MAX_REGISTER_RETURNS = 1;
+
+    public static final String VARARGS_ATTRIBUTE_NAME = "abi/windows/varargs";
 
     private static Windowsx64ABI instance;
 
@@ -67,10 +74,40 @@ public class Windowsx64ABI implements SystemABI {
 
     @Override
     public String name() {
-        return Win64.NAME;
+        return SystemABI.ABI_WINDOWS;
     }
 
-    static Win64.ArgumentClass argumentClassFor(MemoryLayout layout) {
-        return (Win64.ArgumentClass)layout.attribute(Win64.CLASS_ATTRIBUTE_NAME).get();
+    @Override
+    public Optional<MemoryLayout> layoutFor(Type type) {
+        return switch (Objects.requireNonNull(type)) {
+            case BOOL -> Optional.of(C_BOOL);
+            case UNSIGNED_CHAR -> Optional.of(C_UCHAR);
+            case SIGNED_CHAR -> Optional.of(C_SCHAR);
+            case CHAR -> Optional.of(C_CHAR);
+            case SHORT -> Optional.of(C_SHORT);
+            case UNSIGNED_SHORT -> Optional.of(C_USHORT);
+            case INT -> Optional.of(C_INT);
+            case UNSIGNED_INT -> Optional.of(C_UINT);
+            case LONG -> Optional.of(C_LONG);
+            case UNSIGNED_LONG -> Optional.of(C_ULONG);
+            case LONG_LONG -> Optional.of(C_LONGLONG);
+            case UNSIGNED_LONG_LONG -> Optional.of(C_ULONGLONG);
+            case FLOAT -> Optional.of(C_FLOAT);
+            case DOUBLE -> Optional.of(C_DOUBLE);
+            case LONG_DOUBLE -> Optional.of(C_LONGDOUBLE);
+            case POINTER -> Optional.of(C_POINTER);
+            default -> Optional.empty();
+        };
+    }
+
+    static ArgumentClassImpl argumentClassFor(Type type) {
+        return switch (Objects.requireNonNull(type)) {
+            case BOOL, UNSIGNED_CHAR, SIGNED_CHAR, CHAR, SHORT, UNSIGNED_SHORT,
+                INT, UNSIGNED_INT, LONG, UNSIGNED_LONG, LONG_LONG, UNSIGNED_LONG_LONG ->
+                    ArgumentClassImpl.INTEGER;
+            case FLOAT, DOUBLE -> ArgumentClassImpl.SSE;
+            case POINTER -> ArgumentClassImpl.POINTER;
+            default -> null;
+        };
     }
 }

--- a/test/jdk/java/foreign/CallGeneratorHelper.java
+++ b/test/jdk/java/foreign/CallGeneratorHelper.java
@@ -38,7 +38,7 @@ import java.util.stream.IntStream;
 
 import org.testng.annotations.*;
 
-import static jdk.incubator.foreign.SystemABI.*;
+import static jdk.incubator.foreign.MemoryLayouts.*;
 import static org.testng.Assert.*;
 
 public class CallGeneratorHelper extends NativeTestHelper {

--- a/test/jdk/java/foreign/Cstring.java
+++ b/test/jdk/java/foreign/Cstring.java
@@ -28,7 +28,7 @@ import jdk.incubator.foreign.Foreign;
 import jdk.incubator.foreign.MemoryAddress;
 import jdk.incubator.foreign.MemoryLayout;
 import jdk.incubator.foreign.MemorySegment;
-import static jdk.incubator.foreign.SystemABI.C_CHAR;
+import static jdk.incubator.foreign.MemoryLayouts.C_CHAR;
 
 public final class Cstring {
     // don't create!

--- a/test/jdk/java/foreign/NativeTestHelper.java
+++ b/test/jdk/java/foreign/NativeTestHelper.java
@@ -24,34 +24,32 @@
 
 import jdk.incubator.foreign.Foreign;
 import jdk.incubator.foreign.MemoryLayout;
+import jdk.incubator.foreign.MemoryLayouts.WinABI;
 import jdk.incubator.foreign.SystemABI;
+import jdk.incubator.foreign.SystemABI.Type;
 import jdk.incubator.foreign.ValueLayout;
 import jdk.internal.foreign.Utils;
 import java.util.function.Predicate;
+
+import static jdk.incubator.foreign.SystemABI.ABI_WINDOWS;
 
 public class NativeTestHelper {
 
     public static final SystemABI ABI = Foreign.getInstance().getSystemABI();
 
     public static boolean isIntegral(MemoryLayout layout) {
-        return switch (ABI.name()) {
-            case SystemABI.SysV.NAME -> layout.attribute(SystemABI.SysV.CLASS_ATTRIBUTE_NAME).get() == SystemABI.SysV.ArgumentClass.INTEGER;
-            case SystemABI.Win64.NAME -> layout.attribute(SystemABI.Win64.CLASS_ATTRIBUTE_NAME).get() == SystemABI.Win64.ArgumentClass.INTEGER;
-            case SystemABI.AArch64.NAME -> layout.attribute(SystemABI.AArch64.CLASS_ATTRIBUTE_NAME).get() == SystemABI.AArch64.ArgumentClass.INTEGER;
-            default -> throw new AssertionError("unexpected ABI: " + ABI.name());
+        return switch(SystemABI.Type.fromLayout(layout)) {
+            case BOOL, UNSIGNED_CHAR, SIGNED_CHAR, CHAR, SHORT, UNSIGNED_SHORT,
+                INT, UNSIGNED_INT, LONG, UNSIGNED_LONG, LONG_LONG, UNSIGNED_LONG_LONG -> true;
+            default -> false;
         };
     }
 
     public static boolean isPointer(MemoryLayout layout) {
-        return switch (ABI.name()) {
-            case SystemABI.SysV.NAME -> layout.attribute(SystemABI.SysV.CLASS_ATTRIBUTE_NAME).get() == SystemABI.SysV.ArgumentClass.POINTER;
-            case SystemABI.Win64.NAME -> layout.attribute(SystemABI.Win64.CLASS_ATTRIBUTE_NAME).get() == SystemABI.Win64.ArgumentClass.POINTER;
-            case SystemABI.AArch64.NAME -> layout.attribute(SystemABI.AArch64.CLASS_ATTRIBUTE_NAME).get() == SystemABI.AArch64.ArgumentClass.POINTER;
-            default -> throw new AssertionError("unexpected ABI: " + ABI.name());
-        };
+        return SystemABI.Type.fromLayout(layout) == Type.POINTER;
     }
 
     public static ValueLayout asVarArg(ValueLayout layout) {
-        return ABI.name().equals(SystemABI.Win64.NAME) ? SystemABI.Win64.asVarArg(layout) : layout;
+        return ABI.name().equals(ABI_WINDOWS) ? WinABI.asVarArg(layout) : layout;
     }
 }

--- a/test/jdk/java/foreign/StdLibTest.java
+++ b/test/jdk/java/foreign/StdLibTest.java
@@ -62,7 +62,7 @@ import jdk.incubator.foreign.SequenceLayout;
 import jdk.incubator.foreign.SystemABI;
 import org.testng.annotations.*;
 
-import static jdk.incubator.foreign.SystemABI.*;
+import static jdk.incubator.foreign.MemoryLayouts.*;
 import static org.testng.Assert.*;
 
 @Test

--- a/test/jdk/java/foreign/TestCircularInit1.java
+++ b/test/jdk/java/foreign/TestCircularInit1.java
@@ -27,7 +27,7 @@
  * @run testng/othervm TestCircularInit1
  */
 
-import jdk.incubator.foreign.SystemABI;
+import jdk.incubator.foreign.MemoryLayouts;
 import org.testng.annotations.Test;
 
 import static org.testng.Assert.assertNotNull;
@@ -36,8 +36,8 @@ public class TestCircularInit1 {
 
     @Test
     public void testCircularInit() {
-        System.out.println(SystemABI.C_BOOL); // trigger clinit
-        assertNotNull(SystemABI.C_BOOL); // should not be null
+        System.out.println(MemoryLayouts.WinABI.C_BOOL); // trigger clinit
+        assertNotNull(MemoryLayouts.C_BOOL); // should not be null
     }
 
 }

--- a/test/jdk/java/foreign/TestCircularInit2.java
+++ b/test/jdk/java/foreign/TestCircularInit2.java
@@ -27,7 +27,7 @@
  * @run testng/othervm TestCircularInit2
  */
 
-import jdk.incubator.foreign.SystemABI;
+import jdk.incubator.foreign.MemoryLayouts;
 import org.testng.annotations.Test;
 
 import static org.testng.Assert.assertNotNull;
@@ -36,10 +36,10 @@ public class TestCircularInit2 {
 
     @Test
     public void testCircularInit() {
-        System.out.println(SystemABI.C_BOOL); // trigger clinit
-        assertNotNull(SystemABI.C_BOOL);
-        assertNotNull(SystemABI.C_BOOL);
-        assertNotNull(SystemABI.C_BOOL);
+        System.out.println(MemoryLayouts.C_BOOL); // trigger clinit
+        assertNotNull(MemoryLayouts.WinABI.C_BOOL);
+        assertNotNull(MemoryLayouts.SysV.C_BOOL);
+        assertNotNull(MemoryLayouts.AArch64ABI.C_BOOL);
     }
 
 }

--- a/test/jdk/java/foreign/TestUpcall.java
+++ b/test/jdk/java/foreign/TestUpcall.java
@@ -56,7 +56,7 @@ import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
 import static java.lang.invoke.MethodHandles.insertArguments;
-import static jdk.incubator.foreign.SystemABI.C_POINTER;
+import static jdk.incubator.foreign.MemoryLayouts.C_POINTER;
 import static org.testng.Assert.assertEquals;
 
 

--- a/test/jdk/java/foreign/TestVarArgs.java
+++ b/test/jdk/java/foreign/TestVarArgs.java
@@ -52,7 +52,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static jdk.incubator.foreign.MemoryLayout.PathElement.*;
-import static jdk.incubator.foreign.SystemABI.*;
+import static jdk.incubator.foreign.MemoryLayouts.*;
 import static org.testng.Assert.assertEquals;
 
 public class TestVarArgs extends NativeTestHelper {

--- a/test/jdk/java/foreign/callarranger/TestAarch64CallArranger.java
+++ b/test/jdk/java/foreign/callarranger/TestAarch64CallArranger.java
@@ -44,7 +44,7 @@ import org.testng.annotations.Test;
 
 import java.lang.invoke.MethodType;
 
-import static jdk.incubator.foreign.SystemABI.AArch64.*;
+import static jdk.incubator.foreign.MemoryLayouts.AArch64ABI.*;
 import static jdk.internal.foreign.abi.Binding.*;
 import static jdk.internal.foreign.abi.aarch64.AArch64Architecture.*;
 import static org.testng.Assert.assertEquals;

--- a/test/jdk/java/foreign/callarranger/TestSysVCallArranger.java
+++ b/test/jdk/java/foreign/callarranger/TestSysVCallArranger.java
@@ -45,7 +45,8 @@ import org.testng.annotations.Test;
 
 import java.lang.invoke.MethodType;
 
-import static jdk.incubator.foreign.SystemABI.SysV.*;
+import static jdk.incubator.foreign.MemoryLayouts.SysV.*;
+import static jdk.incubator.foreign.MemoryLayouts.WinABI.C_POINTER;
 import static jdk.internal.foreign.abi.Binding.*;
 import static jdk.internal.foreign.abi.x64.X86_64Architecture.*;
 import static org.testng.Assert.assertEquals;

--- a/test/jdk/java/foreign/callarranger/TestWindowsCallArranger.java
+++ b/test/jdk/java/foreign/callarranger/TestWindowsCallArranger.java
@@ -44,7 +44,8 @@ import org.testng.annotations.Test;
 
 import java.lang.invoke.MethodType;
 
-import static jdk.incubator.foreign.SystemABI.Win64.*;
+import static jdk.incubator.foreign.MemoryLayouts.WinABI.*;
+import static jdk.incubator.foreign.MemoryLayouts.WinABI.asVarArg;
 import static jdk.internal.foreign.abi.Binding.*;
 import static jdk.internal.foreign.abi.Binding.copy;
 import static jdk.internal.foreign.abi.x64.X86_64Architecture.*;

--- a/test/micro/org/openjdk/bench/jdk/incubator/foreign/CallOverhead.java
+++ b/test/micro/org/openjdk/bench/jdk/incubator/foreign/CallOverhead.java
@@ -40,7 +40,7 @@ import java.lang.invoke.MethodHandles;
 import java.lang.invoke.MethodType;
 import java.util.concurrent.TimeUnit;
 
-import static jdk.incubator.foreign.SystemABI.C_INT;
+import static jdk.incubator.foreign.MemoryLayouts.C_INT;
 
 @BenchmarkMode(Mode.AverageTime)
 @Warmup(iterations = 5, time = 500, timeUnit = TimeUnit.MILLISECONDS)

--- a/test/micro/org/openjdk/bench/jdk/incubator/foreign/points/support/PanamaPoint.java
+++ b/test/micro/org/openjdk/bench/jdk/incubator/foreign/points/support/PanamaPoint.java
@@ -37,13 +37,13 @@ import java.lang.invoke.VarHandle;
 
 import static java.lang.invoke.MethodType.methodType;
 import static jdk.incubator.foreign.MemoryLayout.PathElement.groupElement;
-import static jdk.incubator.foreign.SystemABI.*;
+import static jdk.incubator.foreign.MemoryLayouts.*;
 
 public class PanamaPoint implements AutoCloseable {
 
     public static final MemoryLayout LAYOUT = MemoryLayout.ofStruct(
-        C_INT.withName("x"),
-        C_INT.withName("y")
+        MemoryLayouts.C_INT.withName("x"),
+        MemoryLayouts.C_INT.withName("y")
     );
 
     private static final VarHandle VH_x = LAYOUT.varHandle(int.class, groupElement("x"));


### PR DESCRIPTION
This reverts commit f7e7b9d6e76e54b1b5d4ff97d2a034769652e132.

The latest reorganization of SystemABI constants did not work with the jextract code, for two reasons:

1) jextract internally converts C types into layouts, and then expects to emit source files which have the 'right' constants (e.g. C_INT, if the layout is that of a C int)

2) for tests, for making sure that the layout of a given e.g. struct field matches the expected one

Of course (1) could be avoided by just re-creating the constant from scratch, but that would lead to footprint issues, and would still not address (2).

So, I'm postponing for now - we'll reserve to make changes in this area in the future.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * Jorn Vernee ([jvernee](@JornVernee) - Committer)

### Download
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/99/head:pull/99`
`$ git checkout pull/99`
