### PR TITLE
8248237: VarHandleByteArrayView nioAccess field should be static final

### DIFF
--- a/src/java.base/share/classes/java/lang/invoke/X-VarHandleByteArrayView.java.template
+++ b/src/java.base/share/classes/java/lang/invoke/X-VarHandleByteArrayView.java.template
@@ -41,7 +41,7 @@ import static java.lang.invoke.MethodHandleStatics.UNSAFE;
 
 final class VarHandleByteArrayAs$Type$s extends VarHandleByteArrayBase {
 
-    static JavaNioAccess nioAccess = SharedSecrets.getJavaNioAccess();
+    static final JavaNioAccess NIO_ACCESS = SharedSecrets.getJavaNioAccess();
 
     static final int ALIGN = $BoxType$.BYTES - 1;
 
@@ -565,7 +565,7 @@ final class VarHandleByteArrayAs$Type$s extends VarHandleByteArrayBase {
 
         @ForceInline
         static int index(ByteBuffer bb, int index) {
-            MemorySegmentProxy segmentProxy = nioAccess.bufferSegment(bb);
+            MemorySegmentProxy segmentProxy = NIO_ACCESS.bufferSegment(bb);
             if (segmentProxy != null) {
                 segmentProxy.checkValidState();
             }


### PR DESCRIPTION
Make static field final and change the name to conform to the naming convention.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [JDK-8248237](https://bugs.openjdk.java.net/browse/JDK-8248237): VarHandleByteArrayView nioAccess field should be static final


### Reviewers
 * Henry Jen ([henryjen](@slowhog) - Committer)
 * Maurizio Cimadamore ([mcimadamore](@mcimadamore) - Committer)


### Download
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/214/head:pull/214`
`$ git checkout pull/214`
