### PR TITLE
Add JMH test for loop over sliced segment

### DIFF
--- a/test/micro/org/openjdk/bench/jdk/incubator/foreign/LoopOverNonConstant.java
+++ b/test/micro/org/openjdk/bench/jdk/incubator/foreign/LoopOverNonConstant.java
@@ -137,9 +137,9 @@ public class LoopOverNonConstant {
     }
 
     @Benchmark
-    public int segment_loop_slice() {
+    public int segment_loop_readonly() {
         int sum = 0;
-        MemoryAddress base = segment.asSlice(0, segment.byteSize()).baseAddress();
+        MemoryAddress base = segment.withAccessModes(MemorySegment.READ).baseAddress();
         for (int i = 0; i < ELEM_SIZE; i++) {
             sum += (int) VH_int.get(base, (long) i);
         }

--- a/test/micro/org/openjdk/bench/jdk/incubator/foreign/LoopOverNonConstant.java
+++ b/test/micro/org/openjdk/bench/jdk/incubator/foreign/LoopOverNonConstant.java
@@ -127,6 +127,26 @@ public class LoopOverNonConstant {
     }
 
     @Benchmark
+    public int segment_loop_slice() {
+        int sum = 0;
+        MemoryAddress base = segment.asSlice(0, segment.byteSize()).baseAddress();
+        for (int i = 0; i < ELEM_SIZE; i++) {
+            sum += (int) VH_int.get(base, (long) i);
+        }
+        return sum;
+    }
+
+    @Benchmark
+    public int segment_loop_slice() {
+        int sum = 0;
+        MemoryAddress base = segment.asSlice(0, segment.byteSize()).baseAddress();
+        for (int i = 0; i < ELEM_SIZE; i++) {
+            sum += (int) VH_int.get(base, (long) i);
+        }
+        return sum;
+    }
+
+    @Benchmark
     public int BB_loop() {
         int sum = 0;
         ByteBuffer bb = byteBuffer;


### PR DESCRIPTION
This simple patch adds a simple benchmark that does a loop on a segment slice. I found this test useful when investigating escape analysis issues of derived segments, so I'm adding it here. With the current implementation (MemorySegmentImpl) the difference between the new `segment_loop` and `segment_loop_slice` are negligible, so this can be used to spot regressions in that logic.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * Jorn Vernee ([jvernee](@JornVernee) - Committer)

### Download
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/107/head:pull/107`
`$ git checkout pull/107`
