### PR TITLE
CSupport::getSystemLinker should not be called from internal API points

### DIFF
--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/LayoutUtils.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/LayoutUtils.java
@@ -197,7 +197,7 @@ public final class LayoutUtils {
             case 8: return Primitive.Kind.Char;
             case 16: return Primitive.Kind.Short;
             case 32: return Primitive.Kind.Int;
-            case 64: return SharedUtils.getSystemLinker().name().equals(CSupport.Win64.NAME) ?
+            case 64: return abi.name().equals(CSupport.Win64.NAME) ?
                     Primitive.Kind.LongLong : Primitive.Kind.Long;
             default:
                 throw new IllegalStateException("Cannot infer container layout");

--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/LayoutUtils.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/LayoutUtils.java
@@ -197,7 +197,7 @@ public final class LayoutUtils {
             case 8: return Primitive.Kind.Char;
             case 16: return Primitive.Kind.Short;
             case 32: return Primitive.Kind.Int;
-            case 64: return CSupport.getSystemLinker().name().equals(CSupport.Win64.NAME) ?
+            case 64: return SharedUtils.getSystemLinker().name().equals(CSupport.Win64.NAME) ?
                     Primitive.Kind.LongLong : Primitive.Kind.Long;
             default:
                 throw new IllegalStateException("Cannot infer container layout");

--- a/test/jdk/java/jextract/Test8239490.h
+++ b/test/jdk/java/jextract/Test8239490.h
@@ -32,3 +32,9 @@ struct Bar {
     unsigned int y:31;
     struct Foo z[1];
 };
+
+struct Baz {
+    unsigned long x:1;
+    unsigned long y:63;
+    struct Bar z[1];
+};

--- a/test/jdk/java/jextract/Test8239490.java
+++ b/test/jdk/java/jextract/Test8239490.java
@@ -55,5 +55,16 @@ public class Test8239490 extends JextractApiTestBase {
             checkBitField(bitfieldsBar, barBitfieldNames[i], intType, barBitfieldSizes[i]);
         }
         checkField(structBar, "z", Type.array(1, Type.declared(structFoo)));
+
+        // check Baz
+        String[] bazBitfieldNames = { "x", "y" };
+        int[] bazBitfieldSizes = { 1, 63 };
+        Declaration.Scoped structBaz = checkStruct(d, "Baz", "", "z");
+        Declaration.Scoped bitfieldsBaz = checkBitfields(structBaz, "", "x", "y");
+        Type longType = ((Declaration.Variable)bitfieldsBaz.members().get(0)).type();
+        for (int i = 0 ; i < bazBitfieldNames.length ; i++) {
+            checkBitField(bitfieldsBaz, bazBitfieldNames[i], longType, bazBitfieldSizes[i]);
+        }
+        checkField(structBaz, "z", Type.array(1, Type.declared(structBar)));
     }
 }


### PR DESCRIPTION
Some jextract internal classes call the external getSystemLinker method, which then does a check on the `foreign.restricted` property (which is disabled when jextract runs).
Trusted internal API points should use the internal factory for the system linker instead.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * Athijegannathan Sundararajan ([sundar](@sundararajana) - Committer) ⚠️ Review applies to fa72d88f54a4730ff8a5a74547e81879d53fd39a


### Download
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/198/head:pull/198`
`$ git checkout pull/198`
