### PR TITLE
8242465: jextract should skip variables and struct fields with types that cannot be handled 

### DIFF
--- a/doc/panama_jextract.html
+++ b/doc/panama_jextract.html
@@ -105,13 +105,13 @@
 </ul></li>
 <li><a href="#using-readline-library-from-java-code-mac-os">Using readline library from Java code (Mac OS)</a>
 <ul>
-<li><a href="#jextract-a-jar-file-for-readline.h">jextract a jar file for readline.h</a></li>
+<li><a href="#jextract-readline.h">jextract readline.h</a></li>
 <li><a href="#java-code-that-uses-readline">Java code that uses readline</a></li>
 <li><a href="#running-the-java-code-that-uses-readline">Running the java code that uses readline</a></li>
 </ul></li>
 <li><a href="#using-libcurl-from-java-mac-os">Using libcurl from Java (Mac OS)</a>
 <ul>
-<li><a href="#jextract-a-jar-for-curl.h">jextract a jar for curl.h</a></li>
+<li><a href="#jextract-curl.h">jextract curl.h</a></li>
 <li><a href="#java-code-that-uses-libcurl">Java code that uses libcurl</a></li>
 <li><a href="#running-the-java-code-that-uses-libcurl">Running the java code that uses libcurl</a></li>
 </ul></li>
@@ -127,6 +127,12 @@
 <li><a href="#jextracting-lapacke.h">jextracting lapacke.h</a></li>
 <li><a href="#java-sample-code-that-uses-lapack-library">Java sample code that uses LAPACK library</a></li>
 <li><a href="#compiling-and-running-the-above-lapack-sample-1">Compiling and running the above LAPACK sample</a></li>
+</ul></li>
+<li><a href="#using-libproc-library-to-list-processes-from-java-mac-os">Using libproc library to list processes from Java (Mac OS)</a>
+<ul>
+<li><a href="#jextract-libproc.h">jextract libproc.h</a></li>
+<li><a href="#java-program-that-uses-libproc-to-list-processes">Java program that uses libproc to list processes</a></li>
+<li><a href="#compiling-and-running-the-libproc-sample">Compiling and running the libproc sample</a></li>
 </ul></li>
 </ul></li>
 </ul>
@@ -210,7 +216,7 @@
 <span id="cb9-2"><a href="#cb9-2"></a><span class="ex">java</span> -Djdk.incubator.foreign.Foreign=permit --add-modules jdk.incubator.foreign \</span>
 <span id="cb9-3"><a href="#cb9-3"></a>    -Djava.library.path=/System/Library/Frameworks/Python.framework/Versions/2.7/lib PythonMain.java</span></code></pre></div>
 <h2 id="using-readline-library-from-java-code-mac-os">Using readline library from Java code (Mac OS)</h2>
-<h3 id="jextract-a-jar-file-for-readline.h">jextract a jar file for readline.h</h3>
+<h3 id="jextract-readline.h">jextract readline.h</h3>
 <div class="sourceCode" id="cb10"><pre class="sourceCode sh"><code class="sourceCode bash"><span id="cb10-1"><a href="#cb10-1"></a></span>
 <span id="cb10-2"><a href="#cb10-2"></a><span class="ex">jextract</span> -l readline -t org.unix \</span>
 <span id="cb10-3"><a href="#cb10-3"></a>  -I /Library/Developer/CommandLineTools/SDKs/MacOSX10.14.sdk/usr/include \</span>
@@ -241,7 +247,7 @@
     -Djava.library.path=/usr/local/opt/readline/lib/ Readline.java
 </code></pre>
 <h2 id="using-libcurl-from-java-mac-os">Using libcurl from Java (Mac OS)</h2>
-<h3 id="jextract-a-jar-for-curl.h">jextract a jar for curl.h</h3>
+<h3 id="jextract-curl.h">jextract curl.h</h3>
 <div class="sourceCode" id="cb13"><pre class="sourceCode sh"><code class="sourceCode bash"><span id="cb13-1"><a href="#cb13-1"></a></span>
 <span id="cb13-2"><a href="#cb13-2"></a><span class="ex">jextract</span> -t org.unix -lcurl \</span>
 <span id="cb13-3"><a href="#cb13-3"></a>  -I /Library/Developer/CommandLineTools/SDKs/MacOSX10.14.sdk/usr/include/ \</span>
@@ -434,5 +440,50 @@
 <span id="cb22-3"><a href="#cb22-3"></a>    --add-modules jdk.incubator.foreign \</span>
 <span id="cb22-4"><a href="#cb22-4"></a>    -Djava.library.path=/usr/local/opt/lapack/lib \</span>
 <span id="cb22-5"><a href="#cb22-5"></a>    TestLapack.java</span></code></pre></div>
