### PR TITLE
Fix Cstring not to call withSize on already bound addresses

### DIFF
--- a/src/jdk.incubator.jextract/share/classes/jdk/incubator/jextract/tool/resources/Cstring.java.template
+++ b/src/jdk.incubator.jextract/share/classes/jdk/incubator/jextract/tool/resources/Cstring.java.template
@@ -69,7 +69,9 @@ public final class Cstring {
 
     public static String toJavaString(MemoryAddress addr) {
         StringBuilder buf = new StringBuilder();
-        MemoryAddress baseAddr = foreign.withSize(addr, Long.MAX_VALUE);
+        MemoryAddress baseAddr = addr.segment() == null ?
+                foreign.withSize(addr, Long.MAX_VALUE) :
+                addr;
         byte curr = (byte) byteArrHandle.get(baseAddr, 0);
         long offset = 0;
         while (curr != 0) {

--- a/test/jdk/java/foreign/Cstring.java
+++ b/test/jdk/java/foreign/Cstring.java
@@ -90,7 +90,9 @@ public final class Cstring {
 
     public static String toJavaString(MemoryAddress addr) {
         StringBuilder buf = new StringBuilder();
-        MemoryAddress sizedAddr = foreign.withSize(addr, Long.MAX_VALUE);
+        MemoryAddress sizedAddr = addr.segment() == null ?
+                foreign.withSize(addr, Long.MAX_VALUE) :
+                addr;
         byte curr = (byte) byteArrHandle.get(sizedAddr, 0);
         long offset = 0;
         while (curr != 0) {


### PR DESCRIPTION
There was a spurious call on withSize left on the synthetic Cstring type which did not make sure that the input address was indeed unchecked.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * Jorn Vernee ([jvernee](@JornVernee) - Committer)

### Download
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/121/head:pull/121`
`$ git checkout pull/121`
