### PR TITLE
8247488: Add support for string helpers in CSupport

### DIFF
--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/CSupport.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/CSupport.java
@@ -533,9 +533,8 @@ public class CSupport {
             MemoryLayout.ofSequence(C_CHAR).varHandle(byte.class, MemoryLayout.PathElement.sequenceElement());
 
     /**
-     * Convert a Java string into a null-terminated C string, using the given
-     * {@linkplain java.nio.charset.Charset charset}, storing the result into a
-     * new native memory segment.
+     * Convert a Java string into a null-terminated C string, using the
+     * platform's default charset, storing the result into a new native memory segment.
      * <p>
      * This method always replaces malformed-input and unmappable-character
      * sequences with this charset's default replacement byte array.  The
@@ -552,8 +551,8 @@ public class CSupport {
     }
 
     /**
-     * Convert a Java string into a null-terminated C string, using the
-     * platform's default charset, storing the result into a new native memory segment.
+     * Convert a Java string into a null-terminated C string, using the given {@linkplain java.nio.charset.Charset charset},
+     * storing the result into a new native memory segment.
      * <p>
      * This method always replaces malformed-input and unmappable-character
      * sequences with this charset's default replacement byte array.  The
@@ -572,9 +571,8 @@ public class CSupport {
     }
 
     /**
-     * Convert a Java string into a null-terminated C string, using the given
-     * {@linkplain java.nio.charset.Charset charset}, storing the result into a
-     * native memory segment allocated using the provided scope.
+     * Convert a Java string into a null-terminated C string, using the platform's default charset,
+     * storing the result into a native memory segment allocated using the provided scope.
      * <p>
      * This method always replaces malformed-input and unmappable-character
      * sequences with this charset's default replacement byte array.  The
@@ -593,9 +591,8 @@ public class CSupport {
     }
 
     /**
-     * Convert a Java string into a null-terminated C string, using the
-     * platform's default charset, storing the result into a new native memory segment
-     * native memory segment allocated using the provided scope.
+     * Convert a Java string into a null-terminated C string, using the given {@linkplain java.nio.charset.Charset charset},
+     * storing the result into a new native memory segment native memory segment allocated using the provided scope.
      * <p>
      * This method always replaces malformed-input and unmappable-character
      * sequences with this charset's default replacement byte array.  The


### PR DESCRIPTION
This fixes the javadoc mix up with charsets.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [JDK-8247488](https://bugs.openjdk.java.net/browse/JDK-8247488): Add support for string helpers in CSupport


### Reviewers
 * Henry Jen ([henryjen](@slowhog) - Committer)


### Download
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/203/head:pull/203`
`$ git checkout pull/203`
