### PR TITLE
8246052: MemorySegment::mapFromPath should take an offset

### DIFF
--- a/test/micro/org/openjdk/bench/jdk/incubator/foreign/LoopOverNonConstantMapped.java
+++ b/test/micro/org/openjdk/bench/jdk/incubator/foreign/LoopOverNonConstantMapped.java
@@ -95,7 +95,7 @@ public class LoopOverNonConstantMapped {
             }
             ((MappedByteBuffer)byteBuffer).force();
         }
-        segment = MemorySegment.mapFromPath(tempPath, ALLOC_SIZE, FileChannel.MapMode.READ_WRITE);
+        segment = MemorySegment.mapFromPath(tempPath, 0L, ALLOC_SIZE, FileChannel.MapMode.READ_WRITE);
         unsafe_addr = segment.baseAddress().toRawLongValue();
     }
 


### PR DESCRIPTION
This is a trivial followup - one of the benchmark working with mapped segments was not upgraded to take the extra argument.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [JDK-8246052](https://bugs.openjdk.java.net/browse/JDK-8246052): MemorySegment::mapFromPath should take an offset


### Reviewers
 * Paul Sandoz ([psandoz](@PaulSandoz) - Committer)


### Download
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/189/head:pull/189`
`$ git checkout pull/189`
