### PR TITLE
8245003: jextract does not generate accessor for MemorySegement typed values

### DIFF
--- a/src/jdk.incubator.jextract/share/classes/jdk/incubator/jextract/tool/ConstantHelper.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/incubator/jextract/tool/ConstantHelper.java
@@ -146,7 +146,8 @@ class ConstantHelper {
                 methodType(
                         MemoryAddress.class,
                         LibraryLookup[].class,
-                        String.class)
+                        String.class,
+                        MemoryLayout.class)
         );
         this.MH_makeCString = findRuntimeHelperBootstrap(
                 cString,
@@ -188,8 +189,8 @@ class ConstantHelper {
         return emitCondyGetter(javaName + "$MH", MethodHandle.class, methodHandleDesc(nativeName, mtype, desc, varargs));
     }
 
-    public DirectMethodHandleDesc addAddress(String javaName, String nativeName) {
-        return emitCondyGetter(javaName + "$ADDR", MemoryAddress.class, globalVarAddressDesc(nativeName));
+    public DirectMethodHandleDesc addAddress(String javaName, String nativeName, MemoryLayout layout) {
+        return emitCondyGetter(javaName + "$ADDR", MemoryAddress.class, globalVarAddressDesc(nativeName, layout));
     }
 
     public DirectMethodHandleDesc addFunctionDesc(String javaName, FunctionDescriptor fDesc) {
@@ -419,8 +420,8 @@ class ConstantHelper {
         }
     }
 
-    private ConstantDesc globalVarAddressDesc(String name) {
-        return DynamicConstantDesc.ofNamed(BSM_INVOKE, "ADDR_" + name, CD_MemoryAddress, MH_lookupGlobalVariable, LIBRARIES, name);
+    private ConstantDesc globalVarAddressDesc(String name, MemoryLayout layout) {
+        return DynamicConstantDesc.ofNamed(BSM_INVOKE, "ADDR_" + name, CD_MemoryAddress, MH_lookupGlobalVariable, LIBRARIES, name, desc(layout));
     }
 
     private ConstantDesc addressDesc(long value) {

--- a/src/jdk.incubator.jextract/share/classes/jdk/incubator/jextract/tool/JavaSourceBuilder.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/incubator/jextract/tool/JavaSourceBuilder.java
@@ -115,8 +115,8 @@ abstract class JavaSourceBuilder {
         emitForwardGetter(constantHelper.addMethodHandle(javaName, nativeName, mtype, desc, varargs));
     }
 
-    public void addAddressGetter(String javaName, String nativeName) {
-        emitForwardGetter(constantHelper.addAddress(javaName, nativeName));
+    public void addAddressGetter(String javaName, String nativeName, MemoryLayout layout) {
+        emitForwardGetter(constantHelper.addAddress(javaName, nativeName, layout));
     }
 
     public void addConstantGetter(String javaName, Class<?> type, Object value) {
@@ -129,7 +129,7 @@ abstract class JavaSourceBuilder {
         sb.append(PUB_MODS + type.getName() + " " + javaName + "$get() {\n");
         incrAlign();
         indent();
-        String vhParam = addressGetCallString(javaName, nativeName);
+        String vhParam = addressGetCallString(javaName, nativeName, layout);
         sb.append("return (" + type.getName() + ")"
                 + varHandleGetCallString(javaName, nativeName, layout, type, null) + ".get(" + vhParam + ");\n");
         decrAlign();
@@ -144,7 +144,7 @@ abstract class JavaSourceBuilder {
         sb.append(PUB_MODS + "void " + javaName + "$set(" + type.getName() + " x) {\n");
         incrAlign();
         indent();
-        String vhParam = addressGetCallString(javaName, nativeName);
+        String vhParam = addressGetCallString(javaName, nativeName, layout);
         sb.append(varHandleGetCallString(javaName, nativeName, layout, type, null) + ".set(" + vhParam + ", x);\n");
         decrAlign();
         indent();
@@ -153,17 +153,13 @@ abstract class JavaSourceBuilder {
     }
 
     public void addAddressOf(String javaName, String nativeName, MemoryLayout layout, Class<?> type, MemoryLayout parentLayout) {
-        DirectMethodHandleDesc desc = constantHelper.addAddress(javaName, nativeName);
+        DirectMethodHandleDesc desc = constantHelper.addAddress(javaName, nativeName, layout);
         incrAlign();
         indent();
         sb.append(PUB_MODS + "MemoryAddress " + javaName + "$addressof() {\n");
         incrAlign();
         indent();
-        sb.append("return MemorySegment.ofNativeRestricted(" + getCallString(desc));
-        sb.append(", ");
-        sb.append(layout.byteSize());
-        sb.append(", ");
-        sb.append("Thread.currentThread(), null, null).baseAddress();\n");
+        sb.append("return " + getCallString(desc) + ";\n");
         decrAlign();
         indent();
         sb.append("}\n");
@@ -225,8 +221,8 @@ abstract class JavaSourceBuilder {
         return getCallString(constantHelper.addVarHandle(javaName, nativeName, layout, type, parentLayout));
     }
 
-    protected String addressGetCallString(String javaName, String nativeName) {
-        return getCallString(constantHelper.addAddress(javaName, nativeName));
+    protected String addressGetCallString(String javaName, String nativeName, MemoryLayout layout) {
+        return getCallString(constantHelper.addAddress(javaName, nativeName, layout));
     }
 
     protected void indent() {

--- a/src/jdk.incubator.jextract/share/classes/jdk/incubator/jextract/tool/OutputFactory.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/incubator/jextract/tool/OutputFactory.java
@@ -24,13 +24,9 @@
  */
 package jdk.incubator.jextract.tool;
 
+import jdk.incubator.foreign.*;
 import jdk.incubator.jextract.Declaration;
 import jdk.incubator.jextract.Type;
-import jdk.incubator.foreign.FunctionDescriptor;
-import jdk.incubator.foreign.MemoryAddress;
-import jdk.incubator.foreign.MemoryLayout;
-import jdk.incubator.foreign.MemorySegment;
-import jdk.incubator.foreign.SystemABI;
 import jdk.incubator.jextract.Type.Primitive;
 import jdk.internal.foreign.abi.SharedUtils;
 
@@ -353,11 +349,6 @@ public class OutputFactory implements Declaration.Visitor<Void, Declaration> {
         String symbol = tree.name();
         assert !symbol.isEmpty();
         assert !fieldName.isEmpty();
-
-        // FIXME: we need tree transformer. The mangling should be a separate tree transform phase
-        if (parent == null) {
-            fieldName = tree.name();
-        }
         fieldName = Utils.javaSafeIdentifier(fieldName);
 
         Type type = tree.type();
@@ -368,23 +359,32 @@ public class OutputFactory implements Declaration.Visitor<Void, Declaration> {
         }
         Class<?> clazz = typeTranslator.getJavaType(type);
         if (tree.kind() == Declaration.Variable.Kind.BITFIELD || clazz == MemoryAddress.class ||
-                clazz == MemorySegment.class || layout.byteSize() > 8) {
+                (layout instanceof ValueLayout && layout.byteSize() > 8)) {
             //skip
             return null;
         }
 
+        boolean isSegment = clazz == MemorySegment.class;
         MemoryLayout treeLayout = tree.layout().orElseThrow();
         if (parent != null) { //struct field
             MemoryLayout parentLayout = parentLayout(parent);
-            structBuilder.addVarHandleGetter(fieldName, tree.name(), treeLayout, clazz, parentLayout);
-            structBuilder.addGetter(fieldName, tree.name(), treeLayout, clazz, parentLayout);
-            structBuilder.addSetter(fieldName, tree.name(), treeLayout, clazz, parentLayout);
+            if (isSegment) {
+                structBuilder.addAddressOf(fieldName, tree.name(), treeLayout, clazz, parentLayout);
+            } else {
+                structBuilder.addVarHandleGetter(fieldName, tree.name(), treeLayout, clazz, parentLayout);
+                structBuilder.addGetter(fieldName, tree.name(), treeLayout, clazz, parentLayout);
+                structBuilder.addSetter(fieldName, tree.name(), treeLayout, clazz, parentLayout);
+            }
         } else {
-            builder.addLayoutGetter(fieldName, layout);
-            builder.addVarHandleGetter(fieldName, tree.name(), treeLayout, clazz, null);
-            builder.addAddressGetter(fieldName, tree.name());
-            builder.addGetter(fieldName, tree.name(), treeLayout, clazz, null);
-            builder.addSetter(fieldName, tree.name(), treeLayout, clazz, null);
+            if (isSegment) {
+                builder.addAddressOf(fieldName, tree.name(), treeLayout, clazz, null);
+            } else {
+                builder.addLayoutGetter(fieldName, layout);
+                builder.addVarHandleGetter(fieldName, tree.name(), treeLayout, clazz,null);
+                builder.addAddressGetter(fieldName, tree.name());
+                builder.addGetter(fieldName, tree.name(), treeLayout, clazz, null);
+                builder.addSetter(fieldName, tree.name(), treeLayout, clazz, null);
+            }
         }
 
         return null;

--- a/src/jdk.incubator.jextract/share/classes/jdk/incubator/jextract/tool/OutputFactory.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/incubator/jextract/tool/OutputFactory.java
@@ -381,7 +381,7 @@ public class OutputFactory implements Declaration.Visitor<Void, Declaration> {
             } else {
                 builder.addLayoutGetter(fieldName, layout);
                 builder.addVarHandleGetter(fieldName, tree.name(), treeLayout, clazz,null);
-                builder.addAddressGetter(fieldName, tree.name());
+                builder.addAddressGetter(fieldName, tree.name(), treeLayout);
                 builder.addGetter(fieldName, tree.name(), treeLayout, clazz, null);
                 builder.addSetter(fieldName, tree.name(), treeLayout, clazz, null);
             }

--- a/src/jdk.incubator.jextract/share/classes/jdk/incubator/jextract/tool/StructBuilder.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/incubator/jextract/tool/StructBuilder.java
@@ -79,14 +79,54 @@ class StructBuilder extends JavaSourceBuilder {
 
     @Override
     public void addGetter(String javaName, String nativeName, MemoryLayout layout, Class<?> type, MemoryLayout parentLayout) {
-        super.addGetter(javaName, nativeName, layout, type, parentLayout);
+        incrAlign();
+        indent();
+        sb.append(PUB_MODS + type.getName() + " " + javaName + "$get(MemoryAddress addr) {\n");
+        incrAlign();
+        indent();
+        sb.append("return (" + type.getName() + ")"
+                + varHandleGetCallString(javaName, nativeName, layout, type, parentLayout) + ".get(addr);\n");
+        decrAlign();
+        indent();
+        sb.append("}\n");
+        decrAlign();
+
         addIndexGetter(javaName, nativeName, layout, type, parentLayout);
     }
 
     @Override
     public void addSetter(String javaName, String nativeName, MemoryLayout layout, Class<?> type, MemoryLayout parentLayout) {
-        super.addSetter(javaName, nativeName, layout, type, parentLayout);
+        incrAlign();
+        indent();
+        String param = MemoryAddress.class.getName() + " addr";
+        sb.append(PUB_MODS + "void " + javaName + "$set(" + param + ", " + type.getName() + " x) {\n");
+        incrAlign();
+        indent();
+        sb.append(varHandleGetCallString(javaName, nativeName, layout, type, null) + ".set(addr, x);\n");
+        decrAlign();
+        indent();
+        sb.append("}\n");
+        decrAlign();
+
         addIndexSetter(javaName, nativeName, layout, type, parentLayout);
+    }
+
+    @Override
+    public void addAddressOf(String javaName, String nativeName, MemoryLayout layout, Class<?> type, MemoryLayout parentLayout) {
+        incrAlign();
+        indent();
+        sb.append(PUB_MODS + "MemoryAddress " + javaName + "$addressof(MemoryAddress addr) {\n");
+        incrAlign();
+        indent();
+        sb.append("return addr.segment().asSlice(");
+        sb.append(parentLayout.byteOffset(MemoryLayout.PathElement.groupElement(nativeName)));
+        sb.append(", ");
+        sb.append(layout.byteSize());
+        sb.append(").baseAddress();\n");
+        decrAlign();
+        indent();
+        sb.append("}\n");
+        decrAlign();
     }
 
     private void emitSizeof() {

--- a/src/jdk.incubator.jextract/share/classes/jdk/incubator/jextract/tool/resources/RuntimeHelper.java.template
+++ b/src/jdk.incubator.jextract/share/classes/jdk/incubator/jextract/tool/resources/RuntimeHelper.java.template
@@ -48,8 +48,11 @@ public class RuntimeHelper {
         }
     }
 
-    public static final MemoryAddress lookupGlobalVariable(LibraryLookup[] LIBRARIES, String name) {
-        return lookup(LIBRARIES, name).orElse(null);
+    public static final MemoryAddress lookupGlobalVariable(LibraryLookup[] LIBRARIES, String name, MemoryLayout layout) {
+        return lookup(LIBRARIES, name).map(a ->
+            MemorySegment.ofNativeRestricted(
+                 a, layout.byteSize(), null, null, a
+            ).withAccessModes(MemorySegment.READ | MemorySegment.WRITE).baseAddress()).orElse(null);
     }
 
     public static final MethodHandle downcallHandle(LibraryLookup[] LIBRARIES, String name, String desc, FunctionDescriptor fdesc, boolean variadic) {

--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/clang/libclang/RuntimeHelper.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/clang/libclang/RuntimeHelper.java
@@ -30,6 +30,8 @@ package jdk.internal.clang.libclang;
 import jdk.incubator.foreign.FunctionDescriptor;
 import jdk.incubator.foreign.LibraryLookup;
 import jdk.incubator.foreign.MemoryAddress;
+import jdk.incubator.foreign.MemoryLayout;
+import jdk.incubator.foreign.MemorySegment;
 import jdk.incubator.foreign.SystemABI;
 import jdk.internal.foreign.abi.SharedUtils;
 
@@ -84,8 +86,11 @@ public class RuntimeHelper {
         }
     }
 
-    public static final MemoryAddress lookupGlobalVariable(LibraryLookup[] LIBRARIES, String name) {
-        return lookup(LIBRARIES, name).orElse(null);
+    public static final MemoryAddress lookupGlobalVariable(LibraryLookup[] LIBRARIES, String name, MemoryLayout layout) {
+        return lookup(LIBRARIES, name).map(a ->
+            MemorySegment.ofNativeRestricted(
+                a, layout.byteSize(), null, null, a
+            ).withAccessModes(MemorySegment.READ | MemorySegment.WRITE).baseAddress()).orElse(null);
     }
 
     public static final MethodHandle downcallHandle(LibraryLookup[] LIBRARIES, String name, String desc, FunctionDescriptor fdesc) {

--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/RecordLayoutComputer.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/RecordLayoutComputer.java
@@ -26,6 +26,7 @@
 
 package jdk.internal.jextract.impl;
 
+import jdk.incubator.foreign.GroupLayout;
 import jdk.incubator.foreign.MemoryLayout;
 import jdk.incubator.foreign.ValueLayout;
 import jdk.internal.clang.Cursor;
@@ -103,10 +104,12 @@ abstract class RecordLayoutComputer {
     }
 
     void addFieldLayout(long offset, Type parent, Cursor c) {
-        MemoryLayout MemoryLayout = c.isAnonymousStruct()?
-            compute(offset, parent, c.type()) :
-            fieldLayout(c);
-        addFieldLayout(MemoryLayout);
+        if (c.isAnonymousStruct()) {
+            GroupLayout layout = (GroupLayout) compute(offset, parent, c.type());
+            fieldLayouts.addAll(layout.memberLayouts());
+        } else {
+            addFieldLayout(fieldLayout(c));
+        }
     }
 
     MemoryLayout fieldLayout(Cursor c) {

--- a/test/jdk/tools/jextract/test8245003/Test8245003.java
+++ b/test/jdk/tools/jextract/test8245003/Test8245003.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import org.testng.annotations.Test;
+import test.jextract.test8245003.*;
+import static org.testng.Assert.assertEquals;
+import static test.jextract.test8245003.test8245003_h.*;
+
+/*
+ * @test
+ * @bug 8245003
+ * @summary jextract does not generate accessor for MemorySegement typed values
+ * @library ..
+ * @modules jdk.incubator.jextract
+ * @run driver JtregJextract -l Test8245003 -t test.jextract.test8245003 -- test8245003.h
+ * @run testng/othervm -Dforeign.restricted=permit Test8245003
+ */
+public class Test8245003 {
+    @Test
+    public void testStructAccessor() {
+        var addr = special_pt$addressof();
+        assertEquals(addr.segment().byteSize(), CPoint.sizeof());
+        assertEquals(CPoint.x$get(addr), 56);
+        assertEquals(CPoint.y$get(addr), 75);
+
+        addr = special_pt3d$addressof();
+        assertEquals(addr.segment().byteSize(), CPoint3D.sizeof());
+        assertEquals(CPoint3D.z$get(addr), 35);
+        var pointAddr = CPoint3D.p$addressof(addr);
+        assertEquals(pointAddr.segment().byteSize(), CPoint.sizeof());
+        assertEquals(CPoint.x$get(pointAddr), 43);
+        assertEquals(CPoint.y$get(pointAddr), 45);
+    }
+
+    @Test
+    public void testArrayAccessor() {
+        var addr = iarr$addressof();
+        assertEquals(addr.segment().byteSize(), Cint.sizeof()*5);
+        int[] arr = Cint.toJavaArray(addr.segment());
+        assertEquals(arr.length, 5);
+        assertEquals(arr[0], 2);
+        assertEquals(arr[1], -2);
+        assertEquals(arr[2], 42);
+        assertEquals(arr[3], -42);
+        assertEquals(arr[4], 345);
+
+        addr = foo$addressof();
+        assertEquals(addr.segment().byteSize(), CFoo.sizeof());
+        assertEquals(CFoo.count$get(addr), 37);
+        var greeting = CFoo.greeting$addressof(addr);
+        byte[] barr = Cchar.toJavaArray(greeting.segment());
+        assertEquals(new String(barr), "hello");
+    }
+}

--- a/test/jdk/tools/jextract/test8245003/libTest8245003.c
+++ b/test/jdk/tools/jextract/test8245003/libTest8245003.c
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+#include "test8245003.h"
+
+EXPORT Point special_pt = { 56, 75 };
+
+EXPORT Point3D special_pt3d = { 35, { 43, 45 } };
+
+EXPORT int iarr[5] = { 2, -2, 42, -42, 345 };
+
+EXPORT Foo foo = { 37, { 'h', 'e', 'l', 'l', 'o' } };

--- a/test/jdk/tools/jextract/test8245003/test8245003.h
+++ b/test/jdk/tools/jextract/test8245003/test8245003.h
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+#ifdef __cplusplus
+extern "C" {
+#endif // __cplusplus
+
+#ifdef _WIN64
+#define EXPORT __declspec(dllexport)
+#else
+#define EXPORT
+#endif
+
+typedef struct Point {
+    int x;
+    int y;
+} Point;
+
+EXPORT Point special_pt;
+
+typedef struct Point3D {
+    int z;
+    struct Point p;
+} Point3D;
+
+EXPORT Point3D special_pt3d;
+
+EXPORT int iarr[5];
+
+typedef struct Foo {
+    int count;
+    char greeting[5];
+} Foo;
+
+EXPORT Foo foo;
+
+#ifdef __cplusplus
+}
+#endif // __cplusplus


### PR DESCRIPTION
addressof accessor added for MemorySegment typed values (structs, unions, arrays).
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [JDK-8245003](https://bugs.openjdk.java.net/browse/JDK-8245003): jextract does not generate accessor for MemorySegement typed values


### Reviewers
 * Jorn Vernee ([jvernee](@JornVernee) - Committer)
 * Maurizio Cimadamore ([mcimadamore](@mcimadamore) - Committer)

### Download
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/165/head:pull/165`
`$ git checkout pull/165`