+<h2 id="using-libproc-library-to-list-processes-from-java-mac-os">Using libproc library to list processes from Java (Mac OS)</h2>
+<h3 id="jextract-libproc.h">jextract libproc.h</h3>
+<div class="sourceCode" id="cb23"><pre class="sourceCode sh"><code class="sourceCode bash"><span id="cb23-1"><a href="#cb23-1"></a></span>
+<span id="cb23-2"><a href="#cb23-2"></a><span class="ex">jextract</span> -t org.unix \</span>
+<span id="cb23-3"><a href="#cb23-3"></a>  -I /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include \</span>
+<span id="cb23-4"><a href="#cb23-4"></a>  --filter libproc.h \</span>
+<span id="cb23-5"><a href="#cb23-5"></a>  /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/libproc.h</span></code></pre></div>
+<h3 id="java-program-that-uses-libproc-to-list-processes">Java program that uses libproc to list processes</h3>
+<div class="sourceCode" id="cb24"><pre class="sourceCode java"><code class="sourceCode java"><span id="cb24-1"><a href="#cb24-1"></a></span>
+<span id="cb24-2"><a href="#cb24-2"></a><span class="kw">import</span><span class="im"> jdk.incubator.foreign.NativeAllocationScope;</span></span>
+<span id="cb24-3"><a href="#cb24-3"></a><span class="kw">import</span><span class="im"> org.unix.*;</span></span>
+<span id="cb24-4"><a href="#cb24-4"></a><span class="kw">import static</span><span class="im"> jdk.incubator.foreign.MemoryAddress.NULL;</span></span>
+<span id="cb24-5"><a href="#cb24-5"></a><span class="kw">import static</span><span class="im"> org.unix.libproc_h.*;</span></span>
+<span id="cb24-6"><a href="#cb24-6"></a></span>
+<span id="cb24-7"><a href="#cb24-7"></a><span class="kw">public</span> <span class="kw">class</span> LibprocMain {</span>
+<span id="cb24-8"><a href="#cb24-8"></a>    <span class="kw">private</span> <span class="dt">static</span> <span class="dt">final</span> <span class="dt">int</span> NAME_BUF_MAX = <span class="dv">256</span>;</span>
+<span id="cb24-9"><a href="#cb24-9"></a></span>
+<span id="cb24-10"><a href="#cb24-10"></a>    <span class="kw">public</span> <span class="dt">static</span> <span class="dt">void</span> <span class="fu">main</span>(<span class="bu">String</span>[] args) {</span>
+<span id="cb24-11"><a href="#cb24-11"></a>        <span class="kw">try</span> (var scope = NativeAllocationScope.<span class="fu">unboundedScope</span>()) {</span>
+<span id="cb24-12"><a href="#cb24-12"></a>            <span class="co">// get the number of processes</span></span>
+<span id="cb24-13"><a href="#cb24-13"></a>            <span class="dt">int</span> numPids = <span class="fu">proc_listallpids</span>(NULL, <span class="dv">0</span>);</span>
+<span id="cb24-14"><a href="#cb24-14"></a>            <span class="co">// allocate an array</span></span>
+<span id="cb24-15"><a href="#cb24-15"></a>            var pids = Cint.<span class="fu">allocateArray</span>(numPids, scope);</span>
+<span id="cb24-16"><a href="#cb24-16"></a>            <span class="co">// list all the pids into the native array</span></span>
+<span id="cb24-17"><a href="#cb24-17"></a>            <span class="fu">proc_listallpids</span>(pids, numPids);</span>
+<span id="cb24-18"><a href="#cb24-18"></a>            <span class="co">// convert native array to java array</span></span>
+<span id="cb24-19"><a href="#cb24-19"></a>            <span class="dt">int</span>[] jpids = Cint.<span class="fu">toJavaArray</span>(pids.<span class="fu">segment</span>());</span>
+<span id="cb24-20"><a href="#cb24-20"></a>            <span class="co">// buffer for process name</span></span>
+<span id="cb24-21"><a href="#cb24-21"></a>            var nameBuf = Cchar.<span class="fu">allocateArray</span>(NAME_BUF_MAX,scope);</span>
+<span id="cb24-22"><a href="#cb24-22"></a>            <span class="kw">for</span> (<span class="dt">int</span> i = <span class="dv">0</span>; i &lt; jpids.<span class="fu">length</span>; i++) {</span>
+<span id="cb24-23"><a href="#cb24-23"></a>                <span class="dt">int</span> pid = jpids[i];</span>
+<span id="cb24-24"><a href="#cb24-24"></a>                <span class="co">// get the process name</span></span>
+<span id="cb24-25"><a href="#cb24-25"></a>                <span class="fu">proc_name</span>(pid, nameBuf, NAME_BUF_MAX);</span>
+<span id="cb24-26"><a href="#cb24-26"></a>                <span class="bu">String</span> procName = Cstring.<span class="fu">toJavaString</span>(nameBuf);</span>
+<span id="cb24-27"><a href="#cb24-27"></a>                <span class="co">// print pid and process name</span></span>
+<span id="cb24-28"><a href="#cb24-28"></a>                <span class="bu">System</span>.<span class="fu">out.printf</span>(<span class="st">&quot;</span><span class="sc">%d</span><span class="st"> </span><span class="sc">%s\n</span><span class="st">&quot;</span>, pid, procName);</span>
+<span id="cb24-29"><a href="#cb24-29"></a>            }</span>
+<span id="cb24-30"><a href="#cb24-30"></a>        }</span>
+<span id="cb24-31"><a href="#cb24-31"></a>    }</span>
+<span id="cb24-32"><a href="#cb24-32"></a>}</span></code></pre></div>
+<h3 id="compiling-and-running-the-libproc-sample">Compiling and running the libproc sample</h3>
+<div class="sourceCode" id="cb25"><pre class="sourceCode sh"><code class="sourceCode bash"><span id="cb25-1"><a href="#cb25-1"></a></span>
+<span id="cb25-2"><a href="#cb25-2"></a><span class="ex">java</span> -Djdk.incubator.foreign.Foreign=permit \</span>
+<span id="cb25-3"><a href="#cb25-3"></a>    --add-modules jdk.incubator.foreign \</span>
+<span id="cb25-4"><a href="#cb25-4"></a>    -Djava.library.path=/usr/lib LibprocMain.java</span></code></pre></div>
 </body>
 </html>

--- a/doc/panama_jextract.html
+++ b/doc/panama_jextract.html
@@ -122,6 +122,12 @@
 <li><a href="#java-sample-code-that-uses-cblas-library">Java sample code that uses cblas library</a></li>
 <li><a href="#compiling-and-running-the-above-lapack-sample">Compiling and running the above LAPACK sample</a></li>
 </ul></li>
+<li><a href="#using-lapack-library-mac-os">Using LAPACK library (Mac OS)</a>
+<ul>
+<li><a href="#jextracting-lapacke.h">jextracting lapacke.h</a></li>
+<li><a href="#java-sample-code-that-uses-lapack-library">Java sample code that uses LAPACK library</a></li>
+<li><a href="#compiling-and-running-the-above-lapack-sample-1">Compiling and running the above LAPACK sample</a></li>
+</ul></li>
 </ul></li>
 </ul>
 </nav>
@@ -177,9 +183,7 @@
 <span id="cb7-3"><a href="#cb7-3"></a>  -I /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include \</span>
 <span id="cb7-4"><a href="#cb7-4"></a>  -I /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/python2.7/ \</span>
 <span id="cb7-5"><a href="#cb7-5"></a>  -t org.python \</span>
-<span id="cb7-6"><a href="#cb7-6"></a>  --filter pythonrun.h \</span>
-<span id="cb7-7"><a href="#cb7-7"></a>  --filter python.h \</span>
-<span id="cb7-8"><a href="#cb7-8"></a>   /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/python2.7/Python.h</span></code></pre></div>
+<span id="cb7-6"><a href="#cb7-6"></a>   /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/python2.7/Python.h</span></code></pre></div>
 <h3 id="java-program-that-uses-extracted-python-interface">Java program that uses extracted Python interface</h3>
 <div class="sourceCode" id="cb8"><pre class="sourceCode java"><code class="sourceCode java"><span id="cb8-1"><a href="#cb8-1"></a></span>
 <span id="cb8-2"><a href="#cb8-2"></a><span class="kw">import</span><span class="im"> jdk.incubator.foreign.Foreign;</span></span>
