### PR TITLE
JDK-8242253: Clarify bulk of addresses backed by same storage

### DIFF
--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/MemoryAddress.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/MemoryAddress.java
@@ -121,7 +121,13 @@ public interface MemoryAddress {
      * through {@code src.addOffset(bytes - 1)} are copied into addresses {@code dst} through {@code dst.addOffset(bytes - 1)}.
      * If the source and address ranges overlap, then the copying is performed as if the bytes at addresses {@code src}
      * through {@code src.addOffset(bytes - 1)} were first copied into a temporary segment with size {@code bytes},
-     * and then the contents of the temporary segment were copied into the bytes at addresses {@code dst} through {@code dst.addOffset(bytes - 1)}.
+     * and then the contents of the temporary segment were copied into the bytes at addresses {@code dst} through
+     * {@code dst.addOffset(bytes - 1)}.
+     * <p>
+     * The result of a bulk copy is unspecified if, in the uncommon case, the source and target address ranges do not
+     * overlap, but refer to overlapping regions of the same backing storage using different addresses.  For example,
+     * this may occur if the same file is {@link MemorySegment#mapFromPath mapped} to two segments.
+     *
      * @param src the source address.
      * @param dst the target address.
      * @param bytes the number of bytes to be copied.


### PR DESCRIPTION
Here is a small tweak to the specification of `MemoryAddress.copy` when source and target address ranges do not overlap, but there are overlapping regions of the same backing storage.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [JDK-8242253](https://bugs.openjdk.java.net/browse/JDK-8242253): Clarify bulk of addresses backed by same storage 


### Reviewers
 * Maurizio Cimadamore ([mcimadamore](@mcimadamore) - Committer)

### Contributors
 * Florian Weimer `<fweimer@redhat.com>`

### Download
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/101/head:pull/101`
`$ git checkout pull/101`
