### PR TITLE
8246693: Restricted native operations should be spelled out clearly

### DIFF
--- a/doc/panama_jextract.html
+++ b/doc/panama_jextract.html
@@ -251,7 +251,7 @@
 <span id="cb11-13"><a href="#cb11-13"></a>            <span class="co">// print char* as is</span></span>
 <span id="cb11-14"><a href="#cb11-14"></a>            <span class="bu">System</span>.<span class="fu">out</span>.<span class="fu">println</span>(p);</span>
 <span id="cb11-15"><a href="#cb11-15"></a>            <span class="co">// convert char* ptr from readline as Java String &amp; print it</span></span>
-<span id="cb11-16"><a href="#cb11-16"></a>            <span class="bu">System</span>.<span class="fu">out</span>.<span class="fu">println</span>(<span class="st">&quot;Hello, &quot;</span> + Cstring.<span class="fu">toJavaString</span>(p));</span>
+<span id="cb11-16"><a href="#cb11-16"></a>            <span class="bu">System</span>.<span class="fu">out</span>.<span class="fu">println</span>(<span class="st">&quot;Hello, &quot;</span> + Cstring.<span class="fu">toJavaStringRestricted</span>(p));</span>
 <span id="cb11-17"><a href="#cb11-17"></a>        }</span>
 <span id="cb11-18"><a href="#cb11-18"></a>    }</span>
 <span id="cb11-19"><a href="#cb11-19"></a>}</span></code></pre></div>