@@ -210,8 +214,7 @@
 <div class="sourceCode" id="cb10"><pre class="sourceCode sh"><code class="sourceCode bash"><span id="cb10-1"><a href="#cb10-1"></a></span>
 <span id="cb10-2"><a href="#cb10-2"></a><span class="ex">jextract</span> -l readline -t org.unix \</span>
 <span id="cb10-3"><a href="#cb10-3"></a>  -I /Library/Developer/CommandLineTools/SDKs/MacOSX10.14.sdk/usr/include \</span>
-<span id="cb10-4"><a href="#cb10-4"></a>  --filter readline.h \</span>
-<span id="cb10-5"><a href="#cb10-5"></a>   /Library/Developer/CommandLineTools/SDKs/MacOSX10.14.sdk/usr/include/readline/readline.h</span></code></pre></div>
+<span id="cb10-4"><a href="#cb10-4"></a>   /Library/Developer/CommandLineTools/SDKs/MacOSX10.14.sdk/usr/include/readline/readline.h</span></code></pre></div>
 <h3 id="java-code-that-uses-readline">Java code that uses readline</h3>
 <div class="sourceCode" id="cb11"><pre class="sourceCode java"><code class="sourceCode java"><span id="cb11-1"><a href="#cb11-1"></a></span>
 <span id="cb11-2"><a href="#cb11-2"></a><span class="kw">import</span><span class="im"> jdk.incubator.foreign.Foreign;</span></span>
@@ -243,9 +246,7 @@
 <span id="cb13-2"><a href="#cb13-2"></a><span class="ex">jextract</span> -t org.unix -lcurl \</span>
 <span id="cb13-3"><a href="#cb13-3"></a>  -I /Library/Developer/CommandLineTools/SDKs/MacOSX10.14.sdk/usr/include/ \</span>
 <span id="cb13-4"><a href="#cb13-4"></a>  -I /Library/Developer/CommandLineTools/SDKs/MacOSX10.14.sdk/usr/include/curl/ \</span>
-<span id="cb13-5"><a href="#cb13-5"></a>  --filter easy.h \</span>
-<span id="cb13-6"><a href="#cb13-6"></a>  --filter curl.h \</span>
-<span id="cb13-7"><a href="#cb13-7"></a>  /Library/Developer/CommandLineTools/SDKs/MacOSX10.14.sdk/usr/include/curl/curl.h</span></code></pre></div>
+<span id="cb13-5"><a href="#cb13-5"></a>  /Library/Developer/CommandLineTools/SDKs/MacOSX10.14.sdk/usr/include/curl/curl.h</span></code></pre></div>
 <h3 id="java-code-that-uses-libcurl">Java code that uses libcurl</h3>
 <div class="sourceCode" id="cb14"><pre class="sourceCode java"><code class="sourceCode java"><span id="cb14-1"><a href="#cb14-1"></a></span>
 <span id="cb14-2"><a href="#cb14-2"></a><span class="kw">import</span><span class="im"> jdk.incubator.foreign.Foreign;</span></span>
@@ -291,8 +292,7 @@
 <div class="sourceCode" id="cb17"><pre class="sourceCode sh"><code class="sourceCode bash"><span id="cb17-1"><a href="#cb17-1"></a></span>
 <span id="cb17-2"><a href="#cb17-2"></a><span class="ex">jextract</span> -C <span class="st">&quot;-D FORCE_OPENBLAS_COMPLEX_STRUCT&quot;</span> \</span>
 <span id="cb17-3"><a href="#cb17-3"></a>  -I /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include \</span>
-<span id="cb17-4"><a href="#cb17-4"></a>  --filter cblas.h \</span>
-<span id="cb17-5"><a href="#cb17-5"></a>  -l openblas -t blas /usr/local/opt/openblas/include/cblas.h</span></code></pre></div>
+<span id="cb17-4"><a href="#cb17-4"></a>  -l openblas -t blas /usr/local/opt/openblas/include/cblas.h</span></code></pre></div>
 <h3 id="java-sample-code-that-uses-cblas-library">Java sample code that uses cblas library</h3>
 <div class="sourceCode" id="cb18"><pre class="sourceCode java"><code class="sourceCode java"><span id="cb18-1"><a href="#cb18-1"></a></span>
 <span id="cb18-2"><a href="#cb18-2"></a><span class="kw">import</span><span class="im"> jdk.incubator.foreign.NativeAllocationScope;</span></span>
@@ -365,5 +365,75 @@
 <span id="cb19-2"><a href="#cb19-2"></a><span class="ex">java</span> -Djdk.incubator.foreign.Foreign=permit --add-modules jdk.incubator.foreign \</span>
 <span id="cb19-3"><a href="#cb19-3"></a>    -Djava.library.path=/usr/local/opt/openblas/lib \</span>
 <span id="cb19-4"><a href="#cb19-4"></a>    TestBlas.java</span></code></pre></div>
