### PR TITLE
8244728: jextract generates separate nested class for struct and union typedefs

### DIFF
--- a/src/jdk.incubator.jextract/share/classes/jdk/incubator/jextract/tool/HeaderBuilder.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/incubator/jextract/tool/HeaderBuilder.java
@@ -113,23 +113,8 @@ class HeaderBuilder extends JavaSourceBuilder {
     public void emitPrimitiveTypedef(Type.Primitive primType, String className) {
         Type.Primitive.Kind kind = primType.kind();
         if (primitiveKindSupported(kind)) {
-            incrAlign();
-            indent();
-            sb.append(PUB_MODS);
-            sb.append("class ");
-            sb.append(className);
-            sb.append(" extends ");
-            sb.append("C" + kind.typeName().replace(" ", "_"));
-            sb.append(" {\n");
-            incrAlign();
-            indent();
-            // private constructor
-            sb.append("private ");
-            sb.append(className);
-            sb.append("() {}");
-            decrAlign();
-            sb.append("}\n");
-            decrAlign();
+            String superClassName = "C" + kind.typeName().replace(" ", "_");
+            emitTypedef(className, superClassName);
         }
     }
 
@@ -138,6 +123,27 @@ class HeaderBuilder extends JavaSourceBuilder {
             case Short, Int, Long, LongLong, Float, Double, LongDouble, Char -> true;
             default -> false;
         };
+    }
+
+    public void emitTypedef(String className, String superClassName) {
+        incrAlign();
+        indent();
+        sb.append(PUB_MODS);
+        sb.append("class ");
+        sb.append(className);
+        sb.append(" extends ");
+        sb.append(superClassName);
+        sb.append(" {\n");
+        incrAlign();
+        indent();
+        // private constructor
+        sb.append("private ");
+        sb.append(className);
+        sb.append("() {}\n");
+        decrAlign();
+        indent();
+        sb.append("}\n");
+        decrAlign();
     }
 
     private void addFunctionalFactory(String className, MethodType mtype, FunctionDescriptor fDesc) {

--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/clang/TranslationUnit.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/clang/TranslationUnit.java
@@ -78,9 +78,9 @@ public class TranslationUnit implements AutoCloseable {
         }
     }
 
-    static long FILENAME_OFFSET = Index_h.CXUnsavedFile$LAYOUT.offset(MemoryLayout.PathElement.groupElement("Filename")) / 8;
-    static long CONTENTS_OFFSET = Index_h.CXUnsavedFile$LAYOUT.offset(MemoryLayout.PathElement.groupElement("Contents")) / 8;
-    static long LENGTH_OFFSET = Index_h.CXUnsavedFile$LAYOUT.offset(MemoryLayout.PathElement.groupElement("Length")) / 8;
+    static long FILENAME_OFFSET = Index_h.CXUnsavedFile$LAYOUT.bitOffset(MemoryLayout.PathElement.groupElement("Filename")) / 8;
+    static long CONTENTS_OFFSET = Index_h.CXUnsavedFile$LAYOUT.bitOffset(MemoryLayout.PathElement.groupElement("Contents")) / 8;
+    static long LENGTH_OFFSET = Index_h.CXUnsavedFile$LAYOUT.bitOffset(MemoryLayout.PathElement.groupElement("Length")) / 8;
 
     public void reparse(Index.UnsavedFile... inMemoryFiles) {
         try (AllocationScope scope = new AllocationScope()) {

--- a/test/jdk/tools/jextract/RepeatedDeclsTest.java
+++ b/test/jdk/tools/jextract/RepeatedDeclsTest.java
@@ -88,9 +88,10 @@ public class RepeatedDeclsTest extends JextractToolRunner {
             checkPoint(pointCls);
             Class<?> point_tCls = loader.loadClass("repeatedDecls_h$CPoint_t");
             checkPoint(point_tCls);
-            pointCls.isAssignableFrom(point_tCls);
+            assertTrue(pointCls.isAssignableFrom(point_tCls));
             Class<?> point$0Cls = loader.loadClass("repeatedDecls_h$CPOINT$0");
             checkPoint(point$0Cls);
+            assertTrue(pointCls.isAssignableFrom(point$0Cls));
 
             // check Point3D layout
             Class<?> point3DCls = loader.loadClass("repeatedDecls_h$CPoint3D");

--- a/test/jdk/tools/jextract/RepeatedDeclsTest.java
+++ b/test/jdk/tools/jextract/RepeatedDeclsTest.java
@@ -84,13 +84,20 @@ public class RepeatedDeclsTest extends JextractToolRunner {
             checkIntGetter(cls, "Y", 2);
 
             // check Point layout
-            checkPoint(loader.loadClass("repeatedDecls_h$CPoint"));
-            checkPoint(loader.loadClass("repeatedDecls_h$CPoint_t"));
-            checkPoint(loader.loadClass("repeatedDecls_h$CPOINT$0"));
+            Class<?> pointCls = loader.loadClass("repeatedDecls_h$CPoint");
+            checkPoint(pointCls);
+            Class<?> point_tCls = loader.loadClass("repeatedDecls_h$CPoint_t");
+            checkPoint(point_tCls);
+            pointCls.isAssignableFrom(point_tCls);
+            Class<?> point$0Cls = loader.loadClass("repeatedDecls_h$CPOINT$0");
+            checkPoint(point$0Cls);
 
             // check Point3D layout
-            checkPoint3D(loader.loadClass("repeatedDecls_h$CPoint3D"));
-            checkPoint3D(loader.loadClass("repeatedDecls_h$CPoint3D_t"));
+            Class<?> point3DCls = loader.loadClass("repeatedDecls_h$CPoint3D");
+            checkPoint3D(point3DCls);
+            Class<?> point3D_tCls = loader.loadClass("repeatedDecls_h$CPoint3D_t");
+            checkPoint3D(point3D_tCls);
+            assertTrue(point3DCls.isAssignableFrom(point3D_tCls));
         } finally {
             deleteDir(repeatedDeclsOutput);
         }


### PR DESCRIPTION
* adding a subclass for struct/union typedefs rather than separate classes
* piggybacking fix for MemoryLayout::offset->MemoryLayout::bitOffset change
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [JDK-8244728](https://bugs.openjdk.java.net/browse/JDK-8244728): jextract generates separate nested class for struct and union typedefs


### Reviewers
 * Maurizio Cimadamore ([mcimadamore](@mcimadamore) - Committer) ⚠️ Review applies to 7d8422dcf72ef96fc7785ef988622db10c20122c
 * Jorn Vernee ([jvernee](@JornVernee) - Committer)

### Download
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/159/head:pull/159`
`$ git checkout pull/159`
