### PR TITLE
JDK-8243089: Foreign address manipulation always fails with exception

### DIFF
--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/InternalForeign.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/InternalForeign.java
@@ -61,7 +61,7 @@ public class InternalForeign implements Foreign {
     }
 
     private void checkRawNativeAddress(MemoryAddress base) {
-        if (base.segment() != AbstractMemorySegmentImpl.NOTHING) {
+        if (base.segment() != null) {
             throw new IllegalArgumentException("Not an unchecked memory address");
         }
     }

--- a/test/jdk/java/foreign/libNativeAccess.c
+++ b/test/jdk/java/foreign/libNativeAccess.c
@@ -23,6 +23,7 @@
  */
 
 #include "jni.h"
+#include <stdlib.h>
 #include <stdio.h>
 #include <stdint.h>
 
@@ -113,4 +114,9 @@ Java_TestNative_getDoubleBuffer(JNIEnv *env, jclass cls, jobject buf, jint index
 JNIEXPORT jlong JNICALL
 Java_TestNative_getCapacity(JNIEnv *env, jclass cls, jobject buf) {
     return (*env)->GetDirectBufferCapacity(env, buf);
+}
+
+JNIEXPORT jlong JNICALL
+Java_TestNative_allocate(JNIEnv *env, jclass cls, jobject buf, jint size) {
+    return (jlong)malloc(size);
 }


### PR DESCRIPTION
This patch fixes a silly mistake in Foreign implementation. Instead of checking whether `MemoryAddress::segment` returns null, we instead check if it returns `AbstractMemorySegmentImpl::NOTHING`.

I've also added positive test, to make sure we catch these issues from now on.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [JDK-8243089](https://bugs.openjdk.java.net/browse/JDK-8243089): Foreign address manipulation always fails with exception


### Reviewers
 * Jorn Vernee ([jvernee](@JornVernee) - Committer)

### Download
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/118/head:pull/118`
`$ git checkout pull/118`
