### PR TITLE
8244128: Allocations larger than MAX_ALIGN can fail to be sliced to proper size.

### DIFF
--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/NativeMemorySegmentImpl.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/NativeMemorySegmentImpl.java
@@ -96,7 +96,7 @@ public class NativeMemorySegmentImpl extends AbstractMemorySegmentImpl {
         MemoryScope scope = new MemoryScope(null, () -> unsafe.freeMemory(buf));
         MemorySegment segment = new NativeMemorySegmentImpl(buf, alignedSize, defaultAccessModes(alignedSize),
                 Thread.currentThread(), scope);
-        if (alignedBuf != buf) {
+        if (alignedSize != bytesSize) {
             long delta = alignedBuf - buf;
             segment = segment.asSlice(delta, bytesSize);
         }


### PR DESCRIPTION
Hi,

This patch fixes a problem where the MemorySegment resulting from an allocation was not always sliced to the requested size, when the allocation code was manually up-sizing the allocation in order to perform manual alignment of the returned MemorySegment, but the initial allocation turned out to be aligned any ways.

Thanks,
Jorn
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [JDK-8244128](https://bugs.openjdk.java.net/browse/JDK-8244128): Allocations larger than MAX_ALIGN can fail to be sliced to proper size.


### Reviewers
 * Maurizio Cimadamore ([mcimadamore](@mcimadamore) - Committer) ⚠️ Review applies to e9d9a2d4a48e446538977d013afba512e71c6959

### Download
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/136/head:pull/136`
`$ git checkout pull/136`
