### PR TITLE
Move MemoryAddress::copy (jextract version)

### DIFF
--- a/src/jdk.incubator.jextract/share/classes/jdk/incubator/jextract/tool/resources/C-X.java.template
+++ b/src/jdk.incubator.jextract/share/classes/jdk/incubator/jextract/tool/resources/C-X.java.template
@@ -23,11 +23,6 @@ public class C-X {
     private static final VarHandle handle = LAYOUT.varHandle(CARRIER);
     private static final VarHandle arrayHandle = arrayHandle(LAYOUT, CARRIER);
 
-    private static void copy(MemoryAddress addr, ${CARRIER}[] arr) {
-        var heapSegment = MemorySegment.ofArray(arr);
-        addr.segment().copyFrom(heapSegment);
-    }
-
     public static ${CARRIER} get(MemoryAddress addr) {
         return (${CARRIER}) handle.get(addr);
     }
@@ -69,14 +64,14 @@ public class C-X {
     public static MemorySegment allocateArray(${CARRIER}[] arr) {
         var arrLayout = MemoryLayout.ofSequence(arr.length, LAYOUT);
         var seg = MemorySegment.allocateNative(arrLayout);
-        copy(seg.baseAddress(), arr);
+        seg.copyFrom(MemorySegment.ofArray(arr));
         return seg;
     }
 
     public static MemoryAddress allocateArray(${CARRIER}[] arr, NativeAllocationScope scope) {
         var arrLayout = MemoryLayout.ofSequence(arr.length, LAYOUT);
         var addr = scope.allocate(arrLayout);
-        copy(addr, arr);
+        addr.segment().copyFrom(MemorySegment.ofArray(arr));
         return addr;
     }
 

--- a/src/jdk.incubator.jextract/share/classes/jdk/incubator/jextract/tool/resources/C-X.java.template
+++ b/src/jdk.incubator.jextract/share/classes/jdk/incubator/jextract/tool/resources/C-X.java.template
@@ -25,7 +25,7 @@ public class C-X {
 
     private static void copy(MemoryAddress addr, ${CARRIER}[] arr) {
         var heapSegment = MemorySegment.ofArray(arr);
-        MemoryAddress.copy(heapSegment.baseAddress(), addr, arr.length * sizeof());
+        addr.segment().copyFrom(heapSegment);
     }
 
     public static ${CARRIER} get(MemoryAddress addr) {
@@ -91,7 +91,7 @@ public class C-X {
             throw new UnsupportedOperationException("segment cannot contain integral number of elements");
         }
         ${CARRIER}[] array = new ${CARRIER}[(int) (segSize / elemSize)];
-        MemoryAddress.copy(seg.baseAddress(), MemorySegment.ofArray(array).baseAddress(), array.length * elemSize);
+        MemorySegment.ofArray(array).copyFrom(seg);
         return array;
     }
 }

--- a/src/jdk.incubator.jextract/share/classes/jdk/incubator/jextract/tool/resources/Cstring.java.template
+++ b/src/jdk.incubator.jextract/share/classes/jdk/incubator/jextract/tool/resources/Cstring.java.template
@@ -19,12 +19,6 @@ public final class Cstring {
     }
     private final static VarHandle byteArrHandle = arrayHandle(C_CHAR, byte.class);
 
-    private static void copy(MemoryAddress addr, byte[] bytes) {
-        var heapSegment = MemorySegment.ofArray(bytes);
-        addr.segment().copyFrom(heapSegment);
-        byteArrHandle.set(addr, (long)bytes.length, (byte)0);
-    }
-
     private static MemorySegment toCString(byte[] bytes) {
         MemoryLayout strLayout = MemoryLayout.ofSequence(bytes.length + 1, C_CHAR);
         MemorySegment segment = MemorySegment.allocateNative(strLayout);
@@ -36,7 +30,7 @@ public final class Cstring {
     private static MemoryAddress toCString(byte[] bytes, NativeAllocationScope scope) {
         MemoryLayout strLayout = MemoryLayout.ofSequence(bytes.length + 1, C_CHAR);
         MemoryAddress addr = scope.allocate(strLayout);
-        copy(addr, bytes);
+        addr.segment().copyFrom(MemorySegment.ofArray(bytes));
         return addr;
     }
 
@@ -47,6 +41,15 @@ public final class Cstring {
     public static void copy(MemoryAddress addr, String str, Charset charset) {
         copy(addr, str.getBytes(charset));
     }
+
+    //where
+    private static void copy(MemoryAddress addr, byte[] bytes) {
+            var heapSegment = MemorySegment.ofArray(bytes);
+            addr.segment()
+                    .asSlice(addr.segmentOffset(), bytes.length)
+                    .copyFrom(heapSegment);
+            byteArrHandle.set(addr, (long)bytes.length, (byte)0);
+        }
 
     public static MemorySegment toCString(String str) {
          return toCString(str.getBytes());

--- a/src/jdk.incubator.jextract/share/classes/jdk/incubator/jextract/tool/resources/Cstring.java.template
+++ b/src/jdk.incubator.jextract/share/classes/jdk/incubator/jextract/tool/resources/Cstring.java.template
@@ -21,7 +21,7 @@ public final class Cstring {
 
     private static void copy(MemoryAddress addr, byte[] bytes) {
         var heapSegment = MemorySegment.ofArray(bytes);
-        MemoryAddress.copy(heapSegment.baseAddress(), addr, bytes.length);
+        addr.segment().copyFrom(heapSegment);
         byteArrHandle.set(addr, (long)bytes.length, (byte)0);
     }
 


### PR DESCRIPTION
This patch addresses the remaining issues with jextrct templating mentioning the old MemoryAddress:copy method.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * Jorn Vernee ([jvernee](@JornVernee) - Committer)

### Download
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/171/head:pull/171`
`$ git checkout pull/171`
