### PR TITLE
8243978: jextract should generate separate classes with static util methods for each struct, union

### DIFF
--- a/src/jdk.incubator.jextract/share/classes/jdk/incubator/jextract/tool/HeaderBuilder.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/incubator/jextract/tool/HeaderBuilder.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package jdk.incubator.jextract.tool;
+
+import jdk.incubator.foreign.FunctionDescriptor;
+import java.lang.invoke.MethodType;
+import java.util.ArrayList;
+import java.util.List;
+import javax.tools.JavaFileObject;
+
+/**
+ * A helper class to generate header interface class in source form.
+ * After aggregating various constituents of a .java source, build
+ * method is called to get overall generated source string.
+ */
+class HeaderBuilder extends JavaSourceBuilder {
+    HeaderBuilder(String className, String pkgName, ConstantHelper constantHelper) {
+        super(className, pkgName, constantHelper);
+    }
+
+    public List<JavaFileObject> build() {
+        String res = sb.toString();
+        this.sb.delete(0, res.length());
+        List<JavaFileObject> outputs = new ArrayList<>(constantHelper.getClasses());
+        outputs.add(Utils.fileFromString(pkgName, className, res));
+        return outputs;
+    }
+
+    public void addFunctionalFactory(String className, MethodType mtype, FunctionDescriptor fDesc) {
+        incrAlign();
+        indent();
+        sb.append(PUB_MODS + "MemoryAddress " + className + "$make(" + className + " fi) {\n");
+        incrAlign();
+        indent();
+        sb.append("return RuntimeHelper.upcallStub(" + className + ".class, fi, " + functionGetCallString(className, fDesc) + ", " +
+                "\"" + mtype.toMethodDescriptorString() + "\");\n");
+        decrAlign();
+        indent();
+        sb.append("}\n");
+        decrAlign();
+    }
+
+    public void addFunctionalInterface(String name, MethodType mtype) {
+        incrAlign();
+        indent();
+        sb.append("public interface " + name + " {\n");
+        incrAlign();
+        indent();
+        sb.append(mtype.returnType().getName() + " apply(");
+        String delim = "";
+        for (int i = 0 ; i < mtype.parameterCount() ; i++) {
+            sb.append(delim + mtype.parameterType(i).getName() + " x" + i);
+            delim = ", ";
+        }
+        sb.append(");\n");
+        decrAlign();
+        indent();
+        sb.append("}\n");
+        decrAlign();
+        indent();
+    }
+
+    public void addStaticFunctionWrapper(String javaName, String nativeName, MethodType mtype, FunctionDescriptor desc, boolean varargs, List<String> paramNames) {
+        incrAlign();
+        indent();
+        sb.append(PUB_MODS + mtype.returnType().getName() + " " + javaName + " (");
+        String delim = "";
+        List<String> pNames = new ArrayList<>();
+        final int numParams = paramNames.size();
+        for (int i = 0 ; i < numParams; i++) {
+            String pName = paramNames.get(i);
+            if (pName.isEmpty()) {
+                pName = "x" + i;
+            }
+            pNames.add(pName);
+            sb.append(delim + mtype.parameterType(i).getName() + " " + pName);
+            delim = ", ";
+        }
+        if (varargs) {
+            String lastArg = "x" + numParams;
+            if (numParams > 0) {
+                sb.append(", ");
+            }
+            sb.append("Object... " + lastArg);
+            pNames.add(lastArg);
+        }
+        sb.append(") {\n");
+        incrAlign();
+        indent();
+        sb.append("try {\n");
+        incrAlign();
+        indent();
+        if (!mtype.returnType().equals(void.class)) {
+            sb.append("return (" + mtype.returnType().getName() + ")");
+        }
+        sb.append(methodHandleGetCallString(javaName, nativeName, mtype, desc, varargs) + ".invokeExact(" + String.join(", ", pNames) + ");\n");
+        decrAlign();
+        indent();
+        sb.append("} catch (Throwable ex) {\n");
+        incrAlign();
+        indent();
+        sb.append("throw new AssertionError(ex);\n");
+        decrAlign();
+        indent();
+        sb.append("}\n");
+        decrAlign();
+        indent();
+        sb.append("}\n");
+        decrAlign();
+    }
+}

