### PR TITLE
8247937: Specialize downcall binding recipes using MethodHandle combinators

### DIFF
--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/Binding.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/Binding.java
@@ -22,11 +22,15 @@
  */
 package jdk.internal.foreign.abi;
 
+import jdk.incubator.foreign.MemoryHandles;
 import jdk.incubator.foreign.MemoryLayout;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+
+import java.lang.invoke.VarHandle;
+import java.nio.ByteOrder;
 
 /**
  * The binding operators defined in the Binding class can be combined into argument and return value processing 'recipes'.
@@ -362,6 +366,10 @@ public abstract class Binding {
 
         public Class<?> type() {
             return type;
+        }
+
+        public VarHandle varHandle() {
+            return MemoryHandles.withOffset(MemoryHandles.varHandle(type, ByteOrder.nativeOrder()), offset);
         }
 
         @Override

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/Binding.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/Binding.java
@@ -22,15 +22,31 @@
  */
 package jdk.internal.foreign.abi;
 
+import jdk.incubator.foreign.MemoryAddress;
 import jdk.incubator.foreign.MemoryHandles;
 import jdk.incubator.foreign.MemoryLayout;
+import jdk.incubator.foreign.MemorySegment;
+import jdk.incubator.foreign.NativeScope;
+import jdk.internal.foreign.MemoryAddressImpl;
 
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
 import java.util.ArrayList;
+import java.util.Deque;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 
 import java.lang.invoke.VarHandle;
 import java.nio.ByteOrder;
