### PR TITLE
8246400: jextract should generate a utility to manage mutliple MemorySegments

### DIFF
--- a/src/jdk.incubator.jextract/share/classes/jdk/incubator/jextract/tool/resources/RuntimeHelper.java.template
+++ b/src/jdk.incubator.jextract/share/classes/jdk/incubator/jextract/tool/resources/RuntimeHelper.java.template
@@ -7,13 +7,18 @@ import jdk.incubator.foreign.LibraryLookup;
 import jdk.incubator.foreign.MemoryAddress;
 import jdk.incubator.foreign.MemoryLayout;
 import jdk.incubator.foreign.MemorySegment;
+import jdk.incubator.foreign.NativeAllocationScope;
 
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.MethodType;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
+import java.util.OptionalLong;
 
 import static ${C_LANG}.*;
 
@@ -78,6 +83,47 @@ public class RuntimeHelper {
             return upcallStub(handle, fdesc);
         } catch (Throwable ex) {
             throw new AssertionError(ex);
+        }
+    }
+
+    public static final class Scope extends NativeAllocationScope {
+        private final NativeAllocationScope impl;
+        private final List<MemorySegment> segments = new ArrayList<>();
+
+        public Scope() {
+            impl = NativeAllocationScope.unboundedScope();
+        }
+
+        public Scope(long size) {
+            impl = NativeAllocationScope.boundedScope(size);
+        }
+
+        @Override
+        public OptionalLong byteSize() {
+            return impl.byteSize();
+        }
+
+        @Override
+        public long allocatedBytes() {
+            return impl.allocatedBytes();
+        }
+
+        @Override
+        public MemoryAddress allocate(long bytesSize, long bytesAlignment) {
+            return impl.allocate(bytesSize, bytesAlignment);
+        }
+
+        @Override
+        public void close() {
+            for (var seg : segments) {
+                seg.close();
+            }
+            impl.close();
+        }
+
+        public MemorySegment register(MemorySegment seg) {
+            segments.add(Objects.requireNonNull(seg));
+            return seg;
         }
     }
 

--- a/src/jdk.incubator.jextract/share/classes/jdk/incubator/jextract/tool/resources/RuntimeHelper.java.template
+++ b/src/jdk.incubator.jextract/share/classes/jdk/incubator/jextract/tool/resources/RuntimeHelper.java.template
@@ -86,15 +86,15 @@ public class RuntimeHelper {
         }
     }
 