--- a/src/jdk.incubator.jextract/share/classes/jdk/incubator/jextract/tool/HeaderBuilder.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/incubator/jextract/tool/HeaderBuilder.java
@@ -28,7 +28,6 @@ import jdk.incubator.foreign.FunctionDescriptor;
 import java.lang.invoke.MethodType;
 import java.util.ArrayList;
 import java.util.List;
-import javax.tools.JavaFileObject;
 
 /**
  * A helper class to generate header interface class in source form.
@@ -38,14 +37,6 @@ import javax.tools.JavaFileObject;
 class HeaderBuilder extends JavaSourceBuilder {
     HeaderBuilder(String className, String pkgName, ConstantHelper constantHelper) {
         super(className, pkgName, constantHelper);
-    }
-
-    public List<JavaFileObject> build() {
-        String res = sb.toString();
-        this.sb.delete(0, res.length());
-        List<JavaFileObject> outputs = new ArrayList<>(constantHelper.getClasses());
-        outputs.add(Utils.fileFromString(pkgName, className, res));
-        return outputs;
     }
 
     public void addFunctionalFactory(String className, MethodType mtype, FunctionDescriptor fDesc) {

--- a/src/jdk.incubator.jextract/share/classes/jdk/incubator/jextract/tool/JavaSourceBuilder.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/incubator/jextract/tool/JavaSourceBuilder.java
@@ -36,49 +36,50 @@ import java.util.ArrayList;
 import java.util.List;
 
 /**
- * A helper class to generate header interface class in source form.
- * After aggregating various constituents of a .java source, build
- * method is called to get overall generated source string.
+ * Superclass for .java source generator classes.
  */
