### PR TITLE
* Fixed include path to be OS/SDK version independent

### DIFF
--- a/doc/panama_jextract.html
+++ b/doc/panama_jextract.html
@@ -200,10 +200,10 @@
 <h3 id="jextract-python.h">jextract Python.h</h3>
 <div class="sourceCode" id="cb7"><pre class="sourceCode sh"><code class="sourceCode bash"><span id="cb7-1"><a href="#cb7-1"></a></span>
 <span id="cb7-2"><a href="#cb7-2"></a><span class="ex">jextract</span> -l python2.7 \</span>
-<span id="cb7-3"><a href="#cb7-3"></a>  -I /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include \</span>
-<span id="cb7-4"><a href="#cb7-4"></a>  -I /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/python2.7/ \</span>
+<span id="cb7-3"><a href="#cb7-3"></a>  -I /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include \</span>
+<span id="cb7-4"><a href="#cb7-4"></a>  -I /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/python2.7/ \</span>
 <span id="cb7-5"><a href="#cb7-5"></a>  -t org.python \</span>
-<span id="cb7-6"><a href="#cb7-6"></a>   /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/python2.7/Python.h</span></code></pre></div>
+<span id="cb7-6"><a href="#cb7-6"></a>   /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/python2.7/Python.h</span></code></pre></div>
 <h3 id="java-program-that-uses-extracted-python-interface">Java program that uses extracted Python interface</h3>
 <div class="sourceCode" id="cb8"><pre class="sourceCode java"><code class="sourceCode java"><span id="cb8-1"><a href="#cb8-1"></a></span>
 <span id="cb8-2"><a href="#cb8-2"></a><span class="kw">import</span><span class="im"> org.python.Cstring;</span></span>
@@ -233,8 +233,9 @@
 <h3 id="jextract-readline.h">jextract readline.h</h3>
 <div class="sourceCode" id="cb10"><pre class="sourceCode sh"><code class="sourceCode bash"><span id="cb10-1"><a href="#cb10-1"></a></span>
 <span id="cb10-2"><a href="#cb10-2"></a><span class="ex">jextract</span> -l readline -t org.unix \</span>
-<span id="cb10-3"><a href="#cb10-3"></a>  -I /Library/Developer/CommandLineTools/SDKs/MacOSX10.14.sdk/usr/include \</span>
-<span id="cb10-4"><a href="#cb10-4"></a>   /Library/Developer/CommandLineTools/SDKs/MacOSX10.14.sdk/usr/include/readline/readline.h</span></code></pre></div>
+<span id="cb10-3"><a href="#cb10-3"></a>  -I /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include \</span>
+<span id="cb10-4"><a href="#cb10-4"></a>   /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/readline/readline.h</span>
+<span id="cb10-5"><a href="#cb10-5"></a></span></code></pre></div>
 <h3 id="java-code-that-uses-readline">Java code that uses readline</h3>
 <div class="sourceCode" id="cb11"><pre class="sourceCode java"><code class="sourceCode java"><span id="cb11-1"><a href="#cb11-1"></a></span>
 <span id="cb11-2"><a href="#cb11-2"></a><span class="kw">import</span><span class="im"> org.unix.Cstring;</span></span>
@@ -263,9 +264,9 @@
 <h3 id="jextract-curl.h">jextract curl.h</h3>
 <div class="sourceCode" id="cb13"><pre class="sourceCode sh"><code class="sourceCode bash"><span id="cb13-1"><a href="#cb13-1"></a></span>
 <span id="cb13-2"><a href="#cb13-2"></a><span class="ex">jextract</span> -t org.unix -lcurl \</span>
