### PR TITLE
JDK-8244601: Cleanup support for upcall handles

### DIFF
--- a/src/hotspot/share/prims/upcallStubs.cpp
+++ b/src/hotspot/share/prims/upcallStubs.cpp
@@ -25,7 +25,7 @@
 #include "runtime/jniHandles.inline.hpp"
 #include "runtime/interfaceSupport.inline.hpp"
 
-JVM_ENTRY(static jboolean, UH_FreeUpcallStub(JNIEnv *env, jobject _unused, jlong addr))
+JVM_ENTRY(static jboolean, UH_FreeUpcallStub0(JNIEnv *env, jobject _unused, jlong addr))
   //acquire code cache lock
   MutexLocker mu(CodeCache_lock, Mutex::_no_safepoint_check_flag);
   //find code blob
@@ -47,7 +47,7 @@ JVM_END
 
 // These are the native methods on jdk.internal.foreign.NativeInvoker.
 static JNINativeMethod UH_methods[] = {
-  {CC "freeUpcallStub",     CC "(J)Z",                FN_PTR(UH_FreeUpcallStub)}
+  {CC "freeUpcallStub0",     CC "(J)Z",                FN_PTR(UH_FreeUpcallStub0)}
 };
 
 /**

--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/SystemABI.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/SystemABI.java
@@ -74,25 +74,17 @@ public interface SystemABI {
     MethodHandle downcallHandle(MemoryAddress symbol, MethodType type, FunctionDescriptor function);
 
     /**
-     * Obtain the pointer to a native stub which
-     * can be used to upcall into a given method handle.
+     * Allocates a native stub segment which contains executable code to upcall into a given method handle.
+     * As such, the base address of the returned stub segment can be passed to other foreign functions
+     * (as a function pointer). The returned segment is <em>not</em> thread-confined, and it only features
+     * the {@link MemorySegment#CLOSE} access mode. When the returned segment is closed,
+     * the corresponding native stub will be deallocated.
      *
      * @param target the target method handle.
      * @param function the function descriptor.
-     * @return the upcall symbol.
+     * @return the native stub segment.
      */
