### PR TITLE
Tweak API and javadoc for VaList

### DIFF
--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/CSupport.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/CSupport.java
@@ -175,7 +175,7 @@ public class CSupport {
          *
          * @param actions a consumer for a builder (see {@link Builder}) which can be used to specify the contents
          *                of the underlying C {@code va_list}.
-         * @return a new {@code VaList} instance backed a fresh C {@code va_list}.
+         * @return a new {@code VaList} instance backed by a fresh C {@code va_list}.
          */
         static VaList make(Consumer<VaList.Builder> actions) {
             return SharedUtils.newVaList(actions);

--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/CSupport.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/CSupport.java
@@ -54,10 +54,6 @@ public class CSupport {
         return SharedUtils.getSystemLinker();
     }
 
-    public static VaList newVaList(Consumer<VaList.Builder> actions) {
-        return SharedUtils.newVaList(actions);
-    }
-
     /**
      * An interface that models a C {@code va_list}.
      *
@@ -76,6 +72,8 @@ public class CSupport {
          *
          * @param layout the layout of the value
          * @return the value read as an {@code int}
+         * @throws IllegalStateException if the C {@code va_list} associated with this instance is no longer valid
+         * (see {@link #close()}).
          */
         int vargAsInt(MemoryLayout layout);
 
@@ -84,6 +82,8 @@ public class CSupport {
          *
          * @param layout the layout of the value
          * @return the value read as an {@code long}
+         * @throws IllegalStateException if the C {@code va_list} associated with this instance is no longer valid
+         * (see {@link #close()}).
          */
         long vargAsLong(MemoryLayout layout);
 
@@ -92,6 +92,8 @@ public class CSupport {
          *
          * @param layout the layout of the value
          * @return the value read as an {@code double}
+         * @throws IllegalStateException if the C {@code va_list} associated with this instance is no longer valid
+         * (see {@link #close()}).
          */
         double vargAsDouble(MemoryLayout layout);
 
@@ -100,6 +102,8 @@ public class CSupport {
          *
          * @param layout the layout of the value
          * @return the value read as an {@code MemoryAddress}
+         * @throws IllegalStateException if the C {@code va_list} associated with this instance is no longer valid
+         * (see {@link #close()}).
          */
         MemoryAddress vargAsAddress(MemoryLayout layout);
 
@@ -108,6 +112,8 @@ public class CSupport {
          *
          * @param layout the layout of the value
          * @return the value read as an {@code MemorySegment}
+         * @throws IllegalStateException if the C {@code va_list} associated with this instance is no longer valid
+         * (see {@link #close()}).
          */
         MemorySegment vargAsSegment(MemoryLayout layout);
 
@@ -115,57 +121,73 @@ public class CSupport {
          * Skips a number of va arguments with the given memory layouts.
          *
          * @param layouts the layout of the value
+         * @throws IllegalStateException if the C {@code va_list} associated with this instance is no longer valid
+         * (see {@link #close()}).
          */
-        void skip(MemoryLayout...layouts);
+        void skip(MemoryLayout... layouts);
 
         /**
-         * A predicate used to check if this va list is alive,
-         * or in other words; if {@code close()} has been called on this
-         * va list.
+         * A predicate used to check if the memory associated with the C {@code va_list} modelled
+         * by this instance is still valid; or, in other words, if {@code close()} has been called on this
+         * instance.
          *
-         * @return true if this va list is still alive.
+         * @return true, if the memory associated with the C {@code va_list} modelled by this instance is still valid
          * @see #close()
          */
         boolean isAlive();
 
         /**
-         * Closes this va list, releasing any resources it was using.
+         * Releases the underlying C {@code va_list} modelled by this instance. As a result, subsequent attempts to call
+         * operations on this instance (e.g. {@link #copy()} will fail with an exception.
          *
          * @see #isAlive()
          */
         void close();
 
         /**
-         * Copies this va list.
+         * Copies this C {@code va_list}.
          *
-         * @return a copy of this va list.
+         * @return a copy of this C {@code va_list}.
+         * @throws IllegalStateException if the C {@code va_list} associated with this instance is no longer valid
+         * (see {@link #close()}).
          */
         VaList copy();
 
         /**
-         * Returns the underlying memory address of this va list.
+         * Returns the memory address of the C {@code va_list} associated with this instance.
          *
-         * @return the address
+         * @return the memory address of the C {@code va_list} associated with this instance.
          */
-        MemoryAddress toAddress();
+        MemoryAddress address();
 
         /**
-         * Constructs a {@code VaList} out of the memory address of a va_list.
+         * Constructs a new {@code VaList} instance out of a memory address pointing to an existing C {@code va_list}.
          *
-         * @param ma the memory address
-         * @return the new {@code VaList}.
+         * @param address a memory address pointing to an existing C {@code va_list}.
+         * @return a new {@code VaList} instance backed by the C {@code va_list} at {@code address}.
          */
-        static VaList ofAddress(MemoryAddress ma) {
-            return SharedUtils.newVaListOfAddress(ma);
+        static VaList ofAddress(MemoryAddress address) {
+            return SharedUtils.newVaListOfAddress(address);
         }
 
         /**
-         * A builder interface used to construct a va list.
+         * Constructs a new {@code VaList} using a builder (see {@link Builder}).
+         *
+         * @param actions a consumer for a builder (see {@link Builder}) which can be used to specify the contents
+         *                of the underlying C {@code va_list}.
+         * @return a new {@code VaList} instance backed a fresh C {@code va_list}.
+         */
+        static VaList make(Consumer<VaList.Builder> actions) {
+            return SharedUtils.newVaList(actions);
+        }
+
+        /**
+         * A builder interface used to construct a C {@code va_list}.
          */
         interface Builder {
 
             /**
-             * Adds a native value represented as an {@code int} to the va list.
+             * Adds a native value represented as an {@code int} to the C {@code va_list} being constructed.
              *
              * @param layout the native layout of the value.
              * @param value the value, represented as an {@code int}.
@@ -174,7 +196,7 @@ public class CSupport {
             Builder vargFromInt(MemoryLayout layout, int value);
 
             /**
-             * Adds a native value represented as a {@code long} to the va list.
+             * Adds a native value represented as a {@code long} to the C {@code va_list} being constructed.
              *
              * @param layout the native layout of the value.
              * @param value the value, represented as a {@code long}.
@@ -183,7 +205,7 @@ public class CSupport {
             Builder vargFromLong(MemoryLayout layout, long value);
 
             /**
-             * Adds a native value represented as a {@code double} to the va list.
+             * Adds a native value represented as a {@code double} to the C {@code va_list} being constructed.
              *
              * @param layout the native layout of the value.
              * @param value the value, represented as a {@code double}.
@@ -192,7 +214,7 @@ public class CSupport {
             Builder vargFromDouble(MemoryLayout layout, double value);
 
             /**
-             * Adds a native value represented as a {@code MemoryAddress} to the va list.
+             * Adds a native value represented as a {@code MemoryAddress} to the C {@code va_list} being constructed.
              *
              * @param layout the native layout of the value.
              * @param value the value, represented as a {@code MemoryAddress}.
@@ -201,7 +223,7 @@ public class CSupport {
             Builder vargFromAddress(MemoryLayout layout, MemoryAddress value);
 
             /**
-             * Adds a native value represented as a {@code MemorySegment} to the va list.
+             * Adds a native value represented as a {@code MemorySegment} to the C {@code va_list} being constructed.
              *
              * @param layout the native layout of the value.
              * @param value the value, represented as a {@code MemorySegment}.

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/x64/sysv/SysVVaList.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/x64/sysv/SysVVaList.java
@@ -292,7 +292,7 @@ public class SysVVaList implements VaList {
     }
 
     @Override
-    public MemoryAddress toAddress() {
+    public MemoryAddress address() {
         return segment.baseAddress();
     }
 

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/x64/windows/WinVaList.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/x64/windows/WinVaList.java
@@ -160,7 +160,7 @@ class WinVaList implements CSupport.VaList {
     }
 
     @Override
-    public MemoryAddress toAddress() {
+    public MemoryAddress address() {
         return ptr;
     }
 

--- a/test/jdk/java/foreign/StdLibTest.java
+++ b/test/jdk/java/foreign/StdLibTest.java
@@ -359,7 +359,7 @@ public class StdLibTest extends NativeTestHelper {
         int vprintf(String format, List<PrintfArg> args) throws Throwable {
             try (MemorySegment formatStr = toCString(format)) {
                 return (int)vprintf.invokeExact(formatStr.baseAddress(),
-                        newVaList(b -> args.forEach(a -> a.accept(b))));
+                        VaList.make(b -> args.forEach(a -> a.accept(b))));
             }
         }
 

--- a/test/jdk/java/foreign/valist/VaListTest.java
+++ b/test/jdk/java/foreign/valist/VaListTest.java
@@ -130,7 +130,7 @@ public class VaListTest {
 
     @Test
     public void testIntSum() throws Throwable {
-        try (VaList vaList = CSupport.newVaList(b ->
+        try (VaList vaList = VaList.make(b ->
                 b.vargFromInt(C_INT, 10)
                  .vargFromInt(C_INT, 15)
                  .vargFromInt(C_INT, 20))) {
@@ -141,7 +141,7 @@ public class VaListTest {
 
     @Test
     public void testDoubleSum() throws Throwable {
-        try (VaList vaList = CSupport.newVaList(b ->
+        try (VaList vaList = VaList.make(b ->
                 b.vargFromDouble(C_DOUBLE, 3.0D)
                  .vargFromDouble(C_DOUBLE, 4.0D)
                  .vargFromDouble(C_DOUBLE, 5.0D))) {
@@ -154,7 +154,7 @@ public class VaListTest {
     public void testVaListMemoryAddress() throws Throwable {
         try (MemorySegment msInt = MemorySegment.allocateNative(C_INT)) {
             VH_int.set(msInt.baseAddress(), 10);
-            try (VaList vaList = CSupport.newVaList(b -> b.vargFromAddress(C_POINTER, msInt.baseAddress()))) {
+            try (VaList vaList = VaList.make(b -> b.vargFromAddress(C_POINTER, msInt.baseAddress()))) {
                 int x = (int) MH_getInt.invokeExact(vaList);
                 assertEquals(x, 10);
             }
@@ -167,7 +167,7 @@ public class VaListTest {
             VH_Point_x.set(struct.baseAddress(), 5);
             VH_Point_y.set(struct.baseAddress(), 10);
 
-            try (VaList vaList = CSupport.newVaList(b -> b.vargFromSegment(Point_LAYOUT, struct))) {
+            try (VaList vaList = VaList.make(b -> b.vargFromSegment(Point_LAYOUT, struct))) {
                 int sum = (int) MH_sumStruct.invokeExact(vaList);
                 assertEquals(sum, 15);
             }
@@ -180,7 +180,7 @@ public class VaListTest {
             VH_BigPoint_x.set(struct.baseAddress(), 5);
             VH_BigPoint_y.set(struct.baseAddress(), 10);
 
-            try (VaList vaList = CSupport.newVaList(b -> b.vargFromSegment(BigPoint_LAYOUT, struct))) {
+            try (VaList vaList = VaList.make(b -> b.vargFromSegment(BigPoint_LAYOUT, struct))) {
                 long sum = (long) MH_sumBigStruct.invokeExact(vaList);
                 assertEquals(sum, 15);
             }


### PR DESCRIPTION
This is a small patch which fixes some javadoc and API issues in the CSupport.VaList class. Main changes are:

* CSupport::newVaList has been moved as a static factory in VaList (new name is `make`)
* Valist::toAddress() renamed to just `address`
* minor javadoc tweaks to better clarify the distinction between underlying C va list and the Java VaList warpper
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * Jorn Vernee ([jvernee](@JornVernee) - Committer)


### Download
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/206/head:pull/206`
`$ git checkout pull/206`
