### PR TITLE
8244412: jextract should generate static utils class for primitive typedefs

### DIFF
--- a/src/jdk.incubator.jextract/share/classes/jdk/incubator/jextract/Type.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/incubator/jextract/Type.java
@@ -90,67 +90,76 @@ public interface Type {
             /**
              * {@code void} type.
              */
-            Void,
+            Void("void"),
             /**
              * {@code Bool} type.
              */
-            Bool,
+            Bool("_Bool"),
             /**
              * {@code char} type.
              */
-            Char,
+            Char("char"),
             /**
              * {@code char16} type.
              */
-            Char16,
+            Char16("char16"),
             /**
              * {@code char32} type.
              */
-            Char32,
+            Char32("char32"),
             /**
              * {@code short} type.
              */
-            Short,
+            Short("short"),
             /**
              * {@code int} type.
              */
-            Int,
+            Int("int"),
             /**
              * {@code long} type.
              */
-            Long,
+            Long("long"),
             /**
              * {@code long long} type.
              */
-            LongLong,
+            LongLong("long long"),
             /**
              * {@code int128} type.
              */
-            Int128,
+            Int128("__int128"),
             /**
              * {@code float} type.
              */
-            Float,
+            Float("float"),
             /**
              * {@code double} type.
              */
-            Double,
+            Double("double"),
             /**
              * {@code long double} type.
              */
-            LongDouble,
+            LongDouble("long double"),
             /**
              * {@code float128} type.
              */
-            Float128,
+            Float128("float128"),
             /**
              * {@code float16} type.
              */
-            HalfFloat,
+            HalfFloat("__fp16"),
             /**
              * {@code wchar} type.
              */
-            WChar
+            WChar("wchar_t");
+
+            private String typeName;
+            Kind(String typeName) {
+                this.typeName = typeName;
+            }
+
+            public String typeName() {
+                return typeName;
+            }
         }
 
         /**

--- a/src/jdk.incubator.jextract/share/classes/jdk/incubator/jextract/tool/HeaderBuilder.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/incubator/jextract/tool/HeaderBuilder.java
@@ -28,6 +28,7 @@ import jdk.incubator.foreign.FunctionDescriptor;
 import java.lang.invoke.MethodType;
 import java.util.ArrayList;
 import java.util.List;
+import jdk.incubator.jextract.Type;
 
 /**
  * A helper class to generate header interface class in source form.
@@ -107,6 +108,37 @@ class HeaderBuilder extends JavaSourceBuilder {
         indent();
         sb.append("}\n");
         decrAlign();
+    }
+
+    public void emitPrimitiveTypedef(Type.Primitive primType, String name) {
+        Type.Primitive.Kind kind = primType.kind();
+        if (primitiveKindSupported(kind)) {
+            incrAlign();
+            indent();
+            sb.append(PUB_MODS);
+            String className = "C" + name;
+            sb.append("class ");
+            sb.append(className);
+            sb.append(" extends ");
+            sb.append("C" + kind.typeName().replace(" ", "_"));
+            sb.append(" {\n");
+            incrAlign();
+            indent();
+            // private constructor
+            sb.append("private ");
+            sb.append(className);
+            sb.append("() {}");
+            decrAlign();
+            sb.append("}\n");
+            decrAlign();
+        }
+    }
+
+    private boolean primitiveKindSupported(Type.Primitive.Kind kind) {
+        return switch(kind) {
+            case Short, Int, Long, LongLong, Float, Double, LongDouble, Char -> true;
+            default -> false;
+        };
     }
 
     private void addFunctionalFactory(String className, MethodType mtype, FunctionDescriptor fDesc) {

--- a/src/jdk.incubator.jextract/share/classes/jdk/incubator/jextract/tool/OutputFactory.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/incubator/jextract/tool/OutputFactory.java
@@ -327,6 +327,8 @@ public class OutputFactory implements Declaration.Visitor<Void, Declaration> {
             if (!s.name().equals(tree.name())) {
                 return visitScoped(s, tree);
             }
+        } else if (type instanceof Type.Primitive) {
+             builder.emitPrimitiveTypedef((Type.Primitive)type, tree.name());
         }
         return null;
     }

--- a/src/jdk.incubator.jextract/share/classes/jdk/incubator/jextract/tool/resources/C-X.java.template
+++ b/src/jdk.incubator.jextract/share/classes/jdk/incubator/jextract/tool/resources/C-X.java.template
@@ -8,9 +8,9 @@ import jdk.incubator.foreign.MemorySegment;
 
 import static ${C_LANG}.*;
 
-public final class C-X {
+public class C-X {
     // don't create!
-    private C-X() {
+    C-X() {
     }
 
     private static VarHandle arrayHandle(MemoryLayout elemLayout, Class<?> elemCarrier) {

--- a/test/jdk/tools/jextract/Test8244412.java
+++ b/test/jdk/tools/jextract/Test8244412.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.nio.file.Path;
+import org.testng.annotations.Test;
+import static org.testng.Assert.assertNotNull;
+
+/*
+ * @test
+ * @modules jdk.incubator.jextract
+ * @library /test/lib
+ * @build JextractToolRunner
+ * @bug 8244412
+ * @summary jextract should generate static utils class for primitive typedefs
+ * @run testng/othervm -Dforeign.restricted=permit Test8244412
+ */
+public class Test8244412 extends JextractToolRunner {
+    @Test
+    public void testPrimitiveTypedefs() {
+        Path typedefsOutput = getOutputFilePath("typedefsgen");
+        Path typedefsH = getInputFilePath("typedefs.h");
+        run("-d", typedefsOutput.toString(), typedefsH.toString()).checkSuccess();
+        try(Loader loader = classLoader(typedefsOutput)) {
+            Class<?> bytetCls = loader.loadClass("typedefs_h$Cbyte_t");
+            assertNotNull(bytetCls);
+            Class<?> sizetCls = loader.loadClass("typedefs_h$Csize_t");
+            assertNotNull(sizetCls);
+        } finally {
+            deleteDir(typedefsOutput);
+        }
+    }
+}