-    public static final class Scope extends NativeAllocationScope {
+    public static final class CScope extends NativeAllocationScope {
         private final NativeAllocationScope impl;
         private final List<MemorySegment> segments = new ArrayList<>();
 
-        public Scope() {
+        public CScope() {
             impl = NativeAllocationScope.unboundedScope();
         }
 
-        public Scope(long size) {
+        public CScope(long size) {
             impl = NativeAllocationScope.boundedScope(size);
         }
 

--- a/test/jdk/tools/jextract/test8246341/LibTest8246341Test.java
+++ b/test/jdk/tools/jextract/test8246341/LibTest8246341Test.java
@@ -21,8 +21,6 @@
  * questions.
  */
 
-import java.util.stream.DoubleStream;
-import java.util.stream.IntStream;
 import jdk.incubator.foreign.MemoryAddress;
 import jdk.incubator.foreign.NativeAllocationScope;
 import org.testng.annotations.Test;
@@ -36,7 +34,7 @@ import static test.jextract.test8246341.test8246341_h.*;
  * @library ..
  * @modules jdk.incubator.jextract
  * @bug 8246341
- * @summary jextract should generate simple allocation, access API for C primitive types
+ * @summary jextract should generate Cpointer utilities class
  * @run driver JtregJextract -l Test8246341 -t test.jextract.test8246341 -- test8246341.h
  * @run testng/othervm -Dforeign.restricted=permit LibTest8246341Test
  */

--- a/test/jdk/tools/jextract/test8246400/LibTest8246400Test.java
+++ b/test/jdk/tools/jextract/test8246400/LibTest8246400Test.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import jdk.incubator.foreign.MemorySegment;
+import org.testng.annotations.Test;
+import test.jextract.test8246400.*;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+import static test.jextract.test8246400.test8246400_h.*;
+import static test.jextract.test8246400.RuntimeHelper.*;
+
+/*
+ * @test
+ * @library ..
+ * @modules jdk.incubator.jextract
+ * @bug 8246400
+ * @summary jextract should generate a utility to manage mutliple MemorySegments
+ * @run driver JtregJextract -l Test8246400 -t test.jextract.test8246400 -- test8246400.h
+ * @run testng/othervm -Dforeign.restricted=permit LibTest8246400Test
+ */
+public class LibTest8246400Test {
+    @Test
+    public void testSegmentRegister() {
+        MemorySegment sum = null, callback = null;
+        try (var scope = new Scope()) {
+            var v1 = CVector.allocate(scope);
+            CVector.x$set(v1, 1.0);
+            CVector.y$set(v1, 0.0);
+
+            var v2 = CVector.allocate(scope);
+            CVector.x$set(v2, 0.0);
+            CVector.y$set(v2, 1.0);
+
+            sum = add(v1.segment(), v2.segment());
+            scope.register(sum);
+
+            assertEquals(CVector.x$get(sum.baseAddress()), 1.0, 0.1);
+            assertEquals(CVector.y$get(sum.baseAddress()), 1.0, 0.1);
+
+            callback = cosine_similarity$dot.allocate((a, b) -> {
+                return (CVector.x$get(a.baseAddress()) * CVector.x$get(b.baseAddress())) +
+                    (CVector.y$get(a.baseAddress()) * CVector.y$get(b.baseAddress()));
+            });
+            scope.register(callback);
+
+            var value = cosine_similarity(v1.segment(), v2.segment(), callback.baseAddress());
+            assertEquals(value, 0.0, 0.1);
+
+            value = cosine_similarity(v1.segment(), v1.segment(), callback.baseAddress());
+            assertEquals(value, 1.0, 0.1);
+        }
+        assertTrue(!sum.isAlive());
+        assertTrue(!callback.isAlive());
+    }
+}

--- a/test/jdk/tools/jextract/test8246400/LibTest8246400Test.java
+++ b/test/jdk/tools/jextract/test8246400/LibTest8246400Test.java
@@ -42,7 +42,7 @@ public class LibTest8246400Test {
     @Test
     public void testSegmentRegister() {
         MemorySegment sum = null, callback = null;
-        try (var scope = new Scope()) {
+        try (var scope = new CScope()) {
             var v1 = CVector.allocate(scope);
             CVector.x$set(v1, 1.0);
             CVector.y$set(v1, 0.0);

--- a/test/jdk/tools/jextract/test8246400/libTest8246400.c
+++ b/test/jdk/tools/jextract/test8246400/libTest8246400.c
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+#include "test8246400.h"
+#include <math.h>
+
+EXPORT Vector add(Vector v1, Vector v2) {
+    Vector res = { v1.x + v2.x, v1.y + v2. y };
+    return res;
+}
+
+EXPORT double cosine_similarity(Vector v1, Vector v2,
+        double (*dot)(Vector, Vector)) {
+    double normv1 = sqrt(dot(v1, v1));
+    double normv2 = sqrt(dot(v2, v2));
+    return dot(v1, v2)/(normv1 * normv2);
+}

--- a/test/jdk/tools/jextract/test8246400/test8246400.h
+++ b/test/jdk/tools/jextract/test8246400/test8246400.h
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+#ifdef __cplusplus
+extern "C" {
+#endif // __cplusplus
+
+#ifdef _WIN64
+#define EXPORT __declspec(dllexport)
+#else
+#define EXPORT
+#endif
+
+typedef struct Vector {
+    double x;
+    double y;
+} Vector;
+
+EXPORT Vector add(Vector v1, Vector v2);
+EXPORT double cosine_similarity(Vector v1, Vector v2, double (*dot)(Vector, Vector));
+
+#ifdef __cplusplus
+}
+#endif // __cplusplus


### PR DESCRIPTION
* Added RuntimeHelper.Scope class.
* Piggybacking to fix test description and unused imports in another test.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [JDK-8246400](https://bugs.openjdk.java.net/browse/JDK-8246400): jextract should generate a utility to manage mutliple MemorySegments


### Reviewers
 * Maurizio Cimadamore ([mcimadamore](@mcimadamore) - Committer) ⚠️ Review applies to a3762aca6329c919ada2afe14d6c827c85e0cf71


### Download
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/192/head:pull/192`
`$ git checkout pull/192`