-class JavaSourceBuilder {
-
-    private static final String PUB_CLS_MODS = "public final ";
-    private static final String PUB_MODS = "public static final ";
-
-    private final String pkgName;
-    private final String[] libraryNames;
+abstract class JavaSourceBuilder {
+    static final String PUB_CLS_MODS = "public final ";
+    static final String PUB_MODS = "public static final ";
+    protected final String className;
+    protected final String pkgName;
+    protected final ConstantHelper constantHelper;
     // buffer
-    protected StringBuffer sb;
+    protected final StringBuffer sb;
     // current line alignment (number of 4-spaces)
-    protected int align;
+    private int align;
 
-    private String className = null;
-    private ConstantHelper constantHelper;
-
-    JavaSourceBuilder(int align, String pkgName, String[] libraryNames) {
-        this.align = align;
-        this.libraryNames = libraryNames;
-        this.sb = new StringBuffer();
+    JavaSourceBuilder(String className, String pkgName, ConstantHelper constantHelper, int align) {
+        this.className = className;
         this.pkgName = pkgName;
+        this.constantHelper = constantHelper;
+        this.align = align;
+        this.sb = new StringBuffer();
     }
 
-    JavaSourceBuilder(String pkgName, String[] libraryNames) {
-        this(0, pkgName, libraryNames);
+    JavaSourceBuilder(String className, String pkgName, ConstantHelper constantHelper) {
+        this(className, pkgName, constantHelper, 0);
     }
 
-    public void classBegin(String name) {
-        className = name;
-        String qualName = pkgName.isEmpty() ? name : pkgName + "." + name;
-        constantHelper = new ConstantHelper(qualName,
-                ClassDesc.of(pkgName, "RuntimeHelper"), ClassDesc.of(pkgName, "Cstring"), libraryNames);
-
+    public void classBegin() {
         addPackagePrefix();
         addImportSection();
 
         indent();
         sb.append(PUB_CLS_MODS + "class ");
-        sb.append(name);
+        sb.append(className);
         sb.append(" {\n\n");
+        emitConstructor();
+    }
+
+    public void emitConstructor() {
+        incrAlign();
+        indent();
+        sb.append("private ");
+        sb.append(className);
+        sb.append("() {}");
+        sb.append('\n');
+        decrAlign();
     }
 
     public void classEnd() {
@@ -104,89 +105,6 @@ class JavaSourceBuilder {
 
     public void addConstantGetter(String javaName, Class<?> type, Object value) {
         emitForwardGetter(constantHelper.addConstant(javaName, type, value));
-    }
-
-    public void addFunctionalFactory(String className, MethodType mtype, FunctionDescriptor fDesc) {
-        incrAlign();
-        indent();
-        sb.append(PUB_MODS + "MemoryAddress " + className + "$make(" + className + " fi) {\n");
-        incrAlign();
-        indent();
-        sb.append("return RuntimeHelper.upcallStub(" + className + ".class, fi, " + functionGetCallString(className, fDesc) + ", " +
-                "\"" + mtype.toMethodDescriptorString() + "\");\n");
-        decrAlign();
-        indent();
-        sb.append("}\n");
-        decrAlign();
-    }
-
-    public void addStaticFunctionWrapper(String javaName, String nativeName, MethodType mtype, FunctionDescriptor desc, boolean varargs, List<String> paramNames) {
-        incrAlign();
-        indent();
-        sb.append(PUB_MODS + mtype.returnType().getName() + " " + javaName + " (");
-        String delim = "";
-        List<String> pNames = new ArrayList<>();
-        final int numParams = paramNames.size();
-        for (int i = 0 ; i < numParams; i++) {
-            String pName = paramNames.get(i);
-            if (pName.isEmpty()) {
-                pName = "x" + i;
-            }
-            pNames.add(pName);
-            sb.append(delim + mtype.parameterType(i).getName() + " " + pName);
-            delim = ", ";
-        }
-        if (varargs) {
-            String lastArg = "x" + numParams;
-            if (numParams > 0) {
-                sb.append(", ");
-            }
-            sb.append("Object... " + lastArg);
-            pNames.add(lastArg);
-        }
-        sb.append(") {\n");
-        incrAlign();
-        indent();
-        sb.append("try {\n");
-        incrAlign();
-        indent();
-        if (!mtype.returnType().equals(void.class)) {
-            sb.append("return (" + mtype.returnType().getName() + ")");
-        }
-        sb.append(methodHandleGetCallString(javaName, nativeName, mtype, desc, varargs) + ".invokeExact(" + String.join(", ", pNames) + ");\n");
-        decrAlign();
-        indent();
-        sb.append("} catch (Throwable ex) {\n");
-        incrAlign();
-        indent();
-        sb.append("throw new AssertionError(ex);\n");
-        decrAlign();
-        indent();
-        sb.append("}\n");
-        decrAlign();
-        indent();
-        sb.append("}\n");
-        decrAlign();
-    }
-
-    public void addFunctionalInterface(String name, MethodType mtype) {
-        incrAlign();
-        indent();
-        sb.append("public interface " + name + " {\n");
-        incrAlign();
-        indent();
-        sb.append(mtype.returnType().getName() + " apply(");
-        String delim = "";
-        for (int i = 0 ; i < mtype.parameterCount() ; i++) {
-            sb.append(delim + mtype.parameterType(i).getName() + " x" + i);
-            delim = ", ";
-        }
-        sb.append(");\n");
-        decrAlign();
-        indent();
-        sb.append("}\n");
-        decrAlign();
-        indent();
     }
 
     public void addGetter(String javaName, String nativeName, MemoryLayout layout, Class<?> type, MemoryLayout parentLayout) {
@@ -222,17 +140,9 @@ class JavaSourceBuilder {
         decrAlign();
     }
 
-    public List<JavaFileObject> build() {
-        String res = sb.toString();
-        this.sb = null;
-        List<JavaFileObject> outputs = new ArrayList<>(constantHelper.getClasses());
-        outputs.add(Utils.fileFromString(pkgName, className, res));
-        return outputs;
-    }
-
     // Utility
 
-    private void addPackagePrefix() {
+    protected void addPackagePrefix() {
         assert pkgName.indexOf('/') == -1 : "package name invalid: " + pkgName;
         sb.append("// Generated by jextract\n\n");
         if (!pkgName.isEmpty()) {
@@ -242,7 +152,7 @@ class JavaSourceBuilder {
         }
     }
 
-    private void addImportSection() {
+    protected void addImportSection() {
         sb.append("import java.lang.invoke.MethodHandle;\n");
         sb.append("import java.lang.invoke.VarHandle;\n");
         sb.append("import jdk.incubator.foreign.*;\n");
@@ -252,7 +162,7 @@ class JavaSourceBuilder {
         sb.append(".*;\n");
     }
 
-    private void emitForwardGetter(DirectMethodHandleDesc desc) {
+    protected void emitForwardGetter(DirectMethodHandleDesc desc) {
         incrAlign();
         indent();
         sb.append(PUB_MODS + displayName(desc.invocationType().returnType()) + " " + desc.methodName() + "() {\n");
@@ -265,42 +175,41 @@ class JavaSourceBuilder {
         decrAlign();
     }
 
-    private String getCallString(DirectMethodHandleDesc desc) {
+    protected String getCallString(DirectMethodHandleDesc desc) {
         return desc.owner().displayName() + "." + desc.methodName() + "()";
     }
 
-    private String displayName(ClassDesc returnType) {
+    protected String displayName(ClassDesc returnType) {
         return returnType.displayName(); // TODO shorten based on imports
     }
 
-    private String functionGetCallString(String javaName, FunctionDescriptor fDesc) {
+    protected String functionGetCallString(String javaName, FunctionDescriptor fDesc) {
         return getCallString(constantHelper.addFunctionDesc(javaName, fDesc));
     }
 
-    private String methodHandleGetCallString(String javaName, String nativeName, MethodType mt, FunctionDescriptor fDesc, boolean varargs) {
+    protected String methodHandleGetCallString(String javaName, String nativeName, MethodType mt, FunctionDescriptor fDesc, boolean varargs) {
         return getCallString(constantHelper.addMethodHandle(javaName, nativeName, mt, fDesc, varargs));
     }
 
-    private String varHandleGetCallString(String javaName, String nativeName, MemoryLayout layout, Class<?> type, MemoryLayout parentLayout) {
+    protected String varHandleGetCallString(String javaName, String nativeName, MemoryLayout layout, Class<?> type, MemoryLayout parentLayout) {
         return getCallString(constantHelper.addVarHandle(javaName, nativeName, layout, type, parentLayout));
     }
 
-    private String addressGetCallString(String javaName, String nativeName) {
+    protected String addressGetCallString(String javaName, String nativeName) {
         return getCallString(constantHelper.addAddress(javaName, nativeName));
     }
 
-    private void indent() {
+    protected void indent() {
         for (int i = 0; i < align; i++) {
             sb.append("    ");
         }
     }
 
-    private void incrAlign() {
+    protected void incrAlign() {
         align++;
     }
 
-    private void decrAlign() {
+    protected void decrAlign() {
         align--;
     }
-
 }

--- a/src/jdk.incubator.jextract/share/classes/jdk/incubator/jextract/tool/JavaSourceBuilder.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/incubator/jextract/tool/JavaSourceBuilder.java
@@ -87,6 +87,12 @@ abstract class JavaSourceBuilder {
         sb.append("}\n\n");
     }
 
+    public JavaFileObject build() {
+        String res = sb.toString();
+        this.sb.delete(0, res.length());
+        return Utils.fileFromString(pkgName, className, res);
+    }
+
     public void addLayoutGetter(String javaName, MemoryLayout layout) {
         emitForwardGetter(constantHelper.addLayout(javaName, layout));
     }

--- a/src/jdk.incubator.jextract/share/classes/jdk/incubator/jextract/tool/OutputFactory.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/incubator/jextract/tool/OutputFactory.java
@@ -120,9 +120,10 @@ public class OutputFactory implements Declaration.Visitor<Void, Declaration> {
         decl.members().forEach(this::generateDecl);
 
         builder.classEnd();
-        List<JavaFileObject> outputs = builder.build();
         try {
-            List<JavaFileObject> files = new ArrayList<>(outputs);
+            List<JavaFileObject> files = new ArrayList<>();
+            files.add(builder.build());
+            files.addAll(constantHelper.getClasses());
             files.add(fileFromString(pkgName,"RuntimeHelper", getRuntimeHelperSource()));
             files.add(getCstringFile(pkgName));
             files.addAll(getPrimitiveTypeFiles(pkgName));

--- a/src/jdk.incubator.jextract/share/classes/jdk/incubator/jextract/tool/StructBuilder.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/incubator/jextract/tool/StructBuilder.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package jdk.incubator.jextract.tool;
+
+import jdk.incubator.foreign.MemoryLayout;
+
+import javax.tools.JavaFileObject;
+import java.lang.constant.DirectMethodHandleDesc;
+
+/**
+ * This class generates static utilities class for C structs, unions.
+ */
+class StructBuilder extends JavaSourceBuilder {
+    StructBuilder(String className, String pkgName, ConstantHelper constantHelper) {
+        super(className, pkgName, constantHelper);
+    }
+
+    public JavaFileObject build() {
+        String res = sb.toString();
+        this.sb.delete(0, res.length());
+        return Utils.fileFromString(pkgName, className, res);
+    }
+
+    @Override
+    public void classEnd() {
+        emitSizeof();
+        emitAllocate();
+        emitScopeAllocate();
+        super.classEnd();
+    }
+
+    @Override
+    public void addLayoutGetter(String javaName, MemoryLayout layout) {
+        var desc = constantHelper.addLayout(javaName, layout);
+        incrAlign();
+        indent();
+        sb.append(PUB_MODS + displayName(desc.invocationType().returnType()) + " $LAYOUT() {\n");
+        incrAlign();
+        indent();
+        sb.append("return " + getCallString(desc) + ";\n");
+        decrAlign();
+        indent();
+        sb.append("}\n");
+        decrAlign();
+    }
+
+    private void emitSizeof() {
+        incrAlign();
+        indent();
+        sb.append(PUB_MODS);
+        sb.append("long sizeof() { return $LAYOUT().byteSize(); }\n");
+        decrAlign();
+    }
+
+    private void emitAllocate() {
+        incrAlign();
+        indent();
+        sb.append(PUB_MODS);
+        sb.append("MemorySegment allocate() { return MemorySegment.allocateNative($LAYOUT()); }\n");
+        decrAlign();
+    }
+
+    private void emitScopeAllocate() {
+        incrAlign();
+        indent();
+        sb.append(PUB_MODS);
+        sb.append("MemoryAddress allocate(NativeAllocationScope scope) { return scope.allocate($LAYOUT()); }\n");
+        decrAlign();
+    }
+}

--- a/src/jdk.incubator.jextract/share/classes/jdk/incubator/jextract/tool/StructBuilder.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/incubator/jextract/tool/StructBuilder.java
@@ -26,7 +26,6 @@ package jdk.incubator.jextract.tool;
 
 import jdk.incubator.foreign.MemoryLayout;
 
-import javax.tools.JavaFileObject;
 import java.lang.constant.DirectMethodHandleDesc;
 
 /**
@@ -35,12 +34,6 @@ import java.lang.constant.DirectMethodHandleDesc;
 class StructBuilder extends JavaSourceBuilder {
     StructBuilder(String className, String pkgName, ConstantHelper constantHelper) {
         super(className, pkgName, constantHelper);
-    }
-
-    public JavaFileObject build() {
-        String res = sb.toString();
-        this.sb.delete(0, res.length());
-        return Utils.fileFromString(pkgName, className, res);
     }
 
     @Override

--- a/test/jdk/tools/jextract/JextractToolRunner.java
+++ b/test/jdk/tools/jextract/JextractToolRunner.java
@@ -244,6 +244,10 @@ public class JextractToolRunner {
         return null;
     }
 
+    protected MemoryLayout findLayout(Class<?> cls) {
+        return findLayout(cls, "");
+    }
+
     protected static void checkFieldABIType(MemoryLayout layout, String fieldName, Type expected) {
         assertEquals(layout.select(PathElement.groupElement(fieldName)).attribute(NATIVE_TYPE)
                                                                        .map(SystemABI.Type.class::cast)

--- a/test/jdk/tools/jextract/RepeatedDeclsTest.java
+++ b/test/jdk/tools/jextract/RepeatedDeclsTest.java
@@ -83,14 +83,16 @@ public class RepeatedDeclsTest extends JextractToolRunner {
             checkIntGetter(cls, "Y", 2);
 
             // check Point layout
-            MemoryLayout pointLayout = findLayout(cls, "Point");
+            Class<?> pointCls = loader.loadClass("CPoint");
+            MemoryLayout pointLayout = findLayout(pointCls);
             assertNotNull(pointLayout);
             assertTrue(((GroupLayout)pointLayout).isStruct());
             checkFieldABIType(pointLayout, "i",  Type.INT);
             checkFieldABIType(pointLayout, "j",  Type.INT);
 
             // check Point3D layout
-            MemoryLayout point3DLayout = findLayout(cls, "Point3D");
+            Class<?> point3DCls = loader.loadClass("CPoint3D");
+            MemoryLayout point3DLayout = findLayout(point3DCls);
             assertNotNull(point3DLayout);
             assertTrue(((GroupLayout)point3DLayout).isStruct());
             checkFieldABIType(point3DLayout, "i",  Type.INT);

--- a/test/jdk/tools/jextract/Test8240811.java
+++ b/test/jdk/tools/jextract/Test8240811.java
@@ -49,31 +49,34 @@ public class Test8240811 extends JextractToolRunner {
             assertNotNull(cls);
 
             // check foo layout
-            MemoryLayout fooLayout = findLayout(cls, "foo");
+            Class<?> fooCls = loader.loadClass("Cfoo");
+            MemoryLayout fooLayout = findLayout(fooCls);
             assertNotNull(fooLayout);
             assertTrue(((GroupLayout)fooLayout).isStruct());
             checkFieldABIType(fooLayout, "x",  Type.INT);
             checkFieldABIType(fooLayout, "y",  Type.INT);
             checkFieldABIType(fooLayout, "z",  Type.INT);
 
-            MemoryLayout fooVarLayout = findLayout(cls, "var$foo");
+            MemoryLayout fooVarLayout = findLayout(cls, "foo");
             assertNotNull(fooVarLayout);
 
             // check foo2 layout
-            MemoryLayout foo2Layout = findLayout(cls, "foo2");
+            Class<?> foo2Cls = loader.loadClass("Cfoo2");
+            MemoryLayout foo2Layout = findLayout(foo2Cls);
             assertNotNull(foo2Layout);
             assertTrue(((GroupLayout)foo2Layout).isUnion());
             checkFieldABIType(foo2Layout, "i",  Type.INT);
             checkFieldABIType(foo2Layout, "l",  Type.LONG);
 
-            MemoryLayout foo2VarLayout = findLayout(cls, "var$foo2");
+            MemoryLayout foo2VarLayout = findLayout(cls, "foo2");
             assertNotNull(foo2VarLayout);
 
             MemoryLayout barVarLayout = findLayout(cls, "bar");
             assertNotNull(barVarLayout);
 
             // check bar layout
-            MemoryLayout barLayout = findLayout(cls, "struct$bar");
+            Class<?> barCls = loader.loadClass("Cbar");
+            MemoryLayout barLayout = findLayout(barCls);
             assertNotNull(barLayout);
             assertTrue(((GroupLayout)barLayout).isStruct());
             checkFieldABIType(barLayout, "f1",  Type.FLOAT);
@@ -83,7 +86,8 @@ public class Test8240811 extends JextractToolRunner {
             assertNotNull(bar2VarLayout);
 
             // check bar layout
-            MemoryLayout bar2Layout = findLayout(cls, "union$bar2");
+            Class<?> bar2Cls = loader.loadClass("Cbar2");
+            MemoryLayout bar2Layout = findLayout(bar2Cls);
             assertNotNull(bar2Layout);
             assertTrue(((GroupLayout)bar2Layout).isUnion());
             checkFieldABIType(bar2Layout, "f",  Type.FLOAT);

--- a/test/jdk/tools/jextract/UniondeclTest.java
+++ b/test/jdk/tools/jextract/UniondeclTest.java
@@ -46,8 +46,9 @@ public class UniondeclTest extends JextractToolRunner {
             Class<?> cls = loader.loadClass("uniondecl_h");
             // check a method for "void func(IntOrFloat*)"
             assertNotNull(findMethod(cls, "func", MemoryAddress.class));
-            // check Point layout
-            GroupLayout intOrFloatLayout = (GroupLayout)findLayout(cls, "IntOrFloat");
+            // check IntOrFloat layout
+            Class<?> intOrFloatCls = loader.loadClass("CIntOrFloat");
+            GroupLayout intOrFloatLayout = (GroupLayout)findLayout(intOrFloatCls);
             assertNotNull(intOrFloatLayout);
             assertTrue(intOrFloatLayout.isUnion());
             checkFieldABIType(intOrFloatLayout, "i",  Type.INT);

--- a/test/jdk/tools/jextract/testClassGen/TestClassGeneration.java
+++ b/test/jdk/tools/jextract/testClassGen/TestClassGeneration.java
@@ -196,17 +196,17 @@ public class TestClassGeneration extends JextractToolRunner {
     @Test(dataProvider = "structMembers")
     public void testStructMember(String structName, MemoryLayout memberLayout, Class<?> expectedType, Object testValue) throws Throwable {
         String memberName = memberLayout.name().orElseThrow();
-        String combinedName = structName + "$" + memberName;
 
-        Method layout_getter = checkMethod(cls, structName + "$LAYOUT", MemoryLayout.class);
+        Class<?> structCls = loader.loadClass("com.acme.C" + structName);
+        Method layout_getter = checkMethod(structCls, "$LAYOUT", MemoryLayout.class);
         MemoryLayout structLayout = (MemoryLayout) layout_getter.invoke(null);
         try (MemorySegment struct = MemorySegment.allocateNative(structLayout)) {
-            Method vh_getter = checkMethod(cls, combinedName + "$VH", VarHandle.class);
+            Method vh_getter = checkMethod(structCls, memberName + "$VH", VarHandle.class);
             VarHandle vh = (VarHandle) vh_getter.invoke(null);
             assertEquals(vh.varType(), expectedType);
 
-            Method getter = checkMethod(cls, combinedName + "$get", expectedType, MemorySegment.class);
-            Method setter = checkMethod(cls, combinedName + "$set", void.class, MemorySegment.class, expectedType);
+            Method getter = checkMethod(structCls, memberName + "$get", expectedType, MemorySegment.class);
+            Method setter = checkMethod(structCls, memberName + "$set", void.class, MemorySegment.class, expectedType);
 
             setter.invoke(null, struct, testValue);
             assertEquals(getter.invoke(null, struct), testValue);

--- a/test/jdk/tools/jextract/testStruct/LibStructTest.java
+++ b/test/jdk/tools/jextract/testStruct/LibStructTest.java
@@ -21,11 +21,13 @@
  * questions.
  */
 
-import jdk.incubator.foreign.MemoryLayout.PathElement;
 import jdk.incubator.foreign.GroupLayout;
+import jdk.incubator.foreign.MemoryLayout.PathElement;
 import jdk.incubator.foreign.SystemABI;
 import jdk.incubator.foreign.SystemABI.Type;
 import org.testng.annotations.Test;
+import test.jextract.struct.CAllTypes;
+import test.jextract.struct.CPoint;
 
 import static jdk.incubator.foreign.SystemABI.NATIVE_TYPE;
 import static org.testng.Assert.assertEquals;
@@ -42,8 +44,15 @@ public class LibStructTest {
     @Test
     public void testMakePoint() {
         try (var seg = makePoint(42, -39)) {
-            assertEquals(Point$x$get(seg), 42);
-            assertEquals(Point$y$get(seg), -39);
+            assertEquals(CPoint.x$get(seg), 42);
+            assertEquals(CPoint.y$get(seg), -39);
+        }
+
+        try (var seg2 = CPoint.allocate()) {
+            CPoint.x$set(seg2, 56);
+            CPoint.y$set(seg2, 65);
+            assertEquals(CPoint.x$get(seg2), 56);
+            assertEquals(CPoint.y$get(seg2), 65);
         }
     }
 
@@ -55,7 +64,7 @@ public class LibStructTest {
 
     @Test
     public void testFieldTypes() {
-        GroupLayout g = (GroupLayout)AllTypes$LAYOUT();
+        GroupLayout g = (GroupLayout)CAllTypes.$LAYOUT();
         checkFieldABIType(g, "sc",  Type.SIGNED_CHAR);
         checkFieldABIType(g, "uc",  Type.UNSIGNED_CHAR);
         checkFieldABIType(g, "s",   Type.SHORT);


### PR DESCRIPTION
JavaSourceBuilder refactored. HeaderBuilder, StructBuilder are added.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [JDK-8243978](https://bugs.openjdk.java.net/browse/JDK-8243978): jextract should generate separate classes with static util methods for each struct, union


### Reviewers
 * Jorn Vernee ([jvernee](@JornVernee) - Committer)

### Download
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/133/head:pull/133`
`$ git checkout pull/133`
