### PR TITLE
Alternative scalable MemoryScope

### DIFF
--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/AbstractMemorySegmentImpl.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/AbstractMemorySegmentImpl.java
@@ -184,12 +184,7 @@ public abstract class AbstractMemorySegmentImpl implements MemorySegment, Memory
         if (owner == newOwner) {
             throw new IllegalArgumentException("Segment already owned by thread: " + newOwner);
         } else {
-            try {
-                return dup(0L, length, mask, newOwner, scope.dup());
-            } finally {
-                //flush read/writes to memory before returning the new segment
-                VarHandle.fullFence();
-            }
+            return dup(0L, length, mask, newOwner, scope.dup());
         }
     }
 
@@ -203,7 +198,7 @@ public abstract class AbstractMemorySegmentImpl implements MemorySegment, Memory
     }
 
     private final void closeNoCheck() {
-        scope.close(true);
+        scope.close();
     }
 
     final AbstractMemorySegmentImpl acquire() {
@@ -421,7 +416,7 @@ public abstract class AbstractMemorySegmentImpl implements MemorySegment, Memory
             modes = bufferSegment.mask;
             owner = bufferSegment.owner;
         } else {
-            bufferScope = new MemoryScope(bb, null);
+            bufferScope = MemoryScope.create(bb, null);
             modes = defaultAccessModes(size);
             owner = Thread.currentThread();
         }

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/AbstractMemorySegmentImpl.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/AbstractMemorySegmentImpl.java
@@ -184,7 +184,12 @@ public abstract class AbstractMemorySegmentImpl implements MemorySegment, Memory
         if (owner == newOwner) {
             throw new IllegalArgumentException("Segment already owned by thread: " + newOwner);
         } else {
-            return dup(0L, length, mask, newOwner, scope.dup());
+            try {
+                return dup(0L, length, mask, newOwner, scope.dup());
+            } finally {
+                //flush read/writes to segment memory before returning the new segment
+                VarHandle.fullFence();
+            }
         }
     }
 

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/HeapMemorySegmentImpl.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/HeapMemorySegmentImpl.java
@@ -121,7 +121,7 @@ public class HeapMemorySegmentImpl<H> extends AbstractMemorySegmentImpl {
 
     static <Z> HeapMemorySegmentImpl<Z> makeHeapSegment(Supplier<Z> obj, int length, int base, int scale) {
         int byteSize = length * scale;
-        MemoryScope scope = new MemoryScope(null, null);
+        MemoryScope scope = MemoryScope.create(null, null);
         return new HeapMemorySegmentImpl<>(base, obj, byteSize, defaultAccessModes(byteSize), Thread.currentThread(), scope);
     }
 }

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/MappedMemorySegmentImpl.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/MappedMemorySegmentImpl.java
@@ -103,7 +103,7 @@ public class MappedMemorySegmentImpl extends NativeMemorySegmentImpl implements 
         if (bytesSize <= 0) throw new IllegalArgumentException("Requested bytes size must be > 0.");
         try (FileChannelImpl channelImpl = (FileChannelImpl)FileChannel.open(path, openOptions(mapMode))) {
             UnmapperProxy unmapperProxy = channelImpl.mapInternal(mapMode, 0L, bytesSize);
-            MemoryScope scope = new MemoryScope(null, unmapperProxy::unmap);
+            MemoryScope scope = MemoryScope.create(null, unmapperProxy::unmap);
             return new MappedMemorySegmentImpl(unmapperProxy.address(), unmapperProxy, bytesSize,
                     defaultAccessModes(bytesSize), Thread.currentThread(), scope);
         }

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/MemoryScope.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/MemoryScope.java
@@ -133,20 +133,14 @@ abstract class MemoryScope {
     }
 
     private static final class Root extends MemoryScope {
-        private final LongAdder acquires;
-        private final LongAdder releases;
+        private final LongAdder acquires = new LongAdder();
+        private final LongAdder releases = new LongAdder();
         private final Object ref;
         private final Runnable cleanupAction;
 
-        private Root(LongAdder acquires, LongAdder releases, Object ref, Runnable cleanupAction) {
-            this.acquires = acquires;
-            this.releases = releases;
+        private Root(Object ref, Runnable cleanupAction) {
             this.ref = ref;
             this.cleanupAction = cleanupAction;
-        }
-
-        private Root(Object ref, Runnable cleanupAction) {
-            this(new LongAdder(), new LongAdder(), ref, cleanupAction);
         }
 
         @Override
@@ -154,14 +148,13 @@ abstract class MemoryScope {
             // increment acquires 1st
             acquires.increment();
             // check state 2nd
-            int state = (int) STATE.getVolatile(this);
-            while (state > STATE_OPEN) {
+            int state;
+            while ((state  = (int) STATE.getVolatile(this)) > STATE_OPEN) {
                 if (state == STATE_CLOSED) {
                     releases.increment();
                     throw new IllegalStateException("This scope is already closed");
                 }
                 Thread.onSpinWait();
-                state = (int) STATE.getVolatile(this);
             }
             return new Child();
         }
@@ -180,10 +173,8 @@ abstract class MemoryScope {
             if (state == STATE_CLOSED) {
                 throw new IllegalStateException("This scope is already closed");
             }
-            // pre-allocate duped scope so we don't get OOME later and be left with this scope closed;
-            // we only return this instance if releases.sum() == acquires.sum(), so both LongAdder(s)
-            // can be reused...
-            var duped = close ? null : new Root(acquires, releases, ref, cleanupAction);
+            // pre-allocate duped scope so we don't get OOME later and be left with this scope closed
+            var duped = close ? null : new Root(ref, cleanupAction);
             // modify state to STATE_CLOSING 1st
             STATE.setVolatile(this, STATE_CLOSING);
             // check for absence of active acquired children 2nd
@@ -201,7 +192,6 @@ abstract class MemoryScope {
                 }
                 return null;
             } else {
-                // assert releases.sum() == acquires.sum() && state == STATE_CLOSED;
                 return duped;
             }
         }

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/MemoryScope.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/MemoryScope.java
@@ -28,99 +28,215 @@ package jdk.internal.foreign;
 
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.VarHandle;
+import java.util.concurrent.atomic.LongAdder;
 
 /**
  * This class manages the temporal bounds associated with a memory segment. A scope has a liveness bit, which is updated
- * when the scope is closed (this operation is triggered by {@link AbstractMemorySegmentImpl#close()}). Furthermore, a scope is
- * associated with an <em>atomic</em> counter which can be incremented (upon calling the {@link #acquire()} method),
- * and is decremented (when a previously acquired segment is later closed).
+ * when the scope is closed (this operation is triggered by {@link AbstractMemorySegmentImpl#close()}). Furthermore,
+ * a scope is either root scope ({@link #create(Object, Runnable) created} when memory segment is allocated) or child scope
+ * ({@link #acquire() acquired} from root scope). When a child scope is acquired from another child scope, it is actually
+ * acquired from the root scope. There is only a single level of children. All child scopes are peers.
+ * A child scope can be {@link #close() closed} at any time, but root scope can only be closed after all its children
+ * have been closed, at which time any associated cleanup action is executed (the associated memory segment is freed).
  */
-public final class MemoryScope {
+abstract class MemoryScope {
+    public static final MemoryScope GLOBAL = new Root(null, null);
 
-    //reference to keep hold onto
-    final Object ref;
+    /**
+     * Creates a root MemoryScope with given ref and cleanupAction.
+     * The returned instance may be published unsafely to and used in any thread, but methods that explicitly state that
+     * they may only be called in "owner" thread, must strictly be called in single thread that has been selected to be the
+     * "owner" thread.
+     *
+     * @param ref           an optional reference to an instance that needs to be kept reachable
+     * @param cleanupAction an optional cleanup action to be executed when returned scope is closed
+     * @return a root MemoryScope
+     */
+    static MemoryScope create(Object ref, Runnable cleanupAction) {
+        return new Root(ref, cleanupAction);
+    }
 
-    int activeCount = UNACQUIRED;
+    private static final int STATE_OPEN = 0;
+    private static final int STATE_CLOSING = 1;
+    private static final int STATE_CLOSED = 2;
 
-    final static VarHandle COUNT_HANDLE;
+    int state; // = STATE_OPEN
+    private static final VarHandle STATE;
 
     static {
         try {
-            COUNT_HANDLE = MethodHandles.lookup().findVarHandle(MemoryScope.class, "activeCount", int.class);
+            STATE = MethodHandles.lookup().findVarHandle(MemoryScope.class, "state", int.class);
         } catch (Throwable ex) {
             throw new ExceptionInInitializerError(ex);
         }
     }
 
-    final static int UNACQUIRED = 0;
-    final static int CLOSED = -1;
-    final static int MAX_ACQUIRE = Integer.MAX_VALUE;
-
-    final Runnable cleanupAction;
-
-    final static MemoryScope GLOBAL = new MemoryScope(null, null);
-
-    public MemoryScope(Object ref, Runnable cleanupAction) {
-        this.ref = ref;
-        this.cleanupAction = cleanupAction;
+    private MemoryScope() {
     }
 
     /**
-     * This method performs a full, thread-safe liveness check; can be used outside confinement thread.
+     * Acquires a child scope (or peer scope if this is a child).
+     * This method may be called in any thread.
+     * The returned instance may be published unsafely to and used in any thread, but methods that explicitly state that
+     * they may only be called in "owner" thread, must strictly be called in single thread that has been selected to be the
+     * "owner" thread.
+     *
+     * @return a child (or peer) scope
+     * @throws IllegalStateException if root scope is already closed
+     */
+    abstract MemoryScope acquire();
+
+    /**
+     * Closes this scope, executing any cleanup action if this is the root scope.
+     * This method may only be called in "owner" thread.
+     *
+     * @throws IllegalStateException if this scope is already closed or if this is
+     *                               a root scope and there is/are still active child
+     *                               scope(s).
+     */
+    abstract void close();
+
+    /**
+     * Duplicates this scope and {@link #close() closes} it. If this is a root scope,
+     * new root scope is returned. If this is a child scope, new child scope is returned.
+     * This method may only be called in "owner" thread.
+     * The returned instance may be published unsafely to and used in any thread, but methods that explicitly state that
+     * they may only be called in "owner" thread, must strictly be called in single thread that has been selected to be the
+     * "owner" thread.
+     *
+     * @return a duplicate of this scope
+     * @throws IllegalStateException if this scope is already closed or if this is
+     *                               a root scope and there is/are still active child
+     *                               scope(s).
+     */
+    abstract MemoryScope dup();
+
+    /**
+     * This method may be called in any thread.
+     *
+     * @return {@code true} if this scope is not closed yet.
      */
     final boolean isAliveThreadSafe() {
-        return ((int)COUNT_HANDLE.getVolatile(this)) != CLOSED;
+        return ((int) STATE.getVolatile(this)) < STATE_CLOSED;
     }
 
     /**
-     * This method performs a quick liveness check; must be called from the confinement thread.
+     * Checks that this scope is still alive.
+     * This method may only be called in "owner" thread.
+     *
+     * @throws IllegalStateException if this scope is already closed
      */
     final void checkAliveConfined() {
-        if (activeCount == CLOSED) {
-            throw new IllegalStateException("Segment is not alive");
+        if (state == STATE_CLOSED) {
+            throw new IllegalStateException("This scope is already closed");
         }
     }
 
-    MemoryScope acquire() {
-        int value;
-        do {
-            value = (int)COUNT_HANDLE.getVolatile(this);
-            if (value == CLOSED) {
-                //segment is not alive!
-                throw new IllegalStateException("Segment is not alive");
-            } else if (value == MAX_ACQUIRE) {
-                //overflow
-                throw new IllegalStateException("Segment acquire limit exceeded");
+    private static final class Root extends MemoryScope {
+        private final LongAdder acquires;
+        private final LongAdder releases;
+        private final Object ref;
+        private final Runnable cleanupAction;
+
+        private Root(LongAdder acquires, LongAdder releases, Object ref, Runnable cleanupAction) {
+            this.acquires = acquires;
+            this.releases = releases;
+            this.ref = ref;
+            this.cleanupAction = cleanupAction;
+        }
+
+        private Root(Object ref, Runnable cleanupAction) {
+            this(new LongAdder(), new LongAdder(), ref, cleanupAction);
+        }
+
+        @Override
+        MemoryScope acquire() {
+            // increment acquires 1st
+            acquires.increment();
+            // check state 2nd
+            int state = (int) STATE.getVolatile(this);
+            while (state > STATE_OPEN) {
+                if (state == STATE_CLOSED) {
+                    releases.increment();
+                    throw new IllegalStateException("This scope is already closed");
+                }
+                Thread.onSpinWait();
+                state = (int) STATE.getVolatile(this);
             }
-        } while (!COUNT_HANDLE.compareAndSet(this, value, value + 1));
-        return new MemoryScope(ref, this::release);
-    }
+            return new Child();
+        }
 
-    private void release() {
-        int value;
-        do {
-            value = (int)COUNT_HANDLE.getVolatile(this);
-            if (value <= UNACQUIRED) {
-                //cannot get here - we can't close segment twice
-                throw new IllegalStateException();
+        @Override
+        MemoryScope dup() { // always called in owner thread
+            return closeOrDup(false);
+        }
+
+        @Override
+        void close() { // always called in owner thread
+            closeOrDup(true);
+        }
+
+        private MemoryScope closeOrDup(boolean close) {
+            if (state == STATE_CLOSED) {
+                throw new IllegalStateException("This scope is already closed");
             }
-        } while (!COUNT_HANDLE.compareAndSet(this, value, value - 1));
-    }
-
-    void close(boolean doCleanup) {
-        if (!COUNT_HANDLE.compareAndSet(this, UNACQUIRED, CLOSED)) {
-            //first check if already closed...
-            checkAliveConfined();
-            //...if not, then we have acquired views that are still active
-            throw new IllegalStateException("Cannot close a segment that has active acquired views");
+            // pre-allocate duped scope so we don't get OOME later and be left with this scope closed;
+            // we only return this instance if releases.sum() == acquires.sum(), so both LongAdder(s)
+            // can be reused...
+            var duped = close ? null : new Root(acquires, releases, ref, cleanupAction);
+            // modify state to STATE_CLOSING 1st
+            STATE.setVolatile(this, STATE_CLOSING);
+            // check for absence of active acquired children 2nd
+            // IMPORTANT: 1st sum releases, then sum acquires !!!
+            if (releases.sum() != acquires.sum()) {
+                STATE.setVolatile(this, STATE_OPEN); // revert back to STATE_OPEN
+                throw new IllegalStateException("Cannot close this scope as it has active acquired children");
+            }
+            // now that we made sure there's no active acquired children, we modify to STATE_CLOSED
+            STATE.setVolatile(this, STATE_CLOSED);
+            // do close or dup
+            if (close) {
+                if (cleanupAction != null) {
+                    cleanupAction.run();
+                }
+                return null;
+            } else {
+                // assert releases.sum() == acquires.sum() && state == STATE_CLOSED;
+                return duped;
+            }
         }
-        if (doCleanup && cleanupAction != null) {
-            cleanupAction.run();
-        }
-    }
 
-    MemoryScope dup() {
-        close(false);
-        return new MemoryScope(ref, cleanupAction);
+        private final class Child extends MemoryScope {
+
+            private Child() {
+            }
+
+            @Override
+            MemoryScope acquire() {
+                return Root.this.acquire();
+            }
+
+            @Override
+            MemoryScope dup() { // always called in owner thread
+                if (state == STATE_CLOSED) {
+                    throw new IllegalStateException("This scope is already closed");
+                }
+                // pre-allocate duped scope so we don't get OOME later and be left with this scope closed
+                var duped = new Child();
+                STATE.setVolatile(this, STATE_CLOSED);
+                return duped;
+            }
+
+            @Override
+            void close() { // always called in owner thread
+                if (state == STATE_CLOSED) {
+                    throw new IllegalStateException("This scope is already closed");
+                }
+                state = STATE_CLOSED;
+                // following acts as a volatile write after plain write above so
+                // plain write gets flushed too (which is important for isAliveThreadSafe())
+                Root.this.releases.increment();
+            }
+        }
     }
 }

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/NativeMemorySegmentImpl.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/NativeMemorySegmentImpl.java
@@ -93,7 +93,7 @@ public class NativeMemorySegmentImpl extends AbstractMemorySegmentImpl {
             unsafe.setMemory(buf, alignedSize, (byte)0);
         }
         long alignedBuf = Utils.alignUp(buf, alignmentBytes);
-        MemoryScope scope = new MemoryScope(null, () -> unsafe.freeMemory(buf));
+        MemoryScope scope = MemoryScope.create(null, () -> unsafe.freeMemory(buf));
         MemorySegment segment = new NativeMemorySegmentImpl(buf, alignedSize, defaultAccessModes(alignedSize),
                 Thread.currentThread(), scope);
         if (alignedSize != bytesSize) {
@@ -104,7 +104,7 @@ public class NativeMemorySegmentImpl extends AbstractMemorySegmentImpl {
     }
 
     public static MemorySegment makeNativeSegmentUnchecked(MemoryAddress min, long bytesSize, Thread owner, Runnable cleanup, Object attachment) {
-        MemoryScope scope = new MemoryScope(attachment, cleanup);
+        MemoryScope scope = MemoryScope.create(attachment, cleanup);
         return new NativeMemorySegmentImpl(min.toRawLongValue(), bytesSize, defaultAccessModes(bytesSize), owner, scope);
     }
 }


### PR DESCRIPTION
This is an alternative MemoryScope which is more scalable when used in a scenario where child scope is frequently acquired and closed concurrently from multiple threads (for example in parallel Stream.findAny())
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * Maurizio Cimadamore ([mcimadamore](@mcimadamore) - Committer)
 * Paul Sandoz ([psandoz](@PaulSandoz) - Committer)

### Download
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/142/head:pull/142`
`$ git checkout pull/142`
