### PR TITLE
JDK-8243073: Add support for serial confinement

### DIFF
--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/MemorySegment.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/MemorySegment.java
@@ -100,6 +100,10 @@ import java.util.function.Consumer;
  * the segment using a memory access var handle. Any attempt to perform such operations from a thread other than the
  * owner thread will result in a runtime failure.
  * <p>
+ * Memory segments support <em>serial thread confinement</em>; that is, ownership of a memory segment can change (see
+ * {@link #withOwnerThread(Thread)}). This allows, for instance, for two threads {@code A} and {@code B} to share
+ * a segment in a controlled, cooperative and race-free fashion.
+ * <p>
  * In some cases, it might be useful for multiple threads to process the contents of the same memory segment concurrently
  * (e.g. in the case of parallel processing); while memory segments provide strong confinement guarantees, it is possible
  * to obtain a {@link Spliterator} from a segment, which can be used to slice the segment and allow multiple thread to
@@ -196,6 +200,22 @@ public interface MemorySegment extends AutoCloseable {
      * @return the thread owning this segment.
      */
     Thread ownerThread();
+
+    /**
+     * Obtains a new memory segment backed by the same underlying memory region as this segment,
+     * but with different owner thread. As a side-effect, this segment will be marked as <em>not alive</em>,
+     * and subsequent operations on this segment will result in runtime errors.
+     * @param newOwner the new owner thread.
+     * @return a new memory segment backed by the same underlying memory region as this segment,
+     *      owned by {@code newOwner}.
+     * @throws IllegalStateException if this segment is not <em>alive</em>, or if access occurs from a thread other than the
+     * thread owning this segment, or if the segment cannot be closed because it is being operated upon by a different
+     * thread (see {@link #spliterator(SequenceLayout)}).
+     * @throws NullPointerException if {@code newOwner == null}
+     * @throws IllegalArgumentException if the segment is already a confined segment owner by {@code newOnwer}.
+     * @throws UnsupportedOperationException if this segment does not support the {@link #HANDOFF} access mode.
+     */
+    MemorySegment withOwnerThread(Thread newOwner);
 
     /**
      * The size (in bytes) of this memory segment.
@@ -546,4 +566,12 @@ allocateNative(bytesSize, 1);
      * @see MemorySegment#withAccessModes(int)
      */
     int ACQUIRE = CLOSE << 1;
+
+    /**
+     * Handoff access mode; this segment support serial thread-confinement via thread ownership changes
+     * (see {@link #withOwnerThread(Thread)}).
+     * @see MemorySegment#accessModes()
+     * @see MemorySegment#withAccessModes(int)
+     */
+    int HANDOFF = ACQUIRE << 1;
 }

--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/MemorySegment.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/MemorySegment.java
@@ -206,8 +206,8 @@ public interface MemorySegment extends AutoCloseable {
      * but with different owner thread. As a side-effect, this segment will be marked as <em>not alive</em>,
      * and subsequent operations on this segment will result in runtime errors.
      * <p>
-     * Write accesses to the segment’s content <a href="../../../java/util/concurrent/package-summary.html#MemoryVisibility"><i>happens-before</i></a>
-     * hand-over from the current owner thread to the new owner thread, which in turn <i>happens before</i> read accesses to the segment’s contents on
+     * Write accesses to the segment's content <a href="../../../java/util/concurrent/package-summary.html#MemoryVisibility"><i>happens-before</i></a>
+     * hand-over from the current owner thread to the new owner thread, which in turn <i>happens before</i> read accesses to the segment's contents on
      * the new owner thread.
      *
      * @param newOwner the new owner thread.

--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/MemorySegment.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/MemorySegment.java
@@ -206,8 +206,8 @@ public interface MemorySegment extends AutoCloseable {
      * but with different owner thread. As a side-effect, this segment will be marked as <em>not alive</em>,
      * and subsequent operations on this segment will result in runtime errors.
      * <p>
-     * Write accesses to the segment’s content happens before hand-over from the current owner thread to the
-     * new owner thread, which in turn happens before read accesses to the segment’s contents on
+     * Write accesses to the segment’s content <a href="../../../java/util/concurrent/package-summary.html#MemoryVisibility"><i>happens-before</i></a>
+     * hand-over from the current owner thread to the new owner thread, which in turn <i>happens before</i> read accesses to the segment’s contents on
      * the new owner thread.
      *
      * @param newOwner the new owner thread.

--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/MemorySegment.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/MemorySegment.java
@@ -205,6 +205,11 @@ public interface MemorySegment extends AutoCloseable {
      * Obtains a new memory segment backed by the same underlying memory region as this segment,
      * but with different owner thread. As a side-effect, this segment will be marked as <em>not alive</em>,
      * and subsequent operations on this segment will result in runtime errors.
+     * <p>
+     * It is important that the segment returned by this method is published by clients in a safe fashion
+     * (e.g. through a {@code volatile} field, or some other form of synchronization). Failures to do so might
+     * result in the new owner thread reading stale values from the memory region backing this segment.
+     *
      * @param newOwner the new owner thread.
      * @return a new memory segment backed by the same underlying memory region as this segment,
      *      owned by {@code newOwner}.

--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/MemorySegment.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/MemorySegment.java
@@ -206,9 +206,9 @@ public interface MemorySegment extends AutoCloseable {
      * but with different owner thread. As a side-effect, this segment will be marked as <em>not alive</em>,
      * and subsequent operations on this segment will result in runtime errors.
      * <p>
-     * It is important that the segment returned by this method is published by clients in a safe fashion
-     * (e.g. through a {@code volatile} field, or some other form of synchronization). Failures to do so might
-     * result in the new owner thread reading stale values from the memory region backing this segment.
+     * Write accesses to the segment’s content happens before hand-over from the current owner thread to the
+     * new owner thread, which in turn happens before read accesses to the segment’s contents on
+     * the new owner thread.
      *
      * @param newOwner the new owner thread.
      * @return a new memory segment backed by the same underlying memory region as this segment,

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/AbstractMemorySegmentImpl.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/AbstractMemorySegmentImpl.java
@@ -35,6 +35,7 @@ import jdk.internal.access.foreign.UnmapperProxy;
 import jdk.internal.vm.annotation.ForceInline;
 import sun.security.action.GetPropertyAction;
 
+import java.lang.invoke.VarHandle;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.List;
@@ -57,11 +58,11 @@ public abstract class AbstractMemorySegmentImpl implements MemorySegment, Memory
     private static final boolean enableSmallSegments =
             Boolean.parseBoolean(GetPropertyAction.privilegedGetProperty("jdk.incubator.foreign.SmallSegments", "true"));
 
-    final static int ACCESS_MASK = READ | WRITE | CLOSE | ACQUIRE;
+    final static int ACCESS_MASK = READ | WRITE | CLOSE | ACQUIRE | HANDOFF;
     final static int FIRST_RESERVED_FLAG = 1 << 16; // upper 16 bits are reserved
     final static int SMALL = FIRST_RESERVED_FLAG;
     final static long NONCE = new Random().nextLong();
-    final static int DEFAULT_MASK = READ | WRITE | CLOSE | ACQUIRE;
+    final static int DEFAULT_MASK = READ | WRITE | CLOSE | ACQUIRE | HANDOFF;
 
     final static JavaNioAccess nioAccess = SharedSecrets.getJavaNioAccess();
 
@@ -174,6 +175,22 @@ public abstract class AbstractMemorySegmentImpl implements MemorySegment, Memory
     }
 
     @Override
+    public MemorySegment withOwnerThread(Thread newOwner) {
+        Objects.requireNonNull(newOwner);
+        checkValidState();
+        if (!isSet(HANDOFF)) {
+            throw unsupportedAccessMode(HANDOFF);
+        }
+        if (owner == newOwner) {
+            throw new IllegalArgumentException("Segment already owned by thread: " + newOwner);
+        } else {
+            //flush read/writes to memory before returning the new segment
+            VarHandle.fullFence();
+            return dup(0L, length, mask, newOwner, scope.dup());
+        }
+    }
+
+    @Override
     public final void close() {
         if (!isSet(CLOSE)) {
             throw unsupportedAccessMode(CLOSE);
@@ -183,7 +200,7 @@ public abstract class AbstractMemorySegmentImpl implements MemorySegment, Memory
     }
 
     private final void closeNoCheck() {
-        scope.close();
+        scope.close(true);
     }
 
     final AbstractMemorySegmentImpl acquire() {
@@ -274,6 +291,9 @@ public abstract class AbstractMemorySegmentImpl implements MemorySegment, Memory
         }
         if ((mode & ACQUIRE) != 0) {
             modes.add("ACQUIRE");
+        }
+        if ((mode & HANDOFF) != 0) {
+            modes.add("HANDOFF");
         }
         return modes;
     }

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/AbstractMemorySegmentImpl.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/AbstractMemorySegmentImpl.java
@@ -184,9 +184,12 @@ public abstract class AbstractMemorySegmentImpl implements MemorySegment, Memory
         if (owner == newOwner) {
             throw new IllegalArgumentException("Segment already owned by thread: " + newOwner);
         } else {
-            //flush read/writes to memory before returning the new segment
-            VarHandle.fullFence();
-            return dup(0L, length, mask, newOwner, scope.dup());
+            try {
+                return dup(0L, length, mask, newOwner, scope.dup());
+            } finally {
+                //flush read/writes to memory before returning the new segment
+                VarHandle.fullFence();
+            }
         }
     }
 

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/MemoryScope.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/MemoryScope.java
@@ -107,15 +107,20 @@ public final class MemoryScope {
         } while (!COUNT_HANDLE.compareAndSet(this, value, value - 1));
     }
 
-    void close() {
+    void close(boolean doCleanup) {
         if (!COUNT_HANDLE.compareAndSet(this, UNACQUIRED, CLOSED)) {
             //first check if already closed...
             checkAliveConfined();
             //...if not, then we have acquired views that are still active
             throw new IllegalStateException("Cannot close a segment that has active acquired views");
         }
-        if (cleanupAction != null) {
+        if (doCleanup && cleanupAction != null) {
             cleanupAction.run();
         }
+    }
+
+    MemoryScope dup() {
+        close(false);
+        return new MemoryScope(ref, cleanupAction);
     }
 }

--- a/test/jdk/java/foreign/TestSegments.java
+++ b/test/jdk/java/foreign/TestSegments.java
@@ -232,7 +232,8 @@ public class TestSegments {
 
         final static List<String> CONFINED_NAMES = List.of(
                 "close",
-                "toByteArray"
+                "toByteArray",
+                "withOwnerThread"
         );
 
         public SegmentMember(Method method, Object[] params) {
@@ -329,6 +330,12 @@ public class TestSegments {
             @Override
             void run(MemorySegment segment) {
                 INT_HANDLE.set(segment.baseAddress(), 42);
+            }
+        },
+        HANDOFF(MemorySegment.HANDOFF) {
+            @Override
+            void run(MemorySegment segment) {
+                segment.withOwnerThread(new Thread());
             }
         };
 

--- a/test/jdk/java/foreign/TestSharedAccess.java
+++ b/test/jdk/java/foreign/TestSharedAccess.java
@@ -41,7 +41,10 @@ import java.util.List;
 import java.util.Spliterator;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
 
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
@@ -50,6 +53,32 @@ import static org.testng.Assert.fail;
 public class TestSharedAccess {
 
     static final VarHandle intHandle = MemoryLayouts.JAVA_INT.varHandle(int.class);
+
+    @Test
+    public void testConfined() throws Throwable {
+        Thread owner = Thread.currentThread();
+        MemorySegment s = MemorySegment.allocateNative(4);
+        AtomicReference<MemorySegment> confined = new AtomicReference<>(s);
+        setInt(s.baseAddress(), 42);
+        assertEquals(getInt(s.baseAddress()), 42);
+        List<Thread> threads = new ArrayList<>();
+        for (int i = 0 ; i < 1000 ; i++) {
+            threads.add(new Thread(() -> {
+                assertEquals(getInt(confined.get().baseAddress()), 42);
+                confined.set(confined.get().withOwnerThread(owner));
+            }));
+        }
+        threads.forEach(t -> {
+            confined.set(confined.get().withOwnerThread(t));
+            t.start();
+            try {
+                t.join();
+            } catch (Throwable e) {
+                throw new IllegalStateException(e);
+            }
+        });
+        confined.get().close();
+    }
 
     @Test
     public void testShared() throws Throwable {
@@ -120,40 +149,65 @@ public class TestSharedAccess {
         }
     }
 
-
     @Test(expectedExceptions=IllegalStateException.class)
-    public void testBadCloseWithPendingAcquire() throws InterruptedException {
-        try (MemorySegment segment = MemorySegment.allocateNative(16)) {
-            Spliterator<MemorySegment> spliterator = MemorySegment.spliterator(segment,
-                    MemoryLayout.ofSequence(16, MemoryLayouts.JAVA_BYTE));
-            Runnable r = () -> spliterator.forEachRemaining(s -> {
-                try {
-                    Thread.sleep(5000 * 100);
-                } catch (InterruptedException ex) {
-                    throw new AssertionError(ex);
-                }
-            });
-            new Thread(r).start();
-            Thread.sleep(5000);
-        } //should fail here!
+    public void testBadCloseWithPendingAcquire() {
+        withAcquired(MemorySegment::close);
     }
 
     @Test(expectedExceptions=IllegalStateException.class)
-    public void testBadCloseWithPendingAcquireBuffer() throws InterruptedException {
+    public void testBadCloseWithPendingAcquireBuffer() {
+        withAcquired(segment -> {
+            segment = MemorySegment.ofByteBuffer(segment.asByteBuffer()); // original segment is lost
+            segment.close(); // this should still fail
+        });
+    }
+
+    @Test(expectedExceptions=IllegalStateException.class)
+    public void testBadHandoffWithPendingAcquire() {
+        withAcquired(segment -> segment.withOwnerThread(new Thread()));
+    }
+
+    @Test(expectedExceptions=IllegalStateException.class)
+    public void testBadHandoffWithPendingAcquireBuffer() {
+        withAcquired(segment -> {
+            segment = MemorySegment.ofByteBuffer(segment.asByteBuffer()); // original segment is lost
+            segment.withOwnerThread(new Thread()); // this should still fail
+        });
+    }
+
+    @Test(expectedExceptions=IllegalArgumentException.class)
+    public void testBadHandoffSameThread() {
+        MemorySegment.ofArray(new int[4]).withOwnerThread(Thread.currentThread());
+    }
+
+    @Test(expectedExceptions=NullPointerException.class)
+    public void testBadHandoffNullThread() {
+        MemorySegment.ofArray(new int[4]).withOwnerThread(null);
+    }
+
+    private void withAcquired(Consumer<MemorySegment> acquiredAction) {
+        CountDownLatch holder = new CountDownLatch(1);
         MemorySegment segment = MemorySegment.allocateNative(16);
         Spliterator<MemorySegment> spliterator = MemorySegment.spliterator(segment,
                 MemoryLayout.ofSequence(16, MemoryLayouts.JAVA_BYTE));
-        Runnable r = () -> spliterator.forEachRemaining(s -> {
+        CountDownLatch acquired = new CountDownLatch(1);
+        Runnable r = () -> spliterator.tryAdvance(s -> {
             try {
-                Thread.sleep(5000 * 100);
+                acquired.countDown();
+                holder.await();
             } catch (InterruptedException ex) {
                 throw new AssertionError(ex);
             }
         });
         new Thread(r).start();
-        Thread.sleep(5000);
-        segment = MemorySegment.ofByteBuffer(segment.asByteBuffer()); // original segment is lost
-        segment.close(); // this should still fail
+        try {
+            acquired.await();
+            acquiredAction.accept(segment);
+        } catch (InterruptedException ex) {
+            throw new AssertionError(ex);
+        } finally {
+            holder.countDown();
+        }
     }
 
     @Test


### PR DESCRIPTION
This patch adds support for serial confinement - e.g. a handoff operation to transfer ownership from thread A to thread B.

The implementation is based on some iterations we have done in the past. I've added a test, and I've also rewritten some of the existing tests not to rely on waits, but to use latches instead, as observed by Paul.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [JDK-8243073](https://bugs.openjdk.java.net/browse/JDK-8243073): Add support for serial confinement


### Reviewers
 * Jorn Vernee ([jvernee](@JornVernee) - Committer) ⚠️ Review applies to 78dbc41f8ffe0ec2ac61638b2e35875408300e09

### Download
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/117/head:pull/117`
`$ git checkout pull/117`