+<h2 id="using-lapack-library-mac-os">Using LAPACK library (Mac OS)</h2>
+<p>On Mac OS, lapack is installed under /usr/local/opt/lapack directory.</p>
+<h3 id="jextracting-lapacke.h">jextracting lapacke.h</h3>
+<div class="sourceCode" id="cb20"><pre class="sourceCode sh"><code class="sourceCode bash"><span id="cb20-1"><a href="#cb20-1"></a></span>
+<span id="cb20-2"><a href="#cb20-2"></a><span class="ex">jextract</span> \</span>
+<span id="cb20-3"><a href="#cb20-3"></a>   -I /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include \</span>
+<span id="cb20-4"><a href="#cb20-4"></a>   -l lapacke -t lapack \</span>
+<span id="cb20-5"><a href="#cb20-5"></a>   --filter lapacke.h \</span>
+<span id="cb20-6"><a href="#cb20-6"></a>   /usr/local/opt/lapack/include/lapacke.h</span></code></pre></div>
+<h3 id="java-sample-code-that-uses-lapack-library">Java sample code that uses LAPACK library</h3>
+<div class="sourceCode" id="cb21"><pre class="sourceCode java"><code class="sourceCode java"><span id="cb21-1"><a href="#cb21-1"></a></span>
+<span id="cb21-2"><a href="#cb21-2"></a><span class="kw">import</span><span class="im"> jdk.incubator.foreign.NativeAllocationScope;</span></span>
+<span id="cb21-3"><a href="#cb21-3"></a><span class="kw">import</span><span class="im"> lapack.*;</span></span>
+<span id="cb21-4"><a href="#cb21-4"></a><span class="kw">import static</span><span class="im"> lapack.lapacke_h.*;</span></span>
+<span id="cb21-5"><a href="#cb21-5"></a></span>
+<span id="cb21-6"><a href="#cb21-6"></a><span class="kw">public</span> <span class="kw">class</span> TestLapack {</span>
+<span id="cb21-7"><a href="#cb21-7"></a>    <span class="kw">public</span> <span class="dt">static</span> <span class="dt">void</span> <span class="fu">main</span>(<span class="bu">String</span>[] args) {</span>
+<span id="cb21-8"><a href="#cb21-8"></a></span>
+<span id="cb21-9"><a href="#cb21-9"></a>        <span class="co">/* Locals */</span></span>
+<span id="cb21-10"><a href="#cb21-10"></a>        <span class="kw">try</span> (var scope = NativeAllocationScope.<span class="fu">unboundedScope</span>()) {</span>
+<span id="cb21-11"><a href="#cb21-11"></a>            var A = Cdouble.<span class="fu">allocateArray</span>(<span class="kw">new</span> <span class="dt">double</span>[]{</span>
+<span id="cb21-12"><a href="#cb21-12"></a>                    <span class="dv">1</span>, <span class="dv">2</span>, <span class="dv">3</span>, <span class="dv">4</span>, <span class="dv">5</span>, <span class="dv">1</span>, <span class="dv">3</span>, <span class="dv">5</span>, <span class="dv">2</span>, <span class="dv">4</span>, <span class="dv">1</span>, <span class="dv">4</span>, <span class="dv">2</span>, <span class="dv">5</span>, <span class="dv">3</span></span>
+<span id="cb21-13"><a href="#cb21-13"></a>            }, scope);</span>
+<span id="cb21-14"><a href="#cb21-14"></a>            var b = Cdouble.<span class="fu">allocateArray</span>(<span class="kw">new</span> <span class="dt">double</span>[]{</span>
+<span id="cb21-15"><a href="#cb21-15"></a>                    -<span class="dv">10</span>, <span class="dv">12</span>, <span class="dv">14</span>, <span class="dv">16</span>, <span class="dv">18</span>, -<span class="dv">3</span>, <span class="dv">14</span>, <span class="dv">12</span>, <span class="dv">16</span>, <span class="dv">16</span></span>
+<span id="cb21-16"><a href="#cb21-16"></a>            }, scope);</span>
+<span id="cb21-17"><a href="#cb21-17"></a>            <span class="dt">int</span> info, m, n, lda, ldb, nrhs;</span>
+<span id="cb21-18"><a href="#cb21-18"></a></span>
+<span id="cb21-19"><a href="#cb21-19"></a>            <span class="co">/* Initialization */</span></span>
+<span id="cb21-20"><a href="#cb21-20"></a>            m = <span class="dv">5</span>;</span>
+<span id="cb21-21"><a href="#cb21-21"></a>            n = <span class="dv">3</span>;</span>
+<span id="cb21-22"><a href="#cb21-22"></a>            nrhs = <span class="dv">2</span>;</span>
+<span id="cb21-23"><a href="#cb21-23"></a>            lda = <span class="dv">5</span>;</span>
+<span id="cb21-24"><a href="#cb21-24"></a>            ldb = <span class="dv">5</span>;</span>
+<span id="cb21-25"><a href="#cb21-25"></a></span>
+<span id="cb21-26"><a href="#cb21-26"></a>            <span class="co">/* Print Entry Matrix */</span></span>
+<span id="cb21-27"><a href="#cb21-27"></a>            <span class="fu">print_matrix_colmajor</span>(<span class="st">&quot;Entry Matrix A&quot;</span>, m, n, Cdouble.<span class="fu">toJavaArray</span>(A.<span class="fu">segment</span>()), lda );</span>
+<span id="cb21-28"><a href="#cb21-28"></a>            <span class="co">/* Print Right Rand Side */</span></span>
+<span id="cb21-29"><a href="#cb21-29"></a>            <span class="fu">print_matrix_colmajor</span>(<span class="st">&quot;Right Hand Side b&quot;</span>, n, nrhs, Cdouble.<span class="fu">toJavaArray</span>(b.<span class="fu">segment</span>()), ldb );</span>
+<span id="cb21-30"><a href="#cb21-30"></a>            <span class="bu">System</span>.<span class="fu">out</span>.<span class="fu">println</span>();</span>
+<span id="cb21-31"><a href="#cb21-31"></a></span>
+<span id="cb21-32"><a href="#cb21-32"></a></span>
+<span id="cb21-33"><a href="#cb21-33"></a>            <span class="co">/* Executable statements */</span></span>
+<span id="cb21-34"><a href="#cb21-34"></a>            <span class="co">//            printf( &quot;LAPACKE_dgels (col-major, high-level) Example Program Results\n&quot; );</span></span>
+<span id="cb21-35"><a href="#cb21-35"></a>            <span class="co">/* Solve least squares problem*/</span></span>
+<span id="cb21-36"><a href="#cb21-36"></a>            info = <span class="fu">LAPACKE_dgels</span>(<span class="fu">LAPACK_COL_MAJOR</span>(), (<span class="dt">byte</span>)<span class="ch">&#39;N&#39;</span>, m, n, nrhs, A, lda, b, ldb);</span>
+<span id="cb21-37"><a href="#cb21-37"></a></span>
+<span id="cb21-38"><a href="#cb21-38"></a>            <span class="co">/* Print Solution */</span></span>
+<span id="cb21-39"><a href="#cb21-39"></a>            <span class="fu">print_matrix_colmajor</span>(<span class="st">&quot;Solution&quot;</span>, n, nrhs, Cdouble.<span class="fu">toJavaArray</span>(b.<span class="fu">segment</span>()), ldb );</span>
+<span id="cb21-40"><a href="#cb21-40"></a>            <span class="bu">System</span>.<span class="fu">out</span>.<span class="fu">println</span>();</span>
+<span id="cb21-41"><a href="#cb21-41"></a>            <span class="bu">System</span>.<span class="fu">exit</span>(info);</span>
+<span id="cb21-42"><a href="#cb21-42"></a>        }</span>
+<span id="cb21-43"><a href="#cb21-43"></a>    }</span>
+<span id="cb21-44"><a href="#cb21-44"></a></span>
+<span id="cb21-45"><a href="#cb21-45"></a>    <span class="dt">static</span> <span class="dt">void</span> <span class="fu">print_matrix_colmajor</span>(<span class="bu">String</span> msg, <span class="dt">int</span> m, <span class="dt">int</span> n, <span class="dt">double</span>[] mat, <span class="dt">int</span> ldm) {</span>
+<span id="cb21-46"><a href="#cb21-46"></a>        <span class="dt">int</span> i, j;</span>
+<span id="cb21-47"><a href="#cb21-47"></a>        <span class="bu">System</span>.<span class="fu">out.printf</span>(<span class="st">&quot;</span><span class="sc">\n</span><span class="st"> </span><span class="sc">%s\n</span><span class="st">&quot;</span>, msg);</span>
+<span id="cb21-48"><a href="#cb21-48"></a></span>
+<span id="cb21-49"><a href="#cb21-49"></a>        <span class="kw">for</span>( i = <span class="dv">0</span>; i &lt; m; i++ ) {</span>
+<span id="cb21-50"><a href="#cb21-50"></a>            <span class="kw">for</span>( j = <span class="dv">0</span>; j &lt; n; j++ ) <span class="bu">System</span>.<span class="fu">out.printf</span>(<span class="st">&quot; </span><span class="sc">%6.2f</span><span class="st">&quot;</span>, mat[i+j*ldm]);</span>
+<span id="cb21-51"><a href="#cb21-51"></a>            <span class="bu">System</span>.<span class="fu">out.printf</span>( <span class="st">&quot;</span><span class="sc">\n</span><span class="st">&quot;</span> );</span>
+<span id="cb21-52"><a href="#cb21-52"></a>        }</span>
+<span id="cb21-53"><a href="#cb21-53"></a>    }</span>
+<span id="cb21-54"><a href="#cb21-54"></a>}</span></code></pre></div>
+<h3 id="compiling-and-running-the-above-lapack-sample-1">Compiling and running the above LAPACK sample</h3>
+<div class="sourceCode" id="cb22"><pre class="sourceCode sh"><code class="sourceCode bash"><span id="cb22-1"><a href="#cb22-1"></a></span>
+<span id="cb22-2"><a href="#cb22-2"></a><span class="ex">java</span> -Djdk.incubator.foreign.Foreign=permit \</span>
+<span id="cb22-3"><a href="#cb22-3"></a>    --add-modules jdk.incubator.foreign \</span>
+<span id="cb22-4"><a href="#cb22-4"></a>    -Djava.library.path=/usr/local/opt/lapack/lib \</span>
+<span id="cb22-5"><a href="#cb22-5"></a>    TestLapack.java</span></code></pre></div>
 </body>
 </html>

--- a/doc/panama_jextract.html
+++ b/doc/panama_jextract.html
@@ -401,34 +401,33 @@
 <span id="cb21-24"><a href="#cb21-24"></a>            ldb = <span class="dv">5</span>;</span>
 <span id="cb21-25"><a href="#cb21-25"></a></span>
 <span id="cb21-26"><a href="#cb21-26"></a>            <span class="co">/* Print Entry Matrix */</span></span>
-<span id="cb21-27"><a href="#cb21-27"></a>            <span class="fu">print_matrix_colmajor</span>(<span class="st">&quot;Entry Matrix A&quot;</span>, m, n, Cdouble.<span class="fu">toJavaArray</span>(A.<span class="fu">segment</span>()), lda );</span>
+<span id="cb21-27"><a href="#cb21-27"></a>            <span class="fu">print_matrix_colmajor</span>(<span class="st">&quot;Entry Matrix A&quot;</span>, m, n, A, lda );</span>
 <span id="cb21-28"><a href="#cb21-28"></a>            <span class="co">/* Print Right Rand Side */</span></span>
-<span id="cb21-29"><a href="#cb21-29"></a>            <span class="fu">print_matrix_colmajor</span>(<span class="st">&quot;Right Hand Side b&quot;</span>, n, nrhs, Cdouble.<span class="fu">toJavaArray</span>(b.<span class="fu">segment</span>()), ldb );</span>
+<span id="cb21-29"><a href="#cb21-29"></a>            <span class="fu">print_matrix_colmajor</span>(<span class="st">&quot;Right Hand Side b&quot;</span>, n, nrhs, b, ldb );</span>
 <span id="cb21-30"><a href="#cb21-30"></a>            <span class="bu">System</span>.<span class="fu">out</span>.<span class="fu">println</span>();</span>
 <span id="cb21-31"><a href="#cb21-31"></a></span>
-<span id="cb21-32"><a href="#cb21-32"></a></span>
-<span id="cb21-33"><a href="#cb21-33"></a>            <span class="co">/* Executable statements */</span></span>
-<span id="cb21-34"><a href="#cb21-34"></a>            <span class="co">//            printf( &quot;LAPACKE_dgels (col-major, high-level) Example Program Results\n&quot; );</span></span>
-<span id="cb21-35"><a href="#cb21-35"></a>            <span class="co">/* Solve least squares problem*/</span></span>
-<span id="cb21-36"><a href="#cb21-36"></a>            info = <span class="fu">LAPACKE_dgels</span>(<span class="fu">LAPACK_COL_MAJOR</span>(), (<span class="dt">byte</span>)<span class="ch">&#39;N&#39;</span>, m, n, nrhs, A, lda, b, ldb);</span>
-<span id="cb21-37"><a href="#cb21-37"></a></span>
-<span id="cb21-38"><a href="#cb21-38"></a>            <span class="co">/* Print Solution */</span></span>
-<span id="cb21-39"><a href="#cb21-39"></a>            <span class="fu">print_matrix_colmajor</span>(<span class="st">&quot;Solution&quot;</span>, n, nrhs, Cdouble.<span class="fu">toJavaArray</span>(b.<span class="fu">segment</span>()), ldb );</span>
-<span id="cb21-40"><a href="#cb21-40"></a>            <span class="bu">System</span>.<span class="fu">out</span>.<span class="fu">println</span>();</span>
-<span id="cb21-41"><a href="#cb21-41"></a>            <span class="bu">System</span>.<span class="fu">exit</span>(info);</span>
-<span id="cb21-42"><a href="#cb21-42"></a>        }</span>
-<span id="cb21-43"><a href="#cb21-43"></a>    }</span>
-<span id="cb21-44"><a href="#cb21-44"></a></span>
-<span id="cb21-45"><a href="#cb21-45"></a>    <span class="dt">static</span> <span class="dt">void</span> <span class="fu">print_matrix_colmajor</span>(<span class="bu">String</span> msg, <span class="dt">int</span> m, <span class="dt">int</span> n, <span class="dt">double</span>[] mat, <span class="dt">int</span> ldm) {</span>
-<span id="cb21-46"><a href="#cb21-46"></a>        <span class="dt">int</span> i, j;</span>
-<span id="cb21-47"><a href="#cb21-47"></a>        <span class="bu">System</span>.<span class="fu">out.printf</span>(<span class="st">&quot;</span><span class="sc">\n</span><span class="st"> </span><span class="sc">%s\n</span><span class="st">&quot;</span>, msg);</span>
-<span id="cb21-48"><a href="#cb21-48"></a></span>
-<span id="cb21-49"><a href="#cb21-49"></a>        <span class="kw">for</span>( i = <span class="dv">0</span>; i &lt; m; i++ ) {</span>
-<span id="cb21-50"><a href="#cb21-50"></a>            <span class="kw">for</span>( j = <span class="dv">0</span>; j &lt; n; j++ ) <span class="bu">System</span>.<span class="fu">out.printf</span>(<span class="st">&quot; </span><span class="sc">%6.2f</span><span class="st">&quot;</span>, mat[i+j*ldm]);</span>
-<span id="cb21-51"><a href="#cb21-51"></a>            <span class="bu">System</span>.<span class="fu">out.printf</span>( <span class="st">&quot;</span><span class="sc">\n</span><span class="st">&quot;</span> );</span>
-<span id="cb21-52"><a href="#cb21-52"></a>        }</span>
-<span id="cb21-53"><a href="#cb21-53"></a>    }</span>
-<span id="cb21-54"><a href="#cb21-54"></a>}</span></code></pre></div>
+<span id="cb21-32"><a href="#cb21-32"></a>            <span class="co">/* Executable statements */</span></span>
+<span id="cb21-33"><a href="#cb21-33"></a>            <span class="co">//            printf( &quot;LAPACKE_dgels (col-major, high-level) Example Program Results\n&quot; );</span></span>
+<span id="cb21-34"><a href="#cb21-34"></a>            <span class="co">/* Solve least squares problem*/</span></span>
+<span id="cb21-35"><a href="#cb21-35"></a>            info = <span class="fu">LAPACKE_dgels</span>(<span class="fu">LAPACK_COL_MAJOR</span>(), (<span class="dt">byte</span>)<span class="ch">&#39;N&#39;</span>, m, n, nrhs, A, lda, b, ldb);</span>
+<span id="cb21-36"><a href="#cb21-36"></a></span>
+<span id="cb21-37"><a href="#cb21-37"></a>            <span class="co">/* Print Solution */</span></span>
+<span id="cb21-38"><a href="#cb21-38"></a>            <span class="fu">print_matrix_colmajor</span>(<span class="st">&quot;Solution&quot;</span>, n, nrhs, b, ldb );</span>
+<span id="cb21-39"><a href="#cb21-39"></a>            <span class="bu">System</span>.<span class="fu">out</span>.<span class="fu">println</span>();</span>
+<span id="cb21-40"><a href="#cb21-40"></a>            <span class="bu">System</span>.<span class="fu">exit</span>(info);</span>
+<span id="cb21-41"><a href="#cb21-41"></a>        }</span>
+<span id="cb21-42"><a href="#cb21-42"></a>    }</span>
+<span id="cb21-43"><a href="#cb21-43"></a></span>
+<span id="cb21-44"><a href="#cb21-44"></a>    <span class="dt">static</span> <span class="dt">void</span> <span class="fu">print_matrix_colmajor</span>(<span class="bu">String</span> msg, <span class="dt">int</span> m, <span class="dt">int</span> n, MemoryAddress mat, <span class="dt">int</span> ldm) {</span>
+<span id="cb21-45"><a href="#cb21-45"></a>        <span class="dt">int</span> i, j;</span>
+<span id="cb21-46"><a href="#cb21-46"></a>        <span class="bu">System</span>.<span class="fu">out.printf</span>(<span class="st">&quot;</span><span class="sc">\n</span><span class="st"> </span><span class="sc">%s\n</span><span class="st">&quot;</span>, msg);</span>
+<span id="cb21-47"><a href="#cb21-47"></a></span>
+<span id="cb21-48"><a href="#cb21-48"></a>        <span class="kw">for</span>( i = <span class="dv">0</span>; i &lt; m; i++ ) {</span>
+<span id="cb21-49"><a href="#cb21-49"></a>            <span class="kw">for</span>( j = <span class="dv">0</span>; j &lt; n; j++ ) <span class="bu">System</span>.<span class="fu">out.printf</span>(<span class="st">&quot; </span><span class="sc">%6.2f</span><span class="st">&quot;</span>, Cdouble.<span class="fu">get</span>(mat, i+j*ldm));</span>
+<span id="cb21-50"><a href="#cb21-50"></a>            <span class="bu">System</span>.<span class="fu">out.printf</span>( <span class="st">&quot;</span><span class="sc">\n</span><span class="st">&quot;</span> );</span>
+<span id="cb21-51"><a href="#cb21-51"></a>        }</span>
+<span id="cb21-52"><a href="#cb21-52"></a>    }</span>
+<span id="cb21-53"><a href="#cb21-53"></a>}</span></code></pre></div>
 <h3 id="compiling-and-running-the-above-lapack-sample-1">Compiling and running the above LAPACK sample</h3>
 <div class="sourceCode" id="cb22"><pre class="sourceCode sh"><code class="sourceCode bash"><span id="cb22-1"><a href="#cb22-1"></a></span>
 <span id="cb22-2"><a href="#cb22-2"></a><span class="ex">java</span> -Djdk.incubator.foreign.Foreign=permit \</span>

