### PR TITLE
8247924: Improve javadoc of Foreign Memory Access API (part one)

### DIFF
--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/MemorySegment.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/MemorySegment.java
@@ -287,7 +287,7 @@ public interface MemorySegment extends AutoCloseable {
     /**
      * Closes this memory segment. Once a memory segment has been closed, any attempt to use the memory segment,
      * or to access any {@link MemoryAddress} instance associated with it will fail with {@link IllegalStateException}.
-     * Depending on the kind of memory segment being closed, calling this method further trigger deallocation of all the resources
+     * Depending on the kind of memory segment being closed, calling this method further triggers deallocation of all the resources
      * associated with the memory segment.
      * @throws IllegalStateException if this segment is not <em>alive</em>, or if access occurs from a thread other than the
      * thread owning this segment, or if the segment cannot be closed because it is being operated upon by a different

--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/MemorySegment.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/MemorySegment.java
@@ -76,12 +76,22 @@ import java.util.function.Consumer;
  * Finally, it is also possible to obtain a memory segment backed by a memory-mapped file using the factory method
  * {@link MemorySegment#mapFromPath(Path, long, long, FileChannel.MapMode)}. Such memory segments are called <em>mapped memory segments</em>
  * (see {@link MappedMemorySegment}).
+ * <p>
+ * Array and buffer segments are effectively <em>views</em> over existing memory regions which might outlive the
+ * lifecycle of the segments derived from them, and can even be manipulated directly (e.g. via array access, or direct use
+ * of the {@link ByteBuffer} API) by other clients. As a result, while sharing array or buffer segments is possible,
+ * it is strongly advised that clients wishing to do so take extra precautions to make sure that the underlying memory sources
+ * associated with such segments remain inaccessible, and that said memory sources are never aliased by more than one segment
+ * at a time - e.g. so as to prevent concurrent modifications of the contents of an array, or buffer segment.
  *
  * <h2>Closing a memory segment</h2>
  *
- * Memory segments are closed explicitly (see {@link MemorySegment#close()}). In general when a segment is closed, all off-heap
- * resources associated with it are released; this has different meanings depending on the kind of memory segment being
- * considered:
+ * Memory segments are closed explicitly (see {@link MemorySegment#close()}). When a segment is closed, it is no longer
+ * <em>alive</em> (see {@link #isAlive()}, and subsequent operation on the segment (or on any {@link MemoryAddress} instance
+ * derived from it) will fail with {@link IllegalStateException}.
+ * <p>
+ * Closing a segment might trigger the releasing of the underlying memory resources associated with said segment, depending on
+ * the kind of memory segment being considered:
  * <ul>
  *     <li>closing a native memory segment results in <em>freeing</em> the native memory associated with it</li>
  *     <li>closing a mapped memory segment results in the backing memory-mapped file to be unmapped</li>

--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/MemorySegment.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/MemorySegment.java
@@ -286,8 +286,8 @@ public interface MemorySegment extends AutoCloseable {
 
     /**
      * Closes this memory segment. Once a memory segment has been closed, any attempt to use the memory segment,
-     * or to access the memory associated with the segment will fail with {@link IllegalStateException}. Depending on
-     * the kind of memory segment being closed, calling this method further trigger deallocation of all the resources
+     * or to access any {@link MemoryAddress} instance associated with it will fail with {@link IllegalStateException}.
+     * Depending on the kind of memory segment being closed, calling this method further trigger deallocation of all the resources
      * associated with the memory segment.
      * @throws IllegalStateException if this segment is not <em>alive</em>, or if access occurs from a thread other than the
      * thread owning this segment, or if the segment cannot be closed because it is being operated upon by a different
@@ -621,7 +621,7 @@ allocateNative(bytesSize, 1);
      * (see {@link #ALL_ACCESS}).
      * <p>
      * This method is <em>restricted</em>. Restricted method are unsafe, and, if used incorrectly, their use might crash
-     * the JVM crash or, worse, silently result in memory corruption. Thus, clients should refrain from depending on
+     * the JVM or, worse, silently result in memory corruption. Thus, clients should refrain from depending on
      * restricted methods, and use safe and supported functionalities, where possible.
      *
      * @param addr the desired base address


### PR DESCRIPTION
This patch clarifies the role of `MemorySegment::close`, and also mentions the fact that external memory sources (arrays/buffers) can be aliased, and that extra care must be taken by clients wanting to share such segments.

I also fixed the typos in restricted methods which we also fixed in foreign-abi.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [JDK-8247924](https://bugs.openjdk.java.net/browse/JDK-8247924): Improve javadoc of Foreign Memory Access API ⚠️ Title mismatch between PR and JBS.


### Reviewers
 * Jorn Vernee ([jvernee](@JornVernee) - Committer) ⚠️ Review applies to 4392f3c043441a1d33ba284c096399e4e831261a


### Download
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/209/head:pull/209`
`$ git checkout pull/209`
