### PR TITLE
Alternative scalable MemoryScope (followup)

### DIFF
--- a/test/jdk/java/foreign/TestByteBuffer.java
+++ b/test/jdk/java/foreign/TestByteBuffer.java
@@ -296,7 +296,7 @@ public class TestByteBuffer {
                 Throwable cause = ex.getCause();
                 if (cause instanceof IllegalStateException) {
                     //all get/set buffer operation should fail because of the scope check
-                    assertTrue(ex.getCause().getMessage().contains("not alive"));
+                    assertTrue(ex.getCause().getMessage().contains("already closed"));
                 } else {
                     //all other exceptions were unexpected - fail
                     assertTrue(false);
@@ -333,7 +333,7 @@ public class TestByteBuffer {
                 handle.invoke(e.getValue());
                 fail();
             } catch (IllegalStateException ex) {
-                assertTrue(ex.getMessage().contains("not alive"));
+                assertTrue(ex.getMessage().contains("already closed"));
             } catch (UnsupportedOperationException ex) {
                 //skip
             } catch (Throwable ex) {

--- a/test/micro/org/openjdk/bench/jdk/incubator/foreign/ParallelSum.java
+++ b/test/micro/org/openjdk/bench/jdk/incubator/foreign/ParallelSum.java
@@ -46,11 +46,14 @@ import jdk.incubator.foreign.MemorySegment;
 import java.lang.invoke.VarHandle;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Optional;
+import java.util.OptionalInt;
 import java.util.Spliterator;
 import java.util.concurrent.CountedCompleter;
 import java.util.concurrent.RecursiveTask;
 import java.util.concurrent.TimeUnit;
 import java.util.function.IntFunction;
+import java.util.function.Predicate;
 import java.util.function.ToIntFunction;
 import java.util.stream.StreamSupport;
 
@@ -148,6 +151,47 @@ public class ParallelSum {
             res += (int)VH_int.get(base, (long) i);
         }
         return res;
+    };
+
+    @Benchmark
+    public Optional<MemorySegment> segment_stream_findany_serial() {
+        return StreamSupport.stream(MemorySegment.spliterator(segment, SEQUENCE_LAYOUT), false)
+                .filter(FIND_SINGLE)
+                .findAny();
+    }
+
+    @Benchmark
+    public Optional<MemorySegment> segment_stream_findany_parallel() {
+        return StreamSupport.stream(MemorySegment.spliterator(segment, SEQUENCE_LAYOUT), true)
+                .filter(FIND_SINGLE)
+                .findAny();
+    }
+
+    @Benchmark
+    public Optional<MemorySegment> segment_stream_findany_serial_bulk() {
+        return StreamSupport.stream(MemorySegment.spliterator(segment, SEQUENCE_LAYOUT_BULK), false)
+                .filter(FIND_BULK)
+                .findAny();
+    }
+
+    @Benchmark
+    public Optional<MemorySegment> segment_stream_findany_parallel_bulk() {
+        return StreamSupport.stream(MemorySegment.spliterator(segment, SEQUENCE_LAYOUT_BULK), true)
+                .filter(FIND_BULK)
+                .findAny();
+    }
+
+    final static Predicate<MemorySegment> FIND_SINGLE = slice ->
+            (int)VH_int.get(slice.baseAddress(), 0L) == (ELEM_SIZE - 1);
+
+    final static Predicate<MemorySegment> FIND_BULK = slice -> {
+        MemoryAddress base = slice.baseAddress();
+        for (int i = 0; i < BULK_FACTOR ; i++) {
+            if ((int)VH_int.get(base, (long)i) == (ELEM_SIZE - 1)) {
+                return true;
+            }
+        }
+        return false;
     };
 
     @Benchmark


### PR DESCRIPTION
This simple patch fixes a regression in the byte buffer test (the test was checking for a different exception message). As I find the new message more informative than the old one, I fixed the test.

I also added some benchmarks to test the new scope (this is already part of the RFR that has been submitted against jdk/jdk - with few tweaks that I will mirror there).
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * Paul Sandoz ([psandoz](@PaulSandoz) - Committer)

### Download
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/156/head:pull/156`
`$ git checkout pull/156`
