### PR TITLE
8244055: jextract should generate struct and union classes as nested classes of header file class

### DIFF
--- a/src/jdk.incubator.jextract/share/classes/jdk/incubator/jextract/tool/JavaSourceBuilder.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/incubator/jextract/tool/JavaSourceBuilder.java
@@ -97,10 +97,7 @@ abstract class JavaSourceBuilder {
     }
 
     public void addContent(String src) {
-        incrAlign();
-        indent();
         sb.append(src);
-        decrAlign();
     }
 
     public JavaFileObject build() {

--- a/src/jdk.incubator.jextract/share/classes/jdk/incubator/jextract/tool/JavaSourceBuilder.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/incubator/jextract/tool/JavaSourceBuilder.java
@@ -61,12 +61,17 @@ abstract class JavaSourceBuilder {
         this(className, pkgName, constantHelper, 0);
     }
 
+    protected String getClassModifiers() {
+        return PUB_CLS_MODS;
+    }
+
     public void classBegin() {
         addPackagePrefix();
         addImportSection();
 
         indent();
-        sb.append(PUB_CLS_MODS + "class ");
+        sb.append(getClassModifiers());
+        sb.append("class ");
         sb.append(className);
         sb.append(" {\n\n");
         emitConstructor();
@@ -85,6 +90,17 @@ abstract class JavaSourceBuilder {
     public void classEnd() {
         indent();
         sb.append("}\n\n");
+    }
+
+    public String getSource() {
+        return sb.toString();
+    }
+
+    public void addContent(String src) {
+        incrAlign();
+        indent();
+        sb.append(src);
+        decrAlign();
     }
 
     public JavaFileObject build() {

--- a/src/jdk.incubator.jextract/share/classes/jdk/incubator/jextract/tool/JavaSourceBuilder.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/incubator/jextract/tool/JavaSourceBuilder.java
@@ -25,6 +25,7 @@
 package jdk.incubator.jextract.tool;
 
 import jdk.incubator.foreign.FunctionDescriptor;
+import jdk.incubator.foreign.MemoryAddress;
 import jdk.incubator.foreign.MemoryLayout;
 import jdk.incubator.foreign.MemorySegment;
 
@@ -129,12 +130,12 @@ abstract class JavaSourceBuilder {
     public void addGetter(String javaName, String nativeName, MemoryLayout layout, Class<?> type, MemoryLayout parentLayout) {
         incrAlign();
         indent();
-        String param = parentLayout != null ? (MemorySegment.class.getName() + " seg") : "";
+        String param = parentLayout != null ? (MemoryAddress.class.getName() + " addr") : "";
         sb.append(PUB_MODS + type.getName() + " " + javaName + "$get(" + param + ") {\n");
         incrAlign();
         indent();
         String vhParam = parentLayout != null ?
-                "seg.baseAddress()" : addressGetCallString(javaName, nativeName);
+                "addr" : addressGetCallString(javaName, nativeName);
         sb.append("return (" + type.getName() + ")"
                 + varHandleGetCallString(javaName, nativeName, layout, type, parentLayout) + ".get(" + vhParam + ");\n");
         decrAlign();
@@ -146,12 +147,12 @@ abstract class JavaSourceBuilder {
     public void addSetter(String javaName, String nativeName, MemoryLayout layout, Class<?> type, MemoryLayout parentLayout) {
         incrAlign();
         indent();
-        String param = parentLayout != null ? (MemorySegment.class.getName() + " seg, ") : "";
+        String param = parentLayout != null ? (MemoryAddress.class.getName() + " addr, ") : "";
         sb.append(PUB_MODS + "void " + javaName + "$set(" + param + type.getName() + " x) {\n");
         incrAlign();
         indent();
         String vhParam = parentLayout != null ?
-                "seg.baseAddress()" : addressGetCallString(javaName, nativeName);
+                "addr" : addressGetCallString(javaName, nativeName);
         sb.append(varHandleGetCallString(javaName, nativeName, layout, type, parentLayout) + ".set(" + vhParam + ", x);\n");
         decrAlign();
         indent();

--- a/src/jdk.incubator.jextract/share/classes/jdk/incubator/jextract/tool/OutputFactory.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/incubator/jextract/tool/OutputFactory.java
@@ -238,6 +238,7 @@ public class OutputFactory implements Declaration.Visitor<Void, Declaration> {
                 case UNION: {
                     structClass = true;
                     this.structBuilder = new StructBuilder("C" + name, pkgName, constantHelper);
+                    structBuilder.incrAlign();
                     structBuilder.classBegin();
                     structBuilder.addLayoutGetter("C" + name, d.layout().get());
                     break;

--- a/src/jdk.incubator.jextract/share/classes/jdk/incubator/jextract/tool/OutputFactory.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/incubator/jextract/tool/OutputFactory.java
@@ -69,7 +69,7 @@ public class OutputFactory implements Declaration.Visitor<Void, Declaration> {
     private final String clsName;
     private final String pkgName;
     private StructBuilder structBuilder;
-    private List<JavaFileObject> structFiles = new ArrayList<>();
+    private List<String> structSources = new ArrayList<>();
 
     // have we seen this Variable earlier?
     protected boolean variableSeen(Declaration.Variable tree) {
@@ -118,7 +118,9 @@ public class OutputFactory implements Declaration.Visitor<Void, Declaration> {
         builder.classBegin();
         //generate all decls
         decl.members().forEach(this::generateDecl);
-
+        for (String src : structSources) {
+            builder.addContent(src);
+        }
         builder.classEnd();
         try {
             List<JavaFileObject> files = new ArrayList<>();
@@ -127,7 +129,6 @@ public class OutputFactory implements Declaration.Visitor<Void, Declaration> {
             files.add(fileFromString(pkgName,"RuntimeHelper", getRuntimeHelperSource()));
             files.add(getCstringFile(pkgName));
             files.addAll(getPrimitiveTypeFiles(pkgName));
-            files.addAll(structFiles);
             return files.toArray(new JavaFileObject[0]);
         } catch (IOException ex) {
             throw new UncheckedIOException(ex);
@@ -246,7 +247,7 @@ public class OutputFactory implements Declaration.Visitor<Void, Declaration> {
         d.members().forEach(fieldTree -> fieldTree.accept(this, d.name().isEmpty() ? parent : d));
         if (structClass) {
             this.structBuilder.classEnd();
-            structFiles.add(structBuilder.build());
+            structSources.add(structBuilder.getSource());
             this.structBuilder = null;
         }
         return null;

--- a/src/jdk.incubator.jextract/share/classes/jdk/incubator/jextract/tool/StructBuilder.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/incubator/jextract/tool/StructBuilder.java
@@ -37,10 +37,27 @@ class StructBuilder extends JavaSourceBuilder {
     }
 
     @Override
+    protected String getClassModifiers() {
+        return PUB_MODS;
+    }
+
+    @Override
+    protected void addPackagePrefix() {
+        // nested class. containing class has necessary package declaration
+    }
+
+    @Override
+    protected void addImportSection() {
+        // nested class. containing class has necessary imports
+    }
+
+    @Override
     public void classEnd() {
         emitSizeof();
         emitAllocate();
         emitScopeAllocate();
+        emitAllocateArray();
+        emitScopeAllocateArray();
         super.classEnd();
     }
 
@@ -80,6 +97,32 @@ class StructBuilder extends JavaSourceBuilder {
         indent();
         sb.append(PUB_MODS);
         sb.append("MemoryAddress allocate(NativeAllocationScope scope) { return scope.allocate($LAYOUT()); }\n");
+        decrAlign();
+    }
+
+    private void emitAllocateArray() {
+        incrAlign();
+        indent();
+        sb.append(PUB_MODS);
+        sb.append("MemorySegment allocateArray(int len) {\n");
+        incrAlign();
+        indent();
+        sb.append("return MemorySegment.allocateNative(MemoryLayout.ofSequence(len, $LAYOUT()));");
+        decrAlign();
+        sb.append("}\n");
+        decrAlign();
+    }
+
+    private void emitScopeAllocateArray() {
+        incrAlign();
+        indent();
+        sb.append(PUB_MODS);
+        sb.append("MemoryAddress allocateArray(int len, NativeAllocationScope scope) {\n");
+        incrAlign();
+        indent();
+        sb.append("return scope.allocate(MemoryLayout.ofSequence(len, $LAYOUT()));");
+        decrAlign();
+        sb.append("}\n");
         decrAlign();
     }
 }

--- a/src/jdk.incubator.jextract/share/classes/jdk/incubator/jextract/tool/StructBuilder.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/incubator/jextract/tool/StructBuilder.java
@@ -24,6 +24,7 @@
  */
 package jdk.incubator.jextract.tool;
 
+import jdk.incubator.foreign.MemoryAddress;
 import jdk.incubator.foreign.MemoryLayout;
 
 import java.lang.constant.DirectMethodHandleDesc;
@@ -76,6 +77,18 @@ class StructBuilder extends JavaSourceBuilder {
         decrAlign();
     }
 
+    @Override
+    public void addGetter(String javaName, String nativeName, MemoryLayout layout, Class<?> type, MemoryLayout parentLayout) {
+        super.addGetter(javaName, nativeName, layout, type, parentLayout);
+        addIndexGetter(javaName, nativeName, layout, type, parentLayout);
+    }
+
+    @Override
+    public void addSetter(String javaName, String nativeName, MemoryLayout layout, Class<?> type, MemoryLayout parentLayout) {
+        super.addSetter(javaName, nativeName, layout, type, parentLayout);
+        addIndexSetter(javaName, nativeName, layout, type, parentLayout);
+    }
+
     private void emitSizeof() {
         incrAlign();
         indent();
@@ -122,6 +135,35 @@ class StructBuilder extends JavaSourceBuilder {
         indent();
         sb.append("return scope.allocate(MemoryLayout.ofSequence(len, $LAYOUT()));");
         decrAlign();
+        sb.append("}\n");
+        decrAlign();
+    }
+
+    private void addIndexGetter(String javaName, String nativeName, MemoryLayout layout, Class<?> type, MemoryLayout parentLayout) {
+        incrAlign();
+        indent();
+        String params = MemoryAddress.class.getName() + " addr, long index";
+        sb.append(PUB_MODS + type.getName() + " " + javaName + "$get(" + params + ") {\n");
+        incrAlign();
+        indent();
+        sb.append("return (" + type.getName() + ")"
+                + varHandleGetCallString(javaName, nativeName, layout, type, parentLayout) + ".get(addr.addOffset(index*sizeof()));\n");
+        decrAlign();
+        indent();
+        sb.append("}\n");
+        decrAlign();
+    }
+
+    private void addIndexSetter(String javaName, String nativeName, MemoryLayout layout, Class<?> type, MemoryLayout parentLayout) {
+        incrAlign();
+        indent();
+        String params = MemoryAddress.class.getName() + " addr, long index, " + type.getName() + " x";
+        sb.append(PUB_MODS + "void " + javaName + "$set(" + params + ") {\n");
+        incrAlign();
+        indent();
+        sb.append(varHandleGetCallString(javaName, nativeName, layout, type, parentLayout) + ".set(addr.addOffset(index*sizeof()), x);\n");
+        decrAlign();
+        indent();
         sb.append("}\n");
         decrAlign();
     }

--- a/test/jdk/tools/jextract/RepeatedDeclsTest.java
+++ b/test/jdk/tools/jextract/RepeatedDeclsTest.java
@@ -83,7 +83,7 @@ public class RepeatedDeclsTest extends JextractToolRunner {
             checkIntGetter(cls, "Y", 2);
 
             // check Point layout
-            Class<?> pointCls = loader.loadClass("CPoint");
+            Class<?> pointCls = loader.loadClass("repeatedDecls_h$CPoint");
             MemoryLayout pointLayout = findLayout(pointCls);
             assertNotNull(pointLayout);
             assertTrue(((GroupLayout)pointLayout).isStruct());
@@ -91,7 +91,7 @@ public class RepeatedDeclsTest extends JextractToolRunner {
             checkFieldABIType(pointLayout, "j",  Type.INT);
 
             // check Point3D layout
-            Class<?> point3DCls = loader.loadClass("CPoint3D");
+            Class<?> point3DCls = loader.loadClass("repeatedDecls_h$CPoint3D");
             MemoryLayout point3DLayout = findLayout(point3DCls);
             assertNotNull(point3DLayout);
             assertTrue(((GroupLayout)point3DLayout).isStruct());

--- a/test/jdk/tools/jextract/Test8240811.java
+++ b/test/jdk/tools/jextract/Test8240811.java
@@ -49,7 +49,7 @@ public class Test8240811 extends JextractToolRunner {
             assertNotNull(cls);
 
             // check foo layout
-            Class<?> fooCls = loader.loadClass("Cfoo");
+            Class<?> fooCls = loader.loadClass("name_collision_h$Cfoo");
             MemoryLayout fooLayout = findLayout(fooCls);
             assertNotNull(fooLayout);
             assertTrue(((GroupLayout)fooLayout).isStruct());
@@ -61,7 +61,7 @@ public class Test8240811 extends JextractToolRunner {
             assertNotNull(fooVarLayout);
 
             // check foo2 layout
-            Class<?> foo2Cls = loader.loadClass("Cfoo2");
+            Class<?> foo2Cls = loader.loadClass("name_collision_h$Cfoo2");
             MemoryLayout foo2Layout = findLayout(foo2Cls);
             assertNotNull(foo2Layout);
             assertTrue(((GroupLayout)foo2Layout).isUnion());
@@ -75,7 +75,7 @@ public class Test8240811 extends JextractToolRunner {
             assertNotNull(barVarLayout);
 
             // check bar layout
-            Class<?> barCls = loader.loadClass("Cbar");
+            Class<?> barCls = loader.loadClass("name_collision_h$Cbar");
             MemoryLayout barLayout = findLayout(barCls);
             assertNotNull(barLayout);
             assertTrue(((GroupLayout)barLayout).isStruct());
@@ -86,7 +86,7 @@ public class Test8240811 extends JextractToolRunner {
             assertNotNull(bar2VarLayout);
 
             // check bar layout
-            Class<?> bar2Cls = loader.loadClass("Cbar2");
+            Class<?> bar2Cls = loader.loadClass("name_collision_h$Cbar2");
             MemoryLayout bar2Layout = findLayout(bar2Cls);
             assertNotNull(bar2Layout);
             assertTrue(((GroupLayout)bar2Layout).isUnion());

--- a/test/jdk/tools/jextract/UniondeclTest.java
+++ b/test/jdk/tools/jextract/UniondeclTest.java
@@ -47,7 +47,7 @@ public class UniondeclTest extends JextractToolRunner {
             // check a method for "void func(IntOrFloat*)"
             assertNotNull(findMethod(cls, "func", MemoryAddress.class));
             // check IntOrFloat layout
-            Class<?> intOrFloatCls = loader.loadClass("CIntOrFloat");
+            Class<?> intOrFloatCls = loader.loadClass("uniondecl_h$CIntOrFloat");
             GroupLayout intOrFloatLayout = (GroupLayout)findLayout(intOrFloatCls);
             assertNotNull(intOrFloatLayout);
             assertTrue(intOrFloatLayout.isUnion());

--- a/test/jdk/tools/jextract/testClassGen/TestClassGeneration.java
+++ b/test/jdk/tools/jextract/testClassGen/TestClassGeneration.java
@@ -197,7 +197,7 @@ public class TestClassGeneration extends JextractToolRunner {
     public void testStructMember(String structName, MemoryLayout memberLayout, Class<?> expectedType, Object testValue) throws Throwable {
         String memberName = memberLayout.name().orElseThrow();
 
-        Class<?> structCls = loader.loadClass("com.acme.C" + structName);
+        Class<?> structCls = loader.loadClass("com.acme.examples_h$C" + structName);
         Method layout_getter = checkMethod(structCls, "$LAYOUT", MemoryLayout.class);
         MemoryLayout structLayout = (MemoryLayout) layout_getter.invoke(null);
         try (MemorySegment struct = MemorySegment.allocateNative(structLayout)) {

--- a/test/jdk/tools/jextract/testClassGen/TestClassGeneration.java
+++ b/test/jdk/tools/jextract/testClassGen/TestClassGeneration.java
@@ -205,11 +205,11 @@ public class TestClassGeneration extends JextractToolRunner {
             VarHandle vh = (VarHandle) vh_getter.invoke(null);
             assertEquals(vh.varType(), expectedType);
 
-            Method getter = checkMethod(structCls, memberName + "$get", expectedType, MemorySegment.class);
-            Method setter = checkMethod(structCls, memberName + "$set", void.class, MemorySegment.class, expectedType);
-
-            setter.invoke(null, struct, testValue);
-            assertEquals(getter.invoke(null, struct), testValue);
+            Method getter = checkMethod(structCls, memberName + "$get", expectedType, MemoryAddress.class);
+            Method setter = checkMethod(structCls, memberName + "$set", void.class, MemoryAddress.class, expectedType);
+            MemoryAddress addr = struct.baseAddress();
+            setter.invoke(null, addr, testValue);
+            assertEquals(getter.invoke(null, addr), testValue);
         }
     }
 

--- a/test/jdk/tools/jextract/testStruct/LibStructTest.java
+++ b/test/jdk/tools/jextract/testStruct/LibStructTest.java
@@ -26,8 +26,6 @@ import jdk.incubator.foreign.MemoryLayout.PathElement;
 import jdk.incubator.foreign.SystemABI;
 import jdk.incubator.foreign.SystemABI.Type;
 import org.testng.annotations.Test;
-import test.jextract.struct.CAllTypes;
-import test.jextract.struct.CPoint;
 
 import static jdk.incubator.foreign.SystemABI.NATIVE_TYPE;
 import static org.testng.Assert.assertEquals;

--- a/test/jdk/tools/jextract/testStruct/LibStructTest.java
+++ b/test/jdk/tools/jextract/testStruct/LibStructTest.java
@@ -42,18 +42,35 @@ public class LibStructTest {
     @Test
     public void testMakePoint() {
         try (var seg = makePoint(42, -39)) {
-            assertEquals(CPoint.x$get(seg), 42);
-            assertEquals(CPoint.y$get(seg), -39);
+            var addr = seg.baseAddress();
+            assertEquals(CPoint.x$get(addr), 42);
+            assertEquals(CPoint.y$get(addr), -39);
         }
     }
 
     @Test
     public void testAllocate() {
         try (var seg = CPoint.allocate()) {
-            CPoint.x$set(seg, 56);
-            CPoint.y$set(seg, 65);
-            assertEquals(CPoint.x$get(seg), 56);
-            assertEquals(CPoint.y$get(seg), 65);
+            var addr = seg.baseAddress();
+            CPoint.x$set(addr, 56);
+            CPoint.y$set(addr, 65);
+            assertEquals(CPoint.x$get(addr), 56);
+            assertEquals(CPoint.y$get(addr), 65);
+        }
+    }
+
+    @Test
+    public void testAllocateArray() {
+        try (var seg = CPoint.allocateArray(3)) {
+            var addr = seg.baseAddress();
+            for (int i = 0; i < 3; i++) {
+                CPoint.x$set(addr, i, 56 + i);
+                CPoint.y$set(addr, i, 65 + i);
+            }
+            for (int i = 0; i < 3; i++) {
+                assertEquals(CPoint.x$get(addr, i), 56 + i);
+                assertEquals(CPoint.y$get(addr, i), 65 + i);
+            }
         }
     }
 

--- a/test/jdk/tools/jextract/testStruct/LibStructTest.java
+++ b/test/jdk/tools/jextract/testStruct/LibStructTest.java
@@ -45,12 +45,15 @@ public class LibStructTest {
             assertEquals(CPoint.x$get(seg), 42);
             assertEquals(CPoint.y$get(seg), -39);
         }
+    }
 
-        try (var seg2 = CPoint.allocate()) {
-            CPoint.x$set(seg2, 56);
-            CPoint.y$set(seg2, 65);
-            assertEquals(CPoint.x$get(seg2), 56);
-            assertEquals(CPoint.y$get(seg2), 65);
+    @Test
+    public void testAllocate() {
+        try (var seg = CPoint.allocate()) {
+            CPoint.x$set(seg, 56);
+            CPoint.y$set(seg, 65);
+            assertEquals(CPoint.x$get(seg), 56);
+            assertEquals(CPoint.y$get(seg), 65);
         }
     }
 


### PR DESCRIPTION
* generating nested classes for structs and unions
* using MemoryAddress instead of MemorySegment as first argument for struct/union getters/setters
* added indexed field setters and getters for array element set/get
* added tests for struct array creation, indexed access get/set
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [JDK-8244055](https://bugs.openjdk.java.net/browse/JDK-8244055): jextract should generate struct and union classes as nested classes of header file class


### Reviewers
 * Maurizio Cimadamore ([mcimadamore](@mcimadamore) - Committer)
 * Jorn Vernee ([jvernee](@JornVernee) - Committer)

### Download
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/134/head:pull/134`
`$ git checkout pull/134`
