### PR TITLE
8247924: Improve javadoc of Foreign Memory Access API (part three)

### DIFF
--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/MemoryLayout.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/MemoryLayout.java
@@ -68,9 +68,9 @@ import java.util.stream.Stream;
  * <blockquote><pre>{@code
 SequenceLayout taggedValues = MemoryLayout.ofSequence(5,
     MemoryLayout.ofStruct(
-        MemoryLayout.ofValueBits(8, ByteOrder.NATIVE_ORDER).withName("kind"),
+        MemoryLayout.ofValueBits(8, ByteOrder.nativeOrder()).withName("kind"),
         MemoryLayout.ofPaddingBits(24),
-        MemoryLayout.ofValueBits(32, ByteOrder.NATIVE_ORDER).withName("value")
+        MemoryLayout.ofValueBits(32, ByteOrder.nativeOrder()).withName("value")
     )
 ).withName("TaggedValues");
  * }</pre></blockquote>
@@ -147,7 +147,7 @@ MemoryLayout taggedValuesWithHole = taggedValues.map(l -> MemoryLayout.ofPadding
  * <blockquote><pre>{@code
 MemoryLayout taggedValuesWithHole = MemoryLayout.ofSequence(5,
     MemoryLayout.ofStruct(
-        MemoryLayout.ofPaddingBits(8, ByteOrder.NATIVE_ORDER).withName("kind").
+        MemoryLayout.ofPaddingBits(8, ByteOrder.nativeOrder()).withName("kind").
         MemoryLayout.ofPaddingBits(32),
         MemoryLayout.ofPaddingBits(32)
 ));


### PR DESCRIPTION
Fix bad references `ByteOrder.NATIVE_ORDER`
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [JDK-8247924](https://bugs.openjdk.java.net/browse/JDK-8247924): Improve javadoc of Foreign Memory Access API ⚠️ Title mismatch between PR and JBS.


### Reviewers
 * Jorn Vernee ([jvernee](@JornVernee) - Committer)


### Download
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/213/head:pull/213`
`$ git checkout pull/213`
