### PR TITLE
Memory access implementation rewrite - post cleanup

### DIFF
--- a/src/java.base/share/classes/java/lang/invoke/X-VarHandleByteArrayView.java.template
+++ b/src/java.base/share/classes/java/lang/invoke/X-VarHandleByteArrayView.java.template
@@ -26,6 +26,7 @@ package java.lang.invoke;
 
 import jdk.internal.access.JavaNioAccess;
 import jdk.internal.access.SharedSecrets;
+import jdk.internal.access.foreign.MemorySegmentProxy;
 import jdk.internal.misc.Unsafe;
 import jdk.internal.util.Preconditions;
 import jdk.internal.vm.annotation.ForceInline;
@@ -564,7 +565,10 @@ final class VarHandleByteArrayAs$Type$s extends VarHandleByteArrayBase {
 
         @ForceInline
         static int index(ByteBuffer bb, int index) {
-            nioAccess.checkSegment(bb);
+            MemorySegmentProxy segmentProxy = nioAccess.bufferSegment(bb);
+            if (segmentProxy != null) {
+                segmentProxy.checkValidState();
+            }
             return Preconditions.checkIndex(index, UNSAFE.getInt(bb, BUFFER_LIMIT) - ALIGN, null);
         }
 

--- a/src/java.base/share/classes/java/nio/Buffer.java
+++ b/src/java.base/share/classes/java/nio/Buffer.java
@@ -798,8 +798,8 @@ public abstract class Buffer {
                 }
 
                 @Override
-                public void checkSegment(Buffer buffer) {
-                    buffer.checkSegment();
+                public MemorySegmentProxy bufferSegment(Buffer buffer) {
+                    return buffer.segment;
                 }
             });
     }

--- a/src/java.base/share/classes/jdk/internal/access/JavaNioAccess.java
+++ b/src/java.base/share/classes/jdk/internal/access/JavaNioAccess.java
@@ -84,7 +84,7 @@ public interface JavaNioAccess {
     UnmapperProxy unmapper(ByteBuffer bb);
 
     /**
-     * Used by byte buffer var handle views.
+     * Used by {@code jdk.internal.foreign.AbstractMemorySegmentImpl} and byte buffer var handle views.
      */
-    void checkSegment(Buffer buffer);
+    MemorySegmentProxy bufferSegment(Buffer buffer);
 }

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/AbstractMemorySegmentImpl.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/AbstractMemorySegmentImpl.java
@@ -399,15 +399,17 @@ public abstract class AbstractMemorySegmentImpl implements MemorySegment, Memory
         MemorySegment bufferSegment = (MemorySegment)nioAccess.bufferSegment(bb);
         int modes = bufferSegment == null ?
                 defaultAccessModes(size) : bufferSegment.accessModes();
+        Thread owner = bufferSegment == null ?
+                Thread.currentThread() : bufferSegment.ownerThread();
         if (bb.isReadOnly()) {
             modes &= ~WRITE;
         }
         if (base != null) {
-            return new HeapMemorySegmentImpl<>(bbAddress + pos, () -> (byte[])base, size, modes, Thread.currentThread(), bufferScope);
+            return new HeapMemorySegmentImpl<>(bbAddress + pos, () -> (byte[])base, size, modes, owner, bufferScope);
         } else if (unmapper == null) {
-            return new NativeMemorySegmentImpl(bbAddress + pos, size, modes, Thread.currentThread(), bufferScope);
+            return new NativeMemorySegmentImpl(bbAddress + pos, size, modes, owner, bufferScope);
         } else {
-            return new MappedMemorySegmentImpl(bbAddress + pos, unmapper, size, modes, Thread.currentThread(), bufferScope);
+            return new MappedMemorySegmentImpl(bbAddress + pos, unmapper, size, modes, owner, bufferScope);
         }
     }
 

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/AbstractMemorySegmentImpl.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/AbstractMemorySegmentImpl.java
@@ -395,12 +395,19 @@ public abstract class AbstractMemorySegmentImpl implements MemorySegment, Memory
 
         MemoryScope bufferScope = new MemoryScope(bb, null);
         int size = limit - pos;
