### PR TITLE
JDK-8243064: Add more support for mapped memory segments

### DIFF
--- a/src/java.base/share/classes/java/nio/Buffer.java
+++ b/src/java.base/share/classes/java/nio/Buffer.java
@@ -814,6 +814,11 @@ public abstract class Buffer {
                 }
 
                 @Override
+                public void unload(long address, boolean isSync, long size) {
+                    MappedMemoryUtils.unload(address, isSync, size);
+                }
+
+                @Override
                 public boolean isLoaded(long address, boolean isSync, long size) {
                     return MappedMemoryUtils.isLoaded(address, isSync, size);
                 }

--- a/src/java.base/share/classes/java/nio/Buffer.java
+++ b/src/java.base/share/classes/java/nio/Buffer.java
@@ -33,6 +33,7 @@ import jdk.internal.access.foreign.UnmapperProxy;
 import jdk.internal.misc.Unsafe;
 import jdk.internal.vm.annotation.ForceInline;
 
+import java.io.FileDescriptor;
 import java.util.Spliterator;
 
 /**
@@ -800,6 +801,21 @@ public abstract class Buffer {
                 @Override
                 public MemorySegmentProxy bufferSegment(Buffer buffer) {
                     return buffer.segment;
+                }
+
+                @Override
+                public void force(FileDescriptor fd, long address, boolean isSync, long offset, long size) {
+                    MappedMemoryUtils.force(fd, address, isSync, offset, size);
+                }
+
+                @Override
+                public void load(long address, boolean isSync, long size) {
+                    MappedMemoryUtils.load(address, isSync, size);
+                }
+
+                @Override
+                public boolean isLoaded(long address, boolean isSync, long size) {
+                    return MappedMemoryUtils.isLoaded(address, isSync, size);
                 }
             });
     }

--- a/src/java.base/share/classes/java/nio/MappedByteBuffer.java
+++ b/src/java.base/share/classes/java/nio/MappedByteBuffer.java
@@ -31,7 +31,6 @@ import java.util.Objects;
 
 import jdk.internal.access.foreign.MemorySegmentProxy;
 import jdk.internal.access.foreign.UnmapperProxy;
-import jdk.internal.misc.Unsafe;
 
 
 /**
@@ -135,60 +134,6 @@ public abstract class MappedByteBuffer
                 } : null;
     }
 
-    // Returns the distance (in bytes) of the buffer start from the
-    // largest page aligned address of the mapping less than or equal
-    // to the start address.
-    private long mappingOffset() {
-        return mappingOffset(0);
-    }
-
-    // Returns the distance (in bytes) of the buffer element
-    // identified by index from the largest page aligned address of
-    // the mapping less than or equal to the element address. Computed
-    // each time to avoid storing in every direct buffer.
-    private long mappingOffset(int index) {
-        int ps = Bits.pageSize();
-        long indexAddress = address + index;
-        long baseAddress = alignDown(indexAddress, ps);
-        return indexAddress - baseAddress;
-    }
-
-    // Given an offset previously obtained from calling
-    // mappingOffset() returns the largest page aligned address of the
-    // mapping less than or equal to the buffer start address.
-    private long mappingAddress(long mappingOffset) {
-        return mappingAddress(mappingOffset, 0);
-    }
-
-    // Given an offset previously otained from calling
-    // mappingOffset(index) returns the largest page aligned address
-    // of the mapping less than or equal to the address of the buffer
-    // element identified by index.
-    private long mappingAddress(long mappingOffset, long index) {
-        long indexAddress = address + index;
-        return indexAddress - mappingOffset;
-    }
-
-    // given a mappingOffset previously otained from calling
-    // mappingOffset() return that offset added to the buffer
-    // capacity.
-    private long mappingLength(long mappingOffset) {
-        return mappingLength(mappingOffset, (long)capacity());
-    }
-
-    // given a mappingOffset previously otained from calling
-    // mappingOffset(index) return that offset added to the supplied
-    // length.
-    private long mappingLength(long mappingOffset, long length) {
-        return length + mappingOffset;
-    }
-
-    // align address down to page size
-    private static long alignDown(long address, int pageSize) {
-        // pageSize must be a power of 2
-        return address & ~(pageSize - 1);
-    }
-
     /**
      * Tells whether this buffer was mapped against a non-volatile
      * memory device by passing one of the sync map modes {@link
@@ -228,19 +173,8 @@ public abstract class MappedByteBuffer
         if (fd == null) {
             return true;
         }
-        // a sync mapped buffer is always loaded
-        if (isSync()) {
-            return true;
-        }
-        if ((address == 0) || (capacity() == 0))
-            return true;
-        long offset = mappingOffset();
-        long length = mappingLength(offset);
-        return isLoaded0(mappingAddress(offset), length, Bits.pageCount(length));
+        return MappedMemoryUtils.isLoaded(address, isSync, capacity());
     }
-
-    // not used, but a potential target for a store, see load() for details.
-    private static byte unused;
 
     /**
      * Loads this buffer's content into physical memory.
@@ -256,37 +190,11 @@ public abstract class MappedByteBuffer
         if (fd == null) {
             return this;
         }
-        // no need to load a sync mapped buffer
-        if (isSync()) {
-            return this;
-        }
-        if ((address == 0) || (capacity() == 0))
-            return this;
-        long offset = mappingOffset();
-        long length = mappingLength(offset);
-        load0(mappingAddress(offset), length);
-
-        // Read a byte from each page to bring it into memory. A checksum
-        // is computed as we go along to prevent the compiler from otherwise
-        // considering the loop as dead code.
-        Unsafe unsafe = Unsafe.getUnsafe();
-        int ps = Bits.pageSize();
-        int count = Bits.pageCount(length);
-        long a = mappingAddress(offset);
-        byte x = 0;
         try {
-            for (int i=0; i<count; i++) {
-                // TODO consider changing to getByteOpaque thus avoiding
-                // dead code elimination and the need to calculate a checksum
-                x ^= unsafe.getByte(a);
-                a += ps;
-            }
+            MappedMemoryUtils.load(address, isSync, capacity());
         } finally {
             Reference.reachabilityFence(this);
         }
-        if (unused != 0)
-            unused = x;
-
         return this;
     }
 
@@ -319,8 +227,7 @@ public abstract class MappedByteBuffer
             return force(0, limit());
         }
         if ((address != 0) && (capacity() != 0)) {
-            long offset = mappingOffset();
-            force0(fd, mappingAddress(offset), mappingLength(offset));
+            return force(0, capacity());
         }
         return this;
     }
@@ -374,21 +281,10 @@ public abstract class MappedByteBuffer
         if ((address != 0) && (limit() != 0)) {
             // check inputs
             Objects.checkFromIndexSize(index, length, limit());
-            if (isSync) {
-                // simply force writeback of associated cache lines
-                Unsafe.getUnsafe().writebackMemory(address + index, length);
-            } else {
-                // force writeback via file descriptor
-                long offset = mappingOffset(index);
-                force0(fd, mappingAddress(offset, index), mappingLength(offset, length));
-            }
+            MappedMemoryUtils.force(fd, address, isSync, index, length);
         }
         return this;
     }
-
-    private native boolean isLoaded0(long address, long length, int pageCount);
-    private native void load0(long address, long length);
-    private native void force0(FileDescriptor fd, long address, long length);
 
     // -- Covariant return type overrides
 

--- a/src/java.base/share/classes/java/nio/MappedMemoryUtils.java
+++ b/src/java.base/share/classes/java/nio/MappedMemoryUtils.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package java.nio;
+
+import jdk.internal.misc.Unsafe;
+
+import java.io.FileDescriptor;
+
+/* package */ class MappedMemoryUtils {
+
+    static boolean isLoaded(long address, boolean isSync, long size) {
+        // a sync mapped buffer is always loaded
+        if (isSync) {
+            return true;
+        }
+        if ((address == 0) || (size == 0))
+            return true;
+        long offset = mappingOffset(address);
+        long length = mappingLength(offset, size);
+        return isLoaded0(mappingAddress(address, offset), length, Bits.pageCount(length));
+    }
+
+    static void load(long address, boolean isSync, long size) {
+        // no need to load a sync mapped buffer
+        if (isSync) {
+            return;
+        }
+        if ((address == 0) || (size == 0))
+            return;
+        long offset = mappingOffset(address);
+        long length = mappingLength(offset, size);
+        load0(mappingAddress(address, offset), length);
+
+        // Read a byte from each page to bring it into memory. A checksum
+        // is computed as we go along to prevent the compiler from otherwise
+        // considering the loop as dead code.
+        Unsafe unsafe = Unsafe.getUnsafe();
+        int ps = Bits.pageSize();
+        int count = Bits.pageCount(length);
+        long a = mappingAddress(address, offset);
+        byte x = 0;
+        for (int i=0; i<count; i++) {
+            // TODO consider changing to getByteOpaque thus avoiding
+            // dead code elimination and the need to calculate a checksum
+            x ^= unsafe.getByte(a);
+            a += ps;
+        }
+        if (unused != 0)
+            unused = x;
+    }
+
+    // not used, but a potential target for a store, see load() for details.
+    private static byte unused;
+
+    static void force(FileDescriptor fd, long address, boolean isSync, long index, long length) {
+        if (isSync) {
+            // simply force writeback of associated cache lines
+            Unsafe.getUnsafe().writebackMemory(address + index, length);
+        } else {
+            // force writeback via file descriptor
+            long offset = mappingOffset(address, index);
+            force0(fd, mappingAddress(address, offset, index), mappingLength(offset, length));
+        }
+    }
+
+    // native methods
+
+    private static native boolean isLoaded0(long address, long length, int pageCount);
+    private static native void load0(long address, long length);
+    private static native void force0(FileDescriptor fd, long address, long length);
+
+    // utility methods
+
+    // Returns the distance (in bytes) of the buffer start from the
+    // largest page aligned address of the mapping less than or equal
+    // to the start address.
+    private static long mappingOffset(long address) {
+        return mappingOffset(address, 0);
+    }
+
+    // Returns the distance (in bytes) of the buffer element
+    // identified by index from the largest page aligned address of
+    // the mapping less than or equal to the element address. Computed
+    // each time to avoid storing in every direct buffer.
+    private static long mappingOffset(long address, long index) {
+        int ps = Bits.pageSize();
+        long indexAddress = address + index;
+        long baseAddress = alignDown(indexAddress, ps);
+        return indexAddress - baseAddress;
+    }
+
+    // Given an offset previously obtained from calling
+    // mappingOffset() returns the largest page aligned address of the
+    // mapping less than or equal to the buffer start address.
+    private static long mappingAddress(long address, long mappingOffset) {
+        return mappingAddress(address, mappingOffset, 0);
+    }
+
+    // Given an offset previously otained from calling
+    // mappingOffset(index) returns the largest page aligned address
+    // of the mapping less than or equal to the address of the buffer
+    // element identified by index.
+    private static long mappingAddress(long address, long mappingOffset, long index) {
+        long indexAddress = address + index;
+        return indexAddress - mappingOffset;
+    }
+
+    // given a mappingOffset previously otained from calling
+    // mappingOffset(index) return that offset added to the supplied
+    // length.
+    private static long mappingLength(long mappingOffset, long length) {
+        return length + mappingOffset;
+    }
+
+    // align address down to page size
+    private static long alignDown(long address, int pageSize) {
+        // pageSize must be a power of 2
+        return address & ~(pageSize - 1);
+    }
+}

