### PR TITLE
JDK-8244601: Cleanup support for upcall handles (jextract part)

### DIFF
--- a/src/jdk.incubator.jextract/share/classes/jdk/incubator/jextract/tool/HeaderBuilder.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/incubator/jextract/tool/HeaderBuilder.java
@@ -142,7 +142,7 @@ class HeaderBuilder extends JavaSourceBuilder {
 
     private void addFunctionalFactory(String className, MethodType mtype, FunctionDescriptor fDesc) {
         indent();
-        sb.append(PUB_MODS + "MemoryAddress allocate(" + className + " fi) {\n");
+        sb.append(PUB_MODS + "MemorySegment allocate(" + className + " fi) {\n");
         incrAlign();
         indent();
         sb.append("return RuntimeHelper.upcallStub(" + className + ".class, fi, " + functionGetCallString(className, fDesc) + ", " +

--- a/src/jdk.incubator.jextract/share/classes/jdk/incubator/jextract/tool/resources/RuntimeHelper.java.template
+++ b/src/jdk.incubator.jextract/share/classes/jdk/incubator/jextract/tool/resources/RuntimeHelper.java.template
@@ -62,11 +62,11 @@ public class RuntimeHelper {
                 }).orElse(null);
     }
 
-    public static final MemoryAddress upcallStub(MethodHandle handle, FunctionDescriptor fdesc) {
+    public static final MemorySegment upcallStub(MethodHandle handle, FunctionDescriptor fdesc) {
         return ABI.upcallStub(handle, fdesc);
     }
 
-    public static final <Z> MemoryAddress upcallStub(Class<Z> fi, Z z, FunctionDescriptor fdesc, String mtypeDesc) {
+    public static final <Z> MemorySegment upcallStub(Class<Z> fi, Z z, FunctionDescriptor fdesc, String mtypeDesc) {
         try {
             MethodHandle handle = MH_LOOKUP.findVirtual(fi, "apply",
                     MethodType.fromMethodDescriptorString(mtypeDesc, LOADER));
@@ -75,10 +75,6 @@ public class RuntimeHelper {
         } catch (Throwable ex) {
             throw new AssertionError(ex);
         }
-    }
-
-    public static void freeUpcallStub(MemoryAddress addr) {
-        ABI.freeUpcallStub(addr);
     }
 
     private static class VarargsInvoker {

--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/clang/libclang/RuntimeHelper.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/clang/libclang/RuntimeHelper.java
@@ -96,7 +96,7 @@ public class RuntimeHelper {
     }
 
     public static final MemoryAddress upcallStub(MethodHandle handle, FunctionDescriptor fdesc) {
-        return ABI.upcallStub(handle, fdesc);
+        return ABI.upcallStub(handle, fdesc).baseAddress();
     }
 
     public static final <Z> MemoryAddress upcallStub(Class<Z> fi, Z z, FunctionDescriptor fdesc, String mtypeDesc) {

--- a/test/jdk/tools/jextract/testClassGen/TestClassGeneration.java
+++ b/test/jdk/tools/jextract/testClassGen/TestClassGeneration.java
@@ -218,7 +218,7 @@ public class TestClassGeneration extends JextractToolRunner {
         Class<?> fiClass = findNestedClass(cls, name);
         assertNotNull(fiClass);
         checkMethod(fiClass, "apply", type);
-        checkMethod(fiClass, "allocate", MemoryAddress.class, fiClass);
+        checkMethod(fiClass, "allocate", MemorySegment.class, fiClass);
     }
 
     @BeforeClass

--- a/test/jdk/tools/jextract/testFunctionPointer/LibFuncPtrTest.java
+++ b/test/jdk/tools/jextract/testFunctionPointer/LibFuncPtrTest.java
@@ -37,8 +37,8 @@ import static test.jextract.fp.funcPtr_h.*;
 public class LibFuncPtrTest {
     @Test
     public void test() {
-        var addr = func$f.allocate(x -> x*x);
-        assertEquals(func(addr, 35), 35*35 + 35);
-        RuntimeHelper.freeUpcallStub(addr);
+        try (var handle = func$f.allocate(x -> x*x)) {
+            assertEquals(func(handle.baseAddress(), 35), 35 * 35 + 35);
+        } //deallocate
     }
 }


### PR DESCRIPTION
This small patch fixes jextract to sync up with latest changes on SystemABI::upcallHandle.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [JDK-8244601](https://bugs.openjdk.java.net/browse/JDK-8244601): Cleanup support for upcall handles


### Reviewers
 * Jorn Vernee ([jvernee](@JornVernee) - Committer)
 * Athijegannathan Sundararajan ([sundar](@sundararajana) - Committer)

### Download
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/155/head:pull/155`
`$ git checkout pull/155`
