### PR TITLE
8244512: jextract throws NPE for a nested struct declaration

### DIFF
--- a/src/jdk.incubator.jextract/share/classes/jdk/incubator/jextract/tool/HeaderBuilder.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/incubator/jextract/tool/HeaderBuilder.java
@@ -110,13 +110,12 @@ class HeaderBuilder extends JavaSourceBuilder {
         decrAlign();
     }
 
-    public void emitPrimitiveTypedef(Type.Primitive primType, String name) {
+    public void emitPrimitiveTypedef(Type.Primitive primType, String className) {
         Type.Primitive.Kind kind = primType.kind();
         if (primitiveKindSupported(kind)) {
             incrAlign();
             indent();
             sb.append(PUB_MODS);
-            String className = "C" + name;
             sb.append("class ");
             sb.append(className);
             sb.append(" extends ");

--- a/src/jdk.incubator.jextract/share/classes/jdk/incubator/jextract/tool/OutputFactory.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/incubator/jextract/tool/OutputFactory.java
@@ -242,6 +242,7 @@ public class OutputFactory implements Declaration.Visitor<Void, Declaration> {
         }
 
         boolean structClass = false;
+        StructBuilder oldStructBuilder = this.structBuilder;
         if (!d.name().isEmpty() || !isRecord(parent)) {
             //only add explicit struct layout if the struct is not to be flattened inside another struct
             switch (d.kind()) {
@@ -261,7 +262,7 @@ public class OutputFactory implements Declaration.Visitor<Void, Declaration> {
         if (structClass) {
             this.structBuilder.classEnd();
             structSources.add(structBuilder.getSource());
-            this.structBuilder = null;
+            this.structBuilder = oldStructBuilder;
         }
         return null;
     }

--- a/test/jdk/tools/jextract/Test8244512.java
+++ b/test/jdk/tools/jextract/Test8244512.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.nio.file.Path;
+import org.testng.annotations.Test;
+import static org.testng.Assert.assertNotNull;
+
+/*
+ * @test
+ * @modules jdk.incubator.jextract
+ * @library /test/lib
+ * @build JextractToolRunner
+ * @bug 8244512
+ * @summary jextract throws NPE for a nested struct declaration
+ * @run testng/othervm -Dforeign.restricted=permit Test8244512
+ */
+public class Test8244512 extends JextractToolRunner {
+    @Test
+    public void testNestedStructs() {
+        Path nestedOutput = getOutputFilePath("nestedgen");
+        Path nestedH = getInputFilePath("nested.h");
+        run("-d", nestedOutput.toString(), nestedH.toString()).checkSuccess();
+        try(Loader loader = classLoader(nestedOutput)) {
+            checkClass(loader, "Foo");
+            checkClass(loader, "Bar");
+            checkClass(loader, "U");
+            checkClass(loader, "Point");
+            checkClass(loader, "MyStruct");
+            checkClass(loader, "MyStruct_Z");
+            checkClass(loader, "MyUnion");
+            checkClass(loader, "MyUnion_Z");
+            checkClass(loader, "X");
+            checkClass(loader, "X2");
+        } finally {
+            deleteDir(nestedOutput);
+        }
+    }
+
+    private static void checkClass(Loader loader, String name) {
+        assertNotNull(loader.loadClass("nested_h$C" + name));
+    }
+}

--- a/test/jdk/tools/jextract/nested.h
+++ b/test/jdk/tools/jextract/nested.h
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+struct Foo {
+    struct Bar {
+        int x, y;
+    } bar;
+
+    enum Color {
+        red, green, blue
+    } color;
+};
+
+union U {
+    struct Point {
+        short x, y;
+    } point;
+
+    enum RGB {
+        r, g, b
+    } rgb;
+
+    int i;
+};
+
+struct MyStruct {
+    char a;
+    struct {
+        int b;
+        union {
+            int c;
+        };
+        char d;
+        struct MyStruct_Z {
+            char e;
+        } f;
+    };
+    union {
+        int g;
+        long h;
+    };
+    enum {
+        X, Y, Z
+    };
+    struct {
+        int i;
+        int j;
+    } k;
+};
+
+union MyUnion {
+    char a;
+    struct {
+        int b;
+        union {
+            int c;
+        };
+        char d;
+        struct MyUnion_Z {
+            char e;
+        } f;
+    };
+    struct {
+        int g;
+        int h;
+    };
+    enum {
+        A, B, C
+    };
+    union {
+        int i;
+        long j;
+    } k;
+};
+
+struct X {
+    struct {
+        union {
+            int y;
+        } Z;
+    };
+};
+
+struct X2 {
+    struct {
+        union {
+            int y;
+        }; // no name this time
+    };
+};

--- a/test/jdk/tools/jextract/test8244412/test8244412.h
+++ b/test/jdk/tools/jextract/test8244412/test8244412.h
@@ -22,3 +22,4 @@
  */
 
 typedef long mysize_t;
+typedef long MYSIZE_T;

--- a/test/jdk/tools/jextract/typedefs.h
+++ b/test/jdk/tools/jextract/typedefs.h
@@ -23,3 +23,4 @@
 
 typedef char byte_t;
 typedef long size_t;
+typedef long SIZE_T;


### PR DESCRIPTION
saving/restoring 'old' struct builder in visitScoped.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [JDK-8244512](https://bugs.openjdk.java.net/browse/JDK-8244512): jextract throws NPE for a nested struct declaration


### Reviewers
 * Maurizio Cimadamore ([mcimadamore](@mcimadamore) - Committer)

### Download
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/146/head:pull/146`
`$ git checkout pull/146`
