### PR TITLE
Workaround JDK-8239083

### DIFF
--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/SharedUtils.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/SharedUtils.java
@@ -59,7 +59,7 @@ public class SharedUtils {
     static {
         try {
             var lookup = MethodHandles.lookup();
-            MH_ALLOC_BUFFER = lookup.findStatic(MemorySegment.class, "allocateNative",
+            MH_ALLOC_BUFFER = lookup.findStatic(SharedUtils.class, "allocateNative",
                     methodType(MemorySegment.class, MemoryLayout.class));
             MH_BASEADDRESS = lookup.findVirtual(MemorySegment.class, "baseAddress",
                     methodType(MemoryAddress.class));
@@ -68,6 +68,11 @@ public class SharedUtils {
         } catch (ReflectiveOperationException e) {
             throw new BootstrapMethodError(e);
         }
+    }
+
+    // workaround for https://bugs.openjdk.java.net/browse/JDK-8239083
+    private static MemorySegment allocateNative(MemoryLayout layout) {
+        return MemorySegment.allocateNative(layout);
     }
 
     /**


### PR DESCRIPTION
Hi,

This patch is a workaround for https://bugs.openjdk.java.net/browse/JDK-8239083 which causes problems when running on a debug build.

Thanks,
Jorn
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * Athijegannathan Sundararajan ([sundar](@sundararajana) - Committer)

### Download
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/151/head:pull/151`
`$ git checkout pull/151`
