### PR TITLE
8245066: struct/union/array address accessor should be x$ADDR() for consistency

### DIFF
--- a/src/jdk.incubator.jextract/share/classes/jdk/incubator/jextract/tool/JavaSourceBuilder.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/incubator/jextract/tool/JavaSourceBuilder.java
@@ -115,7 +115,7 @@ abstract class JavaSourceBuilder {
         emitForwardGetter(constantHelper.addMethodHandle(javaName, nativeName, mtype, desc, varargs));
     }
 
-    public void addAddressGetter(String javaName, String nativeName, MemoryLayout layout) {
+    public void addAddressGetter(String javaName, String nativeName, MemoryLayout layout, MemoryLayout parentLayout) {
         emitForwardGetter(constantHelper.addAddress(javaName, nativeName, layout));
     }
 
@@ -146,20 +146,6 @@ abstract class JavaSourceBuilder {
         indent();
         String vhParam = addressGetCallString(javaName, nativeName, layout);
         sb.append(varHandleGetCallString(javaName, nativeName, layout, type, null) + ".set(" + vhParam + ", x);\n");
-        decrAlign();
-        indent();
-        sb.append("}\n");
-        decrAlign();
-    }
-
-    public void addAddressOf(String javaName, String nativeName, MemoryLayout layout, Class<?> type, MemoryLayout parentLayout) {
-        DirectMethodHandleDesc desc = constantHelper.addAddress(javaName, nativeName, layout);
-        incrAlign();
-        indent();
-        sb.append(PUB_MODS + "MemoryAddress " + javaName + "$addressof() {\n");
-        incrAlign();
-        indent();
-        sb.append("return " + getCallString(desc) + ";\n");
         decrAlign();
         indent();
         sb.append("}\n");

--- a/src/jdk.incubator.jextract/share/classes/jdk/incubator/jextract/tool/OutputFactory.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/incubator/jextract/tool/OutputFactory.java
@@ -369,7 +369,7 @@ public class OutputFactory implements Declaration.Visitor<Void, Declaration> {
         if (parent != null) { //struct field
             MemoryLayout parentLayout = parentLayout(parent);
             if (isSegment) {
-                structBuilder.addAddressOf(fieldName, tree.name(), treeLayout, clazz, parentLayout);
+                structBuilder.addAddressGetter(fieldName, tree.name(), treeLayout, parentLayout);
             } else {
                 structBuilder.addVarHandleGetter(fieldName, tree.name(), treeLayout, clazz, parentLayout);
                 structBuilder.addGetter(fieldName, tree.name(), treeLayout, clazz, parentLayout);
@@ -377,11 +377,11 @@ public class OutputFactory implements Declaration.Visitor<Void, Declaration> {
             }
         } else {
             if (isSegment) {
-                builder.addAddressOf(fieldName, tree.name(), treeLayout, clazz, null);
+                builder.addAddressGetter(fieldName, tree.name(), treeLayout, null);
             } else {
                 builder.addLayoutGetter(fieldName, layout);
                 builder.addVarHandleGetter(fieldName, tree.name(), treeLayout, clazz,null);
-                builder.addAddressGetter(fieldName, tree.name(), treeLayout);
+                builder.addAddressGetter(fieldName, tree.name(), treeLayout, null);
                 builder.addGetter(fieldName, tree.name(), treeLayout, clazz, null);
                 builder.addSetter(fieldName, tree.name(), treeLayout, clazz, null);
             }

--- a/src/jdk.incubator.jextract/share/classes/jdk/incubator/jextract/tool/StructBuilder.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/incubator/jextract/tool/StructBuilder.java
@@ -112,10 +112,10 @@ class StructBuilder extends JavaSourceBuilder {
     }
 
     @Override
-    public void addAddressOf(String javaName, String nativeName, MemoryLayout layout, Class<?> type, MemoryLayout parentLayout) {
+    public void addAddressGetter(String javaName, String nativeName, MemoryLayout layout, MemoryLayout parentLayout) {
         incrAlign();
         indent();
-        sb.append(PUB_MODS + "MemoryAddress " + javaName + "$addressof(MemoryAddress addr) {\n");
+        sb.append(PUB_MODS + "MemoryAddress " + javaName + "$ADDR(MemoryAddress addr) {\n");
         incrAlign();
         indent();
         sb.append("return addr.segment().asSlice(");

--- a/src/jdk.incubator.jextract/share/classes/jdk/incubator/jextract/tool/StructBuilder.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/incubator/jextract/tool/StructBuilder.java
@@ -115,7 +115,7 @@ class StructBuilder extends JavaSourceBuilder {
     public void addAddressGetter(String javaName, String nativeName, MemoryLayout layout, MemoryLayout parentLayout) {
         incrAlign();
         indent();
-        sb.append(PUB_MODS + "MemoryAddress " + javaName + "$ADDR(MemoryAddress addr) {\n");
+        sb.append(PUB_MODS + "MemoryAddress " + javaName + "$addr(MemoryAddress addr) {\n");
         incrAlign();
         indent();
         sb.append("return addr.segment().asSlice(");

--- a/test/jdk/tools/jextract/test8244938/Test8244938.java
+++ b/test/jdk/tools/jextract/test8244938/Test8244938.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import org.testng.annotations.Test;
+import static org.testng.Assert.assertEquals;
+import static test.jextract.test8244938.test8244938_h.*;
+
+/*
+ * @test
+ * @bug 8244938
+ * @summary Crash in foreign ABI CallArranger class when a test native function returns a nested struct
+ * @library ..
+ * @modules jdk.incubator.jextract
+ * @run driver JtregJextract -l Test8244938 -t test.jextract.test8244938 -- test8244938.h
+ * @run testng/othervm -Dforeign.restricted=permit Test8244938
+ */
+public class Test8244938 {
+    @Test
+    public void testNestedStructReturn() {
+         var seg = func();
+         assertEquals(seg.byteSize(), CPoint.sizeof());
+         var addr = seg.baseAddress();
+         assertEquals(CPoint.k$get(addr), 44);
+         var point2dAddr = CPoint.point2d$ADDR(addr);
+         assertEquals(CPoint2D.i$get(point2dAddr), 567);
+         assertEquals(CPoint2D.j$get(point2dAddr), 33);
+    }
+}

--- a/test/jdk/tools/jextract/test8244938/Test8244938.java
+++ b/test/jdk/tools/jextract/test8244938/Test8244938.java
@@ -41,7 +41,7 @@ public class Test8244938 {
          assertEquals(seg.byteSize(), CPoint.sizeof());
          var addr = seg.baseAddress();
          assertEquals(CPoint.k$get(addr), 44);
-         var point2dAddr = CPoint.point2d$ADDR(addr);
+         var point2dAddr = CPoint.point2d$addr(addr);
          assertEquals(CPoint2D.i$get(point2dAddr), 567);
          assertEquals(CPoint2D.j$get(point2dAddr), 33);
     }

--- a/test/jdk/tools/jextract/test8244938/libTest8244938.c
+++ b/test/jdk/tools/jextract/test8244938/libTest8244938.c
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+#include "test8244938.h"
+
+struct Point point = { 44, { 567, 33 } };
+struct Point func(void) {
+    return point;
+}

--- a/test/jdk/tools/jextract/test8244938/libTest8244938.c
+++ b/test/jdk/tools/jextract/test8244938/libTest8244938.c
@@ -23,7 +23,7 @@
 
 #include "test8244938.h"
 
-struct Point point = { 44, { 567, 33 } };
-struct Point func(void) {
+static struct Point point = { 44, { 567, 33 } };
+EXPORT struct Point func(void) {
     return point;
 }

--- a/test/jdk/tools/jextract/test8244938/test8244938.h
+++ b/test/jdk/tools/jextract/test8244938/test8244938.h
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+#ifdef __cplusplus
+extern "C" {
+#endif // __cplusplus
+
+#ifdef _WIN64
+#define EXPORT __declspec(dllexport)
+#else
+#define EXPORT
+#endif
+
+struct Point2D {
+   int i, j;
+};
+
+struct Point {
+  int k;
+  struct Point2D point2d;
+};
+
+struct Point func(void);
+
+#ifdef __cplusplus
+}
+#endif // __cplusplus

--- a/test/jdk/tools/jextract/test8244938/test8244938.h
+++ b/test/jdk/tools/jextract/test8244938/test8244938.h
@@ -40,7 +40,7 @@ struct Point {
   struct Point2D point2d;
 };
 
-struct Point func(void);
+EXPORT struct Point func(void);
 
 #ifdef __cplusplus
 }

--- a/test/jdk/tools/jextract/test8245003/Test8245003.java
+++ b/test/jdk/tools/jextract/test8245003/Test8245003.java
@@ -46,7 +46,7 @@ public class Test8245003 {
         addr = special_pt3d$ADDR();
         assertEquals(addr.segment().byteSize(), CPoint3D.sizeof());
         assertEquals(CPoint3D.z$get(addr), 35);
-        var pointAddr = CPoint3D.p$ADDR(addr);
+        var pointAddr = CPoint3D.p$addr(addr);
         assertEquals(pointAddr.segment().byteSize(), CPoint.sizeof());
         assertEquals(CPoint.x$get(pointAddr), 43);
         assertEquals(CPoint.y$get(pointAddr), 45);
@@ -67,7 +67,7 @@ public class Test8245003 {
         addr = foo$ADDR();
         assertEquals(addr.segment().byteSize(), CFoo.sizeof());
         assertEquals(CFoo.count$get(addr), 37);
-        var greeting = CFoo.greeting$ADDR(addr);
+        var greeting = CFoo.greeting$addr(addr);
         byte[] barr = Cchar.toJavaArray(greeting.segment());
         assertEquals(new String(barr), "hello");
     }

--- a/test/jdk/tools/jextract/test8245003/Test8245003.java
+++ b/test/jdk/tools/jextract/test8245003/Test8245003.java
@@ -38,15 +38,15 @@ import static test.jextract.test8245003.test8245003_h.*;
 public class Test8245003 {
     @Test
     public void testStructAccessor() {
-        var addr = special_pt$addressof();
+        var addr = special_pt$ADDR();
         assertEquals(addr.segment().byteSize(), CPoint.sizeof());
         assertEquals(CPoint.x$get(addr), 56);
         assertEquals(CPoint.y$get(addr), 75);
 
-        addr = special_pt3d$addressof();
+        addr = special_pt3d$ADDR();
         assertEquals(addr.segment().byteSize(), CPoint3D.sizeof());
         assertEquals(CPoint3D.z$get(addr), 35);
-        var pointAddr = CPoint3D.p$addressof(addr);
+        var pointAddr = CPoint3D.p$ADDR(addr);
         assertEquals(pointAddr.segment().byteSize(), CPoint.sizeof());
         assertEquals(CPoint.x$get(pointAddr), 43);
         assertEquals(CPoint.y$get(pointAddr), 45);
@@ -54,7 +54,7 @@ public class Test8245003 {
 
     @Test
     public void testArrayAccessor() {
-        var addr = iarr$addressof();
+        var addr = iarr$ADDR();
         assertEquals(addr.segment().byteSize(), Cint.sizeof()*5);
         int[] arr = Cint.toJavaArray(addr.segment());
         assertEquals(arr.length, 5);
@@ -64,10 +64,10 @@ public class Test8245003 {
         assertEquals(arr[3], -42);
         assertEquals(arr[4], 345);
 
-        addr = foo$addressof();
+        addr = foo$ADDR();
         assertEquals(addr.segment().byteSize(), CFoo.sizeof());
         assertEquals(CFoo.count$get(addr), 37);
-        var greeting = CFoo.greeting$addressof(addr);
+        var greeting = CFoo.greeting$ADDR(addr);
         byte[] barr = Cchar.toJavaArray(greeting.segment());
         assertEquals(new String(barr), "hello");
     }


### PR DESCRIPTION
* renamed struct/union/array accessor as x$ADDR
* Piggybacking to add a jextract based test for bug 8244938
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [JDK-8245066](https://bugs.openjdk.java.net/browse/JDK-8245066): struct/union/array address accessor should be x$ADDR() for consistency


### Reviewers
 * Maurizio Cimadamore ([mcimadamore](@mcimadamore) - Committer)

### Download
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/166/head:pull/166`
`$ git checkout pull/166`
