### PR TITLE
Do not try to resize constant string segments in TestClassGeneration.java

### DIFF
--- a/test/jdk/tools/jextract/testClassGen/TestClassGeneration.java
+++ b/test/jdk/tools/jextract/testClassGen/TestClassGeneration.java
@@ -154,9 +154,9 @@ public class TestClassGeneration extends JextractToolRunner {
     @Test(dataProvider = "stringConstants")
     public void testStringConstant(String name, String expectedValue) throws Throwable {
         Method getter = checkMethod(cls, name, MemoryAddress.class);
-        MemoryAddress ma = (MemoryAddress) getter.invoke(null);
+        MemoryAddress actual = (MemoryAddress) getter.invoke(null);
         byte[] expected = expectedValue.getBytes(StandardCharsets.UTF_8);
-        MemoryAddress actual = FOREIGN.withSize(ma, expected.length);
+        assertEquals(actual.segment().byteSize(), expected.length + 1);
         for (int i = 0; i < expected.length; i++) {
             assertEquals((byte) VH_bytes.get(actual, (long) i), expected[i]);
         }


### PR DESCRIPTION
Hi,

This fixes a problem with the TestClassGeneration test, which tries to resize a MemrorySegment of a string constant, but this is not needed, since the constants will already have a segment of the right size. This is causing a failure since Foreign::withSize requires an unchecked address as input.

This patch replaces the withSize call to an assertion on the size.

Thanks,
Jorn
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * Maurizio Cimadamore ([mcimadamore](@mcimadamore) - Committer)
 * Athijegannathan Sundararajan ([sundar](@sundararajana) - Committer)

### Download
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/120/head:pull/120`
`$ git checkout pull/120`
