### PR TITLE
Move "owner" field and thread-confinement checks to MemoryScope

### DIFF
--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/AbstractMemorySegmentImpl.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/AbstractMemorySegmentImpl.java
@@ -68,14 +68,12 @@ public abstract class AbstractMemorySegmentImpl implements MemorySegment, Memory
 
     final long length;
     final int mask;
-    final Thread owner;
     final MemoryScope scope;
 
     @ForceInline
-    AbstractMemorySegmentImpl(long length, int mask, Thread owner, MemoryScope scope) {
+    AbstractMemorySegmentImpl(long length, int mask, MemoryScope scope) {
         this.length = length;
         this.mask = mask;
-        this.owner = owner;
         this.scope = scope;
     }
 
@@ -83,7 +81,7 @@ public abstract class AbstractMemorySegmentImpl implements MemorySegment, Memory
 
     abstract Object base();
 
-    abstract AbstractMemorySegmentImpl dup(long offset, long size, int mask, Thread owner, MemoryScope scope);
+    abstract AbstractMemorySegmentImpl dup(long offset, long size, int mask, MemoryScope scope);
 
     abstract ByteBuffer makeByteBuffer();
 
@@ -100,7 +98,7 @@ public abstract class AbstractMemorySegmentImpl implements MemorySegment, Memory
     }
 
     private AbstractMemorySegmentImpl asSliceNoCheck(long offset, long newSize) {
-        return dup(offset, newSize, mask, owner, scope);
+        return dup(offset, newSize, mask, scope);
     }
 
     @SuppressWarnings("unchecked")
@@ -145,12 +143,12 @@ public abstract class AbstractMemorySegmentImpl implements MemorySegment, Memory
 
     @Override
     public final boolean isAlive() {
-        return scope.isAliveThreadSafe();
+        return scope.isAlive();
     }
 
     @Override
     public Thread ownerThread() {
-        return owner;
+        return scope.ownerThread();
     }
 
     @Override
@@ -159,7 +157,7 @@ public abstract class AbstractMemorySegmentImpl implements MemorySegment, Memory
         if ((~accessModes() & accessModes) != 0) {
             throw new UnsupportedOperationException("Cannot acquire more access modes");
         }
-        return dup(0, length, (mask & ~ACCESS_MASK) | accessModes, owner, scope);
+        return dup(0, length, (mask & ~ACCESS_MASK) | accessModes, scope);
     }
 
     @Override
