### PR TITLE
Fix bad merge of java.base/module-info.java

### DIFF
--- a/src/java.base/share/classes/module-info.java
+++ b/src/java.base/share/classes/module-info.java
@@ -174,7 +174,6 @@ module java.base {
         jdk.jartool,
         jdk.jfr,
         jdk.jlink,
-        jdk.scripting.nashorn,
         jdk.incubator.jextract;
     exports jdk.internal.org.objectweb.asm.tree to
         jdk.jfr,


### PR DESCRIPTION
This simple patch fixes a merge issue in java.base/module-info after removal of the nashorn engine.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * Jorn Vernee ([jvernee](@JornVernee) - Committer)

### Download
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/119/head:pull/119`
`$ git checkout pull/119`
