### PR TITLE
8246052: MemorySegment::mapFromPath should take an offset

### DIFF
--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/MemorySegment.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/MemorySegment.java
@@ -552,16 +552,18 @@ allocateNative(bytesSize, 1);
      * of mapped memory associated with the returned mapped memory segment is unspecified and should not be relied upon.
      *
      * @param path the path to the file to memory map.
+     * @param bytesOffset the offset (expressed in bytes) within the file at which the mapped segment is to start.
      * @param bytesSize the size (in bytes) of the mapped memory backing the memory segment.
      * @param mapMode a file mapping mode, see {@link FileChannel#map(FileChannel.MapMode, long, long)}; the chosen mapping mode
      *                might affect the behavior of the returned memory mapped segment (see {@link MappedMemorySegment#force()}).
      * @return a new mapped memory segment.
+     * @throws IllegalArgumentException if {@code bytesOffset < 0}.
      * @throws IllegalArgumentException if {@code bytesSize < 0}.
      * @throws UnsupportedOperationException if an unsupported map mode is specified.
      * @throws IOException if the specified path does not point to an existing file, or if some other I/O error occurs.
      */
-    static MappedMemorySegment mapFromPath(Path path, long bytesSize, FileChannel.MapMode mapMode) throws IOException {
-        return MappedMemorySegmentImpl.makeMappedSegment(path, bytesSize, mapMode);
+    static MappedMemorySegment mapFromPath(Path path, long bytesOffset, long bytesSize, FileChannel.MapMode mapMode) throws IOException {
+        return MappedMemorySegmentImpl.makeMappedSegment(path, bytesOffset, bytesSize, mapMode);
     }
 
     /**

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/MappedMemorySegmentImpl.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/MappedMemorySegmentImpl.java
@@ -99,10 +99,11 @@ public class MappedMemorySegmentImpl extends NativeMemorySegmentImpl implements 
 
     // factories
 
-    public static MappedMemorySegment makeMappedSegment(Path path, long bytesSize, FileChannel.MapMode mapMode) throws IOException {
-        if (bytesSize <= 0) throw new IllegalArgumentException("Requested bytes size must be > 0.");
+    public static MappedMemorySegment makeMappedSegment(Path path, long bytesOffset, long bytesSize, FileChannel.MapMode mapMode) throws IOException {
+        if (bytesSize < 0) throw new IllegalArgumentException("Requested bytes size must be > 0.");
+        if (bytesOffset < 0) throw new IllegalArgumentException("Requested bytes offset must be > 0.");
         try (FileChannelImpl channelImpl = (FileChannelImpl)FileChannel.open(path, openOptions(mapMode))) {
-            UnmapperProxy unmapperProxy = channelImpl.mapInternal(mapMode, 0L, bytesSize);
+            UnmapperProxy unmapperProxy = channelImpl.mapInternal(mapMode, bytesOffset, bytesSize);
             MemoryScope scope = MemoryScope.create(null, unmapperProxy::unmap);
             int modes = defaultAccessModes(bytesSize);
             if (mapMode == FileChannel.MapMode.READ_ONLY) {

--- a/test/jdk/java/foreign/TestByteBuffer.java
+++ b/test/jdk/java/foreign/TestByteBuffer.java
@@ -143,17 +143,20 @@ public class TestByteBuffer {
     static VarHandle doubleHandle = doubles.varHandle(double.class, PathElement.sequenceElement());
 
 
-    static void initTuples(MemoryAddress base) {
-        for (long i = 0; i < tuples.elementCount().getAsLong() ; i++) {
+    static void initTuples(MemoryAddress base, long count) {
+        for (long i = 0; i < count ; i++) {
             indexHandle.set(base, i, (int)i);
             valueHandle.set(base, i, (float)(i / 500f));
         }
     }
 
-    static void checkTuples(MemoryAddress base, ByteBuffer bb) {
-        for (long i = 0; i < tuples.elementCount().getAsLong() ; i++) {
-            assertEquals(bb.getInt(), (int)indexHandle.get(base, i));
-            assertEquals(bb.getFloat(), (float)valueHandle.get(base, i));
+    static void checkTuples(MemoryAddress base, ByteBuffer bb, long count) {
+        for (long i = 0; i < count ; i++) {
+            int index;
+            float value;
+            assertEquals(index = bb.getInt(), (int)indexHandle.get(base, i));
+            assertEquals(value = bb.getFloat(), (float)valueHandle.get(base, i));
+            assertEquals(value, index / 500f);
         }
     }
 
@@ -192,10 +195,10 @@ public class TestByteBuffer {
     public void testOffheap() {
         try (MemorySegment segment = MemorySegment.allocateNative(tuples)) {
             MemoryAddress base = segment.baseAddress();
-            initTuples(base);
+            initTuples(base, tuples.elementCount().getAsLong());
 
             ByteBuffer bb = segment.asByteBuffer();
-            checkTuples(base, bb);
+            checkTuples(base, bb, tuples.elementCount().getAsLong());
         }
     }
 
@@ -204,10 +207,10 @@ public class TestByteBuffer {
         byte[] arr = new byte[(int) tuples.byteSize()];
         MemorySegment region = MemorySegment.ofArray(arr);
         MemoryAddress base = region.baseAddress();
-        initTuples(base);
+        initTuples(base, tuples.elementCount().getAsLong());
 
         ByteBuffer bb = region.asByteBuffer();
-        checkTuples(base, bb);
+        checkTuples(base, bb, tuples.elementCount().getAsLong());
     }
 
     @Test
@@ -221,7 +224,7 @@ public class TestByteBuffer {
             withMappedBuffer(channel, FileChannel.MapMode.READ_WRITE, 0, tuples.byteSize(), mbb -> {
                 MemorySegment segment = MemorySegment.ofByteBuffer(mbb);
                 MemoryAddress base = segment.baseAddress();
-                initTuples(base);
+                initTuples(base, tuples.elementCount().getAsLong());
                 mbb.force();
             });
         }
@@ -231,7 +234,7 @@ public class TestByteBuffer {
             withMappedBuffer(channel, FileChannel.MapMode.READ_ONLY, 0, tuples.byteSize(), mbb -> {
                 MemorySegment segment = MemorySegment.ofByteBuffer(mbb);
                 MemoryAddress base = segment.baseAddress();
-                checkTuples(base, mbb);
+                checkTuples(base, mbb, tuples.elementCount().getAsLong());
             });
         }
     }
@@ -240,12 +243,12 @@ public class TestByteBuffer {
 
     @Test
     public void testDefaultAccessModesMappedSegment() throws Throwable {
-        try (MappedMemorySegment segment = MemorySegment.mapFromPath(tempPath, 8, FileChannel.MapMode.READ_WRITE)) {
+        try (MappedMemorySegment segment = MemorySegment.mapFromPath(tempPath, 0L, 8, FileChannel.MapMode.READ_WRITE)) {
             assertTrue(segment.hasAccessModes(ALL_ACCESS_MODES));
             assertEquals(segment.accessModes(), ALL_ACCESS_MODES);
         }
 
-        try (MappedMemorySegment segment = MemorySegment.mapFromPath(tempPath, 8, FileChannel.MapMode.READ_ONLY)) {
+        try (MappedMemorySegment segment = MemorySegment.mapFromPath(tempPath, 0L, 8, FileChannel.MapMode.READ_ONLY)) {
             assertTrue(segment.hasAccessModes(ALL_ACCESS_MODES & ~WRITE));
             assertEquals(segment.accessModes(), ALL_ACCESS_MODES& ~WRITE);
         }
@@ -258,16 +261,44 @@ public class TestByteBuffer {
         f.deleteOnExit();
 
         //write to channel
-        try (MappedMemorySegment segment = MemorySegment.mapFromPath(f.toPath(), tuples.byteSize(), FileChannel.MapMode.READ_WRITE)) {
+        try (MappedMemorySegment segment = MemorySegment.mapFromPath(f.toPath(), 0L, tuples.byteSize(), FileChannel.MapMode.READ_WRITE)) {
             MemoryAddress base = segment.baseAddress();
-            initTuples(base);
+            initTuples(base, tuples.elementCount().getAsLong());
             segment.force();
         }
 
         //read from channel
-        try (MemorySegment segment = MemorySegment.mapFromPath(f.toPath(), tuples.byteSize(), FileChannel.MapMode.READ_ONLY)) {
+        try (MemorySegment segment = MemorySegment.mapFromPath(f.toPath(), 0L, tuples.byteSize(), FileChannel.MapMode.READ_ONLY)) {
             MemoryAddress base = segment.baseAddress();
-            checkTuples(base, segment.asByteBuffer());
+            checkTuples(base, segment.asByteBuffer(), tuples.elementCount().getAsLong());
+        }
+    }
+
+    @Test
+    public void testMappedSegmentOffset() throws Throwable {
+        File f = new File("test3.out");
+        f.createNewFile();
+        f.deleteOnExit();
+
+        MemoryLayout tupleLayout = tuples.elementLayout();
+
+        // write one at a time
+        for (int i = 0 ; i < tuples.byteSize() ; i += tupleLayout.byteSize()) {
+            //write to channel
+            try (MappedMemorySegment segment = MemorySegment.mapFromPath(f.toPath(), i, tuples.byteSize(), FileChannel.MapMode.READ_WRITE)) {
+                MemoryAddress base = segment.baseAddress();
+                initTuples(base, 1);
+                segment.force();
+            }
+        }
+
+        // check one at a time
+        for (int i = 0 ; i < tuples.byteSize() ; i += tupleLayout.byteSize()) {
+            //read from channel
+            try (MemorySegment segment = MemorySegment.mapFromPath(f.toPath(), 0L, tuples.byteSize(), FileChannel.MapMode.READ_ONLY)) {
+                MemoryAddress base = segment.baseAddress();
+                checkTuples(base, segment.asByteBuffer(), 1);
+            }
         }
     }
 
@@ -434,6 +465,31 @@ public class TestByteBuffer {
     public void testTooBigForByteBuffer() {
         try (MemorySegment segment = MemorySegment.allocateNative((long)Integer.MAX_VALUE + 10L)) {
             segment.asByteBuffer();
+        }
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testBadMapNegativeSize() throws IOException {
+        File f = new File("testNeg1.out");
+        f.createNewFile();
+        f.deleteOnExit();
+        MemorySegment.mapFromPath(f.toPath(), 0L, -1, FileChannel.MapMode.READ_WRITE);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testBadMapNegativeOffset() throws IOException {
+        File f = new File("testNeg2.out");
+        f.createNewFile();
+        f.deleteOnExit();
+        MemorySegment.mapFromPath(f.toPath(), -1, 1, FileChannel.MapMode.READ_WRITE);
+    }
+
+    public void testMapZeroSize() throws IOException {
+        File f = new File("testPos1.out");
+        f.createNewFile();
+        f.deleteOnExit();
+        try (MemorySegment segment = MemorySegment.mapFromPath(f.toPath(), 0L, 0L, FileChannel.MapMode.READ_WRITE)) {
+            assertEquals(segment.byteSize(), 0);
         }
     }
 


### PR DESCRIPTION
This patch adds a mapping offset to MemorySegment::mapFromPath. This usability enhancement has been requested many times, and it would be nice to add it to the API, to make it more similar to FileChannel::map, and to allow for more efficient memory usage when dealing with mapped files.

I also added more  tests on mapped segments, to check for edge cases; and also to verify that mapping from offset actually works.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [JDK-8246052](https://bugs.openjdk.java.net/browse/JDK-8246052): MemorySegment::mapFromPath should take an offset


### Reviewers
 * Athijegannathan Sundararajan ([sundar](@sundararajana) - Committer)
 * Chris Hegarty ([chegar](@ChrisHegarty) - no project role)


### Download
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/187/head:pull/187`
`$ git checkout pull/187`
