### PR TITLE
8246053: Add a mask for default access modesAdd a default access mode flag

### DIFF
--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/MemorySegment.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/MemorySegment.java
@@ -396,8 +396,8 @@ public interface MemorySegment extends AutoCloseable {
      * buffer. The segment starts relative to the buffer's position (inclusive)
      * and ends relative to the buffer's limit (exclusive).
      * <p>
-     * The segment will feature all <a href="#access-modes">access modes</a>, unless the given
-     * buffer is {@linkplain ByteBuffer#isReadOnly() read-only} in which case the segment will
+     * The segment will feature all <a href="#access-modes">access modes</a> (see {@link #DEFAULT_ACCESS}),
+     * unless the given buffer is {@linkplain ByteBuffer#isReadOnly() read-only} in which case the segment will
      * not feature the {@link #WRITE} access mode.
      * <p>
      * The resulting memory segment keeps a reference to the backing buffer, to ensure it remains <em>reachable</em>
@@ -414,7 +414,8 @@ public interface MemorySegment extends AutoCloseable {
      * Creates a new array memory segment that models the memory associated with a given heap-allocated byte array.
      * <p>
      * The resulting memory segment keeps a reference to the backing array, to ensure it remains <em>reachable</em>
-     * for the life-time of the segment. The segment will feature all <a href="#access-modes">access modes</a>.
+     * for the life-time of the segment. The segment will feature all <a href="#access-modes">access modes</a>
+     * (see {@link #DEFAULT_ACCESS}).
      *
      * @param arr the primitive array backing the array memory segment.
      * @return a new array memory segment.
@@ -427,7 +428,8 @@ public interface MemorySegment extends AutoCloseable {
      * Creates a new array memory segment that models the memory associated with a given heap-allocated char array.
      * <p>
      * The resulting memory segment keeps a reference to the backing array, to ensure it remains <em>reachable</em>
-     * for the life-time of the segment. The segment will feature all <a href="#access-modes">access modes</a>.
+     * for the life-time of the segment. The segment will feature all <a href="#access-modes">access modes</a>
+     * (see {@link #DEFAULT_ACCESS}).
      *
      * @param arr the primitive array backing the array memory segment.
      * @return a new array memory segment.
@@ -440,7 +442,8 @@ public interface MemorySegment extends AutoCloseable {
      * Creates a new array memory segment that models the memory associated with a given heap-allocated short array.
      * <p>
      * The resulting memory segment keeps a reference to the backing array, to ensure it remains <em>reachable</em>
-     * for the life-time of the segment. The segment will feature all <a href="#access-modes">access modes</a>.
+     * for the life-time of the segment. The segment will feature all <a href="#access-modes">access modes</a>
+     * (see {@link #DEFAULT_ACCESS}).
      *
      * @param arr the primitive array backing the array memory segment.
      * @return a new array memory segment.
@@ -466,7 +469,8 @@ public interface MemorySegment extends AutoCloseable {
      * Creates a new array memory segment that models the memory associated with a given heap-allocated float array.
      * <p>
      * The resulting memory segment keeps a reference to the backing array, to ensure it remains <em>reachable</em>
-     * for the life-time of the segment. The segment will feature all <a href="#access-modes">access modes</a>.
+     * for the life-time of the segment. The segment will feature all <a href="#access-modes">access modes</a>
+     * (see {@link #DEFAULT_ACCESS}).
      *
      * @param arr the primitive array backing the array memory segment.
      * @return a new array memory segment.
@@ -479,7 +483,8 @@ public interface MemorySegment extends AutoCloseable {
      * Creates a new array memory segment that models the memory associated with a given heap-allocated long array.
      * <p>
      * The resulting memory segment keeps a reference to the backing array, to ensure it remains <em>reachable</em>
-     * for the life-time of the segment. The segment will feature all <a href="#access-modes">access modes</a>.
+     * for the life-time of the segment. The segment will feature all <a href="#access-modes">access modes</a>
+     * (see {@link #DEFAULT_ACCESS}).
      *
      * @param arr the primitive array backing the array memory segment.
      * @return a new array memory segment.
@@ -492,7 +497,8 @@ public interface MemorySegment extends AutoCloseable {
      * Creates a new array memory segment that models the memory associated with a given heap-allocated double array.
      * <p>
      * The resulting memory segment keeps a reference to the backing array, to ensure it remains <em>reachable</em>
-     * for the life-time of the segment. The segment will feature all <a href="#access-modes">access modes</a>.
+     * for the life-time of the segment. The segment will feature all <a href="#access-modes">access modes</a>
+     * (see {@link #DEFAULT_ACCESS}).
      *
      * @param arr the primitive array backing the array memory segment.
      * @return a new array memory segment.
@@ -544,9 +550,9 @@ allocateNative(bytesSize, 1);
     /**
      * Creates a new mapped memory segment that models a memory-mapped region of a file from a given path.
      * <p>
-     * The segment will feature all <a href="#access-modes">access modes</a>, unless the given mapping mode
-     * is {@linkplain FileChannel.MapMode#READ_ONLY READ_ONLY}, in which case the segment will not feature
-     * the {@link #WRITE} access mode.
+     * The segment will feature all <a href="#access-modes">access modes</a> (see {@link #DEFAULT_ACCESS}),
+     * unless the given mapping mode is {@linkplain FileChannel.MapMode#READ_ONLY READ_ONLY}, in which case
+     * the segment will not feature the {@link #WRITE} access mode.
      *
      * @implNote When obtaining a mapped segment from a newly created file, the initialization state of the contents of the block
      * of mapped memory associated with the returned mapped memory segment is unspecified and should not be relied upon.
@@ -568,7 +574,8 @@ allocateNative(bytesSize, 1);
 
     /**
      * Creates a new native memory segment that models a newly allocated block of off-heap memory with given size and
-     * alignment constraint (in bytes). The segment will feature all <a href="#access-modes">access modes</a>.
+     * alignment constraint (in bytes). The segment will feature all <a href="#access-modes">access modes</a>
+     * (see {@link #DEFAULT_ACCESS}).
      *
      * @implNote The block of off-heap memory associated with the returned native memory segment is initialized to zero.
      * Moreover, a client is responsible to call the {@link MemorySegment#close()} on a native memory segment,
@@ -598,7 +605,8 @@ allocateNative(bytesSize, 1);
      * bounds, and can therefore be closed; closing such a segment can optionally result in calling an user-provided cleanup
      * action. This method can be very useful when interacting with custom native memory sources (e.g. custom allocators,
      * GPU memory, etc.), where an address to some underlying memory region is typically obtained from native code
-     * (often as a plain {@code long} value). The segment will feature all <a href="#access-modes">access modes</a>.
+     * (often as a plain {@code long} value). The segment will feature all <a href="#access-modes">access modes</a>
+     * (see {@link #DEFAULT_ACCESS}).
      * <p>
      * This method is <em>restricted</em>. Restricted method are unsafe, and, if used incorrectly, their use might crash
      * the JVM crash or, worse, silently result in memory corruption. Thus, clients should refrain from depending on
@@ -666,4 +674,11 @@ allocateNative(bytesSize, 1);
      * @see MemorySegment#withAccessModes(int)
      */
     int HANDOFF = ACQUIRE << 1;
+
+    /**
+     * Default access mode; this is a union of all the access modes supported by memory segments.
+     * @see MemorySegment#accessModes()
+     * @see MemorySegment#withAccessModes(int)
+     */
+    int DEFAULT_ACCESS = READ | WRITE | CLOSE | ACQUIRE | HANDOFF;
 }

--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/MemorySegment.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/MemorySegment.java
@@ -396,7 +396,7 @@ public interface MemorySegment extends AutoCloseable {
      * buffer. The segment starts relative to the buffer's position (inclusive)
      * and ends relative to the buffer's limit (exclusive).
      * <p>
-     * The segment will feature all <a href="#access-modes">access modes</a> (see {@link #DEFAULT_ACCESS}),
+     * The segment will feature all <a href="#access-modes">access modes</a> (see {@link #ALL_ACCESS}),
      * unless the given buffer is {@linkplain ByteBuffer#isReadOnly() read-only} in which case the segment will
      * not feature the {@link #WRITE} access mode.
      * <p>
@@ -415,7 +415,7 @@ public interface MemorySegment extends AutoCloseable {
      * <p>
      * The resulting memory segment keeps a reference to the backing array, to ensure it remains <em>reachable</em>
      * for the life-time of the segment. The segment will feature all <a href="#access-modes">access modes</a>
-     * (see {@link #DEFAULT_ACCESS}).
+     * (see {@link #ALL_ACCESS}).
      *
      * @param arr the primitive array backing the array memory segment.
      * @return a new array memory segment.
@@ -429,7 +429,7 @@ public interface MemorySegment extends AutoCloseable {
      * <p>
      * The resulting memory segment keeps a reference to the backing array, to ensure it remains <em>reachable</em>
      * for the life-time of the segment. The segment will feature all <a href="#access-modes">access modes</a>
-     * (see {@link #DEFAULT_ACCESS}).
+     * (see {@link #ALL_ACCESS}).
      *
      * @param arr the primitive array backing the array memory segment.
      * @return a new array memory segment.
@@ -443,7 +443,7 @@ public interface MemorySegment extends AutoCloseable {
      * <p>
      * The resulting memory segment keeps a reference to the backing array, to ensure it remains <em>reachable</em>
      * for the life-time of the segment. The segment will feature all <a href="#access-modes">access modes</a>
-     * (see {@link #DEFAULT_ACCESS}).
+     * (see {@link #ALL_ACCESS}).
      *
      * @param arr the primitive array backing the array memory segment.
      * @return a new array memory segment.
@@ -470,7 +470,7 @@ public interface MemorySegment extends AutoCloseable {
      * <p>
      * The resulting memory segment keeps a reference to the backing array, to ensure it remains <em>reachable</em>
      * for the life-time of the segment. The segment will feature all <a href="#access-modes">access modes</a>
-     * (see {@link #DEFAULT_ACCESS}).
+     * (see {@link #ALL_ACCESS}).
      *
      * @param arr the primitive array backing the array memory segment.
      * @return a new array memory segment.
@@ -484,7 +484,7 @@ public interface MemorySegment extends AutoCloseable {
      * <p>
      * The resulting memory segment keeps a reference to the backing array, to ensure it remains <em>reachable</em>
      * for the life-time of the segment. The segment will feature all <a href="#access-modes">access modes</a>
-     * (see {@link #DEFAULT_ACCESS}).
+     * (see {@link #ALL_ACCESS}).
      *
      * @param arr the primitive array backing the array memory segment.
      * @return a new array memory segment.
@@ -498,7 +498,7 @@ public interface MemorySegment extends AutoCloseable {
      * <p>
      * The resulting memory segment keeps a reference to the backing array, to ensure it remains <em>reachable</em>
      * for the life-time of the segment. The segment will feature all <a href="#access-modes">access modes</a>
-     * (see {@link #DEFAULT_ACCESS}).
+     * (see {@link #ALL_ACCESS}).
      *
      * @param arr the primitive array backing the array memory segment.
      * @return a new array memory segment.
@@ -550,7 +550,7 @@ allocateNative(bytesSize, 1);
     /**
      * Creates a new mapped memory segment that models a memory-mapped region of a file from a given path.
      * <p>
-     * The segment will feature all <a href="#access-modes">access modes</a> (see {@link #DEFAULT_ACCESS}),
+     * The segment will feature all <a href="#access-modes">access modes</a> (see {@link #ALL_ACCESS}),
      * unless the given mapping mode is {@linkplain FileChannel.MapMode#READ_ONLY READ_ONLY}, in which case
      * the segment will not feature the {@link #WRITE} access mode.
      *
@@ -575,7 +575,7 @@ allocateNative(bytesSize, 1);
     /**
      * Creates a new native memory segment that models a newly allocated block of off-heap memory with given size and
      * alignment constraint (in bytes). The segment will feature all <a href="#access-modes">access modes</a>
-     * (see {@link #DEFAULT_ACCESS}).
+     * (see {@link #ALL_ACCESS}).
      *
      * @implNote The block of off-heap memory associated with the returned native memory segment is initialized to zero.
      * Moreover, a client is responsible to call the {@link MemorySegment#close()} on a native memory segment,
@@ -606,7 +606,7 @@ allocateNative(bytesSize, 1);
      * action. This method can be very useful when interacting with custom native memory sources (e.g. custom allocators,
      * GPU memory, etc.), where an address to some underlying memory region is typically obtained from native code
      * (often as a plain {@code long} value). The segment will feature all <a href="#access-modes">access modes</a>
-     * (see {@link #DEFAULT_ACCESS}).
+     * (see {@link #ALL_ACCESS}).
      * <p>
      * This method is <em>restricted</em>. Restricted method are unsafe, and, if used incorrectly, their use might crash
      * the JVM crash or, worse, silently result in memory corruption. Thus, clients should refrain from depending on
@@ -680,5 +680,5 @@ allocateNative(bytesSize, 1);
      * @see MemorySegment#accessModes()
      * @see MemorySegment#withAccessModes(int)
      */
-    int DEFAULT_ACCESS = READ | WRITE | CLOSE | ACQUIRE | HANDOFF;
+    int ALL_ACCESS = READ | WRITE | CLOSE | ACQUIRE | HANDOFF;
 }

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/AbstractMemorySegmentImpl.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/AbstractMemorySegmentImpl.java
@@ -64,11 +64,9 @@ public abstract class AbstractMemorySegmentImpl implements MemorySegment, Memory
     private static final boolean enableSmallSegments =
             Boolean.parseBoolean(GetPropertyAction.privilegedGetProperty("jdk.incubator.foreign.SmallSegments", "true"));
 
-    final static int ACCESS_MASK = READ | WRITE | CLOSE | ACQUIRE | HANDOFF;
     final static int FIRST_RESERVED_FLAG = 1 << 16; // upper 16 bits are reserved
     final static int SMALL = FIRST_RESERVED_FLAG;
     final static long NONCE = new Random().nextLong();
-    final static int DEFAULT_MASK = READ | WRITE | CLOSE | ACQUIRE | HANDOFF;
 
     final static JavaNioAccess nioAccess = SharedSecrets.getJavaNioAccess();
 
@@ -93,8 +91,8 @@ public abstract class AbstractMemorySegmentImpl implements MemorySegment, Memory
 
     static int defaultAccessModes(long size) {
         return (enableSmallSegments && size < Integer.MAX_VALUE) ?
-                DEFAULT_MASK | SMALL :
-                DEFAULT_MASK;
+                DEFAULT_ACCESS | SMALL :
+                DEFAULT_ACCESS;
     }
 
     @Override
@@ -192,7 +190,7 @@ public abstract class AbstractMemorySegmentImpl implements MemorySegment, Memory
 
     @Override
     public final int accessModes() {
-        return mask & ACCESS_MASK;
+        return mask & DEFAULT_ACCESS;
     }
 
     @Override
@@ -216,7 +214,7 @@ public abstract class AbstractMemorySegmentImpl implements MemorySegment, Memory
         if ((~accessModes() & accessModes) != 0) {
             throw new IllegalArgumentException("Cannot acquire more access modes");
         }
-        return dup(0, length, (mask & ~ACCESS_MASK) | accessModes, scope);
+        return dup(0, length, (mask & ~DEFAULT_ACCESS) | accessModes, scope);
     }
 
     @Override
@@ -226,7 +224,7 @@ public abstract class AbstractMemorySegmentImpl implements MemorySegment, Memory
     }
 
     private void checkAccessModes(int accessModes) {
-        if ((accessModes & ~ACCESS_MASK) != 0) {
+        if ((accessModes & ~DEFAULT_ACCESS) != 0) {
             throw new IllegalArgumentException("Invalid access modes");
         }
     }

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/AbstractMemorySegmentImpl.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/AbstractMemorySegmentImpl.java
@@ -91,8 +91,8 @@ public abstract class AbstractMemorySegmentImpl implements MemorySegment, Memory
 
     static int defaultAccessModes(long size) {
         return (enableSmallSegments && size < Integer.MAX_VALUE) ?
-                DEFAULT_ACCESS | SMALL :
-                DEFAULT_ACCESS;
+                ALL_ACCESS | SMALL :
+                ALL_ACCESS;
     }
 
     @Override
@@ -190,7 +190,7 @@ public abstract class AbstractMemorySegmentImpl implements MemorySegment, Memory
 
     @Override
     public final int accessModes() {
-        return mask & DEFAULT_ACCESS;
+        return mask & ALL_ACCESS;
     }
 
     @Override
@@ -214,7 +214,7 @@ public abstract class AbstractMemorySegmentImpl implements MemorySegment, Memory
         if ((~accessModes() & accessModes) != 0) {
             throw new IllegalArgumentException("Cannot acquire more access modes");
         }
-        return dup(0, length, (mask & ~DEFAULT_ACCESS) | accessModes, scope);
+        return dup(0, length, (mask & ~ALL_ACCESS) | accessModes, scope);
     }
 
     @Override
@@ -224,7 +224,7 @@ public abstract class AbstractMemorySegmentImpl implements MemorySegment, Memory
     }
 
     private void checkAccessModes(int accessModes) {
-        if ((accessModes & ~DEFAULT_ACCESS) != 0) {
+        if ((accessModes & ~ALL_ACCESS) != 0) {
             throw new IllegalArgumentException("Invalid access modes");
         }
     }

--- a/test/jdk/java/foreign/TestByteBuffer.java
+++ b/test/jdk/java/foreign/TestByteBuffer.java
@@ -261,7 +261,7 @@ public class TestByteBuffer {
         //write to channel
         try (MappedMemorySegment segment = MemorySegment.mapFromPath(f.toPath(), 0L, tuples.byteSize(), FileChannel.MapMode.READ_WRITE)) {
             MemoryAddress base = segment.baseAddress();
-            initTuples(base);
+            initTuples(base, tuples.elementCount().getAsLong());
             segment.force();
         }
 

--- a/test/jdk/java/foreign/TestByteBuffer.java
+++ b/test/jdk/java/foreign/TestByteBuffer.java
@@ -242,13 +242,13 @@ public class TestByteBuffer {
     @Test
     public void testDefaultAccessModesMappedSegment() throws Throwable {
         try (MappedMemorySegment segment = MemorySegment.mapFromPath(tempPath, 0L, 8, FileChannel.MapMode.READ_WRITE)) {
-            assertTrue(segment.hasAccessModes(ALL_ACCESS_MODES));
-            assertEquals(segment.accessModes(), ALL_ACCESS_MODES);
+            assertTrue(segment.hasAccessModes(ALL_ACCESS));
+            assertEquals(segment.accessModes(), ALL_ACCESS);
         }
 
         try (MappedMemorySegment segment = MemorySegment.mapFromPath(tempPath, 0L, 8, FileChannel.MapMode.READ_ONLY)) {
-            assertTrue(segment.hasAccessModes(ALL_ACCESS_MODES & ~WRITE));
-            assertEquals(segment.accessModes(), ALL_ACCESS_MODES& ~WRITE);
+            assertTrue(segment.hasAccessModes(ALL_ACCESS & ~WRITE));
+            assertEquals(segment.accessModes(), ALL_ACCESS & ~WRITE);
         }
     }
 
@@ -519,14 +519,14 @@ public class TestByteBuffer {
     public void testDefaultAccessModesOfBuffer() {
         ByteBuffer rwBuffer = ByteBuffer.wrap(new byte[4]);
         try (MemorySegment segment = MemorySegment.ofByteBuffer(rwBuffer)) {
-            assertTrue(segment.hasAccessModes(ALL_ACCESS_MODES));
-            assertEquals(segment.accessModes(), ALL_ACCESS_MODES);
+            assertTrue(segment.hasAccessModes(ALL_ACCESS));
+            assertEquals(segment.accessModes(), ALL_ACCESS);
         }
 
         ByteBuffer roBuffer = rwBuffer.asReadOnlyBuffer();
         try (MemorySegment segment = MemorySegment.ofByteBuffer(roBuffer)) {
-            assertTrue(segment.hasAccessModes(ALL_ACCESS_MODES & ~WRITE));
-            assertEquals(segment.accessModes(), ALL_ACCESS_MODES & ~WRITE);
+            assertTrue(segment.hasAccessModes(ALL_ACCESS & ~WRITE));
+            assertEquals(segment.accessModes(), ALL_ACCESS & ~WRITE);
         }
     }
 

--- a/test/jdk/java/foreign/TestByteBuffer.java
+++ b/test/jdk/java/foreign/TestByteBuffer.java
@@ -239,8 +239,6 @@ public class TestByteBuffer {
         }
     }
 
-    static final int ALL_ACCESS_MODES = READ | WRITE | CLOSE | ACQUIRE | HANDOFF;
-
     @Test
     public void testDefaultAccessModesMappedSegment() throws Throwable {
         try (MappedMemorySegment segment = MemorySegment.mapFromPath(tempPath, 0L, 8, FileChannel.MapMode.READ_WRITE)) {
@@ -263,7 +261,7 @@ public class TestByteBuffer {
         //write to channel
         try (MappedMemorySegment segment = MemorySegment.mapFromPath(f.toPath(), 0L, tuples.byteSize(), FileChannel.MapMode.READ_WRITE)) {
             MemoryAddress base = segment.baseAddress();
-            initTuples(base, tuples.elementCount().getAsLong());
+            initTuples(base);
             segment.force();
         }
 

--- a/test/jdk/java/foreign/TestNative.java
+++ b/test/jdk/java/foreign/TestNative.java
@@ -172,16 +172,14 @@ public class TestNative {
         }
     }
 
-    static final int ALL_ACCESS_MODES = READ | WRITE | CLOSE | ACQUIRE | HANDOFF;
-
     @Test
     public void testDefaultAccessModes() {
         MemoryAddress addr = MemoryAddress.ofLong(allocate(12));
         MemorySegment mallocSegment = MemorySegment.ofNativeRestricted(addr, 12, null,
                 () -> free(addr.toRawLongValue()), null);
         try (MemorySegment segment = mallocSegment) {
-            assertTrue(segment.hasAccessModes(ALL_ACCESS_MODES));
-            assertEquals(segment.accessModes(), ALL_ACCESS_MODES);
+            assertTrue(segment.hasAccessModes(DEFAULT_ACCESS));
+            assertEquals(segment.accessModes(), DEFAULT_ACCESS);
         }
     }
 

--- a/test/jdk/java/foreign/TestNative.java
+++ b/test/jdk/java/foreign/TestNative.java
@@ -178,8 +178,8 @@ public class TestNative {
         MemorySegment mallocSegment = MemorySegment.ofNativeRestricted(addr, 12, null,
                 () -> free(addr.toRawLongValue()), null);
         try (MemorySegment segment = mallocSegment) {
-            assertTrue(segment.hasAccessModes(DEFAULT_ACCESS));
-            assertEquals(segment.accessModes(), DEFAULT_ACCESS);
+            assertTrue(segment.hasAccessModes(ALL_ACCESS));
+            assertEquals(segment.accessModes(), ALL_ACCESS);
         }
     }
 

--- a/test/jdk/java/foreign/TestSegments.java
+++ b/test/jdk/java/foreign/TestSegments.java
@@ -149,8 +149,8 @@ public class TestSegments {
     @Test(dataProvider = "segmentFactories")
     public void testAccessModesOfFactories(Supplier<MemorySegment> memorySegmentSupplier) {
         try (MemorySegment segment = memorySegmentSupplier.get()) {
-            assertTrue(segment.hasAccessModes(DEFAULT_ACCESS));
-            assertEquals(segment.accessModes(), DEFAULT_ACCESS);
+            assertTrue(segment.hasAccessModes(ALL_ACCESS));
+            assertEquals(segment.accessModes(), ALL_ACCESS);
         }
     }
 

--- a/test/jdk/java/foreign/TestSegments.java
+++ b/test/jdk/java/foreign/TestSegments.java
@@ -146,13 +146,11 @@ public class TestSegments {
         }
     }
 
-    static final int ALL_ACCESS_MODES = READ | WRITE | CLOSE | ACQUIRE | HANDOFF;
-
     @Test(dataProvider = "segmentFactories")
     public void testAccessModesOfFactories(Supplier<MemorySegment> memorySegmentSupplier) {
         try (MemorySegment segment = memorySegmentSupplier.get()) {
-            assertTrue(segment.hasAccessModes(ALL_ACCESS_MODES));
-            assertEquals(segment.accessModes(), ALL_ACCESS_MODES);
+            assertTrue(segment.hasAccessModes(DEFAULT_ACCESS));
+            assertEquals(segment.accessModes(), DEFAULT_ACCESS);
         }
     }
 

--- a/test/jdk/java/foreign/TestSpliterator.java
+++ b/test/jdk/java/foreign/TestSpliterator.java
@@ -211,7 +211,7 @@ public class TestSpliterator {
         var mallocSegment = MemorySegment.allocateNative(layout);
 
         Map<Supplier<Spliterator<MemorySegment>>,Integer> l = Map.of(
-            () -> spliterator(mallocSegment.withAccessModes(DEFAULT_ACCESS), layout), DEFAULT_ACCESS,
+            () -> spliterator(mallocSegment.withAccessModes(ALL_ACCESS), layout), ALL_ACCESS,
             () -> spliterator(mallocSegment.withAccessModes(0), layout), 0,
             () -> spliterator(mallocSegment.withAccessModes(READ), layout), READ,
             () -> spliterator(mallocSegment.withAccessModes(CLOSE), layout), 0,

--- a/test/jdk/java/foreign/TestSpliterator.java
+++ b/test/jdk/java/foreign/TestSpliterator.java
@@ -205,15 +205,13 @@ public class TestSpliterator {
         };
     }
 
-    static final int ALL_ACCESS_MODES = READ | WRITE | CLOSE | ACQUIRE | HANDOFF;
-
     @DataProvider(name = "accessScenarios")
     public Object[][] accessScenarios() {
         SequenceLayout layout = MemoryLayout.ofSequence(16, MemoryLayouts.JAVA_INT);
         var mallocSegment = MemorySegment.allocateNative(layout);
 
         Map<Supplier<Spliterator<MemorySegment>>,Integer> l = Map.of(
-            () -> spliterator(mallocSegment.withAccessModes(ALL_ACCESS_MODES), layout), ALL_ACCESS_MODES,
+            () -> spliterator(mallocSegment.withAccessModes(DEFAULT_ACCESS), layout), DEFAULT_ACCESS,
             () -> spliterator(mallocSegment.withAccessModes(0), layout), 0,
             () -> spliterator(mallocSegment.withAccessModes(READ), layout), READ,
             () -> spliterator(mallocSegment.withAccessModes(CLOSE), layout), 0,


### PR DESCRIPTION
This is a simple change which adds a 'default' access mask. This was pointed out during CSR review, and I realized that many tests were also using it.
It can also be handy when creating more restricted masks (e.g. start with default and remove one or two access modes).

I've updated tests, documentation and some of the impl to use the new mask accordingly.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [JDK-8246053](https://bugs.openjdk.java.net/browse/JDK-8246053): Add a mask for default access modes ⚠️ Title mismatch between PR and JBS.


### Reviewers
 * Athijegannathan Sundararajan ([sundar](@sundararajana) - Committer) ⚠️ Review applies to 0d1917377cd2d1bf4a64b971cf0b1170e13d8c7a
 * Chris Hegarty ([chegar](@ChrisHegarty) - no project role) ⚠️ Review applies to 7aec8832d56202aae9cbbe9c11cdd6d28393d6a0


### Download
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/188/head:pull/188`
`$ git checkout pull/188`
