### PR TITLE
Add MemorySegment::mismatch

### DIFF
--- a/src/java.base/share/classes/jdk/internal/util/ArraysSupport.java
+++ b/src/java.base/share/classes/jdk/internal/util/ArraysSupport.java
@@ -171,12 +171,7 @@ public class ArraysSupport {
         long remaining = length;
         int i ;
         while (remaining > 7) {
-            int size;
-            if (remaining > Integer.MAX_VALUE) {
-                size = Integer.MAX_VALUE;
-            } else {
-                size = (int) remaining;
-            }
+            int size = (int) Math.min(Integer.MAX_VALUE, remaining);
             i = vectorizedMismatch(
                     a, aOffset + off,
                     b, bOffset + off,

--- a/src/java.base/share/classes/jdk/internal/util/ArraysSupport.java
+++ b/src/java.base/share/classes/jdk/internal/util/ArraysSupport.java
@@ -160,6 +160,37 @@ public class ArraysSupport {
         }
     }
 
+    /**
+     * Mismatch over long lengths.
+     */
+    public static long vectorizedMismatchLarge(Object a, long aOffset,
+                                               Object b, long bOffset,
+                                               long length,
+                                               int log2ArrayIndexScale) {
+        long off = 0;
+        long remaining = length;
+        int i ;
+        while (remaining > 7) {
+            int size;
+            if (remaining > Integer.MAX_VALUE) {
+                size = Integer.MAX_VALUE;
+            } else {
+                size = (int) remaining;
+            }
+            i = vectorizedMismatch(
+                    a, aOffset + off,
+                    b, bOffset + off,
+                    size, log2ArrayIndexScale);
+            if (i >= 0)
+                return off + i;
+
+            i = size - ~i;
+            off += i;
+            remaining -= i;
+        }
+        return ~off;
+    }
+
     // Booleans
     // Each boolean element takes up one byte
 

--- a/src/java.base/share/classes/module-info.java
+++ b/src/java.base/share/classes/module-info.java
@@ -231,6 +231,8 @@ module java.base {
         jdk.internal.vm.ci,
         jdk.incubator.foreign,
         jdk.unsupported;
+    exports jdk.internal.util to
+            jdk.incubator.foreign;
     exports jdk.internal.util.jar to
         jdk.jartool;
     exports jdk.internal.util.xml to

--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/MemorySegment.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/MemorySegment.java
@@ -344,7 +344,8 @@ public interface MemorySegment extends AutoCloseable {
      * between the two segments at that offset within the respective segments.
      * If one segment is a proper prefix of the other then the returned offset is
      * the smaller of the segment sizes, and it follows that the offset is only
-     * valid for the larger segment. Otherwise, there is no mismatch.
+     * valid for the larger segment. Otherwise, there is no mismatch and {@code
+     * -1} is returned.
      *
      * @param other the segment to be tested for a mismatch with this segment
      * @return the relative offset, in bytes, of the first mismatch between this

--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/MemorySegment.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/MemorySegment.java
@@ -333,6 +333,31 @@ public interface MemorySegment extends AutoCloseable {
     void copyFrom(MemorySegment src);
 
     /**
+     * Finds and returns the offset, in bytes, of the first mismatch between
+     * this segment and a given other segment. The offset is relative to the
+     * {@link #baseAddress() base address} of each segment and will be in the
+     * range of 0 (inclusive) up to the {@link #byteSize() size} (in bytes) of
+     * the smaller memory segment (exclusive).
+     * <p>
+     * If the two segments share a common prefix then the returned offset is
+     * the length of the common prefix and it follows that there is a mismatch
+     * between the two segments at that offset within the respective segments.
+     * If one segment is a proper prefix of the other then the returned offset is
+     * the smaller of the segment sizes, and it follows that the offset is only
+     * valid for the larger segment. Otherwise, there is no mismatch.
+     *
+     * @param other the segment to be tested for a mismatch with this segment
+     * @return the relative offset, in bytes, of the first mismatch between this
+     * and the given other segment, otherwise -1 if no mismatch
+     * @throws IllegalStateException if either this segment of the other segment
+     * have been already closed, or if access occurs from a thread other than the
+     * thread owning either segment
+     * @throws UnsupportedOperationException if either this segment or the other
+     * segment does not feature at least the {@link MemorySegment#READ} access mode
+     */
+    long mismatch(MemorySegment other);
+
+    /**
      * Wraps this segment in a {@link ByteBuffer}. Some of the properties of the returned buffer are linked to
      * the properties of this segment. For instance, if this segment is <em>immutable</em>
      * (e.g. the segment has access mode {@link #READ} but not {@link #WRITE}), then the resulting buffer is <em>read-only</em>

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/AbstractMemorySegmentImpl.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/AbstractMemorySegmentImpl.java
@@ -160,7 +160,6 @@ public abstract class AbstractMemorySegmentImpl implements MemorySegment, Memory
             }
             i = length - ~i;
         }
-
         MemoryAddress thisAddress = this.baseAddress();
         MemoryAddress thatAddress = that.baseAddress();
         for (; i < length; i++) {

--- a/test/jdk/java/foreign/TestMismatch.java
+++ b/test/jdk/java/foreign/TestMismatch.java
@@ -1,0 +1,236 @@
+/*
+ *  Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ *  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ *  This code is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License version 2 only, as
+ *  published by the Free Software Foundation.
+ *
+ *  This code is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ *  version 2 for more details (a copy is included in the LICENSE file that
+ *  accompanied this code).
+ *
+ *  You should have received a copy of the GNU General Public License version
+ *  2 along with this work; if not, write to the Free Software Foundation,
+ *  Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ *  Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ *  or visit www.oracle.com if you need additional information or have any
+ *  questions.
+ */
+
+/*
+ * @test
+ * @run testng TestMismatch
+ */
+
+import java.lang.invoke.VarHandle;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.IntFunction;
+import jdk.incubator.foreign.MemoryAddress;
+import jdk.incubator.foreign.MemoryLayouts;
+import jdk.incubator.foreign.MemorySegment;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+import static java.lang.System.out;
+import static jdk.incubator.foreign.MemorySegment.READ;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertThrows;
+
+public class TestMismatch {
+
+    final static VarHandle BYTE_HANDLE = MemoryLayouts.JAVA_BYTE.varHandle(byte.class);
+
+    // stores a increasing sequence of values into the memory of the given segment
+    static MemorySegment initializeSegment(MemorySegment segment) {
+        MemoryAddress addr = segment.baseAddress();
+        for (int i = 0 ; i < segment.byteSize() ; i++) {
+            BYTE_HANDLE.set(addr.addOffset(i), (byte)i);
+        }
+        return segment;
+    }
+
+    @Test(dataProvider = "slices")
+    public void testSameValues(MemorySegment ss1, MemorySegment ss2) {
+        out.format("testSameValues s1:%s, s2:%s\n", ss1, ss2);
+        MemorySegment s1 = initializeSegment(ss1);
+        MemorySegment s2 = initializeSegment(ss2);
+
+        if (s1.byteSize() == s2.byteSize()) {
+            assertEquals(s1.mismatch(s2), -1);  // identical
+            assertEquals(s2.mismatch(s1), -1);
+        } else if (s1.byteSize() > s2.byteSize()) {
+            assertEquals(s1.mismatch(s2), s2.byteSize());  // proper prefix
+            assertEquals(s2.mismatch(s1), s2.byteSize());
+        } else {
+            assert s1.byteSize() < s2.byteSize();
+            assertEquals(s1.mismatch(s2), s1.byteSize());  // proper prefix
+            assertEquals(s2.mismatch(s1), s1.byteSize());
+        }
+    }
+
+    @Test(dataProvider = "slices")
+    public void testDifferentValues(MemorySegment s1, MemorySegment s2) {
+        out.format("testDifferentValues s1:%s, s2:%s\n", s1, s2);
+        s1 = initializeSegment(s1);
+        s2 = initializeSegment(s2);
+
+        for (long i = s2.byteSize() -1 ; i >= 0; i--) {
+            long expectedMismatchOffset = i;
+            BYTE_HANDLE.set(s2.baseAddress().addOffset(i), (byte) 0xFF);
+
+            if (s1.byteSize() == s2.byteSize()) {
+                assertEquals(s1.mismatch(s2), expectedMismatchOffset);
+                assertEquals(s2.mismatch(s1), expectedMismatchOffset);
+            } else if (s1.byteSize() > s2.byteSize()) {
+                assertEquals(s1.mismatch(s2), expectedMismatchOffset);
+                assertEquals(s2.mismatch(s1), expectedMismatchOffset);
+            } else {
+                assert s1.byteSize() < s2.byteSize();
+                var off = Math.min(s1.byteSize(), expectedMismatchOffset);
+                assertEquals(s1.mismatch(s2), off);  // proper prefix
+                assertEquals(s2.mismatch(s1), off);
+            }
+        }
+    }
+
+    @Test
+    public void testEmpty() {
+        var s1 = MemorySegment.ofArray(new byte[0]);
+        assertEquals(s1.mismatch(s1), -1);
+        try (var nativeSegment = MemorySegment.allocateNative(4)) {
+            var s2 = nativeSegment.asSlice(0, 0);
+            assertEquals(s1.mismatch(s2), -1);
+            assertEquals(s2.mismatch(s1), -1);
+        }
+    }
+
+    @Test
+    public void testLarge() {
+        try (var s1 = MemorySegment.allocateNative((long)Integer.MAX_VALUE + 10L);
+             var s2 = MemorySegment.allocateNative((long)Integer.MAX_VALUE + 10L)) {
+            assertEquals(s1.mismatch(s1), -1);
+            assertEquals(s1.mismatch(s2), -1);
+            assertEquals(s2.mismatch(s1), -1);
+
+            for (long i = s2.byteSize() -1 ; i >= Integer.MAX_VALUE - 10L; i--) {
+                BYTE_HANDLE.set(s2.baseAddress().addOffset(i), (byte) 0xFF);
+                long expectedMismatchOffset = i;
+                assertEquals(s1.mismatch(s2), expectedMismatchOffset);
+                assertEquals(s2.mismatch(s1), expectedMismatchOffset);
+            }
+        }
+    }
+
+    static final Class<IllegalStateException> ISE = IllegalStateException.class;
+    static final Class<UnsupportedOperationException> UOE = UnsupportedOperationException.class;
+
+    @Test
+    public void testClosed() {
+        var s1 = MemorySegment.ofArray(new byte[4]);
+        var s2 = MemorySegment.ofArray(new byte[4]);
+        s1.close();
+        assertThrows(ISE, () -> s1.mismatch(s1));
+        assertThrows(ISE, () -> s1.mismatch(s2));
+        assertThrows(ISE, () -> s2.mismatch(s1));
+    }
+
+    @Test
+    public void testInsufficientAccessModes() {
+        var s1 = MemorySegment.ofArray(new byte[4]);
+        var s2 = MemorySegment.ofArray(new byte[4]);
+        var s1WithoutRead = s1.withAccessModes(s1.accessModes() & ~READ);
+        var s2WithoutRead = s2.withAccessModes(s2.accessModes() & ~READ);
+
+        assertThrows(UOE, () -> s1.mismatch(s2WithoutRead));
+        assertThrows(UOE, () -> s1WithoutRead.mismatch(s2));
+        assertThrows(UOE, () -> s1WithoutRead.mismatch(s2WithoutRead));
+    }
+
+    @Test
+    public void testThreadAccess() throws Exception {
+        var segment = MemorySegment.ofArray(new byte[4]);
+        {
+            AtomicReference<RuntimeException> exception = new AtomicReference<>();
+            Runnable action = () -> {
+                try {
+                    MemorySegment.ofArray(new byte[4]).mismatch(segment);
+                } catch (RuntimeException e) {
+                    exception.set(e);
+                }
+            };
+            Thread thread = new Thread(action);
+            thread.start();
+            thread.join();
+
+            RuntimeException e = exception.get();
+            if (!(e instanceof IllegalStateException)) {
+                throw e;
+            }
+        }
+        {
+            AtomicReference<RuntimeException> exception = new AtomicReference<>();
+            Runnable action = () -> {
+                try {
+                    segment.mismatch(MemorySegment.ofArray(new byte[4]));
+                } catch (RuntimeException e) {
+                    exception.set(e);
+                }
+            };
+            Thread thread = new Thread(action);
+            thread.start();
+            thread.join();
+
+            RuntimeException e = exception.get();
+            if (!(e instanceof IllegalStateException)) {
+                throw e;
+            }
+        }
+    }
+
+    enum SegmentKind {
+        NATIVE(MemorySegment::allocateNative),
+        ARRAY(i -> MemorySegment.ofArray(new byte[i]));
+
+        final IntFunction<MemorySegment> segmentFactory;
+
+        SegmentKind(IntFunction<MemorySegment> segmentFactory) {
+            this.segmentFactory = segmentFactory;
+        }
+
+        MemorySegment makeSegment(int elems) {
+            return segmentFactory.apply(elems);
+        }
+    }
+
+    @DataProvider(name = "slices")
+    static Object[][] slices() {
+        int[] sizes = { 16, 8, 4, 2, 1 };
+        List<MemorySegment> aSlices = new ArrayList<>();
+        List<MemorySegment> bSlices = new ArrayList<>();
+        for (List<MemorySegment> slices : List.of(aSlices, bSlices)) {
+            for (SegmentKind kind : SegmentKind.values()) {
+                MemorySegment segment = kind.makeSegment(16);
+                //compute all slices
+                for (int size : sizes) {
+                    for (int index = 0 ; index < 16 ; index += size) {
+                        MemorySegment slice = segment.asSlice(index, size);
+                        slices.add(slice);
+                    }
+                }
+            }
+        }
+        assert aSlices.size() == bSlices.size();
+        Object[][] sliceArray = new Object[aSlices.size() * bSlices.size()][];
+        for (int i = 0 ; i < aSlices.size() ; i++) {
+            for (int j = 0 ; j < bSlices.size() ; j++) {
+                sliceArray[i * aSlices.size() + j] = new Object[] { aSlices.get(i), bSlices.get(j) };
+            }
+        }
+        return sliceArray;
+    }
+}

--- a/test/jdk/java/foreign/TestMismatch.java
+++ b/test/jdk/java/foreign/TestMismatch.java
@@ -209,7 +209,7 @@ public class TestMismatch {
 
     @DataProvider(name = "slices")
     static Object[][] slices() {
-        int[] sizes = { 16, 8, 4, 2, 1 };
+        int[] sizes = { 16, 8, 1 };
         List<MemorySegment> aSlices = new ArrayList<>();
         List<MemorySegment> bSlices = new ArrayList<>();
         for (List<MemorySegment> slices : List.of(aSlices, bSlices)) {

--- a/test/jdk/java/foreign/TestMismatch.java
+++ b/test/jdk/java/foreign/TestMismatch.java
@@ -151,6 +151,12 @@ public class TestMismatch {
         assertThrows(UOE, () -> s1WithoutRead.mismatch(s2WithoutRead));
     }
 
+    @Test(expectedExceptions = NullPointerException.class)
+    public void testNull() {
+        var segment = MemorySegment.ofArray(new byte[4]);
+        segment.mismatch(null);
+    }
+
     @Test
     public void testThreadAccess() throws Exception {
         var segment = MemorySegment.ofArray(new byte[4]);


### PR DESCRIPTION
Hi,

As part of feedback on the Foreign Memory API (when experimenting with its usage internally in the JDK), a small number of potential usability enhancements could be made to the API. This is the fourth such, and last on my current todo list.

This change proposes to add a new method:
MemorySegment::mismatch

The mismatch semantic is very useful for building equality and comparison logic on top of segments. I found that I needed such when modeling and comparing native socket address in the JDK implementation. It is possible to write your own, but requires a non-trivial amount of not-trivial code - to do it right! I also think that we can provide a more efficient implementation building on top of the JDK's internal mismatch support.

I still need to do some perf testing and add a micro-benchmake ( Maurizio suggested possibly amending TestBulkOps ). There is also the question about possibly improving the JDK's internal implementation to work on long sizes (which could be done separately). For now, I just want to share the idea, along with the proposed specification and initial implementation.

Comments welcome.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * Maurizio Cimadamore ([mcimadamore](@mcimadamore) - Committer)
 * Paul Sandoz ([psandoz](@PaulSandoz) - Committer) ⚠️ Review applies to caf136fde6fb6a97cbb47ea6fd4c47208280d81f

### Download
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/180/head:pull/180`
`$ git checkout pull/180`
