### PR TITLE
8244172: jextract should generate upcall stub creating helper in the functional interface class

### DIFF
--- a/src/jdk.incubator.jextract/share/classes/jdk/incubator/jextract/tool/HeaderBuilder.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/incubator/jextract/tool/HeaderBuilder.java
@@ -111,7 +111,7 @@ class HeaderBuilder extends JavaSourceBuilder {
 
     private void addFunctionalFactory(String className, MethodType mtype, FunctionDescriptor fDesc) {
         indent();
-        sb.append(PUB_MODS + "MemoryAddress $make(" + className + " fi) {\n");
+        sb.append(PUB_MODS + "MemoryAddress allocate(" + className + " fi) {\n");
         incrAlign();
         indent();
         sb.append("return RuntimeHelper.upcallStub(" + className + ".class, fi, " + functionGetCallString(className, fDesc) + ", " +

--- a/src/jdk.incubator.jextract/share/classes/jdk/incubator/jextract/tool/HeaderBuilder.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/incubator/jextract/tool/HeaderBuilder.java
@@ -39,21 +39,7 @@ class HeaderBuilder extends JavaSourceBuilder {
         super(className, pkgName, constantHelper);
     }
 
-    public void addFunctionalFactory(String className, MethodType mtype, FunctionDescriptor fDesc) {
-        incrAlign();
-        indent();
-        sb.append(PUB_MODS + "MemoryAddress " + className + "$make(" + className + " fi) {\n");
-        incrAlign();
-        indent();
-        sb.append("return RuntimeHelper.upcallStub(" + className + ".class, fi, " + functionGetCallString(className, fDesc) + ", " +
-                "\"" + mtype.toMethodDescriptorString() + "\");\n");
-        decrAlign();
-        indent();
-        sb.append("}\n");
-        decrAlign();
-    }
-
-    public void addFunctionalInterface(String name, MethodType mtype) {
+    public void addFunctionalInterface(String name, MethodType mtype,  FunctionDescriptor fDesc) {
         incrAlign();
         indent();
         sb.append("public interface " + name + " {\n");
@@ -66,6 +52,7 @@ class HeaderBuilder extends JavaSourceBuilder {
             delim = ", ";
         }
         sb.append(");\n");
+        addFunctionalFactory(name, mtype, fDesc);
         decrAlign();
         indent();
         sb.append("}\n");
@@ -120,5 +107,17 @@ class HeaderBuilder extends JavaSourceBuilder {
         indent();
         sb.append("}\n");
         decrAlign();
+    }
+
+    private void addFunctionalFactory(String className, MethodType mtype, FunctionDescriptor fDesc) {
+        indent();
+        sb.append(PUB_MODS + "MemoryAddress $make(" + className + " fi) {\n");
+        incrAlign();
+        indent();
+        sb.append("return RuntimeHelper.upcallStub(" + className + ".class, fi, " + functionGetCallString(className, fDesc) + ", " +
+                "\"" + mtype.toMethodDescriptorString() + "\");\n");
+        decrAlign();
+        indent();
+        sb.append("}\n");
     }
 }

--- a/src/jdk.incubator.jextract/share/classes/jdk/incubator/jextract/tool/JavaSourceBuilder.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/incubator/jextract/tool/JavaSourceBuilder.java
@@ -41,7 +41,7 @@ import java.util.List;
  */
 abstract class JavaSourceBuilder {
     static final String PUB_CLS_MODS = "public final ";
-    static final String PUB_MODS = "public static final ";
+    static final String PUB_MODS = "public static ";
     protected final String className;
     protected final String pkgName;
     protected final ConstantHelper constantHelper;

--- a/src/jdk.incubator.jextract/share/classes/jdk/incubator/jextract/tool/OutputFactory.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/incubator/jextract/tool/OutputFactory.java
@@ -284,9 +284,7 @@ public class OutputFactory implements Declaration.Visitor<Void, Declaration> {
                 name = Utils.javaSafeIdentifier(name);
                 //generate functional interface
                 MethodType fitype = typeTranslator.getMethodType(f);
-                builder.addFunctionalInterface(name, fitype);
-                //generate helper
-                builder.addFunctionalFactory(name, fitype, Type.descriptorFor(f).orElseThrow());
+                builder.addFunctionalInterface(name, fitype, Type.descriptorFor(f).orElseThrow());
                 i++;
             }
         }

--- a/src/jdk.incubator.jextract/share/classes/jdk/incubator/jextract/tool/resources/RuntimeHelper.java.template
+++ b/src/jdk.incubator.jextract/share/classes/jdk/incubator/jextract/tool/resources/RuntimeHelper.java.template
@@ -77,6 +77,10 @@ public class RuntimeHelper {
         }
     }
 
+    public static void freeUpcallStub(MemoryAddress addr) {
+        ABI.freeUpcallStub(addr);
+    }
+
     private static class VarargsInvoker {
         private static final MethodHandle INVOKE_MH;
         private final MemoryAddress symbol;

--- a/test/jdk/tools/jextract/testClassGen/TestClassGeneration.java
+++ b/test/jdk/tools/jextract/testClassGen/TestClassGeneration.java
@@ -218,7 +218,7 @@ public class TestClassGeneration extends JextractToolRunner {
         Class<?> fiClass = findNestedClass(cls, name);
         assertNotNull(fiClass);
         checkMethod(fiClass, "apply", type);
-        checkMethod(fiClass, "$make", MemoryAddress.class, fiClass);
+        checkMethod(fiClass, "allocate", MemoryAddress.class, fiClass);
     }
 
     @BeforeClass

--- a/test/jdk/tools/jextract/testClassGen/TestClassGeneration.java
+++ b/test/jdk/tools/jextract/testClassGen/TestClassGeneration.java
@@ -218,7 +218,7 @@ public class TestClassGeneration extends JextractToolRunner {
         Class<?> fiClass = findNestedClass(cls, name);
         assertNotNull(fiClass);
         checkMethod(fiClass, "apply", type);
-        checkMethod(cls, name + "$make", MemoryAddress.class, fiClass);
+        checkMethod(fiClass, "$make", MemoryAddress.class, fiClass);
     }
 
     @BeforeClass

--- a/test/jdk/tools/jextract/testFunctionPointer/LibFuncPtrTest.java
+++ b/test/jdk/tools/jextract/testFunctionPointer/LibFuncPtrTest.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import org.testng.annotations.Test;
+import test.jextract.fp.RuntimeHelper;
+
+import static org.testng.Assert.assertEquals;
+import static test.jextract.fp.funcPtr_h.*;
+
+/*
+ * @test
+ * @library ..
+ * @modules jdk.incubator.jextract
+ * @run driver JtregJextract -l Struct -t test.jextract.fp -- funcPtr.h
+ * @run testng/othervm -Dforeign.restricted=permit LibFuncPtrTest
+ */
+public class LibFuncPtrTest {
+    @Test
+    public void test() {
+        var addr = func$f.$make(x -> x*x);
+        assertEquals(func(addr, 35), 35*35 + 35);
+        RuntimeHelper.freeUpcallStub(addr);
+    }
+}

--- a/test/jdk/tools/jextract/testFunctionPointer/LibFuncPtrTest.java
+++ b/test/jdk/tools/jextract/testFunctionPointer/LibFuncPtrTest.java
@@ -31,7 +31,7 @@ import static test.jextract.fp.funcPtr_h.*;
  * @test
  * @library ..
  * @modules jdk.incubator.jextract
- * @run driver JtregJextract -l Struct -t test.jextract.fp -- funcPtr.h
+ * @run driver JtregJextract -l FuncPtr -t test.jextract.fp -- funcPtr.h
  * @run testng/othervm -Dforeign.restricted=permit LibFuncPtrTest
  */
 public class LibFuncPtrTest {

--- a/test/jdk/tools/jextract/testFunctionPointer/LibFuncPtrTest.java
+++ b/test/jdk/tools/jextract/testFunctionPointer/LibFuncPtrTest.java
@@ -37,7 +37,7 @@ import static test.jextract.fp.funcPtr_h.*;
 public class LibFuncPtrTest {
     @Test
     public void test() {
-        var addr = func$f.$make(x -> x*x);
+        var addr = func$f.allocate(x -> x*x);
         assertEquals(func(addr, 35), 35*35 + 35);
         RuntimeHelper.freeUpcallStub(addr);
     }

--- a/test/jdk/tools/jextract/testFunctionPointer/funcPtr.h
+++ b/test/jdk/tools/jextract/testFunctionPointer/funcPtr.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+#ifdef __cplusplus
+extern "C" {
+#endif // __cplusplus
+
+#ifdef _WIN64
+#define EXPORT __declspec(dllexport)
+#else
+#define EXPORT
+#endif
+
+EXPORT int func(int (*f)(int), int);
+
+#ifdef __cplusplus
+}
+#endif // __cplusplus

--- a/test/jdk/tools/jextract/testFunctionPointer/libFuncPtr.c
+++ b/test/jdk/tools/jextract/testFunctionPointer/libFuncPtr.c
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+#include "funcPtr.h"
+
+EXPORT int func(int (*f)(int), int x) {
+    return x + f(x);
+}


### PR DESCRIPTION
* moved the upcall stub creating utility method as static method of functional interface
* added free upcall stub utility to RuntimeHelper
* added a simple test for function pointer callback
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [JDK-8244172](https://bugs.openjdk.java.net/browse/JDK-8244172): jextract should generate upcall stub creating helper in the functional interface class


### Reviewers
 * Maurizio Cimadamore ([mcimadamore](@mcimadamore) - Committer) ⚠️ Review applies to eedbc34214d2e757e2a53a2bd3a73cf4e0720174

### Download
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/138/head:pull/138`
`$ git checkout pull/138`