-<span id="cb13-3"><a href="#cb13-3"></a>  -I /Library/Developer/CommandLineTools/SDKs/MacOSX10.14.sdk/usr/include/ \</span>
-<span id="cb13-4"><a href="#cb13-4"></a>  -I /Library/Developer/CommandLineTools/SDKs/MacOSX10.14.sdk/usr/include/curl/ \</span>
-<span id="cb13-5"><a href="#cb13-5"></a>  /Library/Developer/CommandLineTools/SDKs/MacOSX10.14.sdk/usr/include/curl/curl.h</span></code></pre></div>
+<span id="cb13-3"><a href="#cb13-3"></a>  -I /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/ \</span>
+<span id="cb13-4"><a href="#cb13-4"></a>  -I /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/curl/ \</span>
+<span id="cb13-5"><a href="#cb13-5"></a>  /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/curl/curl.h</span></code></pre></div>
 <h3 id="java-code-that-uses-libcurl">Java code that uses libcurl</h3>
 <div class="sourceCode" id="cb14"><pre class="sourceCode java"><code class="sourceCode java"><span id="cb14-1"><a href="#cb14-1"></a></span>
 <span id="cb14-2"><a href="#cb14-2"></a><span class="kw">import</span><span class="im"> org.unix.Cstring;</span></span>
@@ -309,7 +310,7 @@
 <p>The following command can be used to extract cblas.h on MacOs</p>
 <div class="sourceCode" id="cb17"><pre class="sourceCode sh"><code class="sourceCode bash"><span id="cb17-1"><a href="#cb17-1"></a></span>
 <span id="cb17-2"><a href="#cb17-2"></a><span class="ex">jextract</span> -C <span class="st">&quot;-D FORCE_OPENBLAS_COMPLEX_STRUCT&quot;</span> \</span>
-<span id="cb17-3"><a href="#cb17-3"></a>  -I /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include \</span>
+<span id="cb17-3"><a href="#cb17-3"></a>  -I /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include \</span>
 <span id="cb17-4"><a href="#cb17-4"></a>  -l openblas -t blas /usr/local/opt/openblas/include/cblas.h</span></code></pre></div>
 <h3 id="java-sample-code-that-uses-cblas-library">Java sample code that uses cblas library</h3>
 <div class="sourceCode" id="cb18"><pre class="sourceCode java"><code class="sourceCode java"><span id="cb18-1"><a href="#cb18-1"></a></span>
@@ -390,7 +391,7 @@
 <h3 id="jextracting-lapacke.h">jextracting lapacke.h</h3>
 <div class="sourceCode" id="cb20"><pre class="sourceCode sh"><code class="sourceCode bash"><span id="cb20-1"><a href="#cb20-1"></a></span>
 <span id="cb20-2"><a href="#cb20-2"></a><span class="ex">jextract</span> \</span>
-<span id="cb20-3"><a href="#cb20-3"></a>   -I /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include \</span>
+<span id="cb20-3"><a href="#cb20-3"></a>   -I /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include \</span>
 <span id="cb20-4"><a href="#cb20-4"></a>   -l lapacke -t lapack \</span>
 <span id="cb20-5"><a href="#cb20-5"></a>   --filter lapacke.h \</span>
 <span id="cb20-6"><a href="#cb20-6"></a>   /usr/local/opt/lapack/include/lapacke.h</span></code></pre></div>
@@ -459,9 +460,9 @@
 <h3 id="jextract-libproc.h">jextract libproc.h</h3>
 <div class="sourceCode" id="cb23"><pre class="sourceCode sh"><code class="sourceCode bash"><span id="cb23-1"><a href="#cb23-1"></a></span>
 <span id="cb23-2"><a href="#cb23-2"></a><span class="ex">jextract</span> -t org.unix \</span>
-<span id="cb23-3"><a href="#cb23-3"></a>  -I /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include \</span>
+<span id="cb23-3"><a href="#cb23-3"></a>  -I /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include \</span>
 <span id="cb23-4"><a href="#cb23-4"></a>  --filter libproc.h \</span>
-<span id="cb23-5"><a href="#cb23-5"></a>  /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/libproc.h</span></code></pre></div>
+<span id="cb23-5"><a href="#cb23-5"></a>  /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/libproc.h</span></code></pre></div>
 <h3 id="java-program-that-uses-libproc-to-list-processes">Java program that uses libproc to list processes</h3>
 <div class="sourceCode" id="cb24"><pre class="sourceCode java"><code class="sourceCode java"><span id="cb24-1"><a href="#cb24-1"></a></span>
 <span id="cb24-2"><a href="#cb24-2"></a><span class="kw">import</span><span class="im"> jdk.incubator.foreign.NativeScope;</span></span>