+import java.util.concurrent.ConcurrentHashMap;
+
+import static java.lang.invoke.MethodHandles.collectArguments;
+import static java.lang.invoke.MethodHandles.filterArguments;
+import static java.lang.invoke.MethodHandles.insertArguments;
+import static java.lang.invoke.MethodHandles.permuteArguments;
+import static java.lang.invoke.MethodType.methodType;
 
 /**
  * The binding operators defined in the Binding class can be combined into argument and return value processing 'recipes'.
@@ -186,6 +202,30 @@ import java.nio.ByteOrder;
  * --------------------
  */
 public abstract class Binding {
+    private static final MethodHandle MH_UNBOX_ADDRESS;
+    private static final MethodHandle MH_BOX_ADDRESS;
+    private static final MethodHandle MH_BASE_ADDRESS;
+    private static final MethodHandle MH_COPY_BUFFER;
+    private static final MethodHandle MH_ALLOCATE_BUFFER;
+
+    static {
+        try {
+            MethodHandles.Lookup lookup = MethodHandles.lookup();
+            MH_UNBOX_ADDRESS = lookup.findVirtual(MemoryAddress.class, "toRawLongValue",
+                    methodType(long.class));
+            MH_BOX_ADDRESS = lookup.findStatic(MemoryAddress.class, "ofLong",
+                    methodType(MemoryAddress.class, long.class));
+            MH_BASE_ADDRESS = lookup.findVirtual(MemorySegment.class, "baseAddress",
+                    methodType(MemoryAddress.class));
+            MH_COPY_BUFFER = lookup.findStatic(Binding.class, "copyBuffer",
+                    methodType(MemorySegment.class, MemorySegment.class, long.class, long.class, NativeScope.class));
+            MH_ALLOCATE_BUFFER = lookup.findStatic(MemorySegment.class, "allocateNative",
+                    methodType(MemorySegment.class, long.class, long.class));
+        } catch (ReflectiveOperationException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
     enum Tag {
         MOVE,
         DEREFERENCE,
@@ -206,9 +246,45 @@ public abstract class Binding {
         return tag;
     }
 
+    public abstract void verifyUnbox(Deque<Class<?>> stack);
+    public abstract void verifyBox(Deque<Class<?>> stack);
+
+    public abstract void unbox(Deque<Object> stack, BindingInterpreter.StoreFunc storeFunc, NativeScope scope);
+    public abstract void box(Deque<Object> stack, BindingInterpreter.LoadFunc loadFunc);
+
+    public abstract MethodHandle specializeUnbox(MethodHandle specializedHandle, int insertPos);
+    public abstract MethodHandle specializeBox(MethodHandle returnFilter);
+
+    private static MethodHandle mergeArguments(MethodHandle mh, int sourceIndex, int destIndex) {
+        MethodType oldType = mh.type();
+        Class<?> sourceType = oldType.parameterType(sourceIndex);
+        Class<?> destType = oldType.parameterType(destIndex);
+        if (sourceType != destType) {
+            // TODO meet?
+            throw new IllegalArgumentException("Parameter types differ: " + sourceType + " != " + destType);
+        }
+        MethodType newType = oldType.dropParameterTypes(destIndex, destIndex + 1);
+        int[] reorder = new int[oldType.parameterCount()];
+        assert destIndex > sourceIndex;
+        for (int i = 0, index = 0; i < reorder.length; i++) {
+            if (i != destIndex) {
+                reorder[i] = index++;
+            } else {
+                reorder[i] = sourceIndex;
+            }
+        }
+        return permuteArguments(mh, newType, reorder);
+    }
+
     private static void checkType(Class<?> type) {
         if (!type.isPrimitive() || type == void.class || type == boolean.class)
             throw new IllegalArgumentException("Illegal type: " + type);
+    }
+
+    private static MemorySegment copyBuffer(MemorySegment operand, long size, long alignment, NativeScope allocator) {
+        MemorySegment copy = allocator.allocate(size, alignment).segment();
+        copy.copyFrom(operand.asSlice(0, size));
+        return copy;
     }
 
     public static Move move(VMStorage storage, Class<?> type) {
@@ -340,6 +416,38 @@ public abstract class Binding {
         public int hashCode() {
             return Objects.hash(tag(), storage, type);
         }
+
+        @Override
+        public void verifyUnbox(Deque<Class<?>> stack) {
+            Class<?> actualType = stack.pop();
+            Class<?> expectedType = type;
+            SharedUtils.checkType(actualType, expectedType);
+        }
+
+        @Override
+        public void verifyBox(Deque<Class<?>> stack) {
+            stack.push(type);
+        }
+
+        @Override
+        public void unbox(Deque<Object> stack, BindingInterpreter.StoreFunc storeFunc, NativeScope scope) {
+            storeFunc.store(storage, type, stack.pop());
+        }
+
+        @Override
+        public void box(Deque<Object> stack, BindingInterpreter.LoadFunc loadFunc) {
+            stack.push(loadFunc.load(storage, type));
+        }
+
+        @Override
+        public MethodHandle specializeUnbox(MethodHandle specializedHandle, int insertPos) {
+            return specializedHandle; // no-op
+        }
+
+        @Override
+        public MethodHandle specializeBox(MethodHandle returnFilter) {
+            return returnFilter; // no-op
+        }
     }
 
     /**
@@ -368,10 +476,6 @@ public abstract class Binding {
             return type;
         }
 
-        public VarHandle varHandle() {
-            return MemoryHandles.withOffset(MemoryHandles.varHandle(type, ByteOrder.nativeOrder()), offset);
-        }
-
         @Override
         public String toString() {
             return "Dereference{" +
@@ -393,6 +497,61 @@ public abstract class Binding {
         @Override
         public int hashCode() {
             return Objects.hash(tag(), offset, type);
+        }
+
+        @Override
+        public void verifyUnbox(Deque<Class<?>> stack) {
+            Class<?> actualType = stack.pop();
+            SharedUtils.checkType(actualType, MemorySegment.class);
+            Class<?> newType = type;
+            stack.push(newType);
+        }
+
+        @Override
+        public void verifyBox(Deque<Class<?>> stack) {
+            Class<?> storeType = stack.pop();
+            SharedUtils.checkType(storeType, type);
+            Class<?> segmentType = stack.pop();
+            SharedUtils.checkType(segmentType, MemorySegment.class);
+        }
+
+        @Override
+        public void unbox(Deque<Object> stack, BindingInterpreter.StoreFunc storeFunc, NativeScope scope) {
+            MemorySegment operand = (MemorySegment) stack.pop();
+            MemoryAddress baseAddress = operand.baseAddress();
+            MemoryAddress readAddress = baseAddress.addOffset(offset);
+            stack.push(SharedUtils.read(readAddress, type));
+        }
+
+        @Override
+        public void box(Deque<Object> stack, BindingInterpreter.LoadFunc loadFunc) {
+            Object value = stack.pop();
+            MemorySegment operand = (MemorySegment) stack.pop();
+            MemoryAddress baseAddress = operand.baseAddress();
+            MemoryAddress writeAddress = baseAddress.addOffset(offset);
+            SharedUtils.write(writeAddress, type, value);
+        }
+
+        private VarHandle varHandle() {
+            return MemoryHandles.withOffset(MemoryHandles.varHandle(type, ByteOrder.nativeOrder()), offset);
+        }
+
+        @Override
+        public MethodHandle specializeUnbox(MethodHandle specializedHandle, int insertPos) {
+            MethodHandle filter = filterArguments(
+                varHandle()
+                    .toMethodHandle(VarHandle.AccessMode.GET)
+                    .asType(methodType(type, MemoryAddress.class)), 0, MH_BASE_ADDRESS);
+            return filterArguments(specializedHandle, insertPos, filter);
+        }
+
+        @Override
+        public MethodHandle specializeBox(MethodHandle returnFilter) {
+            MethodHandle setter = varHandle().toMethodHandle(VarHandle.AccessMode.SET);
+            setter = filterArguments(
+                setter.asType(methodType(void.class, MemoryAddress.class, type)),
+                0, MH_BASE_ADDRESS);
+            return collectArguments(returnFilter, returnFilter.type().parameterCount(), setter);
         }
     }
 
@@ -442,6 +601,49 @@ public abstract class Binding {
         public int hashCode() {
             return Objects.hash(tag(), size, alignment);
         }
+
+        @Override
+        public void verifyUnbox(Deque<Class<?>> stack) {
+            Class<?> actualType = stack.pop();
+            SharedUtils.checkType(actualType, MemorySegment.class);
+            stack.push(MemorySegment.class);
+        }
+
+        @Override
+        public void verifyBox(Deque<Class<?>> stack) {
+            Class<?> actualType = stack.pop();
+            SharedUtils.checkType(actualType, MemoryAddress.class);
+            stack.push(MemorySegment.class);
+        }
+
+        @Override
+        public void unbox(Deque<Object> stack, BindingInterpreter.StoreFunc storeFunc, NativeScope scope) {
+            MemorySegment operand = (MemorySegment) stack.pop();
+            MemorySegment copy = scope.allocate(size, alignment).segment();
+            copy.copyFrom(operand.asSlice(0, size));
+            stack.push(copy);
+        }
+
+        @Override
+        public void box(Deque<Object> stack, BindingInterpreter.LoadFunc loadFunc) {
+            MemoryAddress operand = (MemoryAddress) stack.pop();
+            operand = MemoryAddressImpl.ofLongUnchecked(operand.toRawLongValue(), size);
+            MemorySegment copy = MemorySegment.allocateNative(size, alignment);
+            copy.copyFrom(operand.segment().asSlice(0, size));
+            stack.push(copy); // leaked
+        }
+
+        @Override
+        public MethodHandle specializeUnbox(MethodHandle specializedHandle, int insertPos) {
+            MethodHandle filter = insertArguments(MH_COPY_BUFFER, 1, size, alignment);
+            specializedHandle = collectArguments(specializedHandle, insertPos, filter);
+            return mergeArguments(specializedHandle, 0, insertPos + 1);
+        }
+
+        @Override
+        public MethodHandle specializeBox(MethodHandle returnFilter) {
+            throw new UnsupportedOperationException();
+        }
     }
 
     /**
@@ -488,6 +690,36 @@ public abstract class Binding {
         public int hashCode() {
             return Objects.hash(tag(), size, alignment);
         }
+
+        @Override
+        public void verifyUnbox(Deque<Class<?>> stack) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void verifyBox(Deque<Class<?>> stack) {
+            stack.push(MemorySegment.class);
+        }
+
+        @Override
+        public void unbox(Deque<Object> stack, BindingInterpreter.StoreFunc storeFunc, NativeScope scope) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void box(Deque<Object> stack, BindingInterpreter.LoadFunc loadFunc) {
+            stack.push(MemorySegment.allocateNative(size, alignment));
+        }
+
+        @Override
+        public MethodHandle specializeUnbox(MethodHandle specializedHandle, int insertPos) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public MethodHandle specializeBox(MethodHandle returnFilter) {
+            return collectArguments(returnFilter, 0, insertArguments(MH_ALLOCATE_BUFFER, 0, size, alignment));
+        }
     }
 
     /**
@@ -520,6 +752,40 @@ public abstract class Binding {
             if (this == o) return true;
             return o != null && getClass() == o.getClass();
         }
+
+        @Override
+        public void verifyUnbox(Deque<Class<?>> stack) {
+            Class<?> actualType = stack.pop();
+            SharedUtils.checkType(actualType, MemoryAddress.class);
+            stack.push(long.class);
+        }
+
+        @Override
+        public void verifyBox(Deque<Class<?>> stack) {
+            Class<?> actualType = stack.pop();
+            SharedUtils.checkType(actualType, long.class);
+            stack.push(MemoryAddress.class);
+        }
+
+        @Override
+        public void unbox(Deque<Object> stack, BindingInterpreter.StoreFunc storeFunc, NativeScope scope) {
+            stack.push(((MemoryAddress) stack.pop()).toRawLongValue());
+        }
+
+        @Override
+        public void box(Deque<Object> stack, BindingInterpreter.LoadFunc loadFunc) {
+            stack.push(MemoryAddress.ofLong((long) stack.pop()));
+        }
+
+        @Override
+        public MethodHandle specializeUnbox(MethodHandle specializedHandle, int insertPos) {
+            return filterArguments(specializedHandle, insertPos, MH_UNBOX_ADDRESS);
+        }
+
+        @Override
+        public MethodHandle specializeBox(MethodHandle returnFilter) {
+            return filterArguments(returnFilter, 0, MH_BOX_ADDRESS);
+        }
     }
 
     /**
@@ -550,6 +816,40 @@ public abstract class Binding {
             if (this == o) return true;
             return o != null && getClass() == o.getClass();
         }
+
+        @Override
+        public void verifyUnbox(Deque<Class<?>> stack) {
+            Class<?> actualType = stack.pop();
+            SharedUtils.checkType(actualType, MemorySegment.class);
+            stack.push(MemoryAddress.class);
+        }
+
+        @Override
+        public void verifyBox(Deque<Class<?>> stack) {
+            Class<?> actualType = stack.pop();
+            SharedUtils.checkType(actualType, MemorySegment.class);
+            stack.push(MemoryAddress.class);
+        }
+
+        @Override
+        public void unbox(Deque<Object> stack, BindingInterpreter.StoreFunc storeFunc, NativeScope scope) {
+            stack.push(((MemorySegment) stack.pop()).baseAddress());
+        }
+
+        @Override
+        public void box(Deque<Object> stack, BindingInterpreter.LoadFunc loadFunc) {
+            stack.push(((MemorySegment) stack.pop()).baseAddress());
+        }
+
+        @Override
+        public MethodHandle specializeUnbox(MethodHandle specializedHandle, int insertPos) {
+            return filterArguments(specializedHandle, insertPos, MH_BASE_ADDRESS);
+        }
+
+        @Override
+        public MethodHandle specializeBox(MethodHandle returnFilter) {
+            throw new UnsupportedOperationException();
+        }
     }
 
     /**
@@ -579,6 +879,72 @@ public abstract class Binding {
         public boolean equals(Object o) {
             if (this == o) return true;
             return o != null && getClass() == o.getClass();
+        }
+
+        @Override
+        public void verifyUnbox(Deque<Class<?>> stack) {
+            stack.push(stack.peekLast());
+        }
+
+        @Override
+        public void verifyBox(Deque<Class<?>> stack) {
+            stack.push(stack.peekLast());
+        }
+
+        @Override
+        public void unbox(Deque<Object> stack, BindingInterpreter.StoreFunc storeFunc, NativeScope scope) {
+            stack.push(stack.peekLast());
+        }
+
+        @Override
+        public void box(Deque<Object> stack, BindingInterpreter.LoadFunc loadFunc) {
+            stack.push(stack.peekLast());
+        }
+
+        /*
+         * Fixes up Y-shaped data graphs (produced by DEREFERENCE):
+         *
+         * 1. DUP()
+         * 2. DEREFERENCE(0, int.class)
+         * 3. MOVE  (ignored)
+         * 4. DEREFERENCE(4, int.class)
+         * 5. MOVE  (ignored)
+         *
+         * (specialized in reverse!)
+         *
+         * 5. (int, int) -> void                       insertPos = 1
+         * 4. (MemorySegment, int) -> void             insertPos = 1
+         * 3. (MemorySegment, int) -> void             insertPos = 0
+         * 2. (MemorySegment, MemorySegment) -> void   insertPos = 0
+         * 1. (MemorySegment) -> void                  insertPos = 0
+         *
+         */
+        @Override
+        public MethodHandle specializeUnbox(MethodHandle specializedHandle, int insertPos) {
+            return mergeArguments(specializedHandle, insertPos, insertPos + 1);
+        }
+
+        /*
+         * Fixes up Y-shaped data graphs (produced by DEREFERENCE):
+         *
+         * 1. ALLOCATE_BUFFER(4, 4)
+         * 2. DUP
+         * 3. MOVE  (ignored)
+         * 4. DEREFERNCE(0, int.class)
+         *
+         * (specialized in reverse!)
+         *
+         * input: (MemorySegment) -> MemorySegment (identity function of high-level return)
+         * 4. (MemorySegment, MemorySegment, int) -> MemorySegment
+         * 3. (MemorySegment, MemorySegment, int) -> MemorySegment
+         * 2. (MemorySegment, int) -> MemorySegment
+         * 1. (int) -> MemorySegment
+         *
+         */
+        @Override
+        public MethodHandle specializeBox(MethodHandle returnFilter) {
+            // assumes shape like: (MS, ..., MS, T) R
+            return mergeArguments(returnFilter, 0, returnFilter.type().parameterCount() - 2);
         }
     }
 }

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/BindingInterpreter.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/BindingInterpreter.java
@@ -23,44 +23,31 @@
 package jdk.internal.foreign.abi;
 
 import jdk.incubator.foreign.MemoryAddress;
-import jdk.incubator.foreign.MemoryHandles;
 import jdk.incubator.foreign.MemorySegment;
 import jdk.internal.foreign.MemoryAddressImpl;
 import jdk.internal.foreign.Utils;
 
-import java.lang.invoke.VarHandle;
-import java.nio.ByteOrder;
 import java.util.ArrayDeque;
 import java.util.Deque;
 import java.util.List;
-import java.util.function.Function;
 
 public class BindingInterpreter {
-    private static final VarHandle VH_BYTE = MemoryHandles.varHandle(byte.class, ByteOrder.nativeOrder());
-    private static final VarHandle VH_CHAR = MemoryHandles.varHandle(char.class, ByteOrder.nativeOrder());
-    private static final VarHandle VH_SHORT = MemoryHandles.varHandle(short.class, ByteOrder.nativeOrder());
-    private static final VarHandle VH_INT = MemoryHandles.varHandle(int.class, ByteOrder.nativeOrder());
-    private static final VarHandle VH_LONG = MemoryHandles.varHandle(long.class, ByteOrder.nativeOrder());
-    private static final VarHandle VH_FLOAT = MemoryHandles.varHandle(float.class, ByteOrder.nativeOrder());
-    private static final VarHandle VH_DOUBLE = MemoryHandles.varHandle(double.class, ByteOrder.nativeOrder());
 
-    static void unbox(Object arg, List<Binding> bindings, Function<VMStorage,
-            MemoryAddress> ptrFunction, List<? super MemorySegment> buffers) {
+    static void unbox(Object arg, List<Binding> bindings, StoreFunc storeFunc, List<? super MemorySegment> buffers) {
         Deque<Object> stack = new ArrayDeque<>();
         stack.push(arg);
         for (Binding b : bindings) {
             switch (b.tag()) {
                 case MOVE -> {
                     Binding.Move binding = (Binding.Move) b;
-                    MemoryAddress ptr = ptrFunction.apply(binding.storage());
-                    writeOverSized(ptr, binding.type(), stack.pop());
+                    storeFunc.store(binding.storage(), binding.type(), stack.pop());
                 }
                 case DEREFERENCE -> {
                     Binding.Dereference deref = (Binding.Dereference) b;
                     MemorySegment operand = (MemorySegment) stack.pop();
                     MemoryAddress baseAddress = operand.baseAddress();
                     MemoryAddress readAddress = baseAddress.addOffset(deref.offset());
-                    stack.push(read(readAddress, deref.type()));
+                    stack.push(SharedUtils.read(readAddress, deref.type()));
                 }
                 case COPY_BUFFER -> {
                     Binding.Copy binding = (Binding.Copy) b;
@@ -84,14 +71,13 @@ public class BindingInterpreter {
         }
     }
 
-    static Object box(List<Binding> bindings, Function<VMStorage, MemoryAddress> ptrFunction) {
+    static Object box(List<Binding> bindings, LoadFunc loadFunc) {
         Deque<Object> stack = new ArrayDeque<>();
         for (Binding b : bindings) {
             switch (b.tag()) {
                 case MOVE -> {
                     Binding.Move binding = (Binding.Move) b;
-                    MemoryAddress ptr = ptrFunction.apply(binding.storage());
-                    stack.push(read(ptr, binding.type()));
+                    stack.push(loadFunc.load(binding.storage(), binding.type()));
                 }
                 case DEREFERENCE -> {
                     Binding.Dereference binding = (Binding.Dereference) b;
@@ -99,7 +85,7 @@ public class BindingInterpreter {
                     MemorySegment operand = (MemorySegment) stack.pop();
                     MemoryAddress baseAddress = operand.baseAddress();
                     MemoryAddress writeAddress = baseAddress.addOffset(binding.offset());
-                    write(writeAddress, binding.type(), value);
+                    SharedUtils.write(writeAddress, binding.type(), value);
                 }
                 case COPY_BUFFER -> {
                     Binding.Copy binding = (Binding.Copy) b;
@@ -126,64 +112,11 @@ public class BindingInterpreter {
        return stack.pop();
     }
 
-    private static void writeOverSized(MemoryAddress ptr, Class<?> type, Object o) {
-        // use VH_LONG for integers to zero out the whole register in the process
-        if (type == long.class) {
-            VH_LONG.set(ptr, (long) o);
-        } else if (type == int.class) {
-            VH_LONG.set(ptr, (long) (int) o);
-        } else if (type == short.class) {
-            VH_LONG.set(ptr, (long) (short) o);
-        } else if (type == char.class) {
-            VH_LONG.set(ptr, (long) (char) o);
-        } else if (type == byte.class) {
-            VH_LONG.set(ptr, (long) (byte) o);
-        } else if (type == float.class) {
-            VH_FLOAT.set(ptr, (float) o);
-        } else if (type == double.class) {
-            VH_DOUBLE.set(ptr, (double) o);
-        } else {
-            throw new IllegalArgumentException("Unsupported carrier: " + type);
-        }
+    interface StoreFunc {
+        void store(VMStorage storage, Class<?> type, Object o);
     }
 
-    private static void write(MemoryAddress ptr, Class<?> type, Object o) {
-        if (type == long.class) {
-            VH_LONG.set(ptr, (long) o);
-        } else if (type == int.class) {
-            VH_INT.set(ptr, (int) o);
-        } else if (type == short.class) {
-            VH_SHORT.set(ptr, (short) o);
-        } else if (type == char.class) {
-            VH_CHAR.set(ptr, (char) o);
-        } else if (type == byte.class) {
-            VH_BYTE.set(ptr, (byte) o);
-        } else if (type == float.class) {
-            VH_FLOAT.set(ptr, (float) o);
-        } else if (type == double.class) {
-            VH_DOUBLE.set(ptr, (double) o);
-        } else {
-            throw new IllegalArgumentException("Unsupported carrier: " + type);
-        }
-    }
-
-    private static Object read(MemoryAddress ptr, Class<?> type) {
-        if (type == long.class) {
-            return (long) VH_LONG.get(ptr);
-        } else if (type == int.class) {
-            return (int) VH_INT.get(ptr);
-        } else if (type == short.class) {
-            return (short) VH_SHORT.get(ptr);
-        } else if (type == char.class) {
-            return (char) VH_CHAR.get(ptr);
-        } else if (type == byte.class) {
-            return (byte) VH_BYTE.get(ptr);
-        } else if (type == float.class) {
-            return (float) VH_FLOAT.get(ptr);
-        } else if (type == double.class) {
-            return (double) VH_DOUBLE.get(ptr);
-        } else {
-            throw new IllegalArgumentException("Unsupported carrier: " + type);
-        }
+    interface LoadFunc {
+        Object load(VMStorage storage, Class<?> type);
     }
 }

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/BindingInterpreter.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/BindingInterpreter.java
@@ -22,10 +22,7 @@
  */
 package jdk.internal.foreign.abi;
 
-import jdk.incubator.foreign.MemoryAddress;
-import jdk.incubator.foreign.MemorySegment;
-import jdk.internal.foreign.MemoryAddressImpl;
-import jdk.internal.foreign.Utils;
+import jdk.incubator.foreign.NativeScope;
 
 import java.util.ArrayDeque;
 import java.util.Deque;
@@ -33,82 +30,19 @@ import java.util.List;
 
 public class BindingInterpreter {
 
-    static void unbox(Object arg, List<Binding> bindings, StoreFunc storeFunc, List<? super MemorySegment> buffers) {
+    static void unbox(Object arg, List<Binding> bindings, StoreFunc storeFunc, NativeScope scope) {
         Deque<Object> stack = new ArrayDeque<>();
         stack.push(arg);
         for (Binding b : bindings) {
-            switch (b.tag()) {
-                case MOVE -> {
-                    Binding.Move binding = (Binding.Move) b;
-                    storeFunc.store(binding.storage(), binding.type(), stack.pop());
-                }
-                case DEREFERENCE -> {
-                    Binding.Dereference deref = (Binding.Dereference) b;
-                    MemorySegment operand = (MemorySegment) stack.pop();
-                    MemoryAddress baseAddress = operand.baseAddress();
-                    MemoryAddress readAddress = baseAddress.addOffset(deref.offset());
-                    stack.push(SharedUtils.read(readAddress, deref.type()));
-                }
-                case COPY_BUFFER -> {
-                    Binding.Copy binding = (Binding.Copy) b;
-                    MemorySegment operand = (MemorySegment) stack.pop();
-                    assert operand.byteSize() == binding.size() : "operand size mismatch";
-                    MemorySegment copy = MemorySegment.allocateNative(binding.size(), binding.alignment());
-                    copy.copyFrom(operand.asSlice(0, binding.size()));
-                    buffers.add(copy);
-                    stack.push(copy);
-                }
-                case ALLOC_BUFFER ->
-                    throw new UnsupportedOperationException();
-                case CONVERT_ADDRESS ->
-                    stack.push(((MemoryAddress) stack.pop()).toRawLongValue());
-                case BASE_ADDRESS ->
-                    stack.push(((MemorySegment) stack.pop()).baseAddress());
-                case DUP ->
-                    stack.push(stack.peekLast());
-                default -> throw new IllegalArgumentException("Unsupported tag: " + b);
-            }
+            b.unbox(stack, storeFunc, scope);
         }
     }
 
     static Object box(List<Binding> bindings, LoadFunc loadFunc) {
         Deque<Object> stack = new ArrayDeque<>();
         for (Binding b : bindings) {
-            switch (b.tag()) {
-                case MOVE -> {
-                    Binding.Move binding = (Binding.Move) b;
-                    stack.push(loadFunc.load(binding.storage(), binding.type()));
-                }
-                case DEREFERENCE -> {
-                    Binding.Dereference binding = (Binding.Dereference) b;
-                    Object value = stack.pop();
-                    MemorySegment operand = (MemorySegment) stack.pop();
-                    MemoryAddress baseAddress = operand.baseAddress();
-                    MemoryAddress writeAddress = baseAddress.addOffset(binding.offset());
-                    SharedUtils.write(writeAddress, binding.type(), value);
-                }
-                case COPY_BUFFER -> {
-                    Binding.Copy binding = (Binding.Copy) b;
-                    MemoryAddress operand = (MemoryAddress) stack.pop();
-                    operand = MemoryAddressImpl.ofLongUnchecked(operand.toRawLongValue(), binding.size());
-                    MemorySegment copy = MemorySegment.allocateNative(binding.size(), binding.alignment());
-                    copy.copyFrom(operand.segment().asSlice(0, binding.size()));
-                    stack.push(copy); // leaked
-                }
-                case ALLOC_BUFFER -> {
-                    Binding.Allocate binding = (Binding.Allocate) b;
-                    stack.push(MemorySegment.allocateNative(binding.size(), binding.alignment()));
-                }
-                case CONVERT_ADDRESS ->
-                    stack.push(MemoryAddress.ofLong((long) stack.pop()));
-                case BASE_ADDRESS ->
-                    stack.push(((MemorySegment) stack.pop()).baseAddress());
-                case DUP ->
-                    stack.push(stack.peekLast());
-                default -> throw new IllegalArgumentException("Unsupported tag: " + b);
-            }
+            b.box(stack, loadFunc);
         }
-
        return stack.pop();
     }
 

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/CallingSequence.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/CallingSequence.java
@@ -26,6 +26,7 @@ import jdk.incubator.foreign.FunctionDescriptor;
 
 import java.lang.invoke.MethodType;
 import java.util.List;
+import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
 public class CallingSequence {
@@ -43,11 +44,18 @@ public class CallingSequence {
         this.argumentBindings = argumentBindings;
     }
 
-    public Stream<Binding.Move> moveBindings() {
+    public Stream<Binding.Move> argMoveBindings() {
         return argumentBindings.stream()
                 .flatMap(List::stream)
                 .filter(Binding.Move.class::isInstance)
                 .map(Binding.Move.class::cast);
+    }
+
+    public Stream<Binding.Move> retMoveBindings() {
+        return returnBindings()
+            .stream()
+            .filter(Binding.Move.class::isInstance)
+            .map(Binding.Move.class::cast);
     }
 
     public int argumentCount() {
@@ -56,6 +64,10 @@ public class CallingSequence {
 
     public List<Binding> argumentBindings(int i) {
         return argumentBindings.get(i);
+    }
+
+    public Stream<Binding> argumentBindings() {
+        return argumentBindings.stream().flatMap(List::stream);
     }
 
     public List<Binding> returnBindings() {

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/CallingSequenceBuilder.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/CallingSequenceBuilder.java
@@ -23,9 +23,7 @@
 package jdk.internal.foreign.abi;
 
 import jdk.incubator.foreign.FunctionDescriptor;
-import jdk.incubator.foreign.MemoryAddress;
 import jdk.incubator.foreign.MemoryLayout;
-import jdk.incubator.foreign.MemorySegment;
 import sun.security.action.GetPropertyAction;
 
 import java.lang.invoke.MethodType;
@@ -81,51 +79,12 @@ public class CallingSequenceBuilder {
         }
     }
 
-    private static void checkType(Class<?> actualType, Class<?> expectedType) {
-        if (expectedType != actualType) {
-            throw new IllegalArgumentException(
-                    String.format("Invalid operand type: %s. %s expected", actualType, expectedType));
-        }
-    }
-
     private static void verifyUnboxBindings(Class<?> inType, List<Binding> bindings) {
         Deque<Class<?>> stack = new ArrayDeque<>();
         stack.push(inType);
 
         for (Binding b : bindings) {
-            switch (b.tag()) {
-                case MOVE -> {
-                    Class<?> actualType = stack.pop();
-                    Class<?> expectedType = ((Binding.Move) b).type();
-                    checkType(actualType, expectedType);
-                }
-                case DEREFERENCE -> {
-                    Class<?> actualType = stack.pop();
-                    checkType(actualType, MemorySegment.class);
-                    Class<?> newType = ((Binding.Dereference) b).type();
-                    stack.push(newType);
-                }
-                case BASE_ADDRESS -> {
-                    Class<?> actualType = stack.pop();
-                    checkType(actualType, MemorySegment.class);
-                    stack.push(MemoryAddress.class);
-                }
-                case CONVERT_ADDRESS -> {
-                    Class<?> actualType = stack.pop();
-                    checkType(actualType, MemoryAddress.class);
-                    stack.push(long.class);
-                }
-                case ALLOC_BUFFER ->
-                    throw new UnsupportedOperationException();
-                case COPY_BUFFER -> {
-                    Class<?> actualType = stack.pop();
-                    checkType(actualType, MemorySegment.class);
-                    stack.push(MemorySegment.class);
-                }
-                case DUP ->
-                    stack.push(stack.peekLast());
-                default -> throw new IllegalArgumentException("Unknown binding: " + b);
-            }
+            b.verifyUnbox(stack);
         }
 
         if (!stack.isEmpty()) {
@@ -133,43 +92,11 @@ public class CallingSequenceBuilder {
         }
     }
 
-    private static void verifyBoxBindings(Class<?> outType, List<Binding> bindings) {
+    private static void verifyBoxBindings(Class<?> expectedReturnType, List<Binding> bindings) {
         Deque<Class<?>> stack = new ArrayDeque<>();
 
         for (Binding b : bindings) {
-            switch (b.tag()) {
-                case MOVE -> {
-                    Class<?> newType = ((Binding.Move) b).type();
-                    stack.push(newType);
-                }
-                case DEREFERENCE -> {
-                    Class<?> storeType = stack.pop();
-                    checkType(storeType, ((Binding.Dereference) b).type());
-                    Class<?> segmentType = stack.pop();
-                    checkType(segmentType, MemorySegment.class);
-                }
-                case CONVERT_ADDRESS -> {
-                    Class<?> actualType = stack.pop();
-                    checkType(actualType, long.class);
-                    stack.push(MemoryAddress.class);
-                }
-                case BASE_ADDRESS -> {
-                    Class<?> actualType = stack.pop();
-                    checkType(actualType, MemorySegment.class);
-                    stack.push(MemoryAddress.class);
-                }
-                case ALLOC_BUFFER -> {
-                    stack.push(MemorySegment.class);
-                }
-                case COPY_BUFFER -> {
-                    Class<?> actualType = stack.pop();
-                    checkType(actualType, MemoryAddress.class);
-                    stack.push(MemorySegment.class);
-                }
-                case DUP ->
-                    stack.push(stack.peekLast());
-                default -> throw new IllegalArgumentException("Unknown binding: " + b);
-            }
+            b.verifyBox(stack);
         }
 
         if (stack.size() != 1) {
@@ -177,6 +104,6 @@ public class CallingSequenceBuilder {
         }
 
         Class<?> actualReturnType = stack.pop();
-        checkType(actualReturnType, outType);
+        SharedUtils.checkType(actualReturnType, expectedReturnType);
     }
 }

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/ProgrammableInvoker.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/ProgrammableInvoker.java
@@ -22,11 +22,14 @@
  */
 package jdk.internal.foreign.abi;
 
-import jdk.incubator.foreign.FunctionDescriptor;
 import jdk.incubator.foreign.MemoryAddress;
 import jdk.incubator.foreign.MemoryHandles;
 import jdk.incubator.foreign.MemorySegment;
+import jdk.incubator.foreign.NativeAllocationScope;
+import jdk.internal.access.JavaLangInvokeAccess;
+import jdk.internal.access.SharedSecrets;
 import jdk.internal.foreign.MemoryAddressImpl;
+import jdk.internal.foreign.Utils;
 
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
@@ -34,10 +37,22 @@ import java.lang.invoke.MethodType;
 import java.lang.invoke.VarHandle;
 import java.nio.ByteOrder;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
+import static java.lang.invoke.MethodHandles.collectArguments;
+import static java.lang.invoke.MethodHandles.dropArguments;
+import static java.lang.invoke.MethodHandles.empty;
+import static java.lang.invoke.MethodHandles.filterArguments;
+import static java.lang.invoke.MethodHandles.identity;
+import static java.lang.invoke.MethodHandles.insertArguments;
+import static java.lang.invoke.MethodHandles.permuteArguments;
+import static java.lang.invoke.MethodHandles.tryFinally;
+import static java.lang.invoke.MethodType.methodType;
 import static sun.security.action.GetBooleanAction.privilegedGetProperty;
 
 /**
@@ -48,17 +63,45 @@ import static sun.security.action.GetBooleanAction.privilegedGetProperty;
 public class ProgrammableInvoker {
     private static final boolean DEBUG =
         privilegedGetProperty("jdk.internal.foreign.ProgrammableInvoker.DEBUG");
+    private static final boolean NO_SPEC =
+        privilegedGetProperty("jdk.internal.foreign.ProgrammableInvoker.NO_SPEC");
 
     private static final VarHandle VH_LONG = MemoryHandles.varHandle(long.class, ByteOrder.nativeOrder());
 
-    // Unbound MH for the invoke() method
-    private static final MethodHandle INVOKE_MH;
+    private static final MethodHandle MH_INVOKE_MOVES;
+    private static final MethodHandle MH_INVOKE_INTERP_BINDINGS;
+
+    private static final MethodHandle MH_UNBOX_ADDRESS;
+    private static final MethodHandle MH_BOX_ADDRESS;
+    private static final MethodHandle MH_BASE_ADDRESS;
+    private static final MethodHandle MH_COPY_BUFFER;
+    private static final MethodHandle MH_MAKE_ALLOCATOR;
+    private static final MethodHandle MH_CLOSE_ALLOCATOR;
+    private static final MethodHandle MH_ALLOCATE_BUFFER;
 
     private static final Map<ABIDescriptor, Long> adapterStubs = new ConcurrentHashMap<>();
 
     static {
         try {
-            INVOKE_MH = MethodHandles.lookup().findVirtual(ProgrammableInvoker.class, "invoke", MethodType.methodType(Object.class, Object[].class));
+            MethodHandles.Lookup lookup = MethodHandles.lookup();
+            MH_INVOKE_MOVES = lookup.findVirtual(ProgrammableInvoker.class, "invokeMoves",
+                    methodType(Object.class, Object[].class, Binding.Move[].class, Binding.Move[].class));
+            MH_INVOKE_INTERP_BINDINGS = lookup.findVirtual(ProgrammableInvoker.class, "invokeInterpBindings",
+                    methodType(Object.class, Object[].class, MethodHandle.class, Map.class, Map.class));
+            MH_UNBOX_ADDRESS = lookup.findStatic(ProgrammableInvoker.class, "toRawLongValue",
+                    methodType(long.class, MemoryAddress.class));
+            MH_BOX_ADDRESS = lookup.findStatic(ProgrammableInvoker.class, "ofLong",
+                    methodType(MemoryAddress.class, long.class));
+            MH_BASE_ADDRESS = lookup.findVirtual(MemorySegment.class, "baseAddress",
+                    methodType(MemoryAddress.class));
+            MH_COPY_BUFFER = lookup.findStatic(ProgrammableInvoker.class, "copyBuffer",
+                    methodType(MemorySegment.class, MemorySegment.class, long.class, long.class, NativeAllocationScope.class));
+            MH_MAKE_ALLOCATOR = lookup.findStatic(NativeAllocationScope.class, "boundedScope",
+                    methodType(NativeAllocationScope.class, long.class));
+            MH_CLOSE_ALLOCATOR = lookup.findVirtual(NativeAllocationScope.class, "close",
+                    methodType(void.class));
+            MH_ALLOCATE_BUFFER = lookup.findStatic(MemorySegment.class, "allocateNative",
+                    methodType(MemorySegment.class, long.class, long.class));
         } catch (ReflectiveOperationException e) {
             throw new RuntimeException(e);
         }
@@ -68,12 +111,12 @@ public class ProgrammableInvoker {
     private final BufferLayout layout;
     private final long stackArgsBytes;
 
-    private final MethodType type;
-    private final FunctionDescriptor function;
     private final CallingSequence callingSequence;
 
     private final MemoryAddress addr;
     private final long stubAddress;
+
+    private final long bufferCopySize;
 
     public ProgrammableInvoker(ABIDescriptor abi, MemoryAddress addr, CallingSequence callingSequence) {
         this.abi = abi;
@@ -82,28 +125,211 @@ public class ProgrammableInvoker {
 
         this.addr = addr;
         this.callingSequence = callingSequence;
-        this.type = callingSequence.methodType();
-        this.function = callingSequence.functionDesc();
 
-        this.stackArgsBytes = callingSequence.moveBindings()
+        this.stackArgsBytes = callingSequence.argMoveBindings()
                 .map(Binding.Move::storage)
                 .filter(s -> abi.arch.isStackType(s.type()))
                 .count()
                 * abi.arch.typeSize(abi.arch.stackType());
+
+        this.bufferCopySize = bufferCopySize(callingSequence);
+    }
+
+    private static long bufferCopySize(CallingSequence callingSequence) {
+        // FIXME: > 16 bytes alignment might need extra space since the
+        // starting address of the allocator might be un-aligned.
+        long size = 0;
+        for (int i = 0; i < callingSequence.argumentCount(); i++) {
+            List<Binding> bindings = callingSequence.argumentBindings(i);
+            for (Binding b : bindings) {
+                if (b instanceof Binding.Copy) {
+                    Binding.Copy c = (Binding.Copy) b;
+                    size = Utils.alignUp(size, c.alignment());
+                    size += c.size();
+                }
+            }
+        }
+        return size;
     }
 
     public MethodHandle getBoundMethodHandle() {
-        return INVOKE_MH.bindTo(this).asCollector(Object[].class, type.parameterCount()).asType(type);
+        Binding.Move[] argMoves = callingSequence.argMoveBindings().toArray(Binding.Move[]::new);
+        Class<?>[] argMoveTypes = Arrays.stream(argMoves).map(Binding.Move::type).toArray(Class<?>[]::new);
+
+        Binding.Move[] retMoves = callingSequence.retMoveBindings().toArray(Binding.Move[]::new);
+        Class<?> returnType = retMoves.length == 0
+                ? void.class
+                : retMoves.length == 1
+                    ? retMoves[0].type()
+                    : Object[].class;
+
+        MethodType intrinsicType = methodType(returnType, argMoveTypes);
+
+        MethodHandle handle = insertArguments(MH_INVOKE_MOVES.bindTo(this), 1, argMoves, retMoves)
+                                            .asCollector(Object[].class, intrinsicType.parameterCount())
+                                            .asType(intrinsicType);
+
+        if (NO_SPEC || retMoves.length > 1) {
+            Map<VMStorage, Integer> argIndexMap = indexMap(argMoves);
+            Map<VMStorage, Integer> retIndexMap = indexMap(retMoves);
+    
+            handle = insertArguments(MH_INVOKE_INTERP_BINDINGS.bindTo(this), 1, handle, argIndexMap, retIndexMap);
+            handle = handle.asCollector(Object[].class, callingSequence.methodType().parameterCount())
+                                             .asType(callingSequence.methodType());
+         } else {
+             handle = specialize(handle);
+         }
+
+        return handle;
     }
 
-    Object invoke(Object[] args) {
-        List<MemorySegment> tempBuffers = new ArrayList<>();
+    private MethodHandle specialize(MethodHandle intrinsicHandle) {
+        MethodType type = callingSequence.methodType();
+        MethodType intrinsicType = intrinsicHandle.type();
+
+        int insertPos = -1;
+        if (bufferCopySize > 0) {
+            intrinsicHandle = dropArguments(intrinsicHandle, 0, NativeAllocationScope.class);
+            insertPos++;
+        }
+        for (int i = 0; i < type.parameterCount(); i++) {
+            List<Binding> bindings = callingSequence.argumentBindings(i);
+            insertPos += bindings.stream().filter(Binding.Move.class::isInstance).count() + 1;
+            // We interpret the bindings in reverse since we have to construct a MethodHandle from the bottom up
+            for (int j = bindings.size() - 1; j >= 0; j--) {
+                Binding binding = bindings.get(j);
+                switch (binding.tag()) {
+                    case MOVE -> insertPos--; // handled by fallback
+                    case DUP ->
+                        intrinsicHandle = mergeArguments(intrinsicHandle, insertPos, insertPos + 1);
+                    case CONVERT_ADDRESS ->
+                        intrinsicHandle = filterArguments(intrinsicHandle, insertPos, MH_UNBOX_ADDRESS);
+                    case BASE_ADDRESS ->
+                        intrinsicHandle = filterArguments(intrinsicHandle, insertPos, MH_BASE_ADDRESS);
+                    case DEREFERENCE -> {
+                        Binding.Dereference deref = (Binding.Dereference) binding;
+                        MethodHandle filter = filterArguments(
+                            deref.varHandle()
+                            .toMethodHandle(VarHandle.AccessMode.GET)
+                            .asType(methodType(deref.type(), MemoryAddress.class)), 0, MH_BASE_ADDRESS);
+                        intrinsicHandle = filterArguments(intrinsicHandle, insertPos, filter);
+                    }
+                    case COPY_BUFFER -> {
+                        Binding.Copy copy = (Binding.Copy) binding;
+                        MethodHandle filter = insertArguments(MH_COPY_BUFFER, 1, copy.size(), copy.alignment());
+                        intrinsicHandle = collectArguments(intrinsicHandle, insertPos, filter);
+                        intrinsicHandle = mergeArguments(intrinsicHandle, 0, insertPos + 1);
+                    }
+                    default -> throw new IllegalArgumentException("Illegal tag: " + binding.tag());
+                }
+            }
+        }
+
+        if (type.returnType() != void.class) {
+            MethodHandle returnFilter = identity(type.returnType());
+            List<Binding> bindings = callingSequence.returnBindings();
+            for (int j = bindings.size() - 1; j >= 0; j--) {
+                Binding binding = bindings.get(j);
+                switch (binding.tag()) {
+                    case MOVE -> { /* handled by fallback */ }
+                    case CONVERT_ADDRESS ->
+                        returnFilter = filterArguments(returnFilter, 0, MH_BOX_ADDRESS);
+                    case DEREFERENCE -> {
+                        Binding.Dereference deref = (Binding.Dereference) binding;
+                        MethodHandle setter = deref.varHandle().toMethodHandle(VarHandle.AccessMode.SET);
+                        setter = filterArguments(
+                            setter.asType(methodType(void.class, MemoryAddress.class, deref.type())),
+                            0, MH_BASE_ADDRESS);
+                        returnFilter = collectArguments(returnFilter, returnFilter.type().parameterCount(), setter);
+                    }
+                    case DUP ->
+                        // FIXME assumes shape like: (MS, ..., MS, T) R, is that good enough?
+                        returnFilter = mergeArguments(returnFilter, 0, returnFilter.type().parameterCount() - 2);
+                    case ALLOC_BUFFER -> {
+                        Binding.Allocate alloc = (Binding.Allocate) binding;
+                        returnFilter = collectArguments(returnFilter, 0,
+                                insertArguments(MH_ALLOCATE_BUFFER, 0, alloc.size(), alloc.alignment()));
+                    }
+                    default ->
+                        throw new IllegalArgumentException("Illegal tag: " + binding.tag());
+                }
+            }
+
+            intrinsicHandle = MethodHandles.filterReturnValue(intrinsicHandle, returnFilter);
+        }
+
+        if (bufferCopySize > 0) {
+            MethodHandle closer = intrinsicType.returnType() == void.class
+                  // (Throwable, NativeAllocationScope) -> void
+                ? collectArguments(empty(methodType(void.class, Throwable.class)), 1, MH_CLOSE_ALLOCATOR)
+                  // (Throwable, V, NativeAllocationScope) -> V
+                : collectArguments(dropArguments(identity(intrinsicHandle.type().returnType()), 0, Throwable.class),
+                                   2, MH_CLOSE_ALLOCATOR);
+            intrinsicHandle = tryFinally(intrinsicHandle, closer);
+            intrinsicHandle = collectArguments(intrinsicHandle, 0, insertArguments(MH_MAKE_ALLOCATOR, 0, bufferCopySize));
+        }
+        return intrinsicHandle;
+    }
+
+    private static MethodHandle mergeArguments(MethodHandle mh, int sourceIndex, int destIndex) {
+        MethodType oldType = mh.type();
+        Class<?> sourceType = oldType.parameterType(sourceIndex);
+        Class<?> destType = oldType.parameterType(destIndex);
+        if (sourceType != destType) {
+            // TODO meet?
+            throw new IllegalArgumentException("Parameter types differ: " + sourceType + " != " + destType);
+        }
+        MethodType newType = oldType.dropParameterTypes(destIndex, destIndex + 1);
+        int[] reorder = new int[oldType.parameterCount()];
+        assert destIndex > sourceIndex;
+        for (int i = 0, index = 0; i < reorder.length; i++) {
+            if (i != destIndex) {
+                reorder[i] = index++;
+            } else {
+                reorder[i] = sourceIndex;
+            }
+        }
+        return permuteArguments(mh, newType, reorder);
+    }
+
+    private static MemorySegment copyBuffer(MemorySegment operand, long size, long alignment,
+                                    NativeAllocationScope allocator) {
+        assert operand.byteSize() == size : "operand size mismatch";
+        MemorySegment copy = allocator.allocate(size, alignment).segment();
+        copy.copyFrom(operand.asSlice(0, size));
+        return copy;
+    }
+
+    private static long toRawLongValue(MemoryAddress address) {
+        return address.toRawLongValue(); // Workaround for JDK-8239083
+    }
+
+    private static MemoryAddress ofLong(long address) {
+        return MemoryAddress.ofLong(address); // Workaround for JDK-8239083
+    }
+
+    private Map<VMStorage, Integer> indexMap(Binding.Move[] moves) {
+        return IntStream.range(0, moves.length)
+                        .boxed()
+                        .collect(Collectors.toMap(i -> moves[i].storage(), i -> i));
+    }
+
+    /**
+     * Does a native invocation by moving primitive values from the arg array into an intermediate buffer
+     * and calling the assembly stub that forwards arguments from the buffer to the target function
+     *
+     * @param args an array of primitive values to be copied in to the buffer
+     * @param argBindings Binding.Move values describing how arguments should be copied
+     * @param returnBindings Binding.Move values describing how return values should be copied
+     * @return null, a single primitive value, or an Object[] of primitive values
+     */
+    Object invokeMoves(Object[] args, Binding.Move[] argBindings, Binding.Move[] returnBindings) {
+        MemorySegment stackArgsSeg = null;
         try (MemorySegment argBuffer = MemorySegment.allocateNative(layout.size, 64)) {
             MemoryAddress argsPtr = argBuffer.baseAddress();
             MemoryAddress stackArgs;
             if (stackArgsBytes > 0) {
-                MemorySegment stackArgsSeg = MemorySegment.allocateNative(stackArgsBytes, 8);
-                tempBuffers.add(stackArgsSeg);
+                stackArgsSeg = MemorySegment.allocateNative(stackArgsBytes, 8);
                 stackArgs = stackArgsSeg.baseAddress();
             } else {
                 stackArgs = MemoryAddressImpl.NULL;
@@ -113,15 +339,13 @@ public class ProgrammableInvoker {
             VH_LONG.set(argsPtr.addOffset(layout.stack_args_bytes), stackArgsBytes);
             VH_LONG.set(argsPtr.addOffset(layout.stack_args), stackArgs.toRawLongValue());
 
-            for (int i = 0; i < args.length; i++) {
-                Object arg = args[i];
-                jdk.internal.foreign.abi.BindingInterpreter.unbox(arg, callingSequence.argumentBindings(i),
-                        s -> {
-                            if (abi.arch.isStackType(s.type())) {
-                                return stackArgs.addOffset(s.index() * abi.arch.typeSize(abi.arch.stackType()));
-                            }
-                            return argsPtr.addOffset(layout.argOffset(s));
-                        }, tempBuffers);
+            for (int i = 0; i < argBindings.length; i++) {
+                Binding.Move binding = argBindings[i];
+                VMStorage storage = binding.storage();
+                MemoryAddress ptr = abi.arch.isStackType(storage.type())
+                    ? stackArgs.addOffset(storage.index() * abi.arch.typeSize(abi.arch.stackType()))
+                    : argsPtr.addOffset(layout.argOffset(storage));
+                SharedUtils.writeOverSized(ptr, binding.type(), args[i]);
             }
 
             if (DEBUG) {
@@ -136,10 +360,56 @@ public class ProgrammableInvoker {
                 layout.dump(abi.arch, argsPtr, System.err);
             }
 
-            return function.returnLayout().isEmpty()
-                    ? null
-                    : jdk.internal.foreign.abi.BindingInterpreter.box(callingSequence.returnBindings(),
-                    s -> argsPtr.addOffset(layout.retOffset(s))); // buffers are leaked
+            if (returnBindings.length == 0) {
+                return null;
+            } else if (returnBindings.length == 1) {
+                Binding.Move move = returnBindings[0];
+                VMStorage storage = move.storage();
+                return SharedUtils.read(argsPtr.addOffset(layout.retOffset(storage)), move.type());
+            } else { // length > 1
+                Object[] returns = new Object[returnBindings.length];
+                for (int i = 0; i < returnBindings.length; i++) {
+                    Binding.Move move = returnBindings[i];
+                    VMStorage storage = move.storage();
+                    returns[i] = SharedUtils.read(argsPtr.addOffset(layout.retOffset(storage)), move.type());
+                }
+                return returns;
+            }
+        } finally {
+            if (stackArgsSeg != null) {
+                stackArgsSeg.close();
+            }
+        }
+    }
+
+    Object invokeInterpBindings(Object[] args, MethodHandle leaf,
+                                Map<VMStorage, Integer> argIndexMap,
+                                Map<VMStorage, Integer> retIndexMap) throws Throwable {
+        List<MemorySegment> tempBuffers = new ArrayList<>();
+        try {
+            // do argument processing, get Object[] as result
+            Object[] moves = new Object[leaf.type().parameterCount()];
+            for (int i = 0; i < args.length; i++) {
+                Object arg = args[i];
+                BindingInterpreter.unbox(arg, callingSequence.argumentBindings(i),
+                        (storage, type, value) -> {
+                            moves[argIndexMap.get(storage)] = value;
+                        }, tempBuffers);
+            }
+
+            // call leaf
+            Object o = leaf.invokeWithArguments(moves);
+
+            // return value processing
+            if (o == null) {
+                return null;
+            } else if (o instanceof Object[]) {
+                Object[] oArr = (Object[]) o;
+                return BindingInterpreter.box(callingSequence.returnBindings(),
+                        (storage, type) -> oArr[retIndexMap.get(storage)]);
+            } else {
+                return BindingInterpreter.box(callingSequence.returnBindings(), (storage, type) -> o);
+            }
         } finally {
             tempBuffers.forEach(MemorySegment::close);
         }

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/ProgrammableInvoker.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/ProgrammableInvoker.java
@@ -172,7 +172,7 @@ public class ProgrammableInvoker {
         if (NO_SPEC || retMoves.length > 1) {
             Map<VMStorage, Integer> argIndexMap = indexMap(argMoves);
             Map<VMStorage, Integer> retIndexMap = indexMap(retMoves);
-    
+
             handle = insertArguments(MH_INVOKE_INTERP_BINDINGS.bindTo(this), 1, handle, argIndexMap, retIndexMap);
             handle = handle.asCollector(Object[].class, callingSequence.methodType().parameterCount())
                                              .asType(callingSequence.methodType());

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/ProgrammableUpcallHandler.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/ProgrammableUpcallHandler.java
@@ -89,10 +89,13 @@ public class ProgrammableUpcallHandler implements UpcallHandler {
             MemoryAddress stackArgsBase = MemoryAddressImpl.ofLongUnchecked((long)VH_LONG.get(buffer.rebase(bufferBase.segment()).addOffset(layout.stack_args)));
             Object[] args = new Object[type.parameterCount()];
             for (int i = 0 ; i < type.parameterCount() ; i++) {
-                args[i] = jdk.internal.foreign.abi.BindingInterpreter.box(callingSequence.argumentBindings(i),
-                        s -> abi.arch.isStackType(s.type())
-                            ? stackArgsBase.addOffset(s.index() * abi.arch.typeSize(abi.arch.stackType()))
-                            : bufferBase.addOffset(layout.argOffset(s)));
+                args[i] = BindingInterpreter.box(callingSequence.argumentBindings(i),
+                        (storage, type) -> {
+                            MemoryAddress ptr = abi.arch.isStackType(storage.type())
+                                ? stackArgsBase.addOffset(storage.index() * abi.arch.typeSize(abi.arch.stackType()))
+                                : bufferBase.addOffset(layout.argOffset(storage));
+                            return SharedUtils.read(ptr, type);
+                        });
             }
 
             if (DEBUG) {
@@ -108,8 +111,11 @@ public class ProgrammableUpcallHandler implements UpcallHandler {
             }
 
             if (mh.type().returnType() != void.class) {
-                jdk.internal.foreign.abi.BindingInterpreter.unbox(o,
-                        callingSequence.returnBindings(), s -> bufferBase.addOffset(layout.retOffset(s)), new ArrayList<>());
+                BindingInterpreter.unbox(o, callingSequence.returnBindings(),
+                        (storage, type, value) -> {
+                            MemoryAddress ptr = bufferBase.addOffset(layout.retOffset(storage));
+                            SharedUtils.writeOverSized(ptr, type, value);
+                        }, new ArrayList<>());
             }
 
             if (DEBUG) {

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/ProgrammableUpcallHandler.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/ProgrammableUpcallHandler.java
@@ -115,7 +115,7 @@ public class ProgrammableUpcallHandler implements UpcallHandler {
                         (storage, type, value) -> {
                             MemoryAddress ptr = bufferBase.addOffset(layout.retOffset(storage));
                             SharedUtils.writeOverSized(ptr, type, value);
-                        }, new ArrayList<>());
+                        }, null);
             }
 
             if (DEBUG) {

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/SharedUtils.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/SharedUtils.java
@@ -321,6 +321,13 @@ public class SharedUtils {
         return handle;
     }
 
+    static void checkType(Class<?> actualType, Class<?> expectedType) {
+        if (expectedType != actualType) {
+            throw new IllegalArgumentException(
+                    String.format("Invalid operand type: %s. %s expected", actualType, expectedType));
+        }
+    }
+
     public static class SimpleVaArg {
         public final Class<?> carrier;
         public final MemoryLayout layout;

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/SharedUtils.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/SharedUtils.java
@@ -45,6 +45,7 @@ import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.MethodType;
 import java.lang.invoke.VarHandle;
+import java.nio.ByteOrder;
 import java.util.List;
 import java.util.function.Consumer;
 import java.util.stream.IntStream;
@@ -61,6 +62,14 @@ public class SharedUtils {
     private static final MethodHandle MH_ALLOC_BUFFER;
     private static final MethodHandle MH_BASEADDRESS;
     private static final MethodHandle MH_BUFFER_COPY;
+
+    private static final VarHandle VH_BYTE = MemoryHandles.varHandle(byte.class, ByteOrder.nativeOrder());
+    private static final VarHandle VH_CHAR = MemoryHandles.varHandle(char.class, ByteOrder.nativeOrder());
+    private static final VarHandle VH_SHORT = MemoryHandles.varHandle(short.class, ByteOrder.nativeOrder());
+    private static final VarHandle VH_INT = MemoryHandles.varHandle(int.class, ByteOrder.nativeOrder());
+    private static final VarHandle VH_LONG = MemoryHandles.varHandle(long.class, ByteOrder.nativeOrder());
+    private static final VarHandle VH_FLOAT = MemoryHandles.varHandle(float.class, ByteOrder.nativeOrder());
+    private static final VarHandle VH_DOUBLE = MemoryHandles.varHandle(double.class, ByteOrder.nativeOrder());
 
     static {
         try {
@@ -390,6 +399,67 @@ public class SharedUtils {
         @Override
         public MemoryAddress address() {
             return address;
+        }
+    }
+
+    static void writeOverSized(MemoryAddress ptr, Class<?> type, Object o) {
+        // use VH_LONG for integers to zero out the whole register in the process
+        if (type == long.class) {
+            VH_LONG.set(ptr, (long) o);
+        } else if (type == int.class) {
+            VH_LONG.set(ptr, (long) (int) o);
+        } else if (type == short.class) {
+            VH_LONG.set(ptr, (long) (short) o);
+        } else if (type == char.class) {
+            VH_LONG.set(ptr, (long) (char) o);
+        } else if (type == byte.class) {
+            VH_LONG.set(ptr, (long) (byte) o);
+        } else if (type == float.class) {
+            VH_FLOAT.set(ptr, (float) o);
+        } else if (type == double.class) {
+            VH_DOUBLE.set(ptr, (double) o);
+        } else {
+            throw new IllegalArgumentException("Unsupported carrier: " + type);
+        }
+    }
+
+    static void write(MemoryAddress ptr, Class<?> type, Object o) {
+        if (type == long.class) {
+            VH_LONG.set(ptr, (long) o);
+        } else if (type == int.class) {
+            VH_INT.set(ptr, (int) o);
+        } else if (type == short.class) {
+            VH_SHORT.set(ptr, (short) o);
+        } else if (type == char.class) {
+            VH_CHAR.set(ptr, (char) o);
+        } else if (type == byte.class) {
+            VH_BYTE.set(ptr, (byte) o);
+        } else if (type == float.class) {
+            VH_FLOAT.set(ptr, (float) o);
+        } else if (type == double.class) {
+            VH_DOUBLE.set(ptr, (double) o);
+        } else {
+            throw new IllegalArgumentException("Unsupported carrier: " + type);
+        }
+    }
+
+    static Object read(MemoryAddress ptr, Class<?> type) {
+        if (type == long.class) {
+            return (long) VH_LONG.get(ptr);
+        } else if (type == int.class) {
+            return (int) VH_INT.get(ptr);
+        } else if (type == short.class) {
+            return (short) VH_SHORT.get(ptr);
+        } else if (type == char.class) {
+            return (char) VH_CHAR.get(ptr);
+        } else if (type == byte.class) {
+            return (byte) VH_BYTE.get(ptr);
+        } else if (type == float.class) {
+            return (float) VH_FLOAT.get(ptr);
+        } else if (type == double.class) {
+            return (double) VH_DOUBLE.get(ptr);
+        } else {
+            throw new IllegalArgumentException("Unsupported carrier: " + type);
         }
     }
 }

--- a/test/jdk/java/foreign/TestDowncall.java
+++ b/test/jdk/java/foreign/TestDowncall.java
@@ -30,7 +30,13 @@
  *          java.base/sun.security.action
  * @build NativeTestHelper CallGeneratorHelper TestDowncall
  *
- * @run testng/othervm -Dforeign.restricted=permit TestDowncall
+ * @run testng/othervm
+ *   -Dforeign.restricted=permit
+ *   TestDowncall
+ * @run testng/othervm
+ *   -Dforeign.restricted=permit
+ *   -Djdk.internal.foreign.ProgrammableInvoker.NO_SPEC=true
+ *   TestDowncall
  */
 
 import jdk.incubator.foreign.CSupport;

--- a/test/jdk/java/foreign/TestUpcall.java
+++ b/test/jdk/java/foreign/TestUpcall.java
@@ -30,7 +30,13 @@
  *          java.base/sun.security.action
  * @build NativeTestHelper CallGeneratorHelper TestUpcall
  *
- * @run testng/othervm -Dforeign.restricted=permit TestUpcall
+ * @run testng/othervm
+ *   -Dforeign.restricted=permit
+ *   TestUpcall
+ * @run testng/othervm
+ *   -Dforeign.restricted=permit
+ *   -Djdk.internal.foreign.ProgrammableInvoker.NO_SPEC=true
+ *   TestUpcall
  */
 
 import jdk.incubator.foreign.CSupport;
@@ -138,7 +144,6 @@ public class TestUpcall extends CallGeneratorHelper {
         return args;
     }
 
-    @SuppressWarnings("unchecked")
     static MemoryAddress makeCallback(Ret ret, List<ParamType> params, List<StructFieldType> fields, List<Consumer<Object>> checks, List<Consumer<Object[]>> argChecks) {
         if (params.isEmpty()) {
             return dummyAddress;
@@ -156,9 +161,9 @@ public class TestUpcall extends CallGeneratorHelper {
 
             final int finalI = i;
             if (carrier == MemorySegment.class) {
-                argChecks.add(o -> assertStructEquals((MemorySegment) o[finalI], (MemorySegment) box.get()[finalI], layout));
+                argChecks.add(o -> assertStructEquals((MemorySegment) box.get()[finalI], (MemorySegment) o[finalI], layout));
             } else {
-                argChecks.add(o -> assertEquals(o[finalI], box.get()[finalI]));
+                argChecks.add(o -> assertEquals(box.get()[finalI], o[finalI]));
             }
         }
 
@@ -167,7 +172,7 @@ public class TestUpcall extends CallGeneratorHelper {
         Class<?> firstCarrier = paramCarrier(firstlayout);
 
         if (firstCarrier == MemorySegment.class) {
-            checks.add(o -> assertStructEquals((MemorySegment) o, (MemorySegment) box.get()[0], firstlayout));
+            checks.add(o -> assertStructEquals((MemorySegment) box.get()[0], (MemorySegment) o, firstlayout));
         } else {
             checks.add(o -> assertEquals(o, box.get()[0]));
         }
@@ -182,13 +187,13 @@ public class TestUpcall extends CallGeneratorHelper {
         return stub;
     }
 
-    private static void assertStructEquals(MemorySegment s1, MemorySegment s2, MemoryLayout layout) {
-        assertEquals(s1.byteSize(), s2.byteSize());
+    private static void assertStructEquals(MemorySegment actual, MemorySegment expected, MemoryLayout layout) {
+        assertEquals(actual.byteSize(), expected.byteSize());
         GroupLayout g = (GroupLayout) layout;
         for (MemoryLayout field : g.memberLayouts()) {
             if (field instanceof ValueLayout) {
                 VarHandle vh = g.varHandle(vhCarrier(field), MemoryLayout.PathElement.groupElement(field.name().orElseThrow()));
-                assertEquals(vh.get(s1.baseAddress()), vh.get(s2.baseAddress()));
+                assertEquals(vh.get(actual.baseAddress()), vh.get(expected.baseAddress()));
             }
         }
     }

--- a/test/micro/org/openjdk/bench/jdk/incubator/foreign/CallOverhead.java
+++ b/test/micro/org/openjdk/bench/jdk/incubator/foreign/CallOverhead.java
@@ -166,7 +166,7 @@ public class CallOverhead {
     public void panama_args5_NO_SPEC() throws Throwable {
         args5.invokeExact(10L, 11D, 12L, 13D, 14L);
     }
-    
+
     @Benchmark
     public void panama_args10() throws Throwable {
         args10.invokeExact(10L, 11D, 12L, 13D, 14L,

--- a/test/micro/org/openjdk/bench/jdk/incubator/foreign/CallOverhead.java
+++ b/test/micro/org/openjdk/bench/jdk/incubator/foreign/CallOverhead.java
@@ -26,6 +26,9 @@ import jdk.incubator.foreign.CSupport;
 import jdk.incubator.foreign.FunctionDescriptor;
 import jdk.incubator.foreign.LibraryLookup;
 import jdk.incubator.foreign.ForeignLinker;
+import jdk.incubator.foreign.MemoryAddress;
+import jdk.incubator.foreign.MemoryLayout;
+import jdk.incubator.foreign.MemorySegment;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Fork;
@@ -39,7 +42,10 @@ import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodType;
 import java.util.concurrent.TimeUnit;
 
+import static jdk.incubator.foreign.CSupport.C_DOUBLE;
 import static jdk.incubator.foreign.CSupport.C_INT;
+import static jdk.incubator.foreign.CSupport.C_LONGLONG;
+import static jdk.incubator.foreign.CSupport.C_POINTER;
 
 @BenchmarkMode(Mode.AverageTime)
 @Warmup(iterations = 5, time = 500, timeUnit = TimeUnit.MILLISECONDS)
@@ -52,6 +58,16 @@ public class CallOverhead {
     static final ForeignLinker abi = CSupport.getSystemLinker();
     static final MethodHandle func;
     static final MethodHandle identity;
+    static final MethodHandle identity_struct;
+    static final MethodHandle identity_memory_address;
+    static final MethodHandle args5;
+    static final MethodHandle args10;
+
+    static final MemoryLayout POINT_LAYOUT = MemoryLayout.ofStruct(
+        C_LONGLONG, C_LONGLONG
+    );
+
+    static final MemorySegment point = MemorySegment.allocateNative(POINT_LAYOUT);
 
     static {
         System.loadLibrary("CallOverheadJNI");
@@ -64,6 +80,20 @@ public class CallOverhead {
             identity = abi.downcallHandle(ll.lookup("identity"),
                     MethodType.methodType(int.class, int.class),
                     FunctionDescriptor.of(C_INT, C_INT));
+            identity_struct = abi.downcallHandle(ll.lookup("identity_struct"),
+                    MethodType.methodType(MemorySegment.class, MemorySegment.class),
+                    FunctionDescriptor.of(POINT_LAYOUT, POINT_LAYOUT));
+            identity_memory_address = abi.downcallHandle(ll.lookup("identity_memory_address"),
+                    MethodType.methodType(MemoryAddress.class, MemoryAddress.class),
+                    FunctionDescriptor.of(C_POINTER, C_POINTER));
+            args5 = abi.downcallHandle(ll.lookup("args5"), // just reuse identity
+                    MethodType.methodType(void.class, long.class, double.class, long.class, double.class, long.class),
+                    FunctionDescriptor.ofVoid(C_LONGLONG, C_DOUBLE, C_LONGLONG, C_DOUBLE, C_LONGLONG));
+            args10 = abi.downcallHandle(ll.lookup("args10"),
+                    MethodType.methodType(void.class, long.class, double.class, long.class, double.class, long.class,
+                                                      double.class, long.class, double.class, long.class, double.class),
+                    FunctionDescriptor.ofVoid(C_LONGLONG, C_DOUBLE, C_LONGLONG, C_DOUBLE, C_LONGLONG,
+                                              C_DOUBLE, C_LONGLONG, C_DOUBLE, C_LONGLONG, C_DOUBLE));
         } catch (NoSuchMethodException e) {
             throw new BootstrapMethodError(e);
         }
@@ -102,5 +132,51 @@ public class CallOverhead {
     @Fork(jvmArgsAppend = "-Djdk.internal.foreign.ProgrammableInvoker.NO_SPEC=true")
     public int panama_identity_NO_SPEC() throws Throwable {
         return (int) identity.invokeExact(10);
+    }
+
+    @Benchmark
+    public MemorySegment panama_identity_struct() throws Throwable {
+        return (MemorySegment) identity_struct.invokeExact(point);
+    }
+
+    @Benchmark
+    @Fork(jvmArgsAppend = "-Djdk.internal.foreign.ProgrammableInvoker.NO_SPEC=true")
+    public MemorySegment panama_identity_struct_NO_SPEC() throws Throwable {
+        return (MemorySegment) identity_struct.invokeExact(point);
+    }
+
+    @Benchmark
+    public MemoryAddress panama_identity_memory_address() throws Throwable {
+        return (MemoryAddress) identity_memory_address.invokeExact(MemoryAddress.NULL);
+    }
+
+    @Benchmark
+    @Fork(jvmArgsAppend = "-Djdk.internal.foreign.ProgrammableInvoker.NO_SPEC=true")
+    public MemoryAddress panama_identity_memory_address_NO_SPEC() throws Throwable {
+        return (MemoryAddress) identity_memory_address.invokeExact(MemoryAddress.NULL);
+    }
+
+    @Benchmark
+    public void panama_args5() throws Throwable {
+        args5.invokeExact(10L, 11D, 12L, 13D, 14L);
+    }
+
+    @Benchmark
+    @Fork(jvmArgsAppend = "-Djdk.internal.foreign.ProgrammableInvoker.NO_SPEC=true")
+    public void panama_args5_NO_SPEC() throws Throwable {
+        args5.invokeExact(10L, 11D, 12L, 13D, 14L);
+    }
+    
+    @Benchmark
+    public void panama_args10() throws Throwable {
+        args10.invokeExact(10L, 11D, 12L, 13D, 14L,
+                           15D, 16L, 17D, 18L, 19D);
+    }
+
+    @Benchmark
+    @Fork(jvmArgsAppend = "-Djdk.internal.foreign.ProgrammableInvoker.NO_SPEC=true")
+    public void panama_args10_NO_SPEC() throws Throwable {
+        args10.invokeExact(10L, 11D, 12L, 13D, 14L,
+                           15D, 16L, 17D, 18L, 19D);
     }
 }

--- a/test/micro/org/openjdk/bench/jdk/incubator/foreign/CallOverhead.java
+++ b/test/micro/org/openjdk/bench/jdk/incubator/foreign/CallOverhead.java
@@ -83,12 +83,24 @@ public class CallOverhead {
     }
 
     @Benchmark
+    @Fork(jvmArgsAppend = "-Djdk.internal.foreign.ProgrammableInvoker.NO_SPEC=true")
+    public void panama_blank_NO_SPEC() throws Throwable {
+        func.invokeExact();
+    }
+
+    @Benchmark
     public int jni_identity() throws Throwable {
         return identity(10);
     }
 
     @Benchmark
     public int panama_identity() throws Throwable {
+        return (int) identity.invokeExact(10);
+    }
+
+    @Benchmark
+    @Fork(jvmArgsAppend = "-Djdk.internal.foreign.ProgrammableInvoker.NO_SPEC=true")
+    public int panama_identity_NO_SPEC() throws Throwable {
         return (int) identity.invokeExact(10);
     }
 }

--- a/test/micro/org/openjdk/bench/jdk/incubator/foreign/libCallOverhead.c
+++ b/test/micro/org/openjdk/bench/jdk/incubator/foreign/libCallOverhead.c
@@ -32,3 +32,20 @@ EXPORT void func() {}
 EXPORT int identity(int x) {
   return x;
 }
+
+typedef struct {
+    long long x;
+    long long y;
+} Point;
+
+EXPORT Point identity_struct(Point p) {
+    return p;
+}
+
+EXPORT void* identity_memory_address(void* p) {
+    return p;
+}
+
+EXPORT void args5(long long a0, double a1, long long a2, double a3, long long a4) {}
+EXPORT void args10(long long a0, double a1, long long a2, double a3, long long a4,
+                   double a5, long long a6, double a7, long long a8, double a9) {}


### PR DESCRIPTION
Hi,

This PR adds specialization of downcall binding recipes using MethodHandles. The main addition to the code is the ProgrammableInvoker::specialize method, but there are also some refactorings which I will explain;

The current code has a single `invoke` method that takes the high-level input arguments of the down call as an Object[]. This method calls the BindingInterpreter to pre-process arguments, and also move any low-level values produced by the pre-processing directly into the intermediate argument buffer that is later passed to the native code that copies the values into registers and then calls the target function.

This `invoke` method is split into 2; `invokeInterpBindings`, which pre-processes the arguments and outputs any low-level values produced by the pre-processing into an Object[].

This Object[] is then passed to `invokeMoves`, which moves the low-level values into the intermediate argument buffer that is passed to native.

This split is done so that we can replace the invokeInterpBindings call with a specialized MethodHandle chain based on the binding recipe instead, which is built on top a type handle of invokeMoves.

This takes care of the binding recipe specialization. invokeMoves can later be replaced during C2 compilation with code that passes these low-level values into registers directly (but that is for another patch).

BindingInterpreter now doesn't write values to the intermediate buffer directly, and so instead of passing functors to obtain a pointer to write a low-level value to, it now takes functors that handle the reading or writing (see StoreFunc and LoadFunc).

Since the read/write methods in BindingInterpreter are now called from multiple places, I've moved them to SharedUtils.

---

The process of specializing the binding recipe is as follows:

We first calculate a low-level method type (the 'intrinsicType') based on the MOVE bindings of a particular recipe, this gives us a method type that takes only primitives as arguments, which represent the values to be copied into the various CPU registers before calling the native target function. We then get a low-level MethodHandle that calls invokeMoves, and adapt it to the intrinsic type. On top of that we build the specialized binding recipe method handle chain.

For each argument, we iterate through the bindings in reverse, and for each binding insert a new filter MH onto the handle we already have. At the end we will end up with a handle that features the high-level arguments of our native function (MemorySegment, MemoryAddress, etc.).

The same is done for the return bindings; the return value is repeatedly filtered according to the bindings.

This currently doesn't work for multiple return values, in which case invokeMoves will return an Object[] instead of just a plain Object. This case is not specialized with method handles, but is instead handled solely by invokeInterpBindings. (we detect this in getBoundMethodHandle)

In case the bindings need to do allocation, a NativeAllocationScope is created and passed in as the first argument, which is then forwarded to the various filter MH using mergeArguments (which is a wrapper for MethodHandles::permuteArguments that merges 2 arguments given their indices). The allocation and cleanup of the NativeAllocationScope are handled with a tryFinally combinator.

---

I've added a system property to disable the MethodHandle specialization so that the performance difference can be measured. The speed up I've seen on the CallOverhead benchmark between this and the current code is about 1.5x (but with the C2 intrinsics this gets us on par with JNI). The difference between specialization turned off and on is a little bigger than that, since the split of the 'invoke' method adds a bit of overhead as well, but it's still on overall gain compared to what we currently have.

Finally, I've also fixed a minor problems with TestUpcall where the expected and actual values were reversed when calling asserts.

---

If I've missed anything in the explanation, please feel free to ask!

Thanks,
Jorn
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [JDK-8247937](https://bugs.openjdk.java.net/browse/JDK-8247937): Specialize downcall binding recipes using MethodHandle combinators


### Reviewers
 * Maurizio Cimadamore ([mcimadamore](@mcimadamore) - Committer)


### Download
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/212/head:pull/212`
`$ git checkout pull/212`
