### PR TITLE
Tweak JextractToolRunner to use file helper routines in FileUtils library

### DIFF
--- a/test/jdk/tools/jextract/BadBitfieldTest.java
+++ b/test/jdk/tools/jextract/BadBitfieldTest.java
@@ -25,6 +25,7 @@
  * @test
  * @requires os.family != "windows"
  * @modules jdk.incubator.jextract
+ * @library /test/lib
  * @build BadBitfieldTest
  * @run testng BadBitfieldTest
  */

--- a/test/jdk/tools/jextract/ConstantsTest.java
+++ b/test/jdk/tools/jextract/ConstantsTest.java
@@ -37,6 +37,7 @@ import static org.testng.Assert.assertTrue;
 /*
  * @test
  * @modules jdk.incubator.jextract
+ * @library /test/lib
  * @build ConstantsTest
  * @run testng/othervm -Djdk.incubator.foreign.Foreign=permit ConstantsTest
  */

--- a/test/jdk/tools/jextract/JextractToolProviderTest.java
+++ b/test/jdk/tools/jextract/JextractToolProviderTest.java
@@ -36,6 +36,7 @@ import static org.testng.Assert.assertTrue;
 /*
  * @test
  * @modules jdk.incubator.jextract
+ * @library /test/lib
  * @build JextractToolRunner
  * @bug 8240181
  * @run testng/othervm -Djdk.incubator.foreign.Foreign=permit -Duser.language=en --add-modules jdk.incubator.jextract JextractToolProviderTest

--- a/test/jdk/tools/jextract/JextractToolRunner.java
+++ b/test/jdk/tools/jextract/JextractToolRunner.java
@@ -40,6 +40,7 @@ import jdk.incubator.foreign.MemoryLayout;
 import jdk.incubator.foreign.MemoryLayout.PathElement;
 import jdk.incubator.foreign.SystemABI;
 import jdk.incubator.foreign.SystemABI.Type;
+import jdk.test.lib.util.FileUtils;
 
 import static jdk.incubator.foreign.SystemABI.NATIVE_TYPE;
 import static org.testng.Assert.assertEquals;
@@ -125,7 +126,7 @@ public class JextractToolRunner {
 
     protected static void deleteFile(Path path) {
         try {
-            Files.deleteIfExists(path);
+            FileUtils.deleteFileIfExistsWithRetry(path);
         } catch (IOException ioExp) {
             throw new RuntimeException(ioExp);
         }
@@ -133,19 +134,7 @@ public class JextractToolRunner {
 
     protected static void deleteDir(Path path) {
         try {
-            Files.walkFileTree(path, new SimpleFileVisitor<>() {
-                @Override
-                public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) {
-                    deleteFile(file);
-                    return FileVisitResult.CONTINUE;
-                }
-
-                @Override
-                public FileVisitResult postVisitDirectory(Path dir, IOException exc) {
-                    deleteFile(dir);
-                    return FileVisitResult.CONTINUE;
-                }
-            });
+            FileUtils.deleteFileTreeWithRetry(path);
         } catch (IOException ioExp) {
             throw new RuntimeException(ioExp);
         }

--- a/test/jdk/tools/jextract/RepeatedDeclsTest.java
+++ b/test/jdk/tools/jextract/RepeatedDeclsTest.java
@@ -39,6 +39,7 @@ import static org.testng.Assert.assertTrue;
  * @bug 8240300
  * @summary jextract produces non compilable code with repeated declarations
  * @modules jdk.incubator.jextract
+ * @library /test/lib
  * @build JextractToolRunner
  * @run testng/othervm -Djdk.incubator.foreign.Foreign=permit RepeatedDeclsTest
  */

--- a/test/jdk/tools/jextract/Test8240181.java
+++ b/test/jdk/tools/jextract/Test8240181.java
@@ -27,6 +27,7 @@ import org.testng.annotations.Test;
 /*
  * @test
  * @modules jdk.incubator.jextract
+ * @library /test/lib
  * @build JextractToolRunner
  * @bug 8240181
  * @run testng/othervm -Djdk.incubator.foreign.Foreign=permit -Duser.language=en --add-modules jdk.incubator.jextract Test8240181

--- a/test/jdk/tools/jextract/Test8240657.java
+++ b/test/jdk/tools/jextract/Test8240657.java
@@ -28,6 +28,7 @@ import static org.testng.Assert.assertNotNull;
 /*
  * @test
  * @modules jdk.incubator.jextract
+ * @library /test/lib
  * @build JextractToolRunner
  * @bug 8240657
  * @summary when Java keywords are used as identifiers in C header, jextract generates non-compilable java code

--- a/test/jdk/tools/jextract/Test8240752.java
+++ b/test/jdk/tools/jextract/Test8240752.java
@@ -31,6 +31,7 @@ import static org.testng.Assert.assertTrue;
 /*
  * @test
  * @modules jdk.incubator.jextract
+ * @library /test/lib
  * @build JextractToolRunner
  * @bug 8240752
  * @summary jextract generates non-compilable code for special floating point values

--- a/test/jdk/tools/jextract/Test8240811.java
+++ b/test/jdk/tools/jextract/Test8240811.java
@@ -32,6 +32,7 @@ import static org.testng.Assert.assertTrue;
 /*
  * @test
  * @modules jdk.incubator.jextract
+ * @library /test/lib
  * @build JextractToolRunner
  * @bug 8240811
  * @summary jextract generates non-compilable code for name collision between a struct and a global variable

--- a/test/jdk/tools/jextract/UniondeclTest.java
+++ b/test/jdk/tools/jextract/UniondeclTest.java
@@ -32,6 +32,7 @@ import static org.testng.Assert.assertTrue;
 /*
  * @test
  * @modules jdk.incubator.jextract
+ * @library /test/lib
  * @build JextractToolRunner
  * @run testng/othervm -Djdk.incubator.foreign.Foreign=permit UniondeclTest
  */


### PR DESCRIPTION
This is an attempt to fix some of the jextract tests that are failing in our build infra; I looked over the tests and I couldn't find anything obviously wrong (such as streams left open and such). But speaking with Alan, he raised the possibility that the failures are a result of a known bad interaction with the AV solution installed in some of the Windows test machines.
To workaround this, we have an helper library called FileUtils which has a deleteFileWithRetry method, which is meant to address these issues. I think it could be worth trying whether this fixes our issues before investigating further - in any case, at the very least this patch improves the code by reusing sharing helper functionalities already available in the test folder.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * Henry Jen ([henryjen](@slowhog) - Committer)

### Download
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/100/head:pull/100`
`$ git checkout pull/100`
