### PR TITLE
8243485: adjust panama_jextract.md samples after recent foreign-abi changes

### DIFF
--- a/doc/panama_jextract.html
+++ b/doc/panama_jextract.html
@@ -99,7 +99,7 @@
 </ul></li>
 <li><a href="#embedding-python-interpreter-in-your-java-program-mac-os">Embedding Python interpreter in your Java program (Mac OS)</a>
 <ul>
-<li><a href="#jextract-a-jar-file-for-python.h">jextract a Jar file for Python.h</a></li>
+<li><a href="#jextract-python.h">jextract Python.h</a></li>
 <li><a href="#java-program-that-uses-extracted-python-interface">Java program that uses extracted Python interface</a></li>
 <li><a href="#running-the-java-code-that-calls-python-interpreter">Running the Java code that calls Python interpreter</a></li>
 </ul></li>
@@ -120,13 +120,13 @@
 <li><a href="#installing-openblas-mac-os">Installing OpenBLAS (Mac OS)</a></li>
 <li><a href="#jextracting-cblas.h-macos">jextracting cblas.h (MacOS)</a></li>
 <li><a href="#java-sample-code-that-uses-cblas-library">Java sample code that uses cblas library</a></li>
-<li><a href="#compiling-and-running-the-above-lapack-sample">Compiling and running the above LAPACK sample</a></li>
+<li><a href="#compiling-and-running-the-above-blas-sample">Compiling and running the above BLAS sample</a></li>
 </ul></li>
 <li><a href="#using-lapack-library-mac-os">Using LAPACK library (Mac OS)</a>
 <ul>
 <li><a href="#jextracting-lapacke.h">jextracting lapacke.h</a></li>
 <li><a href="#java-sample-code-that-uses-lapack-library">Java sample code that uses LAPACK library</a></li>
-<li><a href="#compiling-and-running-the-above-lapack-sample-1">Compiling and running the above LAPACK sample</a></li>
+<li><a href="#compiling-and-running-the-above-lapack-sample">Compiling and running the above LAPACK sample</a></li>
 </ul></li>
 <li><a href="#using-libproc-library-to-list-processes-from-java-mac-os">Using libproc library to list processes from Java (Mac OS)</a>
 <ul>
@@ -181,9 +181,9 @@
 <span id="cb5-8"><a href="#cb5-8"></a>}</span></code></pre></div>
 <h3 id="running-the-java-code-that-invokes-helloworld">Running the Java code that invokes helloworld</h3>
 <div class="sourceCode" id="cb6"><pre class="sourceCode sh"><code class="sourceCode bash"><span id="cb6-1"><a href="#cb6-1"></a></span>
-<span id="cb6-2"><a href="#cb6-2"></a><span class="ex">java</span> -Djdk.incubator.foreign.Foreign=permit --add-modules jdk.incubator.foreign HelloWorld.java</span></code></pre></div>
+<span id="cb6-2"><a href="#cb6-2"></a><span class="ex">java</span> -Dforeign.restricted=permit --add-modules jdk.incubator.foreign HelloWorld.java</span></code></pre></div>
 <h2 id="embedding-python-interpreter-in-your-java-program-mac-os">Embedding Python interpreter in your Java program (Mac OS)</h2>
-<h3 id="jextract-a-jar-file-for-python.h">jextract a Jar file for Python.h</h3>
+<h3 id="jextract-python.h">jextract Python.h</h3>
 <div class="sourceCode" id="cb7"><pre class="sourceCode sh"><code class="sourceCode bash"><span id="cb7-1"><a href="#cb7-1"></a></span>
 <span id="cb7-2"><a href="#cb7-2"></a><span class="ex">jextract</span> -l python2.7 \</span>
 <span id="cb7-3"><a href="#cb7-3"></a>  -I /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include \</span>
@@ -192,29 +192,29 @@
 <span id="cb7-6"><a href="#cb7-6"></a>   /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/python2.7/Python.h</span></code></pre></div>
 <h3 id="java-program-that-uses-extracted-python-interface">Java program that uses extracted Python interface</h3>
 <div class="sourceCode" id="cb8"><pre class="sourceCode java"><code class="sourceCode java"><span id="cb8-1"><a href="#cb8-1"></a></span>
