### PR TITLE
8244938: Crash in foreign ABI CallArranger class when a test native function returns a nested struct

### DIFF
--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/x64/sysv/CallArranger.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/x64/sysv/CallArranger.java
@@ -459,6 +459,7 @@ public class CallArranger {
             ArgumentClassImpl c = classes.get(i);
 
             if (c == ArgumentClassImpl.MEMORY) {
+                // if any of the eightbytes was passed in memory, pass the whole thing in memory
                 return createMemoryClassArray(classes.size());
             }
 
@@ -541,7 +542,11 @@ public class CallArranger {
                 layouts = new ArrayList<>();
                 groups[(int)offset / 8] = layouts;
             }
-            layouts.add(classifyValueType((ValueLayout)l));
+            // if the aggregate contains unaligned fields, it has class MEMORY
+            ArgumentClassImpl argumentClass = (offset % l.byteAlignment()) == 0 ?
+                    classifyValueType((ValueLayout)l) :
+                    ArgumentClassImpl.MEMORY;
+            layouts.add(argumentClass);
         } else {
             throw new IllegalStateException("Unexpected layout: " + l);
         }

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/x64/sysv/CallArranger.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/x64/sysv/CallArranger.java
@@ -172,23 +172,21 @@ public class CallArranger {
             this.classes = classes;
         }
 