@@ -511,7 +512,7 @@
 <h3 id="jextract-git2.h">jextract git2.h</h3>
 <div class="sourceCode" id="cb26"><pre class="sourceCode sh"><code class="sourceCode bash"><span id="cb26-1"><a href="#cb26-1"></a></span>
 <span id="cb26-2"><a href="#cb26-2"></a><span class="ex">jextract</span> -t com.github -lgit2 \</span>
-<span id="cb26-3"><a href="#cb26-3"></a>  -I /Library/Developer/CommandLineTools/SDKs/MacOSX10.14.sdk/usr/include/ \</span>
+<span id="cb26-3"><a href="#cb26-3"></a>  -I /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/ \</span>
 <span id="cb26-4"><a href="#cb26-4"></a>  -I <span class="va">${LIBGIT2_HOME}</span>/include/ \</span>
 <span id="cb26-5"><a href="#cb26-5"></a>  -I <span class="va">${LIBGIT2_HOME}</span>/include/git2 \</span>
 <span id="cb26-6"><a href="#cb26-6"></a>  <span class="va">${LIBGIT2_HOME}</span>/include/git2.h</span></code></pre></div>
@@ -521,24 +522,23 @@
 <span id="cb27-3"><a href="#cb27-3"></a><span class="kw">import static</span><span class="im"> com.github.git2_h.*;</span></span>
 <span id="cb27-4"><a href="#cb27-4"></a><span class="kw">import static</span><span class="im"> jdk.incubator.foreign.CSupport.*;</span></span>
 <span id="cb27-5"><a href="#cb27-5"></a><span class="kw">import static</span><span class="im"> jdk.incubator.foreign.MemoryAddress.NULL;</span></span>