--- a/doc/panama_jextract.html
+++ b/doc/panama_jextract.html
@@ -440,7 +440,6 @@
 <span id="cb22-3"><a href="#cb22-3"></a>    --add-modules jdk.incubator.foreign \</span>
 <span id="cb22-4"><a href="#cb22-4"></a>    -Djava.library.path=/usr/local/opt/lapack/lib \</span>
 <span id="cb22-5"><a href="#cb22-5"></a>    TestLapack.java</span></code></pre></div>
-<p>&lt;&lt;&lt;&lt;&lt;&lt;&lt; HEAD</p>
 <h2 id="using-libproc-library-to-list-processes-from-java-mac-os">Using libproc library to list processes from Java (Mac OS)</h2>
 <h3 id="jextract-libproc.h">jextract libproc.h</h3>
 <div class="sourceCode" id="cb23"><pre class="sourceCode sh"><code class="sourceCode bash"><span id="cb23-1"><a href="#cb23-1"></a></span>

--- a/doc/panama_jextract.md
+++ b/doc/panama_jextract.md
@@ -388,11 +388,10 @@ public class TestLapack {
             ldb = 5;
 
             /* Print Entry Matrix */
-            print_matrix_colmajor("Entry Matrix A", m, n, Cdouble.toJavaArray(A.segment()), lda );
+            print_matrix_colmajor("Entry Matrix A", m, n, A, lda );
             /* Print Right Rand Side */
-            print_matrix_colmajor("Right Hand Side b", n, nrhs, Cdouble.toJavaArray(b.segment()), ldb );
+            print_matrix_colmajor("Right Hand Side b", n, nrhs, b, ldb );
             System.out.println();
-
 
             /* Executable statements */
             //            printf( "LAPACKE_dgels (col-major, high-level) Example Program Results\n" );
@@ -400,18 +399,18 @@ public class TestLapack {
             info = LAPACKE_dgels(LAPACK_COL_MAJOR(), (byte)'N', m, n, nrhs, A, lda, b, ldb);
 
             /* Print Solution */
-            print_matrix_colmajor("Solution", n, nrhs, Cdouble.toJavaArray(b.segment()), ldb );
+            print_matrix_colmajor("Solution", n, nrhs, b, ldb );
             System.out.println();
             System.exit(info);
         }
     }
 
