### PR TITLE
8247439: NativeAllocationScope should have a way to register existing segments onto it (followup)

### DIFF
--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/NativeScope.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/NativeScope.java
@@ -253,8 +253,8 @@ public abstract class NativeScope implements AutoCloseable {
      * but whose life-cycle is tied to that of this native scope.
      * @throws IllegalStateException if {@code segment} is not <em>alive</em> (see {@link MemorySegment#isAlive()}).
      * @throws NullPointerException if {@code segment == null}
-     * @throws IllegalArgumentException if {@code segment.ownerThread() != this.ownerThread()}, or if {@code segment}
-     * does not feature the {@link MemorySegment#CLOSE} access mode.
+     * @throws IllegalArgumentException if {@code segment} is not confined and {@code segment.ownerThread() != this.ownerThread()},
+     * or if {@code segment} does not feature the {@link MemorySegment#CLOSE} access mode.
      */
     public abstract MemorySegment register(MemorySegment segment);
 

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/AbstractNativeScope.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/AbstractNativeScope.java
@@ -55,7 +55,7 @@ public abstract class AbstractNativeScope extends NativeScope {
     @Override
     public MemorySegment register(MemorySegment segment) {
         Objects.requireNonNull(segment);
-        if (segment.ownerThread() != ownerThread()) {
+        if (segment.ownerThread() != null && (segment.ownerThread() != ownerThread())) {
             throw new IllegalArgumentException("Cannot register segment owned by a different thread");
         } else if (!segment.hasAccessModes(MemorySegment.CLOSE)) {
             throw new IllegalArgumentException("Cannot register a non-closeable segment");

--- a/test/jdk/java/foreign/TestNativeScope.java
+++ b/test/jdk/java/foreign/TestNativeScope.java
@@ -24,7 +24,7 @@
 
 /*
  * @test
- * @run testng TestNativeScope
+ * @run testng/othervm -Dforeign.restricted=permit TestNativeScope
  */
 
 import jdk.incubator.foreign.MemorySegment;
@@ -182,6 +182,17 @@ public class TestNativeScope {
         t.start();
         t.join();
         assertTrue(failed.get());
+    }
+
+    @Test
+    public void testRegisterFromUnconfined() {
+        MemorySegment unconfined = MemorySegment.ofNativeRestricted(MemoryAddress.ofLong(42), 10, null, null, null);
+        NativeScope scope = NativeScope.boundedScope(10);
+        MemorySegment registered = scope.register(unconfined);
+        assertFalse(unconfined.isAlive());
+        assertEquals(registered.ownerThread(), scope.ownerThread());
+        scope.close();
+        assertFalse(registered.isAlive());
     }
 
     @DataProvider(name = "nativeScopes")


### PR DESCRIPTION
This simple followup removes ownership check in case the registered segment is unconfined.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [JDK-8247439](https://bugs.openjdk.java.net/browse/JDK-8247439): NativeAllocationScope should have a way to register existing segments onto it ⚠️ Title mismatch between PR and JBS.


### Reviewers
 * Paul Sandoz ([psandoz](@PaulSandoz) - Committer) ⚠️ Review applies to 1730722f422b8f7c2b516a9cef6dcadaf254871d


### Download
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/202/head:pull/202`
`$ git checkout pull/202`
