### PR TITLE
8248474: jextract uses header file name as part of identifier

### DIFF
--- a/src/jdk.incubator.jextract/share/classes/jdk/incubator/jextract/tool/Main.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/incubator/jextract/tool/Main.java
@@ -187,7 +187,7 @@ public class Main {
 
             JavaFileObject[] files = OutputFactory.generateWrapped(
                 toplevel,
-                header.getFileName().toString().replace(".h", "_h"),
+                Utils.javaSafeIdentifier(header.getFileName().toString().replace(".h", "_h"), true),
                 options.targetPackage,
                 options.libraryNames);
             jextractTask.write(output, files);

--- a/src/jdk.incubator.jextract/share/classes/jdk/incubator/jextract/tool/Utils.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/incubator/jextract/tool/Utils.java
@@ -49,10 +49,35 @@ final class Utils {
     }
 
     static String javaSafeIdentifier(String name) {
-        // We never get the problem of Java non-identifiers (like 123, ab-xy) as
-        // C identifiers. But we may have a java keyword used as a C identifier.
-        assert SourceVersion.isIdentifier(name);
+        return javaSafeIdentifier(name, false);
+    }
 
-        return SourceVersion.isKeyword(name)? (name + "_") : name;
+    static String javaSafeIdentifier(String name, boolean checkAllChars) {
+        if (checkAllChars) {
+            StringBuilder buf = new StringBuilder();
+            char[] chars = name.toCharArray();
+            if (Character.isJavaIdentifierStart(chars[0])) {
+                buf.append(chars[0]);
+            } else {
+                buf.append('_');
+            }
+            if (chars.length > 1) {
+                for (int i = 1; i < chars.length; i++) {
+                    char ch = chars[i];
+                    if (Character.isJavaIdentifierPart(ch)) {
+                        buf.append(ch);
+                    } else {
+                        buf.append('_');
+                    }
+                }
+            }
+            return buf.toString();
+        } else {
+            // We never get the problem of Java non-identifiers (like 123, ab-xy) as
+            // C identifiers. But we may have a java keyword used as a C identifier.
+            assert SourceVersion.isIdentifier(name);
+
+            return SourceVersion.isKeyword(name) ? (name + "_") : name;
+        }
     }
 }

--- a/test/jdk/tools/jextract/JDK-8248474.h
+++ b/test/jdk/tools/jextract/JDK-8248474.h
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+void func(int);

--- a/test/jdk/tools/jextract/Test8248474.java
+++ b/test/jdk/tools/jextract/Test8248474.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.nio.file.Path;
+
+import org.testng.annotations.Test;
+import static org.testng.Assert.assertNotNull;
+
+/*
+ * @test
+ * @modules jdk.incubator.jextract
+ * @library /test/lib
+ * @build JextractToolRunner
+ * @bug 8248474
+ * @summary jextract uses header file name as part of identifier
+ * @run testng/othervm -Dforeign.restricted=permit Test8248474
+ */
+public class Test8248474 extends JextractToolRunner {
+    @Test
+    public void testUnsafeHeaderName() {
+        Path test8248474Output = getOutputFilePath("test8248474_gen");
+        Path test8248474H = getInputFilePath("JDK-8248474.h");
+        run("-d", test8248474Output.toString(), test8248474H.toString()).checkSuccess();
+        try(Loader loader = classLoader(test8248474Output)) {
+            Class<?> cls = loader.loadClass("JDK_8248474_h");
+            assertNotNull(cls);
+        } finally {
+            deleteDir(test8248474Output);
+        }
+    }
+}


### PR DESCRIPTION
Generating safe class name for header class
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [JDK-8248474](https://bugs.openjdk.java.net/browse/JDK-8248474): jextract uses header file name as part of identifier


### Reviewers
 * Maurizio Cimadamore ([mcimadamore](@mcimadamore) - Committer)


### Download
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/218/head:pull/218`
`$ git checkout pull/218`
