### PR TITLE
8244337: jextract generates struct static utils class for typedef names only if struct name is empty

### DIFF
--- a/src/jdk.incubator.jextract/share/classes/jdk/incubator/jextract/tool/OutputFactory.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/incubator/jextract/tool/OutputFactory.java
@@ -70,6 +70,11 @@ public class OutputFactory implements Declaration.Visitor<Void, Declaration> {
     private final String pkgName;
     private StructBuilder structBuilder;
     private List<String> structSources = new ArrayList<>();
+    private Set<String> structClassNames = new HashSet<>();
+    private int structClassNameCount = 0;
+    private String uniqueStructClassName(String name) {
+        return structClassNames.add(name.toLowerCase())? name : (name + "$" + structClassNameCount++);
+    }
 
     // have we seen this Variable earlier?
     protected boolean variableSeen(Declaration.Variable tree) {
@@ -223,7 +228,7 @@ public class OutputFactory implements Declaration.Visitor<Void, Declaration> {
             return null;
         }
         String name = d.name();
-        if (name.isEmpty() && parent != null) {
+        if (parent instanceof Declaration.Typedef) {
             name = parent.name();
         }
 
@@ -234,10 +239,20 @@ public class OutputFactory implements Declaration.Visitor<Void, Declaration> {
                 case STRUCT:
                 case UNION: {
                     structClass = true;
-                    this.structBuilder = new StructBuilder("C" + name, pkgName, constantHelper);
+                    /*
+                     * We may have case-insensitive name collision! A C program may have
+                     * defined structs with the names FooS, fooS, FoOs, fOOs. Because we
+                     * map structs and unions to nested classes of header classes, such
+                     * a case-insensitive name collision is problematic. This is because in
+                     * a case-insensitive file system javac will overwrite classes for
+                     * Header$CFooS, Header$CfooS, Header$CFoOs and so on! We solve this by
+                     * generating unique case-insensitive names for classes.
+                     */
+                    String structClassName = uniqueStructClassName("C" + name);
+                    this.structBuilder = new StructBuilder(structClassName, pkgName, constantHelper);
                     structBuilder.incrAlign();
                     structBuilder.classBegin();
-                    structBuilder.addLayoutGetter("C" + name, d.layout().get());
+                    structBuilder.addLayoutGetter(structClassName, d.layout().get());
                     break;
                 }
             }
@@ -309,9 +324,7 @@ public class OutputFactory implements Declaration.Visitor<Void, Declaration> {
         Type type = tree.type();
         if (type instanceof Type.Declared) {
             Declaration.Scoped s = ((Type.Declared) type).tree();
-            // only generate unnamed for now
-            // skip typedef with different name
-            if (s.name().isEmpty()) {
+            if (!s.name().equals(tree.name())) {
                 return visitScoped(s, tree);
             }
         }

--- a/test/jdk/tools/jextract/RepeatedDeclsTest.java
+++ b/test/jdk/tools/jextract/RepeatedDeclsTest.java
@@ -83,23 +83,32 @@ public class RepeatedDeclsTest extends JextractToolRunner {
             checkIntGetter(cls, "Y", 2);
 
             // check Point layout
-            Class<?> pointCls = loader.loadClass("repeatedDecls_h$CPoint");
-            MemoryLayout pointLayout = findLayout(pointCls);
-            assertNotNull(pointLayout);
-            assertTrue(((GroupLayout)pointLayout).isStruct());
-            checkFieldABIType(pointLayout, "i",  Type.INT);
-            checkFieldABIType(pointLayout, "j",  Type.INT);
+            checkPoint(loader.loadClass("repeatedDecls_h$CPoint"));
+            checkPoint(loader.loadClass("repeatedDecls_h$CPoint_t"));
+            checkPoint(loader.loadClass("repeatedDecls_h$CPOINT$0"));
 
             // check Point3D layout
-            Class<?> point3DCls = loader.loadClass("repeatedDecls_h$CPoint3D");
-            MemoryLayout point3DLayout = findLayout(point3DCls);
-            assertNotNull(point3DLayout);
-            assertTrue(((GroupLayout)point3DLayout).isStruct());
-            checkFieldABIType(point3DLayout, "i",  Type.INT);
-            checkFieldABIType(point3DLayout, "j",  Type.INT);
-            checkFieldABIType(point3DLayout, "k",  Type.INT);
+            checkPoint3D(loader.loadClass("repeatedDecls_h$CPoint3D"));
+            checkPoint3D(loader.loadClass("repeatedDecls_h$CPoint3D_t"));
         } finally {
             deleteDir(repeatedDeclsOutput);
         }
+    }
+
+    private void checkPoint(Class<?> pointCls) {
+        MemoryLayout pointLayout = findLayout(pointCls);
+        assertNotNull(pointLayout);
+        assertTrue(((GroupLayout)pointLayout).isStruct());
+        checkFieldABIType(pointLayout, "i",  Type.INT);
+        checkFieldABIType(pointLayout, "j",  Type.INT);
+    }
+
+    private void checkPoint3D(Class<?> point3DCls) {
+        MemoryLayout point3DLayout = findLayout(point3DCls);
+        assertNotNull(point3DLayout);
+        assertTrue(((GroupLayout)point3DLayout).isStruct());
+        checkFieldABIType(point3DLayout, "i",  Type.INT);
+        checkFieldABIType(point3DLayout, "j",  Type.INT);
+        checkFieldABIType(point3DLayout, "k",  Type.INT);
     }
 }

--- a/test/jdk/tools/jextract/repeatedDecls.h
+++ b/test/jdk/tools/jextract/repeatedDecls.h
@@ -61,14 +61,16 @@ struct Point {
 };
 
 typedef struct Point POINT;
+typedef struct Point Point_t;
+
 double distance(struct Point p);
 double distance(POINT p);
 
-struct Point3D {
+typedef struct Point3D {
     int i;
     int j;
     int k;
-};
+} Point3D_t;
 struct Point3D;
 
 enum RGBColor;


### PR DESCRIPTION
* generating a separate class for typedef name always.
* also taking care of case insensitive name collisions.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [JDK-8244337](https://bugs.openjdk.java.net/browse/JDK-8244337): jextract generates struct static utils class for typedef names only if struct name is empty


### Reviewers
 * Henry Jen ([henryjen](@slowhog) - Committer)

### Download
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/143/head:pull/143`
`$ git checkout pull/143`