-<span id="cb8-2"><a href="#cb8-2"></a><span class="kw">import</span><span class="im"> jdk.incubator.foreign.Foreign;</span></span>
-<span id="cb8-3"><a href="#cb8-3"></a><span class="kw">import</span><span class="im"> org.python.Cstring;</span></span>
-<span id="cb8-4"><a href="#cb8-4"></a><span class="kw">import static</span><span class="im"> jdk.incubator.foreign.MemoryAddress.NULL;</span></span>
-<span id="cb8-5"><a href="#cb8-5"></a><span class="co">// import jextracted python &#39;header&#39; class</span></span>
-<span id="cb8-6"><a href="#cb8-6"></a><span class="kw">import static</span><span class="im"> org.python.RuntimeHelper.*;</span></span>
-<span id="cb8-7"><a href="#cb8-7"></a><span class="kw">import static</span><span class="im"> org.python.Python_h.*;</span></span>
-<span id="cb8-8"><a href="#cb8-8"></a></span>
-<span id="cb8-9"><a href="#cb8-9"></a><span class="kw">public</span> <span class="kw">class</span> PythonMain {</span>
-<span id="cb8-10"><a href="#cb8-10"></a>    <span class="kw">public</span> <span class="dt">static</span> <span class="dt">void</span> <span class="fu">main</span>(<span class="bu">String</span>[] args) {</span>
-<span id="cb8-11"><a href="#cb8-11"></a>        <span class="bu">String</span> script = <span class="st">&quot;print(sum([33, 55, 66])); print(&#39;Hello from Python!&#39;)</span><span class="sc">\n</span><span class="st">&quot;</span>;</span>
-<span id="cb8-12"><a href="#cb8-12"></a></span>
-<span id="cb8-13"><a href="#cb8-13"></a>        <span class="fu">Py_Initialize</span>();</span>
-<span id="cb8-14"><a href="#cb8-14"></a>        <span class="kw">try</span> (var s = Cstring.<span class="fu">toCString</span>(script)) {</span>
-<span id="cb8-15"><a href="#cb8-15"></a>            var str = s.<span class="fu">baseAddress</span>();</span>
-<span id="cb8-16"><a href="#cb8-16"></a>            <span class="fu">PyRun_SimpleStringFlags</span>(str, NULL);</span>
-<span id="cb8-17"><a href="#cb8-17"></a>            <span class="fu">Py_Finalize</span>();</span>
-<span id="cb8-18"><a href="#cb8-18"></a>        }</span>
-<span id="cb8-19"><a href="#cb8-19"></a>    }</span>
-<span id="cb8-20"><a href="#cb8-20"></a>}</span></code></pre></div>
+<span id="cb8-2"><a href="#cb8-2"></a><span class="kw">import</span><span class="im"> org.python.Cstring;</span></span>
+<span id="cb8-3"><a href="#cb8-3"></a><span class="kw">import static</span><span class="im"> jdk.incubator.foreign.MemoryAddress.NULL;</span></span>
+<span id="cb8-4"><a href="#cb8-4"></a><span class="co">// import jextracted python &#39;header&#39; class</span></span>
+<span id="cb8-5"><a href="#cb8-5"></a><span class="kw">import static</span><span class="im"> org.python.RuntimeHelper.*;</span></span>
+<span id="cb8-6"><a href="#cb8-6"></a><span class="kw">import static</span><span class="im"> org.python.Python_h.*;</span></span>
+<span id="cb8-7"><a href="#cb8-7"></a></span>
+<span id="cb8-8"><a href="#cb8-8"></a><span class="kw">public</span> <span class="kw">class</span> PythonMain {</span>
+<span id="cb8-9"><a href="#cb8-9"></a>    <span class="kw">public</span> <span class="dt">static</span> <span class="dt">void</span> <span class="fu">main</span>(<span class="bu">String</span>[] args) {</span>
+<span id="cb8-10"><a href="#cb8-10"></a>        <span class="bu">String</span> script = <span class="st">&quot;print(sum([33, 55, 66])); print(&#39;Hello from Python!&#39;)</span><span class="sc">\n</span><span class="st">&quot;</span>;</span>
+<span id="cb8-11"><a href="#cb8-11"></a></span>
+<span id="cb8-12"><a href="#cb8-12"></a>        <span class="fu">Py_Initialize</span>();</span>
+<span id="cb8-13"><a href="#cb8-13"></a>        <span class="kw">try</span> (var s = Cstring.<span class="fu">toCString</span>(script)) {</span>
+<span id="cb8-14"><a href="#cb8-14"></a>            var str = s.<span class="fu">baseAddress</span>();</span>
+<span id="cb8-15"><a href="#cb8-15"></a>            <span class="fu">PyRun_SimpleStringFlags</span>(str, NULL);</span>
+<span id="cb8-16"><a href="#cb8-16"></a>            <span class="fu">Py_Finalize</span>();</span>
+<span id="cb8-17"><a href="#cb8-17"></a>        }</span>
+<span id="cb8-18"><a href="#cb8-18"></a>    }</span>
+<span id="cb8-19"><a href="#cb8-19"></a>}</span></code></pre></div>
 <h3 id="running-the-java-code-that-calls-python-interpreter">Running the Java code that calls Python interpreter</h3>
 <div class="sourceCode" id="cb9"><pre class="sourceCode sh"><code class="sourceCode bash"><span id="cb9-1"><a href="#cb9-1"></a></span>
-<span id="cb9-2"><a href="#cb9-2"></a><span class="ex">java</span> -Djdk.incubator.foreign.Foreign=permit --add-modules jdk.incubator.foreign \</span>
-<span id="cb9-3"><a href="#cb9-3"></a>    -Djava.library.path=/System/Library/Frameworks/Python.framework/Versions/2.7/lib PythonMain.java</span></code></pre></div>
+<span id="cb9-2"><a href="#cb9-2"></a><span class="ex">java</span> -Dforeign.restricted=permit --add-modules jdk.incubator.foreign \</span>
+<span id="cb9-3"><a href="#cb9-3"></a>    -Djava.library.path=/System/Library/Frameworks/Python.framework/Versions/2.7/lib \</span>
+<span id="cb9-4"><a href="#cb9-4"></a>    PythonMain.java</span></code></pre></div>
 <h2 id="using-readline-library-from-java-code-mac-os">Using readline library from Java code (Mac OS)</h2>
 <h3 id="jextract-readline.h">jextract readline.h</h3>
 <div class="sourceCode" id="cb10"><pre class="sourceCode sh"><code class="sourceCode bash"><span id="cb10-1"><a href="#cb10-1"></a></span>
@@ -223,27 +223,26 @@
 <span id="cb10-4"><a href="#cb10-4"></a>   /Library/Developer/CommandLineTools/SDKs/MacOSX10.14.sdk/usr/include/readline/readline.h</span></code></pre></div>
 <h3 id="java-code-that-uses-readline">Java code that uses readline</h3>
 <div class="sourceCode" id="cb11"><pre class="sourceCode java"><code class="sourceCode java"><span id="cb11-1"><a href="#cb11-1"></a></span>
-<span id="cb11-2"><a href="#cb11-2"></a><span class="kw">import</span><span class="im"> jdk.incubator.foreign.Foreign;</span></span>
-<span id="cb11-3"><a href="#cb11-3"></a><span class="kw">import</span><span class="im"> org.unix.Cstring;</span></span>
-<span id="cb11-4"><a href="#cb11-4"></a><span class="kw">import static</span><span class="im"> org.unix.RuntimeHelper.*;</span></span>
-<span id="cb11-5"><a href="#cb11-5"></a><span class="kw">import static</span><span class="im"> org.unix.readline_h.*;</span></span>
-<span id="cb11-6"><a href="#cb11-6"></a></span>
-<span id="cb11-7"><a href="#cb11-7"></a><span class="kw">public</span> <span class="kw">class</span> Readline {</span>
-<span id="cb11-8"><a href="#cb11-8"></a>    <span class="kw">public</span> <span class="dt">static</span> <span class="dt">void</span> <span class="fu">main</span>(<span class="bu">String</span>[] args) {</span>
-<span id="cb11-9"><a href="#cb11-9"></a>        <span class="kw">try</span> (var s = Cstring.<span class="fu">toCString</span>(<span class="st">&quot;name? &quot;</span>)) {</span>
-<span id="cb11-10"><a href="#cb11-10"></a>            var pstr = s.<span class="fu">baseAddress</span>();</span>
-<span id="cb11-11"><a href="#cb11-11"></a>            <span class="co">// call &quot;readline&quot; API</span></span>
-<span id="cb11-12"><a href="#cb11-12"></a>            var p = <span class="fu">readline</span>(pstr);</span>
-<span id="cb11-13"><a href="#cb11-13"></a></span>
-<span id="cb11-14"><a href="#cb11-14"></a>            <span class="co">// print char* as is</span></span>
-<span id="cb11-15"><a href="#cb11-15"></a>            <span class="bu">System</span>.<span class="fu">out</span>.<span class="fu">println</span>(p);</span>
-<span id="cb11-16"><a href="#cb11-16"></a>            <span class="co">// convert char* ptr from readline as Java String &amp; print it</span></span>
-<span id="cb11-17"><a href="#cb11-17"></a>            <span class="bu">System</span>.<span class="fu">out</span>.<span class="fu">println</span>(<span class="st">&quot;Hello, &quot;</span> + Cstring.<span class="fu">toJavaString</span>(p));</span>
-<span id="cb11-18"><a href="#cb11-18"></a>        }</span>
-<span id="cb11-19"><a href="#cb11-19"></a>    }</span>
-<span id="cb11-20"><a href="#cb11-20"></a>}</span></code></pre></div>
+<span id="cb11-2"><a href="#cb11-2"></a><span class="kw">import</span><span class="im"> org.unix.Cstring;</span></span>
+<span id="cb11-3"><a href="#cb11-3"></a><span class="kw">import static</span><span class="im"> org.unix.RuntimeHelper.*;</span></span>
+<span id="cb11-4"><a href="#cb11-4"></a><span class="kw">import static</span><span class="im"> org.unix.readline_h.*;</span></span>
+<span id="cb11-5"><a href="#cb11-5"></a></span>
+<span id="cb11-6"><a href="#cb11-6"></a><span class="kw">public</span> <span class="kw">class</span> Readline {</span>
+<span id="cb11-7"><a href="#cb11-7"></a>    <span class="kw">public</span> <span class="dt">static</span> <span class="dt">void</span> <span class="fu">main</span>(<span class="bu">String</span>[] args) {</span>
+<span id="cb11-8"><a href="#cb11-8"></a>        <span class="kw">try</span> (var s = Cstring.<span class="fu">toCString</span>(<span class="st">&quot;name? &quot;</span>)) {</span>
+<span id="cb11-9"><a href="#cb11-9"></a>            var pstr = s.<span class="fu">baseAddress</span>();</span>
+<span id="cb11-10"><a href="#cb11-10"></a>            <span class="co">// call &quot;readline&quot; API</span></span>
+<span id="cb11-11"><a href="#cb11-11"></a>            var p = <span class="fu">readline</span>(pstr);</span>
+<span id="cb11-12"><a href="#cb11-12"></a></span>
+<span id="cb11-13"><a href="#cb11-13"></a>            <span class="co">// print char* as is</span></span>
+<span id="cb11-14"><a href="#cb11-14"></a>            <span class="bu">System</span>.<span class="fu">out</span>.<span class="fu">println</span>(p);</span>
+<span id="cb11-15"><a href="#cb11-15"></a>            <span class="co">// convert char* ptr from readline as Java String &amp; print it</span></span>
+<span id="cb11-16"><a href="#cb11-16"></a>            <span class="bu">System</span>.<span class="fu">out</span>.<span class="fu">println</span>(<span class="st">&quot;Hello, &quot;</span> + Cstring.<span class="fu">toJavaString</span>(p));</span>
+<span id="cb11-17"><a href="#cb11-17"></a>        }</span>
+<span id="cb11-18"><a href="#cb11-18"></a>    }</span>
+<span id="cb11-19"><a href="#cb11-19"></a>}</span></code></pre></div>
 <h3 id="running-the-java-code-that-uses-readline">Running the java code that uses readline</h3>
-<pre><code>java -Djdk.incubator.foreign.Foreign=permit --add-modules jdk.incubator.foreign \
+<pre><code>java -Dforeign.restricted=permit --add-modules jdk.incubator.foreign \
     -Djava.library.path=/usr/local/opt/readline/lib/ Readline.java
 </code></pre>
 <h2 id="using-libcurl-from-java-mac-os">Using libcurl from Java (Mac OS)</h2>
@@ -255,35 +254,34 @@
 <span id="cb13-5"><a href="#cb13-5"></a>  /Library/Developer/CommandLineTools/SDKs/MacOSX10.14.sdk/usr/include/curl/curl.h</span></code></pre></div>
 <h3 id="java-code-that-uses-libcurl">Java code that uses libcurl</h3>
 <div class="sourceCode" id="cb14"><pre class="sourceCode java"><code class="sourceCode java"><span id="cb14-1"><a href="#cb14-1"></a></span>
-<span id="cb14-2"><a href="#cb14-2"></a><span class="kw">import</span><span class="im"> jdk.incubator.foreign.Foreign;</span></span>
-<span id="cb14-3"><a href="#cb14-3"></a><span class="kw">import</span><span class="im"> org.unix.Cstring;</span></span>
-<span id="cb14-4"><a href="#cb14-4"></a><span class="kw">import static</span><span class="im"> jdk.incubator.foreign.MemoryAddress.NULL;</span></span>
-<span id="cb14-5"><a href="#cb14-5"></a><span class="kw">import static</span><span class="im"> org.unix.RuntimeHelper.*;</span></span>
-<span id="cb14-6"><a href="#cb14-6"></a><span class="kw">import static</span><span class="im"> org.unix.curl_h.*;</span></span>
-<span id="cb14-7"><a href="#cb14-7"></a></span>
-<span id="cb14-8"><a href="#cb14-8"></a><span class="kw">public</span> <span class="kw">class</span> CurlMain {</span>
-<span id="cb14-9"><a href="#cb14-9"></a>   <span class="kw">public</span> <span class="dt">static</span> <span class="dt">void</span> <span class="fu">main</span>(<span class="bu">String</span>[] args) {</span>
-<span id="cb14-10"><a href="#cb14-10"></a>       var urlStr = args[<span class="dv">0</span>];</span>
-<span id="cb14-11"><a href="#cb14-11"></a>       <span class="fu">curl_global_init</span>(<span class="fu">CURL_GLOBAL_DEFAULT</span>());</span>
-<span id="cb14-12"><a href="#cb14-12"></a>       var curl = <span class="fu">curl_easy_init</span>();</span>
-<span id="cb14-13"><a href="#cb14-13"></a>       <span class="kw">if</span>(!curl.<span class="fu">equals</span>(NULL)) {</span>
-<span id="cb14-14"><a href="#cb14-14"></a>           <span class="kw">try</span> (var s = Cstring.<span class="fu">toCString</span>(urlStr)) {</span>
-<span id="cb14-15"><a href="#cb14-15"></a>               var url = s.<span class="fu">baseAddress</span>();</span>
-<span id="cb14-16"><a href="#cb14-16"></a>               <span class="fu">curl_easy_setopt</span>(curl, <span class="fu">CURLOPT_URL</span>(), url);</span>
-<span id="cb14-17"><a href="#cb14-17"></a>               <span class="dt">int</span> res = <span class="fu">curl_easy_perform</span>(curl);</span>
-<span id="cb14-18"><a href="#cb14-18"></a>               <span class="kw">if</span> (res != <span class="fu">CURLE_OK</span>()) {</span>
-<span id="cb14-19"><a href="#cb14-19"></a>                   <span class="fu">curl_easy_cleanup</span>(curl);</span>
-<span id="cb14-20"><a href="#cb14-20"></a>               }</span>
-<span id="cb14-21"><a href="#cb14-21"></a>           }</span>
-<span id="cb14-22"><a href="#cb14-22"></a>       }</span>
-<span id="cb14-23"><a href="#cb14-23"></a>       <span class="fu">curl_global_cleanup</span>();</span>
-<span id="cb14-24"><a href="#cb14-24"></a>   }</span>
-<span id="cb14-25"><a href="#cb14-25"></a>}</span></code></pre></div>
+<span id="cb14-2"><a href="#cb14-2"></a><span class="kw">import</span><span class="im"> org.unix.Cstring;</span></span>
+<span id="cb14-3"><a href="#cb14-3"></a><span class="kw">import static</span><span class="im"> jdk.incubator.foreign.MemoryAddress.NULL;</span></span>
+<span id="cb14-4"><a href="#cb14-4"></a><span class="kw">import static</span><span class="im"> org.unix.RuntimeHelper.*;</span></span>
+<span id="cb14-5"><a href="#cb14-5"></a><span class="kw">import static</span><span class="im"> org.unix.curl_h.*;</span></span>
+<span id="cb14-6"><a href="#cb14-6"></a></span>
+<span id="cb14-7"><a href="#cb14-7"></a><span class="kw">public</span> <span class="kw">class</span> CurlMain {</span>
+<span id="cb14-8"><a href="#cb14-8"></a>   <span class="kw">public</span> <span class="dt">static</span> <span class="dt">void</span> <span class="fu">main</span>(<span class="bu">String</span>[] args) {</span>
+<span id="cb14-9"><a href="#cb14-9"></a>       var urlStr = args[<span class="dv">0</span>];</span>
+<span id="cb14-10"><a href="#cb14-10"></a>       <span class="fu">curl_global_init</span>(<span class="fu">CURL_GLOBAL_DEFAULT</span>());</span>
+<span id="cb14-11"><a href="#cb14-11"></a>       var curl = <span class="fu">curl_easy_init</span>();</span>
+<span id="cb14-12"><a href="#cb14-12"></a>       <span class="kw">if</span>(!curl.<span class="fu">equals</span>(NULL)) {</span>
+<span id="cb14-13"><a href="#cb14-13"></a>           <span class="kw">try</span> (var s = Cstring.<span class="fu">toCString</span>(urlStr)) {</span>
+<span id="cb14-14"><a href="#cb14-14"></a>               var url = s.<span class="fu">baseAddress</span>();</span>
+<span id="cb14-15"><a href="#cb14-15"></a>               <span class="fu">curl_easy_setopt</span>(curl, <span class="fu">CURLOPT_URL</span>(), url);</span>
+<span id="cb14-16"><a href="#cb14-16"></a>               <span class="dt">int</span> res = <span class="fu">curl_easy_perform</span>(curl);</span>
+<span id="cb14-17"><a href="#cb14-17"></a>               <span class="kw">if</span> (res != <span class="fu">CURLE_OK</span>()) {</span>
+<span id="cb14-18"><a href="#cb14-18"></a>                   <span class="fu">curl_easy_cleanup</span>(curl);</span>
+<span id="cb14-19"><a href="#cb14-19"></a>               }</span>
+<span id="cb14-20"><a href="#cb14-20"></a>           }</span>
+<span id="cb14-21"><a href="#cb14-21"></a>       }</span>
+<span id="cb14-22"><a href="#cb14-22"></a>       <span class="fu">curl_global_cleanup</span>();</span>
+<span id="cb14-23"><a href="#cb14-23"></a>   }</span>
+<span id="cb14-24"><a href="#cb14-24"></a>}</span></code></pre></div>
 <h3 id="running-the-java-code-that-uses-libcurl">Running the java code that uses libcurl</h3>
 <div class="sourceCode" id="cb15"><pre class="sourceCode sh"><code class="sourceCode bash"><span id="cb15-1"><a href="#cb15-1"></a></span>
 <span id="cb15-2"><a href="#cb15-2"></a><span class="co"># run this shell script by passing a URL as first argument</span></span>
-<span id="cb15-3"><a href="#cb15-3"></a><span class="ex">java</span> -Djdk.incubator.foreign.Foreign=permit --add-modules \</span>
-<span id="cb15-4"><a href="#cb15-4"></a>    jdk.incubator.foreign -Djava.library.path=/usr/lib CurlMain.java <span class="va">$*</span></span></code></pre></div>
+<span id="cb15-3"><a href="#cb15-3"></a><span class="ex">java</span> -Dforeign.restricted=permit --add-modules jdk.incubator.foreign \</span>
+<span id="cb15-4"><a href="#cb15-4"></a>    -Djava.library.path=/usr/lib CurlMain.java <span class="va">$*</span></span></code></pre></div>
 <h2 id="using-blas-library">Using BLAS library</h2>
 <p>BLAS is a popular library that allows fast matrix and vector computation: <a href="http://www.netlib.org/blas/">http://www.netlib.org/blas/</a>.</p>
 <h3 id="installing-openblas-mac-os">Installing OpenBLAS (Mac OS)</h3>
@@ -366,9 +364,9 @@
 <span id="cb18-64"><a href="#cb18-64"></a>        }</span>
 <span id="cb18-65"><a href="#cb18-65"></a>    }</span>
 <span id="cb18-66"><a href="#cb18-66"></a>}</span></code></pre></div>
