### PR TITLE
8244127: "memory stomping error" when running java/foreign/TestNative.java on a debug build

### DIFF
--- a/test/jdk/java/foreign/TestNative.java
+++ b/test/jdk/java/foreign/TestNative.java
@@ -149,6 +149,7 @@ public class TestNative {
     public static native long getCapacity(Buffer buffer);
 
     public static native long allocate(int size);
+    public static native long free(long address);
 
     @Test(dataProvider="nativeAccessOps")
     public void testNativeAccess(Consumer<MemoryAddress> checker, Consumer<MemoryAddress> initializer, SequenceLayout seq) {
@@ -176,7 +177,7 @@ public class TestNative {
         MemoryAddress addr = MemoryAddress.ofLong(allocate(12));
         assertNull(addr.segment());
         MemorySegment mallocSegment = MemorySegment.ofNativeRestricted(addr, 12, null,
-                () -> UNSAFE.freeMemory(addr.toRawLongValue()), null);
+                () -> free(addr.toRawLongValue()), null);
         assertEquals(mallocSegment.byteSize(), 12);
         mallocSegment.close(); //free here
         assertTrue(!mallocSegment.isAlive());

--- a/test/jdk/java/foreign/libNativeAccess.c
+++ b/test/jdk/java/foreign/libNativeAccess.c
@@ -117,6 +117,11 @@ Java_TestNative_getCapacity(JNIEnv *env, jclass cls, jobject buf) {
 }
 
 JNIEXPORT jlong JNICALL
-Java_TestNative_allocate(JNIEnv *env, jclass cls, jobject buf, jint size) {
+Java_TestNative_allocate(JNIEnv *env, jclass cls, jint size) {
     return (jlong)malloc(size);
+}
+
+JNIEXPORT void JNICALL
+Java_TestNative_free(JNIEnv *env, jclass cls, jlong ptr) {
+    free((void*) ptr);
 }


### PR DESCRIPTION
Hi,

This patch fixes a fatal error when running the TestNative test on a debug build. (See the JBS issue for more details).

Thanks,
Jorn
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [JDK-8244127](https://bugs.openjdk.java.net/browse/JDK-8244127): "memory stomping error" when running java/foreign/TestNative.java on a debug build


### Reviewers
 * Paul Sandoz ([psandoz](@PaulSandoz) - Committer)

### Download
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/135/head:pull/135`
`$ git checkout pull/135`
