### PR TITLE
Preserve memory scope for buffer segments

### DIFF
--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/AbstractMemorySegmentImpl.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/AbstractMemorySegmentImpl.java
@@ -392,15 +392,21 @@ public abstract class AbstractMemorySegmentImpl implements MemorySegment, Memory
 
         int pos = bb.position();
         int limit = bb.limit();
-
-        MemoryScope bufferScope = new MemoryScope(bb, null);
         int size = limit - pos;
 
-        MemorySegment bufferSegment = (MemorySegment)nioAccess.bufferSegment(bb);
-        int modes = bufferSegment == null ?
-                defaultAccessModes(size) : bufferSegment.accessModes();
-        Thread owner = bufferSegment == null ?
-                Thread.currentThread() : bufferSegment.ownerThread();
+        AbstractMemorySegmentImpl bufferSegment = (AbstractMemorySegmentImpl)nioAccess.bufferSegment(bb);
+        final MemoryScope bufferScope;
+        int modes;
+        final Thread owner;
+        if (bufferSegment != null) {
+            bufferScope = bufferSegment.scope;
+            modes = bufferSegment.mask;
+            owner = bufferSegment.owner;
+        } else {
+            bufferScope = new MemoryScope(bb, null);
+            modes = defaultAccessModes(size);
+            owner = Thread.currentThread();
+        }
         if (bb.isReadOnly()) {
             modes &= ~WRITE;
         }

--- a/test/jdk/java/foreign/TestByteBuffer.java
+++ b/test/jdk/java/foreign/TestByteBuffer.java
@@ -470,6 +470,16 @@ public class TestByteBuffer {
         }
     }
 
+    @Test(expectedExceptions = IllegalStateException.class)
+    public void testDeadAccessOnClosedBufferSegment() {
+        MemorySegment s1 = MemorySegment.allocateNative(MemoryLayouts.JAVA_INT);
+        MemorySegment s2 = MemorySegment.ofByteBuffer(s1.asByteBuffer());
+
+        s1.close(); // memory freed
+
+        intHandle.set(s2.baseAddress(), 0L, 10); // Dead access!
+    }
+
     @DataProvider(name = "bufferOps")
     public static Object[][] bufferOps() throws Throwable {
         return new Object[][]{

--- a/test/jdk/java/foreign/TestSharedAccess.java
+++ b/test/jdk/java/foreign/TestSharedAccess.java
@@ -138,6 +138,23 @@ public class TestSharedAccess {
         } //should fail here!
     }
 
+    @Test(expectedExceptions=IllegalStateException.class)
+    public void testBadCloseWithPendingAcquireBuffer() throws InterruptedException {
+        MemorySegment segment = MemorySegment.allocateNative(16);
+        Spliterator<MemorySegment> spliterator = segment.spliterator(MemoryLayout.ofSequence(16, MemoryLayouts.JAVA_BYTE));
+        Runnable r = () -> spliterator.forEachRemaining(s -> {
+            try {
+                Thread.sleep(5000 * 100);
+            } catch (InterruptedException ex) {
+                throw new AssertionError(ex);
+            }
+        });
+        new Thread(r).start();
+        Thread.sleep(5000);
+        segment = MemorySegment.ofByteBuffer(segment.asByteBuffer()); // original segment is lost
+        segment.close(); // this should still fail
+    }
+
     @Test
     public void testOutsideConfinementThread() throws Throwable {
         CountDownLatch a = new CountDownLatch(1);


### PR DESCRIPTION
Not 100% sure about this, but wanted to share this PR for evaluation. Basically, I've realized that we are also not preserving the memory scope of the original segment when we do a segment -> buffer -> segment transition.

This means that, e.g. code like this:

```
MemorySegment segment = MemorySegment.allocateNative(16);
segment = MemorySegment.ofByteBuffer(segment.asByteBuffer());
segment.close(); // no cleanup of native memory
```

will not really 'close' the original segment. Similarly, if the original segment is being worked upon by some other thread (through a spliterator) it is possible for the morphed segment to lose this info, and to allow a close - if the scope is created afresh (as is now).

This patch fixes this, but I'm torn as to whether it makes things better; preserving access modes and thread ownership is mostly about not allowing clients to use the byte buffer escape hatch as a way to defy the segment restrictions. I don't think preserving scope falls into the same bucket - e.g. this is a separate question as to whether a segment S2 obtained through S1 -> BB -> S2 is just a *view* of S1 (with same temporal bounds), or is just an independent segment, with new temporal bounds. I think both answers are legitimate, and it's mostly a question of making up our mind.

My take is that inferring scope like this can be seen a bit too magic - and you are never sure of what happens when you do a MemorySegment::close, so perhaps what we have w/o this patch is preferrable. What do you think?
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * Jorn Vernee ([jvernee](@JornVernee) - Committer)

### Download
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/113/head:pull/113`
`$ git checkout pull/113`