-<h3 id="compiling-and-running-the-above-lapack-sample">Compiling and running the above LAPACK sample</h3>
+<h3 id="compiling-and-running-the-above-blas-sample">Compiling and running the above BLAS sample</h3>
 <div class="sourceCode" id="cb19"><pre class="sourceCode sh"><code class="sourceCode bash"><span id="cb19-1"><a href="#cb19-1"></a></span>
-<span id="cb19-2"><a href="#cb19-2"></a><span class="ex">java</span> -Djdk.incubator.foreign.Foreign=permit --add-modules jdk.incubator.foreign \</span>
+<span id="cb19-2"><a href="#cb19-2"></a><span class="ex">java</span> -Dforeign.restricted=permit --add-modules jdk.incubator.foreign \</span>
 <span id="cb19-3"><a href="#cb19-3"></a>    -Djava.library.path=/usr/local/opt/openblas/lib \</span>
 <span id="cb19-4"><a href="#cb19-4"></a>    TestBlas.java</span></code></pre></div>
 <h2 id="using-lapack-library-mac-os">Using LAPACK library (Mac OS)</h2>
@@ -434,9 +432,9 @@
 <span id="cb21-51"><a href="#cb21-51"></a>        }</span>
 <span id="cb21-52"><a href="#cb21-52"></a>    }</span>
 <span id="cb21-53"><a href="#cb21-53"></a>}</span></code></pre></div>
