### PR TITLE
configure should fail if libclang path is not specified

### DIFF
--- a/make/autoconf/lib-clang.m4
+++ b/make/autoconf/lib-clang.m4
@@ -163,7 +163,7 @@ AC_DEFUN_ONCE([LIB_SETUP_LIBCLANG],
       else
         AC_MSG_CHECKING([if libclang should be enabled])
         AC_MSG_RESULT([no, not found])
-        AC_MSG_NOTICE([Cannot locate libclang! You can download pre-built llvm
+        AC_MSG_ERROR([Cannot locate libclang! You can download pre-built llvm
             binary from http://llvm.org/releases/download.html, then specify the
             location using --with-libclang])
       fi


### PR DESCRIPTION
configure fails after the message rather than continuging after warning
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * Chris Hegarty ([chegar](@ChrisHegarty) - no project role)
 * Maurizio Cimadamore ([mcimadamore](@mcimadamore) - Committer)


### Download
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/190/head:pull/190`
`$ git checkout pull/190`
