### PR TITLE
8245988: Add a special VaList carrier

### DIFF
--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/CSupport.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/CSupport.java
@@ -55,31 +55,137 @@ public class CSupport {
     }
 
     /**
+     * An interface that models a C {@code va_list}.
+     *
      * Per the C specification (see C standard 6.5.2.2 Function calls - item 6),
      * arguments to variadic calls are erased by way of 'default argument promotions',
      * which erases integral types by way of integer promotion (see C standard 6.3.1.1 - item 2),
      * and which erases all {@code float} arguments to {@code double}.
      *
-     * As such, this reader interface only supports reading {@code int}, {@code double},
-     * and any other type that fits into a {@code long} (when given it's layout).
+     * As such, this interface only supports reading {@code int}, {@code double},
+     * and any other type that fits into a {@code long}.
      */
-    public interface VaList extends AutoCloseable /* permits */ {
+    public interface VaList extends AutoCloseable {
+
+        /**
+         * Reads a value into an {@code int}
+         *
+         * @param layout the layout of the value
+         * @return the value read as an {@code int}
+         */
         int readInt(MemoryLayout layout);
+
+        /**
+         * Reads a value into a {@code long}
+         *
+         * @param layout the layout of the value
+         * @return the value read as an {@code long}
+         */
         long readLong(MemoryLayout layout);
+
+        /**
+         * Reads a value into a {@code double}
+         *
+         * @param layout the layout of the value
+         * @return the value read as an {@code double}
+         */
         double readDouble(MemoryLayout layout);
+
+        /**
+         * Reads a value into a {@code MemoryAddress}
+         *
+         * @param layout the layout of the value
+         * @return the value read as an {@code MemoryAddress}
+         */
         MemoryAddress readPointer(MemoryLayout layout);
+
+        /**
+         * Reads a value into a {@code MemorySegment}
+         *
+         * @param layout the layout of the value
+         * @return the value read as an {@code MemorySegment}
+         */
         MemorySegment readStructOrUnion(MemoryLayout layout);
+
+        /**
+         * Skips a number of va arguments with the given memory layouts.
+         *
+         * @param layouts the layout of the value
+         */
         void skip(MemoryLayout...layouts);
 
+        /**
+         * A predicate used to check if this va list is alive,
+         * or in other words; if {@code close()} has been called on this
+         * va list.
+         *
+         * @return true if this va list is still alive.
+         * @see #close()
+         */
         boolean isAlive();
+
+        /**
+         * Closes this va list, releasing any resources it was using.
+         *
+         * @see #isAlive()
+         */
         void close();
+
+        /**
+         * Copies this va list.
+         *
+         * @return a copy of this va list.
+         */
         VaList copy();
 
+        /**
+         * A builder interface used to construct a va list.
+         */
         interface Builder {
+
+            /**
+             * Adds a native value represented as an {@code int} to the va list.
+             *
+             * @param layout the native layout of the value.
+             * @param value the value, represented as an {@code int}.
+             * @return this builder.
+             */
             Builder intArg(MemoryLayout layout, int value);
+
+            /**
+             * Adds a native value represented as a {@code long} to the va list.
+             *
+             * @param layout the native layout of the value.
+             * @param value the value, represented as a {@code long}.
+             * @return this builder.
+             */
             Builder longArg(MemoryLayout layout, long value);
+
+            /**
+             * Adds a native value represented as a {@code double} to the va list.
+             *
+             * @param layout the native layout of the value.
+             * @param value the value, represented as a {@code double}.
+             * @return this builder.
+             */
             Builder doubleArg(MemoryLayout layout, double value);
+
+            /**
+             * Adds a native value represented as a {@code MemoryAddress} to the va list.
+             *
+             * @param layout the native layout of the value.
+             * @param value the value, represented as a {@code MemoryAddress}.
+             * @return this builder.
+             */
             Builder memoryAddressArg(MemoryLayout layout, MemoryAddress value);
+
+            /**
+             * Adds a native value represented as a {@code MemorySegment} to the va list.
+             *
+             * @param layout the native layout of the value.
+             * @param value the value, represented as a {@code MemorySegment}.
+             * @return this builder.
+             */
             Builder memorySegmentArg(MemoryLayout layout, MemorySegment value);
         }
     }

--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/CSupport.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/CSupport.java
@@ -139,6 +139,23 @@ public class CSupport {
         VaList copy();
 
         /**
+         * Returns the underlying memory address of this va list.
+         *
+         * @return the address
+         */
+        MemoryAddress toAddress();
+
+        /**
+         * Constructs a {@code VaList} out of the memory address of a va_list.
+         *
+         * @param ma the memory address
+         * @return the new {@code VaList}.
+         */
+        static VaList ofAddress(MemoryAddress ma) {
+            return SharedUtils.newVaListOfAddress(ma);
+        }
+
+        /**
          * A builder interface used to construct a va list.
          */
         interface Builder {

--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/CSupport.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/CSupport.java
@@ -73,7 +73,7 @@ public class CSupport {
          * @param layout the layout of the value
          * @return the value read as an {@code int}
          */
-        int readInt(MemoryLayout layout);
+        int vargAsInt(MemoryLayout layout);
 
         /**
          * Reads a value into a {@code long}
@@ -81,7 +81,7 @@ public class CSupport {
          * @param layout the layout of the value
          * @return the value read as an {@code long}
          */
-        long readLong(MemoryLayout layout);
+        long vargAsLong(MemoryLayout layout);
 
         /**
          * Reads a value into a {@code double}
@@ -89,7 +89,7 @@ public class CSupport {
          * @param layout the layout of the value
          * @return the value read as an {@code double}
          */
-        double readDouble(MemoryLayout layout);
+        double vargAsDouble(MemoryLayout layout);
 
         /**
          * Reads a value into a {@code MemoryAddress}
@@ -97,7 +97,7 @@ public class CSupport {
          * @param layout the layout of the value
          * @return the value read as an {@code MemoryAddress}
          */
-        MemoryAddress readPointer(MemoryLayout layout);
+        MemoryAddress vargAsAddress(MemoryLayout layout);
 
         /**
          * Reads a value into a {@code MemorySegment}
@@ -105,7 +105,7 @@ public class CSupport {
          * @param layout the layout of the value
          * @return the value read as an {@code MemorySegment}
          */
-        MemorySegment readStructOrUnion(MemoryLayout layout);
+        MemorySegment vargAsSegment(MemoryLayout layout);
 
         /**
          * Skips a number of va arguments with the given memory layouts.
@@ -167,7 +167,7 @@ public class CSupport {
              * @param value the value, represented as an {@code int}.
              * @return this builder.
              */
-            Builder intArg(MemoryLayout layout, int value);
+            Builder vargFromInt(MemoryLayout layout, int value);
 
             /**
              * Adds a native value represented as a {@code long} to the va list.
@@ -176,7 +176,7 @@ public class CSupport {
              * @param value the value, represented as a {@code long}.
              * @return this builder.
              */
-            Builder longArg(MemoryLayout layout, long value);
+            Builder vargFromLong(MemoryLayout layout, long value);
 
             /**
              * Adds a native value represented as a {@code double} to the va list.
@@ -185,7 +185,7 @@ public class CSupport {
              * @param value the value, represented as a {@code double}.
              * @return this builder.
              */
-            Builder doubleArg(MemoryLayout layout, double value);
+            Builder vargFromDouble(MemoryLayout layout, double value);
 
             /**
              * Adds a native value represented as a {@code MemoryAddress} to the va list.
@@ -194,7 +194,7 @@ public class CSupport {
              * @param value the value, represented as a {@code MemoryAddress}.
              * @return this builder.
              */
-            Builder memoryAddressArg(MemoryLayout layout, MemoryAddress value);
+            Builder vargFromAddress(MemoryLayout layout, MemoryAddress value);
 
             /**
              * Adds a native value represented as a {@code MemorySegment} to the va list.
@@ -203,7 +203,7 @@ public class CSupport {
              * @param value the value, represented as a {@code MemorySegment}.
              * @return this builder.
              */
-            Builder memorySegmentArg(MemoryLayout layout, MemorySegment value);
+            Builder vargFromSegment(MemoryLayout layout, MemorySegment value);
         }
     }
 

--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/CSupport.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/CSupport.java
@@ -54,30 +54,26 @@ public class CSupport {
         return SharedUtils.newVaList(actions);
     }
 
+    /**
+     * Per the C specification (see C standard 6.5.2.2 Function calls - item 6),
+     * arguments to variadic calls are erased by way of 'default argument promotions',
+     * which erases integral types by way of integer promotion (see C standard 6.3.1.1 - item 2),
+     * and which erases all {@code float} arguments to {@code double}.
+     *
+     * As such, this reader interface only supports reading {@code int}, {@code double},
+     * and any other type that fits into a {@code long} (when given it's layout).
+     */
     public interface VaList extends AutoCloseable /* permits */ {
-        Reader reader(int num);
+        int readInt(MemoryLayout layout);
+        long readLong(MemoryLayout layout);
+        double readDouble(MemoryLayout layout);
+        MemoryAddress readPointer(MemoryLayout layout);
+        MemorySegment readStructOrUnion(MemoryLayout layout);
+        void skip(MemoryLayout...layouts);
+
         boolean isAlive();
         void close();
-
-        /**
-         * Reader interface used to read values from a va_list
-         *
-         * Per the C specification (see C standard 6.5.2.2 Function calls - item 6),
-         * arguments to variadic calls are erased by way of 'default argument promotions',
-         * which erases integral types by way of integer promotion (see C standard 6.3.1.1 - item 2),
-         * and which erases all {@code float} arguments to {@code double}.
-         *
-         * As such, this reader interface only supports reading {@code int}, {@code double},
-         * and any other type that fits into a {@code long} (when given it's layout).
-         */
-        interface Reader {
-            int readInt(MemoryLayout layout);
-            long readLong(MemoryLayout layout);
-            double readDouble(MemoryLayout layout);
-            MemoryAddress readPointer(MemoryLayout layout);
-            MemorySegment readStructOrUnion(MemoryLayout layout);
-            void skip(MemoryLayout...layouts);
-        }
+        VaList copy();
 
         interface Builder {
             Builder intArg(MemoryLayout layout, int value);

--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/CSupport.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/CSupport.java
@@ -29,6 +29,7 @@ import jdk.internal.foreign.Utils;
 import jdk.internal.foreign.abi.SharedUtils;
 
 import java.nio.ByteOrder;
+import java.util.function.Consumer;
 
 /**
  * A set of utilities for working with libraries using the C language/ABI
@@ -47,6 +48,44 @@ public class CSupport {
     public static ForeignLinker getSystemLinker() {
         Utils.checkRestrictedAccess("CSupport.getSystemLinker");
         return SharedUtils.getSystemLinker();
+    }
+
+    public static VaList newVaList(Consumer<VaList.Builder> actions) {
+        return SharedUtils.newVaList(actions);
+    }
+
+    public interface VaList extends AutoCloseable /* permits */ {
+        Reader reader(int num);
+        boolean isAlive();
+        void close();
+
+        /**
+         * Reader interface used to read values from a va_list
+         *
+         * Per the C specification (see C standard 6.5.2.2 Function calls - item 6),
+         * arguments to variadic calls are erased by way of 'default argument promotions',
+         * which erases integral types by way of integer promotion (see C standard 6.3.1.1 - item 2),
+         * and which erases all {@code float} arguments to {@code double}.
+         *
+         * As such, this reader interface only supports reading {@code int}, {@code double},
+         * and any other type that fits into a {@code long} (when given it's layout).
+         */
+        interface Reader {
+            int readInt(MemoryLayout layout);
+            long readLong(MemoryLayout layout);
+            double readDouble(MemoryLayout layout);
+            MemoryAddress readPointer(MemoryLayout layout);
+            MemorySegment readStructOrUnion(MemoryLayout layout);
+            void skip(MemoryLayout...layouts);
+        }
+
+        interface Builder {
+            Builder intArg(MemoryLayout layout, int value);
+            Builder longArg(MemoryLayout layout, long value);
+            Builder doubleArg(MemoryLayout layout, double value);
+            Builder memoryAddressArg(MemoryLayout layout, MemoryAddress value);
+            Builder memorySegmentArg(MemoryLayout layout, MemorySegment value);
+        }
     }
 
     /**
@@ -89,6 +128,11 @@ public class CSupport {
      * The {@code T*} native type.
      */
     public static final ValueLayout C_POINTER = Utils.pick(SysV.C_POINTER, Win64.C_POINTER, AArch64.C_POINTER);
+
+    /**
+     * The {@code va_list} native type.
+     */
+    public static final MemoryLayout C_VA_LIST = Utils.pick(SysV.C_VA_LIST, Win64.C_VA_LIST, null);
 
     /**
      * This class defines layout constants modelling standard primitive types supported by the x64 SystemV ABI.
@@ -178,6 +222,11 @@ public class CSupport {
          */
         public static final ValueLayout C_POINTER = MemoryLayouts.BITS_64_LE
                 .withAttribute(CLASS_ATTRIBUTE_NAME, ArgumentClass.POINTER);
+
+        /**
+         * The {@code va_list} native type, as it is passed to a function.
+         */
+        public static final MemoryLayout C_VA_LIST = SysV.C_POINTER;
     }
 
     /**
@@ -263,6 +312,11 @@ public class CSupport {
          */
         public static final ValueLayout C_POINTER = MemoryLayouts.BITS_64_LE
                 .withAttribute(CLASS_ATTRIBUTE_NAME, ArgumentClass.POINTER);
+
+        /**
+         * The {@code va_list} native type, as it is passed to a function.
+         */
+        public static final MemoryLayout C_VA_LIST = Win64.C_POINTER;
 
         public static ValueLayout asVarArg(ValueLayout l) {
             return l.withAttribute(VARARGS_ATTRIBUTE_NAME, "true");

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/Utils.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/Utils.java
@@ -67,6 +67,11 @@ public final class Utils {
         return (n + alignment - 1) & -alignment;
     }
 
+    public static MemoryAddress alignUp(MemoryAddress ma, long alignment) {
+        long offset = ma.toRawLongValue();
+        return ma.addOffset(alignUp(offset, alignment) - offset);
+    }
+
     public static long bitsToBytesOrThrow(long bits, Supplier<RuntimeException> exFactory) {
         if (bits % 8 == 0) {
             return bits / 8;

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/SharedUtils.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/SharedUtils.java
@@ -262,11 +262,6 @@ public class SharedUtils {
             ? MemoryHandles.asAddressVarHandle(layout.varHandle(primitiveCarrierForSize(layout.byteSize())))
             : layout.varHandle(carrier);
     }
-
-    public static MemorySegment withOwnerThreadOrNoOp(MemorySegment segment, Thread thread) {
-        return segment.ownerThread() != thread ? segment.withOwnerThread(thread) : segment;
-    }
-
     public static class SimpleVaArg {
         public final Class<?> carrier;
         public final MemoryLayout layout;

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/SharedUtils.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/SharedUtils.java
@@ -24,10 +24,12 @@
  */
 package jdk.internal.foreign.abi;
 
+import jdk.incubator.foreign.CSupport;
 import jdk.incubator.foreign.ForeignLinker;
 import jdk.incubator.foreign.FunctionDescriptor;
 import jdk.incubator.foreign.GroupLayout;
 import jdk.incubator.foreign.MemoryAddress;
+import jdk.incubator.foreign.MemoryHandles;
 import jdk.incubator.foreign.MemoryLayout;
 import jdk.incubator.foreign.MemorySegment;
 import jdk.incubator.foreign.SequenceLayout;
@@ -41,7 +43,9 @@ import jdk.internal.foreign.abi.x64.windows.Windowsx64Linker;
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.MethodType;
+import java.lang.invoke.VarHandle;
 import java.util.List;
+import java.util.function.Consumer;
 import java.util.stream.IntStream;
 
 import static java.lang.invoke.MethodHandles.collectArguments;
@@ -49,6 +53,7 @@ import static java.lang.invoke.MethodHandles.identity;
 import static java.lang.invoke.MethodHandles.insertArguments;
 import static java.lang.invoke.MethodHandles.permuteArguments;
 import static java.lang.invoke.MethodType.methodType;
+import static jdk.incubator.foreign.CSupport.*;
 
 public class SharedUtils {
 
@@ -185,15 +190,15 @@ public class SharedUtils {
         return dest;
     }
 
-    private static void checkCompatibleType(Class<?> carrier, MemoryLayout layout, long addressSize) {
+    public static void checkCompatibleType(Class<?> carrier, MemoryLayout layout, long addressSize) {
         if (carrier.isPrimitive()) {
             Utils.checkPrimitiveCarrierCompat(carrier, layout);
         } else if (carrier == MemoryAddress.class) {
             Utils.checkLayoutType(layout, ValueLayout.class);
             if (layout.bitSize() != addressSize)
                 throw new IllegalArgumentException("Address size mismatch: " + addressSize + " != " + layout.bitSize());
-        } else if(carrier == MemorySegment.class) {
-           Utils.checkLayoutType(layout, GroupLayout.class);
+        } else if (carrier == MemorySegment.class) {
+            Utils.checkLayoutType(layout, GroupLayout.class);
         } else {
             throw new IllegalArgumentException("Unsupported carrier: " + carrier);
         }
@@ -240,5 +245,43 @@ public class SharedUtils {
             return AArch64Linker.getInstance();
         }
         throw new UnsupportedOperationException("Unsupported os or arch: " + os + ", " + arch);
+    }
+
+    public static VaList newVaList(Consumer<VaList.Builder> actions) {
+        String name = CSupport.getSystemLinker().name();
+        return switch(name) {
+            case Win64.NAME -> Windowsx64Linker.newVaList(actions);
+            case SysV.NAME -> SysVx64Linker.newVaList(actions);
+            case AArch64.NAME -> throw new UnsupportedOperationException("Not yet implemented for this platform");
+            default -> throw new IllegalStateException("Unknown linker name: " + name);
+        };
+    }
+
+    public static VarHandle vhPrimitiveOrAddress(Class<?> carrier, MemoryLayout layout) {
+        return carrier == MemoryAddress.class
+            ? MemoryHandles.asAddressVarHandle(layout.varHandle(primitiveCarrierForSize(layout.byteSize())))
+            : layout.varHandle(carrier);
+    }
+
+    public static MemorySegment withOwnerThreadOrNoOp(MemorySegment segment, Thread thread) {
+        return segment.ownerThread() != thread ? segment.withOwnerThread(thread) : segment;
+    }
+
+    public static class SimpleVaArg {
+        public final Class<?> carrier;
+        public final MemoryLayout layout;
+        public final Object value;
+
+        public SimpleVaArg(Class<?> carrier, MemoryLayout layout, Object value) {
+            this.carrier = carrier;
+            this.layout = layout;
+            this.value = value;
+        }
+
+        public VarHandle varHandle() {
+            return carrier == MemoryAddress.class
+                ? MemoryHandles.asAddressVarHandle(layout.varHandle(primitiveCarrierForSize(layout.byteSize())))
+                : layout.varHandle(carrier);
+        }
     }
 }

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/SharedUtils.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/SharedUtils.java
@@ -262,6 +262,17 @@ public class SharedUtils {
             ? MemoryHandles.asAddressVarHandle(layout.varHandle(primitiveCarrierForSize(layout.byteSize())))
             : layout.varHandle(carrier);
     }
+
+    public static VaList newVaListOfAddress(MemoryAddress ma) {
+        String name = CSupport.getSystemLinker().name();
+        return switch(name) {
+            case Win64.NAME -> Windowsx64Linker.newVaListOfAddress(ma);
+            case SysV.NAME -> SysVx64Linker.newVaListOfAddress(ma);
+            case AArch64.NAME -> throw new UnsupportedOperationException("Not yet implemented for this platform");
+            default -> throw new IllegalStateException("Unknown linker name: " + name);
+        };
+    }
+
     public static class SimpleVaArg {
         public final Class<?> carrier;
         public final MemoryLayout layout;

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/x64/sysv/SysVVaList.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/x64/sysv/SysVVaList.java
@@ -1,0 +1,398 @@
+/*
+ *  Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ *  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ *  This code is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License version 2 only, as
+ *  published by the Free Software Foundation.  Oracle designates this
+ *  particular file as subject to the "Classpath" exception as provided
+ *  by Oracle in the LICENSE file that accompanied this code.
+ *
+ *  This code is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ *  version 2 for more details (a copy is included in the LICENSE file that
+ *  accompanied this code).
+ *
+ *  You should have received a copy of the GNU General Public License version
+ *  2 along with this work; if not, write to the Free Software Foundation,
+ *  Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ *   Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ *  or visit www.oracle.com if you need additional information or have any
+ *  questions.
+ *
+ */
+package jdk.internal.foreign.abi.x64.sysv;
+
+import jdk.incubator.foreign.CSupport;
+import jdk.incubator.foreign.GroupLayout;
+import jdk.incubator.foreign.MemoryAddress;
+import jdk.incubator.foreign.MemoryHandles;
+import jdk.incubator.foreign.MemoryLayout;
+import jdk.incubator.foreign.MemorySegment;
+import jdk.internal.foreign.Utils;
+import jdk.internal.foreign.abi.SharedUtils;
+
+import java.lang.invoke.VarHandle;
+import java.nio.ByteOrder;
+import java.util.ArrayList;
+import java.util.List;
+
+import static jdk.incubator.foreign.CSupport.SysV;
+import static jdk.incubator.foreign.CSupport.VaList;
+import static jdk.incubator.foreign.CSupport.SysV.C_DOUBLE;
+import static jdk.incubator.foreign.CSupport.SysV.C_INT;
+import static jdk.incubator.foreign.CSupport.Win64.C_POINTER;
+import static jdk.incubator.foreign.MemoryLayout.PathElement.groupElement;
+import static jdk.incubator.foreign.MemorySegment.READ;
+import static jdk.incubator.foreign.MemorySegment.WRITE;
+import static jdk.internal.foreign.abi.SharedUtils.SimpleVaArg;
+import static jdk.internal.foreign.abi.SharedUtils.checkCompatibleType;
+import static jdk.internal.foreign.abi.SharedUtils.vhPrimitiveOrAddress;
+import static jdk.internal.foreign.abi.SharedUtils.withOwnerThreadOrNoOp;
+
+// See https://software.intel.com/sites/default/files/article/402129/mpx-linux64-abi.pdf "3.5.7 Variable Argument Lists"
+public class SysVVaList implements VaList {
+    static final Class<?> CARRIER = MemoryAddress.class;
+
+//    struct typedef __va_list_tag __va_list_tag {
+//        unsigned int               gp_offset;            /*     0     4 */
+//        unsigned int               fp_offset;            /*     4     4 */
+//        void *                     overflow_arg_area;    /*     8     8 */
+//        void *                     reg_save_area;        /*    16     8 */
+//
+//        /* size: 24, cachelines: 1, members: 4 */
+//        /* last cacheline: 24 bytes */
+//    };
+    static final GroupLayout LAYOUT = MemoryLayout.ofStruct(
+        SysV.C_INT.withName("gp_offset"),
+        SysV.C_INT.withName("fp_offset"),
+        SysV.C_POINTER.withName("overflow_arg_area"),
+        SysV.C_POINTER.withName("reg_save_area")
+    ).withName("__va_list_tag");
+
+    private static final MemoryLayout GP_REG = MemoryLayout.ofValueBits(64, ByteOrder.nativeOrder());
+    private static final MemoryLayout FP_REG = MemoryLayout.ofValueBits(128, ByteOrder.nativeOrder());
+
+    private static final GroupLayout LAYOUT_REG_SAVE_AREA = MemoryLayout.ofStruct(
+        GP_REG.withName("%rdi"),
+        GP_REG.withName("%rsi"),
+        GP_REG.withName("%rdx"),
+        GP_REG.withName("%rcx"),
+        GP_REG.withName("%r8"),
+        GP_REG.withName("%r9"),
+        FP_REG.withName("%xmm0"),
+        FP_REG.withName("%xmm1"),
+        FP_REG.withName("%xmm2"),
+        FP_REG.withName("%xmm3"),
+        FP_REG.withName("%xmm4"),
+        FP_REG.withName("%xmm5"),
+        FP_REG.withName("%xmm6"),
+        FP_REG.withName("%xmm7")
+// specification and implementation differ as to whether the following are part of a reg save area
+// Let's go with the implementation, since then it actually works :)
+//        FP_REG.withName("%xmm8"),
+//        FP_REG.withName("%xmm9"),
+//        FP_REG.withName("%xmm10"),
+//        FP_REG.withName("%xmm11"),
+//        FP_REG.withName("%xmm12"),
+//        FP_REG.withName("%xmm13"),
+//        FP_REG.withName("%xmm14"),
+//        FP_REG.withName("%xmm15")
+    );
+
+    private static final long FP_OFFSET = LAYOUT_REG_SAVE_AREA.byteOffset(groupElement("%xmm0"));
+
+    private static final int GP_SLOT_SIZE = (int) GP_REG.byteSize();
+    private static final int FP_SLOT_SIZE = (int) FP_REG.byteSize();
+
+    private static final int MAX_GP_OFFSET = (int) FP_OFFSET; // 6 regs used
+    private static final int MAX_FP_OFFSET = (int) LAYOUT_REG_SAVE_AREA.byteSize(); // 8 16 byte regs
+
+    private static final VarHandle VH_fp_offset = LAYOUT.varHandle(int.class, groupElement("fp_offset"));
+    private static final VarHandle VH_gp_offset = LAYOUT.varHandle(int.class, groupElement("gp_offset"));
+    private static final VarHandle VH_overflow_arg_area
+        = MemoryHandles.asAddressVarHandle(LAYOUT.varHandle(long.class, groupElement("overflow_arg_area")));
+    private static final VarHandle VH_reg_save_area
+        = MemoryHandles.asAddressVarHandle(LAYOUT.varHandle(long.class, groupElement("reg_save_area")));
+
+    private final MemorySegment segment;
+    private final List<MemorySegment> slices = new ArrayList<>();
+
+    SysVVaList(MemorySegment segment) {
+        this.segment = segment;
+    }
+
+    static SysVVaList.Builder builder() {
+        return new SysVVaList.Builder();
+    }
+
+    public static VaList ofAddress(MemoryAddress ma) {
+        return new SysVVaList(MemorySegment.ofNativeRestricted(ma, LAYOUT.byteSize(), Thread.currentThread(), null, null));
+    }
+
+    MemorySegment getSegment() {
+        return segment;
+    }
+
+    @Override
+    public Reader reader(int num) {
+        return new Reader();
+    }
+
+    @Override
+    public boolean isAlive() {
+        return segment.isAlive();
+    }
+
+    @Override
+    public void close() {
+        segment.close();
+        slices.forEach(MemorySegment::close);
+    }
+
+    private static boolean isRegOverflow(long currentGPOffset, long currentFPOffset, TypeClass typeClass) {
+        return currentGPOffset > MAX_GP_OFFSET - typeClass.nIntegerRegs() * GP_SLOT_SIZE
+                || currentFPOffset > MAX_FP_OFFSET - typeClass.nVectorRegs() * FP_SLOT_SIZE;
+    }
+
+    @Override
+    public String toString() {
+        int gp_offset = (int) VH_gp_offset.get(segment.baseAddress());
+        int fp_offset = (int) VH_gp_offset.get(segment.baseAddress());
+        MemoryAddress overflowArgArea = (MemoryAddress) VH_overflow_arg_area.get(segment.baseAddress());
+        MemoryAddress regSaveArea = (MemoryAddress) VH_reg_save_area.get(segment.baseAddress());
+
+        return "SysVVaList{"
+               + "gp_offset=" + gp_offset
+               + ", fp_offset=" + fp_offset
+               + ", overflow_arg_area=" + overflowArgArea
+               + ", reg_save_area=" + regSaveArea
+               + '}';
+    }
+
+    static class Builder implements CSupport.VaList.Builder {
+        private final MemorySegment reg_save_area = MemorySegment.allocateNative(LAYOUT_REG_SAVE_AREA);
+        private long currentGPOffset = 0;
+        private long currentFPOffset = FP_OFFSET;
+        private final List<SimpleVaArg> stackArgs = new ArrayList<>();
+
+        @Override
+        public Builder intArg(MemoryLayout layout, int value) {
+            return arg(int.class, layout, value);
+        }
+
+        @Override
+        public Builder longArg(MemoryLayout layout, long value) {
+            return arg(long.class, layout, value);
+        }
+
+        @Override
+        public Builder doubleArg(MemoryLayout layout, double value) {
+            return arg(double.class, layout, value);
+        }
+
+        @Override
+        public Builder memoryAddressArg(MemoryLayout layout, MemoryAddress value) {
+            return arg(MemoryAddress.class, layout, value);
+        }
+
+        @Override
+        public Builder memorySegmentArg(MemoryLayout layout, MemorySegment value) {
+            return arg(MemorySegment.class, layout, value);
+        }
+
+        private Builder arg(Class<?> carrier, MemoryLayout layout, Object value) {
+            checkCompatibleType(carrier, layout, SysVx64Linker.ADDRESS_SIZE);
+            TypeClass typeClass = TypeClass.classifyLayout(layout);
+            if (isRegOverflow(currentGPOffset, currentFPOffset, typeClass)) {
+                // stack it!
+                stackArgs.add(new SimpleVaArg(carrier, layout, value));
+            } else {
+                switch (typeClass.kind()) {
+                    case STRUCT -> {
+
+                        MemorySegment valueSegment = (MemorySegment) value;
+                        int classIdx = 0;
+                        long offset = 0;
+                        while (offset < layout.byteSize()) {
+                            final long copy = Math.min(layout.byteSize() - offset, 8);
+                            boolean isSSE = typeClass.classes.get(classIdx++) == ArgumentClassImpl.SSE;
+                            MemorySegment slice = valueSegment.asSlice(offset, copy);
+                            if (isSSE) {
+                                reg_save_area.asSlice(currentFPOffset, copy).copyFrom(slice);
+                                currentFPOffset += FP_SLOT_SIZE;
+                            } else {
+                                reg_save_area.asSlice(currentGPOffset, copy).copyFrom(slice);
+                                currentGPOffset += GP_SLOT_SIZE;
+                            }
+                            offset += copy;
+                        }
+                    }
+                    case POINTER, INTEGER -> {
+                        VarHandle writer = SharedUtils.vhPrimitiveOrAddress(carrier, layout);
+                        writer.set(reg_save_area.baseAddress().addOffset(currentGPOffset), value);
+                        currentGPOffset += GP_SLOT_SIZE;
+                    }
+                    case FLOAT -> {
+                        VarHandle writer = layout.varHandle(carrier);
+                        writer.set(reg_save_area.baseAddress().addOffset(currentFPOffset), value);
+                        currentFPOffset += FP_SLOT_SIZE;
+                    }
+                }
+            }
+            return this;
+        }
+
+        public SysVVaList build() {
+            MemorySegment vaListSegment = MemorySegment.allocateNative(LAYOUT.byteSize());
+            SysVVaList res = new SysVVaList(vaListSegment);
+            MemoryAddress stackArgsPtr = MemoryAddress.NULL;
+            if (!stackArgs.isEmpty()) {
+                long stackArgsSize = stackArgs.stream().reduce(0L, (acc, e) -> acc + e.layout.byteSize(), Long::sum);
+                MemorySegment stackArgsSegment = MemorySegment.allocateNative(stackArgsSize, 16);
+                MemoryAddress maOverflowArgArea = stackArgsSegment.baseAddress();
+                for (SimpleVaArg arg : stackArgs) {
+                    if (arg.layout.byteSize() > 8) {
+                        maOverflowArgArea = Utils.alignUp(maOverflowArgArea, Math.min(16, arg.layout.byteSize()));
+                    }
+                    VarHandle writer = arg.varHandle();
+                    writer.set(maOverflowArgArea, arg.value);
+                    maOverflowArgArea = maOverflowArgArea.addOffset(arg.layout.byteSize());
+                }
+                stackArgsPtr = stackArgsSegment.baseAddress();
+                res.slices.add(stackArgsSegment);
+            }
+
+            MemoryAddress vaListAddr = vaListSegment.baseAddress();
+            VH_fp_offset.set(vaListAddr, (int) FP_OFFSET);
+            VH_overflow_arg_area.set(vaListAddr, stackArgsPtr);
+            VH_reg_save_area.set(vaListAddr, reg_save_area.baseAddress());
+            res.slices.add(reg_save_area);
+            assert reg_save_area.ownerThread() == vaListSegment.ownerThread();
+            return res;
+        }
+    }
+
+    class Reader implements CSupport.VaList.Reader {
+        private long currentGPOffset;
+        private long currentFPOffset;
+        private MemoryAddress stackPtr;
+        private final MemorySegment regSaveArea;
+
+        private Reader() {
+            regSaveArea = MemorySegment.ofNativeRestricted((MemoryAddress) VH_reg_save_area.get(segment.baseAddress()),
+                    LAYOUT_REG_SAVE_AREA.byteSize(), segment.ownerThread(), null, null);
+            slices.add(regSaveArea);
+            stackPtr = (MemoryAddress) VH_overflow_arg_area.get(segment.baseAddress());
+            currentGPOffset = (int) VH_gp_offset.get(segment.baseAddress());
+            currentFPOffset = (int) VH_fp_offset.get(segment.baseAddress());
+        }
+
+        private void preAlignStack(MemoryLayout layout) {
+            if (layout.byteAlignment() > 8) {
+                stackPtr = Utils.alignUp(stackPtr, 16);
+            }
+        }
+
+        private void postAlignStack(MemoryLayout layout) {
+            stackPtr = Utils.alignUp(stackPtr.addOffset(layout.byteSize()), 8);
+        }
+
+        @Override
+        public int readInt(MemoryLayout layout) {
+            return (int) read(int.class, layout);
+        }
+
+        @Override
+        public long readLong(MemoryLayout layout) {
+            return (long) read(long.class, layout);
+        }
+
+        @Override
+        public double readDouble(MemoryLayout layout) {
+            return (double) read(double.class, layout);
+        }
+
+        @Override
+        public MemoryAddress readPointer(MemoryLayout layout) {
+            return (MemoryAddress) read(MemoryAddress.class, layout);
+        }
+
+        @Override
+        public MemorySegment readStructOrUnion(MemoryLayout layout) {
+            return (MemorySegment) read(MemorySegment.class, layout);
+        }
+
+        private Object read(Class<?> carrier, MemoryLayout layout) {
+            checkCompatibleType(carrier, layout, SysVx64Linker.ADDRESS_SIZE);
+            TypeClass typeClass = TypeClass.classifyLayout(layout);
+            if (isRegOverflow(currentGPOffset, currentFPOffset, typeClass)) {
+                preAlignStack(layout);
+                return switch (typeClass.kind()) {
+                    case STRUCT -> {
+                        MemorySegment slice = MemorySegment.ofNativeRestricted(stackPtr, layout.byteSize(),
+                                segment.ownerThread(), null, null);
+                        slices.add(slice);
+                        postAlignStack(layout);
+                        yield slice.withAccessModes(WRITE | READ);
+                    }
+                    case POINTER, INTEGER, FLOAT -> {
+                        VarHandle reader = vhPrimitiveOrAddress(carrier, layout);
+                        Object res;
+                        try (MemorySegment slice = MemorySegment.ofNativeRestricted(stackPtr, layout.byteSize(),
+                                                                                    segment.ownerThread(), null, null)) {
+                            res = reader.get(slice.baseAddress());
+                        }
+                        postAlignStack(layout);
+                        yield res;
+                    }
+                };
+            } else {
+                return switch (typeClass.kind()) {
+                    case STRUCT -> {
+                        MemorySegment value = withOwnerThreadOrNoOp(MemorySegment.allocateNative(layout), segment.ownerThread());
+                        int classIdx = 0;
+                        long offset = 0;
+                        while (offset < layout.byteSize()) {
+                            final long copy = Math.min(layout.byteSize() - offset, 8);
+                            boolean isSSE = typeClass.classes.get(classIdx++) == ArgumentClassImpl.SSE;
+                            MemorySegment slice = value.asSlice(offset, copy);
+                            if (isSSE) {
+                                slice.copyFrom(regSaveArea.asSlice(currentFPOffset, copy));
+                                currentFPOffset += FP_SLOT_SIZE;
+                            } else {
+                                slice.copyFrom(regSaveArea.asSlice(currentGPOffset, copy));
+                                currentGPOffset += GP_SLOT_SIZE;
+                            }
+                            offset += copy;
+                        }
+                        slices.add(value);
+                        yield value.withAccessModes(WRITE | READ);
+                    }
+                    case POINTER, INTEGER -> {
+                        VarHandle reader = SharedUtils.vhPrimitiveOrAddress(carrier, layout);
+                        Object res = reader.get(regSaveArea.baseAddress().addOffset(currentGPOffset));
+                        currentGPOffset += GP_SLOT_SIZE;
+                        yield res;
+                    }
+                    case FLOAT -> {
+                        VarHandle reader = layout.varHandle(carrier);
+                        Object res = reader.get(regSaveArea.baseAddress().addOffset(currentFPOffset));
+                        currentFPOffset += FP_SLOT_SIZE;
+                        yield res;
+                    }
+                };
+            }
+        }
+
+        @Override
+        public void skip(MemoryLayout... layouts) {
+            for (MemoryLayout layout : layouts) {
+                preAlignStack(layout);
+                postAlignStack(layout);
+            }
+        }
+    }
+}

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/x64/sysv/SysVVaList.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/x64/sysv/SysVVaList.java
@@ -161,27 +161,27 @@ public class SysVVaList implements VaList {
     }
 
     @Override
-    public int readInt(MemoryLayout layout) {
+    public int vargAsInt(MemoryLayout layout) {
         return (int) read(int.class, layout);
     }
 
     @Override
-    public long readLong(MemoryLayout layout) {
+    public long vargAsLong(MemoryLayout layout) {
         return (long) read(long.class, layout);
     }
 
     @Override
-    public double readDouble(MemoryLayout layout) {
+    public double vargAsDouble(MemoryLayout layout) {
         return (double) read(double.class, layout);
     }
 
     @Override
-    public MemoryAddress readPointer(MemoryLayout layout) {
+    public MemoryAddress vargAsAddress(MemoryLayout layout) {
         return (MemoryAddress) read(MemoryAddress.class, layout);
     }
 
     @Override
-    public MemorySegment readStructOrUnion(MemoryLayout layout) {
+    public MemorySegment vargAsSegment(MemoryLayout layout) {
         return (MemorySegment) read(MemorySegment.class, layout);
     }
 
@@ -318,27 +318,27 @@ public class SysVVaList implements VaList {
         private final List<SimpleVaArg> stackArgs = new ArrayList<>();
 
         @Override
-        public Builder intArg(MemoryLayout layout, int value) {
+        public Builder vargFromInt(MemoryLayout layout, int value) {
             return arg(int.class, layout, value);
         }
 
         @Override
-        public Builder longArg(MemoryLayout layout, long value) {
+        public Builder vargFromLong(MemoryLayout layout, long value) {
             return arg(long.class, layout, value);
         }
 
         @Override
-        public Builder doubleArg(MemoryLayout layout, double value) {
+        public Builder vargFromDouble(MemoryLayout layout, double value) {
             return arg(double.class, layout, value);
         }
 
         @Override
-        public Builder memoryAddressArg(MemoryLayout layout, MemoryAddress value) {
+        public Builder vargFromAddress(MemoryLayout layout, MemoryAddress value) {
             return arg(MemoryAddress.class, layout, value);
         }
 
         @Override
-        public Builder memorySegmentArg(MemoryLayout layout, MemorySegment value) {
+        public Builder vargFromSegment(MemoryLayout layout, MemorySegment value) {
             return arg(MemorySegment.class, layout, value);
         }
 

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/x64/sysv/SysVx64Linker.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/x64/sysv/SysVx64Linker.java
@@ -24,6 +24,7 @@
  */
 package jdk.internal.foreign.abi.x64.sysv;
 
+import jdk.incubator.foreign.CSupport;
 import jdk.incubator.foreign.ForeignLinker;
 import jdk.incubator.foreign.FunctionDescriptor;
 import jdk.incubator.foreign.MemoryAddress;
@@ -32,8 +33,10 @@ import jdk.incubator.foreign.MemorySegment;
 import jdk.internal.foreign.abi.UpcallStubs;
 
 import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
 import java.lang.invoke.MethodType;
 import java.util.Optional;
+import java.util.function.Consumer;
 
 import static jdk.incubator.foreign.CSupport.*;
 
@@ -51,6 +54,21 @@ public class SysVx64Linker implements ForeignLinker {
 
     static final long ADDRESS_SIZE = 64; // bits
 
+    private static final MethodHandle MH_unboxVaList;
+    private static final MethodHandle MH_boxVaList;
+
+    static {
+        try {
+            MethodHandles.Lookup lookup = MethodHandles.lookup();
+            MH_unboxVaList = lookup.findStatic(SysVx64Linker.class, "unboxVaList",
+                MethodType.methodType(MemoryAddress.class, CSupport.VaList.class));
+            MH_boxVaList = lookup.findStatic(SysVx64Linker.class, "boxVaList",
+                MethodType.methodType(VaList.class, MemoryAddress.class));
+        } catch (ReflectiveOperationException e) {
+            throw new ExceptionInInitializerError(e);
+        }
+    }
+
     public static SysVx64Linker getInstance() {
         if (instance == null) {
             instance = new SysVx64Linker();
@@ -58,13 +76,51 @@ public class SysVx64Linker implements ForeignLinker {
         return instance;
     }
 
+    public static VaList newVaList(Consumer<VaList.Builder> actions) {
+        SysVVaList.Builder builder = SysVVaList.builder();
+        actions.accept(builder);
+        return builder.build();
+    }
+
+    private static MethodType convertVaListCarriers(MethodType mt) {
+        Class<?>[] params = new Class<?>[mt.parameterCount()];
+        for (int i = 0; i < params.length; i++) {
+            Class<?> pType = mt.parameterType(i);
+            params[i] = ((pType == CSupport.VaList.class) ? SysVVaList.CARRIER : pType);
+        }
+        return MethodType.methodType(mt.returnType(), params);
+    }
+
+    private static MethodHandle unxboxVaLists(MethodType type, MethodHandle handle) {
+        for (int i = 0; i < type.parameterCount(); i++) {
+            if (type.parameterType(i) == VaList.class) {
+               handle = MethodHandles.filterArguments(handle, i, MH_unboxVaList);
+            }
+        }
+        return handle;
+    }
+
     @Override
     public MethodHandle downcallHandle(MemoryAddress symbol, MethodType type, FunctionDescriptor function) {
-        return CallArranger.arrangeDowncall(symbol, type, function);
+        MethodType llMt = convertVaListCarriers(type);
+        MethodHandle handle = CallArranger.arrangeDowncall(symbol, llMt, function);
+        handle = unxboxVaLists(type, handle);
+        return handle;
+    }
+
+    private static MethodHandle boxVaLists(MethodHandle handle) {
+        MethodType type = handle.type();
+        for (int i = 0; i < type.parameterCount(); i++) {
+            if (type.parameterType(i) == VaList.class) {
+               handle = MethodHandles.filterArguments(handle, i, MH_boxVaList);
+            }
+        }
+        return handle;
     }
 
     @Override
     public MemorySegment upcallStub(MethodHandle target, FunctionDescriptor function) {
+        target = boxVaLists(target);
         return UpcallStubs.upcallAddress(CallArranger.arrangeUpcall(target, target.type(), function));
     }
 
@@ -85,5 +141,13 @@ public class SysVx64Linker implements ForeignLinker {
             case POINTER -> ArgumentClassImpl.POINTER;
             default -> null;
         });
+    }
+
+    private static MemoryAddress unboxVaList(CSupport.VaList list) {
+        return ((SysVVaList) list).getSegment().baseAddress();
+    }
+
+    private static CSupport.VaList boxVaList(MemoryAddress ma) {
+        return SysVVaList.ofAddress(ma);
     }
 }

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/x64/sysv/SysVx64Linker.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/x64/sysv/SysVx64Linker.java
@@ -150,4 +150,8 @@ public class SysVx64Linker implements ForeignLinker {
     private static CSupport.VaList boxVaList(MemoryAddress ma) {
         return SysVVaList.ofAddress(ma);
     }
+
+    public static VaList newVaListOfAddress(MemoryAddress ma) {
+        return SysVVaList.ofAddress(ma);
+    }
 }

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/x64/sysv/TypeClass.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/x64/sysv/TypeClass.java
@@ -1,0 +1,240 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package jdk.internal.foreign.abi.x64.sysv;
+
+import jdk.incubator.foreign.GroupLayout;
+import jdk.incubator.foreign.MemoryLayout;
+import jdk.incubator.foreign.SequenceLayout;
+import jdk.incubator.foreign.ValueLayout;
+import jdk.internal.foreign.Utils;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static jdk.internal.foreign.abi.x64.sysv.SysVx64Linker.argumentClassFor;
+
+class TypeClass {
+    enum Kind {
+        STRUCT,
+        POINTER,
+        INTEGER,
+        FLOAT
+    }
+
+    private final Kind kind;
+    final List<ArgumentClassImpl> classes;
+
+    private TypeClass(Kind kind, List<ArgumentClassImpl> classes) {
+        this.kind = kind;
+        this.classes = classes;
+    }
+
+    public static TypeClass ofValue(ValueLayout layout) {
+        final Kind kind;
+        ArgumentClassImpl argClass = classifyValueType(layout);
+        switch (argClass) {
+            case POINTER: kind = Kind.POINTER; break;
+            case INTEGER: kind = Kind.INTEGER; break;
+            case SSE: kind = Kind.FLOAT; break;
+            default:
+                throw new IllegalStateException();
+        }
+        return new TypeClass(kind, List.of(argClass));
+    }
+
+    public static TypeClass ofStruct(GroupLayout layout) {
+        return new TypeClass(Kind.STRUCT, classifyStructType(layout));
+    }
+
+    boolean inMemory() {
+        return classes.stream().anyMatch(c -> c == ArgumentClassImpl.MEMORY);
+    }
+
+    private long numClasses(ArgumentClassImpl clazz) {
+        return classes.stream().filter(c -> c == clazz).count();
+    }
+
+    public long nIntegerRegs() {
+        return numClasses(ArgumentClassImpl.INTEGER) + numClasses(ArgumentClassImpl.POINTER);
+    }
+
+    public long nVectorRegs() {
+        return numClasses(ArgumentClassImpl.SSE);
+    }
+
+    public Kind kind() {
+        return kind;
+    }
+
+    // layout classification
+
+    // The AVX 512 enlightened ABI says "eight eightbytes"
+    // Although AMD64 0.99.6 states 4 eightbytes
+    private static final int MAX_AGGREGATE_REGS_SIZE = 8;
+    static final List<ArgumentClassImpl> COMPLEX_X87_CLASSES = List.of(
+         ArgumentClassImpl.X87,
+         ArgumentClassImpl.X87UP,
+         ArgumentClassImpl.X87,
+         ArgumentClassImpl.X87UP
+    );
+
+    private static List<ArgumentClassImpl> createMemoryClassArray(long size) {
+        return IntStream.range(0, (int)size)
+                .mapToObj(i -> ArgumentClassImpl.MEMORY)
+                .collect(Collectors.toCollection(ArrayList::new));
+    }
+
+    // TODO: handle '__int128' and 'long double'
+    private static ArgumentClassImpl classifyValueType(ValueLayout type) {
+        if (type.byteSize() > 8) {
+            throw new IllegalStateException("");
+        }
+        ArgumentClassImpl clazz = SysVx64Linker.argumentClassFor(type)
+                .orElseThrow(() -> new IllegalStateException("Unexpected value layout: could not determine ABI class"));
+        return clazz;
+    }
+
+    // TODO: handle zero length arrays
+    private static List<ArgumentClassImpl> classifyStructType(GroupLayout type) {
+        if (argumentClassFor(type)
+                .filter(argClass -> argClass == ArgumentClassImpl.COMPLEX_X87)
+                .isPresent()) {
+            return COMPLEX_X87_CLASSES;
+        }
+
+        List<ArgumentClassImpl>[] eightbytes = groupByEightBytes(type);
+        long nWords = eightbytes.length;
+        if (nWords > MAX_AGGREGATE_REGS_SIZE) {
+            return createMemoryClassArray(nWords);
+        }
+
+        ArrayList<ArgumentClassImpl> classes = new ArrayList<>();
+
+        for (int idx = 0; idx < nWords; idx++) {
+            List<ArgumentClassImpl> subclasses = eightbytes[idx];
+            ArgumentClassImpl result = subclasses.stream()
+                    .reduce(ArgumentClassImpl.NO_CLASS, ArgumentClassImpl::merge);
+            classes.add(result);
+        }
+
+        for (int i = 0; i < classes.size(); i++) {
+            ArgumentClassImpl c = classes.get(i);
+
+            if (c == ArgumentClassImpl.MEMORY) {
+                // if any of the eightbytes was passed in memory, pass the whole thing in memory
+                return createMemoryClassArray(classes.size());
+            }
+
+            if (c == ArgumentClassImpl.X87UP) {
+                if (i == 0) {
+                    throw new IllegalArgumentException("Unexpected leading X87UP class");
+                }
+
+                if (classes.get(i - 1) != ArgumentClassImpl.X87) {
+                    return createMemoryClassArray(classes.size());
+                }
+            }
+        }
+
+        if (classes.size() > 2) {
+            if (classes.get(0) != ArgumentClassImpl.SSE) {
+                return createMemoryClassArray(classes.size());
+            }
+
+            for (int i = 1; i < classes.size(); i++) {
+                if (classes.get(i) != ArgumentClassImpl.SSEUP) {
+                    return createMemoryClassArray(classes.size());
+                }
+            }
+        }
+
+        return classes;
+    }
+
+    static TypeClass classifyLayout(MemoryLayout type) {
+        try {
+            if (type instanceof ValueLayout) {
+                return ofValue((ValueLayout)type);
+            } else if (type instanceof GroupLayout) {
+                return ofStruct((GroupLayout)type);
+            } else {
+                throw new IllegalArgumentException("Unhandled type " + type);
+            }
+        } catch (UnsupportedOperationException e) {
+            System.err.println("Failed to classify layout: " + type);
+            throw e;
+        }
+    }
+
+    private static List<ArgumentClassImpl>[] groupByEightBytes(GroupLayout group) {
+        long offset = 0L;
+        int nEightbytes = (int) Utils.alignUp(group.byteSize(), 8) / 8;
+        @SuppressWarnings({"unchecked", "rawtypes"})
+        List<ArgumentClassImpl>[] groups = new List[nEightbytes];
+        for (MemoryLayout l : group.memberLayouts()) {
+            groupByEightBytes(l, offset, groups);
+            if (group.isStruct()) {
+                offset += l.byteSize();
+            }
+        }
+        return groups;
+    }
+
+    private static void groupByEightBytes(MemoryLayout l, long offset, List<ArgumentClassImpl>[] groups) {
+        if (l instanceof GroupLayout) {
+            GroupLayout group = (GroupLayout)l;
+            for (MemoryLayout m : group.memberLayouts()) {
+                groupByEightBytes(m, offset, groups);
+                if (group.isStruct()) {
+                    offset += m.byteSize();
+                }
+            }
+        } else if (l.isPadding()) {
+            return;
+        } else if (l instanceof SequenceLayout) {
+            SequenceLayout seq = (SequenceLayout)l;
+            MemoryLayout elem = seq.elementLayout();
+            for (long i = 0 ; i < seq.elementCount().getAsLong() ; i++) {
+                groupByEightBytes(elem, offset, groups);
+                offset += elem.byteSize();
+            }
+        } else if (l instanceof ValueLayout) {
+            List<ArgumentClassImpl> layouts = groups[(int)offset / 8];
+            if (layouts == null) {
+                layouts = new ArrayList<>();
+                groups[(int)offset / 8] = layouts;
+            }
+            // if the aggregate contains unaligned fields, it has class MEMORY
+            ArgumentClassImpl argumentClass = (offset % l.byteAlignment()) == 0 ?
+                    classifyValueType((ValueLayout)l) :
+                    ArgumentClassImpl.MEMORY;
+            layouts.add(argumentClass);
+        } else {
+            throw new IllegalStateException("Unexpected layout: " + l);
+        }
+    }
+}

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/x64/windows/CallArranger.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/x64/windows/CallArranger.java
@@ -27,8 +27,6 @@ import jdk.incubator.foreign.GroupLayout;
 import jdk.incubator.foreign.MemoryAddress;
 import jdk.incubator.foreign.MemoryLayout;
 import jdk.incubator.foreign.MemorySegment;
-import jdk.incubator.foreign.SequenceLayout;
-import jdk.incubator.foreign.ValueLayout;
 import jdk.internal.foreign.Utils;
 import jdk.internal.foreign.abi.CallingSequenceBuilder;
 import jdk.internal.foreign.abi.UpcallHandler;
@@ -47,7 +45,6 @@ import java.util.List;
 import java.util.Optional;
 
 import static jdk.incubator.foreign.CSupport.*;
-import static jdk.incubator.foreign.CSupport.Win64.VARARGS_ATTRIBUTE_NAME;
 import static jdk.internal.foreign.abi.x64.X86_64Architecture.*;
 
 /**
@@ -146,75 +143,8 @@ public class CallArranger {
     private static boolean isInMemoryReturn(Optional<MemoryLayout> returnLayout) {
         return returnLayout
                 .filter(GroupLayout.class::isInstance)
-                .filter(g -> !isRegisterAggregate(g))
+                .filter(g -> !TypeClass.isRegisterAggregate(g))
                 .isPresent();
-    }
-
-    private enum TypeClass {
-        STRUCT_REGISTER,
-        STRUCT_REFERENCE,
-        POINTER,
-        INTEGER,
-        FLOAT,
-        VARARG_FLOAT
-    }
-
-    private static TypeClass classifyValueType(ValueLayout type) {
-        Win64.ArgumentClass clazz = Windowsx64Linker.argumentClassFor(type);
-        if (clazz == null) {
-            //padding not allowed here
-            throw new IllegalStateException("Unexpected value layout: could not determine ABI class");
-        }
-
-        // No 128 bit integers in the Windows C ABI. There are __m128(i|d) intrinsic types but they act just
-        // like a struct when passing as an argument (passed by pointer).
-        // https://docs.microsoft.com/en-us/cpp/cpp/m128?view=vs-2019
-
-        // x87 is ignored on Windows:
-        // "The x87 register stack is unused, and may be used by the callee,
-        // but must be considered volatile across function calls."
-        // https://docs.microsoft.com/en-us/cpp/build/x64-calling-convention?view=vs-2019
-
-        if (clazz == Win64.ArgumentClass.INTEGER) {
-            return TypeClass.INTEGER;
-        } else if(clazz == Win64.ArgumentClass.POINTER) {
-            return TypeClass.POINTER;
-        } else if (clazz == Win64.ArgumentClass.FLOAT) {
-            if (type.attribute(VARARGS_ATTRIBUTE_NAME)
-                    .map(String.class::cast)
-                    .map(Boolean::parseBoolean).orElse(false)) {
-                return TypeClass.VARARG_FLOAT;
-            }
-            return TypeClass.FLOAT;
-        }
-        throw new IllegalArgumentException("Unknown ABI class: " + clazz);
-    }
-
-    private static boolean isRegisterAggregate(MemoryLayout type) {
-        long size = type.byteSize();
-        return size == 1
-            || size == 2
-            || size == 4
-            || size == 8;
-    }
-
-    private static TypeClass classifyStructType(MemoryLayout layout) {
-        if (isRegisterAggregate(layout)) {
-            return TypeClass.STRUCT_REGISTER;
-        }
-        return TypeClass.STRUCT_REFERENCE;
-    }
-
-    private static TypeClass classifyType(MemoryLayout type) {
-        if (type instanceof ValueLayout) {
-            return classifyValueType((ValueLayout) type);
-        } else if (type instanceof  GroupLayout) {
-            return classifyStructType(type);
-        } else if (type instanceof SequenceLayout) {
-            return TypeClass.INTEGER;
-        } else {
-            throw new IllegalArgumentException("Unhandled type " + type);
-        }
     }
 
     static class StorageCalculator {
@@ -263,7 +193,7 @@ public class CallArranger {
 
         @Override
         public List<Binding> getBindings(Class<?> carrier, MemoryLayout layout) {
-            TypeClass argumentClass = classifyType(layout);
+            TypeClass argumentClass = TypeClass.typeClassFor(layout);
             Binding.Builder bindings = Binding.builder();
             switch (argumentClass) {
                 case STRUCT_REGISTER: {
@@ -326,7 +256,7 @@ public class CallArranger {
 
         @Override
         public List<Binding> getBindings(Class<?> carrier, MemoryLayout layout) {
-            TypeClass argumentClass = classifyType(layout);
+            TypeClass argumentClass = TypeClass.typeClassFor(layout);
             Binding.Builder bindings = Binding.builder();
             switch (argumentClass) {
                 case STRUCT_REGISTER: {

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/x64/windows/TypeClass.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/x64/windows/TypeClass.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package jdk.internal.foreign.abi.x64.windows;
+
+import jdk.incubator.foreign.CSupport;
+import jdk.incubator.foreign.GroupLayout;
+import jdk.incubator.foreign.MemoryLayout;
+import jdk.incubator.foreign.SequenceLayout;
+import jdk.incubator.foreign.ValueLayout;
+
+import static jdk.incubator.foreign.CSupport.Win64.VARARGS_ATTRIBUTE_NAME;
+
+enum TypeClass {
+    STRUCT_REGISTER,
+    STRUCT_REFERENCE,
+    POINTER,
+    INTEGER,
+    FLOAT,
+    VARARG_FLOAT;
+
+
+    private static TypeClass classifyValueType(ValueLayout type) {
+        CSupport.Win64.ArgumentClass clazz = Windowsx64Linker.argumentClassFor(type);
+        if (clazz == null) {
+            //padding not allowed here
+            throw new IllegalStateException("Unexpected value layout: could not determine ABI class");
+        }
+
+        // No 128 bit integers in the Windows C ABI. There are __m128(i|d) intrinsic types but they act just
+        // like a struct when passing as an argument (passed by pointer).
+        // https://docs.microsoft.com/en-us/cpp/cpp/m128?view=vs-2019
+
+        // x87 is ignored on Windows:
+        // "The x87 register stack is unused, and may be used by the callee,
+        // but must be considered volatile across function calls."
+        // https://docs.microsoft.com/en-us/cpp/build/x64-calling-convention?view=vs-2019
+
+        if (clazz == CSupport.Win64.ArgumentClass.INTEGER) {
+            return INTEGER;
+        } else if(clazz == CSupport.Win64.ArgumentClass.POINTER) {
+            return POINTER;
+        } else if (clazz == CSupport.Win64.ArgumentClass.FLOAT) {
+            if (type.attribute(VARARGS_ATTRIBUTE_NAME)
+                    .map(String.class::cast)
+                    .map(Boolean::parseBoolean).orElse(false)) {
+                return VARARG_FLOAT;
+            }
+            return FLOAT;
+        }
+        throw new IllegalArgumentException("Unknown ABI class: " + clazz);
+    }
+
+    static boolean isRegisterAggregate(MemoryLayout type) {
+        long size = type.byteSize();
+        return size == 1
+            || size == 2
+            || size == 4
+            || size == 8;
+    }
+
+    private static TypeClass classifyStructType(MemoryLayout layout) {
+        if (isRegisterAggregate(layout)) {
+            return STRUCT_REGISTER;
+        }
+        return STRUCT_REFERENCE;
+    }
+
+    static TypeClass typeClassFor(MemoryLayout type) {
+        if (type instanceof ValueLayout) {
+            return classifyValueType((ValueLayout) type);
+        } else if (type instanceof GroupLayout) {
+            return classifyStructType(type);
+        } else if (type instanceof SequenceLayout) {
+            return INTEGER;
+        } else {
+            throw new IllegalArgumentException("Unhandled type " + type);
+        }
+    }
+}

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/x64/windows/WinVaList.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/x64/windows/WinVaList.java
@@ -1,0 +1,238 @@
+/*
+ *  Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ *  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ *  This code is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License version 2 only, as
+ *  published by the Free Software Foundation.  Oracle designates this
+ *  particular file as subject to the "Classpath" exception as provided
+ *  by Oracle in the LICENSE file that accompanied this code.
+ *
+ *  This code is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ *  version 2 for more details (a copy is included in the LICENSE file that
+ *  accompanied this code).
+ *
+ *  You should have received a copy of the GNU General Public License version
+ *  2 along with this work; if not, write to the Free Software Foundation,
+ *  Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ *   Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ *  or visit www.oracle.com if you need additional information or have any
+ *  questions.
+ *
+ */
+package jdk.internal.foreign.abi.x64.windows;
+
+import jdk.incubator.foreign.CSupport;
+import jdk.incubator.foreign.MemoryAddress;
+import jdk.incubator.foreign.MemoryHandles;
+import jdk.incubator.foreign.MemoryLayout;
+import jdk.incubator.foreign.MemorySegment;
+import jdk.internal.foreign.abi.SharedUtils;
+import jdk.internal.foreign.abi.SharedUtils.SimpleVaArg;
+
+import java.lang.invoke.VarHandle;
+import java.util.ArrayList;
+import java.util.List;
+
+import static jdk.incubator.foreign.CSupport.Win64.C_DOUBLE;
+import static jdk.incubator.foreign.CSupport.Win64.C_INT;
+import static jdk.incubator.foreign.CSupport.Win64.C_POINTER;
+import static jdk.incubator.foreign.MemorySegment.CLOSE;
+import static jdk.incubator.foreign.MemorySegment.READ;
+import static jdk.incubator.foreign.MemorySegment.WRITE;
+
+// see vadefs.h (VC header)
+//
+// in short
+// -> va_list is just a pointer to a buffer with 64 bit entries.
+// -> non-power-of-two-sized, or larger than 64 bit types passed by reference.
+// -> other types passed in 64 bit slots by normal function calling convention.
+//
+// X64 va_arg impl:
+//
+//    typedef char* va_list;
+//
+//    #define __crt_va_arg(ap, t)                                               \
+//        ((sizeof(t) > sizeof(__int64) || (sizeof(t) & (sizeof(t) - 1)) != 0) \
+//            ? **(t**)((ap += sizeof(__int64)) - sizeof(__int64))             \
+//            :  *(t* )((ap += sizeof(__int64)) - sizeof(__int64)))
+//
+class WinVaList implements CSupport.VaList {
+    public static final Class<?> CARRIER = MemoryAddress.class;
+    private static final long VA_SLOT_SIZE_BYTES = 8;
+    private static final VarHandle VH_address = MemoryHandles.asAddressVarHandle(C_POINTER.varHandle(long.class));
+
+    private final MemorySegment segment;
+    private final List<MemorySegment> slices;
+
+    WinVaList(MemorySegment segment) {
+        this(segment, new ArrayList<>());
+    }
+
+    WinVaList(MemorySegment segment, List<MemorySegment> slices) {
+        this.segment = segment;
+        this.slices = slices;
+    }
+
+    static Builder builder() {
+        return new Builder();
+    }
+
+    MemorySegment getSegment() {
+        return segment;
+    }
+
+    @Override
+    public void close() {
+        segment.close();
+        slices.forEach(MemorySegment::close);
+    }
+
+    @Override
+    public Reader reader(int num) {
+        return new Reader(num);
+    }
+
+    @Override
+    public boolean isAlive() {
+        return segment.isAlive();
+    }
+
+    static class Builder implements CSupport.VaList.Builder {
+
+        private final List<SimpleVaArg> args = new ArrayList<>();
+
+        private Builder arg(Class<?> carrier, MemoryLayout layout, Object value) {
+            SharedUtils.checkCompatibleType(carrier, layout, Windowsx64Linker.ADDRESS_SIZE);
+            args.add(new SimpleVaArg(carrier, layout, value));
+            return this;
+        }
+
+        @Override
+        public Builder intArg(MemoryLayout layout, int value) {
+            return arg(int.class, layout, value);
+        }
+
+        @Override
+        public Builder longArg(MemoryLayout layout, long value) {
+            return arg(long.class, layout, value);
+        }
+
+        @Override
+        public Builder doubleArg(MemoryLayout layout, double value) {
+            return arg(double.class, layout, value);
+        }
+
+        @Override
+        public Builder memoryAddressArg(MemoryLayout layout, MemoryAddress value) {
+            return arg(MemoryAddress.class, layout, value);
+        }
+
+        @Override
+        public Builder memorySegmentArg(MemoryLayout layout, MemorySegment value) {
+            return arg(MemorySegment.class, layout, value);
+        }
+
+        public WinVaList build() {
+            MemorySegment ms = MemorySegment.allocateNative(VA_SLOT_SIZE_BYTES * args.size());
+            List<MemorySegment> slices = new ArrayList<>();
+
+            MemoryAddress addr = ms.baseAddress();
+            for (SimpleVaArg arg : args) {
+                if (arg.carrier == MemorySegment.class) {
+                    MemorySegment msArg = ((MemorySegment) arg.value);
+                    TypeClass typeClass = TypeClass.typeClassFor(arg.layout);
+                    switch (typeClass) {
+                        case STRUCT_REFERENCE -> {
+                            MemorySegment copy = MemorySegment.allocateNative(arg.layout);
+                            copy.copyFrom(msArg); // by-value
+                            slices.add(copy);
+                            VH_address.set(addr, copy.baseAddress());
+                        }
+                        case STRUCT_REGISTER -> {
+                            MemorySegment slice = ms.asSlice(addr.segmentOffset(), VA_SLOT_SIZE_BYTES);
+                            slice.copyFrom(msArg);
+                        }
+                        default -> throw new IllegalStateException("Unexpected TypeClass: " + typeClass);
+                    }
+                } else {
+                    VarHandle writer = arg.varHandle();
+                    writer.set(addr, arg.value);
+                }
+                addr = addr.addOffset(VA_SLOT_SIZE_BYTES);
+            }
+
+            return new WinVaList(ms.withAccessModes(CLOSE | READ), slices);
+        }
+    }
+
+    class Reader implements CSupport.VaList.Reader {
+        private MemoryAddress ptr;
+
+        public Reader(int num) {
+            ptr = segment.asSlice(0, num * VA_SLOT_SIZE_BYTES).baseAddress();
+        }
+
+        @Override
+        public int readInt(MemoryLayout layout) {
+            return (int) read(int.class, layout);
+        }
+
+        @Override
+        public long readLong(MemoryLayout layout) {
+            return (long) read(long.class, layout);
+        }
+
+        @Override
+        public double readDouble(MemoryLayout layout) {
+            return (double) read(double.class, layout);
+        }
+
+        @Override
+        public MemoryAddress readPointer(MemoryLayout layout) {
+            return (MemoryAddress) read(MemoryAddress.class, layout);
+        }
+
+        @Override
+        public MemorySegment readStructOrUnion(MemoryLayout layout) {
+            return (MemorySegment) read(MemorySegment.class, layout);
+        }
+
+        private Object read(Class<?> carrier, MemoryLayout layout) {
+            SharedUtils.checkCompatibleType(carrier, layout, Windowsx64Linker.ADDRESS_SIZE);
+            Object res;
+            if (carrier == MemorySegment.class) {
+                TypeClass typeClass = TypeClass.typeClassFor(layout);
+                switch (typeClass) {
+                    case STRUCT_REFERENCE -> {
+                        MemoryAddress structAddr = (MemoryAddress) VH_address.get(ptr);
+                        MemorySegment struct = MemorySegment.ofNativeRestricted(structAddr, layout.byteSize(),
+                                                                                segment.ownerThread(), null, null);
+                        slices.add(struct);
+                        res = struct.withAccessModes(WRITE | READ);
+                    }
+                    case STRUCT_REGISTER -> {
+                        MemorySegment struct = MemorySegment.allocateNative(layout);
+                        struct.copyFrom(segment.asSlice(ptr.segmentOffset(), layout.byteSize()));
+                        slices.add(struct);
+                        res = struct.withAccessModes(WRITE | READ);
+                    }
+                    default -> throw new IllegalStateException("Unexpected TypeClass: " + typeClass);
+                }
+            } else {
+                VarHandle reader = SharedUtils.vhPrimitiveOrAddress(carrier, layout);
+                res = reader.get(ptr);
+            }
+            ptr = ptr.addOffset(VA_SLOT_SIZE_BYTES);
+            return res;
+        }
+
+        @Override
+        public void skip(MemoryLayout... layouts) {
+            ptr = ptr.addOffset(layouts.length * VA_SLOT_SIZE_BYTES);
+        }
+    }
+}

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/x64/windows/WinVaList.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/x64/windows/WinVaList.java
@@ -77,27 +77,27 @@ class WinVaList implements CSupport.VaList {
     }
 
     @Override
-    public int readInt(MemoryLayout layout) {
+    public int vargAsInt(MemoryLayout layout) {
         return (int) read(int.class, layout);
     }
 
     @Override
-    public long readLong(MemoryLayout layout) {
+    public long vargAsLong(MemoryLayout layout) {
         return (long) read(long.class, layout);
     }
 
     @Override
-    public double readDouble(MemoryLayout layout) {
+    public double vargAsDouble(MemoryLayout layout) {
         return (double) read(double.class, layout);
     }
 
     @Override
-    public MemoryAddress readPointer(MemoryLayout layout) {
+    public MemoryAddress vargAsAddress(MemoryLayout layout) {
         return (MemoryAddress) read(MemoryAddress.class, layout);
     }
 
     @Override
-    public MemorySegment readStructOrUnion(MemoryLayout layout) {
+    public MemorySegment vargAsSegment(MemoryLayout layout) {
         return (MemorySegment) read(MemorySegment.class, layout);
     }
 
@@ -180,27 +180,27 @@ class WinVaList implements CSupport.VaList {
         }
 
         @Override
-        public Builder intArg(MemoryLayout layout, int value) {
+        public Builder vargFromInt(MemoryLayout layout, int value) {
             return arg(int.class, layout, value);
         }
 
         @Override
-        public Builder longArg(MemoryLayout layout, long value) {
+        public Builder vargFromLong(MemoryLayout layout, long value) {
             return arg(long.class, layout, value);
         }
 
         @Override
-        public Builder doubleArg(MemoryLayout layout, double value) {
+        public Builder vargFromDouble(MemoryLayout layout, double value) {
             return arg(double.class, layout, value);
         }
 
         @Override
-        public Builder memoryAddressArg(MemoryLayout layout, MemoryAddress value) {
+        public Builder vargFromAddress(MemoryLayout layout, MemoryAddress value) {
             return arg(MemoryAddress.class, layout, value);
         }
 
         @Override
-        public Builder memorySegmentArg(MemoryLayout layout, MemorySegment value) {
+        public Builder vargFromSegment(MemoryLayout layout, MemorySegment value) {
             return arg(MemorySegment.class, layout, value);
         }
 

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/x64/windows/WinVaList.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/x64/windows/WinVaList.java
@@ -156,7 +156,12 @@ class WinVaList implements CSupport.VaList {
 
     @Override
     public CSupport.VaList copy() {
-        return WinVaList.ofAddress(ptr.addOffset(0));
+        return WinVaList.ofAddress(ptr);
+    }
+
+    @Override
+    public MemoryAddress toAddress() {
+        return ptr;
     }
 
     @Override

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/x64/windows/Windowsx64Linker.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/x64/windows/Windowsx64Linker.java
@@ -141,4 +141,9 @@ public class Windowsx64Linker implements ForeignLinker {
     private static CSupport.VaList boxVaList(MemoryAddress ma) {
         return WinVaList.ofAddress(ma);
     }
+
+    public static VaList newVaListOfAddress(MemoryAddress ma) {
+        return WinVaList.ofAddress(ma);
+    }
+
 }

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/x64/windows/Windowsx64Linker.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/x64/windows/Windowsx64Linker.java
@@ -24,6 +24,7 @@
  */
 package jdk.internal.foreign.abi.x64.windows;
 
+import jdk.incubator.foreign.CSupport;
 import jdk.incubator.foreign.ForeignLinker;
 import jdk.incubator.foreign.FunctionDescriptor;
 import jdk.incubator.foreign.MemoryAddress;
@@ -32,7 +33,9 @@ import jdk.incubator.foreign.MemorySegment;
 import jdk.internal.foreign.abi.UpcallStubs;
 
 import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
 import java.lang.invoke.MethodType;
+import java.util.function.Consumer;
 
 import static jdk.incubator.foreign.CSupport.*;
 
@@ -52,6 +55,21 @@ public class Windowsx64Linker implements ForeignLinker {
 
     static final long ADDRESS_SIZE = 64; // bits
 
+    private static final MethodHandle MH_unboxVaList;
+    private static final MethodHandle MH_boxVaList;
+
+    static {
+        try {
+            MethodHandles.Lookup lookup = MethodHandles.lookup();
+            MH_unboxVaList = lookup.findStatic(Windowsx64Linker.class, "unboxVaList",
+                MethodType.methodType(MemoryAddress.class, CSupport.VaList.class));
+            MH_boxVaList = lookup.findStatic(Windowsx64Linker.class, "boxVaList",
+                MethodType.methodType(VaList.class, MemoryAddress.class));
+        } catch (ReflectiveOperationException e) {
+            throw new ExceptionInInitializerError(e);
+        }
+    }
+
     public static Windowsx64Linker getInstance() {
         if (instance == null) {
             instance = new Windowsx64Linker();
@@ -59,13 +77,51 @@ public class Windowsx64Linker implements ForeignLinker {
         return instance;
     }
 
+    public static VaList newVaList(Consumer<VaList.Builder> actions) {
+        WinVaList.Builder builder = WinVaList.builder();
+        actions.accept(builder);
+        return builder.build();
+    }
+
+    private static MethodType convertVaListCarriers(MethodType mt) {
+        Class<?>[] params = new Class<?>[mt.parameterCount()];
+        for (int i = 0; i < params.length; i++) {
+            Class<?> pType = mt.parameterType(i);
+            params[i] = ((pType == CSupport.VaList.class) ? WinVaList.CARRIER : pType);
+        }
+        return MethodType.methodType(mt.returnType(), params);
+    }
+
+    private static MethodHandle unxboxVaLists(MethodType type, MethodHandle handle) {
+        for (int i = 0; i < type.parameterCount(); i++) {
+            if (type.parameterType(i) == VaList.class) {
+               handle = MethodHandles.filterArguments(handle, i, MH_unboxVaList);
+            }
+        }
+        return handle;
+    }
+
     @Override
     public MethodHandle downcallHandle(MemoryAddress symbol, MethodType type, FunctionDescriptor function) {
-        return CallArranger.arrangeDowncall(symbol, type, function);
+        MethodType llMt = convertVaListCarriers(type);
+        MethodHandle handle = CallArranger.arrangeDowncall(symbol, llMt, function);
+        handle = unxboxVaLists(type, handle);
+        return handle;
+    }
+
+    private static MethodHandle boxVaLists(MethodHandle handle) {
+        MethodType type = handle.type();
+        for (int i = 0; i < type.parameterCount(); i++) {
+            if (type.parameterType(i) == VaList.class) {
+               handle = MethodHandles.filterArguments(handle, i, MH_boxVaList);
+            }
+        }
+        return handle;
     }
 
     @Override
     public MemorySegment upcallStub(MethodHandle target, FunctionDescriptor function) {
+        target = boxVaLists(target);
         return UpcallStubs.upcallAddress(CallArranger.arrangeUpcall(target, target.type(), function));
     }
 
@@ -76,5 +132,13 @@ public class Windowsx64Linker implements ForeignLinker {
 
     static Win64.ArgumentClass argumentClassFor(MemoryLayout layout) {
         return (Win64.ArgumentClass)layout.attribute(Win64.CLASS_ATTRIBUTE_NAME).get();
+    }
+
+    private static MemoryAddress unboxVaList(CSupport.VaList list) {
+        return ((WinVaList) list).getSegment().baseAddress();
+    }
+
+    private static CSupport.VaList boxVaList(MemoryAddress ma) {
+        return new WinVaList(MemorySegment.ofNativeRestricted(ma, Long.MAX_VALUE, Thread.currentThread(), null, null));
     }
 }

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/x64/windows/Windowsx64Linker.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/x64/windows/Windowsx64Linker.java
@@ -139,6 +139,6 @@ public class Windowsx64Linker implements ForeignLinker {
     }
 
     private static CSupport.VaList boxVaList(MemoryAddress ma) {
-        return new WinVaList(MemorySegment.ofNativeRestricted(ma, Long.MAX_VALUE, Thread.currentThread(), null, null));
+        return WinVaList.ofAddress(ma);
     }
 }

--- a/test/jdk/java/foreign/valist/VaListTest.java
+++ b/test/jdk/java/foreign/valist/VaListTest.java
@@ -1,0 +1,321 @@
+/*
+ *  Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ *  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ *  This code is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License version 2 only, as
+ *  published by the Free Software Foundation.
+ *
+ *  This code is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ *  version 2 for more details (a copy is included in the LICENSE file that
+ *  accompanied this code).
+ *
+ *  You should have received a copy of the GNU General Public License version
+ *  2 along with this work; if not, write to the Free Software Foundation,
+ *  Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ *   Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ *  or visit www.oracle.com if you need additional information or have any
+ *  questions.
+ *
+ */
+
+/*
+ * @test
+ * @run testng/othervm -Dforeign.restricted=permit VaListTest
+ */
+
+import jdk.incubator.foreign.CSupport;
+import jdk.incubator.foreign.CSupport.VaList;
+import jdk.incubator.foreign.ForeignLinker;
+import jdk.incubator.foreign.FunctionDescriptor;
+import jdk.incubator.foreign.GroupLayout;
+import jdk.incubator.foreign.LibraryLookup;
+import jdk.incubator.foreign.MemoryAddress;
+import jdk.incubator.foreign.MemoryLayout;
+import jdk.incubator.foreign.MemorySegment;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+import java.lang.invoke.VarHandle;
+
+import static jdk.incubator.foreign.CSupport.C_DOUBLE;
+import static jdk.incubator.foreign.CSupport.C_INT;
+import static jdk.incubator.foreign.CSupport.C_LONGLONG;
+import static jdk.incubator.foreign.CSupport.C_POINTER;
+import static jdk.incubator.foreign.CSupport.C_VA_LIST;
+import static jdk.incubator.foreign.CSupport.Win64.asVarArg;
+import static jdk.incubator.foreign.MemoryLayout.PathElement.groupElement;
+import static org.testng.Assert.assertEquals;
+
+public class VaListTest {
+
+    private static final ForeignLinker abi = CSupport.getSystemLinker();
+    private static final LibraryLookup lookup = LibraryLookup.ofLibrary("VaList");
+
+    private static final VarHandle VH_int = C_INT.varHandle(int.class);
+
+    private static final MethodHandle MH_sumInts = link("sumInts",
+            MethodType.methodType(int.class, int.class, VaList.class),
+            FunctionDescriptor.of(C_INT, C_INT, CSupport.C_VA_LIST));
+    private static final MethodHandle MH_sumDoubles = link("sumDoubles",
+            MethodType.methodType(double.class, int.class, VaList.class),
+            FunctionDescriptor.of(C_DOUBLE, C_INT, CSupport.C_VA_LIST));
+    private static final MethodHandle MH_getInt = link("getInt",
+            MethodType.methodType(int.class, VaList.class),
+            FunctionDescriptor.of(C_INT, C_VA_LIST));
+    private static final MethodHandle MH_sumStruct = link("sumStruct",
+            MethodType.methodType(int.class, VaList.class),
+            FunctionDescriptor.of(C_INT, C_VA_LIST));
+    private static final MethodHandle MH_sumBigStruct = link("sumBigStruct",
+            MethodType.methodType(long.class, VaList.class),
+            FunctionDescriptor.of(C_LONGLONG, C_VA_LIST));
+    private static final MethodHandle MH_sumStack = link("sumStack",
+            MethodType.methodType(void.class, MemoryAddress.class, MemoryAddress.class, int.class,
+                long.class, long.class, long.class, long.class,
+                long.class, long.class, long.class, long.class,
+                long.class, long.class, long.class, long.class,
+                long.class, long.class, long.class, long.class,
+                double.class, double.class, double.class, double.class,
+                double.class, double.class, double.class, double.class,
+                double.class, double.class, double.class, double.class,
+                double.class, double.class, double.class, double.class
+            ),
+            FunctionDescriptor.ofVoid(C_POINTER, C_POINTER, C_INT,
+                asVarArg(C_LONGLONG), asVarArg(C_LONGLONG), asVarArg(C_LONGLONG), asVarArg(C_LONGLONG),
+                asVarArg(C_LONGLONG), asVarArg(C_LONGLONG), asVarArg(C_LONGLONG), asVarArg(C_LONGLONG),
+                asVarArg(C_LONGLONG), asVarArg(C_LONGLONG), asVarArg(C_LONGLONG), asVarArg(C_LONGLONG),
+                asVarArg(C_LONGLONG), asVarArg(C_LONGLONG), asVarArg(C_LONGLONG), asVarArg(C_LONGLONG),
+                asVarArg(C_DOUBLE), asVarArg(C_DOUBLE), asVarArg(C_DOUBLE), asVarArg(C_DOUBLE),
+                asVarArg(C_DOUBLE), asVarArg(C_DOUBLE), asVarArg(C_DOUBLE), asVarArg(C_DOUBLE),
+                asVarArg(C_DOUBLE), asVarArg(C_DOUBLE), asVarArg(C_DOUBLE), asVarArg(C_DOUBLE),
+                asVarArg(C_DOUBLE), asVarArg(C_DOUBLE), asVarArg(C_DOUBLE), asVarArg(C_DOUBLE)
+            ));
+
+    private static final VarHandle VH_long = C_LONGLONG.varHandle(long.class);
+    private static final VarHandle VH_double = C_DOUBLE.varHandle(double.class);
+
+    private static MethodHandle link(String symbol, MethodType mt, FunctionDescriptor fd) {
+        try {
+            return abi.downcallHandle(lookup.lookup(symbol), mt, fd);
+        } catch (NoSuchMethodException e) {
+            throw new NoSuchMethodError(e.getMessage());
+        }
+    }
+
+    private static MethodHandle linkVaListCB(String symbol) {
+        return link(symbol,
+            MethodType.methodType(void.class, MemoryAddress.class),
+            FunctionDescriptor.ofVoid(C_POINTER));
+
+    }
+
+    private static final GroupLayout BigPoint_LAYOUT = MemoryLayout.ofStruct(
+        C_LONGLONG.withName("x"),
+        C_LONGLONG.withName("y")
+    );
+    private static final VarHandle VH_BigPoint_x = BigPoint_LAYOUT.varHandle(long.class, groupElement("x"));
+    private static final VarHandle VH_BigPoint_y = BigPoint_LAYOUT.varHandle(long.class, groupElement("y"));
+    private static final GroupLayout Point_LAYOUT = MemoryLayout.ofStruct(
+        C_INT.withName("x"),
+        C_INT.withName("y")
+    );
+    private static final VarHandle VH_Point_x = Point_LAYOUT.varHandle(int.class, groupElement("x"));
+    private static final VarHandle VH_Point_y = Point_LAYOUT.varHandle(int.class, groupElement("y"));
+
+    @Test
+    public void testIntSum() throws Throwable {
+        try (VaList vaList = CSupport.newVaList(b ->
+                b.intArg(C_INT, 10)
+                 .intArg(C_INT, 15)
+                 .intArg(C_INT, 20))) {
+            int x = (int) MH_sumInts.invokeExact(3, vaList);
+            assertEquals(x, 45);
+        }
+    }
+
+    @Test
+    public void testDoubleSum() throws Throwable {
+        try (VaList vaList = CSupport.newVaList(b ->
+                b.doubleArg(C_DOUBLE, 3.0D)
+                 .doubleArg(C_DOUBLE, 4.0D)
+                 .doubleArg(C_DOUBLE, 5.0D))) {
+            double x = (double) MH_sumDoubles.invokeExact(3, vaList);
+            assertEquals(x, 12.0D);
+        }
+    }
+
+    @Test
+    public void testVaListMemoryAddress() throws Throwable {
+        try (MemorySegment msInt = MemorySegment.allocateNative(C_INT)) {
+            VH_int.set(msInt.baseAddress(), 10);
+            try (VaList vaList = CSupport.newVaList(b -> b.memoryAddressArg(C_POINTER, msInt.baseAddress()))) {
+                int x = (int) MH_getInt.invokeExact(vaList);
+                assertEquals(x, 10);
+            }
+        }
+    }
+
+    @Test
+    public void testWinStructByValue() throws Throwable {
+        try (MemorySegment struct = MemorySegment.allocateNative(Point_LAYOUT)) {
+            VH_Point_x.set(struct.baseAddress(), 5);
+            VH_Point_y.set(struct.baseAddress(), 10);
+
+            try (VaList vaList = CSupport.newVaList(b -> b.memorySegmentArg(Point_LAYOUT, struct))) {
+                int sum = (int) MH_sumStruct.invokeExact(vaList);
+                assertEquals(sum, 15);
+            }
+        }
+    }
+
+    @Test
+    public void testWinStructByReference() throws Throwable {
+        try (MemorySegment struct = MemorySegment.allocateNative(BigPoint_LAYOUT)) {
+            VH_BigPoint_x.set(struct.baseAddress(), 5);
+            VH_BigPoint_y.set(struct.baseAddress(), 10);
+
+            try (VaList vaList = CSupport.newVaList(b -> b.memorySegmentArg(BigPoint_LAYOUT, struct))) {
+                long sum = (long) MH_sumBigStruct.invokeExact(vaList);
+                assertEquals(sum, 15);
+            }
+        }
+    }
+
+    @Test
+    public void testStack() throws Throwable {
+       try (MemorySegment longSum = MemorySegment.allocateNative(C_LONGLONG);
+            MemorySegment doubleSum = MemorySegment.allocateNative(C_DOUBLE)) {
+            VH_long.set(longSum.baseAddress(), 0L);
+            VH_double.set(doubleSum.baseAddress(), 0D);
+
+            MH_sumStack.invokeExact(longSum.baseAddress(), doubleSum.baseAddress(), 32,
+                1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L, 9L, 10L, 11L, 12L, 13L, 14L, 15L, 16L,
+                1D, 2D, 3D, 4D, 5D, 6D, 7D, 8D, 9D, 10D, 11D, 12D, 13D, 14D, 15D, 16D);
+
+            long lSum = (long) VH_long.get(longSum.baseAddress());
+            double dSum = (double) VH_double.get(doubleSum.baseAddress());
+
+            assertEquals(lSum, 136L);
+            assertEquals(dSum, 136D);
+        }
+    }
+
+    @Test(dataProvider = "upcalls")
+    public void testUpcall(MethodHandle target, MethodHandle callback) throws Throwable {
+        FunctionDescriptor desc = FunctionDescriptor.ofVoid(C_VA_LIST);
+        try (MemorySegment stub = abi.upcallStub(callback, desc)) {
+            target.invokeExact(stub.baseAddress());
+        }
+    }
+
+    @DataProvider
+    public static Object[][] upcalls() {
+        return new Object[][]{
+            { linkVaListCB("upcallBigStruct"), VaListConsumer.mh(vaList -> {
+                VaList.Reader reader = vaList.reader(1);
+                MemorySegment struct = reader.readStructOrUnion(BigPoint_LAYOUT);
+                assertEquals((long) VH_BigPoint_x.get(struct.baseAddress()), 8);
+                assertEquals((long) VH_BigPoint_y.get(struct.baseAddress()), 16);
+            })},
+            { linkVaListCB("upcallStruct"), VaListConsumer.mh(vaList -> {
+                VaList.Reader reader = vaList.reader(1);
+                MemorySegment struct = reader.readStructOrUnion(Point_LAYOUT);
+                assertEquals((int) VH_Point_x.get(struct.baseAddress()), 5);
+                assertEquals((int) VH_Point_y.get(struct.baseAddress()), 10);
+            })},
+            { linkVaListCB("upcallMemoryAddress"), VaListConsumer.mh(vaList -> {
+                VaList.Reader reader = vaList.reader(1);
+                MemoryAddress intPtr = reader.readPointer(C_POINTER);
+                MemorySegment ms = MemorySegment.ofNativeRestricted(intPtr, C_INT.byteSize(),
+                                                                    Thread.currentThread(), null, null);
+                int x = (int) VH_int.get(ms.baseAddress());
+                assertEquals(x, 10);
+            })},
+            { linkVaListCB("upcallDoubles"), VaListConsumer.mh(vaList -> {
+                VaList.Reader reader = vaList.reader(3);
+                assertEquals(reader.readDouble(C_DOUBLE), 3.0);
+                assertEquals(reader.readDouble(C_DOUBLE), 4.0);
+                assertEquals(reader.readDouble(C_DOUBLE), 5.0);
+            })},
+            { linkVaListCB("upcallInts"), VaListConsumer.mh(vaList -> {
+                VaList.Reader reader = vaList.reader(3);
+                assertEquals(reader.readInt(C_INT), 10);
+                assertEquals(reader.readInt(C_INT), 15);
+                assertEquals(reader.readInt(C_INT), 20);
+            })},
+            { linkVaListCB("upcallStack"), VaListConsumer.mh(vaList -> {
+                VaList.Reader reader = vaList.reader(32 + 14);
+                // skip all registers
+                assertEquals(reader.readLong(C_LONGLONG), 1L); // windows are read from shadow space 1
+                assertEquals(reader.readLong(C_LONGLONG), 2L); // windows are read from shadow space 2
+                assertEquals(reader.readLong(C_LONGLONG), 3L); // windows first stack arg (int/float)
+                assertEquals(reader.readLong(C_LONGLONG), 4L);
+                assertEquals(reader.readLong(C_LONGLONG), 5L);
+                assertEquals(reader.readLong(C_LONGLONG), 6L);
+                assertEquals(reader.readLong(C_LONGLONG), 7L); // sysv 1st int stack arg
+                assertEquals(reader.readLong(C_LONGLONG), 8L);
+                assertEquals(reader.readLong(C_LONGLONG), 9L);
+                assertEquals(reader.readLong(C_LONGLONG), 10L);
+                assertEquals(reader.readLong(C_LONGLONG), 11L);
+                assertEquals(reader.readLong(C_LONGLONG), 12L);
+                assertEquals(reader.readLong(C_LONGLONG), 13L);
+                assertEquals(reader.readLong(C_LONGLONG), 14L);
+                assertEquals(reader.readLong(C_LONGLONG), 15L);
+                assertEquals(reader.readLong(C_LONGLONG), 16L);
+                assertEquals(reader.readDouble(C_DOUBLE), 1.0D);
+                assertEquals(reader.readDouble(C_DOUBLE), 2.0D);
+                assertEquals(reader.readDouble(C_DOUBLE), 3.0D);
+                assertEquals(reader.readDouble(C_DOUBLE), 4.0D);
+                assertEquals(reader.readDouble(C_DOUBLE), 5.0D);
+                assertEquals(reader.readDouble(C_DOUBLE), 6.0D);
+                assertEquals(reader.readDouble(C_DOUBLE), 7.0D);
+                assertEquals(reader.readDouble(C_DOUBLE), 8.0D);
+                assertEquals(reader.readDouble(C_DOUBLE), 9.0D); // sysv 1st float stack arg
+                assertEquals(reader.readDouble(C_DOUBLE), 10.0D);
+                assertEquals(reader.readDouble(C_DOUBLE), 11.0D);
+                assertEquals(reader.readDouble(C_DOUBLE), 12.0D);
+                assertEquals(reader.readDouble(C_DOUBLE), 13.0D);
+                assertEquals(reader.readDouble(C_DOUBLE), 14.0D);
+                assertEquals(reader.readDouble(C_DOUBLE), 15.0D);
+                assertEquals(reader.readDouble(C_DOUBLE), 16.0D);
+
+                // test some arbitrary values on the stack
+                assertEquals((byte) reader.readInt(C_INT), (byte) 1);
+                assertEquals((char) reader.readInt(C_INT), 'a');
+                assertEquals((short) reader.readInt(C_INT), (short) 3);
+                assertEquals(reader.readInt(C_INT), 4);
+                assertEquals(reader.readLong(C_LONGLONG), 5L);
+                assertEquals((float) reader.readDouble(C_DOUBLE), 6.0F);
+                assertEquals(reader.readDouble(C_DOUBLE), 7.0D);
+                assertEquals((byte) reader.readInt(C_INT), (byte) 8);
+                assertEquals((char) reader.readInt(C_INT), 'b');
+                assertEquals((short) reader.readInt(C_INT), (short) 10);
+                assertEquals(reader.readInt(C_INT), 11);
+                assertEquals(reader.readLong(C_LONGLONG), 12L);
+                assertEquals((float) reader.readDouble(C_DOUBLE), 13.0F);
+                assertEquals(reader.readDouble(C_DOUBLE), 14.0D);
+
+            })},
+        };
+    }
+
+    interface VaListConsumer {
+        void accept(CSupport.VaList list);
+
+        static MethodHandle mh(VaListConsumer instance) {
+            try {
+                return MethodHandles.lookup().findVirtual(VaListConsumer.class, "accept",
+                    MethodType.methodType(void.class, VaList.class)).bindTo(instance);
+            } catch (ReflectiveOperationException e) {
+                throw new InternalError(e);
+            }
+        }
+    }
+
+}

--- a/test/jdk/java/foreign/valist/VaListTest.java
+++ b/test/jdk/java/foreign/valist/VaListTest.java
@@ -131,9 +131,9 @@ public class VaListTest {
     @Test
     public void testIntSum() throws Throwable {
         try (VaList vaList = CSupport.newVaList(b ->
-                b.intArg(C_INT, 10)
-                 .intArg(C_INT, 15)
-                 .intArg(C_INT, 20))) {
+                b.vargFromInt(C_INT, 10)
+                 .vargFromInt(C_INT, 15)
+                 .vargFromInt(C_INT, 20))) {
             int x = (int) MH_sumInts.invokeExact(3, vaList);
             assertEquals(x, 45);
         }
@@ -142,9 +142,9 @@ public class VaListTest {
     @Test
     public void testDoubleSum() throws Throwable {
         try (VaList vaList = CSupport.newVaList(b ->
-                b.doubleArg(C_DOUBLE, 3.0D)
-                 .doubleArg(C_DOUBLE, 4.0D)
-                 .doubleArg(C_DOUBLE, 5.0D))) {
+                b.vargFromDouble(C_DOUBLE, 3.0D)
+                 .vargFromDouble(C_DOUBLE, 4.0D)
+                 .vargFromDouble(C_DOUBLE, 5.0D))) {
             double x = (double) MH_sumDoubles.invokeExact(3, vaList);
             assertEquals(x, 12.0D);
         }
@@ -154,7 +154,7 @@ public class VaListTest {
     public void testVaListMemoryAddress() throws Throwable {
         try (MemorySegment msInt = MemorySegment.allocateNative(C_INT)) {
             VH_int.set(msInt.baseAddress(), 10);
-            try (VaList vaList = CSupport.newVaList(b -> b.memoryAddressArg(C_POINTER, msInt.baseAddress()))) {
+            try (VaList vaList = CSupport.newVaList(b -> b.vargFromAddress(C_POINTER, msInt.baseAddress()))) {
                 int x = (int) MH_getInt.invokeExact(vaList);
                 assertEquals(x, 10);
             }
@@ -167,7 +167,7 @@ public class VaListTest {
             VH_Point_x.set(struct.baseAddress(), 5);
             VH_Point_y.set(struct.baseAddress(), 10);
 
-            try (VaList vaList = CSupport.newVaList(b -> b.memorySegmentArg(Point_LAYOUT, struct))) {
+            try (VaList vaList = CSupport.newVaList(b -> b.vargFromSegment(Point_LAYOUT, struct))) {
                 int sum = (int) MH_sumStruct.invokeExact(vaList);
                 assertEquals(sum, 15);
             }
@@ -180,7 +180,7 @@ public class VaListTest {
             VH_BigPoint_x.set(struct.baseAddress(), 5);
             VH_BigPoint_y.set(struct.baseAddress(), 10);
 
-            try (VaList vaList = CSupport.newVaList(b -> b.memorySegmentArg(BigPoint_LAYOUT, struct))) {
+            try (VaList vaList = CSupport.newVaList(b -> b.vargFromSegment(BigPoint_LAYOUT, struct))) {
                 long sum = (long) MH_sumBigStruct.invokeExact(vaList);
                 assertEquals(sum, 15);
             }
@@ -218,14 +218,14 @@ public class VaListTest {
     public static Object[][] upcalls() {
         return new Object[][]{
             { linkVaListCB("upcallBigStruct"), VaListConsumer.mh(vaList -> {
-                try (MemorySegment struct = vaList.readStructOrUnion(BigPoint_LAYOUT)) {
+                try (MemorySegment struct = vaList.vargAsSegment(BigPoint_LAYOUT)) {
                     assertEquals((long) VH_BigPoint_x.get(struct.baseAddress()), 8);
                     assertEquals((long) VH_BigPoint_y.get(struct.baseAddress()), 16);
                 }
             })},
             { linkVaListCB("upcallBigStruct"), VaListConsumer.mh(vaList -> {
                 VaList copy = vaList.copy();
-                try (MemorySegment struct = vaList.readStructOrUnion(BigPoint_LAYOUT)) {
+                try (MemorySegment struct = vaList.vargAsSegment(BigPoint_LAYOUT)) {
                     assertEquals((long) VH_BigPoint_x.get(struct.baseAddress()), 8);
                     assertEquals((long) VH_BigPoint_y.get(struct.baseAddress()), 16);
 
@@ -234,92 +234,92 @@ public class VaListTest {
                 }
 
                 // should be independent
-                try (MemorySegment struct = copy.readStructOrUnion(BigPoint_LAYOUT)) {
+                try (MemorySegment struct = copy.vargAsSegment(BigPoint_LAYOUT)) {
                     assertEquals((long) VH_BigPoint_x.get(struct.baseAddress()), 8);
                     assertEquals((long) VH_BigPoint_y.get(struct.baseAddress()), 16);
                 }
             })},
             { linkVaListCB("upcallStruct"), VaListConsumer.mh(vaList -> {
-                try (MemorySegment struct = vaList.readStructOrUnion(Point_LAYOUT)) {
+                try (MemorySegment struct = vaList.vargAsSegment(Point_LAYOUT)) {
                     assertEquals((int) VH_Point_x.get(struct.baseAddress()), 5);
                     assertEquals((int) VH_Point_y.get(struct.baseAddress()), 10);
                 }
             })},
             { linkVaListCB("upcallMemoryAddress"), VaListConsumer.mh(vaList -> {
-                MemoryAddress intPtr = vaList.readPointer(C_POINTER);
+                MemoryAddress intPtr = vaList.vargAsAddress(C_POINTER);
                 MemorySegment ms = MemorySegment.ofNativeRestricted(intPtr, C_INT.byteSize(),
                                                                     Thread.currentThread(), null, null);
                 int x = (int) VH_int.get(ms.baseAddress());
                 assertEquals(x, 10);
             })},
             { linkVaListCB("upcallDoubles"), VaListConsumer.mh(vaList -> {
-                assertEquals(vaList.readDouble(C_DOUBLE), 3.0);
-                assertEquals(vaList.readDouble(C_DOUBLE), 4.0);
-                assertEquals(vaList.readDouble(C_DOUBLE), 5.0);
+                assertEquals(vaList.vargAsDouble(C_DOUBLE), 3.0);
+                assertEquals(vaList.vargAsDouble(C_DOUBLE), 4.0);
+                assertEquals(vaList.vargAsDouble(C_DOUBLE), 5.0);
             })},
             { linkVaListCB("upcallInts"), VaListConsumer.mh(vaList -> {
-                assertEquals(vaList.readInt(C_INT), 10);
-                assertEquals(vaList.readInt(C_INT), 15);
-                assertEquals(vaList.readInt(C_INT), 20);
+                assertEquals(vaList.vargAsInt(C_INT), 10);
+                assertEquals(vaList.vargAsInt(C_INT), 15);
+                assertEquals(vaList.vargAsInt(C_INT), 20);
             })},
             { linkVaListCB("upcallStack"), VaListConsumer.mh(vaList -> {
                 // skip all registers
-                assertEquals(vaList.readLong(C_LONGLONG), 1L); // 1st windows arg read from shadow space
-                assertEquals(vaList.readLong(C_LONGLONG), 2L); // 2nd windows arg read from shadow space
-                assertEquals(vaList.readLong(C_LONGLONG), 3L); // windows 1st stack arg (int/float)
-                assertEquals(vaList.readLong(C_LONGLONG), 4L);
-                assertEquals(vaList.readLong(C_LONGLONG), 5L);
-                assertEquals(vaList.readLong(C_LONGLONG), 6L);
-                assertEquals(vaList.readLong(C_LONGLONG), 7L); // sysv 1st int stack arg
-                assertEquals(vaList.readLong(C_LONGLONG), 8L);
-                assertEquals(vaList.readLong(C_LONGLONG), 9L);
-                assertEquals(vaList.readLong(C_LONGLONG), 10L);
-                assertEquals(vaList.readLong(C_LONGLONG), 11L);
-                assertEquals(vaList.readLong(C_LONGLONG), 12L);
-                assertEquals(vaList.readLong(C_LONGLONG), 13L);
-                assertEquals(vaList.readLong(C_LONGLONG), 14L);
-                assertEquals(vaList.readLong(C_LONGLONG), 15L);
-                assertEquals(vaList.readLong(C_LONGLONG), 16L);
-                assertEquals(vaList.readDouble(C_DOUBLE), 1.0D);
-                assertEquals(vaList.readDouble(C_DOUBLE), 2.0D);
-                assertEquals(vaList.readDouble(C_DOUBLE), 3.0D);
-                assertEquals(vaList.readDouble(C_DOUBLE), 4.0D);
-                assertEquals(vaList.readDouble(C_DOUBLE), 5.0D);
-                assertEquals(vaList.readDouble(C_DOUBLE), 6.0D);
-                assertEquals(vaList.readDouble(C_DOUBLE), 7.0D);
-                assertEquals(vaList.readDouble(C_DOUBLE), 8.0D);
-                assertEquals(vaList.readDouble(C_DOUBLE), 9.0D); // sysv 1st float stack arg
-                assertEquals(vaList.readDouble(C_DOUBLE), 10.0D);
-                assertEquals(vaList.readDouble(C_DOUBLE), 11.0D);
-                assertEquals(vaList.readDouble(C_DOUBLE), 12.0D);
-                assertEquals(vaList.readDouble(C_DOUBLE), 13.0D);
-                assertEquals(vaList.readDouble(C_DOUBLE), 14.0D);
-                assertEquals(vaList.readDouble(C_DOUBLE), 15.0D);
-                assertEquals(vaList.readDouble(C_DOUBLE), 16.0D);
+                assertEquals(vaList.vargAsLong(C_LONGLONG), 1L); // 1st windows arg read from shadow space
+                assertEquals(vaList.vargAsLong(C_LONGLONG), 2L); // 2nd windows arg read from shadow space
+                assertEquals(vaList.vargAsLong(C_LONGLONG), 3L); // windows 1st stack arg (int/float)
+                assertEquals(vaList.vargAsLong(C_LONGLONG), 4L);
+                assertEquals(vaList.vargAsLong(C_LONGLONG), 5L);
+                assertEquals(vaList.vargAsLong(C_LONGLONG), 6L);
+                assertEquals(vaList.vargAsLong(C_LONGLONG), 7L); // sysv 1st int stack arg
+                assertEquals(vaList.vargAsLong(C_LONGLONG), 8L);
+                assertEquals(vaList.vargAsLong(C_LONGLONG), 9L);
+                assertEquals(vaList.vargAsLong(C_LONGLONG), 10L);
+                assertEquals(vaList.vargAsLong(C_LONGLONG), 11L);
+                assertEquals(vaList.vargAsLong(C_LONGLONG), 12L);
+                assertEquals(vaList.vargAsLong(C_LONGLONG), 13L);
+                assertEquals(vaList.vargAsLong(C_LONGLONG), 14L);
+                assertEquals(vaList.vargAsLong(C_LONGLONG), 15L);
+                assertEquals(vaList.vargAsLong(C_LONGLONG), 16L);
+                assertEquals(vaList.vargAsDouble(C_DOUBLE), 1.0D);
+                assertEquals(vaList.vargAsDouble(C_DOUBLE), 2.0D);
+                assertEquals(vaList.vargAsDouble(C_DOUBLE), 3.0D);
+                assertEquals(vaList.vargAsDouble(C_DOUBLE), 4.0D);
+                assertEquals(vaList.vargAsDouble(C_DOUBLE), 5.0D);
+                assertEquals(vaList.vargAsDouble(C_DOUBLE), 6.0D);
+                assertEquals(vaList.vargAsDouble(C_DOUBLE), 7.0D);
+                assertEquals(vaList.vargAsDouble(C_DOUBLE), 8.0D);
+                assertEquals(vaList.vargAsDouble(C_DOUBLE), 9.0D); // sysv 1st float stack arg
+                assertEquals(vaList.vargAsDouble(C_DOUBLE), 10.0D);
+                assertEquals(vaList.vargAsDouble(C_DOUBLE), 11.0D);
+                assertEquals(vaList.vargAsDouble(C_DOUBLE), 12.0D);
+                assertEquals(vaList.vargAsDouble(C_DOUBLE), 13.0D);
+                assertEquals(vaList.vargAsDouble(C_DOUBLE), 14.0D);
+                assertEquals(vaList.vargAsDouble(C_DOUBLE), 15.0D);
+                assertEquals(vaList.vargAsDouble(C_DOUBLE), 16.0D);
 
                 // test some arbitrary values on the stack
-                assertEquals((byte) vaList.readInt(C_INT), (byte) 1);
-                assertEquals((char) vaList.readInt(C_INT), 'a');
-                assertEquals((short) vaList.readInt(C_INT), (short) 3);
-                assertEquals(vaList.readInt(C_INT), 4);
-                assertEquals(vaList.readLong(C_LONGLONG), 5L);
-                assertEquals((float) vaList.readDouble(C_DOUBLE), 6.0F);
-                assertEquals(vaList.readDouble(C_DOUBLE), 7.0D);
-                assertEquals((byte) vaList.readInt(C_INT), (byte) 8);
-                assertEquals((char) vaList.readInt(C_INT), 'b');
-                assertEquals((short) vaList.readInt(C_INT), (short) 10);
-                assertEquals(vaList.readInt(C_INT), 11);
-                assertEquals(vaList.readLong(C_LONGLONG), 12L);
-                assertEquals((float) vaList.readDouble(C_DOUBLE), 13.0F);
-                assertEquals(vaList.readDouble(C_DOUBLE), 14.0D);
+                assertEquals((byte) vaList.vargAsInt(C_INT), (byte) 1);
+                assertEquals((char) vaList.vargAsInt(C_INT), 'a');
+                assertEquals((short) vaList.vargAsInt(C_INT), (short) 3);
+                assertEquals(vaList.vargAsInt(C_INT), 4);
+                assertEquals(vaList.vargAsLong(C_LONGLONG), 5L);
+                assertEquals((float) vaList.vargAsDouble(C_DOUBLE), 6.0F);
+                assertEquals(vaList.vargAsDouble(C_DOUBLE), 7.0D);
+                assertEquals((byte) vaList.vargAsInt(C_INT), (byte) 8);
+                assertEquals((char) vaList.vargAsInt(C_INT), 'b');
+                assertEquals((short) vaList.vargAsInt(C_INT), (short) 10);
+                assertEquals(vaList.vargAsInt(C_INT), 11);
+                assertEquals(vaList.vargAsLong(C_LONGLONG), 12L);
+                assertEquals((float) vaList.vargAsDouble(C_DOUBLE), 13.0F);
+                assertEquals(vaList.vargAsDouble(C_DOUBLE), 14.0D);
 
-                try (MemorySegment point = vaList.readStructOrUnion(Point_LAYOUT)) {
+                try (MemorySegment point = vaList.vargAsSegment(Point_LAYOUT)) {
                     assertEquals((int) VH_Point_x.get(point.baseAddress()), 5);
                     assertEquals((int) VH_Point_y.get(point.baseAddress()), 10);
                 }
 
                 VaList copy = vaList.copy();
-                try (MemorySegment bigPoint = vaList.readStructOrUnion(BigPoint_LAYOUT)) {
+                try (MemorySegment bigPoint = vaList.vargAsSegment(BigPoint_LAYOUT)) {
                     assertEquals((long) VH_BigPoint_x.get(bigPoint.baseAddress()), 15);
                     assertEquals((long) VH_BigPoint_y.get(bigPoint.baseAddress()), 20);
 
@@ -328,7 +328,7 @@ public class VaListTest {
                 }
 
                 // should be independent
-                try (MemorySegment struct = copy.readStructOrUnion(BigPoint_LAYOUT)) {
+                try (MemorySegment struct = copy.vargAsSegment(BigPoint_LAYOUT)) {
                     assertEquals((long) VH_BigPoint_x.get(struct.baseAddress()), 15);
                     assertEquals((long) VH_BigPoint_y.get(struct.baseAddress()), 20);
                 }
@@ -336,13 +336,13 @@ public class VaListTest {
             // test skip
             { linkVaListCB("upcallStack"), VaListConsumer.mh(vaList -> {
                 vaList.skip(C_LONGLONG, C_LONGLONG, C_LONGLONG, C_LONGLONG);
-                assertEquals(vaList.readLong(C_LONGLONG), 5L);
+                assertEquals(vaList.vargAsLong(C_LONGLONG), 5L);
                 vaList.skip(C_LONGLONG, C_LONGLONG, C_LONGLONG, C_LONGLONG);
-                assertEquals(vaList.readLong(C_LONGLONG), 10L);
+                assertEquals(vaList.vargAsLong(C_LONGLONG), 10L);
                 vaList.skip(C_LONGLONG, C_LONGLONG, C_LONGLONG, C_LONGLONG, C_LONGLONG, C_LONGLONG);
-                assertEquals(vaList.readDouble(C_DOUBLE), 1.0D);
+                assertEquals(vaList.vargAsDouble(C_DOUBLE), 1.0D);
                 vaList.skip(C_DOUBLE, C_DOUBLE, C_DOUBLE, C_DOUBLE);
-                assertEquals(vaList.readDouble(C_DOUBLE), 6.0D);
+                assertEquals(vaList.vargAsDouble(C_DOUBLE), 6.0D);
             })},
         };
     }

--- a/test/jdk/java/foreign/valist/VaListTest.java
+++ b/test/jdk/java/foreign/valist/VaListTest.java
@@ -161,6 +161,11 @@ public class VaListTest {
         }
     }
 
+    // TODO
+    // check by-value struct immutability on both ABIS
+    // check read/write/close access (not just read) of values read from va_list
+    // check va_copy is really an effective copy, and no argument aliasing can occur
+
     @Test
     public void testWinStructByValue() throws Throwable {
         try (MemorySegment struct = MemorySegment.allocateNative(Point_LAYOUT)) {
@@ -218,88 +223,82 @@ public class VaListTest {
     public static Object[][] upcalls() {
         return new Object[][]{
             { linkVaListCB("upcallBigStruct"), VaListConsumer.mh(vaList -> {
-                VaList.Reader reader = vaList.reader(1);
-                MemorySegment struct = reader.readStructOrUnion(BigPoint_LAYOUT);
+                MemorySegment struct = vaList.readStructOrUnion(BigPoint_LAYOUT);
                 assertEquals((long) VH_BigPoint_x.get(struct.baseAddress()), 8);
                 assertEquals((long) VH_BigPoint_y.get(struct.baseAddress()), 16);
             })},
             { linkVaListCB("upcallStruct"), VaListConsumer.mh(vaList -> {
-                VaList.Reader reader = vaList.reader(1);
-                MemorySegment struct = reader.readStructOrUnion(Point_LAYOUT);
+                MemorySegment struct = vaList.readStructOrUnion(Point_LAYOUT);
                 assertEquals((int) VH_Point_x.get(struct.baseAddress()), 5);
                 assertEquals((int) VH_Point_y.get(struct.baseAddress()), 10);
             })},
             { linkVaListCB("upcallMemoryAddress"), VaListConsumer.mh(vaList -> {
-                VaList.Reader reader = vaList.reader(1);
-                MemoryAddress intPtr = reader.readPointer(C_POINTER);
+                MemoryAddress intPtr = vaList.readPointer(C_POINTER);
                 MemorySegment ms = MemorySegment.ofNativeRestricted(intPtr, C_INT.byteSize(),
                                                                     Thread.currentThread(), null, null);
                 int x = (int) VH_int.get(ms.baseAddress());
                 assertEquals(x, 10);
             })},
             { linkVaListCB("upcallDoubles"), VaListConsumer.mh(vaList -> {
-                VaList.Reader reader = vaList.reader(3);
-                assertEquals(reader.readDouble(C_DOUBLE), 3.0);
-                assertEquals(reader.readDouble(C_DOUBLE), 4.0);
-                assertEquals(reader.readDouble(C_DOUBLE), 5.0);
+                assertEquals(vaList.readDouble(C_DOUBLE), 3.0);
+                assertEquals(vaList.readDouble(C_DOUBLE), 4.0);
+                assertEquals(vaList.readDouble(C_DOUBLE), 5.0);
             })},
             { linkVaListCB("upcallInts"), VaListConsumer.mh(vaList -> {
-                VaList.Reader reader = vaList.reader(3);
-                assertEquals(reader.readInt(C_INT), 10);
-                assertEquals(reader.readInt(C_INT), 15);
-                assertEquals(reader.readInt(C_INT), 20);
+                assertEquals(vaList.readInt(C_INT), 10);
+                assertEquals(vaList.readInt(C_INT), 15);
+                assertEquals(vaList.readInt(C_INT), 20);
             })},
             { linkVaListCB("upcallStack"), VaListConsumer.mh(vaList -> {
-                VaList.Reader reader = vaList.reader(32 + 14);
                 // skip all registers
-                assertEquals(reader.readLong(C_LONGLONG), 1L); // windows are read from shadow space 1
-                assertEquals(reader.readLong(C_LONGLONG), 2L); // windows are read from shadow space 2
-                assertEquals(reader.readLong(C_LONGLONG), 3L); // windows first stack arg (int/float)
-                assertEquals(reader.readLong(C_LONGLONG), 4L);
-                assertEquals(reader.readLong(C_LONGLONG), 5L);
-                assertEquals(reader.readLong(C_LONGLONG), 6L);
-                assertEquals(reader.readLong(C_LONGLONG), 7L); // sysv 1st int stack arg
-                assertEquals(reader.readLong(C_LONGLONG), 8L);
-                assertEquals(reader.readLong(C_LONGLONG), 9L);
-                assertEquals(reader.readLong(C_LONGLONG), 10L);
-                assertEquals(reader.readLong(C_LONGLONG), 11L);
-                assertEquals(reader.readLong(C_LONGLONG), 12L);
-                assertEquals(reader.readLong(C_LONGLONG), 13L);
-                assertEquals(reader.readLong(C_LONGLONG), 14L);
-                assertEquals(reader.readLong(C_LONGLONG), 15L);
-                assertEquals(reader.readLong(C_LONGLONG), 16L);
-                assertEquals(reader.readDouble(C_DOUBLE), 1.0D);
-                assertEquals(reader.readDouble(C_DOUBLE), 2.0D);
-                assertEquals(reader.readDouble(C_DOUBLE), 3.0D);
-                assertEquals(reader.readDouble(C_DOUBLE), 4.0D);
-                assertEquals(reader.readDouble(C_DOUBLE), 5.0D);
-                assertEquals(reader.readDouble(C_DOUBLE), 6.0D);
-                assertEquals(reader.readDouble(C_DOUBLE), 7.0D);
-                assertEquals(reader.readDouble(C_DOUBLE), 8.0D);
-                assertEquals(reader.readDouble(C_DOUBLE), 9.0D); // sysv 1st float stack arg
-                assertEquals(reader.readDouble(C_DOUBLE), 10.0D);
-                assertEquals(reader.readDouble(C_DOUBLE), 11.0D);
-                assertEquals(reader.readDouble(C_DOUBLE), 12.0D);
-                assertEquals(reader.readDouble(C_DOUBLE), 13.0D);
-                assertEquals(reader.readDouble(C_DOUBLE), 14.0D);
-                assertEquals(reader.readDouble(C_DOUBLE), 15.0D);
-                assertEquals(reader.readDouble(C_DOUBLE), 16.0D);
+                assertEquals(vaList.readLong(C_LONGLONG), 1L); // windows are read from shadow space 1
+                assertEquals(vaList.readLong(C_LONGLONG), 2L); // windows are read from shadow space 2
+                assertEquals(vaList.readLong(C_LONGLONG), 3L); // windows first stack arg (int/float)
+                assertEquals(vaList.readLong(C_LONGLONG), 4L);
+                assertEquals(vaList.readLong(C_LONGLONG), 5L);
+                assertEquals(vaList.readLong(C_LONGLONG), 6L);
+                assertEquals(vaList.readLong(C_LONGLONG), 7L); // sysv 1st int stack arg
+                assertEquals(vaList.readLong(C_LONGLONG), 8L);
+                assertEquals(vaList.readLong(C_LONGLONG), 9L);
+                assertEquals(vaList.readLong(C_LONGLONG), 10L);
+                assertEquals(vaList.readLong(C_LONGLONG), 11L);
+                assertEquals(vaList.readLong(C_LONGLONG), 12L);
+                assertEquals(vaList.readLong(C_LONGLONG), 13L);
+                assertEquals(vaList.readLong(C_LONGLONG), 14L);
+                assertEquals(vaList.readLong(C_LONGLONG), 15L);
+                assertEquals(vaList.readLong(C_LONGLONG), 16L);
+                assertEquals(vaList.readDouble(C_DOUBLE), 1.0D);
+                assertEquals(vaList.readDouble(C_DOUBLE), 2.0D);
+                assertEquals(vaList.readDouble(C_DOUBLE), 3.0D);
+                assertEquals(vaList.readDouble(C_DOUBLE), 4.0D);
+                assertEquals(vaList.readDouble(C_DOUBLE), 5.0D);
+                assertEquals(vaList.readDouble(C_DOUBLE), 6.0D);
+                assertEquals(vaList.readDouble(C_DOUBLE), 7.0D);
+                assertEquals(vaList.readDouble(C_DOUBLE), 8.0D);
+                assertEquals(vaList.readDouble(C_DOUBLE), 9.0D); // sysv 1st float stack arg
+                assertEquals(vaList.readDouble(C_DOUBLE), 10.0D);
+                assertEquals(vaList.readDouble(C_DOUBLE), 11.0D);
+                assertEquals(vaList.readDouble(C_DOUBLE), 12.0D);
+                assertEquals(vaList.readDouble(C_DOUBLE), 13.0D);
+                assertEquals(vaList.readDouble(C_DOUBLE), 14.0D);
+                assertEquals(vaList.readDouble(C_DOUBLE), 15.0D);
+                assertEquals(vaList.readDouble(C_DOUBLE), 16.0D);
 
                 // test some arbitrary values on the stack
-                assertEquals((byte) reader.readInt(C_INT), (byte) 1);
-                assertEquals((char) reader.readInt(C_INT), 'a');
-                assertEquals((short) reader.readInt(C_INT), (short) 3);
-                assertEquals(reader.readInt(C_INT), 4);
-                assertEquals(reader.readLong(C_LONGLONG), 5L);
-                assertEquals((float) reader.readDouble(C_DOUBLE), 6.0F);
-                assertEquals(reader.readDouble(C_DOUBLE), 7.0D);
-                assertEquals((byte) reader.readInt(C_INT), (byte) 8);
-                assertEquals((char) reader.readInt(C_INT), 'b');
-                assertEquals((short) reader.readInt(C_INT), (short) 10);
-                assertEquals(reader.readInt(C_INT), 11);
-                assertEquals(reader.readLong(C_LONGLONG), 12L);
-                assertEquals((float) reader.readDouble(C_DOUBLE), 13.0F);
-                assertEquals(reader.readDouble(C_DOUBLE), 14.0D);
+                assertEquals((byte) vaList.readInt(C_INT), (byte) 1);
+                assertEquals((char) vaList.readInt(C_INT), 'a');
+                assertEquals((short) vaList.readInt(C_INT), (short) 3);
+                assertEquals(vaList.readInt(C_INT), 4);
+                assertEquals(vaList.readLong(C_LONGLONG), 5L);
+                assertEquals((float) vaList.readDouble(C_DOUBLE), 6.0F);
+                assertEquals(vaList.readDouble(C_DOUBLE), 7.0D);
+                assertEquals((byte) vaList.readInt(C_INT), (byte) 8);
+                assertEquals((char) vaList.readInt(C_INT), 'b');
+                assertEquals((short) vaList.readInt(C_INT), (short) 10);
+                assertEquals(vaList.readInt(C_INT), 11);
+                assertEquals(vaList.readLong(C_LONGLONG), 12L);
+                assertEquals((float) vaList.readDouble(C_DOUBLE), 13.0F);
+                assertEquals(vaList.readDouble(C_DOUBLE), 14.0D);
 
             })},
         };

--- a/test/jdk/java/foreign/valist/VaListTest.java
+++ b/test/jdk/java/foreign/valist/VaListTest.java
@@ -223,14 +223,16 @@ public class VaListTest {
     public static Object[][] upcalls() {
         return new Object[][]{
             { linkVaListCB("upcallBigStruct"), VaListConsumer.mh(vaList -> {
-                MemorySegment struct = vaList.readStructOrUnion(BigPoint_LAYOUT);
-                assertEquals((long) VH_BigPoint_x.get(struct.baseAddress()), 8);
-                assertEquals((long) VH_BigPoint_y.get(struct.baseAddress()), 16);
+                try (MemorySegment struct = vaList.readStructOrUnion(BigPoint_LAYOUT)) {
+                    assertEquals((long) VH_BigPoint_x.get(struct.baseAddress()), 8);
+                    assertEquals((long) VH_BigPoint_y.get(struct.baseAddress()), 16);
+                }
             })},
             { linkVaListCB("upcallStruct"), VaListConsumer.mh(vaList -> {
-                MemorySegment struct = vaList.readStructOrUnion(Point_LAYOUT);
-                assertEquals((int) VH_Point_x.get(struct.baseAddress()), 5);
-                assertEquals((int) VH_Point_y.get(struct.baseAddress()), 10);
+                try (MemorySegment struct = vaList.readStructOrUnion(Point_LAYOUT)) {
+                    assertEquals((int) VH_Point_x.get(struct.baseAddress()), 5);
+                    assertEquals((int) VH_Point_y.get(struct.baseAddress()), 10);
+                }
             })},
             { linkVaListCB("upcallMemoryAddress"), VaListConsumer.mh(vaList -> {
                 MemoryAddress intPtr = vaList.readPointer(C_POINTER);
@@ -251,9 +253,9 @@ public class VaListTest {
             })},
             { linkVaListCB("upcallStack"), VaListConsumer.mh(vaList -> {
                 // skip all registers
-                assertEquals(vaList.readLong(C_LONGLONG), 1L); // windows are read from shadow space 1
-                assertEquals(vaList.readLong(C_LONGLONG), 2L); // windows are read from shadow space 2
-                assertEquals(vaList.readLong(C_LONGLONG), 3L); // windows first stack arg (int/float)
+                assertEquals(vaList.readLong(C_LONGLONG), 1L); // 1st windows arg read from shadow space
+                assertEquals(vaList.readLong(C_LONGLONG), 2L); // 2nd windows arg read from shadow space
+                assertEquals(vaList.readLong(C_LONGLONG), 3L); // windows 1st stack arg (int/float)
                 assertEquals(vaList.readLong(C_LONGLONG), 4L);
                 assertEquals(vaList.readLong(C_LONGLONG), 5L);
                 assertEquals(vaList.readLong(C_LONGLONG), 6L);
@@ -300,6 +302,15 @@ public class VaListTest {
                 assertEquals((float) vaList.readDouble(C_DOUBLE), 13.0F);
                 assertEquals(vaList.readDouble(C_DOUBLE), 14.0D);
 
+                try (MemorySegment point = vaList.readStructOrUnion(Point_LAYOUT)) {
+                    assertEquals((int) VH_Point_x.get(point.baseAddress()), 5);
+                    assertEquals((int) VH_Point_y.get(point.baseAddress()), 10);
+                }
+
+                try (MemorySegment bigPoint = vaList.readStructOrUnion(BigPoint_LAYOUT)) {
+                    assertEquals((long) VH_BigPoint_x.get(bigPoint.baseAddress()), 15);
+                    assertEquals((long) VH_BigPoint_y.get(bigPoint.baseAddress()), 20);
+                }
             })},
         };
     }

--- a/test/jdk/java/foreign/valist/libVaList.c
+++ b/test/jdk/java/foreign/valist/libVaList.c
@@ -1,0 +1,139 @@
+/*
+ *  Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ *  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ *  This code is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License version 2 only, as
+ *  published by the Free Software Foundation.
+ *
+ *  This code is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ *  version 2 for more details (a copy is included in the LICENSE file that
+ *  accompanied this code).
+ *
+ *  You should have received a copy of the GNU General Public License version
+ *  2 along with this work; if not, write to the Free Software Foundation,
+ *  Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ *   Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ *  or visit www.oracle.com if you need additional information or have any
+ *  questions.
+ *
+ */
+
+#include <stdarg.h>
+
+#ifdef _WIN64
+#define EXPORT __declspec(dllexport)
+#else
+#define EXPORT
+#endif
+
+// ###### Down calls
+
+EXPORT int sumInts(int argNum, va_list list) {
+    int sum = 0;
+    for (int i = 0; i < argNum; i++) {
+        sum += va_arg(list, int);
+    }
+    return sum;
+}
+
+EXPORT double sumDoubles(int argNum, va_list list) {
+    double sum = 0;
+    for (int i = 0; i < argNum; i++) {
+        sum += va_arg(list, double);
+    }
+    return sum;
+}
+
+EXPORT int getInt(va_list list) {
+    int* ptr = va_arg(list, int*);
+    return *ptr;
+}
+
+typedef struct {
+    int x;
+    int y;
+} Point;
+
+EXPORT int sumStruct(va_list list) {
+    Point point = va_arg(list, Point);
+    return point.x + point.y;
+}
+
+typedef struct {
+    long long x;
+    long long y;
+} BigPoint;
+
+EXPORT long long sumBigStruct(va_list list) {
+    BigPoint point = va_arg(list, BigPoint);
+    return point.x + point.y;
+}
+
+EXPORT void sumStack(long long* longSum, double* doubleSum, int numArgs, ...) { // numArgs required by spec
+    va_list list;
+    va_start(list, numArgs);
+    long long lSum = 0;
+    for (int i = 0; i < 16; i++) {
+        lSum += va_arg(list, long long);
+    }
+    *longSum = lSum;
+    double dSum = 0.0;
+    for (int i = 0; i < 16; i++) {
+        dSum += va_arg(list, double);
+    }
+    *doubleSum = dSum;
+    va_end(list);
+}
+
+// ###### Up calls
+
+typedef void CB(va_list);
+
+static void passToUpcall(CB cb, int numArgs, ...) {
+    va_list list;
+    va_start(list, numArgs);
+    cb(list);
+    va_end(list);
+}
+
+EXPORT void upcallInts(CB cb) {
+    passToUpcall(cb, 3, 10, 15, 20);
+}
+
+EXPORT void upcallDoubles(CB cb) {
+    passToUpcall(cb, 3, 3.0, 4.0, 5.0);
+}
+
+EXPORT void upcallStack(CB cb) {
+    passToUpcall(cb, 32 + 14,
+        1LL, 2LL, 3LL, 4LL, 5LL, 6LL, 7LL, 8LL,
+        9LL, 10LL, 11LL, 12LL, 13LL, 14LL, 15LL, 16LL,
+        1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0,
+        9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0,
+        // should all be passed on the stack
+        1, 'a', 3,  4,  5LL,  6.0f,  7.0,
+        8, 'b', 10, 11, 12LL, 13.0f, 14.0);
+}
+
+EXPORT void upcallMemoryAddress(CB cb) {
+    int x = 10;
+    passToUpcall(cb, 1, &x);
+}
+
+EXPORT void upcallStruct(CB cb) {
+    Point point;
+    point.x = 5;
+    point.y = 10;
+    passToUpcall(cb, 1, point);
+}
+
+EXPORT void upcallBigStruct(CB cb) {
+    BigPoint point;
+    point.x = 8;
+    point.y = 16;
+    passToUpcall(cb, 1, point);
+}

--- a/test/jdk/java/foreign/valist/libVaList.c
+++ b/test/jdk/java/foreign/valist/libVaList.c
@@ -109,6 +109,14 @@ EXPORT void upcallDoubles(CB cb) {
 }
 
 EXPORT void upcallStack(CB cb) {
+    Point point;
+    point.x = 5;
+    point.y = 10;
+
+    BigPoint bigPoint;
+    bigPoint.x = 15;
+    bigPoint.y = 20;
+
     passToUpcall(cb, 32 + 14,
         1LL, 2LL, 3LL, 4LL, 5LL, 6LL, 7LL, 8LL,
         9LL, 10LL, 11LL, 12LL, 13LL, 14LL, 15LL, 16LL,
@@ -116,7 +124,8 @@ EXPORT void upcallStack(CB cb) {
         9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0,
         // should all be passed on the stack
         1, 'a', 3,  4,  5LL,  6.0f,  7.0,
-        8, 'b', 10, 11, 12LL, 13.0f, 14.0);
+        8, 'b', 10, 11, 12LL, 13.0f, 14.0,
+        point, bigPoint);
 }
 
 EXPORT void upcallMemoryAddress(CB cb) {

--- a/test/micro/org/openjdk/bench/jdk/incubator/foreign/VaList.java
+++ b/test/micro/org/openjdk/bench/jdk/incubator/foreign/VaList.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.bench.jdk.incubator.foreign;
+
+import jdk.incubator.foreign.CSupport;
+import jdk.incubator.foreign.ForeignLinker;
+import jdk.incubator.foreign.FunctionDescriptor;
+import jdk.incubator.foreign.LibraryLookup;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodType;
+import java.util.concurrent.TimeUnit;
+
+import static jdk.incubator.foreign.CSupport.C_DOUBLE;
+import static jdk.incubator.foreign.CSupport.C_INT;
+import static jdk.incubator.foreign.CSupport.C_LONGLONG;
+import static jdk.incubator.foreign.CSupport.Win64.asVarArg;
+
+@BenchmarkMode(Mode.AverageTime)
+@Warmup(iterations = 5, time = 500, timeUnit = TimeUnit.MILLISECONDS)
+@Measurement(iterations = 10, time = 500, timeUnit = TimeUnit.MILLISECONDS)
+@State(org.openjdk.jmh.annotations.Scope.Thread)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Fork(3)
+public class VaList {
+
+    static final ForeignLinker linker = CSupport.getSystemLinker();
+    static final LibraryLookup lookup = LibraryLookup.ofLibrary("VaList");
+
+    static final MethodHandle MH_ellipsis;
+    static final MethodHandle MH_vaList;
+
+    static {
+        try {
+            MH_ellipsis = linker.downcallHandle(lookup.lookup("ellipsis"),
+                    MethodType.methodType(void.class, int.class, int.class, double.class, long.class),
+                    FunctionDescriptor.ofVoid(C_INT, asVarArg(C_INT), asVarArg(C_DOUBLE), asVarArg(C_LONGLONG)));
+            MH_vaList = linker.downcallHandle(lookup.lookup("vaList"),
+                    MethodType.methodType(void.class, int.class, CSupport.VaList.class),
+                    FunctionDescriptor.ofVoid(C_INT, CSupport.C_VA_LIST));
+        } catch (NoSuchMethodException e) {
+            throw new InternalError(e);
+        }
+    }
+
+    @Benchmark
+    public void ellipsis() throws Throwable {
+        MH_ellipsis.invokeExact(3,
+                                1, 2D, 3L);
+    }
+
+    @Benchmark
+    public void vaList() throws Throwable {
+        try (CSupport.VaList vaList = CSupport.newVaList(b ->
+            b.intArg(C_INT, 1)
+             .doubleArg(C_DOUBLE, 2D)
+             .longArg(C_LONGLONG, 3L)
+        )) {
+            MH_vaList.invokeExact(3,
+                                  vaList);
+        }
+    }
+}

--- a/test/micro/org/openjdk/bench/jdk/incubator/foreign/VaList.java
+++ b/test/micro/org/openjdk/bench/jdk/incubator/foreign/VaList.java
@@ -80,9 +80,9 @@ public class VaList {
     @Benchmark
     public void vaList() throws Throwable {
         try (CSupport.VaList vaList = CSupport.newVaList(b ->
-            b.intArg(C_INT, 1)
-             .doubleArg(C_DOUBLE, 2D)
-             .longArg(C_LONGLONG, 3L)
+            b.vargFromInt(C_INT, 1)
+             .vargFromDouble(C_DOUBLE, 2D)
+             .vargFromLong(C_LONGLONG, 3L)
         )) {
             MH_vaList.invokeExact(3,
                                   vaList);

--- a/test/micro/org/openjdk/bench/jdk/incubator/foreign/libVaList.c
+++ b/test/micro/org/openjdk/bench/jdk/incubator/foreign/libVaList.c
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+#include <stdarg.h>
+
+#ifdef _WIN64
+#define EXPORT __declspec(dllexport)
+#else
+#define EXPORT
+#endif
+
+EXPORT void vaList(int argCount, va_list list) {
+    //...
+}
+
+EXPORT void ellipsis(int argCount, ...) {
+    va_list list;
+    va_start(list, argCount);
+    vaList(argCount, list);
+    va_end(list);
+}


### PR DESCRIPTION
Hi,

This patch adds a special VaList carrier to CSupport that can be used by C linker implementations to pass `va_list` arguments to upcalls and downcalls.

Currently Windows VaList and SysV VaLists are implemented, but AArach64 not yet.

The API for the Reader and Builder might be a bit strange; the limitation to int, long, and double comes from the standard argument promotions that are done in C when calling a variadic function. Since we do not know how to promote any arbitrary value, at least for now the API restricts itself to accepting only types that would not be promoted in C, leaving any needed conversion up to the user.

For reviewers; I moved CallArranger.TypeClass + classification code to the top level, since it is now shared with the VaList implementations, so that's where the CallArranger diff comes from.

Thanks,
Jorn
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [JDK-8245988](https://bugs.openjdk.java.net/browse/JDK-8245988): Add a special VaList carrier


### Reviewers
 * Maurizio Cimadamore ([mcimadamore](@mcimadamore) - Committer)


### Download
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/184/head:pull/184`
`$ git checkout pull/184`
