### PR TITLE
8242276: tools/launcher/VersionCheck.java fails for jextract

### DIFF
--- a/test/jdk/tools/launcher/VersionCheck.java
+++ b/test/jdk/tools/launcher/VersionCheck.java
@@ -81,6 +81,7 @@ public class VersionCheck extends TestHelper {
         "javadoc",
         "javacpl",
         "javaws",
+        "jextract",
         "jcmd",
         "jconsole",
         "jcontrol",


### PR DESCRIPTION
Hi,

This trivial patch fixes a the tier2 VersionCheck test failure, by blacklisting jextract in the test.

Thanks,
Jorn
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [JDK-8242276](https://bugs.openjdk.java.net/browse/JDK-8242276): tools/launcher/VersionCheck.java fails for jextract


### Reviewers
 * Maurizio Cimadamore ([mcimadamore](@mcimadamore) - Committer)

### Download
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/103/head:pull/103`
`$ git checkout pull/103`