-    static void print_matrix_colmajor(String msg, int m, int n, double[] mat, int ldm) {
+    static void print_matrix_colmajor(String msg, int m, int n, MemoryAddress mat, int ldm) {
         int i, j;
         System.out.printf("\n %s\n", msg);
 
         for( i = 0; i < m; i++ ) {
-            for( j = 0; j < n; j++ ) System.out.printf(" %6.2f", mat[i+j*ldm]);
+            for( j = 0; j < n; j++ ) System.out.printf(" %6.2f", Cdouble.get(mat, i+j*ldm));
             System.out.printf( "\n" );
         }
     }

--- a/doc/panama_jextract.md
+++ b/doc/panama_jextract.md
@@ -428,8 +428,6 @@ java -Djdk.incubator.foreign.Foreign=permit \
     TestLapack.java
 
 ```
-<<<<<<< HEAD
-
 ## Using libproc library to list processes from Java (Mac OS)
 
 ### jextract libproc.h

--- a/doc/panama_jextract.md
+++ b/doc/panama_jextract.md
@@ -131,7 +131,7 @@ java -Djdk.incubator.foreign.Foreign=permit --add-modules jdk.incubator.foreign 
 
 ## Using readline library from Java code (Mac OS)
 
-### jextract a jar file for readline.h
+### jextract readline.h
 
 ```sh
 
@@ -177,7 +177,7 @@ java -Djdk.incubator.foreign.Foreign=permit --add-modules jdk.incubator.foreign 
 
 ## Using libcurl from Java (Mac OS)
 
-### jextract a jar for curl.h
+### jextract curl.h
 
 ```sh
 
@@ -426,5 +426,66 @@ java -Djdk.incubator.foreign.Foreign=permit \
     --add-modules jdk.incubator.foreign \
     -Djava.library.path=/usr/local/opt/lapack/lib \
     TestLapack.java
+
+```
+
+## Using libproc library to list processes from Java (Mac OS)
+
+### jextract libproc.h
+
+```sh
+
+jextract -t org.unix \
+  -I /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include \
+  --filter libproc.h \
+  /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/libproc.h
+
+```
+
+### Java program that uses libproc to list processes
+
+```java
+
+import jdk.incubator.foreign.NativeAllocationScope;
+import org.unix.*;
+import static jdk.incubator.foreign.MemoryAddress.NULL;
+import static org.unix.libproc_h.*;
+
+public class LibprocMain {
+    private static final int NAME_BUF_MAX = 256;
+
+    public static void main(String[] args) {
+        try (var scope = NativeAllocationScope.unboundedScope()) {
+            // get the number of processes
+            int numPids = proc_listallpids(NULL, 0);
+            // allocate an array
+            var pids = Cint.allocateArray(numPids, scope);
+            // list all the pids into the native array
+            proc_listallpids(pids, numPids);
+            // convert native array to java array
+            int[] jpids = Cint.toJavaArray(pids.segment());
+            // buffer for process name
+            var nameBuf = Cchar.allocateArray(NAME_BUF_MAX,scope);
+            for (int i = 0; i < jpids.length; i++) {
+                int pid = jpids[i];
+                // get the process name
+                proc_name(pid, nameBuf, NAME_BUF_MAX);
+                String procName = Cstring.toJavaString(nameBuf);
+                // print pid and process name
+                System.out.printf("%d %s\n", pid, procName);
+            }
+        }
+    }
+}
+
+```
+
+### Compiling and running the libproc sample
+
+```sh
+
+java -Djdk.incubator.foreign.Foreign=permit \
+    --add-modules jdk.incubator.foreign \
+    -Djava.library.path=/usr/lib LibprocMain.java
 
 ```

--- a/doc/panama_jextract.md
+++ b/doc/panama_jextract.md
@@ -90,8 +90,6 @@ jextract -l python2.7 \
   -I /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include \
   -I /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/python2.7/ \
   -t org.python \
-  --filter pythonrun.h \
-  --filter python.h \
    /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/python2.7/Python.h
 
 ```
@@ -139,7 +137,6 @@ java -Djdk.incubator.foreign.Foreign=permit --add-modules jdk.incubator.foreign 
 
 jextract -l readline -t org.unix \
   -I /Library/Developer/CommandLineTools/SDKs/MacOSX10.14.sdk/usr/include \
-  --filter readline.h \
    /Library/Developer/CommandLineTools/SDKs/MacOSX10.14.sdk/usr/include/readline/readline.h
 
 ```
@@ -187,8 +184,6 @@ java -Djdk.incubator.foreign.Foreign=permit --add-modules jdk.incubator.foreign 
 jextract -t org.unix -lcurl \
   -I /Library/Developer/CommandLineTools/SDKs/MacOSX10.14.sdk/usr/include/ \
   -I /Library/Developer/CommandLineTools/SDKs/MacOSX10.14.sdk/usr/include/curl/ \
-  --filter easy.h \
-  --filter curl.h \
   /Library/Developer/CommandLineTools/SDKs/MacOSX10.14.sdk/usr/include/curl/curl.h
 
 ```
@@ -262,7 +257,6 @@ The following command can be used to extract cblas.h on MacOs
 
 jextract -C "-D FORCE_OPENBLAS_COMPLEX_STRUCT" \
   -I /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include \
-  --filter cblas.h \
   -l openblas -t blas /usr/local/opt/openblas/include/cblas.h
 
 ```
@@ -346,5 +340,92 @@ public class TestBlas {
 java -Djdk.incubator.foreign.Foreign=permit --add-modules jdk.incubator.foreign \
     -Djava.library.path=/usr/local/opt/openblas/lib \
     TestBlas.java
+
+```
+
+## Using LAPACK library (Mac OS)
+
+On Mac OS, lapack is installed under /usr/local/opt/lapack directory.
+
+### jextracting lapacke.h
+
+```sh
+
+jextract \
+   -I /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include \
+   -l lapacke -t lapack \
+   --filter lapacke.h \
+   /usr/local/opt/lapack/include/lapacke.h
+
+```
+
+### Java sample code that uses LAPACK library
+
+```java
+
+import jdk.incubator.foreign.NativeAllocationScope;
+import lapack.*;
+import static lapack.lapacke_h.*;
+
+public class TestLapack {
+    public static void main(String[] args) {
+
+        /* Locals */
+        try (var scope = NativeAllocationScope.unboundedScope()) {
+            var A = Cdouble.allocateArray(new double[]{
+                    1, 2, 3, 4, 5, 1, 3, 5, 2, 4, 1, 4, 2, 5, 3
+            }, scope);
+            var b = Cdouble.allocateArray(new double[]{
+                    -10, 12, 14, 16, 18, -3, 14, 12, 16, 16
+            }, scope);
+            int info, m, n, lda, ldb, nrhs;
+
+            /* Initialization */
+            m = 5;
+            n = 3;
+            nrhs = 2;
+            lda = 5;
+            ldb = 5;
+
+            /* Print Entry Matrix */
+            print_matrix_colmajor("Entry Matrix A", m, n, Cdouble.toJavaArray(A.segment()), lda );
+            /* Print Right Rand Side */
+            print_matrix_colmajor("Right Hand Side b", n, nrhs, Cdouble.toJavaArray(b.segment()), ldb );
+            System.out.println();
+
+
+            /* Executable statements */
+            //            printf( "LAPACKE_dgels (col-major, high-level) Example Program Results\n" );
+            /* Solve least squares problem*/
+            info = LAPACKE_dgels(LAPACK_COL_MAJOR(), (byte)'N', m, n, nrhs, A, lda, b, ldb);
+
+            /* Print Solution */
+            print_matrix_colmajor("Solution", n, nrhs, Cdouble.toJavaArray(b.segment()), ldb );
+            System.out.println();
+            System.exit(info);
+        }
+    }
+
+    static void print_matrix_colmajor(String msg, int m, int n, double[] mat, int ldm) {
+        int i, j;
+        System.out.printf("\n %s\n", msg);
+
+        for( i = 0; i < m; i++ ) {
+            for( j = 0; j < n; j++ ) System.out.printf(" %6.2f", mat[i+j*ldm]);
+            System.out.printf( "\n" );
+        }
+    }
+}
+
+```
+
+### Compiling and running the above LAPACK sample
+
+```sh
+
+java -Djdk.incubator.foreign.Foreign=permit \
+    --add-modules jdk.incubator.foreign \
+    -Djava.library.path=/usr/local/opt/lapack/lib \
+    TestLapack.java
 
 ```

--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/LayoutUtils.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/LayoutUtils.java
@@ -113,7 +113,7 @@ public final class LayoutUtils {
             case Unexposed:
                 Type canonical = t.canonicalType();
                 if (canonical.equalType(t)) {
-                    throw new IllegalStateException("Unknown type with same canonical type: " + t.spelling());
+                    throw new TypeMaker.TypeException("Unknown type with same canonical type: " + t.spelling());
                 }
                 return getLayout(canonical);
             case Typedef:

--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/TreeMaker.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/TreeMaker.java
@@ -212,7 +212,14 @@ class TreeMaker {
                 .map(this::createTree).collect(Collectors.toList()));
         if (c.isDefinition()) {
             //just a declaration AND definition, we have a layout
-            MemoryLayout layout = LayoutUtils.getLayout(c.type());
+            MemoryLayout layout = null;
+            try {
+                layout = LayoutUtils.getLayout(c.type());
+            } catch (TypeMaker.TypeException ex) {
+                System.err.println(ex);
+                System.err.println("WARNING: generating empty struct: " + c.spelling());
+                return factoryNoLayout.make(toPos(c), c.spelling(), decls.toArray(new Declaration[0]));
+            }
             List<Declaration> adaptedDecls = layout instanceof GroupLayout ?
                     collectBitfields(layout, decls) :
                     decls;
@@ -260,7 +267,15 @@ class TreeMaker {
             return Declaration.bitfield(toPos(c), c.spelling(), toType(c),
                     MemoryLayout.ofValueBits(c.getBitFieldWidth(), ByteOrder.nativeOrder()));
         } else {
-            return varFactory.make(toPos(c), c.spelling(), toType(c));
+            Type type = null;
+            try {
+                type = toType(c);
+            } catch (TypeMaker.TypeException ex) {
+                System.err.println(ex);
+                System.err.println("WARNING: ignoring variable: " + c.spelling());
+                return null;
+            }
+            return varFactory.make(toPos(c), c.spelling(), type);
         }
     }
 

--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/TypeMaker.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/TypeMaker.java
@@ -106,6 +106,14 @@ class TypeMaker {
         return rv;
     }
 
+    static class TypeException extends RuntimeException {
+        static final long serialVersionUID = 1L;
+
+        TypeException(String msg) {
+            super(msg);
+        }
+    }
+
     Type makeTypeInternal(jdk.internal.clang.Type t) {
         switch(t.kind()) {
             case Auto:
@@ -160,7 +168,7 @@ class TypeMaker {
             case Elaborated:
                 jdk.internal.clang.Type canonical = t.canonicalType();
                 if (canonical.equalType(t)) {
-                    throw new IllegalStateException("Unknown type with same canonical type: " + t.spelling());
+                    throw new TypeException("Unknown type with same canonical type: " + t.spelling());
                 }
                 return makeType(canonical);
             case ConstantArray: {


### PR DESCRIPTION
skipping problematic variables, generating empty structs for structs with problematic fields.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [JDK-8242465](https://bugs.openjdk.java.net/browse/JDK-8242465): jextract should skip variables and struct fields with types that cannot be handled 


### Reviewers
 * Maurizio Cimadamore ([mcimadamore](@mcimadamore) - Committer) ⚠️ Review applies to 7b2d2715ae395d68acab3a170c9796613b31f5a3

### Download
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/108/head:pull/108`
`$ git checkout pull/108`
