### PR TITLE
Add test for vprintf

### DIFF
--- a/test/jdk/java/foreign/StdLibTest.java
+++ b/test/jdk/java/foreign/StdLibTest.java
@@ -46,6 +46,7 @@ import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.LongStream;
@@ -159,6 +160,21 @@ public class StdLibTest extends NativeTestHelper {
         assertEquals(found, expected.length());
     }
 
+    @Test(dataProvider = "printfArgs")
+    void test_vprintf(List<PrintfArg> args) throws Throwable {
+        String formatArgs = args.stream()
+                .map(a -> a.format)
+                .collect(Collectors.joining(","));
+
+        String formatString = "hello(" + formatArgs + ")\n";
+
+        String expected = String.format(formatString, args.stream()
+                .map(a -> a.javaValue).toArray());
+
+        int found = stdLibHelper.vprintf(formatString, args);
+        assertEquals(found, expected.length());
+    }
+
     static class StdLibHelper {
 
         final static MethodHandle strcat;
@@ -170,6 +186,7 @@ public class StdLibTest extends NativeTestHelper {
         final static MethodHandle qsortCompar;
         final static FunctionDescriptor qsortComparFunction;
         final static MethodHandle rand;
+        final static MethodHandle vprintf;
         final static MemoryAddress printfAddr;
         final static FunctionDescriptor printfBase;
 
@@ -210,6 +227,10 @@ public class StdLibTest extends NativeTestHelper {
                 rand = abi.downcallHandle(lookup.lookup("rand"),
                         MethodType.methodType(int.class),
                         FunctionDescriptor.of(C_INT));
+
+                vprintf = abi.downcallHandle(lookup.lookup("vprintf"),
+                        MethodType.methodType(int.class, MemoryAddress.class, VaList.class),
+                        FunctionDescriptor.of(C_INT, C_POINTER, C_VA_LIST));
 
                 printfAddr = lookup.lookup("printf");
 
@@ -335,6 +356,13 @@ public class StdLibTest extends NativeTestHelper {
             }
         }
 
+        int vprintf(String format, List<PrintfArg> args) throws Throwable {
+            try (MemorySegment formatStr = toCString(format)) {
+                return (int)vprintf.invokeExact(formatStr.baseAddress(),
+                        newVaList(b -> args.forEach(a -> a.accept(b))));
+            }
+        }
+
         private MethodHandle specializedPrintf(List<PrintfArg> args) {
             //method type
             MethodType mt = MethodType.methodType(int.class, MemoryAddress.class);
@@ -402,24 +430,38 @@ public class StdLibTest extends NativeTestHelper {
                 .toArray(Object[][]::new);
     }
 
-    enum PrintfArg {
-        INTEGRAL(int.class, asVarArg(C_INT), "%d", 42, 42),
-        STRING(MemoryAddress.class, asVarArg(C_POINTER), "%s", toCString("str").baseAddress(), "str"),
-        CHAR(byte.class, asVarArg(C_CHAR), "%c", (byte) 'h', 'h'),
-        DOUBLE(double.class, asVarArg(C_DOUBLE), "%.4f", 1.2345d, 1.2345d);
+    enum PrintfArg implements Consumer<VaList.Builder> {
+
+        INTEGRAL(int.class, asVarArg(C_INT), "%d", 42, 42, VaList.Builder::vargFromInt),
+        STRING(MemoryAddress.class, asVarArg(C_POINTER), "%s", toCString("str").baseAddress(), "str", VaList.Builder::vargFromAddress),
+        CHAR(byte.class, asVarArg(C_CHAR), "%c", (byte) 'h', 'h', (builder, layout, value) -> builder.vargFromInt(C_INT, (int)value)),
+        DOUBLE(double.class, asVarArg(C_DOUBLE), "%.4f", 1.2345d, 1.2345d, VaList.Builder::vargFromDouble);
 
         final Class<?> carrier;
         final MemoryLayout layout;
         final String format;
         final Object nativeValue;
         final Object javaValue;
+        @SuppressWarnings("rawtypes")
+        final VaListBuilderCall builderCall;
 
-        PrintfArg(Class<?> carrier, MemoryLayout layout, String format, Object nativeValue, Object javaValue) {
+        <Z> PrintfArg(Class<?> carrier, MemoryLayout layout, String format, Z nativeValue, Object javaValue, VaListBuilderCall<Z> builderCall) {
             this.carrier = carrier;
             this.layout = layout;
             this.format = format;
             this.nativeValue = nativeValue;
             this.javaValue = javaValue;
+            this.builderCall = builderCall;
+        }
+
+        @Override
+        @SuppressWarnings("unchecked")
+        public void accept(VaList.Builder builder) {
+            builderCall.build(builder, layout, nativeValue);
+        }
+
+        interface VaListBuilderCall<V> {
+            void build(VaList.Builder builder, MemoryLayout layout, V value);
         }
     }
 


### PR DESCRIPTION
For completeness, I added a test for `vprintf` in our `StdLibTest`. The logic is the same as for the `printf` test, but instead of passing arguments separately to a specialized handle, we instead construct the correct valist object which is then passed to the shared `vprintf` handle.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * Athijegannathan Sundararajan ([sundar](@sundararajana) - Committer)


### Download
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/205/head:pull/205`
`$ git checkout pull/205`
