### PR TITLE
Clarify exception behaviour for MemorySegment::toByteArray when the segment does not feature the READ access mode.

### DIFF
--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/MemorySegment.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/MemorySegment.java
@@ -356,8 +356,8 @@ public interface MemorySegment extends AutoCloseable {
     /**
      * Copy the contents of this memory segment into a fresh byte array.
      * @return a fresh byte array copy of this memory segment.
-     * @throws UnsupportedOperationException if this segment's contents cannot be copied into a {@link byte[]} instance,
-     * e.g. its size is greater than {@link Integer#MAX_VALUE}.
+     * @throws UnsupportedOperationException if the segment does not feature the {@link #READ} access mode, or if this
+     * segment's contents cannot be copied into a {@link byte[]} instance, e.g. its size is greater than {@link Integer#MAX_VALUE},
      * @throws IllegalStateException if this segment has been closed, or if access occurs from a thread other than the
      * thread owning this segment.
      */

--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/MemorySegment.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/MemorySegment.java
@@ -356,7 +356,7 @@ public interface MemorySegment extends AutoCloseable {
     /**
      * Copy the contents of this memory segment into a fresh byte array.
      * @return a fresh byte array copy of this memory segment.
-     * @throws UnsupportedOperationException if the segment does not feature the {@link #READ} access mode, or if this
+     * @throws UnsupportedOperationException if this segment does not feature the {@link #READ} access mode, or if this
      * segment's contents cannot be copied into a {@link byte[]} instance, e.g. its size is greater than {@link Integer#MAX_VALUE},
      * @throws IllegalStateException if this segment has been closed, or if access occurs from a thread other than the
      * thread owning this segment.

--- a/test/jdk/java/foreign/TestArrays.java
+++ b/test/jdk/java/foreign/TestArrays.java
@@ -39,6 +39,8 @@ import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 
 import org.testng.annotations.*;
+
+import static jdk.incubator.foreign.MemorySegment.READ;
 import static org.testng.Assert.*;
 
 public class TestArrays {
@@ -113,6 +115,20 @@ public class TestArrays {
     public void testArrayFromClosedSegment() {
         MemorySegment segment = MemorySegment.allocateNative(8);
         segment.close();
+        segment.toByteArray();
+    }
+
+    @Test(expectedExceptions = UnsupportedOperationException.class)
+    public void testArrayFromHeapSegmentWithoutAccess() {
+        MemorySegment segment = MemorySegment.ofArray(new byte[8]);
+        segment = segment.withAccessModes(segment.accessModes() & ~READ);
+        segment.toByteArray();
+    }
+
+    @Test(expectedExceptions = UnsupportedOperationException.class)
+    public void testArrayFromNativeSegmentWithoutAccess() {
+        MemorySegment segment = MemorySegment.allocateNative(8);
+        segment = segment.withAccessModes(segment.accessModes() & ~READ);
         segment.toByteArray();
     }
 


### PR DESCRIPTION
Clarify exception behaviour for MemorySegment::toByteArray when the segment does not feature the READ access mode.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * Jorn Vernee ([jvernee](@JornVernee) - Committer)

### Download
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/178/head:pull/178`
`$ git checkout pull/178`