@@ -177,15 +175,14 @@ public abstract class AbstractMemorySegmentImpl implements MemorySegment, Memory
     @Override
     public MemorySegment withOwnerThread(Thread newOwner) {
         Objects.requireNonNull(newOwner);
-        checkValidState();
         if (!isSet(HANDOFF)) {
             throw unsupportedAccessMode(HANDOFF);
         }
-        if (owner == newOwner) {
+        if (scope.ownerThread() == newOwner) {
             throw new IllegalArgumentException("Segment already owned by thread: " + newOwner);
         } else {
             try {
-                return dup(0L, length, mask, newOwner, scope.dup());
+                return dup(0L, length, mask, scope.dup(newOwner));
             } finally {
                 //flush read/writes to segment memory before returning the new segment
                 VarHandle.fullFence();
@@ -198,7 +195,6 @@ public abstract class AbstractMemorySegmentImpl implements MemorySegment, Memory
         if (!isSet(CLOSE)) {
             throw unsupportedAccessMode(CLOSE);
         }
-        checkValidState();
         closeNoCheck();
     }
 
@@ -210,7 +206,7 @@ public abstract class AbstractMemorySegmentImpl implements MemorySegment, Memory
         if (Thread.currentThread() != ownerThread() && !isSet(ACQUIRE)) {
             throw unsupportedAccessMode(ACQUIRE);
         }
-        return dup(0, length, mask, Thread.currentThread(), scope.acquire());
+        return dup(0, length, mask, scope.acquire());
     }
 
     @Override
@@ -227,7 +223,7 @@ public abstract class AbstractMemorySegmentImpl implements MemorySegment, Memory
     }
 
     void checkRange(long offset, long length, boolean writeAccess) {
-        checkValidState();
+        scope.checkValidState();
         if (writeAccess && !isSet(WRITE)) {
             throw unsupportedAccessMode(WRITE);
         } else if (!writeAccess && !isSet(READ)) {
@@ -238,10 +234,7 @@ public abstract class AbstractMemorySegmentImpl implements MemorySegment, Memory
 
     @Override
     public final void checkValidState() {
-        if (owner != null && owner != Thread.currentThread()) {
-            throw new IllegalStateException("Attempt to access segment outside owning thread");
-        }
-        scope.checkAliveConfined();
+        scope.checkValidState();
     }
 
     // Helper methods
@@ -415,29 +408,28 @@ public abstract class AbstractMemorySegmentImpl implements MemorySegment, Memory
         AbstractMemorySegmentImpl bufferSegment = (AbstractMemorySegmentImpl)nioAccess.bufferSegment(bb);
         final MemoryScope bufferScope;
         int modes;
-        final Thread owner;
         if (bufferSegment != null) {
             bufferScope = bufferSegment.scope;
             modes = bufferSegment.mask;
-            owner = bufferSegment.owner;
         } else {
             bufferScope = MemoryScope.create(bb, null);
             modes = defaultAccessModes(size);
-            owner = Thread.currentThread();
         }
         if (bb.isReadOnly()) {
             modes &= ~WRITE;
         }
         if (base != null) {
-            return new HeapMemorySegmentImpl<>(bbAddress + pos, () -> (byte[])base, size, modes, owner, bufferScope);
+            return new HeapMemorySegmentImpl<>(bbAddress + pos, () -> (byte[])base, size, modes, bufferScope);
         } else if (unmapper == null) {
-            return new NativeMemorySegmentImpl(bbAddress + pos, size, modes, owner, bufferScope);
+            return new NativeMemorySegmentImpl(bbAddress + pos, size, modes, bufferScope);
         } else {
-            return new MappedMemorySegmentImpl(bbAddress + pos, unmapper, size, modes, owner, bufferScope);
+            return new MappedMemorySegmentImpl(bbAddress + pos, unmapper, size, modes, bufferScope);
         }
     }
 
-    public static AbstractMemorySegmentImpl NOTHING = new AbstractMemorySegmentImpl(0, 0, null, MemoryScope.GLOBAL) {
+    public static AbstractMemorySegmentImpl NOTHING = new AbstractMemorySegmentImpl(
+        0, 0, MemoryScope.createUnchecked(null, null, null)
+    ) {
         @Override
         ByteBuffer makeByteBuffer() {
             throw new UnsupportedOperationException();
@@ -454,7 +446,7 @@ public abstract class AbstractMemorySegmentImpl implements MemorySegment, Memory
         }
 
         @Override
-        AbstractMemorySegmentImpl dup(long offset, long size, int mask, Thread owner, MemoryScope scope) {
+        AbstractMemorySegmentImpl dup(long offset, long size, int mask, MemoryScope scope) {
             throw new UnsupportedOperationException();
         }
     };

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/HeapMemorySegmentImpl.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/HeapMemorySegmentImpl.java
@@ -52,8 +52,8 @@ public class HeapMemorySegmentImpl<H> extends AbstractMemorySegmentImpl {
     final Supplier<H> baseProvider;
 
     @ForceInline
-    HeapMemorySegmentImpl(long offset, Supplier<H> baseProvider, long length, int mask, Thread owner, MemoryScope scope) {
-        super(length, mask, owner, scope);
+    HeapMemorySegmentImpl(long offset, Supplier<H> baseProvider, long length, int mask, MemoryScope scope) {
+        super(length, mask, scope);
         this.offset = offset;
         this.baseProvider = baseProvider;
     }
@@ -69,8 +69,8 @@ public class HeapMemorySegmentImpl<H> extends AbstractMemorySegmentImpl {
     }
 
     @Override
-    HeapMemorySegmentImpl<H> dup(long offset, long size, int mask, Thread owner, MemoryScope scope) {
-        return new HeapMemorySegmentImpl<H>(this.offset + offset, baseProvider, size, mask, owner, scope);
+    HeapMemorySegmentImpl<H> dup(long offset, long size, int mask, MemoryScope scope) {
+        return new HeapMemorySegmentImpl<>(this.offset + offset, baseProvider, size, mask, scope);
     }
 
     @Override
@@ -122,6 +122,6 @@ public class HeapMemorySegmentImpl<H> extends AbstractMemorySegmentImpl {
     static <Z> HeapMemorySegmentImpl<Z> makeHeapSegment(Supplier<Z> obj, int length, int base, int scale) {
         int byteSize = length * scale;
         MemoryScope scope = MemoryScope.create(null, null);
-        return new HeapMemorySegmentImpl<>(base, obj, byteSize, defaultAccessModes(byteSize), Thread.currentThread(), scope);
+        return new HeapMemorySegmentImpl<>(base, obj, byteSize, defaultAccessModes(byteSize), scope);
     }
 }

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/MappedMemorySegmentImpl.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/MappedMemorySegmentImpl.java
@@ -48,8 +48,8 @@ public class MappedMemorySegmentImpl extends NativeMemorySegmentImpl implements 
 
     private final UnmapperProxy unmapper;
 
-    MappedMemorySegmentImpl(long min, UnmapperProxy unmapper, long length, int mask, Thread owner, MemoryScope scope) {
-        super(min, length, mask, owner, scope);
+    MappedMemorySegmentImpl(long min, UnmapperProxy unmapper, long length, int mask, MemoryScope scope) {
+        super(min, length, mask, scope);
         this.unmapper = unmapper;
     }
 
@@ -60,8 +60,8 @@ public class MappedMemorySegmentImpl extends NativeMemorySegmentImpl implements 
     }
 
     @Override
-    MappedMemorySegmentImpl dup(long offset, long size, int mask, Thread owner, MemoryScope scope) {
-        return new MappedMemorySegmentImpl(min + offset, unmapper, size, mask, owner, scope);
+    MappedMemorySegmentImpl dup(long offset, long size, int mask, MemoryScope scope) {
+        return new MappedMemorySegmentImpl(min + offset, unmapper, size, mask, scope);
     }
 
     // mapped segment methods
@@ -105,7 +105,7 @@ public class MappedMemorySegmentImpl extends NativeMemorySegmentImpl implements 
             UnmapperProxy unmapperProxy = channelImpl.mapInternal(mapMode, 0L, bytesSize);
             MemoryScope scope = MemoryScope.create(null, unmapperProxy::unmap);
             return new MappedMemorySegmentImpl(unmapperProxy.address(), unmapperProxy, bytesSize,
-                    defaultAccessModes(bytesSize), Thread.currentThread(), scope);
+                    defaultAccessModes(bytesSize), scope);
         }
     }
 

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/MemoryScope.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/MemoryScope.java
@@ -265,7 +265,7 @@ abstract class MemoryScope {
             // enter critical section - no acquires are possible past this point
             long stamp = lock.writeLock();
             try {
-                checkAliveConfined(this); // plain read is enough here (full write lock)
+                checkValidState(); // plain read is enough here (full write lock)
                 // check for absence of active acquired children
                 if (acquired.sum() > 0) {
                     throw new IllegalStateException("Cannot close this scope as it has active acquired children");

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/MemoryScope.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/MemoryScope.java
@@ -26,38 +26,73 @@
 
 package jdk.internal.foreign;
 
+import jdk.internal.vm.annotation.ForceInline;
+
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.VarHandle;
+import java.util.Objects;
 import java.util.concurrent.atomic.LongAdder;
 import java.util.concurrent.locks.StampedLock;
 
 /**
- * This class manages the temporal bounds associated with a memory segment. A scope has a liveness bit, which is updated
- * when the scope is closed (this operation is triggered by {@link AbstractMemorySegmentImpl#close()}). Furthermore,
- * a scope is either root scope ({@link #create(Object, Runnable) created} when memory segment is allocated) or child scope
- * ({@link #acquire() acquired} from root scope). When a child scope is acquired from another child scope, it is actually
- * acquired from the root scope. There is only a single level of children. All child scopes are peers.
- * A child scope can be {@link #close() closed} at any time, but root scope can only be closed after all its children
- * have been closed, at which time any associated cleanup action is executed (the associated memory segment is freed).
+ * This class manages the temporal bounds associated with a memory segment as well
+ * as thread confinement.
+ * A scope has a liveness bit, which is updated when the scope is closed
+ * (this operation is triggered by {@link AbstractMemorySegmentImpl#close()}).
+ * A scope may also have an associated "owner" thread that confines some operations to
+ * associated owner thread such as {@link #close()} or {@link #dup(Thread)}.
+ * Furthermore, a scope is either root scope ({@link #create(Object, Runnable) created}
+ * when memory segment is allocated) or child scope ({@link #acquire() acquired} from root scope).
+ * When a child scope is acquired from another child scope, it is actually acquired from
+ * the root scope. There is only a single level of children. All child scopes are peers.
+ * A child scope can be {@link #close() closed} at any time, but root scope can only
+ * be closed after all its children have been closed, at which time any associated
+ * cleanup action is executed (the associated memory segment is freed).
+ * Besides thread-confined checked scopes, {@linkplain #createUnchecked(Object, Runnable, Thread)}
+ * method may be used passing {@code null} as the "owner" thread to create an
+ * unchecked scope that doesn't check for thread-confinement or temporal bounds.
  */
 abstract class MemoryScope {
-    public static final MemoryScope GLOBAL = new Root(null, null);
 
     /**
-     * Creates a root MemoryScope with given ref and cleanupAction.
-     * The returned instance may be published unsafely to and used in any thread, but methods that explicitly state that
-     * they may only be called in "owner" thread, must strictly be called in single thread that has been selected to be the
-     * "owner" thread.
+     * Creates a root MemoryScope with given ref, cleanupAction and current
+     * thread as the "owner" thread.
+     * This method may be called in any thread.
+     * The returned instance may be published unsafely to and used in any thread,
+     * but methods that explicitly state that they may only be called in "owner" thread,
+     * must strictly be called in the thread that created the scope
+     * or else IllegalStateException is thrown.
      *
      * @param ref           an optional reference to an instance that needs to be kept reachable
      * @param cleanupAction an optional cleanup action to be executed when returned scope is closed
      * @return a root MemoryScope
      */
     static MemoryScope create(Object ref, Runnable cleanupAction) {
-        return new Root(ref, cleanupAction);
+        return new Root(Thread.currentThread(), ref, cleanupAction);
     }
 
-    boolean closed = false;
+    /**
+     * Creates a root MemoryScope with given ref, cleanupAction and "owner" thread.
+     * This method may be called in any thread.
+     * The returned instance may be published unsafely to and used in any thread,
+     * but methods that explicitly state that they may only be called in "owner" thread,
+     * must strictly be called in given owner thread or else IllegalStateException is thrown.
+     * If given owner thread is null, the returned MemoryScope is unchecked, meaning
+     * that all methods may be called in any thread and that {@link #checkValidState()}
+     * does not check for temporal bounds.
+     *
+     * @param ref           an optional reference to an instance that needs to be kept reachable
+     * @param cleanupAction an optional cleanup action to be executed when returned scope is closed
+     * @param owner         the desired owner thread. If {@code owner == null},
+     *                      the returned scope is <em>not</em> thread-confined and not checked.
+     * @return a root MemoryScope
+     */
+    static MemoryScope createUnchecked(Object ref, Runnable cleanupAction, Thread owner) {
+        return new Root(owner, ref, cleanupAction);
+    }
+
+    private final Thread owner;
+    boolean closed; // = false
     private static final VarHandle CLOSED;
 
     static {
@@ -68,15 +103,18 @@ abstract class MemoryScope {
         }
     }
 
-    private MemoryScope() {
+    private MemoryScope(Thread owner) {
+        this.owner = owner;
     }
 
     /**
-     * Acquires a child scope (or peer scope if this is a child).
+     * Acquires a child scope (or peer scope if this is a child) with current
+     * thread as the "owner" thread.
      * This method may be called in any thread.
-     * The returned instance may be published unsafely to and used in any thread, but methods that explicitly state that
-     * they may only be called in "owner" thread, must strictly be called in single thread that has been selected to be the
-     * "owner" thread.
+     * The returned instance may be published unsafely to and used in any thread,
+     * but methods that explicitly state that they may only be called in "owner" thread,
+     * must strictly be called in the thread that acquired the scope
+     * or else IllegalStateException is thrown.
      *
      * @return a child (or peer) scope
      * @throws IllegalStateException if root scope is already closed
@@ -85,44 +123,83 @@ abstract class MemoryScope {
 
     /**
      * Closes this scope, executing any cleanup action if this is the root scope.
-     * This method may only be called in "owner" thread.
+     * This method may only be called in "owner" thread of this scope unless the
+     * scope is a root scope with no owner thread - i.e. is not checked.
      *
      * @throws IllegalStateException if this scope is already closed or if this is
      *                               a root scope and there is/are still active child
-     *                               scope(s).
+     *                               scope(s) or if this method is called outside of
+     *                               owner thread in checked scope
      */
     abstract void close();
 
     /**
-     * Duplicates this scope and {@link #close() closes} it. If this is a root scope,
-     * new root scope is returned. If this is a child scope, new child scope is returned.
-     * This method may only be called in "owner" thread.
-     * The returned instance may be published unsafely to and used in any thread, but methods that explicitly state that
-     * they may only be called in "owner" thread, must strictly be called in single thread that has been selected to be the
-     * "owner" thread.
+     * Duplicates this scope with given new "owner" thread and {@link #close() closes} it.
+     * If this is a root scope, new root scope is returned, this root scope is closed but
+     * eventual cleanup action is not executed yet - it is inherited by duped scope.
+     * If this is a child scope, new child scope is returned.
+     * This method may only be called in "owner" thread of this scope unless the
+     * scope is a root scope with no owner thread - i.e. is not checked.
+     * The returned instance may be published unsafely to and used in any thread,
+     * but methods that explicitly state that they may only be called in "owner" thread,
+     * must strictly be called in given new "owner" thread
+     * or else IllegalStateException is thrown.
      *
+     * @param owner new owner thread of the returned MemoryScope
      * @return a duplicate of this scope
+     * @throws NullPointerException  if given owner thread is null
      * @throws IllegalStateException if this scope is already closed or if this is
      *                               a root scope and there is/are still active child
-     *                               scope(s).
+     *                               scope(s) or if this method is called outside of
+     *                               owner thread in checked scope
      */
-    abstract MemoryScope dup();
+    abstract MemoryScope dup(Thread owner);
+
+    /**
+     * Returns "owner" thread of this scope.
+     *
+     * @return owner thread (or null for unchecked scope)
+     */
+    final Thread ownerThread() {
+        return owner;
+    }
 
     /**
      * This method may be called in any thread.
      *
      * @return {@code true} if this scope is not closed yet.
      */
-    final boolean isAliveThreadSafe() {
+    final boolean isAlive() {
         return !((boolean)CLOSED.getVolatile(this));
     }
 
     /**
+     * Checks that this scope is still alive and that this method is executed
+     * in the "owner" thread of this scope or this scope is unchecked (not associated
+     * with owner thread).
+     *
+     * @throws IllegalStateException if this scope is already closed or this
+     *                               method is executed outside owning thread
+     *                               in checked scope
+     */
+    @ForceInline
+    final void checkValidState() {
+        if (owner != null) {
+            if (owner != Thread.currentThread()) {
+                throw new IllegalStateException("Attempted access outside owning thread");
+            }
+            checkAliveConfined();
+        }
+    }
+
+    /**
      * Checks that this scope is still alive.
-     * This method may only be called in "owner" thread.
+     * This method is a MemoryScope internal API and is package-private only
+     * as an implementation detail. Not for direct consumption from other classes.
      *
      * @throws IllegalStateException if this scope is already closed
      */
+    @ForceInline
     final void checkAliveConfined() {
         if (closed) {
             throw new IllegalStateException("This scope is already closed");
@@ -130,22 +207,20 @@ abstract class MemoryScope {
     }
 
     private static final class Root extends MemoryScope {
+        private final StampedLock lock = new StampedLock();
         private final LongAdder acquired = new LongAdder();
         private final Object ref;
         private final Runnable cleanupAction;
 
-        private final StampedLock lock = new StampedLock();
-
-
-
-        private Root(Object ref, Runnable cleanupAction) {
+        private Root(Thread owner, Object ref, Runnable cleanupAction) {
+            super(owner);
             this.ref = ref;
             this.cleanupAction = cleanupAction;
         }
 
         @Override
         MemoryScope acquire() {
-            //try to optimistically acquire the lock
+            // try to optimistically acquire the lock
             long stamp = lock.tryOptimisticRead();
             try {
                 for (; ; stamp = lock.readLock()) {
@@ -158,7 +233,7 @@ abstract class MemoryScope {
                     // did a call to close() occur since we acquired the lock?
                     if (lock.validate(stamp)) {
                         // no, just return the acquired scope
-                        return new Child();
+                        return new Child(Thread.currentThread());
                     } else {
                         // yes, just back off and retry (close might have failed, after all)
                         acquired.decrement();
@@ -171,18 +246,19 @@ abstract class MemoryScope {
         }
 
         @Override
-        MemoryScope dup() { // always called in owner thread
-            return closeOrDup(false);
+        MemoryScope dup(Thread owner) {
+            Objects.requireNonNull(owner, "owner");
+            return closeOrDup(owner);
         }
 
         @Override
-        void close() { // always called in owner thread
-            closeOrDup(true);
+        void close() {
+            closeOrDup(null);
         }
 
-        private MemoryScope closeOrDup(boolean close) {
+        private MemoryScope closeOrDup(Thread newOwner) {
             // pre-allocate duped scope so we don't get OOME later and be left with this scope closed
-            var duped = close ? null : new Root(ref, cleanupAction);
+            var duped = newOwner == null ? null : new Root(newOwner, ref, cleanupAction);
             // enter critical section - no acquires are possible past this point
             long stamp = lock.writeLock();
             try {
@@ -199,7 +275,7 @@ abstract class MemoryScope {
             }
 
             // do close or dup
-            if (close) {
+            if (duped == null) {
                 if (cleanupAction != null) {
                     cleanupAction.run();
                 }
@@ -211,7 +287,8 @@ abstract class MemoryScope {
 
         private final class Child extends MemoryScope {
 
-            private Child() {
+            private Child(Thread owner) {
+                super(owner);
             }
 
             @Override
@@ -220,17 +297,17 @@ abstract class MemoryScope {
             }
 
             @Override
-            MemoryScope dup() { // always called in owner thread
-                checkAliveConfined();
+            MemoryScope dup(Thread newOwner) {
+                checkValidState(); // child scope is always checked
                 // pre-allocate duped scope so we don't get OOME later and be left with this scope closed
-                var duped = new Child();
+                var duped = new Child(newOwner);
                 CLOSED.setVolatile(this, true);
                 return duped;
             }
 
             @Override
-            void close() { // always called in owner thread
-                checkAliveConfined();
+            void close() {
+                checkValidState(); // child scope is always checked
                 closed = true;
                 // following acts as a volatile write after plain write above so
                 // plain write gets flushed too (which is important for isAliveThreadSafe())

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/NativeMemorySegmentImpl.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/NativeMemorySegmentImpl.java
@@ -53,14 +53,14 @@ public class NativeMemorySegmentImpl extends AbstractMemorySegmentImpl {
     final long min;
 
     @ForceInline
-    NativeMemorySegmentImpl(long min, long length, int mask, Thread owner, MemoryScope scope) {
-        super(length, mask, owner, scope);
+    NativeMemorySegmentImpl(long min, long length, int mask, MemoryScope scope) {
+        super(length, mask, scope);
         this.min = min;
     }
 
     @Override
-    NativeMemorySegmentImpl dup(long offset, long size, int mask, Thread owner, MemoryScope scope) {
-        return new NativeMemorySegmentImpl(min + offset, size, mask, owner, scope);
+    NativeMemorySegmentImpl dup(long offset, long size, int mask, MemoryScope scope) {
+        return new NativeMemorySegmentImpl(min + offset, size, mask, scope);
     }
 
     @Override
@@ -94,8 +94,9 @@ public class NativeMemorySegmentImpl extends AbstractMemorySegmentImpl {
         }
         long alignedBuf = Utils.alignUp(buf, alignmentBytes);
         MemoryScope scope = MemoryScope.create(null, () -> unsafe.freeMemory(buf));
-        MemorySegment segment = new NativeMemorySegmentImpl(buf, alignedSize, defaultAccessModes(alignedSize),
-                Thread.currentThread(), scope);
+        MemorySegment segment = new NativeMemorySegmentImpl(buf, alignedSize,
+                                                            defaultAccessModes(alignedSize),
+                                                            scope);
         if (alignedSize != bytesSize) {
             long delta = alignedBuf - buf;
             segment = segment.asSlice(delta, bytesSize);
@@ -104,7 +105,7 @@ public class NativeMemorySegmentImpl extends AbstractMemorySegmentImpl {
     }
 
     public static MemorySegment makeNativeSegmentUnchecked(MemoryAddress min, long bytesSize, Thread owner, Runnable cleanup, Object attachment) {
-        MemoryScope scope = MemoryScope.create(attachment, cleanup);
-        return new NativeMemorySegmentImpl(min.toRawLongValue(), bytesSize, defaultAccessModes(bytesSize), owner, scope);
+        MemoryScope scope = MemoryScope.createUnchecked(attachment, cleanup, owner);
+        return new NativeMemorySegmentImpl(min.toRawLongValue(), bytesSize, defaultAccessModes(bytesSize), scope);
     }
 }

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/NativeMemorySegmentImpl.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/NativeMemorySegmentImpl.java
@@ -105,7 +105,7 @@ public class NativeMemorySegmentImpl extends AbstractMemorySegmentImpl {
     }
 
     public static MemorySegment makeNativeSegmentUnchecked(MemoryAddress min, long bytesSize, Thread owner, Runnable cleanup, Object attachment) {
-        MemoryScope scope = MemoryScope.createUnchecked(attachment, cleanup, owner);
+        MemoryScope scope = MemoryScope.createUnchecked(owner, attachment, cleanup);
         return new NativeMemorySegmentImpl(min.toRawLongValue(), bytesSize, defaultAccessModes(bytesSize), scope);
     }
 }


### PR DESCRIPTION
Now MemoryScope is simplified, I re-based this change and am opening this PR on top. Currently MemorySegment is encapsulating thread-confinement logic and state (owner field) while MemoryScope is encapsulating temporal-confinement logic and state. But the interplay between the two must be very carefully caried out (for example, close() or dup() on child scopes may only be called in owner thread). By moving the thread-confinement logic and state to MemoryScope, I think we get better encapsulation as all MemoryScope methods become "safe" - some can still be called in owner thread only, but failing to do so throws IllegalSateException instead of exhibiting undefined behavior.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * Maurizio Cimadamore ([mcimadamore](@mcimadamore) - Committer)

### Download
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/167/head:pull/167`
`$ git checkout pull/167`