-<h3 id="compiling-and-running-the-above-lapack-sample-1">Compiling and running the above LAPACK sample</h3>
+<h3 id="compiling-and-running-the-above-lapack-sample">Compiling and running the above LAPACK sample</h3>
 <div class="sourceCode" id="cb22"><pre class="sourceCode sh"><code class="sourceCode bash"><span id="cb22-1"><a href="#cb22-1"></a></span>
-<span id="cb22-2"><a href="#cb22-2"></a><span class="ex">java</span> -Djdk.incubator.foreign.Foreign=permit \</span>
+<span id="cb22-2"><a href="#cb22-2"></a><span class="ex">java</span> -Dforeign.restricted=permit \</span>
 <span id="cb22-3"><a href="#cb22-3"></a>    --add-modules jdk.incubator.foreign \</span>
 <span id="cb22-4"><a href="#cb22-4"></a>    -Djava.library.path=/usr/local/opt/lapack/lib \</span>
 <span id="cb22-5"><a href="#cb22-5"></a>    TestLapack.java</span></code></pre></div>
@@ -482,7 +480,7 @@
 <span id="cb24-32"><a href="#cb24-32"></a>}</span></code></pre></div>
 <h3 id="compiling-and-running-the-libproc-sample">Compiling and running the libproc sample</h3>
 <div class="sourceCode" id="cb25"><pre class="sourceCode sh"><code class="sourceCode bash"><span id="cb25-1"><a href="#cb25-1"></a></span>
