### PR TITLE
Add MemorySegment::fill

### DIFF
--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/MemorySegment.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/MemorySegment.java
@@ -207,6 +207,8 @@ public interface MemorySegment extends AutoCloseable {
      * for (long l = 0; l < segment.byteSize(); l++) {
      *     byteHandle.set(segment.baseAddress(), l, value);
      * }</pre></blockquote>
+     * without any regard or guarantees on the ordering of particular memory
+     * elements being set.
      * <p>
      * Fill can be useful to initialize or reset the memory of a segment.
      *

--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/MemorySegment.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/MemorySegment.java
@@ -196,34 +196,6 @@ public interface MemorySegment extends AutoCloseable {
     }
 
     /**
-     * Fills a value into the given memory segment.
-     * <p>
-     * More specifically, the given value is filled into each address of the
-     * segment. Equivalent to (but likely more efficient than) the following code:
-     *
-     * <blockquote><pre>
-     * byteHandle = MemoryLayout.ofSequence(MemoryLayouts.JAVA_BYTE)
-     *         .varHandle(byte.class, MemoryLayout.PathElement.sequenceElement());
-     * for (long l = 0; l < segment.byteSize(); l++) {
-     *     byteHandle.set(segment.baseAddress(), l, value);
-     * }</pre></blockquote>
-     * without any regard or guarantees on the ordering of particular memory
-     * elements being set.
-     * <p>
-     * Fill can be useful to initialize or reset the memory of a segment.
-     *
-     * @param segment the segment to fill
-     * @param value the value to fill into the segment
-     * @throws IllegalStateException if the segment is not <em>alive</em>, or if access occurs from a thread other than the
-     * thread owning this segment
-     * @throws UnsupportedOperationException if this segment does not support the {@link #WRITE} access mode
-     * @throws NullPointerException if {@code segment == null}
-     */
-    static void fill(MemorySegment segment, byte value) {
-        AbstractMemorySegmentImpl.fill(segment, value);
-    }
-
-    /**
      * The thread owning this segment.
      * @return the thread owning this segment.
      */
@@ -310,6 +282,31 @@ public interface MemorySegment extends AutoCloseable {
      * @throws UnsupportedOperationException if this segment does not support the {@link #CLOSE} access mode.
      */
     void close();
+
+    /**
+     * Fills a value into this memory segment.
+     * <p>
+     * More specifically, the given value is filled into each address of this
+     * segment. Equivalent to (but likely more efficient than) the following code:
+     *
+     * <blockquote><pre>
+     * byteHandle = MemoryLayout.ofSequence(MemoryLayouts.JAVA_BYTE)
+     *         .varHandle(byte.class, MemoryLayout.PathElement.sequenceElement());
+     * for (long l = 0; l < segment.byteSize(); l++) {
+     *     byteHandle.set(segment.baseAddress(), l, value);
+     * }</pre></blockquote>
+     * without any regard or guarantees on the ordering of particular memory
+     * elements being set.
+     * <p>
+     * Fill can be useful to initialize or reset the memory of a segment.
+     *
+     * @param value the value to fill into this segment
+     * @return this memory segment
+     * @throws IllegalStateException if this segment is not <em>alive</em>, or if access occurs from a thread other than the
+     * thread owning this segment
+     * @throws UnsupportedOperationException if this segment does not support the {@link #WRITE} access mode
+     */
+    MemorySegment fill(byte value);
 
     /**
      * Wraps this segment in a {@link ByteBuffer}. Some of the properties of the returned buffer are linked to

--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/MemorySegment.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/MemorySegment.java
@@ -196,6 +196,32 @@ public interface MemorySegment extends AutoCloseable {
     }
 
     /**
+     * Fills a value into the given memory segment.
+     * <p>
+     * More specifically, the given value is filled into each address of the
+     * segment. Equivalent to (but likely more efficient than) the following code:
+     *
+     * <blockquote><pre>
+     * byteHandle = MemoryLayout.ofSequence(MemoryLayouts.JAVA_BYTE)
+     *         .varHandle(byte.class, MemoryLayout.PathElement.sequenceElement());
+     * for (long l = 0; l < segment.byteSize(); l++) {
+     *     byteHandle.set(segment.baseAddress(), l, value);
+     * }</pre></blockquote>
+     * <p>
+     * Fill can be useful to initialize or reset the memory of a segment.
+     *
+     * @param segment the segment to fill
+     * @param value the value to fill into the segment
+     * @throws IllegalStateException if the segment is not <em>alive</em>, or if access occurs from a thread other than the
+     * thread owning this segment
+     * @throws UnsupportedOperationException if this segment does not support the {@link #WRITE} access mode
+     * @throws NullPointerException if {@code segment == null}
+     */
+    static void fill(MemorySegment segment, byte value) {
+        AbstractMemorySegmentImpl.fill(segment, value);
+    }
+
+    /**
      * The thread owning this segment.
      * @return the thread owning this segment.
      */

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/AbstractMemorySegmentImpl.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/AbstractMemorySegmentImpl.java
@@ -116,10 +116,11 @@ public abstract class AbstractMemorySegmentImpl implements MemorySegment, Memory
                 (AbstractMemorySegmentImpl)segment.withAccessModes(segment.accessModes() & ~CLOSE));
     }
 
-    public static void fill(MemorySegment segment, byte value) {
-        AbstractMemorySegmentImpl segmentImpl = (AbstractMemorySegmentImpl) segment;
-        segmentImpl.checkRange(0, segmentImpl.length, true);
-        UNSAFE.setMemory(segmentImpl.base(), segmentImpl.min(), segmentImpl.length, value);
+    @Override
+    public final MemorySegment fill(byte value){
+        checkRange(0, length, true);
+        UNSAFE.setMemory(base(), min(), length, value);
+        return this;
     }
 
     @Override

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/AbstractMemorySegmentImpl.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/AbstractMemorySegmentImpl.java
@@ -118,10 +118,7 @@ public abstract class AbstractMemorySegmentImpl implements MemorySegment, Memory
 
     public static void fill(MemorySegment segment, byte value) {
         AbstractMemorySegmentImpl segmentImpl = (AbstractMemorySegmentImpl) segment;
-        segmentImpl.checkValidState();
-        if (!segmentImpl.isSet(WRITE)) {
-            throw segmentImpl.unsupportedAccessMode(WRITE);
-        }
+        segmentImpl.checkRange(0, segmentImpl.length, true);
         UNSAFE.setMemory(segmentImpl.base(), segmentImpl.min(), segmentImpl.length, value);
     }
 

--- a/test/jdk/java/foreign/TestSegments.java
+++ b/test/jdk/java/foreign/TestSegments.java
@@ -254,7 +254,7 @@ public class TestSegments {
     }
 
     @Test(expectedExceptions = NullPointerException.class)
-    public void testFillWithNull() {
+    public void testFillNull() {
         MemorySegment.fill(null, (byte) 0xFF);
     }
 


### PR DESCRIPTION
Hi,

As part of feedback on the Foreign Memory API (when experimenting with
its usage internally in the JDK), a small number of potential usability
enhancements could be made to the API. This is the second such.

This change proposes to add a new method:
  MemorySegment::fill

Which fills a value into the given memory segment. Fill can be useful to
initialize or reset the memory of a segment, similar(ish) to memset.

There are obviously different ways to provide such functionality, e.g.
accepting a fill value with a bit width greater than 8 bits, but on
balance this single method will likely satisfy the majority of simple
use-cases. Other more advanced initialization scenarios would likely be 
served better from an interaction with the Vector API, or some such.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * Jim Laskey ([jlaskey](@JimLaskey) - Committer) ⚠️ Review applies to e66ab857c91a48aec9985b367fce031c88b12d23
 * Jorn Vernee ([jvernee](@JornVernee) - Committer) ⚠️ Review applies to e66ab857c91a48aec9985b367fce031c88b12d23
 * Paul Sandoz ([psandoz](@PaulSandoz) - Committer) ⚠️ Review applies to af894de2e57b94424da9119e85d0f3db77d3f146
 * Maurizio Cimadamore ([mcimadamore](@mcimadamore) - Committer)

### Download
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/161/head:pull/161`
`$ git checkout pull/161`
