### PR TITLE
Move MemoryAddress::copy (ABI version)

### DIFF
--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/BindingInterpreter.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/BindingInterpreter.java
@@ -67,7 +67,7 @@ public class BindingInterpreter {
                     MemorySegment operand = (MemorySegment) stack.pop();
                     assert operand.byteSize() == binding.size() : "operand size mismatch";
                     MemorySegment copy = MemorySegment.allocateNative(binding.size(), binding.alignment());
-                    MemoryAddress.copy(operand.baseAddress(), copy.baseAddress(), binding.size());
+                    copy.copyFrom(operand.asSlice(0, binding.size()));
                     buffers.add(copy);
                     stack.push(copy);
                 }
@@ -106,7 +106,7 @@ public class BindingInterpreter {
                     MemoryAddress operand = (MemoryAddress) stack.pop();
                     operand = MemoryAddressImpl.ofLongUnchecked(operand.toRawLongValue(), binding.size());
                     MemorySegment copy = MemorySegment.allocateNative(binding.size(), binding.alignment());
-                    MemoryAddress.copy(operand, copy.baseAddress(), binding.size());
+                    copy.copyFrom(operand.segment().asSlice(0, binding.size()));
                     stack.push(copy); // leaked
                 }
                 case ALLOC_BUFFER -> {

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/SharedUtils.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/SharedUtils.java
@@ -180,9 +180,8 @@ public class SharedUtils {
     }
 
     private static MemoryAddress bufferCopy(MemoryAddress dest, MemorySegment buffer) {
-        MemoryAddress.copy(buffer.baseAddress(),
-                MemoryAddressImpl.ofLongUnchecked(dest.toRawLongValue(), buffer.byteSize()),
-                buffer.byteSize());
+        MemoryAddressImpl.ofLongUnchecked(dest.toRawLongValue(), buffer.byteSize())
+                .segment().copyFrom(buffer);
         return dest;
     }
 

--- a/test/jdk/java/foreign/Cstring.java
+++ b/test/jdk/java/foreign/Cstring.java
@@ -42,7 +42,7 @@ public final class Cstring {
 
     private static void copy(MemoryAddress addr, byte[] bytes) {
         var heapSegment = MemorySegment.ofArray(bytes);
-        MemoryAddress.copy(heapSegment.baseAddress(), addr, bytes.length);
+        addr.segment().copyFrom(heapSegment);
         byteArrHandle.set(addr, (long)bytes.length, (byte)0);
     }
 


### PR DESCRIPTION
This simple patch fixes references to MemoryAddress::copy from the ABI code and tests.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * Jorn Vernee ([jvernee](@JornVernee) - Committer)

### Download
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/170/head:pull/170`
`$ git checkout pull/170`