-<span id="cb25-2"><a href="#cb25-2"></a><span class="ex">java</span> -Djdk.incubator.foreign.Foreign=permit \</span>
+<span id="cb25-2"><a href="#cb25-2"></a><span class="ex">java</span> -Dforeign.restricted=permit \</span>
 <span id="cb25-3"><a href="#cb25-3"></a>    --add-modules jdk.incubator.foreign \</span>
 <span id="cb25-4"><a href="#cb25-4"></a>    -Djava.library.path=/usr/lib LibprocMain.java</span></code></pre></div>
 </body>

--- a/doc/panama_jextract.md
+++ b/doc/panama_jextract.md
@@ -76,13 +76,13 @@ public class HelloWorld {
 
 ```sh
 
-java -Djdk.incubator.foreign.Foreign=permit --add-modules jdk.incubator.foreign HelloWorld.java
+java -Dforeign.restricted=permit --add-modules jdk.incubator.foreign HelloWorld.java
 
 ```
 
 ## Embedding Python interpreter in your Java program (Mac OS)
 
-### jextract a Jar file for Python.h
+### jextract Python.h
 
 ```sh
 
@@ -98,7 +98,6 @@ jextract -l python2.7 \
 
 ```java
 
-import jdk.incubator.foreign.Foreign;
 import org.python.Cstring;
 import static jdk.incubator.foreign.MemoryAddress.NULL;
 // import jextracted python 'header' class
@@ -124,8 +123,9 @@ public class PythonMain {
 
 ```sh
 
-java -Djdk.incubator.foreign.Foreign=permit --add-modules jdk.incubator.foreign \
-    -Djava.library.path=/System/Library/Frameworks/Python.framework/Versions/2.7/lib PythonMain.java
+java -Dforeign.restricted=permit --add-modules jdk.incubator.foreign \
+    -Djava.library.path=/System/Library/Frameworks/Python.framework/Versions/2.7/lib \
+    PythonMain.java
 
 ```
 
@@ -145,7 +145,6 @@ jextract -l readline -t org.unix \
 
 ```java
 
-import jdk.incubator.foreign.Foreign;
 import org.unix.Cstring;
 import static org.unix.RuntimeHelper.*;
 import static org.unix.readline_h.*;
@@ -170,7 +169,7 @@ public class Readline {
 ### Running the java code that uses readline
 
 ```
-java -Djdk.incubator.foreign.Foreign=permit --add-modules jdk.incubator.foreign \
+java -Dforeign.restricted=permit --add-modules jdk.incubator.foreign \
     -Djava.library.path=/usr/local/opt/readline/lib/ Readline.java
 
 ```
@@ -192,7 +191,6 @@ jextract -t org.unix -lcurl \
 
 ```java
 
-import jdk.incubator.foreign.Foreign;
 import org.unix.Cstring;
 import static jdk.incubator.foreign.MemoryAddress.NULL;
 import static org.unix.RuntimeHelper.*;
@@ -224,8 +222,8 @@ public class CurlMain {
 ```sh
 
 # run this shell script by passing a URL as first argument
-java -Djdk.incubator.foreign.Foreign=permit --add-modules \
-    jdk.incubator.foreign -Djava.library.path=/usr/lib CurlMain.java $*
+java -Dforeign.restricted=permit --add-modules jdk.incubator.foreign \
+    -Djava.library.path=/usr/lib CurlMain.java $*
 
 ```
 
@@ -333,11 +331,11 @@ public class TestBlas {
 
 ```
 
-### Compiling and running the above LAPACK sample
+### Compiling and running the above BLAS sample
 
 ```sh
 
-java -Djdk.incubator.foreign.Foreign=permit --add-modules jdk.incubator.foreign \
+java -Dforeign.restricted=permit --add-modules jdk.incubator.foreign \
     -Djava.library.path=/usr/local/opt/openblas/lib \
     TestBlas.java
 
@@ -422,7 +420,7 @@ public class TestLapack {
 
 ```sh
 
-java -Djdk.incubator.foreign.Foreign=permit \
+java -Dforeign.restricted=permit \
     --add-modules jdk.incubator.foreign \
     -Djava.library.path=/usr/local/opt/lapack/lib \
     TestLapack.java
@@ -483,7 +481,7 @@ public class LibprocMain {
 
 ```sh
 
-java -Djdk.incubator.foreign.Foreign=permit \
+java -Dforeign.restricted=permit \
     --add-modules jdk.incubator.foreign \
     -Djava.library.path=/usr/lib LibprocMain.java
 


### PR DESCRIPTION
removed references to Foreign class. Changed system property in scripts.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [JDK-8243485](https://bugs.openjdk.java.net/browse/JDK-8243485): adjust panama_jextract.md samples after recent foreign-abi changes


### Reviewers
 * Henry Jen ([henryjen](@slowhog) - Committer)

### Download
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/130/head:pull/130`
`$ git checkout pull/130`