-<span id="cb27-6"><a href="#cb27-6"></a><span class="kw">import static</span><span class="im"> com.github.Cstring.*;</span></span>
-<span id="cb27-7"><a href="#cb27-7"></a></span>
-<span id="cb27-8"><a href="#cb27-8"></a><span class="kw">public</span> <span class="kw">class</span> GitClone {</span>
-<span id="cb27-9"><a href="#cb27-9"></a>    <span class="kw">public</span> <span class="dt">static</span> <span class="dt">void</span> <span class="fu">main</span>(<span class="bu">String</span>[] args) {</span>
-<span id="cb27-10"><a href="#cb27-10"></a>          <span class="kw">if</span> (args.<span class="fu">length</span> != <span class="dv">2</span>) {</span>
-<span id="cb27-11"><a href="#cb27-11"></a>              <span class="bu">System</span>.<span class="fu">err</span>.<span class="fu">println</span>(<span class="st">&quot;java GitClone &lt;url&gt; &lt;path&gt;&quot;</span>);</span>
-<span id="cb27-12"><a href="#cb27-12"></a>              <span class="bu">System</span>.<span class="fu">exit</span>(<span class="dv">1</span>);</span>
-<span id="cb27-13"><a href="#cb27-13"></a>          }</span>
-<span id="cb27-14"><a href="#cb27-14"></a>          <span class="fu">git_libgit2_init</span>();</span>
-<span id="cb27-15"><a href="#cb27-15"></a>          <span class="kw">try</span> (var scope = NativeScope.<span class="fu">unboundedScope</span>()) {</span>
-<span id="cb27-16"><a href="#cb27-16"></a>              var repo = scope.<span class="fu">allocate</span>(C_POINTER, NULL);</span>
-<span id="cb27-17"><a href="#cb27-17"></a>              var url = <span class="fu">toCString</span>(args[<span class="dv">0</span>], scope);</span>
-<span id="cb27-18"><a href="#cb27-18"></a>              var path = <span class="fu">toCString</span>(args[<span class="dv">1</span>], scope);</span>
-<span id="cb27-19"><a href="#cb27-19"></a>              <span class="bu">System</span>.<span class="fu">out</span>.<span class="fu">println</span>(<span class="fu">git_clone</span>(repo, url, path, NULL));</span>
-<span id="cb27-20"><a href="#cb27-20"></a>          }</span>
-<span id="cb27-21"><a href="#cb27-21"></a>          <span class="fu">git_libgit2_shutdown</span>();</span>
-<span id="cb27-22"><a href="#cb27-22"></a>    }</span>
-<span id="cb27-23"><a href="#cb27-23"></a>}</span></code></pre></div>
+<span id="cb27-6"><a href="#cb27-6"></a></span>
+<span id="cb27-7"><a href="#cb27-7"></a><span class="kw">public</span> <span class="kw">class</span> GitClone {</span>
+<span id="cb27-8"><a href="#cb27-8"></a>    <span class="kw">public</span> <span class="dt">static</span> <span class="dt">void</span> <span class="fu">main</span>(<span class="bu">String</span>[] args) {</span>
+<span id="cb27-9"><a href="#cb27-9"></a>          <span class="kw">if</span> (args.<span class="fu">length</span> != <span class="dv">2</span>) {</span>
+<span id="cb27-10"><a href="#cb27-10"></a>              <span class="bu">System</span>.<span class="fu">err</span>.<span class="fu">println</span>(<span class="st">&quot;java GitClone &lt;url&gt; &lt;path&gt;&quot;</span>);</span>
+<span id="cb27-11"><a href="#cb27-11"></a>              <span class="bu">System</span>.<span class="fu">exit</span>(<span class="dv">1</span>);</span>
+<span id="cb27-12"><a href="#cb27-12"></a>          }</span>
+<span id="cb27-13"><a href="#cb27-13"></a>          <span class="fu">git_libgit2_init</span>();</span>
+<span id="cb27-14"><a href="#cb27-14"></a>          <span class="kw">try</span> (var scope = NativeScope.<span class="fu">unboundedScope</span>()) {</span>
+<span id="cb27-15"><a href="#cb27-15"></a>              var repo = scope.<span class="fu">allocate</span>(C_POINTER, NULL);</span>
+<span id="cb27-16"><a href="#cb27-16"></a>              var url = <span class="fu">toCString</span>(args[<span class="dv">0</span>], scope);</span>
+<span id="cb27-17"><a href="#cb27-17"></a>              var path = <span class="fu">toCString</span>(args[<span class="dv">1</span>], scope);</span>
+<span id="cb27-18"><a href="#cb27-18"></a>              <span class="bu">System</span>.<span class="fu">out</span>.<span class="fu">println</span>(<span class="fu">git_clone</span>(repo, url, path, NULL));</span>
+<span id="cb27-19"><a href="#cb27-19"></a>          }</span>
+<span id="cb27-20"><a href="#cb27-20"></a>          <span class="fu">git_libgit2_shutdown</span>();</span>
+<span id="cb27-21"><a href="#cb27-21"></a>    }</span>
+<span id="cb27-22"><a href="#cb27-22"></a>}</span></code></pre></div>
 <h3 id="compiling-and-running-the-libgit2-sample">Compiling and running the libgit2 sample</h3>
 <div class="sourceCode" id="cb28"><pre class="sourceCode sh"><code class="sourceCode bash"><span id="cb28-1"><a href="#cb28-1"></a></span>
 <span id="cb28-2"><a href="#cb28-2"></a><span class="co"># file run.sh</span></span>
@@ -553,8 +553,8 @@
 <h3 id="jextract-sqlite3.h">jextract sqlite3.h</h3>
 <div class="sourceCode" id="cb30"><pre class="sourceCode sh"><code class="sourceCode bash"><span id="cb30-1"><a href="#cb30-1"></a></span>
 <span id="cb30-2"><a href="#cb30-2"></a><span class="ex">jextract</span> \</span>
-<span id="cb30-3"><a href="#cb30-3"></a>  -I /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include \</span>
-<span id="cb30-4"><a href="#cb30-4"></a>  /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/sqlite3.h \</span>
+<span id="cb30-3"><a href="#cb30-3"></a>  -I /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include \</span>
+<span id="cb30-4"><a href="#cb30-4"></a>  /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/sqlite3.h \</span>
 <span id="cb30-5"><a href="#cb30-5"></a>  -t org.sqlite -lsqlite3</span></code></pre></div>
 <h3 id="java-program-that-uses-sqlite3">Java program that uses sqlite3</h3>
 <div class="sourceCode" id="cb31"><pre class="sourceCode java"><code class="sourceCode java"><span id="cb31-1"><a href="#cb31-1"></a></span>

