### PR TITLE
Fix bad use of MemorySegment::spliterator in TestSharedAccess

### DIFF
--- a/test/jdk/java/foreign/TestSharedAccess.java
+++ b/test/jdk/java/foreign/TestSharedAccess.java
@@ -141,7 +141,8 @@ public class TestSharedAccess {
     @Test(expectedExceptions=IllegalStateException.class)
     public void testBadCloseWithPendingAcquireBuffer() throws InterruptedException {
         MemorySegment segment = MemorySegment.allocateNative(16);
-        Spliterator<MemorySegment> spliterator = segment.spliterator(MemoryLayout.ofSequence(16, MemoryLayouts.JAVA_BYTE));
+        Spliterator<MemorySegment> spliterator = MemorySegment.spliterator(segment,
+                MemoryLayout.ofSequence(16, MemoryLayouts.JAVA_BYTE));
         Runnable r = () -> spliterator.forEachRemaining(s -> {
             try {
                 Thread.sleep(5000 * 100);


### PR DESCRIPTION
By accident, the patch for  https://git.openjdk.java.net/panama-foreign/pull/115contains a mistake on TestSharedAccess, where the `MemorySegment::spliterator`
is still accessed in a non-static fashion, thus preventing compilation.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * Jorn Vernee ([jvernee](@JornVernee) - Committer)

### Download
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/125/head:pull/125`
`$ git checkout pull/125`
