### PR TITLE
8248484: jextract should use raw names for generated identifiers as much as possible

### DIFF
--- a/src/jdk.incubator.jextract/share/classes/jdk/incubator/jextract/tool/OutputFactory.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/incubator/jextract/tool/OutputFactory.java
@@ -81,11 +81,12 @@ public class OutputFactory implements Declaration.Visitor<Void, Declaration> {
      * generating unique case-insensitive names for nested classes.
      */
     private String uniqueNestedClassName(String name) {
+        name = Utils.javaSafeIdentifier(name);
         return nestedClassNames.add(name.toLowerCase())? name : (name + "$" + nestedClassNameCount++);
     }
 
     private String structClassName(Declaration decl) {
-        return structClassNames.computeIfAbsent(decl, d -> uniqueNestedClassName("C" + d.name()));
+        return structClassNames.computeIfAbsent(decl, d -> uniqueNestedClassName(d.name()));
     }
 
     private boolean structDefinitionSeen(Declaration decl) {
@@ -146,7 +147,7 @@ public class OutputFactory implements Declaration.Visitor<Void, Declaration> {
         for (Declaration.Typedef td : unresolvedStructTypedefs) {
             Declaration.Scoped structDef = ((Type.Declared)td.type()).tree();
             if (structDefinitionSeen(structDef)) {
-                builder.emitTypedef(uniqueNestedClassName("C" + td.name()), structClassName(structDef));
+                builder.emitTypedef(uniqueNestedClassName(td.name()), structClassName(structDef));
             }
         }
         builder.classEnd();
@@ -358,7 +359,7 @@ public class OutputFactory implements Declaration.Visitor<Void, Declaration> {
                              * };
                              */
                             if (structDefinitionSeen(s)) {
-                                builder.emitTypedef(uniqueNestedClassName("C" + tree.name()), structClassName(s));
+                                builder.emitTypedef(uniqueNestedClassName(tree.name()), structClassName(s));
                             } else {
                                 /*
                                  * Definition of typedef'ed struct/union not seen yet. May be the definition comes later.
@@ -374,7 +375,7 @@ public class OutputFactory implements Declaration.Visitor<Void, Declaration> {
                 }
             }
         } else if (type instanceof Type.Primitive) {
-             builder.emitPrimitiveTypedef((Type.Primitive)type, uniqueNestedClassName("C" + tree.name()));
+             builder.emitPrimitiveTypedef((Type.Primitive)type, uniqueNestedClassName(tree.name()));
         }
         return null;
     }

--- a/src/jdk.incubator.jextract/share/classes/jdk/incubator/jextract/tool/StructBuilder.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/incubator/jextract/tool/StructBuilder.java
@@ -64,7 +64,7 @@ class StructBuilder extends JavaSourceBuilder {
 
     @Override
     public void addLayoutGetter(String javaName, MemoryLayout layout) {
-        var desc = constantHelper.addLayout(javaName, layout);
+        var desc = constantHelper.addLayout(javaName + "$struct", layout);
         incrAlign();
         indent();
         sb.append(PUB_MODS + displayName(desc.invocationType().returnType()) + " $LAYOUT() {\n");

--- a/test/jdk/tools/jextract/RepeatedDeclsTest.java
+++ b/test/jdk/tools/jextract/RepeatedDeclsTest.java
@@ -82,19 +82,19 @@ public class RepeatedDeclsTest extends JextractToolRunner {
             checkIntGetter(cls, "Y", 2);
 
             // check Point layout
-            Class<?> pointCls = loader.loadClass("repeatedDecls_h$CPoint");
+            Class<?> pointCls = loader.loadClass("repeatedDecls_h$Point");
             checkPoint(pointCls);
-            Class<?> point_tCls = loader.loadClass("repeatedDecls_h$CPoint_t");
+            Class<?> point_tCls = loader.loadClass("repeatedDecls_h$Point_t");
             checkPoint(point_tCls);
             assertTrue(pointCls.isAssignableFrom(point_tCls));
-            Class<?> point$0Cls = loader.loadClass("repeatedDecls_h$CPOINT$0");
+            Class<?> point$0Cls = loader.loadClass("repeatedDecls_h$POINT$0");
             checkPoint(point$0Cls);
             assertTrue(pointCls.isAssignableFrom(point$0Cls));
 
             // check Point3D layout
-            Class<?> point3DCls = loader.loadClass("repeatedDecls_h$CPoint3D");
+            Class<?> point3DCls = loader.loadClass("repeatedDecls_h$Point3D");
             checkPoint3D(point3DCls);
-            Class<?> point3D_tCls = loader.loadClass("repeatedDecls_h$CPoint3D_t");
+            Class<?> point3D_tCls = loader.loadClass("repeatedDecls_h$Point3D_t");
             checkPoint3D(point3D_tCls);
             assertTrue(point3DCls.isAssignableFrom(point3D_tCls));
         } finally {

--- a/test/jdk/tools/jextract/Test8240811.java
+++ b/test/jdk/tools/jextract/Test8240811.java
@@ -50,7 +50,7 @@ public class Test8240811 extends JextractToolRunner {
             assertNotNull(cls);
 
             // check foo layout
-            Class<?> fooCls = loader.loadClass("name_collision_h$Cfoo");
+            Class<?> fooCls = loader.loadClass("name_collision_h$foo");
             MemoryLayout fooLayout = findLayout(fooCls);
             assertNotNull(fooLayout);
             assertTrue(((GroupLayout)fooLayout).isStruct());
@@ -62,7 +62,7 @@ public class Test8240811 extends JextractToolRunner {
             assertNotNull(fooVarLayout);
 
             // check foo2 layout
-            Class<?> foo2Cls = loader.loadClass("name_collision_h$Cfoo2");
+            Class<?> foo2Cls = loader.loadClass("name_collision_h$foo2");
             MemoryLayout foo2Layout = findLayout(foo2Cls);
             assertNotNull(foo2Layout);
             assertTrue(((GroupLayout)foo2Layout).isUnion());
@@ -76,7 +76,7 @@ public class Test8240811 extends JextractToolRunner {
             assertNotNull(barVarLayout);
 
             // check bar layout
-            Class<?> barCls = loader.loadClass("name_collision_h$Cbar");
+            Class<?> barCls = loader.loadClass("name_collision_h$bar");
             MemoryLayout barLayout = findLayout(barCls);
             assertNotNull(barLayout);
             assertTrue(((GroupLayout)barLayout).isStruct());
@@ -87,7 +87,7 @@ public class Test8240811 extends JextractToolRunner {
             assertNotNull(bar2VarLayout);
 
             // check bar layout
-            Class<?> bar2Cls = loader.loadClass("name_collision_h$Cbar2");
+            Class<?> bar2Cls = loader.loadClass("name_collision_h$bar2");
             MemoryLayout bar2Layout = findLayout(bar2Cls);
             assertNotNull(bar2Layout);
             assertTrue(((GroupLayout)bar2Layout).isUnion());

--- a/test/jdk/tools/jextract/Test8244412.java
+++ b/test/jdk/tools/jextract/Test8244412.java
@@ -41,9 +41,9 @@ public class Test8244412 extends JextractToolRunner {
         Path typedefsH = getInputFilePath("typedefs.h");
         run("-d", typedefsOutput.toString(), typedefsH.toString()).checkSuccess();
         try(Loader loader = classLoader(typedefsOutput)) {
-            Class<?> bytetCls = loader.loadClass("typedefs_h$Cbyte_t");
+            Class<?> bytetCls = loader.loadClass("typedefs_h$byte_t");
             assertNotNull(bytetCls);
-            Class<?> sizetCls = loader.loadClass("typedefs_h$Cmysize_t");
+            Class<?> sizetCls = loader.loadClass("typedefs_h$mysize_t");
             assertNotNull(sizetCls);
         } finally {
             deleteDir(typedefsOutput);

--- a/test/jdk/tools/jextract/Test8244512.java
+++ b/test/jdk/tools/jextract/Test8244512.java
@@ -57,6 +57,6 @@ public class Test8244512 extends JextractToolRunner {
     }
 
     private static void checkClass(Loader loader, String name) {
-        assertNotNull(loader.loadClass("nested_h$C" + name));
+        assertNotNull(loader.loadClass("nested_h$" + name));
     }
 }

--- a/test/jdk/tools/jextract/Test8245767.java
+++ b/test/jdk/tools/jextract/Test8245767.java
@@ -48,15 +48,15 @@ public class Test8245767 extends JextractToolRunner {
             assertNotNull(cls);
 
             // no class should be generated for typedef on opaque struct
-            Class<?> fooCls = loader.loadClass("test8245767_h$CFoo");
+            Class<?> fooCls = loader.loadClass("test8245767_h$Foo");
             assertNull(fooCls);
 
             // check Point_t
-            Class<?> point_tCls = loader.loadClass("test8245767_h$CPoint_t");
+            Class<?> point_tCls = loader.loadClass("test8245767_h$Point_t");
             assertNotNull(point_tCls);
 
             // check Point
-            Class<?> pointCls = loader.loadClass("test8245767_h$CPoint");
+            Class<?> pointCls = loader.loadClass("test8245767_h$Point");
             assertNotNull(pointCls);
             assertTrue(pointCls.isAssignableFrom(point_tCls));
         } finally {

--- a/test/jdk/tools/jextract/UniondeclTest.java
+++ b/test/jdk/tools/jextract/UniondeclTest.java
@@ -47,7 +47,7 @@ public class UniondeclTest extends JextractToolRunner {
             // check a method for "void func(IntOrFloat*)"
             assertNotNull(findMethod(cls, "func", MemoryAddress.class));
             // check IntOrFloat layout
-            Class<?> intOrFloatCls = loader.loadClass("uniondecl_h$CIntOrFloat");
+            Class<?> intOrFloatCls = loader.loadClass("uniondecl_h$IntOrFloat");
             GroupLayout intOrFloatLayout = (GroupLayout)findLayout(intOrFloatCls);
             assertNotNull(intOrFloatLayout);
             assertTrue(intOrFloatLayout.isUnion());

--- a/test/jdk/tools/jextract/test8244412/LibTest8244412Test.java
+++ b/test/jdk/tools/jextract/test8244412/LibTest8244412Test.java
@@ -44,11 +44,11 @@ public class LibTest8244412Test {
     @Test
     public void test() {
         try (var scope = NativeScope.unboundedScope()) {
-            var addr = Cmysize_t.allocate(0L, scope);
-            assertEquals(Cmysize_t.get(addr), 0L);
-            Cmysize_t.set(addr, 13455566L);
-            assertEquals(Cmysize_t.get(addr), 13455566L);
-            assertTrue(Cmysize_t.sizeof() == Clong_long.sizeof());
+            var addr = mysize_t.allocate(0L, scope);
+            assertEquals(mysize_t.get(addr), 0L);
+            mysize_t.set(addr, 13455566L);
+            assertEquals(mysize_t.get(addr), 13455566L);
+            assertTrue(mysize_t.sizeof() == Clong_long.sizeof());
         }
     }
 }

--- a/test/jdk/tools/jextract/test8244938/Test8244938.java
+++ b/test/jdk/tools/jextract/test8244938/Test8244938.java
@@ -38,11 +38,11 @@ public class Test8244938 {
     @Test
     public void testNestedStructReturn() {
          var seg = func();
-         assertEquals(seg.byteSize(), CPoint.sizeof());
+         assertEquals(seg.byteSize(), Point.sizeof());
          var addr = seg.baseAddress();
-         assertEquals(CPoint.k$get(addr), 44);
-         var point2dAddr = CPoint.point2d$addr(addr);
-         assertEquals(CPoint2D.i$get(point2dAddr), 567);
-         assertEquals(CPoint2D.j$get(point2dAddr), 33);
+         assertEquals(Point.k$get(addr), 44);
+         var point2dAddr = Point.point2d$addr(addr);
+         assertEquals(Point2D.i$get(point2dAddr), 567);
+         assertEquals(Point2D.j$get(point2dAddr), 33);
     }
 }

--- a/test/jdk/tools/jextract/test8245003/Test8245003.java
+++ b/test/jdk/tools/jextract/test8245003/Test8245003.java
@@ -39,17 +39,17 @@ public class Test8245003 {
     @Test
     public void testStructAccessor() {
         var addr = special_pt$ADDR();
-        assertEquals(addr.segment().byteSize(), CPoint.sizeof());
-        assertEquals(CPoint.x$get(addr), 56);
-        assertEquals(CPoint.y$get(addr), 75);
+        assertEquals(addr.segment().byteSize(), Point.sizeof());
+        assertEquals(Point.x$get(addr), 56);
+        assertEquals(Point.y$get(addr), 75);
 
         addr = special_pt3d$ADDR();
-        assertEquals(addr.segment().byteSize(), CPoint3D.sizeof());
-        assertEquals(CPoint3D.z$get(addr), 35);
-        var pointAddr = CPoint3D.p$addr(addr);
-        assertEquals(pointAddr.segment().byteSize(), CPoint.sizeof());
-        assertEquals(CPoint.x$get(pointAddr), 43);
-        assertEquals(CPoint.y$get(pointAddr), 45);
+        assertEquals(addr.segment().byteSize(), Point3D.sizeof());
+        assertEquals(Point3D.z$get(addr), 35);
+        var pointAddr = Point3D.p$addr(addr);
+        assertEquals(pointAddr.segment().byteSize(), Point.sizeof());
+        assertEquals(Point.x$get(pointAddr), 43);
+        assertEquals(Point.y$get(pointAddr), 45);
     }
 
     @Test
@@ -65,9 +65,9 @@ public class Test8245003 {
         assertEquals(arr[4], 345);
 
         addr = foo$ADDR();
-        assertEquals(addr.segment().byteSize(), CFoo.sizeof());
-        assertEquals(CFoo.count$get(addr), 37);
-        var greeting = CFoo.greeting$addr(addr);
+        assertEquals(addr.segment().byteSize(), Foo.sizeof());
+        assertEquals(Foo.count$get(addr), 37);
+        var greeting = Foo.greeting$addr(addr);
         byte[] barr = Cchar.toJavaArray(greeting.segment());
         assertEquals(new String(barr), "hello");
     }

--- a/test/jdk/tools/jextract/test8246400/LibTest8246400Test.java
+++ b/test/jdk/tools/jextract/test8246400/LibTest8246400Test.java
@@ -46,23 +46,23 @@ public class LibTest8246400Test {
         MemorySegment sum = null;
         MemoryAddress callback = null;
         try (var scope = NativeScope.unboundedScope()) {
-            var v1 = CVector.allocate(scope);
-            CVector.x$set(v1, 1.0);
-            CVector.y$set(v1, 0.0);
+            var v1 = Vector.allocate(scope);
+            Vector.x$set(v1, 1.0);
+            Vector.y$set(v1, 0.0);
 
-            var v2 = CVector.allocate(scope);
-            CVector.x$set(v2, 0.0);
-            CVector.y$set(v2, 1.0);
+            var v2 = Vector.allocate(scope);
+            Vector.x$set(v2, 0.0);
+            Vector.y$set(v2, 1.0);
 
             sum = add(v1.segment(), v2.segment());
             sum = scope.register(sum);
 
-            assertEquals(CVector.x$get(sum.baseAddress()), 1.0, 0.1);
-            assertEquals(CVector.y$get(sum.baseAddress()), 1.0, 0.1);
+            assertEquals(Vector.x$get(sum.baseAddress()), 1.0, 0.1);
+            assertEquals(Vector.y$get(sum.baseAddress()), 1.0, 0.1);
 
             callback = cosine_similarity$dot.allocate((a, b) -> {
-                return (CVector.x$get(a.baseAddress()) * CVector.x$get(b.baseAddress())) +
-                    (CVector.y$get(a.baseAddress()) * CVector.y$get(b.baseAddress()));
+                return (Vector.x$get(a.baseAddress()) * Vector.x$get(b.baseAddress())) +
+                    (Vector.y$get(a.baseAddress()) * Vector.y$get(b.baseAddress()));
             }, scope);
 
             var value = cosine_similarity(v1.segment(), v2.segment(), callback);

--- a/test/jdk/tools/jextract/testClassGen/TestClassGeneration.java
+++ b/test/jdk/tools/jextract/testClassGen/TestClassGeneration.java
@@ -197,7 +197,7 @@ public class TestClassGeneration extends JextractToolRunner {
     public void testStructMember(String structName, MemoryLayout memberLayout, Class<?> expectedType, Object testValue) throws Throwable {
         String memberName = memberLayout.name().orElseThrow();
 
-        Class<?> structCls = loader.loadClass("com.acme.examples_h$C" + structName);
+        Class<?> structCls = loader.loadClass("com.acme.examples_h$" + structName);
         Method layout_getter = checkMethod(structCls, "$LAYOUT", MemoryLayout.class);
         MemoryLayout structLayout = (MemoryLayout) layout_getter.invoke(null);
         try (MemorySegment struct = MemorySegment.allocateNative(structLayout)) {

--- a/test/jdk/tools/jextract/testStruct/LibStructTest.java
+++ b/test/jdk/tools/jextract/testStruct/LibStructTest.java
@@ -42,33 +42,33 @@ public class LibStructTest {
     public void testMakePoint() {
         try (var seg = makePoint(42, -39)) {
             var addr = seg.baseAddress();
-            assertEquals(CPoint.x$get(addr), 42);
-            assertEquals(CPoint.y$get(addr), -39);
+            assertEquals(Point.x$get(addr), 42);
+            assertEquals(Point.y$get(addr), -39);
         }
     }
 
     @Test
     public void testAllocate() {
-        try (var seg = CPoint.allocate()) {
+        try (var seg = Point.allocate()) {
             var addr = seg.baseAddress();
-            CPoint.x$set(addr, 56);
-            CPoint.y$set(addr, 65);
-            assertEquals(CPoint.x$get(addr), 56);
-            assertEquals(CPoint.y$get(addr), 65);
+            Point.x$set(addr, 56);
+            Point.y$set(addr, 65);
+            assertEquals(Point.x$get(addr), 56);
+            assertEquals(Point.y$get(addr), 65);
         }
     }
 
     @Test
     public void testAllocateArray() {
-        try (var seg = CPoint.allocateArray(3)) {
+        try (var seg = Point.allocateArray(3)) {
             var addr = seg.baseAddress();
             for (int i = 0; i < 3; i++) {
-                CPoint.x$set(addr, i, 56 + i);
-                CPoint.y$set(addr, i, 65 + i);
+                Point.x$set(addr, i, 56 + i);
+                Point.y$set(addr, i, 65 + i);
             }
             for (int i = 0; i < 3; i++) {
-                assertEquals(CPoint.x$get(addr, i), 56 + i);
-                assertEquals(CPoint.y$get(addr, i), 65 + i);
+                assertEquals(Point.x$get(addr, i), 56 + i);
+                assertEquals(Point.y$get(addr, i), 65 + i);
             }
         }
     }
@@ -79,7 +79,7 @@ public class LibStructTest {
 
     @Test
     public void testFieldTypes() {
-        GroupLayout g = (GroupLayout)CAllTypes.$LAYOUT();
+        GroupLayout g = (GroupLayout)AllTypes.$LAYOUT();
         checkField(g, "sc", CSupport.C_CHAR);
         checkField(g, "uc", CSupport.C_CHAR);
         checkField(g, "s",  CSupport.C_SHORT);


### PR DESCRIPTION
jextracts avoid "C" prefix for struct/union/typedef nested classes.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [JDK-8248484](https://bugs.openjdk.java.net/browse/JDK-8248484): jextract should use raw names for generated identifiers as much as possible


### Reviewers
 * Jorn Vernee ([jvernee](@JornVernee) - Committer)
 * Maurizio Cimadamore ([mcimadamore](@mcimadamore) - Committer)


### Download
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/220/head:pull/220`
`$ git checkout pull/220`
