### PR TITLE
Fix some jextract test failures on Windows

### DIFF
--- a/test/jdk/tools/jextract/Test8244412.java
+++ b/test/jdk/tools/jextract/Test8244412.java
@@ -43,7 +43,7 @@ public class Test8244412 extends JextractToolRunner {
         try(Loader loader = classLoader(typedefsOutput)) {
             Class<?> bytetCls = loader.loadClass("typedefs_h$Cbyte_t");
             assertNotNull(bytetCls);
-            Class<?> sizetCls = loader.loadClass("typedefs_h$Csize_t");
+            Class<?> sizetCls = loader.loadClass("typedefs_h$Cmysize_t");
             assertNotNull(sizetCls);
         } finally {
             deleteDir(typedefsOutput);

--- a/test/jdk/tools/jextract/test8244412/LibTest8244412Test.java
+++ b/test/jdk/tools/jextract/test8244412/LibTest8244412Test.java
@@ -26,7 +26,7 @@ import jdk.incubator.foreign.MemoryAddress;
 import jdk.incubator.foreign.NativeAllocationScope;
 
 import org.testng.annotations.Test;
-import test.jextract.test8244412.Clong;
+import test.jextract.test8244412.Clong_long;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 import static test.jextract.test8244412.test8244412_h.*;
@@ -48,7 +48,7 @@ public class LibTest8244412Test {
             assertEquals(Cmysize_t.get(addr), 0L);
             Cmysize_t.set(addr, 13455566L);
             assertEquals(Cmysize_t.get(addr), 13455566L);
-            assertTrue(Cmysize_t.sizeof() == Clong.sizeof());
+            assertTrue(Cmysize_t.sizeof() == Clong_long.sizeof());
         }
     }
 }

--- a/test/jdk/tools/jextract/test8244412/test8244412.h
+++ b/test/jdk/tools/jextract/test8244412/test8244412.h
@@ -21,5 +21,5 @@
  * questions.
  */
 
-typedef long mysize_t;
-typedef long MYSIZE_T;
+typedef long long mysize_t;
+typedef long long MYSIZE_T;

--- a/test/jdk/tools/jextract/typedefs.h
+++ b/test/jdk/tools/jextract/typedefs.h
@@ -22,5 +22,5 @@
  */
 
 typedef char byte_t;
-typedef long size_t;
-typedef long SIZE_T;
+typedef long mysize_t;
+typedef long MYSIZE_T;


### PR DESCRIPTION
Hi,

This PR fixes some jextract test failure I was seeing locally, caused by use of `long` which has a different size/carrier type on Windows.

MSVC also doesn't allow redefining `size_t` in a typedef, so I've changed the name of that.

Thanks,
Jorn
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * Maurizio Cimadamore ([mcimadamore](@mcimadamore) - Committer)

### Download
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/150/head:pull/150`
`$ git checkout pull/150`