@@ -593,7 +593,7 @@
 <span id="cb31-36"><a href="#cb31-36"></a></span>
 <span id="cb31-37"><a href="#cb31-37"></a>            <span class="kw">if</span> (rc != <span class="dv">0</span>) {</span>
 <span id="cb31-38"><a href="#cb31-38"></a>                <span class="bu">System</span>.<span class="fu">err</span>.<span class="fu">println</span>(<span class="st">&quot;sqlite3_exec failed: &quot;</span> + rc);</span>
-<span id="cb31-39"><a href="#cb31-39"></a>                <span class="bu">System</span>.<span class="fu">err</span>.<span class="fu">println</span>(<span class="st">&quot;SQL error: &quot;</span> + Cstring.<span class="fu">toJavaString</span>(Cpointer.<span class="fu">get</span>(errMsgPtrPtr)));</span>
+<span id="cb31-39"><a href="#cb31-39"></a>                <span class="bu">System</span>.<span class="fu">err</span>.<span class="fu">println</span>(<span class="st">&quot;SQL error: &quot;</span> + Cstring.<span class="fu">toJavaStringRestricted</span>(Cpointer.<span class="fu">get</span>(errMsgPtrPtr)));</span>
 <span id="cb31-40"><a href="#cb31-40"></a>                <span class="fu">sqlite3_free</span>(Cpointer.<span class="fu">get</span>(errMsgPtrPtr));</span>
 <span id="cb31-41"><a href="#cb31-41"></a>            } <span class="kw">else</span> {</span>
 <span id="cb31-42"><a href="#cb31-42"></a>                <span class="bu">System</span>.<span class="fu">out</span>.<span class="fu">println</span>(<span class="st">&quot;employee table created&quot;</span>);</span>
@@ -610,7 +610,7 @@
 <span id="cb31-53"><a href="#cb31-53"></a></span>
 <span id="cb31-54"><a href="#cb31-54"></a>            <span class="kw">if</span> (rc != <span class="dv">0</span>) {</span>
 <span id="cb31-55"><a href="#cb31-55"></a>                <span class="bu">System</span>.<span class="fu">err</span>.<span class="fu">println</span>(<span class="st">&quot;sqlite3_exec failed: &quot;</span> + rc);</span>
-<span id="cb31-56"><a href="#cb31-56"></a>                <span class="bu">System</span>.<span class="fu">err</span>.<span class="fu">println</span>(<span class="st">&quot;SQL error: &quot;</span> + Cstring.<span class="fu">toJavaString</span>(Cpointer.<span class="fu">get</span>(errMsgPtrPtr)));</span>
+<span id="cb31-56"><a href="#cb31-56"></a>                <span class="bu">System</span>.<span class="fu">err</span>.<span class="fu">println</span>(<span class="st">&quot;SQL error: &quot;</span> + Cstring.<span class="fu">toJavaStringRestricted</span>(Cpointer.<span class="fu">get</span>(errMsgPtrPtr)));</span>
 <span id="cb31-57"><a href="#cb31-57"></a>                <span class="fu">sqlite3_free</span>(Cpointer.<span class="fu">get</span>(errMsgPtrPtr));</span>
 <span id="cb31-58"><a href="#cb31-58"></a>            } <span class="kw">else</span> {</span>
 <span id="cb31-59"><a href="#cb31-59"></a>                <span class="bu">System</span>.<span class="fu">out</span>.<span class="fu">println</span>(<span class="st">&quot;rows inserted&quot;</span>);</span>
@@ -621,11 +621,11 @@
 <span id="cb31-64"><a href="#cb31-64"></a>            var callback = sqlite3_exec$callback.<span class="fu">allocate</span>((a, argc, argv, columnNames) -&gt; {</span>
 <span id="cb31-65"><a href="#cb31-65"></a>                <span class="bu">System</span>.<span class="fu">out</span>.<span class="fu">println</span>(<span class="st">&quot;Row num: &quot;</span> + rowNum[<span class="dv">0</span>]++);</span>
 <span id="cb31-66"><a href="#cb31-66"></a>                <span class="bu">System</span>.<span class="fu">out</span>.<span class="fu">println</span>(<span class="st">&quot;numColumns = &quot;</span> + argc);</span>
-<span id="cb31-67"><a href="#cb31-67"></a>                argv = Cpointer.<span class="fu">asArray</span>(argv, argc);</span>
-<span id="cb31-68"><a href="#cb31-68"></a>                columnNames = Cpointer.<span class="fu">asArray</span>(columnNames, argc);</span>
+<span id="cb31-67"><a href="#cb31-67"></a>                argv = Cpointer.<span class="fu">asArrayRestricted</span>(argv, argc);</span>
+<span id="cb31-68"><a href="#cb31-68"></a>                columnNames = Cpointer.<span class="fu">asArrayRestricted</span>(columnNames, argc);</span>
 <span id="cb31-69"><a href="#cb31-69"></a>                <span class="kw">for</span> (<span class="dt">int</span> i = <span class="dv">0</span>; i &lt; argc; i++) {</span>
-<span id="cb31-70"><a href="#cb31-70"></a>                     <span class="bu">String</span> name = Cstring.<span class="fu">toJavaString</span>(Cpointer.<span class="fu">get</span>(columnNames, i));</span>
-<span id="cb31-71"><a href="#cb31-71"></a>                     <span class="bu">String</span> value = Cstring.<span class="fu">toJavaString</span>(Cpointer.<span class="fu">get</span>(argv, i));</span>
+<span id="cb31-70"><a href="#cb31-70"></a>                     <span class="bu">String</span> name = Cstring.<span class="fu">toJavaStringRestricted</span>(Cpointer.<span class="fu">get</span>(columnNames, i));</span>
+<span id="cb31-71"><a href="#cb31-71"></a>                     <span class="bu">String</span> value = Cstring.<span class="fu">toJavaStringRestricted</span>(Cpointer.<span class="fu">get</span>(argv, i));</span>
 <span id="cb31-72"><a href="#cb31-72"></a>                     <span class="bu">System</span>.<span class="fu">out.printf</span>(<span class="st">&quot;</span><span class="sc">%s</span><span class="st"> = </span><span class="sc">%s\n</span><span class="st">&quot;</span>, name, value);</span>
 <span id="cb31-73"><a href="#cb31-73"></a>                }</span>
 <span id="cb31-74"><a href="#cb31-74"></a>                <span class="kw">return</span> <span class="dv">0</span>;</span>
@@ -637,7 +637,7 @@
 <span id="cb31-80"><a href="#cb31-80"></a></span>
 <span id="cb31-81"><a href="#cb31-81"></a>            <span class="kw">if</span> (rc != <span class="dv">0</span>) {</span>
 <span id="cb31-82"><a href="#cb31-82"></a>                <span class="bu">System</span>.<span class="fu">err</span>.<span class="fu">println</span>(<span class="st">&quot;sqlite3_exec failed: &quot;</span> + rc);</span>
-<span id="cb31-83"><a href="#cb31-83"></a>                <span class="bu">System</span>.<span class="fu">err</span>.<span class="fu">println</span>(<span class="st">&quot;SQL error: &quot;</span> + Cstring.<span class="fu">toJavaString</span>(Cpointer.<span class="fu">get</span>(errMsgPtrPtr)));</span>
+<span id="cb31-83"><a href="#cb31-83"></a>                <span class="bu">System</span>.<span class="fu">err</span>.<span class="fu">println</span>(<span class="st">&quot;SQL error: &quot;</span> + Cstring.<span class="fu">toJavaStringRestricted</span>(Cpointer.<span class="fu">get</span>(errMsgPtrPtr)));</span>
 <span id="cb31-84"><a href="#cb31-84"></a>                <span class="fu">sqlite3_free</span>(Cpointer.<span class="fu">get</span>(errMsgPtrPtr));</span>
 <span id="cb31-85"><a href="#cb31-85"></a>            } <span class="kw">else</span> {</span>
 <span id="cb31-86"><a href="#cb31-86"></a>                <span class="bu">System</span>.<span class="fu">out</span>.<span class="fu">println</span>(<span class="st">&quot;done&quot;</span>);</span>

--- a/doc/panama_jextract.md
+++ b/doc/panama_jextract.md
@@ -159,7 +159,7 @@ public class Readline {
             // print char* as is
             System.out.println(p);
             // convert char* ptr from readline as Java String & print it
-            System.out.println("Hello, " + Cstring.toJavaString(p));
+            System.out.println("Hello, " + Cstring.toJavaStringRestricted(p));
         }
     }
 }
@@ -609,7 +609,7 @@ public class SqliteMain {
 
             if (rc != 0) {
                 System.err.println("sqlite3_exec failed: " + rc);
-                System.err.println("SQL error: " + Cstring.toJavaString(Cpointer.get(errMsgPtrPtr)));
+                System.err.println("SQL error: " + Cstring.toJavaStringRestricted(Cpointer.get(errMsgPtrPtr)));
                 sqlite3_free(Cpointer.get(errMsgPtrPtr));
             } else {
                 System.out.println("employee table created");
@@ -626,7 +626,7 @@ public class SqliteMain {
 
             if (rc != 0) {
                 System.err.println("sqlite3_exec failed: " + rc);
-                System.err.println("SQL error: " + Cstring.toJavaString(Cpointer.get(errMsgPtrPtr)));
+                System.err.println("SQL error: " + Cstring.toJavaStringRestricted(Cpointer.get(errMsgPtrPtr)));
                 sqlite3_free(Cpointer.get(errMsgPtrPtr));
             } else {
                 System.out.println("rows inserted");
@@ -637,11 +637,11 @@ public class SqliteMain {
             var callback = sqlite3_exec$callback.allocate((a, argc, argv, columnNames) -> {
                 System.out.println("Row num: " + rowNum[0]++);
                 System.out.println("numColumns = " + argc);
-                argv = Cpointer.asArray(argv, argc);
-                columnNames = Cpointer.asArray(columnNames, argc);
+                argv = Cpointer.asArrayRestricted(argv, argc);
+                columnNames = Cpointer.asArrayRestricted(columnNames, argc);
                 for (int i = 0; i < argc; i++) {
-                     String name = Cstring.toJavaString(Cpointer.get(columnNames, i));
-                     String value = Cstring.toJavaString(Cpointer.get(argv, i));
+                     String name = Cstring.toJavaStringRestricted(Cpointer.get(columnNames, i));
+                     String value = Cstring.toJavaStringRestricted(Cpointer.get(argv, i));
                      System.out.printf("%s = %s\n", name, value);
                 }
                 return 0;
@@ -653,7 +653,7 @@ public class SqliteMain {
 
             if (rc != 0) {
                 System.err.println("sqlite3_exec failed: " + rc);
-                System.err.println("SQL error: " + Cstring.toJavaString(Cpointer.get(errMsgPtrPtr)));
+                System.err.println("SQL error: " + Cstring.toJavaStringRestricted(Cpointer.get(errMsgPtrPtr)));
                 sqlite3_free(Cpointer.get(errMsgPtrPtr));
             } else {
                 System.out.println("done");

--- a/src/jdk.incubator.jextract/share/classes/jdk/incubator/jextract/tool/resources/C-X.java.template
+++ b/src/jdk.incubator.jextract/share/classes/jdk/incubator/jextract/tool/resources/C-X.java.template
@@ -23,9 +23,17 @@ public class C-X {
     private static final VarHandle handle = LAYOUT.varHandle(CARRIER);
     private static final VarHandle arrayHandle = arrayHandle(LAYOUT, CARRIER);
 
-    public static MemoryAddress asArray(MemoryAddress addr, int numElements) {
+    public static MemoryAddress asArrayRestricted(MemoryAddress addr, int numElements) {
         return MemorySegment.ofNativeRestricted(addr, numElements * LAYOUT.byteSize(),
                Thread.currentThread(), null, null).baseAddress();
+    }
+
+    public static MemoryAddress asArray(MemoryAddress addr, int numElements) {
+        var seg = addr.segment();
+        if (seg == null) {
+            throw new IllegalArgumentException("no underlying segment for the address");
+        }
+        return seg.asSlice(addr.segmentOffset(), numElements * LAYOUT.byteSize()).baseAddress();
     }
 
     public static ${CARRIER} get(MemoryAddress addr) {

--- a/src/jdk.incubator.jextract/share/classes/jdk/incubator/jextract/tool/resources/Cpointer.java.template
+++ b/src/jdk.incubator.jextract/share/classes/jdk/incubator/jextract/tool/resources/Cpointer.java.template
@@ -18,9 +18,17 @@ public final class Cpointer {
     private static final VarHandle handle = MemoryHandles.asAddressVarHandle(LAYOUT.varHandle(CARRIER));
     private static final VarHandle arrayHandle = MemoryHandles.asAddressVarHandle(arrayHandle(LAYOUT, CARRIER));
 
-    public static MemoryAddress asArray(MemoryAddress addr, int numPointers) {
+    public static MemoryAddress asArrayRestricted(MemoryAddress addr, int numPointers) {
         return MemorySegment.ofNativeRestricted(addr, numPointers * LAYOUT.byteSize(),
                Thread.currentThread(), null, null).baseAddress();
+    }
+
+    public static MemoryAddress asArray(MemoryAddress addr, int numPointers) {
+        var seg = addr.segment();
+        if (seg == null) {
+            throw new IllegalArgumentException("no underlying segment for the address");
+        }
+        return seg.asSlice(addr.segmentOffset(), numPointers * LAYOUT.byteSize()).baseAddress();
     }
 
     public static MemoryAddress get(MemoryAddress addr) {

--- a/src/jdk.incubator.jextract/share/classes/jdk/incubator/jextract/tool/resources/Cstring.java.template
+++ b/src/jdk.incubator.jextract/share/classes/jdk/incubator/jextract/tool/resources/Cstring.java.template
@@ -66,17 +66,28 @@ public final class Cstring {
         return toCString(str.getBytes(charset), scope);
     }
 
-    public static String toJavaString(MemoryAddress addr) {
-        StringBuilder buf = new StringBuilder();
+    public static String toJavaStringRestricted(MemoryAddress addr) {
         MemoryAddress baseAddr = addr.segment() != null ?
                 addr :
                 MemorySegment.ofNativeRestricted(addr, Long.MAX_VALUE, Thread.currentThread(),
                         null, null).baseAddress();
-        byte curr = (byte) byteArrHandle.get(baseAddr, 0);
+        return readString(baseAddr);
+    }
+
+    public static String toJavaString(MemoryAddress addr) {
+        if (addr.segment() == null) {
+            throw new IllegalArgumentException("no underlying segment for the address");
+        }
+        return readString(addr);
+    }
+
+    private static String readString(MemoryAddress addr) {
+        StringBuilder buf = new StringBuilder();
+        byte curr = (byte) byteArrHandle.get(addr, 0);
         long offset = 0;
         while (curr != 0) {
             buf.append((char) curr);
-            curr = (byte) byteArrHandle.get(baseAddr, ++offset);
+            curr = (byte) byteArrHandle.get(addr, ++offset);
         }
         return buf.toString();
     }

--- a/test/jdk/tools/jextract/test8241925/LibTest8241925Test.java
+++ b/test/jdk/tools/jextract/test8241925/LibTest8241925Test.java
@@ -67,12 +67,12 @@ public class LibTest8241925Test {
                 assertEquals(dblArray[i], convertedDblArray[i], 0.1);
             }
 
-            assertEquals(Cstring.toJavaString(name()), "java");
+            assertEquals(Cstring.toJavaStringRestricted(name()), "java");
 
             var dest = Cchar.allocateArray(12, scope);
             Cstring.copy(dest, "hello ");
             var src = Cstring.toCString("world", scope);
-            assertEquals(Cstring.toJavaString(concatenate(dest, src)), "hello world");
+            assertEquals(Cstring.toJavaStringRestricted(concatenate(dest, src)), "hello world");
         }
     }
 }

--- a/test/jdk/tools/jextract/test8246341/LibTest8246341Test.java
+++ b/test/jdk/tools/jextract/test8246341/LibTest8246341Test.java
@@ -27,6 +27,7 @@ import test.jextract.test8246341.*;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 import static test.jextract.test8246341.test8246341_h.*;
+import static test.jextract.test8246341.Cstring.toJavaStringRestricted;
 
 /*
  * @test
@@ -43,12 +44,12 @@ public class LibTest8246341Test {
         boolean[] callbackCalled = new boolean[1];
         try (var callback = func$callback.allocate((argc, argv) -> {
             callbackCalled[0] = true;
-            var addr = Cpointer.asArray(argv, argc);
+            var addr = Cpointer.asArrayRestricted(argv, argc);
             assertEquals(argc, 4);
-            assertEquals(Cstring.toJavaString(Cpointer.get(addr, 0)), "java");
-            assertEquals(Cstring.toJavaString(Cpointer.get(addr, 1)), "python");
-            assertEquals(Cstring.toJavaString(Cpointer.get(addr, 2)), "javascript");
-            assertEquals(Cstring.toJavaString(Cpointer.get(addr, 3)), "c++");
+            assertEquals(toJavaStringRestricted(Cpointer.get(addr, 0)), "java");
+            assertEquals(toJavaStringRestricted(Cpointer.get(addr, 1)), "python");
+            assertEquals(toJavaStringRestricted(Cpointer.get(addr, 2)), "javascript");
+            assertEquals(toJavaStringRestricted(Cpointer.get(addr, 3)), "c++");
         })) {
             func(callback.baseAddress());
         }
@@ -60,13 +61,13 @@ public class LibTest8246341Test {
         try (var scope = new CScope(Cpointer.sizeof())) {
             var addr = Cpointer.allocate(MemoryAddress.NULL, scope);
             fillin(addr);
-            assertEquals(Cstring.toJavaString(Cpointer.get(addr)), "hello world");
+            assertEquals(toJavaStringRestricted(Cpointer.get(addr)), "hello world");
         }
 
         try (var seg = Cpointer.allocate(MemoryAddress.NULL)) {
             var addr = seg.baseAddress();
             fillin(addr);
-            assertEquals(Cstring.toJavaString(Cpointer.get(addr)), "hello world");
+            assertEquals(toJavaStringRestricted(Cpointer.get(addr)), "hello world");
         }
     }
 }


### PR DESCRIPTION
APIs renamed as suggested in bug report.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [JDK-8246693](https://bugs.openjdk.java.net/browse/JDK-8246693): Restricted native operations should be spelled out clearly


### Reviewers
 * Maurizio Cimadamore ([mcimadamore](@mcimadamore) - Committer) ⚠️ Review applies to 47bdea558dfaff1e2f69bcd6bbfb97b40806c45b


### Download
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/197/head:pull/197`
`$ git checkout pull/197`
