### PR TITLE
Fix failing TestClassGeneration

### DIFF
--- a/test/jdk/tools/jextract/testClassGen/TestClassGeneration.java
+++ b/test/jdk/tools/jextract/testClassGen/TestClassGeneration.java
@@ -28,7 +28,7 @@
  *          jdk.incubator.foreign/jdk.internal.foreign
  *          jdk.incubator.foreign/jdk.internal.foreign.abi
  *          java.base/sun.security.action
- * @library ..
+ * @library .. /test/lib
  * @build JextractToolRunner
  * @run testng/othervm -Djdk.incubator.foreign.Foreign=permit -Duser.language=en TestClassGeneration
  */


### PR DESCRIPTION
Hi,

I forgot to rebase https://github.com/openjdk/panama-foreign/pull/102 this morning and rerun the tests after https://github.com/openjdk/panama-foreign/pull/100 went in last night, and as a result the new TestClassGeneration test is failing.

Trivial fix is to add a missing @library entry.

Thanks,
Jorn
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * Athijegannathan Sundararajan ([sundar](@sundararajana) - Committer)

### Download
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/104/head:pull/104`
`$ git checkout pull/104`
