### PR TITLE
8244425: primitive typedef names differing only in case mapped to nested classes with names differing only in case

### DIFF
--- a/src/jdk.incubator.jextract/share/classes/jdk/incubator/jextract/tool/HeaderBuilder.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/incubator/jextract/tool/HeaderBuilder.java
@@ -110,13 +110,12 @@ class HeaderBuilder extends JavaSourceBuilder {
         decrAlign();
     }
 
-    public void emitPrimitiveTypedef(Type.Primitive primType, String name) {
+    public void emitPrimitiveTypedef(Type.Primitive primType, String className) {
         Type.Primitive.Kind kind = primType.kind();
         if (primitiveKindSupported(kind)) {
             incrAlign();
             indent();
             sb.append(PUB_MODS);
-            String className = "C" + name;
             sb.append("class ");
             sb.append(className);
             sb.append(" extends ");

--- a/test/jdk/tools/jextract/test8244412/test8244412.h
+++ b/test/jdk/tools/jextract/test8244412/test8244412.h
@@ -22,3 +22,4 @@
  */
 
 typedef long mysize_t;
+typedef long MYSIZE_T;

--- a/test/jdk/tools/jextract/typedefs.h
+++ b/test/jdk/tools/jextract/typedefs.h
@@ -23,3 +23,4 @@
 
 typedef char byte_t;
 typedef long size_t;
+typedef long SIZE_T;


### PR DESCRIPTION
creating case-insensitive unique names for all nested classes.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [JDK-8244425](https://bugs.openjdk.java.net/browse/JDK-8244425): primitive typedef names differing only in case mapped to nested classes with names differing only in case


### Reviewers
 * Maurizio Cimadamore ([mcimadamore](@mcimadamore) - Committer)

### Download
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/145/head:pull/145`
`$ git checkout pull/145`