-        public static TypeClass ofValue(List<ArgumentClassImpl> classes) {
-            if (classes.size() != 1) {
-                throw new IllegalStateException("Multiple classes not supported: " + classes);
-            }
+        public static TypeClass ofValue(ValueLayout layout) {
             final Kind kind;
-            switch (classes.get(0)) {
+            ArgumentClassImpl argClass = classifyValueType(layout);
+            switch (argClass) {
                 case POINTER: kind = Kind.POINTER; break;
                 case INTEGER: kind = Kind.INTEGER; break;
                 case SSE: kind = Kind.FLOAT; break;
                 default:
                     throw new IllegalStateException();
             }
-            return new TypeClass(kind, classes);
+            return new TypeClass(kind, List.of(argClass));
         }
 
-        public static TypeClass ofStruct(List<ArgumentClassImpl> classes) {
-            return new TypeClass(Kind.STRUCT, classes);
+        public static TypeClass ofStruct(GroupLayout layout) {
+            return new TypeClass(Kind.STRUCT, classifyStructType(layout));
         }
 
         boolean inMemory() {
@@ -418,100 +416,23 @@ public class CallArranger {
         COMPLEX_X87_CLASSES.add(ArgumentClassImpl.X87UP);
     }
 
-
     private static List<ArgumentClassImpl> createMemoryClassArray(long size) {
         return IntStream.range(0, (int)size)
                 .mapToObj(i -> ArgumentClassImpl.MEMORY)
                 .collect(Collectors.toCollection(ArrayList::new));
     }
 
-
-    private static List<ArgumentClassImpl> classifyValueType(ValueLayout type) {
-        ArrayList<ArgumentClassImpl> classes = new ArrayList<>();
+    // TODO: handle '__int128' and 'long double'
+    private static ArgumentClassImpl classifyValueType(ValueLayout type) {
+        if (type.byteSize() > 8) {
+            throw new IllegalStateException("");
+        }
         ArgumentClassImpl clazz = SysVx64ABI.argumentClassFor(type)
                 .orElseThrow(() -> new IllegalStateException("Unexpected value layout: could not determine ABI class"));
-        classes.add(clazz);
-        if (clazz == ArgumentClassImpl.INTEGER) {
-            // int128
-            long left = (type.byteSize()) - 8;
-            while (left > 0) {
-                classes.add(ArgumentClassImpl.INTEGER);
-                left -= 8;
-            }
-            return classes;
-        } else if (clazz == ArgumentClassImpl.X87) {
-            classes.add(ArgumentClassImpl.X87UP);
-        }
-
-        return classes;
-    }
-
-    private static List<ArgumentClassImpl> classifyArrayType(SequenceLayout type) {
-        long nWords = Utils.alignUp((type.byteSize()), 8) / 8;
-        if (nWords > MAX_AGGREGATE_REGS_SIZE) {
-            return createMemoryClassArray(nWords);
-        }
-
-        ArrayList<ArgumentClassImpl> classes = new ArrayList<>();
-
-        for (long i = 0; i < nWords; i++) {
-            classes.add(ArgumentClassImpl.NO_CLASS);
-        }
-
-        long offset = 0;
-        final long count = type.elementCount().orElseThrow();
-        for (long idx = 0; idx < count; idx++) {
-            MemoryLayout t = type.elementLayout();
-            offset = SharedUtils.align(t, false, offset);
-            List<ArgumentClassImpl> subclasses = classifyType(t);
-            if (subclasses.isEmpty()) {
-                return classes;
-            }
-
-            for (int i = 0; i < subclasses.size(); i++) {
-                int pos = (int)(offset / 8);
-                ArgumentClassImpl newClass = classes.get(i + pos).merge(subclasses.get(i));
-                classes.set(i + pos, newClass);
-            }
-
-            offset += t.byteSize();
-        }
-
-        for (int i = 0; i < classes.size(); i++) {
-            ArgumentClassImpl c = classes.get(i);
-
-            if (c == ArgumentClassImpl.MEMORY) {
-                return createMemoryClassArray(classes.size());
-            }
-
-            if (c == ArgumentClassImpl.X87UP) {
-                if (i == 0) {
-                    throw new IllegalArgumentException("Unexpected leading X87UP class");
-                }
-
-                if (classes.get(i - 1) != ArgumentClassImpl.X87) {
-                    return createMemoryClassArray(classes.size());
-                }
-            }
-        }
-
-        if (classes.size() > 2) {
-            if (classes.get(0) != ArgumentClassImpl.SSE) {
-                return createMemoryClassArray(classes.size());
-            }
-
-            for (int i = 1; i < classes.size(); i++) {
-                if (classes.get(i) != ArgumentClassImpl.SSEUP) {
-                    return createMemoryClassArray(classes.size());
-                }
-            }
-        }
-
-        return classes;
+        return clazz;
     }
 
     // TODO: handle zero length arrays
-    // TODO: Handle nested structs (and primitives)
     private static List<ArgumentClassImpl> classifyStructType(GroupLayout type) {
         if (argumentClassFor(type)
                 .filter(argClass -> argClass == ArgumentClassImpl.COMPLEX_X87)
@@ -519,47 +440,19 @@ public class CallArranger {
             return COMPLEX_X87_CLASSES;
         }
 
-        long nWords = Utils.alignUp((type.byteSize()), 8) / 8;
+        List<ArgumentClassImpl>[] eightbytes = groupByEightBytes(type);
+        long nWords = eightbytes.length;
         if (nWords > MAX_AGGREGATE_REGS_SIZE) {
             return createMemoryClassArray(nWords);
         }
 
         ArrayList<ArgumentClassImpl> classes = new ArrayList<>();
 
-        for (long i = 0; i < nWords; i++) {
-            classes.add(ArgumentClassImpl.NO_CLASS);
-        }
-
-        long offset = 0;
-        final int count = type.memberLayouts().size();
-        for (int idx = 0; idx < count; idx++) {
-            MemoryLayout t = type.memberLayouts().get(idx);
-            if (t.isPadding()) {
-                continue;
-            }
-            // ignore zero-length array for now
-            // TODO: handle zero length arrays here
-            if (t instanceof SequenceLayout) {
-                if (((SequenceLayout) t).elementCount().orElseThrow() == 0) {
-                    continue;
-                }
-            }
-            offset = SharedUtils.align(t, false, offset);
-            List<ArgumentClassImpl> subclasses = classifyType(t);
-            if (subclasses.isEmpty()) {
-                return classes;
-            }
-
-            for (int i = 0; i < subclasses.size(); i++) {
-                int pos = (int)(offset / 8);
-                ArgumentClassImpl newClass = classes.get(i + pos).merge(subclasses.get(i));
-                classes.set(i + pos, newClass);
-            }
-
-            // TODO: validate union strategy is sound
-            if (type.isStruct()) {
-                offset += t.byteSize();
-            }
+        for (int idx = 0; idx < nWords; idx++) {
+            List<ArgumentClassImpl> subclasses = eightbytes[idx];
+            ArgumentClassImpl result = subclasses.stream()
+                    .reduce(ArgumentClassImpl.NO_CLASS, ArgumentClassImpl::merge);
+            classes.add(result);
         }
 
         for (int i = 0; i < classes.size(); i++) {
@@ -595,14 +488,12 @@ public class CallArranger {
         return classes;
     }
 
-    private static List<ArgumentClassImpl> classifyType(MemoryLayout type) {
+    private static TypeClass classifyLayout(MemoryLayout type) {
         try {
             if (type instanceof ValueLayout) {
-                return classifyValueType((ValueLayout) type);
-            } else if (type instanceof SequenceLayout) {
-                return classifyArrayType((SequenceLayout) type);
+                return TypeClass.ofValue((ValueLayout)type);
             } else if (type instanceof GroupLayout) {
-                return classifyStructType((GroupLayout) type);
+                return TypeClass.ofStruct((GroupLayout)type);
             } else {
                 throw new IllegalArgumentException("Unhandled type " + type);
             }
@@ -612,19 +503,47 @@ public class CallArranger {
         }
     }
 
-    private static TypeClass classifyLayout(MemoryLayout type) {
-        List<ArgumentClassImpl> classes = classifyType(type);
-        try {
-            if (type instanceof ValueLayout) {
-                return TypeClass.ofValue(classes);
-            } else if (type instanceof GroupLayout) {
-                return TypeClass.ofStruct(classes);
-            } else {
-                throw new IllegalArgumentException("Unhandled type " + type);
+    private static List<ArgumentClassImpl>[] groupByEightBytes(GroupLayout group) {
+        long offset = 0L;
+        int nEightbytes = (int)Utils.alignUp(group.byteSize(), 8) / 8;
+        @SuppressWarnings({"unchecked", "rawtypes"})
+        List<ArgumentClassImpl>[] groups = new List[nEightbytes];
+        for (MemoryLayout l : group.memberLayouts()) {
+            groupByEightBytes(l, offset, groups);
+            if (group.isStruct()) {
+                offset += l.byteSize();
             }
-        } catch (UnsupportedOperationException e) {
-            System.err.println("Failed to classify layout: " + type);
-            throw e;
+        }
+        return groups;
+    }
+
+    private static void groupByEightBytes(MemoryLayout l, long offset, List<ArgumentClassImpl>[] groups) {
+        if (l instanceof GroupLayout) {
+            GroupLayout group = (GroupLayout)l;
+            for (MemoryLayout m : group.memberLayouts()) {
+                groupByEightBytes(m, offset, groups);
+                if (group.isStruct()) {
+                    offset += m.byteSize();
+                }
+            }
+        } else if (l.isPadding()) {
+            return;
+        } else if (l instanceof SequenceLayout) {
+            SequenceLayout seq = (SequenceLayout)l;
+            MemoryLayout elem = seq.elementLayout();
+            for (long i = 0 ; i < seq.elementCount().getAsLong() ; i++) {
+                groupByEightBytes(elem, offset, groups);
+                offset += elem.byteSize();
+            }
+        } else if (l instanceof ValueLayout) {
+            List<ArgumentClassImpl> layouts = groups[(int)offset / 8];
+            if (layouts == null) {
+                layouts = new ArrayList<>();
+                groups[(int)offset / 8] = layouts;
+            }
+            layouts.add(classifyValueType((ValueLayout)l));
+        } else {
+            throw new IllegalStateException("Unexpected layout: " + l);
         }
     }
 }

--- a/test/jdk/java/foreign/callarranger/TestSysVCallArranger.java
+++ b/test/jdk/java/foreign/callarranger/TestSysVCallArranger.java
@@ -75,6 +75,65 @@ public class TestSysVCallArranger extends CallArrangerTestBase {
     }
 
     @Test
+    public void testNestedStructs() {
+        MemoryLayout POINT = MemoryLayout.ofStruct(
+                C_INT,
+                MemoryLayout.ofStruct(
+                        C_INT,
+                        C_INT
+                )
+        );
+        MethodType mt = MethodType.methodType(void.class, MemorySegment.class);
+        FunctionDescriptor fd = FunctionDescriptor.ofVoid(POINT);
+        CallArranger.Bindings bindings = CallArranger.getBindings(mt, fd, false);
+
+        assertFalse(bindings.isInMemoryReturn);
+        CallingSequence callingSequence = bindings.callingSequence;
+        assertEquals(callingSequence.methodType(), mt.appendParameterTypes(long.class));
+        assertEquals(callingSequence.functionDesc(), fd.appendArgumentLayouts(C_LONG));
+
+        checkArgumentBindings(callingSequence, new Binding[][]{
+                { dup(), dereference(0, long.class), move(rdi, long.class),
+                  dereference(8, int.class), move(rsi, int.class)},
+                { move(rax, long.class) },
+        });
+
+        checkReturnBindings(callingSequence, new Binding[]{});
+
+        assertEquals(bindings.nVectorArgs, 0);
+    }
+
+    @Test
+    public void testNestedUnion() {
+        MemoryLayout POINT = MemoryLayout.ofStruct(
+                C_INT,
+                MemoryLayout.ofPaddingBits(32),
+                MemoryLayout.ofUnion(
+                        MemoryLayout.ofStruct(C_INT, C_INT),
+                        C_LONG
+                )
+        );
+        MethodType mt = MethodType.methodType(void.class, MemorySegment.class);
+        FunctionDescriptor fd = FunctionDescriptor.ofVoid(POINT);
+        CallArranger.Bindings bindings = CallArranger.getBindings(mt, fd, false);
+
+        assertFalse(bindings.isInMemoryReturn);
+        CallingSequence callingSequence = bindings.callingSequence;
+        assertEquals(callingSequence.methodType(), mt.appendParameterTypes(long.class));
+        assertEquals(callingSequence.functionDesc(), fd.appendArgumentLayouts(C_LONG));
+
+        checkArgumentBindings(callingSequence, new Binding[][]{
+                { dup(), dereference(0, long.class), move(rdi, long.class),
+                        dereference(8, long.class), move(rsi, long.class)},
+                { move(rax, long.class) },
+        });
+
+        checkReturnBindings(callingSequence, new Binding[]{});
+
+        assertEquals(bindings.nVectorArgs, 0);
+    }
+
+    @Test
     public void testIntegerRegs() {
         MethodType mt = MethodType.methodType(void.class,
                 int.class, int.class, int.class, int.class, int.class, int.class);


### PR DESCRIPTION
This is a nasty issue with the SysV struct classification algorithm (which is rather complex).

The algortigm as specified, is designed to work on 8-byte chunks at a time (the SysV spec calls them `eighbytes`). This means that when there are nested structs, some structs might need to be broken apart to implement the algorithm correctly. Consider this case:

```
MemoryLayout POINT = MemoryLayout.ofStruct(
                C_INT.withName("x"),
                MemoryLayout.ofStruct(
                        C_INT.withName("y"),
                        C_INT.withName("z")
                )
        );
```

Here we have an int field (`x`) and then two nested int fields (namely, `y` and `z`).

The currently implemented logic, sees the first field, and classifies it as `INTEGER`. It then calls the classification recursively on the second field, which is a struct. Since the struct fits in 8 bytes, the recursive classification yields a single class, namely INTEGER. The outer classification logic then attempts two merge the two INTEGER classes (one from the first field, the other from the struct), and obtain a *single* INTEGER class as a result. This is a wrong result, as 12 bytes cannot obviously fit in a single eightbyte.

To address this issue I first considered flattening structs, but then I quickly gave up, since it was pretty messy to make sure that flattening worked correctly with respect to unions (e.g. structs inside unions).

I then settled on a simpler scheme: since the classification logic is meant to work on one eightbyte at a time, I just wrote a routine that parses the incoming `GroupLayout` and breaks it apart into an array of `ArgumentClassImpl`, where the size of the array is the number of eightbytes into which the group is to be classified.

We recursively scan the layout, trying to find all the fields, and keeping track of their offsets. Eventually, when we come to leaves layouts (values) we add their corresponding ArgumentClassImpl to the array slot that corresponds to the eightbyte associated with the offset being considered.

Once this processing is done, classifying the struct is a breeze, as what's left to do is simply to *merge* all the classes in a single eightbyte slot (which can be done with a simple reduce step).

Note: for this logic to work, we have to assume that all value layouts in the group are not bigger than 8 bytes. In practice this is not a big issue, since bigger value layouts were not supported anyway. I also believe it won't be an issue moving forward, since we can simply make sure that e.g. the SysV type `__int128` is modelled with this layout:

```
MemoryLayout.ofStruct(C_INT, C_INT)
```

Or that `long double` is handle like this:

```
MemoryLayout.ofStruct(
    C_LONG.withAttribute(ArgumentClass.X87),
    C_LONG.withAttribute(ArgumentClass.X87_UP)
```

And so forth for vector types. In other words, rather than making the classification logic more complex, we can simply define the ABI layout constants accordingly, so that they are already broken up into 8-byte chunks.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [JDK-8244938](https://bugs.openjdk.java.net/browse/JDK-8244938): Crash in foreign ABI CallArranger class when a test native function returns a nested struct


### Reviewers
 * Jorn Vernee ([jvernee](@JornVernee) - Committer)

### Download
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/162/head:pull/162`
`$ git checkout pull/162`