--- a/test/jdk/tools/jextract/test8244412/LibTest8244412Test.java
+++ b/test/jdk/tools/jextract/test8244412/LibTest8244412Test.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+
+import jdk.incubator.foreign.MemoryAddress;
+import jdk.incubator.foreign.NativeAllocationScope;
+
+import org.testng.annotations.Test;
+import test.jextract.test8244412.Clong;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+import static test.jextract.test8244412.test8244412_h.*;
+
+/*
+ * @test
+ * @library ..
+ * @modules jdk.incubator.jextract
+ * @bug 8244412
+ * @summary jextract should generate static utils class for primitive typedefs
+ * @run driver JtregJextract -t test.jextract.test8244412 -- test8244412.h
+ * @run testng/othervm -Dforeign.restricted=permit LibTest8244412Test
+ */
+public class LibTest8244412Test {
+    @Test
+    public void test() {
+        try (var scope = NativeAllocationScope.unboundedScope()) {
+            var addr = Cmysize_t.allocate(0L, scope);
+            assertEquals(Cmysize_t.get(addr), 0L);
+            Cmysize_t.set(addr, 13455566L);
+            assertEquals(Cmysize_t.get(addr), 13455566L);
+            assertTrue(Cmysize_t.sizeof() == Clong.sizeof());
+        }
+    }
+}

--- a/test/jdk/tools/jextract/test8244412/test8244412.h
+++ b/test/jdk/tools/jextract/test8244412/test8244412.h
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+typedef long mysize_t;

--- a/test/jdk/tools/jextract/typedefs.h
+++ b/test/jdk/tools/jextract/typedefs.h
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+typedef char byte_t;
+typedef long size_t;


### PR DESCRIPTION
generating static utils classes for (subset of) primitive typedef trees.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [JDK-8244412](https://bugs.openjdk.java.net/browse/JDK-8244412): jextract should generate static utils class for primitive typedefs


### Reviewers
 * Maurizio Cimadamore ([mcimadamore](@mcimadamore) - Committer)

### Download
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/144/head:pull/144`
`$ git checkout pull/144`
