### PR TITLE
Fix foreign-jextract after latest library lookup changes

### DIFF
--- a/src/jdk.incubator.jextract/share/classes/jdk/incubator/jextract/tool/resources/RuntimeHelper.java.template
+++ b/src/jdk.incubator.jextract/share/classes/jdk/incubator/jextract/tool/resources/RuntimeHelper.java.template
@@ -29,7 +29,7 @@ public class RuntimeHelper {
             return new LibraryLookup[] { LibraryLookup.ofDefault() };
         } else {
             return Arrays.stream(libNames)
-                .map(libName -> LibraryLookup.ofLibrary(MH_LOOKUP, libName))
+                .map(libName -> LibraryLookup.ofLibrary(libName))
                 .toArray(LibraryLookup[]::new);
         }
     }

--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/clang/libclang/RuntimeHelper.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/clang/libclang/RuntimeHelper.java
@@ -58,8 +58,8 @@ public class RuntimeHelper {
             return Arrays.stream(libNames).map(libName -> {
                 Optional<Path> absPath = findLibraryPath(paths, libName);
                 return absPath.isPresent() ?
-                        LibraryLookup.ofPath(MH_LOOKUP, absPath.get().toString()) :
-                        LibraryLookup.ofLibrary(MH_LOOKUP, libName);
+                        LibraryLookup.ofPath(absPath.get().toString()) :
+                        LibraryLookup.ofLibrary(libName);
             }).toArray(LibraryLookup[]::new);
         }
     }


### PR DESCRIPTION
This is a simple patch which fixes up the calls to LibraryLookup so that the heading `MethodHandles.Lookup` parameter is dropped.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * Henry Jen ([henryjen](@slowhog) - Committer)

### Download
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/139/head:pull/139`
`$ git checkout pull/139`
