### PR TITLE
8247488: Add support for string helpers in CSupport (decoding support)

### DIFF
--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/CSupport.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/CSupport.java
@@ -45,7 +45,7 @@ public class CSupport {
      * Obtain a linker that uses the de facto C ABI of the current system to do it's linking.
      * <p>
      * This method is <em>restricted</em>. Restricted method are unsafe, and, if used incorrectly, their use might crash
-     * the JVM crash or, worse, silently result in memory corruption. Thus, clients should refrain from depending on
+     * the JVM or, worse, silently result in memory corruption. Thus, clients should refrain from depending on
      * restricted methods, and use safe and supported functionalities, where possible.
      * @return a linker for this system.
      * @throws IllegalAccessError if the runtime property {@code foreign.restricted} is not set to either
@@ -645,7 +645,7 @@ public class CSupport {
      * over the decoding process is required.
      * <p>
      * This method is <em>restricted</em>. Restricted method are unsafe, and, if used incorrectly, their use might crash
-     * the JVM crash or, worse, silently result in memory corruption. Thus, clients should refrain from depending on
+     * the JVM or, worse, silently result in memory corruption. Thus, clients should refrain from depending on
      * restricted methods, and use safe and supported functionalities, where possible.
      * @param addr the address at which the string is stored.
      * @return a Java string with the contents of the null-terminated C string at given address.
@@ -666,7 +666,7 @@ public class CSupport {
      * over the decoding process is required.
      * <p>
      * This method is <em>restricted</em>. Restricted method are unsafe, and, if used incorrectly, their use might crash
-     * the JVM crash or, worse, silently result in memory corruption. Thus, clients should refrain from depending on
+     * the JVM or, worse, silently result in memory corruption. Thus, clients should refrain from depending on
      * restricted methods, and use safe and supported functionalities, where possible.
      * @param addr the address at which the string is stored.
      * @param charset The {@linkplain java.nio.charset.Charset} to be used to compute the contents of the Java string.

--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/MemorySegment.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/MemorySegment.java
@@ -611,7 +611,7 @@ allocateNative(bytesSize, 1);
      * (see {@link #ALL_ACCESS}).
      * <p>
      * This method is <em>restricted</em>. Restricted method are unsafe, and, if used incorrectly, their use might crash
-     * the JVM crash or, worse, silently result in memory corruption. Thus, clients should refrain from depending on
+     * the JVM or, worse, silently result in memory corruption. Thus, clients should refrain from depending on
      * restricted methods, and use safe and supported functionalities, where possible.
      *
      * @param addr the desired base address

--- a/test/jdk/java/foreign/StdLibTest.java
+++ b/test/jdk/java/foreign/StdLibTest.java
@@ -316,7 +316,7 @@ public class StdLibTest extends NativeTestHelper {
             }
             boolean isdst() {
                 byte b = (byte)byteHandle.get(base.addOffset(32));
-                return b == 0 ? false : true;
+                return b != 0;
             }
         }
 


### PR DESCRIPTION
This patch add more symmetric support for charset-driven decoding of the contents of a native string.
That means we can no longer using a StringBuilder, but, instead, we have to get the byte array and create a `String` out of that using specified `Charset` instance.

Implementation-wise, following an offline discussion with Jorn, I've settled for an approach which finds string length, then does a bulk copy to a byte array. Not sure this is going to peform well on small strings. The alternative would have been to use `ByteArrayOutputStream` - but the issue there is that both `write` and `toString` methods there are `synchronized`.

In any case, I think the implementation can be made more efficient later, if we find that to be an issue.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [JDK-8247488](https://bugs.openjdk.java.net/browse/JDK-8247488): Add support for string helpers in CSupport ⚠️ Title mismatch between PR and JBS.


### Reviewers
 * Henry Jen ([henryjen](@slowhog) - Committer) ⚠️ Review applies to f538ccb6dda7db8d3e5296d5b0b810a1daf56b0b
 * Jorn Vernee ([jvernee](@JornVernee) - Committer)


### Download
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/207/head:pull/207`
`$ git checkout pull/207`
