### PR TITLE
8248415: Create VarHandles for pointer fields through the MemoryHandles API

### DIFF
--- a/src/jdk.incubator.jextract/share/classes/jdk/incubator/jextract/tool/ConstantHelper.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/incubator/jextract/tool/ConstantHelper.java
@@ -27,6 +27,7 @@ package jdk.incubator.jextract.tool;
 import jdk.incubator.foreign.FunctionDescriptor;
 import jdk.incubator.foreign.LibraryLookup;
 import jdk.incubator.foreign.MemoryAddress;
+import jdk.incubator.foreign.MemoryHandles;
 import jdk.incubator.foreign.MemoryLayout;
 import jdk.incubator.foreign.MemorySegment;
 import jdk.internal.org.objectweb.asm.ClassWriter;
@@ -99,6 +100,13 @@ class ConstantHelper {
             desc(methodType(MemoryAddress.class))
     );
 
+    private static final DirectMethodHandleDesc MH_MemoryHandles_asAddressVarHandle = MethodHandleDesc.ofMethod(
+            Kind.STATIC,
+            desc(MemoryHandles.class),
+            "asAddressVarHandle",
+            desc(methodType(VarHandle.class, VarHandle.class))
+    );
+
     private static final DirectMethodHandleDesc BSM_GET_STATIC_FINAL = ConstantDescs.ofConstantBootstrap(
             CD_ConstantBootstraps,
             "getStaticFinal",
@@ -122,6 +130,17 @@ class ConstantHelper {
     private final ConstantDesc LIBRARIES;
 
     private final Map<String, DirectMethodHandleDesc> pool = new HashMap<>();
+
+    private static final Map<Class<?>, ClassDesc> CARRIERS = Map.ofEntries(
+            Map.entry(Byte.TYPE,                desc(Byte.TYPE)),
+            Map.entry(Short.TYPE,               desc(Short.TYPE)),
+            Map.entry(Character.TYPE,           desc(Character.TYPE)),
+            Map.entry(Integer.TYPE,             desc(Integer.TYPE)),
+            Map.entry(Long.TYPE,                desc(Short.TYPE)),
+            Map.entry(Float.TYPE,               desc(Short.TYPE)),
+            Map.entry(Double.TYPE,              desc(Short.TYPE)),
+            Map.entry(MemoryAddress.class,      desc(Long.TYPE))
+    );
 
     ConstantHelper(String parentClassName, ClassDesc runtimeHelper, ClassDesc cString, String[] libraryNames) {
         this.cw = new ClassWriter(ClassWriter.COMPUTE_FRAMES);
@@ -408,16 +427,25 @@ class ConstantHelper {
         return DynamicConstantDesc.ofNamed(BSM_INVOKE, "VH_" + name, CD_VarHandle, MH_MemoryLayout_varHandle, memoryLayout, carrier);
     }
 
+    private static ConstantDesc addressVarHandleDesc(String name, ConstantDesc varHandle) {
+        return DynamicConstantDesc.ofNamed(BSM_INVOKE, "VH_" + name, CD_VarHandle, MH_MemoryHandles_asAddressVarHandle, varHandle);
+    }
+
     private static ConstantDesc groupElementDesc(String fieldName) {
         return DynamicConstantDesc.ofNamed(BSM_INVOKE, "groupElement_" + fieldName, CD_PathElelemt, MH_PathElement_groupElement, fieldName);
     }
 
     private static ConstantDesc varHandleDesc(String javaName, String nativeName, MemoryLayout layout, Class<?> type, MemoryLayout parentLayout) {
-        if (parentLayout != null) {
-            return varHandleDesc(javaName, desc(parentLayout), desc(type), groupElementDesc(nativeName));
-        } else {
-            return varHandleDesc(javaName, desc(layout), desc(type));
+        var carrier = CARRIERS.get(type);
+        if (carrier == null) {
+            carrier = desc(type);
         }
+
+        var varHandle = parentLayout != null ?
+                varHandleDesc(javaName, desc(parentLayout), carrier, groupElementDesc(nativeName)) :
+                varHandleDesc(javaName, desc(layout), carrier);
+
+        return type == MemoryAddress.class ? addressVarHandleDesc(javaName, varHandle) : varHandle;
     }
 
     private ConstantDesc globalVarAddressDesc(String name, MemoryLayout layout) {

--- a/src/jdk.incubator.jextract/share/classes/jdk/incubator/jextract/tool/ConstantHelper.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/incubator/jextract/tool/ConstantHelper.java
@@ -136,9 +136,9 @@ class ConstantHelper {
             Map.entry(Short.TYPE,               desc(Short.TYPE)),
             Map.entry(Character.TYPE,           desc(Character.TYPE)),
             Map.entry(Integer.TYPE,             desc(Integer.TYPE)),
-            Map.entry(Long.TYPE,                desc(Short.TYPE)),
-            Map.entry(Float.TYPE,               desc(Short.TYPE)),
-            Map.entry(Double.TYPE,              desc(Short.TYPE)),
+            Map.entry(Long.TYPE,                desc(Long.TYPE)),
+            Map.entry(Float.TYPE,               desc(Float.TYPE)),
+            Map.entry(Double.TYPE,              desc(Double.TYPE)),
             Map.entry(MemoryAddress.class,      desc(Long.TYPE))
     );
 

--- a/src/jdk.incubator.jextract/share/classes/jdk/incubator/jextract/tool/OutputFactory.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/incubator/jextract/tool/OutputFactory.java
@@ -357,7 +357,7 @@ public class OutputFactory implements Declaration.Visitor<Void, Declaration> {
             return null;
         }
         Class<?> clazz = typeTranslator.getJavaType(type);
-        if (tree.kind() == Declaration.Variable.Kind.BITFIELD || clazz == MemoryAddress.class ||
+        if (tree.kind() == Declaration.Variable.Kind.BITFIELD ||
                 (layout instanceof ValueLayout && layout.byteSize() > 8)) {
             //skip
             return null;

--- a/test/jdk/tools/jextract/Test8248415.java
+++ b/test/jdk/tools/jextract/Test8248415.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.nio.file.Path;
+import jdk.incubator.foreign.MemoryAddress;
+import org.testng.annotations.Test;
+
+/*
+ * @test
+ * @library /test/lib
+ * @modules jdk.incubator.jextract
+ * @build JextractToolRunner
+ * @bug 8248415
+ * @summary jextract does not generate getter and setter for pointer typed fields in structs
+ * @run testng/othervm -Dforeign.restricted=permit Test8248415
+ */
+public class Test8248415 extends JextractToolRunner {
+
+    @Test
+    public void testPointerFields() {
+        Path outputPath = getOutputFilePath("output");
+        Path headerFile = getInputFilePath("test8248415.h");
+        run("-d", outputPath.toString(), headerFile.toString()).checkSuccess();
+        try(Loader loader = classLoader(outputPath)) {
+            Class<?> nodeClass = loader.loadClass("test8248415_h$Node");
+
+            // Check if getters for pointer fields were generated
+            checkMethod(nodeClass, "next$get", MemoryAddress.class, MemoryAddress.class);
+            checkMethod(nodeClass, "next$get", MemoryAddress.class, MemoryAddress.class, long.class);
+
+            // Check if setters for pointer fields were generated
+            checkMethod(nodeClass, "next$set", void.class, MemoryAddress.class, MemoryAddress.class);
+            checkMethod(nodeClass, "next$set", void.class, MemoryAddress.class, long.class, MemoryAddress.class);
+        } finally {
+            deleteDir(outputPath);
+        }
+    }
+}

--- a/test/jdk/tools/jextract/test8248415.h
+++ b/test/jdk/tools/jextract/test8248415.h
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+struct Node {
+  struct Node *next;
+};


### PR DESCRIPTION
This PR creates an adapted [`VarHandle`](https://github.com/openjdk/panama-foreign/blob/foreign-jextract/src/java.base/share/classes/java/lang/invoke/VarHandle.java) usable with [`MemoryAddress`](https://github.com/openjdk/panama-foreign/blob/foreign-jextract/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/MemoryAddress.java) carriers for pointer fields. It uses [`MemoryHandles#asAddressVarHandle`](https://github.com/openjdk/panama-foreign/blob/foreign-jextract/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/MemoryHandles.java#L334-L350) and a previously created `long` VarHandle to do so.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [JDK-8248415](https://bugs.openjdk.java.net/browse/JDK-8248415): jextract does not generate getter and setter for pointer typed fields in structs ⚠️ Title mismatch between PR and JBS.


### Reviewers
 * Jorn Vernee ([jvernee](@JornVernee) - Committer)


### Download
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/216/head:pull/216`
`$ git checkout pull/216`
