### PR TITLE
8247547: jextract generated Cstring should use foreign.CSupport string utility methods

### DIFF
--- a/src/jdk.incubator.jextract/share/classes/jdk/incubator/jextract/tool/resources/Cstring.java.template
+++ b/src/jdk.incubator.jextract/share/classes/jdk/incubator/jextract/tool/resources/Cstring.java.template
@@ -2,6 +2,7 @@
 
 import java.lang.invoke.VarHandle;
 import java.nio.charset.Charset;
+import jdk.incubator.foreign.CSupport;
 import jdk.incubator.foreign.MemoryAddress;
 import jdk.incubator.foreign.MemoryLayout;
 import jdk.incubator.foreign.MemorySegment;
@@ -18,21 +19,6 @@ public final class Cstring {
                 .varHandle(elemCarrier, MemoryLayout.PathElement.sequenceElement());
     }
     private final static VarHandle byteArrHandle = arrayHandle(C_CHAR, byte.class);
-
-    private static MemorySegment toCString(byte[] bytes) {
-        MemoryLayout strLayout = MemoryLayout.ofSequence(bytes.length + 1, C_CHAR);
-        MemorySegment segment = MemorySegment.allocateNative(strLayout);
-        MemoryAddress addr = segment.baseAddress();
-        copy(addr, bytes);
-        return segment;
-    }
-
-    private static MemoryAddress toCString(byte[] bytes, NativeScope scope) {
-        MemoryLayout strLayout = MemoryLayout.ofSequence(bytes.length + 1, C_CHAR);
-        MemoryAddress addr = scope.allocate(strLayout);
-        addr.segment().copyFrom(MemorySegment.ofArray(bytes));
-        return addr;
-    }
 
     public static void copy(MemoryAddress addr, String str) {
         copy(addr, str.getBytes());
@@ -52,44 +38,26 @@ public final class Cstring {
         }
 
     public static MemorySegment toCString(String str) {
-         return toCString(str.getBytes());
+         return CSupport.toCString(str);
     }
 
     public static MemorySegment toCString(String str, Charset charset) {
-         return toCString(str.getBytes(charset));
+         return CSupport.toCString(str, charset);
     }
 
     public static MemoryAddress toCString(String str, NativeScope scope) {
-        return toCString(str.getBytes(), scope);
+        return CSupport.toCString(str, scope);
     }
 
     public static MemoryAddress toCString(String str, Charset charset, NativeScope scope) {
-        return toCString(str.getBytes(charset), scope);
+        return CSupport.toCString(str, charset, scope);
     }
 
     public static String toJavaStringRestricted(MemoryAddress addr) {
-        MemoryAddress baseAddr = addr.segment() != null ?
-                addr :
-                MemorySegment.ofNativeRestricted(addr, Long.MAX_VALUE, Thread.currentThread(),
-                        null, null).baseAddress();
-        return readString(baseAddr);
+        return CSupport.toJavaStringRestricted(addr);
     }
 
     public static String toJavaString(MemoryAddress addr) {
-        if (addr.segment() == null) {
-            throw new IllegalArgumentException("no underlying segment for the address");
-        }
-        return readString(addr);
-    }
-
-    private static String readString(MemoryAddress addr) {
-        StringBuilder buf = new StringBuilder();
-        byte curr = (byte) byteArrHandle.get(addr, 0);
-        long offset = 0;
-        while (curr != 0) {
-            buf.append((char) curr);
-            curr = (byte) byteArrHandle.get(addr, ++offset);
-        }
-        return buf.toString();
+        return CSupport.toJavaString(addr);
     }
 }


### PR DESCRIPTION
Changed Cstring to use CSupport string utils.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [JDK-8247547](https://bugs.openjdk.java.net/browse/JDK-8247547): jextract generated Cstring should use foreign.CSupport string utility methods


### Reviewers
 * Maurizio Cimadamore ([mcimadamore](@mcimadamore) - Committer)


### Download
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/204/head:pull/204`
`$ git checkout pull/204`