--- a/src/java.base/share/classes/java/nio/MappedMemoryUtils.java
+++ b/src/java.base/share/classes/java/nio/MappedMemoryUtils.java
@@ -75,6 +75,18 @@ import java.io.FileDescriptor;
     // not used, but a potential target for a store, see load() for details.
     private static byte unused;
 
+    static void unload(long address, boolean isSync, long size) {
+        // no need to load a sync mapped buffer
+        if (isSync) {
+            return;
+        }
+        if ((address == 0) || (size == 0))
+            return;
+        long offset = mappingOffset(address);
+        long length = mappingLength(offset, size);
+        unload0(mappingAddress(address, offset), length);
+    }
+
     static void force(FileDescriptor fd, long address, boolean isSync, long index, long length) {
         if (isSync) {
             // simply force writeback of associated cache lines
@@ -90,6 +102,7 @@ import java.io.FileDescriptor;
 
     private static native boolean isLoaded0(long address, long length, int pageCount);
     private static native void load0(long address, long length);
+    private static native void unload0(long address, long length);
     private static native void force0(FileDescriptor fd, long address, long length);
 
     // utility methods

--- a/src/java.base/share/classes/jdk/internal/access/JavaNioAccess.java
+++ b/src/java.base/share/classes/jdk/internal/access/JavaNioAccess.java
@@ -100,6 +100,11 @@ public interface JavaNioAccess {
     void load(long address, boolean isSync, long size);
 
     /**
+     * Used by {@code jdk.internal.foreign.MappedMemorySegmentImpl}.
+     */
+    void unload(long address, boolean isSync, long size);
+
+    /**
      * Used by {@code jdk.internal.foreign.MappedMemorySegmentImpl} and byte buffer var handle views.
      */
     boolean isLoaded(long address, boolean isSync, long size);

--- a/src/java.base/share/classes/jdk/internal/access/JavaNioAccess.java
+++ b/src/java.base/share/classes/jdk/internal/access/JavaNioAccess.java
@@ -28,6 +28,7 @@ package jdk.internal.access;
 import jdk.internal.access.foreign.MemorySegmentProxy;
 import jdk.internal.access.foreign.UnmapperProxy;
 
+import java.io.FileDescriptor;
 import java.nio.Buffer;
 import java.nio.ByteBuffer;
 
@@ -87,4 +88,19 @@ public interface JavaNioAccess {
      * Used by {@code jdk.internal.foreign.AbstractMemorySegmentImpl} and byte buffer var handle views.
      */
     MemorySegmentProxy bufferSegment(Buffer buffer);
+
+    /**
+     * Used by {@code jdk.internal.foreign.MappedMemorySegmentImpl} and byte buffer var handle views.
+     */
+    void force(FileDescriptor fd, long address, boolean isSync, long offset, long size);
+
+    /**
+     * Used by {@code jdk.internal.foreign.MappedMemorySegmentImpl} and byte buffer var handle views.
+     */
+    void load(long address, boolean isSync, long size);
+
+    /**
+     * Used by {@code jdk.internal.foreign.MappedMemorySegmentImpl} and byte buffer var handle views.
+     */
+    boolean isLoaded(long address, boolean isSync, long size);
 }

--- a/src/java.base/unix/native/libnio/MappedMemoryUtils.c
+++ b/src/java.base/unix/native/libnio/MappedMemoryUtils.c
@@ -27,7 +27,7 @@
 #include "jni_util.h"
 #include "jvm.h"
 #include "jlong.h"
-#include "java_nio_MappedByteBuffer.h"
+#include "java_nio_MappedMemoryUtils.h"
 #include <assert.h>
 #include <sys/mman.h>
 #include <stddef.h>
@@ -55,7 +55,7 @@ static long calculate_number_of_pages_in_range(void* address, size_t len, size_t
 #endif
 
 JNIEXPORT jboolean JNICALL
-Java_java_nio_MappedByteBuffer_isLoaded0(JNIEnv *env, jobject obj, jlong address,
+Java_java_nio_MappedMemoryUtils_isLoaded0(JNIEnv *env, jobject obj, jlong address,
                                          jlong len, jint numPages)
 {
     jboolean loaded = JNI_TRUE;
@@ -104,7 +104,7 @@ Java_java_nio_MappedByteBuffer_isLoaded0(JNIEnv *env, jobject obj, jlong address
 
 
 JNIEXPORT void JNICALL
-Java_java_nio_MappedByteBuffer_load0(JNIEnv *env, jobject obj, jlong address,
+Java_java_nio_MappedMemoryUtils_load0(JNIEnv *env, jobject obj, jlong address,
                                      jlong len)
 {
     char *a = (char *)jlong_to_ptr(address);
@@ -116,7 +116,7 @@ Java_java_nio_MappedByteBuffer_load0(JNIEnv *env, jobject obj, jlong address,
 
 
 JNIEXPORT void JNICALL
-Java_java_nio_MappedByteBuffer_force0(JNIEnv *env, jobject obj, jobject fdo,
+Java_java_nio_MappedMemoryUtils_force0(JNIEnv *env, jobject obj, jobject fdo,
                                       jlong address, jlong len)
 {
     void* a = (void *)jlong_to_ptr(address);

--- a/src/java.base/unix/native/libnio/MappedMemoryUtils.c
+++ b/src/java.base/unix/native/libnio/MappedMemoryUtils.c
@@ -114,6 +114,16 @@ Java_java_nio_MappedMemoryUtils_load0(JNIEnv *env, jobject obj, jlong address,
     }
 }
 
+JNIEXPORT void JNICALL
+Java_java_nio_MappedMemoryUtils_unload0(JNIEnv *env, jobject obj, jlong address,
+                                     jlong len)
+{
+    char *a = (char *)jlong_to_ptr(address);
+    int result = madvise((caddr_t)a, (size_t)len, MADV_DONTNEED);
+    if (result == -1) {
+        JNU_ThrowIOExceptionWithLastError(env, "madvise failed");
+    }
+}
 
 JNIEXPORT void JNICALL
 Java_java_nio_MappedMemoryUtils_force0(JNIEnv *env, jobject obj, jobject fdo,

--- a/src/java.base/windows/native/libnio/MappedMemoryUtils.c
+++ b/src/java.base/windows/native/libnio/MappedMemoryUtils.c
@@ -51,6 +51,13 @@ Java_java_nio_MappedMemoryUtils_load0(JNIEnv *env, jobject obj, jlong address,
 }
 
 JNIEXPORT void JNICALL
+Java_java_nio_MappedMemoryUtils_unload0(JNIEnv *env, jobject obj, jlong address,
+                                     jlong len)
+{
+    // no madvise available
+}
+
+JNIEXPORT void JNICALL
 Java_java_nio_MappedMemoryUtils_force0(JNIEnv *env, jobject obj, jobject fdo,
                                       jlong address, jlong len)
 {

--- a/src/java.base/windows/native/libnio/MappedMemoryUtils.c
+++ b/src/java.base/windows/native/libnio/MappedMemoryUtils.c
@@ -27,11 +27,11 @@
 #include "jni_util.h"
 #include "jvm.h"
 #include "jlong.h"
-#include "java_nio_MappedByteBuffer.h"
+#include "java_nio_MappedMemoryUtils.h"
 #include <stdlib.h>
 
 JNIEXPORT jboolean JNICALL
-Java_java_nio_MappedByteBuffer_isLoaded0(JNIEnv *env, jobject obj, jlong address,
+Java_java_nio_MappedMemoryUtils_isLoaded0(JNIEnv *env, jobject obj, jlong address,
                                          jlong len, jint numPages)
 {
     jboolean loaded = JNI_FALSE;
@@ -44,14 +44,14 @@ Java_java_nio_MappedByteBuffer_isLoaded0(JNIEnv *env, jobject obj, jlong address
 }
 
 JNIEXPORT void JNICALL
-Java_java_nio_MappedByteBuffer_load0(JNIEnv *env, jobject obj, jlong address,
+Java_java_nio_MappedMemoryUtils_load0(JNIEnv *env, jobject obj, jlong address,
                                      jlong len)
 {
     // no madvise available
 }
 
 JNIEXPORT void JNICALL
-Java_java_nio_MappedByteBuffer_force0(JNIEnv *env, jobject obj, jobject fdo,
+Java_java_nio_MappedMemoryUtils_force0(JNIEnv *env, jobject obj, jobject fdo,
                                       jlong address, jlong len)
 {
     void *a = (void *) jlong_to_ptr(address);

--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/MappedMemorySegment.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/MappedMemorySegment.java
@@ -94,11 +94,21 @@ public interface MappedMemorySegment extends MemorySegment {
      * Loads this segment's content into physical memory.
      *
      * <p> This method makes a best effort to ensure that, when it returns,
-     * this segment's content is resident in physical memory.  Invoking this
+     * this segment's contents is resident in physical memory.  Invoking this
      * method may cause some number of page faults and I/O operations to
      * occur. </p>
      */
     void load();
+
+    /**
+     * Unloads this segment's content from physical memory.
+     *
+     * <p> This method makes a best effort to ensure that this segment's contents are
+     * are no longer resident in physical memory. Accessing this segment's contents
+     * after invoking this method may cause some number of page faults and I/O operations to
+     * occur (as this segment's contents might need to be paged back in). </p>
+     */
+    void unload();
 
     /**
      * Tells whether or not this segment's content is resident in physical

--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/MappedMemorySegment.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/MappedMemorySegment.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package jdk.incubator.foreign;
+
+/**
+ * Mapped memory segment.
+ */
+public interface MappedMemorySegment extends MemorySegment {
+    @Override
+    MappedMemorySegment withAccessModes(int accessModes);
+
+    @Override
+    MappedMemorySegment asSlice(long offset, long newSize);
+
+    /**
+     * Force
+     */
+    void force();
+
+    /**
+     * Load
+     */
+    void load();
+
+    /**
+     * Is loaded
+     * @return true, if loaded.
+     */
+    boolean isLoaded();
+}

--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/MappedMemorySegment.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/MappedMemorySegment.java
@@ -25,10 +25,43 @@
 
 package jdk.incubator.foreign;
 
+import java.nio.channels.FileChannel;
+import java.nio.file.Path;
+
 /**
- * Mapped memory segment.
+ * A mapped memory segment, that is, a memory segment backed by memory-mapped file.
+ *
+ * <p> Mapped memory segments are created via the {@link MemorySegment#mapFromPath(Path, long, FileChannel.MapMode)}.
+ * Mapped memory segments behave like ordinary segments, but also provide additional capabilities that are specific to
+ * mapped memory segments, such as {@link #force()} and {@link #load()}.
+ * <p>
+ * All implementations of this interface must be <a href="{@docRoot}/java.base/java/lang/doc-files/ValueBased.html">value-based</a>;
+ * use of identity-sensitive operations (including reference equality ({@code ==}), identity hash code, or synchronization) on
+ * instances of {@code MemoryLayout} may have unpredictable results and should be avoided. The {@code equals} method should
+ * be used for comparisons.
+ * <p>
+ * Non-platform classes should not implement {@linkplain MappedMemorySegment} directly.
+ *
+ * <p> The content of a mapped memory segment can change at any time, for example
+ * if the content of the corresponding region of the mapped file is changed by
+ * this (or another) program.  Whether or not such changes occur, and when they
+ * occur, is operating-system dependent and therefore unspecified.
+ *
+ * All or part of a mapped memory segment may become
+ * inaccessible at any time, for example if the backing mapped file is truncated.  An
+ * attempt to access an inaccessible region of a mapped memory segment will not
+ * change the segment's content and will cause an unspecified exception to be
+ * thrown either at the time of the access or at some later time.  It is
+ * therefore strongly recommended that appropriate precautions be taken to
+ * avoid the manipulation of a mapped file by this (or another) program, except to read or write
+ * the file's content.
+ *
+ * @apiNote In the future, if the Java language permits, {@link MemorySegment}
+ * may become a {@code sealed} interface, which would prohibit subclassing except by
+ * explicitly permitted subtypes.
  */
 public interface MappedMemorySegment extends MemorySegment {
+
     @Override
     MappedMemorySegment withAccessModes(int accessModes);
 
@@ -36,18 +69,54 @@ public interface MappedMemorySegment extends MemorySegment {
     MappedMemorySegment asSlice(long offset, long newSize);
 
     /**
-     * Force
+     * Forces any changes made to this segment's content to be written to the
+     * storage device containing the mapped file.
+     *
+     * <p> If the file mapped into this segment resides on a local storage
+     * device then when this method returns it is guaranteed that all changes
+     * made to the segment since it was created, or since this method was last
+     * invoked, will have been written to that device.
+     *
+     * <p> If the file does not reside on a local device then no such guarantee
+     * is made.
+     *
+     * <p> If this segment was not mapped in read/write mode ({@link
+     * java.nio.channels.FileChannel.MapMode#READ_WRITE}) then
+     * invoking this method may have no effect. In particular, the
+     * method has no effect for segments mapped in read-only or private
+     * mapping modes. This method may or may not have an effect for
+     * implementation-specific mapping modes.
+     * </p>
      */
     void force();
 
     /**
-     * Load
+     * Loads this segment's content into physical memory.
+     *
+     * <p> This method makes a best effort to ensure that, when it returns,
+     * this segment's content is resident in physical memory.  Invoking this
+     * method may cause some number of page faults and I/O operations to
+     * occur. </p>
      */
     void load();
 
     /**
-     * Is loaded
-     * @return true, if loaded.
+     * Tells whether or not this segment's content is resident in physical
+     * memory.
+     *
+     * <p> A return value of {@code true} implies that it is highly likely
+     * that all of the data in this segment is resident in physical memory and
+     * may therefore be accessed without incurring any virtual-memory page
+     * faults or I/O operations.  A return value of {@code false} does not
+     * necessarily imply that the segment's content is not resident in physical
+     * memory.
+     *
+     * <p> The returned value is a hint, rather than a guarantee, because the
+     * underlying operating system may have paged out some of the segment's data
+     * by the time that an invocation of this method returns.  </p>
+     *
+     * @return  {@code true} if it is likely that this segment's content
+     *          is resident in physical memory
      */
     boolean isLoaded();
 }

--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/MemorySegment.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/MemorySegment.java
@@ -72,7 +72,8 @@ import java.util.function.Consumer;
  * by native memory.
  * <p>
  * Finally, it is also possible to obtain a memory segment backed by a memory-mapped file using the factory method
- * {@link MemorySegment#mapFromPath(Path, long, FileChannel.MapMode)}. Such memory segments are called <em>mapped memory segments</em>.
+ * {@link MemorySegment#mapFromPath(Path, long, FileChannel.MapMode)}. Such memory segments are called <em>mapped memory segments</em>
+ * (see {@link MappedMemorySegment}).
  *
  * <h2>Closing a memory segment</h2>
  *
@@ -146,7 +147,7 @@ MemorySegment roSegment = segment.withAccessModes(segment.accessModes() & ~WRITE
  *
  * @apiNote In the future, if the Java language permits, {@link MemorySegment}
  * may become a {@code sealed} interface, which would prohibit subclassing except by
- * explicitly permitted types.
+ * {@link MappedMemorySegment} and other explicitly permitted subtypes.
  *
  * @implSpec
  * Implementations of this interface are immutable and thread-safe.
@@ -440,7 +441,8 @@ allocateNative(bytesSize, 1);
      *
      * @param path the path to the file to memory map.
      * @param bytesSize the size (in bytes) of the mapped memory backing the memory segment.
-     * @param mapMode a file mapping mode, see {@link FileChannel#map(FileChannel.MapMode, long, long)}.
+     * @param mapMode a file mapping mode, see {@link FileChannel#map(FileChannel.MapMode, long, long)}; the chosen mapping mode
+     *                might affect the behavior of the returned memory mapped segment (see {@link MappedMemorySegment#force()}).
      * @return a new mapped memory segment.
      * @throws IllegalArgumentException if {@code bytesSize < 0}.
      * @throws UnsupportedOperationException if an unsupported map mode is specified.

--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/MemorySegment.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/MemorySegment.java
@@ -162,7 +162,7 @@ public interface MemorySegment extends AutoCloseable {
     MemoryAddress baseAddress();
 
     /**
-     * Returns a spliterator for this memory segment. The returned spliterator reports {@link Spliterator#SIZED},
+     * Returns a spliterator for the given memory segment. The returned spliterator reports {@link Spliterator#SIZED},
      * {@link Spliterator#SUBSIZED}, {@link Spliterator#IMMUTABLE}, {@link Spliterator#NONNULL} and {@link Spliterator#ORDERED}
      * characteristics.
      * <p>
@@ -177,12 +177,16 @@ public interface MemorySegment extends AutoCloseable {
      * fail with an exception, it is possible to close a segment when a spliterator has been obtained but no thread
      * is actively working on it using {@link Spliterator#tryAdvance(Consumer)}; in such cases, any subsequent call
      * to {@link Spliterator#tryAdvance(Consumer)} will fail with an exception.
+     * @param segment the segment to be used for splitting.
      * @param layout the layout to be used for splitting.
+     * @param <S> the memory segment type
      * @return the element spliterator for this segment
-     * @throws IllegalStateException if this segment is not <em>alive</em>, or if access occurs from a thread other than the
+     * @throws IllegalStateException if the segment is not <em>alive</em>, or if access occurs from a thread other than the
      * thread owning this segment
      */
-    Spliterator<MemorySegment> spliterator(SequenceLayout layout);
+    static <S extends MemorySegment> Spliterator<S> spliterator(S segment, SequenceLayout layout) {
+        return AbstractMemorySegmentImpl.spliterator(segment, layout);
+    }
 
     /**
      * The thread owning this segment.
@@ -246,7 +250,7 @@ public interface MemorySegment extends AutoCloseable {
      * associated with the memory segment.
      * @throws IllegalStateException if this segment is not <em>alive</em>, or if access occurs from a thread other than the
      * thread owning this segment, or if the segment cannot be closed because it is being operated upon by a different
-     * thread (see {@link #spliterator(SequenceLayout)}).
+     * thread (see {@link #spliterator(MemorySegment, SequenceLayout)}).
      * @throws UnsupportedOperationException if this segment does not support the {@link #CLOSE} access mode.
      */
     void close();
@@ -442,7 +446,7 @@ allocateNative(bytesSize, 1);
      * @throws UnsupportedOperationException if an unsupported map mode is specified.
      * @throws IOException if the specified path does not point to an existing file, or if some other I/O error occurs.
      */
-    static MemorySegment mapFromPath(Path path, long bytesSize, FileChannel.MapMode mapMode) throws IOException {
+    static MappedMemorySegment mapFromPath(Path path, long bytesSize, FileChannel.MapMode mapMode) throws IOException {
         return MappedMemorySegmentImpl.makeMappedSegment(path, bytesSize, mapMode);
     }
 
@@ -498,7 +502,7 @@ allocateNative(bytesSize, 1);
 
     /**
      * Acquire access mode; this segment support sharing with threads other than the owner thread, via spliterator
-     * (see {@link #spliterator(SequenceLayout)}).
+     * (see {@link #spliterator(MemorySegment, SequenceLayout)}).
      * @see MemorySegment#accessModes()
      * @see MemorySegment#withAccessModes(int)
      */

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/AbstractMemorySegmentImpl.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/AbstractMemorySegmentImpl.java
@@ -93,7 +93,7 @@ public abstract class AbstractMemorySegmentImpl implements MemorySegment, Memory
     }
 
     @Override
-    public final MemorySegment asSlice(long offset, long newSize) {
+    public AbstractMemorySegmentImpl asSlice(long offset, long newSize) {
         checkBounds(offset, newSize);
         return asSliceNoCheck(offset, newSize);
     }
@@ -102,14 +102,14 @@ public abstract class AbstractMemorySegmentImpl implements MemorySegment, Memory
         return dup(offset, newSize, mask, owner, scope);
     }
 
-    @Override
-    public Spliterator<MemorySegment> spliterator(SequenceLayout sequenceLayout) {
-        checkValidState();
-        if (sequenceLayout.byteSize() != byteSize()) {
+    @SuppressWarnings("unchecked")
+    public static <S extends MemorySegment> Spliterator<S> spliterator(S segment, SequenceLayout sequenceLayout) {
+        ((AbstractMemorySegmentImpl)segment).checkValidState();
+        if (sequenceLayout.byteSize() != segment.byteSize()) {
             throw new IllegalArgumentException();
         }
-        return new SegmentSplitter(sequenceLayout.elementLayout().byteSize(), sequenceLayout.elementCount().getAsLong(),
-                this.withAccessModes(accessModes() & ~CLOSE));
+        return (Spliterator<S>)new SegmentSplitter(sequenceLayout.elementLayout().byteSize(), sequenceLayout.elementCount().getAsLong(),
+                (AbstractMemorySegmentImpl)segment.withAccessModes(segment.accessModes() & ~CLOSE));
     }
 
     @Override

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/HeapMemorySegmentImpl.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/HeapMemorySegmentImpl.java
@@ -69,7 +69,7 @@ public class HeapMemorySegmentImpl<H> extends AbstractMemorySegmentImpl {
     }
 
     @Override
-    AbstractMemorySegmentImpl dup(long offset, long size, int mask, Thread owner, MemoryScope scope) {
+    HeapMemorySegmentImpl<H> dup(long offset, long size, int mask, Thread owner, MemoryScope scope) {
         return new HeapMemorySegmentImpl<H>(this.offset + offset, baseProvider, size, mask, owner, scope);
     }
 

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/MappedMemorySegmentImpl.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/MappedMemorySegmentImpl.java
@@ -64,6 +64,20 @@ public class MappedMemorySegmentImpl extends NativeMemorySegmentImpl {
         return new MappedMemorySegmentImpl(min + offset, unmapper, size, mask, owner, scope);
     }
 
+    // mapped segment methods
+
+    public void load() {
+        nioAccess.load(min, unmapper.isSync(), length);
+    }
+
+    public boolean isLoaded() {
+        return nioAccess.isLoaded(min, unmapper.isSync(), length);
+    }
+
+    public void force() {
+        nioAccess.force(unmapper.fileDescriptor(), min, unmapper.isSync(), 0, length);
+    }
+
     // factories
 
     public static MemorySegment makeMappedSegment(Path path, long bytesSize, FileChannel.MapMode mapMode) throws IOException {

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/MappedMemorySegmentImpl.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/MappedMemorySegmentImpl.java
@@ -83,6 +83,11 @@ public class MappedMemorySegmentImpl extends NativeMemorySegmentImpl implements 
     }
 
     @Override
+    public void unload() {
+        nioAccess.unload(min, unmapper.isSync(), length);
+    }
+
+    @Override
     public boolean isLoaded() {
         return nioAccess.isLoaded(min, unmapper.isSync(), length);
     }

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/MappedMemorySegmentImpl.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/MappedMemorySegmentImpl.java
@@ -25,7 +25,7 @@
 
 package jdk.internal.foreign;
 
-import jdk.incubator.foreign.MemorySegment;
+import jdk.incubator.foreign.MappedMemorySegment;
 import jdk.internal.access.JavaNioAccess;
 import jdk.internal.access.SharedSecrets;
 import jdk.internal.access.foreign.UnmapperProxy;
@@ -44,7 +44,7 @@ import java.nio.file.StandardOpenOption;
  * memory mapped segment, such as the file descriptor associated with the mapping. This information is crucial
  * in order to correctly reconstruct a byte buffer object from the segment (see {@link #makeByteBuffer()}).
  */
-public class MappedMemorySegmentImpl extends NativeMemorySegmentImpl {
+public class MappedMemorySegmentImpl extends NativeMemorySegmentImpl implements MappedMemorySegment {
 
     private final UnmapperProxy unmapper;
 
@@ -60,27 +60,41 @@ public class MappedMemorySegmentImpl extends NativeMemorySegmentImpl {
     }
 
     @Override
-    AbstractMemorySegmentImpl dup(long offset, long size, int mask, Thread owner, MemoryScope scope) {
+    MappedMemorySegmentImpl dup(long offset, long size, int mask, Thread owner, MemoryScope scope) {
         return new MappedMemorySegmentImpl(min + offset, unmapper, size, mask, owner, scope);
     }
 
     // mapped segment methods
 
+
+    @Override
+    public MappedMemorySegmentImpl asSlice(long offset, long newSize) {
+        return (MappedMemorySegmentImpl)super.asSlice(offset, newSize);
+    }
+
+    @Override
+    public MappedMemorySegmentImpl withAccessModes(int accessModes) {
+        return (MappedMemorySegmentImpl)super.withAccessModes(accessModes);
+    }
+
+    @Override
     public void load() {
         nioAccess.load(min, unmapper.isSync(), length);
     }
 
+    @Override
     public boolean isLoaded() {
         return nioAccess.isLoaded(min, unmapper.isSync(), length);
     }
 
+    @Override
     public void force() {
         nioAccess.force(unmapper.fileDescriptor(), min, unmapper.isSync(), 0, length);
     }
 
     // factories
 
-    public static MemorySegment makeMappedSegment(Path path, long bytesSize, FileChannel.MapMode mapMode) throws IOException {
+    public static MappedMemorySegment makeMappedSegment(Path path, long bytesSize, FileChannel.MapMode mapMode) throws IOException {
         if (bytesSize <= 0) throw new IllegalArgumentException("Requested bytes size must be > 0.");
         try (FileChannelImpl channelImpl = (FileChannelImpl)FileChannel.open(path, openOptions(mapMode))) {
             UnmapperProxy unmapperProxy = channelImpl.mapInternal(mapMode, 0L, bytesSize);

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/MemoryAddressImpl.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/MemoryAddressImpl.java
@@ -96,11 +96,11 @@ public final class MemoryAddressImpl implements MemoryAddress, MemoryAddressProx
 
     @Override
     public MemoryAddress rebase(MemorySegment segment) {
-        AbstractMemorySegmentImpl segmentImpl = (AbstractMemorySegmentImpl) segment;
+        AbstractMemorySegmentImpl segmentImpl = (AbstractMemorySegmentImpl)segment;
         if (segmentImpl.base() != this.segment.base()) {
             throw new IllegalArgumentException("Invalid rebase target: " + segment);
         }
-        return new MemoryAddressImpl((AbstractMemorySegmentImpl) segment,
+        return new MemoryAddressImpl((AbstractMemorySegmentImpl)segment,
                 unsafeGetOffset() - ((MemoryAddressImpl)segment.baseAddress()).unsafeGetOffset());
     }
 

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/NativeMemorySegmentImpl.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/NativeMemorySegmentImpl.java
@@ -58,7 +58,7 @@ public class NativeMemorySegmentImpl extends AbstractMemorySegmentImpl {
     }
 
     @Override
-    AbstractMemorySegmentImpl dup(long offset, long size, int mask, Thread owner, MemoryScope scope) {
+    NativeMemorySegmentImpl dup(long offset, long size, int mask, Thread owner, MemoryScope scope) {
         return new NativeMemorySegmentImpl(min + offset, size, mask, owner, scope);
     }
 

--- a/test/jdk/java/foreign/TestByteBuffer.java
+++ b/test/jdk/java/foreign/TestByteBuffer.java
@@ -31,6 +31,7 @@
  */
 
 
+import jdk.incubator.foreign.MappedMemorySegment;
 import jdk.incubator.foreign.MemoryLayouts;
 import jdk.incubator.foreign.MemoryLayout;
 import jdk.incubator.foreign.MemoryAddress;
@@ -221,7 +222,7 @@ public class TestByteBuffer {
                 MemorySegment segment = MemorySegment.ofByteBuffer(mbb);
                 MemoryAddress base = segment.baseAddress();
                 initTuples(base);
-                ((MappedByteBuffer)segment.asByteBuffer()).force(); //force via segment
+                mbb.force();
             });
         }
 
@@ -242,9 +243,10 @@ public class TestByteBuffer {
         f.deleteOnExit();
 
         //write to channel
-        try (MemorySegment segment = MemorySegment.mapFromPath(f.toPath(), tuples.byteSize(), FileChannel.MapMode.READ_WRITE)) {
+        try (MappedMemorySegment segment = MemorySegment.mapFromPath(f.toPath(), tuples.byteSize(), FileChannel.MapMode.READ_WRITE)) {
             MemoryAddress base = segment.baseAddress();
             initTuples(base);
+            segment.force();
         }
 
         //read from channel

--- a/test/jdk/java/foreign/TestSegments.java
+++ b/test/jdk/java/foreign/TestSegments.java
@@ -232,7 +232,6 @@ public class TestSegments {
 
         final static List<String> CONFINED_NAMES = List.of(
                 "close",
-                "spliterator",
                 "toByteArray"
         );
 
@@ -292,7 +291,7 @@ public class TestSegments {
             @Override
             void run(MemorySegment segment) {
                 Spliterator<MemorySegment> spliterator =
-                        segment.spliterator(MemoryLayout.ofSequence(segment.byteSize(), MemoryLayouts.JAVA_BYTE));
+                        MemorySegment.spliterator(segment, MemoryLayout.ofSequence(segment.byteSize(), MemoryLayouts.JAVA_BYTE));
                 AtomicReference<RuntimeException> exception = new AtomicReference<>();
                 Runnable action = () -> {
                     try {

--- a/test/jdk/java/foreign/TestSharedAccess.java
+++ b/test/jdk/java/foreign/TestSharedAccess.java
@@ -62,7 +62,7 @@ public class TestSharedAccess {
             }
             List<Thread> threads = new ArrayList<>();
             List<Spliterator<MemorySegment>> spliterators = new ArrayList<>();
-            spliterators.add(s.spliterator(layout));
+            spliterators.add(MemorySegment.spliterator(s, layout));
             while (true) {
                 boolean progress = false;
                 List<Spliterator<MemorySegment>> newSpliterators = new ArrayList<>();
@@ -125,7 +125,8 @@ public class TestSharedAccess {
     @Test(expectedExceptions=IllegalStateException.class)
     public void testBadCloseWithPendingAcquire() throws InterruptedException {
         try (MemorySegment segment = MemorySegment.allocateNative(16)) {
-            Spliterator<MemorySegment> spliterator = segment.spliterator(MemoryLayout.ofSequence(16, MemoryLayouts.JAVA_BYTE));
+            Spliterator<MemorySegment> spliterator = MemorySegment.spliterator(segment,
+                    MemoryLayout.ofSequence(16, MemoryLayouts.JAVA_BYTE));
             Runnable r = () -> spliterator.forEachRemaining(s -> {
                 try {
                     Thread.sleep(5000 * 100);

--- a/test/jdk/java/foreign/TestSpliterator.java
+++ b/test/jdk/java/foreign/TestSpliterator.java
@@ -68,13 +68,13 @@ public class TestSpliterator {
         long serial = sum(0, segment);
         assertEquals(serial, expected);
         //parallel counted completer
-        long parallelCounted = new SumSegmentCounted(null, segment.spliterator(layout), threshold).invoke();
+        long parallelCounted = new SumSegmentCounted(null, MemorySegment.spliterator(segment, layout), threshold).invoke();
         assertEquals(parallelCounted, expected);
         //parallel recursive action
-        long parallelRecursive = new SumSegmentRecursive(segment.spliterator(layout), threshold).invoke();
+        long parallelRecursive = new SumSegmentRecursive(MemorySegment.spliterator(segment, layout), threshold).invoke();
         assertEquals(parallelRecursive, expected);
         //parallel stream
-        long streamParallel = StreamSupport.stream(segment.spliterator(layout), true)
+        long streamParallel = StreamSupport.stream(MemorySegment.spliterator(segment, layout), true)
                 .reduce(0L, TestSpliterator::sumSingle, Long::sum);
         assertEquals(streamParallel, expected);
         segment.close();
@@ -92,8 +92,8 @@ public class TestSpliterator {
 
         //check that a segment w/o ACQUIRE access mode can still be used from same thread
         AtomicLong spliteratorSum = new AtomicLong();
-        segment.withAccessModes(MemorySegment.READ)
-                .spliterator(layout).forEachRemaining(s -> spliteratorSum.addAndGet(sumSingle(0L, s)));
+        MemorySegment.spliterator(segment.withAccessModes(MemorySegment.READ), layout)
+                .forEachRemaining(s -> spliteratorSum.addAndGet(sumSingle(0L, s)));
         assertEquals(spliteratorSum.get(), expected);
     }
 

--- a/test/jdk/java/util/stream/test/org/openjdk/tests/java/util/stream/SpliteratorTest.java
+++ b/test/jdk/java/util/stream/test/org/openjdk/tests/java/util/stream/SpliteratorTest.java
@@ -66,7 +66,7 @@ public class SpliteratorTest {
     public void testSegmentSpliterator(String name, SequenceLayout layout, SpliteratorTestHelper.ContentAsserter<MemorySegment> contentAsserter) {
         try (MemorySegment segment = MemorySegment.allocateNative(layout)) {
             SegmentTestDataProvider.initSegment(segment);
-            SpliteratorTestHelper.testSpliterator(() -> segment.spliterator(layout),
+            SpliteratorTestHelper.testSpliterator(() -> MemorySegment.spliterator(segment, layout),
                     SegmentTestDataProvider::segmentCopier, contentAsserter);
         }
     }

--- a/test/micro/org/openjdk/bench/jdk/incubator/foreign/ParallelSum.java
+++ b/test/micro/org/openjdk/bench/jdk/incubator/foreign/ParallelSum.java
@@ -118,23 +118,23 @@ public class ParallelSum {
 
     @Benchmark
     public int segment_parallel() {
-        return new SumSegment(segment.spliterator(SEQUENCE_LAYOUT), SEGMENT_TO_INT).invoke();
+        return new SumSegment(MemorySegment.spliterator(segment, SEQUENCE_LAYOUT), SEGMENT_TO_INT).invoke();
     }
 
     @Benchmark
     public int segment_parallel_bulk() {
-        return new SumSegment(segment.spliterator(SEQUENCE_LAYOUT_BULK), SEGMENT_TO_INT_BULK).invoke();
+        return new SumSegment(MemorySegment.spliterator(segment, SEQUENCE_LAYOUT_BULK), SEGMENT_TO_INT_BULK).invoke();
     }
 
     @Benchmark
     public int segment_stream_parallel() {
-        return StreamSupport.stream(segment.spliterator(SEQUENCE_LAYOUT), true)
+        return StreamSupport.stream(MemorySegment.spliterator(segment, SEQUENCE_LAYOUT), true)
                 .mapToInt(SEGMENT_TO_INT).sum();
     }
 
     @Benchmark
     public int segment_stream_parallel_bulk() {
-        return StreamSupport.stream(segment.spliterator(SEQUENCE_LAYOUT_BULK), true)
+        return StreamSupport.stream(MemorySegment.spliterator(segment, SEQUENCE_LAYOUT_BULK), true)
                 .mapToInt(SEGMENT_TO_INT_BULK).sum();
     }
 


### PR DESCRIPTION
This patch adds more targeted support for mapped segments, by providing the same set operations also offered by MappedByteBuffer (force/load/isLoaded).

To get there some refactoring of the undelying mapped routines was necessary so that it could be shared across MappedByteBuffer and MappedMemorySegment.

One notable consequence of this work is that, in order to keep the typing sharp, I had to turn the MemorySegment::spliterator method from instance to static, so that I could take advantage of generic method type variables. With an instance method it is not possible to write a covariant override that makes sense for clients (note: returning `Spliterator<? extends MemorySegment>` is possible in principle, but useless in practice, as calls to e.g. `tryAdvance` will fail). Overall, I think that is a decent compromise.

Here's a link to the javadoc:

http://cr.openjdk.java.net/~mcimadamore/panama/8243064/javadoc/jdk/incubator/foreign/package-summary.html

The doc for the new memory mapped segment heavily borrows from MappedByteBuffer - I did only minor tuning here and there to make the doc fit better within the memory segment javadoc.

The testing side is thin/non-existing. Unfortunately I could not find any relevant JDK test for mapped buffers that stressed the behavior of the various routines in a meaningful way. For instance, there's a test `MappedByteBuffer/Force.java` which doesn't really test anything, other than calling force() doesn't fail with some error. I've added a call to MappedMemorySegment::force in the buffer segment test, but I realize that this is pretty ad-hoc. If anybody has ideas on how to test this thing in a reliable way, suggestions are welcome :-)
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [JDK-8243064](https://bugs.openjdk.java.net/browse/JDK-8243064): Add more support for mapped memory segments


### Reviewers
 * Paul Sandoz ([psandoz](@PaulSandoz) - Committer) ⚠️ Review applies to 2313601f9ca9aea8b458d0579782e360e319fa25
 * Jorn Vernee ([jvernee](@JornVernee) - Committer)

### Download
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/115/head:pull/115`
`$ git checkout pull/115`