+
+        MemorySegment bufferSegment = (MemorySegment)nioAccess.bufferSegment(bb);
+        int modes = bufferSegment == null ?
+                defaultAccessModes(size) : bufferSegment.accessModes();
+        if (bb.isReadOnly()) {
+            modes &= ~WRITE;
+        }
         if (base != null) {
-            return new HeapMemorySegmentImpl<>(bbAddress + pos, () -> (byte[])base, size, defaultAccessModes(size), Thread.currentThread(), bufferScope);
+            return new HeapMemorySegmentImpl<>(bbAddress + pos, () -> (byte[])base, size, modes, Thread.currentThread(), bufferScope);
         } else if (unmapper == null) {
-            return new NativeMemorySegmentImpl(bbAddress + pos, size, defaultAccessModes(size), Thread.currentThread(), bufferScope);
+            return new NativeMemorySegmentImpl(bbAddress + pos, size, modes, Thread.currentThread(), bufferScope);
         } else {
-            return new MappedMemorySegmentImpl(bbAddress + pos, unmapper, size, defaultAccessModes(size), Thread.currentThread(), bufferScope);
+            return new MappedMemorySegmentImpl(bbAddress + pos, unmapper, size, modes, Thread.currentThread(), bufferScope);
         }
     }
 

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/InternalForeign.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/InternalForeign.java
@@ -49,13 +49,21 @@ public class InternalForeign implements Foreign {
 
     @Override
     public MemoryAddress withSize(MemoryAddress base, long byteSize) throws IllegalAccessError {
+        checkRawNativeAddress(base);
         return NativeMemorySegmentImpl.makeNativeSegmentUnchecked(base.toRawLongValue(), byteSize, null, false)
                 .baseAddress();
     }
 
     @Override
     public MemorySegment asMallocSegment(MemoryAddress base, long byteSize) throws IllegalAccessError {
+        checkRawNativeAddress(base);
         return NativeMemorySegmentImpl.makeNativeSegmentUnchecked(base.toRawLongValue(), byteSize, Thread.currentThread(), true);
+    }
+
+    private void checkRawNativeAddress(MemoryAddress base) {
+        if (base.segment() != AbstractMemorySegmentImpl.NOTHING) {
+            throw new IllegalArgumentException("Not an unchecked memory address");
+        }
     }
 
     @Override

--- a/test/jdk/java/foreign/TestByteBuffer.java
+++ b/test/jdk/java/foreign/TestByteBuffer.java
@@ -447,12 +447,14 @@ public class TestByteBuffer {
     @Test(dataProvider="bufferSources")
     public void testBufferToSegment(ByteBuffer bb, Predicate<MemorySegment> segmentChecker) {
         MemorySegment segment = MemorySegment.ofByteBuffer(bb);
+        assertEquals(segment.hasAccessModes(MemorySegment.WRITE), !bb.isReadOnly());
         assertTrue(segmentChecker.test(segment));
         assertTrue(segmentChecker.test(segment.asSlice(0, segment.byteSize())));
         assertTrue(segmentChecker.test(segment.withAccessModes(MemorySegment.READ)));
         assertEquals(bb.capacity(), segment.byteSize());
         //another round trip
         segment = MemorySegment.ofByteBuffer(segment.asByteBuffer());
+        assertEquals(segment.hasAccessModes(MemorySegment.WRITE), !bb.isReadOnly());
         assertTrue(segmentChecker.test(segment));
         assertTrue(segmentChecker.test(segment.asSlice(0, segment.byteSize())));
         assertTrue(segmentChecker.test(segment.withAccessModes(MemorySegment.READ)));
@@ -608,12 +610,18 @@ public class TestByteBuffer {
         Predicate<MemorySegment> heapTest = segment -> segment instanceof HeapMemorySegmentImpl;
         Predicate<MemorySegment> nativeTest = segment -> segment instanceof NativeMemorySegmentImpl;
         Predicate<MemorySegment> mappedTest = segment -> segment instanceof MappedMemorySegmentImpl;
-        try (FileChannel channel = FileChannel.open(tempPath)) {
+        try (FileChannel channel = FileChannel.open(tempPath, StandardOpenOption.READ, StandardOpenOption.WRITE)) {
             return new Object[][]{
                     { ByteBuffer.wrap(new byte[256]), heapTest },
                     { ByteBuffer.allocate(256), heapTest },
                     { ByteBuffer.allocateDirect(256), nativeTest },
-                    { channel.map(FileChannel.MapMode.READ_ONLY, 0L, 256), mappedTest }
+                    { channel.map(FileChannel.MapMode.READ_WRITE, 0L, 256), mappedTest },
+
+                    { ByteBuffer.wrap(new byte[256]).asReadOnlyBuffer(), heapTest },
+                    { ByteBuffer.allocate(256).asReadOnlyBuffer(), heapTest },
+                    { ByteBuffer.allocateDirect(256).asReadOnlyBuffer(), nativeTest },
+                    { channel.map(FileChannel.MapMode.READ_WRITE, 0L, 256).asReadOnlyBuffer(),
+                            nativeTest /* this seems to be an existing bug in the BB implementation */ }
             };
         } catch (IOException ex) {
             throw new ExceptionInInitializerError(ex);

--- a/test/jdk/java/foreign/TestByteBuffer.java
+++ b/test/jdk/java/foreign/TestByteBuffer.java
@@ -461,6 +461,15 @@ public class TestByteBuffer {
         assertEquals(bb.capacity(), segment.byteSize());
     }
 
+    @Test
+    public void testRoundTripAccess() {
+        try(MemorySegment ms = MemorySegment.allocateNative(4)) {
+            MemorySegment msNoAccess = ms.withAccessModes(MemorySegment.READ); // READ is required to make BB
+            MemorySegment msRoundTrip = MemorySegment.ofByteBuffer(msNoAccess.asByteBuffer());
+            assertEquals(msNoAccess.accessModes(), msRoundTrip.accessModes());
+        }
+    }
+
     @DataProvider(name = "bufferOps")
     public static Object[][] bufferOps() throws Throwable {
         return new Object[][]{

--- a/test/jdk/java/foreign/TestNative.java
+++ b/test/jdk/java/foreign/TestNative.java
@@ -25,16 +25,18 @@
 /*
  * @test
  * @modules java.base/jdk.internal.misc
- *          jdk.incubator.foreign
+ *          jdk.incubator.foreign/jdk.internal.foreign
  * @run testng TestNative
  */
 
+import jdk.incubator.foreign.Foreign;
 import jdk.incubator.foreign.MemoryAddress;
 import jdk.incubator.foreign.MemoryLayout;
 import jdk.incubator.foreign.MemoryLayout.PathElement;
 import jdk.incubator.foreign.MemoryLayouts;
 import jdk.incubator.foreign.MemorySegment;
 import jdk.incubator.foreign.SequenceLayout;
+import jdk.internal.foreign.InternalForeign;
 import jdk.internal.misc.Unsafe;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -166,6 +168,20 @@ public class TestNative {
             int expected = capacity / elemSize;
             assertEquals(buf.capacity(), expected);
             assertEquals(getCapacity(buf), expected);
+        }
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testBadResize() {
+        try (MemorySegment segment = MemorySegment.allocateNative(4)) {
+            InternalForeign.getInstancePrivileged().withSize(segment.baseAddress(), 12);
+        }
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testBadMallocSegment() {
+        try (MemorySegment segment = MemorySegment.allocateNative(4)) {
+            InternalForeign.getInstancePrivileged().asMallocSegment(segment.baseAddress(), 12);
         }
     }
 

--- a/test/jdk/java/foreign/TestSharedAccess.java
+++ b/test/jdk/java/foreign/TestSharedAccess.java
@@ -36,12 +36,18 @@ import jdk.incubator.foreign.SequenceLayout;
 import org.testng.annotations.Test;
 
 import java.lang.invoke.VarHandle;
+import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Spliterator;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
 
 public class TestSharedAccess {
 
@@ -130,6 +136,41 @@ public class TestSharedAccess {
             new Thread(r).start();
             Thread.sleep(5000);
         } //should fail here!
+    }
+
+    @Test
+    public void testOutsideConfinementThread() throws Throwable {
+        CountDownLatch a = new CountDownLatch(1);
+        CountDownLatch b = new CountDownLatch(1);
+        CompletableFuture<?> r;
+        try (MemorySegment s1 = MemorySegment.allocateNative(MemoryLayout.ofSequence(2, MemoryLayouts.JAVA_INT))) {
+            r = CompletableFuture.runAsync(() -> {
+                try {
+                    ByteBuffer bb = s1.asByteBuffer();
+
+                    MemorySegment s2 = MemorySegment.ofByteBuffer(bb);
+                    a.countDown();
+
+                    try {
+                        b.await();
+                    } catch (InterruptedException e) {
+                    }
+
+                    MemoryAddress base = s2.baseAddress();
+                    setInt(base.addOffset(4), -42);
+                    fail();
+                } catch (IllegalStateException ex) {
+                    assertTrue(ex.getMessage().contains("owning thread"));
+                }
+            });
+
+            a.await();
+            MemoryAddress base = s1.baseAddress();
+            setInt(base.addOffset(4), 42);
+        }
+
+        b.countDown();
+        r.get();
     }
 
     static int getInt(MemoryAddress address) {


### PR DESCRIPTION
* Fix access modes not preserved in AbstractMemorySegmentImpl.ofBuffer
* Add check to ensure that Foreign::withSize and Foreign::asMallocSegment are called with unchecked address
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * Jorn Vernee ([jvernee](@JornVernee) - Committer) ⚠️ Review applies to c7e953b299b2e65c80b9fce3f1d9130809d96505
 * Paul Sandoz ([psandoz](@PaulSandoz) - Committer)

### Download
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/111/head:pull/111`
`$ git checkout pull/111`