--- a/doc/panama_jextract.md
+++ b/doc/panama_jextract.md
@@ -87,10 +87,10 @@ java -Dforeign.restricted=permit --add-modules jdk.incubator.foreign HelloWorld.
 ```sh
 
 jextract -l python2.7 \
-  -I /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include \
-  -I /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/python2.7/ \
+  -I /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include \
+  -I /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/python2.7/ \
   -t org.python \
-   /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/python2.7/Python.h
+   /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/python2.7/Python.h
 
 ```
 
@@ -136,8 +136,9 @@ java -Dforeign.restricted=permit --add-modules jdk.incubator.foreign \
 ```sh
 
 jextract -l readline -t org.unix \
-  -I /Library/Developer/CommandLineTools/SDKs/MacOSX10.14.sdk/usr/include \
-   /Library/Developer/CommandLineTools/SDKs/MacOSX10.14.sdk/usr/include/readline/readline.h
+  -I /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include \
+   /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/readline/readline.h
+
 
 ```
 
@@ -181,9 +182,9 @@ java -Dforeign.restricted=permit --add-modules jdk.incubator.foreign \
 ```sh
 
 jextract -t org.unix -lcurl \
-  -I /Library/Developer/CommandLineTools/SDKs/MacOSX10.14.sdk/usr/include/ \
-  -I /Library/Developer/CommandLineTools/SDKs/MacOSX10.14.sdk/usr/include/curl/ \
-  /Library/Developer/CommandLineTools/SDKs/MacOSX10.14.sdk/usr/include/curl/curl.h
+  -I /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/ \
+  -I /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/curl/ \
+  /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/curl/curl.h
 
 ```
 
@@ -254,7 +255,7 @@ The following command can be used to extract cblas.h on MacOs
 ```sh
 
 jextract -C "-D FORCE_OPENBLAS_COMPLEX_STRUCT" \
-  -I /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include \
+  -I /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include \
   -l openblas -t blas /usr/local/opt/openblas/include/cblas.h
 
 ```
@@ -352,7 +353,7 @@ On Mac OS, lapack is installed under /usr/local/opt/lapack directory.
 ```sh
 
 jextract \
-   -I /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include \
+   -I /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include \
    -l lapacke -t lapack \
    --filter lapacke.h \
    /usr/local/opt/lapack/include/lapacke.h
@@ -436,9 +437,9 @@ java -Dforeign.restricted=permit \
 ```sh
 
 jextract -t org.unix \
-  -I /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include \
+  -I /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include \
   --filter libproc.h \
-  /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/libproc.h
+  /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/libproc.h
 
 ```
 
@@ -504,7 +505,7 @@ java -Dforeign.restricted=permit \
 ```sh
 
 jextract -t com.github -lgit2 \
-  -I /Library/Developer/CommandLineTools/SDKs/MacOSX10.14.sdk/usr/include/ \
+  -I /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/ \
   -I ${LIBGIT2_HOME}/include/ \
   -I ${LIBGIT2_HOME}/include/git2 \
   ${LIBGIT2_HOME}/include/git2.h
@@ -519,7 +520,6 @@ import jdk.incubator.foreign.NativeScope;
 import static com.github.git2_h.*;
 import static jdk.incubator.foreign.CSupport.*;
 import static jdk.incubator.foreign.MemoryAddress.NULL;
-import static com.github.Cstring.*;
 
 public class GitClone {
     public static void main(String[] args) {
@@ -566,8 +566,8 @@ sh run.sh https://github.com/libgit2/libgit2.git libgit2
 ```sh
 
 jextract \
-  -I /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include \
-  /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/sqlite3.h \
+  -I /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include \
+  /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/sqlite3.h \
   -t org.sqlite -lsqlite3
 
 ```


### PR DESCRIPTION
* Fixed CSupport.* and Cstring.* clash in GitClone.java

all samples run fine on Mac OS 10.5.5
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * Maurizio Cimadamore ([mcimadamore](@mcimadamore) - Committer)


### Download
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/210/head:pull/210`
`$ git checkout pull/210`