-    MemoryAddress upcallStub(MethodHandle target, FunctionDescriptor function);
-
-    /**
-     * Frees an upcall stub given it's memory address.
-     *
-     * @param address the memory address of the upcall stub, returned from
-     *                {@link SystemABI#upcallStub(MethodHandle, FunctionDescriptor)}.
-     * @throws IllegalArgumentException if the given address is not a valid upcall stub address.
-     */
-    default void freeUpcallStub(MemoryAddress address) {
-        UpcallStubs.freeUpcallStub(address);
-    }
+    MemorySegment upcallStub(MethodHandle target, FunctionDescriptor function);
 
     /**
      * Returns the name of this ABI.

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/aarch64/AArch64ABI.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/aarch64/AArch64ABI.java
@@ -28,6 +28,7 @@ package jdk.internal.foreign.abi.aarch64;
 import jdk.incubator.foreign.FunctionDescriptor;
 import jdk.incubator.foreign.MemoryAddress;
 import jdk.incubator.foreign.MemoryLayout;
+import jdk.incubator.foreign.MemorySegment;
 import jdk.incubator.foreign.SystemABI;
 import jdk.internal.foreign.abi.*;
 
@@ -54,7 +55,7 @@ public class AArch64ABI implements SystemABI {
     }
 
     @Override
-    public MemoryAddress upcallStub(MethodHandle target, FunctionDescriptor function) {
+    public MemorySegment upcallStub(MethodHandle target, FunctionDescriptor function) {
         return UpcallStubs.upcallAddress(CallArranger.arrangeUpcall(target, target.type(), function));
     }
 

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/x64/sysv/SysVx64ABI.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/x64/sysv/SysVx64ABI.java
@@ -27,6 +27,7 @@ package jdk.internal.foreign.abi.x64.sysv;
 import jdk.incubator.foreign.FunctionDescriptor;
 import jdk.incubator.foreign.MemoryAddress;
 import jdk.incubator.foreign.MemoryLayout;
+import jdk.incubator.foreign.MemorySegment;
 import jdk.incubator.foreign.SystemABI;
 import jdk.internal.foreign.abi.*;
 
@@ -59,7 +60,7 @@ public class SysVx64ABI implements SystemABI {
     }
 
     @Override
-    public MemoryAddress upcallStub(MethodHandle target, FunctionDescriptor function) {
+    public MemorySegment upcallStub(MethodHandle target, FunctionDescriptor function) {
         return UpcallStubs.upcallAddress(CallArranger.arrangeUpcall(target, target.type(), function));
     }
 

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/x64/windows/Windowsx64ABI.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/x64/windows/Windowsx64ABI.java
@@ -27,6 +27,7 @@ package jdk.internal.foreign.abi.x64.windows;
 import jdk.incubator.foreign.FunctionDescriptor;
 import jdk.incubator.foreign.MemoryAddress;
 import jdk.incubator.foreign.MemoryLayout;
+import jdk.incubator.foreign.MemorySegment;
 import jdk.incubator.foreign.SystemABI;
 import jdk.internal.foreign.abi.x64.sysv.ArgumentClassImpl;
 import jdk.internal.foreign.abi.*;
@@ -61,7 +62,7 @@ public class Windowsx64ABI implements SystemABI {
     }
 
     @Override
-    public MemoryAddress upcallStub(MethodHandle target, FunctionDescriptor function) {
+    public MemorySegment upcallStub(MethodHandle target, FunctionDescriptor function) {
         return UpcallStubs.upcallAddress(CallArranger.arrangeUpcall(target, target.type(), function));
     }
 

--- a/test/jdk/java/foreign/CallGeneratorHelper.java
+++ b/test/jdk/java/foreign/CallGeneratorHelper.java
@@ -333,12 +333,7 @@ public class CallGeneratorHelper extends NativeTestHelper {
         if (arg instanceof MemoryAddress) {
             cleanup(((MemoryAddress)arg).segment());
         } else if (arg instanceof MemorySegment) {
-            try {
-                ((MemorySegment) arg).close();
-            } catch (UnsupportedOperationException e) {
-                assertTrue(e.getMessage().contains("Required access mode"));
-                // fine, NOTHING segment for upcall stubs
-            }
+            ((MemorySegment) arg).close();
         }
     }
 

--- a/test/jdk/java/foreign/StdLibTest.java
+++ b/test/jdk/java/foreign/StdLibTest.java
@@ -308,9 +308,9 @@ public class StdLibTest extends NativeTestHelper {
                         .forEach(i -> intArrHandle.set(nativeArr.baseAddress(), i, arr[i]));
 
                 //call qsort
-                MemoryAddress qsortUpcallAddr = abi.upcallStub(qsortCompar.bindTo(nativeArr), qsortComparFunction);
-                qsort.invokeExact(nativeArr.baseAddress(), seq.elementCount().getAsLong(), C_INT.byteSize(), qsortUpcallAddr);
-                abi.freeUpcallStub(qsortUpcallAddr);
+                try (MemorySegment qsortUpcallStub = abi.upcallStub(qsortCompar.bindTo(nativeArr), qsortComparFunction)) {
+                    qsort.invokeExact(nativeArr.baseAddress(), seq.elementCount().getAsLong(), C_INT.byteSize(), qsortUpcallStub.baseAddress());
+                }
 
                 //convert back to Java array
                 return LongStream.range(0, arr.length)

--- a/test/jdk/java/foreign/TestUpcall.java
+++ b/test/jdk/java/foreign/TestUpcall.java
@@ -41,6 +41,8 @@ import jdk.incubator.foreign.MemoryLayout;
 import jdk.incubator.foreign.MemorySegment;
 import jdk.incubator.foreign.SystemABI;
 import jdk.incubator.foreign.ValueLayout;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import java.lang.invoke.MethodHandle;
@@ -63,8 +65,6 @@ public class TestUpcall extends CallGeneratorHelper {
 
     static LibraryLookup lib = LibraryLookup.ofLibrary("TestUpcall");
     static SystemABI abi = SystemABI.getSystemABI();
-    static final MemoryAddress dummyAddress;
-    static final Cleaner cleaner = Cleaner.create();
 
     static MethodHandle DUMMY;
     static MethodHandle PASS_AND_SAVE;
@@ -73,14 +73,22 @@ public class TestUpcall extends CallGeneratorHelper {
         try {
             DUMMY = MethodHandles.lookup().findStatic(TestUpcall.class, "dummy", MethodType.methodType(void.class));
             PASS_AND_SAVE = MethodHandles.lookup().findStatic(TestUpcall.class, "passAndSave", MethodType.methodType(Object.class, Object[].class, AtomicReference.class));
-
-            dummyAddress = abi.upcallStub(DUMMY, FunctionDescriptor.ofVoid());
-            cleaner.register(dummyAddress, () -> abi.freeUpcallStub(dummyAddress));
         } catch (Throwable ex) {
             throw new IllegalStateException(ex);
         }
     }
 
+    static MemoryAddress dummyAddress;
+
+    @BeforeClass
+    void setup() {
+        dummyAddress = abi.upcallStub(DUMMY, FunctionDescriptor.ofVoid()).baseAddress();
+    }
+
+    @AfterClass
+    void teardown() {
+        dummyAddress.segment().close();
+    }
 
     @Test(dataProvider="functions", dataProviderClass=CallGeneratorHelper.class)
     public void testUpcalls(String fName, Ret ret, List<ParamType> paramTypes, List<StructFieldType> fields) throws Throwable {
@@ -96,7 +104,9 @@ public class TestUpcall extends CallGeneratorHelper {
             returnChecks.forEach(c -> c.accept(res));
         }
         for (Object arg : args) {
-            cleanup(arg);
+            if (arg != dummyAddress) {
+                cleanup(arg);
+            }
         }
     }
 
@@ -168,8 +178,7 @@ public class TestUpcall extends CallGeneratorHelper {
         FunctionDescriptor func = ret != Ret.VOID
                 ? FunctionDescriptor.of(firstlayout, paramLayouts)
                 : FunctionDescriptor.ofVoid(paramLayouts);
-        MemoryAddress stub = abi.upcallStub(mh, func);
-        cleaner.register(stub, () -> abi.freeUpcallStub(stub));
+        MemoryAddress stub = abi.upcallStub(mh, func).baseAddress();
         return stub;
     }
 


### PR DESCRIPTION
This patch removes the SystemABI::freeUpcallStub routine and, in its place, allows SystemABI::upcallHandle to return a *stub segment* which can be explicitly closed by the user.

I think having one less method in SystemABI is cleaner - but I'm not 100% sure that using a segment as the return type is the way to go; I found myself split between returning MemoryAddress and MemorySegment while writing this patch. I ultimately went for MemorySegment because I think it makes idiomatic code a tad cleaner (look at StdLibTest).

When writing this I also wondered if we couldn't benefit from a separate abstraction for callbacks - something like:

```
interface UpcallHandle extends AutoCloseable {
   MethodHandle handle();
   MemoryAddress address();
   void close();
}
```

And then teach SystemABI about this carrier (the translation into a raw address should be relatively painless). But then we'd still need to support cases where the function pointer is obtained through another native call (in which case the carrier will just be MemoryAddress). So I'm not sure in the end having this additional abstraction will change things significantly compared to just having a segment and have the user calling `baseAddress`.

That said, I'm open to suggestions if people feel strongly one way or another.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [JDK-8244601](https://bugs.openjdk.java.net/browse/JDK-8244601): Cleanup support for upcall handles


### Reviewers
 * Athijegannathan Sundararajan ([sundar](@sundararajana) - Committer)
 * Jorn Vernee ([jvernee](@JornVernee) - Committer)

### Download
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/154/head:pull/154`
`$ git checkout pull/154`
