### PR TITLE
Simplify MemoryScope implementation to use StampedLock

### DIFF
--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/MemoryScope.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/MemoryScope.java
@@ -29,6 +29,7 @@ package jdk.internal.foreign;
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.VarHandle;
 import java.util.concurrent.atomic.LongAdder;
+import java.util.concurrent.locks.StampedLock;
 
 /**
  * This class manages the temporal bounds associated with a memory segment. A scope has a liveness bit, which is updated
@@ -56,16 +57,12 @@ abstract class MemoryScope {
         return new Root(ref, cleanupAction);
     }
 
-    private static final int STATE_OPEN = 0;
-    private static final int STATE_CLOSING = 1;
-    private static final int STATE_CLOSED = 2;
-
-    int state; // = STATE_OPEN
-    private static final VarHandle STATE;
+    boolean closed = false;
+    private static final VarHandle CLOSED;
 
     static {
         try {
-            STATE = MethodHandles.lookup().findVarHandle(MemoryScope.class, "state", int.class);
+            CLOSED = MethodHandles.lookup().findVarHandle(MemoryScope.class, "closed", boolean.class);
         } catch (Throwable ex) {
             throw new ExceptionInInitializerError(ex);
         }
@@ -117,7 +114,7 @@ abstract class MemoryScope {
      * @return {@code true} if this scope is not closed yet.
      */
     final boolean isAliveThreadSafe() {
-        return ((int) STATE.getVolatile(this)) < STATE_CLOSED;
+        return !((boolean)CLOSED.getVolatile(this));
     }
 
     /**
@@ -127,16 +124,19 @@ abstract class MemoryScope {
      * @throws IllegalStateException if this scope is already closed
      */
     final void checkAliveConfined() {
-        if (state == STATE_CLOSED) {
+        if (closed) {
             throw new IllegalStateException("This scope is already closed");
         }
     }
 
     private static final class Root extends MemoryScope {
-        private final LongAdder acquires = new LongAdder();
-        private final LongAdder releases = new LongAdder();
+        private final LongAdder acquired = new LongAdder();
         private final Object ref;
         private final Runnable cleanupAction;
+
+        private final StampedLock lock = new StampedLock();
+
+
 
         private Root(Object ref, Runnable cleanupAction) {
             this.ref = ref;
@@ -145,18 +145,29 @@ abstract class MemoryScope {
 
         @Override
         MemoryScope acquire() {
-            // increment acquires 1st
-            acquires.increment();
-            // check state 2nd
-            int state;
-            while ((state  = (int) STATE.getVolatile(this)) > STATE_OPEN) {
-                if (state == STATE_CLOSED) {
-                    releases.increment();
-                    throw new IllegalStateException("This scope is already closed");
+            //try to optimistically acquire the lock
+            long stamp = lock.tryOptimisticRead();
+            try {
+                for (; ; stamp = lock.readLock()) {
+                    if (stamp == 0L)
+                        continue;
+                    checkAliveConfined(); // plain read is enough here (either successful optimistic read, or ful read lock)
+
+                    // increment acquires
+                    acquired.increment();
+                    // did a call to close() occurred since we acquired the lock?
+                    if (lock.validate(stamp)) {
+                        // no, just return the acquired scope
+                        return new Child();
+                    } else {
+                        // yes, just back off and retry (close might have failed, after all)
+                        acquired.decrement();
+                    }
                 }
-                Thread.onSpinWait();
+            } finally {
+                if (StampedLock.isReadLockStamp(stamp))
+                    lock.unlockRead(stamp);
             }
-            return new Child();
         }
 
         @Override
@@ -170,21 +181,23 @@ abstract class MemoryScope {
         }
 
         private MemoryScope closeOrDup(boolean close) {
-            if (state == STATE_CLOSED) {
-                throw new IllegalStateException("This scope is already closed");
-            }
             // pre-allocate duped scope so we don't get OOME later and be left with this scope closed
             var duped = close ? null : new Root(ref, cleanupAction);
-            // modify state to STATE_CLOSING 1st
-            STATE.setVolatile(this, STATE_CLOSING);
-            // check for absence of active acquired children 2nd
-            // IMPORTANT: 1st sum releases, then sum acquires !!!
-            if (releases.sum() != acquires.sum()) {
-                STATE.setVolatile(this, STATE_OPEN); // revert back to STATE_OPEN
-                throw new IllegalStateException("Cannot close this scope as it has active acquired children");
+            // enter critical section - no acquires are possible past this point
+            long stamp = lock.writeLock();
+            try {
+                checkAliveConfined(); // plain read is enough here (full write lock)
+                // check for absence of active acquired children
+                if (acquired.sum() > 0) {
+                    throw new IllegalStateException("Cannot close this scope as it has active acquired children");
+                }
+                // now that we made sure there's no active acquired children, we can mark scope as closed
+                closed = true; // plain write is enough here (full write lock)
+            } finally {
+                // leave critical section
+                lock.unlockWrite(stamp);
             }
-            // now that we made sure there's no active acquired children, we modify to STATE_CLOSED
-            STATE.setVolatile(this, STATE_CLOSED);
+
             // do close or dup
             if (close) {
                 if (cleanupAction != null) {
@@ -208,24 +221,20 @@ abstract class MemoryScope {
 
             @Override
             MemoryScope dup() { // always called in owner thread
-                if (state == STATE_CLOSED) {
-                    throw new IllegalStateException("This scope is already closed");
-                }
+                checkAliveConfined();
                 // pre-allocate duped scope so we don't get OOME later and be left with this scope closed
                 var duped = new Child();
-                STATE.setVolatile(this, STATE_CLOSED);
+                CLOSED.setVolatile(this, true);
                 return duped;
             }
 
             @Override
             void close() { // always called in owner thread
-                if (state == STATE_CLOSED) {
-                    throw new IllegalStateException("This scope is already closed");
-                }
-                state = STATE_CLOSED;
+                checkAliveConfined();
+                closed = true;
                 // following acts as a volatile write after plain write above so
                 // plain write gets flushed too (which is important for isAliveThreadSafe())
-                Root.this.releases.increment();
+                Root.this.acquired.decrement();
             }
         }
     }

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/MemoryScope.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/MemoryScope.java
@@ -151,11 +151,11 @@ abstract class MemoryScope {
                 for (; ; stamp = lock.readLock()) {
                     if (stamp == 0L)
                         continue;
-                    checkAliveConfined(); // plain read is enough here (either successful optimistic read, or ful read lock)
+                    checkAliveConfined(); // plain read is enough here (either successful optimistic read, or full read lock)
 
                     // increment acquires
                     acquired.increment();
-                    // did a call to close() occurred since we acquired the lock?
+                    // did a call to close() occur since we acquired the lock?
                     if (lock.validate(stamp)) {
                         // no, just return the acquired scope
                         return new Child();

--- a/test/jdk/java/foreign/TestByteBuffer.java
+++ b/test/jdk/java/foreign/TestByteBuffer.java
@@ -296,7 +296,7 @@ public class TestByteBuffer {
                 Throwable cause = ex.getCause();
                 if (cause instanceof IllegalStateException) {
                     //all get/set buffer operation should fail because of the scope check
-                    assertTrue(ex.getCause().getMessage().contains("not alive"));
+                    assertTrue(ex.getCause().getMessage().contains("already closed"));
                 } else {
                     //all other exceptions were unexpected - fail
                     assertTrue(false);
@@ -333,7 +333,7 @@ public class TestByteBuffer {
                 handle.invoke(e.getValue());
                 fail();
             } catch (IllegalStateException ex) {
-                assertTrue(ex.getMessage().contains("not alive"));
+                assertTrue(ex.getMessage().contains("already closed"));
             } catch (UnsupportedOperationException ex) {
                 //skip
             } catch (Throwable ex) {

--- a/test/micro/org/openjdk/bench/jdk/incubator/foreign/ParallelSum.java
+++ b/test/micro/org/openjdk/bench/jdk/incubator/foreign/ParallelSum.java
@@ -46,11 +46,14 @@ import jdk.incubator.foreign.MemorySegment;
 import java.lang.invoke.VarHandle;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Optional;
+import java.util.OptionalInt;
 import java.util.Spliterator;
 import java.util.concurrent.CountedCompleter;
 import java.util.concurrent.RecursiveTask;
 import java.util.concurrent.TimeUnit;
 import java.util.function.IntFunction;
+import java.util.function.Predicate;
 import java.util.function.ToIntFunction;
 import java.util.stream.StreamSupport;
 
@@ -148,6 +151,47 @@ public class ParallelSum {
             res += (int)VH_int.get(base, (long) i);
         }
         return res;
+    };
+
+    @Benchmark
+    public Optional<MemorySegment> segment_stream_findany_serial() {
+        return StreamSupport.stream(MemorySegment.spliterator(segment, SEQUENCE_LAYOUT), false)
+                .filter(FIND_SINGLE)
+                .findAny();
+    }
+
+    @Benchmark
+    public Optional<MemorySegment> segment_stream_findany_parallel() {
+        return StreamSupport.stream(MemorySegment.spliterator(segment, SEQUENCE_LAYOUT), true)
+                .filter(FIND_SINGLE)
+                .findAny();
+    }
+
+    @Benchmark
+    public Optional<MemorySegment> segment_stream_findany_serial_bulk() {
+        return StreamSupport.stream(MemorySegment.spliterator(segment, SEQUENCE_LAYOUT_BULK), false)
+                .filter(FIND_BULK)
+                .findAny();
+    }
+
+    @Benchmark
+    public Optional<MemorySegment> segment_stream_findany_parallel_bulk() {
+        return StreamSupport.stream(MemorySegment.spliterator(segment, SEQUENCE_LAYOUT_BULK), true)
+                .filter(FIND_BULK)
+                .findAny();
+    }
+
+    final static Predicate<MemorySegment> FIND_SINGLE = slice ->
+            (int)VH_int.get(slice.baseAddress(), 0L) == (ELEM_SIZE - 1);
+
+    final static Predicate<MemorySegment> FIND_BULK = slice -> {
+        MemoryAddress base = slice.baseAddress();
+        for (int i = 0; i < BULK_FACTOR ; i++) {
+            if ((int)VH_int.get(base, (long)i) == (ELEM_SIZE - 1)) {
+                return true;
+            }
+        }
+        return false;
     };
 
     @Benchmark


### PR DESCRIPTION
I've been playing around a bit and discussed this offline with @JornVernee too. A realization I had some time ago is that what we're trying to do here is a read/write lock, where multiple acquire can occur at the same time, but where close of the root should be exclusive. I think all the machinery around `CLOSING` is essentially due to the code trying to mimic that pattern.

This patch simplifies over the status quo, by using a `StampedLock` instead of managing races manually through a `CLOSING` state. The tweaked implementation also adds back the atomicity w.r.t. close() vs. dup() which was seeked in a previous attempt (see https://git.openjdk.java.net/panama-foreign/pull/160). Also, since now there some guarantee that no acquire can take place while a close is also taking place (and pending acquires will be invalidated - using the optimistic read logic), then we can just use a single long adder instead of two.

The state is also simplified, since we just need a boolean flag.

I ran the `ParallelSum` benchmark and could not spot any obvious regression compared to the previous code.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * Paul Sandoz ([psandoz](@PaulSandoz) - Committer)

### Download
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/163/head:pull/163`
`$ git checkout pull/163`
