### PR TITLE
8247678: StdLibTest fails to create an empty VaList on Windows

### DIFF
--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/CSupport.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/CSupport.java
@@ -173,12 +173,26 @@ public class CSupport {
         /**
          * Constructs a new {@code VaList} using a builder (see {@link Builder}).
          *
+         * Note that when there are no arguments added to the created va list,
+         * this method will return the same as {@linkplain #empty()}.
+         *
          * @param actions a consumer for a builder (see {@link Builder}) which can be used to specify the contents
          *                of the underlying C {@code va_list}.
          * @return a new {@code VaList} instance backed by a fresh C {@code va_list}.
          */
         static VaList make(Consumer<VaList.Builder> actions) {
             return SharedUtils.newVaList(actions);
+        }
+
+        /**
+         * Returns an empty C {@code va_list} constant.
+         *
+         * The returned {@code VaList} can not be closed.
+         *
+         * @return a {@code VaList} modelling an empty C {@code va_list}.
+         */
+        static VaList empty() {
+            return SharedUtils.emptyVaList();
         }
 
         /**

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/SharedUtils.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/SharedUtils.java
@@ -37,6 +37,7 @@ import jdk.incubator.foreign.ValueLayout;
 import jdk.internal.foreign.MemoryAddressImpl;
 import jdk.internal.foreign.Utils;
 import jdk.internal.foreign.abi.aarch64.AArch64Linker;
+import jdk.internal.foreign.abi.x64.sysv.SysVVaList;
 import jdk.internal.foreign.abi.x64.sysv.SysVx64Linker;
 import jdk.internal.foreign.abi.x64.windows.Windowsx64Linker;
 
@@ -273,6 +274,44 @@ public class SharedUtils {
         };
     }
 
+    public static VaList emptyVaList() {
+        String name = CSupport.getSystemLinker().name();
+        return switch(name) {
+            case Win64.NAME -> Windowsx64Linker.emptyVaList();
+            case SysV.NAME -> SysVx64Linker.emptyVaList();
+            case AArch64.NAME -> throw new UnsupportedOperationException("Not yet implemented for this platform");
+            default -> throw new IllegalStateException("Unknown linker name: " + name);
+        };
+    }
+
+    public static MethodType convertVaListCarriers(MethodType mt, Class<?> carrier) {
+        Class<?>[] params = new Class<?>[mt.parameterCount()];
+        for (int i = 0; i < params.length; i++) {
+            Class<?> pType = mt.parameterType(i);
+            params[i] = ((pType == VaList.class) ? carrier : pType);
+        }
+        return methodType(mt.returnType(), params);
+    }
+
+    public static MethodHandle unboxVaLists(MethodType type, MethodHandle handle, MethodHandle unboxer) {
+        for (int i = 0; i < type.parameterCount(); i++) {
+            if (type.parameterType(i) == VaList.class) {
+               handle = MethodHandles.filterArguments(handle, i, unboxer);
+            }
+        }
+        return handle;
+    }
+
+    public static MethodHandle boxVaLists(MethodHandle handle, MethodHandle boxer) {
+        MethodType type = handle.type();
+        for (int i = 0; i < type.parameterCount(); i++) {
+            if (type.parameterType(i) == VaList.class) {
+               handle = MethodHandles.filterArguments(handle, i, boxer);
+            }
+        }
+        return handle;
+    }
+
     public static class SimpleVaArg {
         public final Class<?> carrier;
         public final MemoryLayout layout;
@@ -288,6 +327,69 @@ public class SharedUtils {
             return carrier == MemoryAddress.class
                 ? MemoryHandles.asAddressVarHandle(layout.varHandle(primitiveCarrierForSize(layout.byteSize())))
                 : layout.varHandle(carrier);
+        }
+    }
+
+    public static class EmptyVaList implements CSupport.VaList {
+
+        private final MemoryAddress address;
+
+        public EmptyVaList(MemoryAddress address) {
+            this.address = address;
+        }
+
+        private static UnsupportedOperationException uoe() {
+            return new UnsupportedOperationException("Empty VaList");
+        }
+
+        @Override
+        public int vargAsInt(MemoryLayout layout) {
+            throw uoe();
+        }
+
+        @Override
+        public long vargAsLong(MemoryLayout layout) {
+            throw uoe();
+        }
+
+        @Override
+        public double vargAsDouble(MemoryLayout layout) {
+            throw uoe();
+        }
+
+        @Override
+        public MemoryAddress vargAsAddress(MemoryLayout layout) {
+            throw uoe();
+        }
+
+        @Override
+        public MemorySegment vargAsSegment(MemoryLayout layout) {
+            throw uoe();
+        }
+
+        @Override
+        public void skip(MemoryLayout... layouts) {
+            throw uoe();
+        }
+
+        @Override
+        public boolean isAlive() {
+            return true;
+        }
+
+        @Override
+        public void close() {
+            throw uoe();
+        }
+
+        @Override
+        public VaList copy() {
+            return this;
+        }
+
+        @Override
+        public MemoryAddress address() {
+            return address;
         }
     }
 }

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/x64/sysv/SysVVaList.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/x64/sysv/SysVVaList.java
@@ -139,9 +139,7 @@ public class SysVVaList implements VaList {
         VH_fp_offset.set(base, MAX_FP_OFFSET);
         VH_overflow_arg_area.set(base, MemoryAddress.NULL);
         VH_reg_save_area.set(base, MemoryAddress.NULL);
-        MemorySegment unconfined = NativeMemorySegmentImpl.makeNativeSegmentUnchecked(
-                base, ms.byteSize(), null, null, null).withAccessModes(0);
-        return unconfined.baseAddress();
+        return ms.withAccessModes(0).baseAddress();
     }
 
     public static CSupport.VaList empty() {

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/x64/sysv/SysVx64Linker.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/x64/sysv/SysVx64Linker.java
@@ -30,6 +30,7 @@ import jdk.incubator.foreign.FunctionDescriptor;
 import jdk.incubator.foreign.MemoryAddress;
 import jdk.incubator.foreign.MemoryLayout;
 import jdk.incubator.foreign.MemorySegment;
+import jdk.internal.foreign.abi.SharedUtils;
 import jdk.internal.foreign.abi.UpcallStubs;
 
 import java.lang.invoke.MethodHandle;
@@ -60,9 +61,9 @@ public class SysVx64Linker implements ForeignLinker {
     static {
         try {
             MethodHandles.Lookup lookup = MethodHandles.lookup();
-            MH_unboxVaList = lookup.findStatic(SysVx64Linker.class, "unboxVaList",
-                MethodType.methodType(MemoryAddress.class, CSupport.VaList.class));
-            MH_boxVaList = lookup.findStatic(SysVx64Linker.class, "boxVaList",
+            MH_unboxVaList = lookup.findVirtual(CSupport.VaList.class, "address",
+                MethodType.methodType(MemoryAddress.class));
+            MH_boxVaList = lookup.findStatic(SysVx64Linker.class, "newVaListOfAddress",
                 MethodType.methodType(VaList.class, MemoryAddress.class));
         } catch (ReflectiveOperationException e) {
             throw new ExceptionInInitializerError(e);
@@ -82,45 +83,17 @@ public class SysVx64Linker implements ForeignLinker {
         return builder.build();
     }
 
-    private static MethodType convertVaListCarriers(MethodType mt) {
-        Class<?>[] params = new Class<?>[mt.parameterCount()];
-        for (int i = 0; i < params.length; i++) {
-            Class<?> pType = mt.parameterType(i);
-            params[i] = ((pType == CSupport.VaList.class) ? SysVVaList.CARRIER : pType);
-        }
-        return MethodType.methodType(mt.returnType(), params);
-    }
-
-    private static MethodHandle unxboxVaLists(MethodType type, MethodHandle handle) {
-        for (int i = 0; i < type.parameterCount(); i++) {
-            if (type.parameterType(i) == VaList.class) {
-               handle = MethodHandles.filterArguments(handle, i, MH_unboxVaList);
-            }
-        }
-        return handle;
-    }
-
     @Override
     public MethodHandle downcallHandle(MemoryAddress symbol, MethodType type, FunctionDescriptor function) {
-        MethodType llMt = convertVaListCarriers(type);
+        MethodType llMt = SharedUtils.convertVaListCarriers(type, SysVVaList.CARRIER);
         MethodHandle handle = CallArranger.arrangeDowncall(symbol, llMt, function);
-        handle = unxboxVaLists(type, handle);
-        return handle;
-    }
-
-    private static MethodHandle boxVaLists(MethodHandle handle) {
-        MethodType type = handle.type();
-        for (int i = 0; i < type.parameterCount(); i++) {
-            if (type.parameterType(i) == VaList.class) {
-               handle = MethodHandles.filterArguments(handle, i, MH_boxVaList);
-            }
-        }
+        handle = SharedUtils.unboxVaLists(type, handle, MH_unboxVaList);
         return handle;
     }
 
     @Override
     public MemorySegment upcallStub(MethodHandle target, FunctionDescriptor function) {
-        target = boxVaLists(target);
+        target = SharedUtils.boxVaLists(target, MH_boxVaList);
         return UpcallStubs.upcallAddress(CallArranger.arrangeUpcall(target, target.type(), function));
     }
 
@@ -143,15 +116,11 @@ public class SysVx64Linker implements ForeignLinker {
         });
     }
 
-    private static MemoryAddress unboxVaList(CSupport.VaList list) {
-        return ((SysVVaList) list).getSegment().baseAddress();
-    }
-
-    private static CSupport.VaList boxVaList(MemoryAddress ma) {
-        return SysVVaList.ofAddress(ma);
-    }
-
     public static VaList newVaListOfAddress(MemoryAddress ma) {
         return SysVVaList.ofAddress(ma);
+    }
+
+    public static VaList emptyVaList() {
+        return SysVVaList.empty();
     }
 }

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/x64/windows/WinVaList.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/x64/windows/WinVaList.java
@@ -205,6 +205,9 @@ class WinVaList implements CSupport.VaList {
         }
 
         public WinVaList build() {
+            if (args.isEmpty()) {
+                return new WinVaList(MemorySegment.allocateNative(1).withAccessModes(CLOSE), List.of());
+            }
             MemorySegment ms = MemorySegment.allocateNative(VA_SLOT_SIZE_BYTES * args.size());
             List<MemorySegment> copies = new ArrayList<>();
 

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/x64/windows/Windowsx64Linker.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/x64/windows/Windowsx64Linker.java
@@ -30,6 +30,7 @@ import jdk.incubator.foreign.FunctionDescriptor;
 import jdk.incubator.foreign.MemoryAddress;
 import jdk.incubator.foreign.MemoryLayout;
 import jdk.incubator.foreign.MemorySegment;
+import jdk.internal.foreign.abi.SharedUtils;
 import jdk.internal.foreign.abi.UpcallStubs;
 
 import java.lang.invoke.MethodHandle;
@@ -61,9 +62,9 @@ public class Windowsx64Linker implements ForeignLinker {
     static {
         try {
             MethodHandles.Lookup lookup = MethodHandles.lookup();
-            MH_unboxVaList = lookup.findStatic(Windowsx64Linker.class, "unboxVaList",
-                MethodType.methodType(MemoryAddress.class, CSupport.VaList.class));
-            MH_boxVaList = lookup.findStatic(Windowsx64Linker.class, "boxVaList",
+            MH_unboxVaList = lookup.findVirtual(CSupport.VaList.class, "address",
+                MethodType.methodType(MemoryAddress.class));
+            MH_boxVaList = lookup.findStatic(Windowsx64Linker.class, "newVaListOfAddress",
                 MethodType.methodType(VaList.class, MemoryAddress.class));
         } catch (ReflectiveOperationException e) {
             throw new ExceptionInInitializerError(e);
@@ -83,45 +84,17 @@ public class Windowsx64Linker implements ForeignLinker {
         return builder.build();
     }
 
-    private static MethodType convertVaListCarriers(MethodType mt) {
-        Class<?>[] params = new Class<?>[mt.parameterCount()];
-        for (int i = 0; i < params.length; i++) {
-            Class<?> pType = mt.parameterType(i);
-            params[i] = ((pType == CSupport.VaList.class) ? WinVaList.CARRIER : pType);
-        }
-        return MethodType.methodType(mt.returnType(), params);
-    }
-
-    private static MethodHandle unxboxVaLists(MethodType type, MethodHandle handle) {
-        for (int i = 0; i < type.parameterCount(); i++) {
-            if (type.parameterType(i) == VaList.class) {
-               handle = MethodHandles.filterArguments(handle, i, MH_unboxVaList);
-            }
-        }
-        return handle;
-    }
-
     @Override
     public MethodHandle downcallHandle(MemoryAddress symbol, MethodType type, FunctionDescriptor function) {
-        MethodType llMt = convertVaListCarriers(type);
+        MethodType llMt = SharedUtils.convertVaListCarriers(type, WinVaList.CARRIER);
         MethodHandle handle = CallArranger.arrangeDowncall(symbol, llMt, function);
-        handle = unxboxVaLists(type, handle);
-        return handle;
-    }
-
-    private static MethodHandle boxVaLists(MethodHandle handle) {
-        MethodType type = handle.type();
-        for (int i = 0; i < type.parameterCount(); i++) {
-            if (type.parameterType(i) == VaList.class) {
-               handle = MethodHandles.filterArguments(handle, i, MH_boxVaList);
-            }
-        }
+        handle = SharedUtils.unboxVaLists(type, handle, MH_unboxVaList);
         return handle;
     }
 
     @Override
     public MemorySegment upcallStub(MethodHandle target, FunctionDescriptor function) {
-        target = boxVaLists(target);
+        target = SharedUtils.boxVaLists(target, MH_boxVaList);
         return UpcallStubs.upcallAddress(CallArranger.arrangeUpcall(target, target.type(), function));
     }
 
@@ -134,16 +107,11 @@ public class Windowsx64Linker implements ForeignLinker {
         return (Win64.ArgumentClass)layout.attribute(Win64.CLASS_ATTRIBUTE_NAME).get();
     }
 
-    private static MemoryAddress unboxVaList(CSupport.VaList list) {
-        return ((WinVaList) list).getSegment().baseAddress();
-    }
-
-    private static CSupport.VaList boxVaList(MemoryAddress ma) {
-        return WinVaList.ofAddress(ma);
-    }
-
     public static VaList newVaListOfAddress(MemoryAddress ma) {
         return WinVaList.ofAddress(ma);
     }
 
+    public static VaList emptyVaList() {
+        return WinVaList.empty();
+    }
 }

--- a/test/jdk/java/foreign/StdLibTest.java
+++ b/test/jdk/java/foreign/StdLibTest.java
@@ -358,8 +358,15 @@ public class StdLibTest extends NativeTestHelper {
 
         int vprintf(String format, List<PrintfArg> args) throws Throwable {
             try (MemorySegment formatStr = toCString(format)) {
-                return (int)vprintf.invokeExact(formatStr.baseAddress(),
-                        VaList.make(b -> args.forEach(a -> a.accept(b))));
+                VaList vaList = VaList.make(b -> args.forEach(a -> a.accept(b)));
+                int result = (int)vprintf.invokeExact(formatStr.baseAddress(), vaList);
+                try {
+                    vaList.close();
+                }
+                catch (UnsupportedOperationException e) {
+                    assertEquals(e.getMessage(), "Empty VaList");
+                }
+                return result;
             }
         }
 

--- a/test/jdk/java/foreign/valist/VaListTest.java
+++ b/test/jdk/java/foreign/valist/VaListTest.java
@@ -214,6 +214,20 @@ public class VaListTest {
         }
     }
 
+    @Test(expectedExceptions = UnsupportedOperationException.class,
+          expectedExceptionsMessageRegExp = ".*Empty VaList.*")
+    public void testEmptyNotCloseable() {
+        VaList list = VaList.empty();
+        list.close();
+    }
+
+    @Test(expectedExceptions = UnsupportedOperationException.class,
+          expectedExceptionsMessageRegExp = ".*Empty VaList.*")
+    public void testEmptyVaListFromBuilderNotCloseable() {
+        VaList list = VaList.make(b -> {});
+        list.close();
+    }
+
     @DataProvider
     public static Object[][] upcalls() {
         return new Object[][]{

--- a/test/micro/org/openjdk/bench/jdk/incubator/foreign/VaList.java
+++ b/test/micro/org/openjdk/bench/jdk/incubator/foreign/VaList.java
@@ -79,7 +79,7 @@ public class VaList {
 
     @Benchmark
     public void vaList() throws Throwable {
-        try (CSupport.VaList vaList = CSupport.newVaList(b ->
+        try (CSupport.VaList vaList = CSupport.VaList.make(b ->
             b.vargFromInt(C_INT, 1)
              .vargFromDouble(C_DOUBLE, 2D)
              .vargFromLong(C_LONGLONG, 3L)


### PR DESCRIPTION
Hi,

This patch addresses a test failure in StdLibTest, caused by trying to allocate an empty VaList in the Windows implementation.

(After some discussion with Maurizio) this is fixed by special casing empty va lists in the implementation. VaList.Builder.build() now returns a special empty va list constant when the VaList is empty. There's also an added VaList.empty() method, to directly create an empty VaList.

To implement this I removed the getSegment methods in the VaList implementation classes, and instead rely on VaList::address for unboxing a VaList. This works better with the spacial case empty VaList. Along with that I moved some of the shared code for handling VaList in the linkers to SharedUtils.

I added tests for the empty() API to verify that the returned VaList is non-closeable, and also updated StdLibTest to close the VaLists it creates (it wasn't doing this yet).

Thanks,
Jorn
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [JDK-8247678](https://bugs.openjdk.java.net/browse/JDK-8247678): StdLibTest fails to create an empty VaList on Windows


### Reviewers
 * Maurizio Cimadamore ([mcimadamore](@mcimadamore) - Committer) ⚠️ Review applies to eb80703cdb22b648b02ddb8378a77b55ea595d5c


### Download
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/208/head:pull/208`
`$ git checkout pull/208`
