### PR TITLE
8244959: Jextract's VarargsInvoker fails to link functions when passing integer types other than long

### DIFF
--- a/src/jdk.incubator.jextract/share/classes/jdk/incubator/jextract/tool/resources/RuntimeHelper.java.template
+++ b/src/jdk.incubator.jextract/share/classes/jdk/incubator/jextract/tool/resources/RuntimeHelper.java.template
@@ -180,9 +180,13 @@ public class RuntimeHelper {
         }
 
         private MemoryLayout variadicLayout(Class<?> c) {
-            if (c == char.class || c == byte.class || c == short.class || c == int.class || c == long.class) {
-                //it is ok to approximate with a machine word here; numerics arguments in a prototype-less
-                //function call are always rounded up to a register size anyway.
+            if (c == byte.class) {
+                return C_CHAR;
+            } else if (c == char.class || c == short.class) {
+                return C_SHORT;
+            } else if (c == int.class) {
+                return C_INT;
+            } else if (c == long.class) {
                 return C_LONGLONG;
             } else if (c == float.class || c == double.class) {
                 return C_DOUBLE;

--- a/src/jdk.incubator.jextract/share/classes/jdk/incubator/jextract/tool/resources/RuntimeHelper.java.template
+++ b/src/jdk.incubator.jextract/share/classes/jdk/incubator/jextract/tool/resources/RuntimeHelper.java.template
@@ -165,10 +165,20 @@ public class RuntimeHelper {
             }
         }
 
+        private Class<?> promote(Class<?> c) {
+            if (c == byte.class || c == char.class || c == short.class || c == int.class) {
+                return long.class;
+            } else if (c == float.class) {
+                return double.class;
+            } else {
+                return c;
+            }
+        }
+
         private Class<?> normalize(Class<?> c) {
             c = unboxIfNeeded(c);
             if (c.isPrimitive()) {
-                return c;
+                return promote(c);
             }
             if (MemoryAddress.class.isAssignableFrom(c)) {
                 return MemoryAddress.class;
@@ -180,15 +190,9 @@ public class RuntimeHelper {
         }
 
         private MemoryLayout variadicLayout(Class<?> c) {
-            if (c == byte.class) {
-                return C_CHAR;
-            } else if (c == char.class || c == short.class) {
-                return C_SHORT;
-            } else if (c == int.class) {
-                return C_INT;
-            } else if (c == long.class) {
+            if (c == long.class) {
                 return C_LONGLONG;
-            } else if (c == float.class || c == double.class) {
+            } else if (c == double.class) {
                 return C_DOUBLE;
             } else if (MemoryAddress.class.isAssignableFrom(c)) {
                 return C_POINTER;

--- a/test/jdk/tools/jextract/test8244959/Test8244959.java
+++ b/test/jdk/tools/jextract/test8244959/Test8244959.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import org.testng.annotations.Test;
+
+import jdk.incubator.foreign.MemorySegment;
+
+import static org.testng.Assert.assertEquals;
+import static test.jextract.printf.Cstring.*;
+import static test.jextract.printf.printf_h.*;
+
+/*
+ * @test
+ * @library ..
+ * @modules jdk.incubator.jextract
+ * @run driver JtregJextract -t test.jextract.printf -- printf.h
+ * @run testng/othervm -Dforeign.restricted=permit Test8244959
+ */
+public class Test8244959 {
+    @Test
+    public void testsPrintf() {
+        try (MemorySegment s = MemorySegment.allocateNative(1024)) {
+            sprintf(s.baseAddress(),
+                toCString("%hhd %hd %d %ld %lld %c").baseAddress(),
+                (byte) 1, (short) 2, 3, 4l, 5l, 'a');
+            String str = toJavaString(s.baseAddress());
+            assertEquals(str, "1 2 3 4 5 a");
+        }
+    }
+}

--- a/test/jdk/tools/jextract/test8244959/Test8244959.java
+++ b/test/jdk/tools/jextract/test8244959/Test8244959.java
@@ -41,10 +41,10 @@ public class Test8244959 {
     public void testsPrintf() {
         try (MemorySegment s = MemorySegment.allocateNative(1024)) {
             sprintf(s.baseAddress(),
-                toCString("%hhd %hd %d %ld %lld %c").baseAddress(),
-                (byte) 1, (short) 2, 3, 4l, 5l, 'a');
+                toCString("%hhd %c %.2f %.2f %ld %ld %d %hd %d %d %lld %c").baseAddress(),
+                (byte) 1, 'b', -1.25f, 5.5d, -200l, Long.MAX_VALUE, (byte) -2, (short) 2, 3, (short) -4, 5l, 'a');
             String str = toJavaString(s.baseAddress());
-            assertEquals(str, "1 2 3 4 5 a");
+            assertEquals(str, "1 b -1.25 5.50 -200 " + Long.MAX_VALUE + " -2 2 3 -4 5 a");
         }
     }
 }

--- a/test/jdk/tools/jextract/test8244959/printf.h
+++ b/test/jdk/tools/jextract/test8244959/printf.h
@@ -1,0 +1,1 @@
+int sprintf(char *buf, const char *fmt, ...);


### PR DESCRIPTION
This PR makes sure VarargsInvoker use exact size match layout for carrier type for varargs parameters.

Use sprintf as the test case, tested on Mac OS X, need verification on Windows to verify the needed share library is loaded by JVM.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [JDK-8244959](https://bugs.openjdk.java.net/browse/JDK-8244959): Jextract's VarargsInvoker fails to link functions when passing integer types other than long


### Reviewers
 * Athijegannathan Sundararajan ([sundar](@sundararajana) - Committer) ⚠️ Review applies to 36c21c2e5e1ed17c84a674923ed6815171715ed2
 * Maurizio Cimadamore ([mcimadamore](@mcimadamore) - Committer)
 * Jorn Vernee ([jvernee](@JornVernee) - Committer) ⚠️ Review applies to 36c21c2e5e1ed17c84a674923ed6815171715ed2

### Download
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/164/head:pull/164`
`$ git checkout pull/164`
