### PR TITLE
8248499: Add methods to allocate off heap arrays from Java arrays

### DIFF
--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/MemoryAccess.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/MemoryAccess.java
@@ -1,0 +1,744 @@
+package jdk.incubator.foreign;
+
+import java.lang.invoke.VarHandle;
+import java.nio.ByteOrder;
+
+/**
+ * This class defines ready-made static accessors which can be used to dereference memory segments in many ways.
+ * Each accessor (see {@link #getInt(MemoryAddress, long)} takes a <em>base</em> address and an offset (expressed in bytes).
+ * The final address at which the dereference will occur will be computed by offsetting the base address by
+ * the specified offset, as if by calling {@link MemoryAddress#addOffset(long)} on the specified base address.
+ */
+public final class MemoryAccess {
+
+    private MemoryAccess() {
+        // just the one
+    }
+
+    private static final VarHandle byte_LE_handle = indexedHandle(MemoryLayouts.BITS_8_LE, byte.class);
+    private static final VarHandle char_LE_handle = indexedHandle(MemoryLayouts.BITS_16_LE, char.class);
+    private static final VarHandle short_LE_handle = indexedHandle(MemoryLayouts.BITS_16_LE, short.class);
+    private static final VarHandle int_LE_handle = indexedHandle(MemoryLayouts.BITS_32_LE, int.class);
+    private static final VarHandle float_LE_handle = indexedHandle(MemoryLayouts.BITS_32_LE, float.class);
+    private static final VarHandle long_LE_handle = indexedHandle(MemoryLayouts.BITS_64_LE, long.class);
+    private static final VarHandle double_LE_handle = indexedHandle(MemoryLayouts.BITS_64_LE, double.class);
+    private static final VarHandle byte_BE_handle = indexedHandle(MemoryLayouts.BITS_8_BE, byte.class);
+    private static final VarHandle char_BE_handle = indexedHandle(MemoryLayouts.BITS_16_BE, char.class);
+    private static final VarHandle short_BE_handle = indexedHandle(MemoryLayouts.BITS_16_BE, short.class);
+    private static final VarHandle int_BE_handle = indexedHandle(MemoryLayouts.BITS_32_BE, int.class);
+    private static final VarHandle float_BE_handle = indexedHandle(MemoryLayouts.BITS_32_BE, float.class);
+    private static final VarHandle long_BE_handle = indexedHandle(MemoryLayouts.BITS_64_BE, long.class);
+    private static final VarHandle double_BE_handle = indexedHandle(MemoryLayouts.BITS_64_BE, double.class);
+    private static final VarHandle address_handle = MemoryHandles.asAddressVarHandle((ByteOrder.nativeOrder() == ByteOrder.BIG_ENDIAN) ? long_BE_handle : long_LE_handle);
+
+    /**
+     * Read a byte from given address and offset, with byte order set to {@link ByteOrder#LITTLE_ENDIAN}.
+     * <p>
+     * This is equivalent to the following code:
+     * <blockquote><pre>{@code
+    VarHandle handle = MemoryHandles.withStride(BITS_8_LE.withBitAlignment(8).varHandle(byte.class), 1L);
+    byte value = (byte)handle.get(addr, offset);
+     * }</pre></blockquote>
+     *
+     * @param addr base address.
+     * @param offset offset (relative to {@code addr}). The final address of this read operation can be expressed as {@code addr.addOffset(offset)}.
+     * @return a byte value read from {@code addr} at the offset specified by {@code offset}.
+     */
+    public static byte getByte_LE(MemoryAddress addr, long offset) {
+        return (byte)byte_LE_handle.get(addr, offset);
+    }
+
+    /**
+     * Writes a byte at given address and offset, with byte order set to {@link ByteOrder#LITTLE_ENDIAN}.
+     * <p>
+     * This is equivalent to the following code:
+     * <blockquote><pre>{@code
+    VarHandle handle = MemoryHandles.withStride(BITS_8_LE.withBitAlignment(8).varHandle(byte.class), 1L);
+    handle.set(addr, offset, value);
+     * }</pre></blockquote>
+     * @param addr base address.
+     * @param offset offset (relative to {@code addr}). The final address of this read operation can be expressed as {@code addr.addOffset(offset)}.
+     * @param value the byte value to be written.
+     */
+    public static void setByte_LE(MemoryAddress addr, long offset, byte value) {
+        byte_LE_handle.set(addr, offset, value);
+    }
+
+    /**
+     * Read a char from given address and offset, with byte order set to {@link ByteOrder#LITTLE_ENDIAN}.
+     * <p>
+     * This is equivalent to the following code:
+     * <blockquote><pre>{@code
+    VarHandle handle = MemoryHandles.withStride(BITS_16_LE.withBitAlignment(8).varHandle(char.class), 1L);
+    char value = (char)handle.get(addr, offset);
+     * }</pre></blockquote>
+     * @param addr base address.
+     * @param offset offset (relative to {@code addr}). The final address of this read operation can be expressed as {@code addr.addOffset(offset)}.
+     * @return a char value read from {@code addr} at the offset specified by {@code offset}.
+     */
+    public static char getChar_LE(MemoryAddress addr, long offset) {
+        return (char)char_LE_handle.get(addr, offset);
+    }
+
+    /**
+     * Writes a char at given address and offset, with byte order set to {@link ByteOrder#LITTLE_ENDIAN}.
+     * <p>
+     * This is equivalent to the following code:
+     * <blockquote><pre>{@code
+    VarHandle handle = MemoryHandles.withStride(BITS_16_LE.withBitAlignment(8).varHandle(char.class), 1L);
+    handle.set(addr, offset, value);
+     * }</pre></blockquote>
+     * @param addr base address.
+     * @param offset offset (relative to {@code addr}). The final address of this read operation can be expressed as {@code addr.addOffset(offset)}.
+     * @param value the char value to be written.
+     */
+    public static void setChar_LE(MemoryAddress addr, long offset, char value) {
+        char_LE_handle.set(addr, offset, value);
+    }
+
+    /**
+     * Read a short from given address and offset, with byte order set to {@link ByteOrder#LITTLE_ENDIAN}.
+     * <p>
+     * This is equivalent to the following code:
+     * <blockquote><pre>{@code
+    VarHandle handle = MemoryHandles.withStride(BITS_16_LE.withBitAlignment(8).varHandle(short.class), 1L);
+    short value = (short)handle.get(addr, offset);
+     * }</pre></blockquote>
+     * @param addr base address.
+     * @param offset offset (relative to {@code addr}). The final address of this read operation can be expressed as {@code addr.addOffset(offset)}.
+     * @return a short value read from {@code addr} at the offset specified by {@code offset}.
+     */
+    public static short getShort_LE(MemoryAddress addr, long offset) {
+        return (short)short_LE_handle.get(addr, offset);
+    }
+
+    /**
+     * Writes a short at given address and offset, with byte order set to {@link ByteOrder#LITTLE_ENDIAN}.
+     * <p>
+     * This is equivalent to the following code:
+     * <blockquote><pre>{@code
+    VarHandle handle = MemoryHandles.withStride(BITS_16_LE.withBitAlignment(8).varHandle(short.class), 1L);
+    handle.set(addr, offset, value);
+     * }</pre></blockquote>
+     * @param addr base address.
+     * @param offset offset (relative to {@code addr}). The final address of this read operation can be expressed as {@code addr.addOffset(offset)}.
+     * @param value the short value to be written.
+     */
+    public static void setShort_LE(MemoryAddress addr, long offset, short value) {
+        short_LE_handle.set(addr, offset, value);
+    }
+
+    /**
+     * Read an int from given address and offset, with byte order set to {@link ByteOrder#LITTLE_ENDIAN}.
+     * <p>
+     * This is equivalent to the following code:
+     * <blockquote><pre>{@code
+    VarHandle handle = MemoryHandles.withStride(BITS_32_LE.withBitAlignment(8).varHandle(int.class), 1L);
+    int value = (int)handle.get(addr, offset);
+     * }</pre></blockquote>
+     * @param addr base address.
+     * @param offset offset (relative to {@code addr}). The final address of this read operation can be expressed as {@code addr.addOffset(offset)}.
+     * @return an int value read from {@code addr} at the offset specified by {@code offset}.
+     */
+    public static int getInt_LE(MemoryAddress addr, long offset) {
+        return (int)int_LE_handle.get(addr, offset);
+    }
+
+    /**
+     * Writes an int at given address and offset, with byte order set to {@link ByteOrder#LITTLE_ENDIAN}.
+     * <p>
+     * This is equivalent to the following code:
+     * <blockquote><pre>{@code
+    VarHandle handle = MemoryHandles.withStride(BITS_32_LE.withBitAlignment(8).varHandle(int.class), 1L);
+    handle.set(addr, offset, value);
+     * }</pre></blockquote>
+     * @param addr base address.
+     * @param offset offset (relative to {@code addr}). The final address of this read operation can be expressed as {@code addr.addOffset(offset)}.
+     * @param value the int value to be written.
+     */
+    public static void setInt_LE(MemoryAddress addr, long offset, int value) {
+        int_LE_handle.set(addr, offset, value);
+    }
+
+    /**
+     * Read a float from given address and offset, with byte order set to {@link ByteOrder#LITTLE_ENDIAN}.
+     * <p>
+     * This is equivalent to the following code:
+     * <blockquote><pre>{@code
+    VarHandle handle = MemoryHandles.withStride(BITS_32_LE.withBitAlignment(8).varHandle(float.class), 1L);
+    float value = (float)handle.get(addr, offset);
+     * }</pre></blockquote>
+     * @param addr base address.
+     * @param offset offset (relative to {@code addr}). The final address of this read operation can be expressed as {@code addr.addOffset(offset)}.
+     * @return a float value read from {@code addr} at the offset specified by {@code offset}.
+     */
+    public static float getFloat_LE(MemoryAddress addr, long offset) {
+        return (float)float_LE_handle.get(addr, offset);
+    }
+
+    /**
+     * Writes a float at given address and offset, with byte order set to {@link ByteOrder#LITTLE_ENDIAN}.
+     * <p>
+     * This is equivalent to the following code:
+     * <blockquote><pre>{@code
+    VarHandle handle = MemoryHandles.withStride(BITS_32_LE.withBitAlignment(8).varHandle(float.class), 1L);
+    handle.set(addr, offset, value);
+     * }</pre></blockquote>
+     * @param addr base address.
+     * @param offset offset (relative to {@code addr}). The final address of this read operation can be expressed as {@code addr.addOffset(offset)}.
+     * @param value the float value to be written.
+     */
+    public static void setFloat_LE(MemoryAddress addr, long offset, float value) {
+        float_LE_handle.set(addr, offset, value);
+    }
+
+    /**
+     * Read a long from given address and offset, with byte order set to {@link ByteOrder#LITTLE_ENDIAN}.
+     * <p>
+     * This is equivalent to the following code:
+     * <blockquote><pre>{@code
+    VarHandle handle = MemoryHandles.withStride(BITS_64_LE.withBitAlignment(8).varHandle(long.class), 1L);
+    long value = (long)handle.get(addr, offset);
+     * }</pre></blockquote>
+     * @param addr base address.
+     * @param offset offset (relative to {@code addr}). The final address of this read operation can be expressed as {@code addr.addOffset(offset)}.
+     * @return a long value read from {@code addr} at the offset specified by {@code offset}.
+     */
+    public static long getLong_LE(MemoryAddress addr, long offset) {
+        return (long)long_LE_handle.get(addr, offset);
+    }
+
+    /**
+     * Writes a long at given address and offset, with byte order set to {@link ByteOrder#LITTLE_ENDIAN}.
+     * <p>
+     * This is equivalent to the following code:
+     * <blockquote><pre>{@code
+    VarHandle handle = MemoryHandles.withStride(BITS_64_LE.withBitAlignment(8).varHandle(long.class), 1L);
+    handle.set(addr, offset, value);
+     * }</pre></blockquote>
+     * @param addr base address.
+     * @param offset offset (relative to {@code addr}). The final address of this read operation can be expressed as {@code addr.addOffset(offset)}.
+     * @param value the long value to be written.
+     */
+    public static void setLong_LE(MemoryAddress addr, long offset, long value) {
+        long_LE_handle.set(addr, offset, value);
+    }
+
+    /**
+     * Read a double from given address and offset, with byte order set to {@link ByteOrder#LITTLE_ENDIAN}.
+     * <p>
+     * This is equivalent to the following code:
+     * <blockquote><pre>{@code
+    VarHandle handle = MemoryHandles.withStride(BITS_32_LE.withBitAlignment(8).varHandle(double.class), 1L);
+    double value = (double)handle.get(addr, offset);
+     * }</pre></blockquote>
+     * @param addr base address.
+     * @param offset offset (relative to {@code addr}). The final address of this read operation can be expressed as {@code addr.addOffset(offset)}.
+     * @return a double value read from {@code addr} at the offset specified by {@code offset}.
+     */
+    public static double getDouble_LE(MemoryAddress addr, long offset) {
+        return (double)double_LE_handle.get(addr, offset);
+    }
+
+    /**
+     * Writes a double at given address and offset, with byte order set to {@link ByteOrder#LITTLE_ENDIAN}.
+     * <p>
+     * This is equivalent to the following code:
+     * <blockquote><pre>{@code
+    VarHandle handle = MemoryHandles.withStride(BITS_64_LE.withBitAlignment(8).varHandle(double.class), 1L);
+    handle.set(addr, offset, value);
+     * }</pre></blockquote>
+     * @param addr base address.
+     * @param offset offset (relative to {@code addr}). The final address of this read operation can be expressed as {@code addr.addOffset(offset)}.
+     * @param value the double value to be written.
+     */
+    public static void setDouble_LE(MemoryAddress addr, long offset, double value) {
+        double_LE_handle.set(addr, offset, value);
+    }
+
+    /**
+     * Read a byte from given address and offset, with byte order set to {@link ByteOrder#BIG_ENDIAN}.
+     * <p>
+     * This is equivalent to the following code:
+     * <blockquote><pre>{@code
+    VarHandle handle = MemoryHandles.withStride(BITS_8_BE.withBitAlignment(8).varHandle(byte.class), 1L);
+    byte value = (byte)handle.get(addr, offset);
+     * }</pre></blockquote>
+     *
+     * @param addr base address.
+     * @param offset offset (relative to {@code addr}). The final address of this read operation can be expressed as {@code addr.addOffset(offset)}.
+     * @return a byte value read from {@code addr} at the offset specified by {@code offset}.
+     */
+    public static byte getByte_BE(MemoryAddress addr, long offset) {
+        return (byte)byte_BE_handle.get(addr, offset);
+    }
+
+    /**
+     * Writes a byte at given address and offset, with byte order set to {@link ByteOrder#BIG_ENDIAN}.
+     * <p>
+     * This is equivalent to the following code:
+     * <blockquote><pre>{@code
+    VarHandle handle = MemoryHandles.withStride(BITS_8_BE.withBitAlignment(8).varHandle(byte.class), 1L);
+    handle.set(addr, offset, value);
+     * }</pre></blockquote>
+     * @param addr base address.
+     * @param offset offset (relative to {@code addr}). The final address of this read operation can be expressed as {@code addr.addOffset(offset)}.
+     * @param value the byte value to be written.
+     */
+    public static void setByte_BE(MemoryAddress addr, long offset, byte value) {
+        byte_BE_handle.set(addr, offset, value);
+    }
+
+    /**
+     * Read a char from given address and offset, with byte order set to {@link ByteOrder#BIG_ENDIAN}.
+     * <p>
+     * This is equivalent to the following code:
+     * <blockquote><pre>{@code
+    VarHandle handle = MemoryHandles.withStride(BITS_16_BE.withBitAlignment(8).varHandle(char.class), 1L);
+    char value = (char)handle.get(addr, offset);
+     * }</pre></blockquote>
+     * @param addr base address.
+     * @param offset offset (relative to {@code addr}). The final address of this read operation can be expressed as {@code addr.addOffset(offset)}.
+     * @return a char value read from {@code addr} at the offset specified by {@code offset}.
+     */
+    public static char getChar_BE(MemoryAddress addr, long offset) {
+        return (char)char_BE_handle.get(addr, offset);
+    }
+
+    /**
+     * Writes a char at given address and offset, with byte order set to {@link ByteOrder#BIG_ENDIAN}.
+     * <p>
+     * This is equivalent to the following code:
+     * <blockquote><pre>{@code
+    VarHandle handle = MemoryHandles.withStride(BITS_16_BE.withBitAlignment(8).varHandle(char.class), 1L);
+    handle.set(addr, offset, value);
+     * }</pre></blockquote>
+     * @param addr base address.
+     * @param offset offset (relative to {@code addr}). The final address of this read operation can be expressed as {@code addr.addOffset(offset)}.
+     * @param value the char value to be written.
+     */
+    public static void setChar_BE(MemoryAddress addr, long offset, char value) {
+        char_BE_handle.set(addr, offset, value);
+    }
+
+    /**
+     * Read a short from given address and offset, with byte order set to {@link ByteOrder#BIG_ENDIAN}.
+     * <p>
+     * This is equivalent to the following code:
+     * <blockquote><pre>{@code
+    VarHandle handle = MemoryHandles.withStride(BITS_16_BE.withBitAlignment(8).varHandle(short.class), 1L);
+    short value = (short)handle.get(addr, offset);
+     * }</pre></blockquote>
+     * @param addr base address.
+     * @param offset offset (relative to {@code addr}). The final address of this read operation can be expressed as {@code addr.addOffset(offset)}.
+     * @return a short value read from {@code addr} at the offset specified by {@code offset}.
+     */
+    public static short getShort_BE(MemoryAddress addr, long offset) {
+        return (short)short_BE_handle.get(addr, offset);
+    }
+
+    /**
+     * Writes a short at given address and offset, with byte order set to {@link ByteOrder#BIG_ENDIAN}.
+     * <p>
+     * This is equivalent to the following code:
+     * <blockquote><pre>{@code
+    VarHandle handle = MemoryHandles.withStride(BITS_16_BE.withBitAlignment(8).varHandle(short.class), 1L);
+    handle.set(addr, offset, value);
+     * }</pre></blockquote>
+     * @param addr base address.
+     * @param offset offset (relative to {@code addr}). The final address of this read operation can be expressed as {@code addr.addOffset(offset)}.
+     * @param value the short value to be written.
+     */
+    public static void setShort_BE(MemoryAddress addr, long offset, short value) {
+        short_BE_handle.set(addr, offset, value);
+    }
+
+    /**
+     * Read an int from given address and offset, with byte order set to {@link ByteOrder#BIG_ENDIAN}.
+     * <p>
+     * This is equivalent to the following code:
+     * <blockquote><pre>{@code
+    VarHandle handle = MemoryHandles.withStride(BITS_32_BE.withBitAlignment(8).varHandle(int.class), 1L);
+    int value = (int)handle.get(addr, offset);
+     * }</pre></blockquote>
+     * @param addr base address.
+     * @param offset offset (relative to {@code addr}). The final address of this read operation can be expressed as {@code addr.addOffset(offset)}.
+     * @return an int value read from {@code addr} at the offset specified by {@code offset}.
+     */
+    public static int getInt_BE(MemoryAddress addr, long offset) {
+        return (int)int_BE_handle.get(addr, offset);
+    }
+
+    /**
+     * Writes an int at given address and offset, with byte order set to {@link ByteOrder#BIG_ENDIAN}.
+     * <p>
+     * This is equivalent to the following code:
+     * <blockquote><pre>{@code
+    VarHandle handle = MemoryHandles.withStride(BITS_32_BE.withBitAlignment(8).varHandle(int.class), 1L);
+    handle.set(addr, offset, value);
+     * }</pre></blockquote>
+     * @param addr base address.
+     * @param offset offset (relative to {@code addr}). The final address of this read operation can be expressed as {@code addr.addOffset(offset)}.
+     * @param value the int value to be written.
+     */
+    public static void setInt_BE(MemoryAddress addr, long offset, int value) {
+        int_BE_handle.set(addr, offset, value);
+    }
+
+    /**
+     * Read a float from given address and offset, with byte order set to {@link ByteOrder#BIG_ENDIAN}.
+     * <p>
+     * This is equivalent to the following code:
+     * <blockquote><pre>{@code
+    VarHandle handle = MemoryHandles.withStride(BITS_32_BE.withBitAlignment(8).varHandle(float.class), 1L);
+    float value = (float)handle.get(addr, offset);
+     * }</pre></blockquote>
+     * @param addr base address.
+     * @param offset offset (relative to {@code addr}). The final address of this read operation can be expressed as {@code addr.addOffset(offset)}.
+     * @return a float value read from {@code addr} at the offset specified by {@code offset}.
+     */
+    public static float getFloat_BE(MemoryAddress addr, long offset) {
+        return (float)float_BE_handle.get(addr, offset);
+    }
+
+    /**
+     * Writes a float at given address and offset, with byte order set to {@link ByteOrder#BIG_ENDIAN}.
+     * <p>
+     * This is equivalent to the following code:
+     * <blockquote><pre>{@code
+    VarHandle handle = MemoryHandles.withStride(BITS_32_BE.withBitAlignment(8).varHandle(float.class), 1L);
+    handle.set(addr, offset, value);
+     * }</pre></blockquote>
+     * @param addr base address.
+     * @param offset offset (relative to {@code addr}). The final address of this read operation can be expressed as {@code addr.addOffset(offset)}.
+     * @param value the float value to be written.
+     */
+    public static void setFloat_BE(MemoryAddress addr, long offset, float value) {
+        float_BE_handle.set(addr, offset, value);
+    }
+
+    /**
+     * Read a long from given address and offset, with byte order set to {@link ByteOrder#BIG_ENDIAN}.
+     * <p>
+     * This is equivalent to the following code:
+     * <blockquote><pre>{@code
+    VarHandle handle = MemoryHandles.withStride(BITS_64_BE.withBitAlignment(8).varHandle(long.class), 1L);
+    long value = (long)handle.get(addr, offset);
+     * }</pre></blockquote>
+     * @param addr base address.
+     * @param offset offset (relative to {@code addr}). The final address of this read operation can be expressed as {@code addr.addOffset(offset)}.
+     * @return a long value read from {@code addr} at the offset specified by {@code offset}.
+     */
+    public static long getLong_BE(MemoryAddress addr, long offset) {
+        return (long)long_BE_handle.get(addr, offset);
+    }
+
+    /**
+     * Writes a long at given address and offset, with byte order set to {@link ByteOrder#BIG_ENDIAN}.
+     * <p>
+     * This is equivalent to the following code:
+     * <blockquote><pre>{@code
+    VarHandle handle = MemoryHandles.withStride(BITS_64_BE.withBitAlignment(8).varHandle(long.class), 1L);
+    handle.set(addr, offset, value);
+     * }</pre></blockquote>
+     * @param addr base address.
+     * @param offset offset (relative to {@code addr}). The final address of this read operation can be expressed as {@code addr.addOffset(offset)}.
+     * @param value the long value to be written.
+     */
+    public static void setLong_BE(MemoryAddress addr, long offset, long value) {
+        long_BE_handle.set(addr, offset, value);
+    }
+
+    /**
+     * Read a double from given address and offset, with byte order set to {@link ByteOrder#BIG_ENDIAN}.
+     * <p>
+     * This is equivalent to the following code:
+     * <blockquote><pre>{@code
+    VarHandle handle = MemoryHandles.withStride(BITS_32_BE.withBitAlignment(8).varHandle(double.class), 1L);
+    double value = (double)handle.get(addr, offset);
+     * }</pre></blockquote>
+     * @param addr base address.
+     * @param offset offset (relative to {@code addr}). The final address of this read operation can be expressed as {@code addr.addOffset(offset)}.
+     * @return a double value read from {@code addr} at the offset specified by {@code offset}.
+     */
+    public static double getDouble_BE(MemoryAddress addr, long offset) {
+        return (double)double_BE_handle.get(addr, offset);
+    }
+
+    /**
+     * Writes a double at given address and offset, with byte order set to {@link ByteOrder#BIG_ENDIAN}.
+     * <p>
+     * This is equivalent to the following code:
+     * <blockquote><pre>{@code
+    VarHandle handle = MemoryHandles.withStride(BITS_64_BE.withBitAlignment(8).varHandle(double.class), 1L);
+    handle.set(addr, offset, value);
+     * }</pre></blockquote>
+     * @param addr base address.
+     * @param offset offset (relative to {@code addr}). The final address of this read operation can be expressed as {@code addr.addOffset(offset)}.
+     * @param value the double value to be written.
+     */
+    public static void setDouble_BE(MemoryAddress addr, long offset, double value) {
+        double_BE_handle.set(addr, offset, value);
+    }
+
+    /**
+     * Read a byte from given address and offset, with byte order set to {@link ByteOrder#nativeOrder()}.
+     * <p>
+     * This is equivalent to the following code:
+     * <blockquote><pre>{@code
+    VarHandle handle = MemoryHandles.withStride(JAVA_BYTE.withBitAlignment(8).varHandle(byte.class), 1L);
+    byte value = (byte)handle.get(addr, offset);
+     * }</pre></blockquote>
+     *
+     * @param addr base address.
+     * @param offset offset (relative to {@code addr}). The final address of this read operation can be expressed as {@code addr.addOffset(offset)}.
+     * @return a byte value read from {@code addr} at the offset specified by {@code offset}.
+     */
+    public static byte getByte(MemoryAddress addr, long offset) {
+        return (byte)((ByteOrder.nativeOrder() == ByteOrder.BIG_ENDIAN) ? byte_BE_handle : byte_LE_handle).get(addr, offset);
+    }
+
+    /**
+     * Writes a byte at given address and offset, with byte order set to {@link ByteOrder#nativeOrder()}.
+     * <p>
+     * This is equivalent to the following code:
+     * <blockquote><pre>{@code
+    VarHandle handle = MemoryHandles.withStride(JAVA_BYTE.withBitAlignment(8).varHandle(byte.class), 1L);
+    handle.set(addr, offset, value);
+     * }</pre></blockquote>
+     * @param addr base address.
+     * @param offset offset (relative to {@code addr}). The final address of this read operation can be expressed as {@code addr.addOffset(offset)}.
+     * @param value the byte value to be written.
+     */
+    public static void setByte(MemoryAddress addr, long offset, byte value) {
+        ((ByteOrder.nativeOrder() == ByteOrder.BIG_ENDIAN) ? byte_BE_handle : byte_LE_handle).set(addr, offset, value);
+    }
+
+    /**
+     * Read a char from given address and offset, with byte order set to {@link ByteOrder#nativeOrder()}.
+     * <p>
+     * This is equivalent to the following code:
+     * <blockquote><pre>{@code
+    VarHandle handle = MemoryHandles.withStride(JAVA_CHAR.withBitAlignment(8).varHandle(char.class), 1L);
+    char value = (char)handle.get(addr, offset);
+     * }</pre></blockquote>
+     * @param addr base address.
+     * @param offset offset (relative to {@code addr}). The final address of this read operation can be expressed as {@code addr.addOffset(offset)}.
+     * @return a char value read from {@code addr} at the offset specified by {@code offset}.
+     */
+    public static char getChar(MemoryAddress addr, long offset) {
+        return (char)((ByteOrder.nativeOrder() == ByteOrder.BIG_ENDIAN) ? char_BE_handle : char_LE_handle).get(addr, offset);
+    }
+
+    /**
+     * Writes a char at given address and offset, with byte order set to {@link ByteOrder#nativeOrder()}.
+     * <p>
+     * This is equivalent to the following code:
+     * <blockquote><pre>{@code
+    VarHandle handle = MemoryHandles.withStride(JAVA_CHAR.withBitAlignment(8).varHandle(char.class), 1L);
+    handle.set(addr, offset, value);
+     * }</pre></blockquote>
+     * @param addr base address.
+     * @param offset offset (relative to {@code addr}). The final address of this read operation can be expressed as {@code addr.addOffset(offset)}.
+     * @param value the char value to be written.
+     */
+    public static void setChar(MemoryAddress addr, long offset, char value) {
+        ((ByteOrder.nativeOrder() == ByteOrder.BIG_ENDIAN) ? char_BE_handle : char_LE_handle).set(addr, offset, value);
+    }
+
+    /**
+     * Read a short from given address and offset, with byte order set to {@link ByteOrder#nativeOrder()}.
+     * <p>
+     * This is equivalent to the following code:
+     * <blockquote><pre>{@code
+    VarHandle handle = MemoryHandles.withStride(JAVA_SHORT.withBitAlignment(8).varHandle(short.class), 1L);
+    short value = (short)handle.get(addr, offset);
+     * }</pre></blockquote>
+     * @param addr base address.
+     * @param offset offset (relative to {@code addr}). The final address of this read operation can be expressed as {@code addr.addOffset(offset)}.
+     * @return a short value read from {@code addr} at the offset specified by {@code offset}.
+     */
+    public static short getShort(MemoryAddress addr, long offset) {
+        return (short)((ByteOrder.nativeOrder() == ByteOrder.BIG_ENDIAN) ? short_BE_handle : short_LE_handle).get(addr, offset);
+    }
+
+    /**
+     * Writes a short at given address and offset, with byte order set to {@link ByteOrder#nativeOrder()}.
+     * <p>
+     * This is equivalent to the following code:
+     * <blockquote><pre>{@code
+    VarHandle handle = MemoryHandles.withStride(JAVA_SHORT.withBitAlignment(8).varHandle(short.class), 1L);
+    handle.set(addr, offset, value);
+     * }</pre></blockquote>
+     * @param addr base address.
+     * @param offset offset (relative to {@code addr}). The final address of this read operation can be expressed as {@code addr.addOffset(offset)}.
+     * @param value the short value to be written.
+     */
+    public static void setShort(MemoryAddress addr, long offset, short value) {
+        ((ByteOrder.nativeOrder() == ByteOrder.BIG_ENDIAN) ? short_BE_handle : short_LE_handle).set(addr, offset, value);
+    }
+
+    /**
+     * Read an int from given address and offset, with byte order set to {@link ByteOrder#nativeOrder()}.
+     * <p>
+     * This is equivalent to the following code:
+     * <blockquote><pre>{@code
+    VarHandle handle = MemoryHandles.withStride(JAVA_INT.withBitAlignment(8).varHandle(int.class), 1L);
+    int value = (int)handle.get(addr, offset);
+     * }</pre></blockquote>
+     * @param addr base address.
+     * @param offset offset (relative to {@code addr}). The final address of this read operation can be expressed as {@code addr.addOffset(offset)}.
+     * @return an int value read from {@code addr} at the offset specified by {@code offset}.
+     */
+    public static int getInt(MemoryAddress addr, long offset) {
+        return (int)((ByteOrder.nativeOrder() == ByteOrder.BIG_ENDIAN) ? int_BE_handle : int_LE_handle).get(addr, offset);
+    }
+
+    /**
+     * Writes an int at given address and offset, with byte order set to {@link ByteOrder#nativeOrder()}.
+     * <p>
+     * This is equivalent to the following code:
+     * <blockquote><pre>{@code
+    VarHandle handle = MemoryHandles.withStride(JAVA_INT.withBitAlignment(8).varHandle(int.class), 1L);
+    handle.set(addr, offset, value);
+     * }</pre></blockquote>
+     * @param addr base address.
+     * @param offset offset (relative to {@code addr}). The final address of this read operation can be expressed as {@code addr.addOffset(offset)}.
+     * @param value the int value to be written.
+     */
+    public static void setInt(MemoryAddress addr, long offset, int value) {
+        ((ByteOrder.nativeOrder() == ByteOrder.BIG_ENDIAN) ? int_BE_handle : int_LE_handle).set(addr, offset, value);
+    }
+
+    /**
+     * Read a float from given address and offset, with byte order set to {@link ByteOrder#nativeOrder()}.
+     * <p>
+     * This is equivalent to the following code:
+     * <blockquote><pre>{@code
+    VarHandle handle = MemoryHandles.withStride(JAVA_FLOAT.withBitAlignment(8).varHandle(float.class), 1L);
+    float value = (float)handle.get(addr, offset);
+     * }</pre></blockquote>
+     * @param addr base address.
+     * @param offset offset (relative to {@code addr}). The final address of this read operation can be expressed as {@code addr.addOffset(offset)}.
+     * @return a float value read from {@code addr} at the offset specified by {@code offset}.
+     */
+    public static float getFloat(MemoryAddress addr, long offset) {
+        return (float)((ByteOrder.nativeOrder() == ByteOrder.BIG_ENDIAN) ? float_BE_handle : float_LE_handle).get(addr, offset);
+    }
+
+    /**
+     * Writes a float at given address and offset, with byte order set to {@link ByteOrder#nativeOrder()}.
+     * <p>
+     * This is equivalent to the following code:
+     * <blockquote><pre>{@code
+    VarHandle handle = MemoryHandles.withStride(JAVA_FLOAT.withBitAlignment(8).varHandle(float.class), 1L);
+    handle.set(addr, offset, value);
+     * }</pre></blockquote>
+     * @param addr base address.
+     * @param offset offset (relative to {@code addr}). The final address of this read operation can be expressed as {@code addr.addOffset(offset)}.
+     * @param value the float value to be written.
+     */
+    public static void setFloat(MemoryAddress addr, long offset, float value) {
+        ((ByteOrder.nativeOrder() == ByteOrder.BIG_ENDIAN) ? float_BE_handle : float_LE_handle).set(addr, offset, value);
+    }
+
+    /**
+     * Read a long from given address and offset, with byte order set to {@link ByteOrder#nativeOrder()}.
+     * <p>
+     * This is equivalent to the following code:
+     * <blockquote><pre>{@code
+    VarHandle handle = MemoryHandles.withStride(JAVA_LONG.withBitAlignment(8).varHandle(long.class), 1L);
+    long value = (long)handle.get(addr, offset);
+     * }</pre></blockquote>
+     * @param addr base address.
+     * @param offset offset (relative to {@code addr}). The final address of this read operation can be expressed as {@code addr.addOffset(offset)}.
+     * @return a long value read from {@code addr} at the offset specified by {@code offset}.
+     */
+    public static long getLong(MemoryAddress addr, long offset) {
+        return (long)((ByteOrder.nativeOrder() == ByteOrder.BIG_ENDIAN) ? long_BE_handle : long_LE_handle).get(addr, offset);
+    }
+
+    /**
+     * Writes a long at given address and offset, with byte order set to {@link ByteOrder#nativeOrder()}.
+     * <p>
+     * This is equivalent to the following code:
+     * <blockquote><pre>{@code
+    VarHandle handle = MemoryHandles.withStride(JAVA_LONG.withBitAlignment(8).varHandle(long.class), 1L);
+    handle.set(addr, offset, value);
+     * }</pre></blockquote>
+     * @param addr base address.
+     * @param offset offset (relative to {@code addr}). The final address of this read operation can be expressed as {@code addr.addOffset(offset)}.
+     * @param value the long value to be written.
+     */
+    public static void setLong(MemoryAddress addr, long offset, long value) {
+        ((ByteOrder.nativeOrder() == ByteOrder.BIG_ENDIAN) ? long_BE_handle : long_LE_handle).set(addr, offset, value);
+    }
+
+    /**
+     * Read a double from given address and offset, with byte order set to {@link ByteOrder#nativeOrder()}.
+     * <p>
+     * This is equivalent to the following code:
+     * <blockquote><pre>{@code
+    VarHandle handle = MemoryHandles.withStride(JAVA_DOUBLE.withBitAlignment(8).varHandle(double.class), 1L);
+    double value = (double)handle.get(addr, offset);
+     * }</pre></blockquote>
+     * @param addr base address.
+     * @param offset offset (relative to {@code addr}). The final address of this read operation can be expressed as {@code addr.addOffset(offset)}.
+     * @return a double value read from {@code addr} at the offset specified by {@code offset}.
+     */
+    public static double getDouble(MemoryAddress addr, long offset) {
+        return (double)((ByteOrder.nativeOrder() == ByteOrder.BIG_ENDIAN) ? double_BE_handle : double_LE_handle).get(addr, offset);
+    }
+
+    /**
+     * Writes a double at given address and offset, with byte order set to {@link ByteOrder#nativeOrder()}.
+     * <p>
+     * This is equivalent to the following code:
+     * <blockquote><pre>{@code
+    VarHandle handle = MemoryHandles.withStride(JAVA_DOUBLE.withBitAlignment(8).varHandle(double.class), 1L);
+    handle.set(addr, offset, value);
+     * }</pre></blockquote>
+     * @param addr base address.
+     * @param offset offset (relative to {@code addr}). The final address of this read operation can be expressed as {@code addr.addOffset(offset)}.
+     * @param value the double value to be written.
+     */
+    public static void setDouble(MemoryAddress addr, long offset, double value) {
+        ((ByteOrder.nativeOrder() == ByteOrder.BIG_ENDIAN) ? double_BE_handle : double_LE_handle).set(addr, offset, value);
+    }
+
+    /**
+     * Read a memory address from given address and offset, with byte order set to {@link ByteOrder#nativeOrder()}.
+     * <p>
+     * This is equivalent to the following code:
+     * <blockquote><pre>{@code
+    VarHandle handle = MemoryHandles.asAddressHandle(MemoryHandles.withStride(JAVA_LONG.withBitAlignment(8).varHandle(long.class), 1L));
+    MemoryAddress value = (MemoryAddress)handle.get(addr, offset);
+     * }</pre></blockquote>
+     * @param addr base address.
+     * @param offset offset (relative to {@code addr}). The final address of this read operation can be expressed as {@code addr.addOffset(offset)}.
+     * @return a memory address read from {@code addr} at the offset specified by {@code offset}.
+     */
+    public static MemoryAddress getAddress(MemoryAddress addr, long offset) {
+        return (MemoryAddress)address_handle.get(addr, offset);
+    }
+
+    /**
+     * Writes a memory address at given address and offset, with byte order set to {@link ByteOrder#nativeOrder()}.
+     * <p>
+     * This is equivalent to the following code:
+     * <blockquote><pre>{@code
+    VarHandle handle = MemoryHandles.asAddressHandle(MemoryHandles.withStride(JAVA_LONG.withBitAlignment(8).varHandle(long.class), 1L));
+    handle.set(addr, offset, value);
+     * }</pre></blockquote>
+     * @param addr base address.
+     * @param offset offset (relative to {@code addr}). The final address of this read operation can be expressed as {@code addr.addOffset(offset)}.
+     * @param value the memory address to be written.
+     */
+    public static void setAddress(MemoryAddress addr, long offset, MemoryAddress value) {
+        address_handle.set(addr, offset, value);
+    }
+
+    private static VarHandle indexedHandle(MemoryLayout elementLayout, Class<?> carrier) {
+        return MemoryHandles.withStride(elementLayout.withBitAlignment(8).varHandle(carrier), 1L);
+    }
+}

--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/MemorySegment.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/MemorySegment.java
@@ -404,6 +404,72 @@ for (long l = 0; l < segment.byteSize(); l++) {
     byte[] toByteArray();
 
     /**
+     * Copy the contents of this memory segment into a fresh short array.
+     * @return a fresh short array copy of this memory segment.
+     * @throws UnsupportedOperationException if this segment does not feature the {@link #READ} access mode, or if this
+     * segment's contents cannot be copied into a {@link short[]} instance, e.g. because {@code byteSize() % 2 != 0},
+     * or {@code byteSize() / 2 > Integer#MAX_VALUE}.
+     * @throws IllegalStateException if this segment has been closed, or if access occurs from a thread other than the
+     * thread owning this segment.
+     */
+    short[] toShortArray();
+
+    /**
+     * Copy the contents of this memory segment into a fresh char array.
+     * @return a fresh char array copy of this memory segment.
+     * @throws UnsupportedOperationException if this segment does not feature the {@link #READ} access mode, or if this
+     * segment's contents cannot be copied into a {@link char[]} instance, e.g. because {@code byteSize() % 2 != 0},
+     * or {@code byteSize() / 2 > Integer#MAX_VALUE}.
+     * @throws IllegalStateException if this segment has been closed, or if access occurs from a thread other than the
+     * thread owning this segment.
+     */
+    char[] toCharArray();
+
+    /**
+     * Copy the contents of this memory segment into a fresh int array.
+     * @return a fresh int array copy of this memory segment.
+     * @throws UnsupportedOperationException if this segment does not feature the {@link #READ} access mode, or if this
+     * segment's contents cannot be copied into a {@link int[]} instance, e.g. because {@code byteSize() % 4 != 0},
+     * or {@code byteSize() / 4 > Integer#MAX_VALUE}.
+     * @throws IllegalStateException if this segment has been closed, or if access occurs from a thread other than the
+     * thread owning this segment.
+     */
+    int[] toIntArray();
+
+    /**
+     * Copy the contents of this memory segment into a fresh float array.
+     * @return a fresh float array copy of this memory segment.
+     * @throws UnsupportedOperationException if this segment does not feature the {@link #READ} access mode, or if this
+     * segment's contents cannot be copied into a {@link float[]} instance, e.g. because {@code byteSize() % 4 != 0},
+     * or {@code byteSize() / 4 > Integer#MAX_VALUE}.
+     * @throws IllegalStateException if this segment has been closed, or if access occurs from a thread other than the
+     * thread owning this segment.
+     */
+    float[] toFloatArray();
+
+    /**
+     * Copy the contents of this memory segment into a fresh long array.
+     * @return a fresh long array copy of this memory segment.
+     * @throws UnsupportedOperationException if this segment does not feature the {@link #READ} access mode, or if this
+     * segment's contents cannot be copied into a {@link long[]} instance, e.g. because {@code byteSize() % 8 != 0},
+     * or {@code byteSize() / 8 > Integer#MAX_VALUE}.
+     * @throws IllegalStateException if this segment has been closed, or if access occurs from a thread other than the
+     * thread owning this segment.
+     */
+    long[] toLongArray();
+
+    /**
+     * Copy the contents of this memory segment into a fresh double array.
+     * @return a fresh double array copy of this memory segment.
+     * @throws UnsupportedOperationException if this segment does not feature the {@link #READ} access mode, or if this
+     * segment's contents cannot be copied into a {@link double[]} instance, e.g. because {@code byteSize() % 8 != 0},
+     * or {@code byteSize() / 8 > Integer#MAX_VALUE}.
+     * @throws IllegalStateException if this segment has been closed, or if access occurs from a thread other than the
+     * thread owning this segment.
+     */
+    double[] toDoubleArray();
+
+    /**
      * Creates a new buffer memory segment that models the memory associated with the given byte
      * buffer. The segment starts relative to the buffer's position (inclusive)
      * and ends relative to the buffer's limit (exclusive).

--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/NativeScope.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/NativeScope.java
@@ -319,11 +319,10 @@ public abstract class NativeScope implements AutoCloseable {
     allocate(MemoryLayout.ofSequence(size, elementLayout));
      * }</pre>
      * @param elementLayout the array element layout.
-     * @param size the array size.
+     * @param size the array element count.
      * @return an address which points to the newly allocated memory block.
      * @throws OutOfMemoryError if there is not enough space left in this native scope, that is, if
      * {@code limit() - size() < (elementLayout.byteSize() * size)}.
-     * @throws IllegalArgumentException if {@code elementLayout.byteSize()} does not conform to the size of a double value.
      */
     public MemoryAddress allocateArray(MemoryLayout elementLayout, long size) {
         return allocate(MemoryLayout.ofSequence(size, elementLayout));

--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/NativeScope.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/NativeScope.java
@@ -52,8 +52,6 @@ import java.util.OptionalLong;
  */
 public abstract class NativeScope implements AutoCloseable {
 
-    Unsafe unsafe = Unsafe.getUnsafe();
-
     /**
      * If this native scope is bounded, returns the size, in bytes, of this native scope.
      * @return the size, in bytes, of this native scope (if available).
@@ -354,6 +352,25 @@ public abstract class NativeScope implements AutoCloseable {
      */
     public MemoryAddress allocate(MemoryLayout layout) {
         return allocate(layout.byteSize(), layout.byteAlignment());
+    }
+
+    /**
+     * Allocate a block of memory corresponding to an array with given element layout and size.
+     * The address returned by this method is associated with a segment which cannot be closed.
+     * Moreover, the returned address must conform to the layout alignment constraints. This is equivalent to the
+     * following code:
+     * <pre>{@code
+    allocate(MemoryLayout.ofSequence(size, elementLayout));
+     * }</pre>
+     * @param elementLayout the array element layout.
+     * @param size the array size.
+     * @return an address which points to the newly allocated memory block.
+     * @throws OutOfMemoryError if there is not enough space left in this native scope, that is, if
+     * {@code limit() - size() < (elementLayout.byteSize() * size)}.
+     * @throws IllegalArgumentException if {@code elementLayout.byteSize()} does not conform to the size of a double value.
+     */
+    public MemoryAddress allocateArray(MemoryLayout elementLayout, long size) {
+        return allocate(MemoryLayout.ofSequence(size, elementLayout));
     }
 
     /**

--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/NativeScope.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/NativeScope.java
@@ -26,9 +26,12 @@
 
 package jdk.incubator.foreign;
 
+import jdk.internal.foreign.AbstractMemorySegmentImpl;
 import jdk.internal.foreign.AbstractNativeScope;
+import jdk.internal.misc.Unsafe;
 
 import java.lang.invoke.VarHandle;
+import java.nio.ByteOrder;
 import java.util.OptionalLong;
 
 /**
@@ -48,6 +51,8 @@ import java.util.OptionalLong;
  * allocation and usage under a single <em>try-with-resources block</em>.
  */
 public abstract class NativeScope implements AutoCloseable {
+
+    Unsafe unsafe = Unsafe.getUnsafe();
 
     /**
      * If this native scope is bounded, returns the size, in bytes, of this native scope.
@@ -176,31 +181,167 @@ public abstract class NativeScope implements AutoCloseable {
     }
 
     /**
-     * Allocate a block of memory in this native scope with given layout and initialize it with given address value.
+     * Allocate a block of memory in this native scope with given layout and initialize it with given byte array.
      * The address returned by this method is associated with a segment which cannot be closed. Moreover, the returned
      * address must conform to the layout alignment constraints.
-     * @param layout the layout of the block of memory to be allocated.
-     * @param value the value to be set on the newly allocated memory block.
+     * @param elementLayout the element layout of the array to be allocated.
+     * @param array the array to be copied on the newly allocated memory block.
      * @return an address which points to the newly allocated memory block.
      * @throws OutOfMemoryError if there is not enough space left in this native scope, that is, if
-     * {@code limit() - size() < layout.byteSize()}.
-     * @throws IllegalArgumentException if {@code layout.byteSize()} does not conform to the size of an address value.
+     * {@code limit() - size() < (elementLayout.byteSize() * array.length)}.
+     * @throws IllegalArgumentException if {@code elementLayout.byteSize()} does not conform to the size of a byte value.
      */
-    public MemoryAddress allocate(MemoryLayout layout, MemoryAddress value) {
-        VarHandle handle = MemoryHandles.asAddressVarHandle(layout.varHandle(carrierForSize(layout.byteSize())));
-        MemoryAddress addr = allocate(layout);
-        handle.set(addr, value);
+    public MemoryAddress allocateArray(ValueLayout elementLayout, byte[] array) {
+        if (elementLayout.byteSize() != 1) {
+            throw new IllegalArgumentException("Bad layout size");
+        }
+        MemoryAddress addr = allocate(MemoryLayout.ofSequence(array.length, elementLayout));
+        addr.segment().copyFrom(MemorySegment.ofArray(array));
         return addr;
     }
 
-    private static Class<?> carrierForSize(long size) {
-        return switch ((int)size) {
-            case 1 -> byte.class;
-            case 2 -> short.class;
-            case 4 -> int.class;
-            case 8 -> long.class;
-            default -> throw new IllegalArgumentException("Bad layout size: " + size);
-        };
+    /**
+     * Allocate a block of memory in this native scope with given layout and initialize it with given short array.
+     * The address returned by this method is associated with a segment which cannot be closed. Moreover, the returned
+     * address must conform to the layout alignment constraints.
+     * @param elementLayout the element layout of the array to be allocated.
+     * @param array the array to be copied on the newly allocated memory block.
+     * @return an address which points to the newly allocated memory block.
+     * @throws OutOfMemoryError if there is not enough space left in this native scope, that is, if
+     * {@code limit() - size() < (elementLayout.byteSize() * array.length)}.
+     * @throws IllegalArgumentException if {@code elementLayout.byteSize()} does not conform to the size of a short value.
+     */
+    public MemoryAddress allocateArray(ValueLayout elementLayout, short[] array) {
+        if (elementLayout.byteSize() != 2) {
+            throw new IllegalArgumentException("Bad layout size");
+        }
+        MemoryAddress addr = allocate(MemoryLayout.ofSequence(array.length, elementLayout));
+        if (elementLayout.order() == ByteOrder.nativeOrder()) {
+            addr.segment().copyFrom(MemorySegment.ofArray(array));
+        } else {
+            ((AbstractMemorySegmentImpl)addr.segment()).copyFromSwap(MemorySegment.ofArray(array), elementLayout.byteSize());
+        }
+        return addr;
+    }
+
+    /**
+     * Allocate a block of memory in this native scope with given layout and initialize it with given char array.
+     * The address returned by this method is associated with a segment which cannot be closed. Moreover, the returned
+     * address must conform to the layout alignment constraints.
+     * @param elementLayout the element layout of the array to be allocated.
+     * @param array the array to be copied on the newly allocated memory block.
+     * @return an address which points to the newly allocated memory block.
+     * @throws OutOfMemoryError if there is not enough space left in this native scope, that is, if
+     * {@code limit() - size() < (elementLayout.byteSize() * array.length)}.
+     * @throws IllegalArgumentException if {@code elementLayout.byteSize()} does not conform to the size of a char value.
+     */
+    public MemoryAddress allocateArray(ValueLayout elementLayout, char[] array) {
+        if (elementLayout.byteSize() != 2) {
+            throw new IllegalArgumentException("Bad layout size");
+        }
+        MemoryAddress addr = allocate(MemoryLayout.ofSequence(array.length, elementLayout));
+        if (elementLayout.order() == ByteOrder.nativeOrder()) {
+            addr.segment().copyFrom(MemorySegment.ofArray(array));
+        } else {
+            ((AbstractMemorySegmentImpl)addr.segment()).copyFromSwap(MemorySegment.ofArray(array), elementLayout.byteSize());
+        }
+        return addr;
+    }
+
+    /**
+     * Allocate a block of memory in this native scope with given layout and initialize it with given int array.
+     * The address returned by this method is associated with a segment which cannot be closed. Moreover, the returned
+     * address must conform to the layout alignment constraints.
+     * @param elementLayout the element layout of the array to be allocated.
+     * @param array the array to be copied on the newly allocated memory block.
+     * @return an address which points to the newly allocated memory block.
+     * @throws OutOfMemoryError if there is not enough space left in this native scope, that is, if
+     * {@code limit() - size() < (elementLayout.byteSize() * array.length)}.
+     * @throws IllegalArgumentException if {@code elementLayout.byteSize()} does not conform to the size of a int value.
+     */
+    public MemoryAddress allocateArray(ValueLayout elementLayout, int[] array) {
+        if (elementLayout.byteSize() != 4) {
+            throw new IllegalArgumentException("Bad layout size");
+        }
+        MemoryAddress addr = allocate(MemoryLayout.ofSequence(array.length, elementLayout));
+        if (elementLayout.order() == ByteOrder.nativeOrder()) {
+            addr.segment().copyFrom(MemorySegment.ofArray(array));
+        } else {
+            ((AbstractMemorySegmentImpl)addr.segment()).copyFromSwap(MemorySegment.ofArray(array), elementLayout.byteSize());
+        }
+        return addr;
+    }
+
+    /**
+     * Allocate a block of memory in this native scope with given layout and initialize it with given float array.
+     * The address returned by this method is associated with a segment which cannot be closed. Moreover, the returned
+     * address must conform to the layout alignment constraints.
+     * @param elementLayout the element layout of the array to be allocated.
+     * @param array the array to be copied on the newly allocated memory block.
+     * @return an address which points to the newly allocated memory block.
+     * @throws OutOfMemoryError if there is not enough space left in this native scope, that is, if
+     * {@code limit() - size() < (elementLayout.byteSize() * array.length)}.
+     * @throws IllegalArgumentException if {@code elementLayout.byteSize()} does not conform to the size of a float value.
+     */
+    public MemoryAddress allocateArray(ValueLayout elementLayout, float[] array) {
+        if (elementLayout.byteSize() != 4) {
+            throw new IllegalArgumentException("Bad layout size");
+        }
+        MemoryAddress addr = allocate(MemoryLayout.ofSequence(array.length, elementLayout));
+        if (elementLayout.order() == ByteOrder.nativeOrder()) {
+            addr.segment().copyFrom(MemorySegment.ofArray(array));
+        } else {
+            ((AbstractMemorySegmentImpl)addr.segment()).copyFromSwap(MemorySegment.ofArray(array), elementLayout.byteSize());
+        }
+        return addr;
+    }
+
+    /**
+     * Allocate a block of memory in this native scope with given layout and initialize it with given long array.
+     * The address returned by this method is associated with a segment which cannot be closed. Moreover, the returned
+     * address must conform to the layout alignment constraints.
+     * @param elementLayout the element layout of the array to be allocated.
+     * @param array the array to be copied on the newly allocated memory block.
+     * @return an address which points to the newly allocated memory block.
+     * @throws OutOfMemoryError if there is not enough space left in this native scope, that is, if
+     * {@code limit() - size() < (elementLayout.byteSize() * array.length)}.
+     * @throws IllegalArgumentException if {@code elementLayout.byteSize()} does not conform to the size of a long value.
+     */
+    public MemoryAddress allocateArray(ValueLayout elementLayout, long[] array) {
+        if (elementLayout.byteSize() != 8) {
+            throw new IllegalArgumentException("Bad layout size");
+        }
+        MemoryAddress addr = allocate(MemoryLayout.ofSequence(array.length, elementLayout));
+        if (elementLayout.order() == ByteOrder.nativeOrder()) {
+            addr.segment().copyFrom(MemorySegment.ofArray(array));
+        } else {
+            ((AbstractMemorySegmentImpl)addr.segment()).copyFromSwap(MemorySegment.ofArray(array), elementLayout.byteSize());
+        }
+        return addr;
+    }
+
+    /**
+     * Allocate a block of memory in this native scope with given layout and initialize it with given double array.
+     * The address returned by this method is associated with a segment which cannot be closed. Moreover, the returned
+     * address must conform to the layout alignment constraints.
+     * @param elementLayout the element layout of the array to be allocated.
+     * @param array the array to be copied on the newly allocated memory block.
+     * @return an address which points to the newly allocated memory block.
+     * @throws OutOfMemoryError if there is not enough space left in this native scope, that is, if
+     * {@code limit() - size() < (elementLayout.byteSize() * array.length)}.
+     * @throws IllegalArgumentException if {@code elementLayout.byteSize()} does not conform to the size of a double value.
+     */
+    public MemoryAddress allocateArray(ValueLayout elementLayout, double[] array) {
+        if (elementLayout.byteSize() != 8) {
+            throw new IllegalArgumentException("Bad layout size");
+        }
+        MemoryAddress addr = allocate(MemoryLayout.ofSequence(array.length, elementLayout));
+        if (elementLayout.order() == ByteOrder.nativeOrder()) {
+            addr.segment().copyFrom(MemorySegment.ofArray(array));
+        } else {
+            ((AbstractMemorySegmentImpl)addr.segment()).copyFromSwap(MemorySegment.ofArray(array), elementLayout.byteSize());
+        }
+        return addr;
     }
 
     /**

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/AbstractMemorySegmentImpl.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/AbstractMemorySegmentImpl.java
@@ -134,6 +134,16 @@ public abstract class AbstractMemorySegmentImpl implements MemorySegment, Memory
                 base(), min(), size);
     }
 
+    public void copyFromSwap(MemorySegment src, long elemSize) {
+        AbstractMemorySegmentImpl that = (AbstractMemorySegmentImpl)src;
+        long size = that.byteSize();
+        checkRange(0, size, true);
+        that.checkRange(0, size, false);
+        UNSAFE.copySwapMemory(
+                that.base(), that.min(),
+                base(), min(), size, elemSize);
+    }
+
     private final static VarHandle BYTE_HANDLE = MemoryLayout.ofSequence(MemoryLayouts.JAVA_BYTE)
             .varHandle(byte.class, MemoryLayout.PathElement.sequenceElement());
 

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/AbstractMemorySegmentImpl.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/AbstractMemorySegmentImpl.java
@@ -47,6 +47,8 @@ import java.util.Objects;
 import java.util.Random;
 import java.util.Spliterator;
 import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.function.IntFunction;
 
 /**
  * This abstract class provides an immutable implementation for the {@code MemorySegment} interface. This class contains information
@@ -184,7 +186,7 @@ public abstract class AbstractMemorySegmentImpl implements MemorySegment, Memory
         if (!isSet(READ)) {
             throw unsupportedAccessMode(READ);
         }
-        checkIntSize("ByteBuffer");
+        checkArraySize("ByteBuffer", 1);
         ByteBuffer _bb = makeByteBuffer();
         if (!isSet(WRITE)) {
             //scope is IMMUTABLE - obtain a RO byte buffer
@@ -277,9 +279,43 @@ public abstract class AbstractMemorySegmentImpl implements MemorySegment, Memory
 
     @Override
     public final byte[] toByteArray() {
-        checkIntSize("byte[]");
-        byte[] arr = new byte[(int)length];
-        MemorySegment arrSegment = MemorySegment.ofArray(arr);
+        return toArray(byte[].class, 1, byte[]::new, MemorySegment::ofArray);
+    }
+
+    @Override
+    public final short[] toShortArray() {
+        return toArray(short[].class, 2, short[]::new, MemorySegment::ofArray);
+    }
+
+    @Override
+    public final char[] toCharArray() {
+        return toArray(char[].class, 2, char[]::new, MemorySegment::ofArray);
+    }
+
+    @Override
+    public final int[] toIntArray() {
+        return toArray(int[].class, 4, int[]::new, MemorySegment::ofArray);
+    }
+
+    @Override
+    public final float[] toFloatArray() {
+        return toArray(float[].class, 4, float[]::new, MemorySegment::ofArray);
+    }
+
+    @Override
+    public final long[] toLongArray() {
+        return toArray(long[].class, 8, long[]::new, MemorySegment::ofArray);
+    }
+
+    @Override
+    public final double[] toDoubleArray() {
+        return toArray(double[].class, 8, double[]::new, MemorySegment::ofArray);
+    }
+
+    private <Z> Z toArray(Class<Z> arrayClass, int elemSize, IntFunction<Z> arrayFactory, Function<Z, MemorySegment> segmentFactory) {
+        int size = checkArraySize(arrayClass.getSimpleName(), elemSize);
+        Z arr = arrayFactory.apply(size);
+        MemorySegment arrSegment = segmentFactory.apply(arr);
         arrSegment.copyFrom(this);
         return arr;
     }
@@ -309,10 +345,15 @@ public abstract class AbstractMemorySegmentImpl implements MemorySegment, Memory
         return (this.mask & mask) != 0;
     }
 
-    private void checkIntSize(String typeName) {
-        if (length > (Integer.MAX_VALUE - 8)) { //conservative check
+    private int checkArraySize(String typeName, int elemSize) {
+        if (length % elemSize != 0) {
+            throw new UnsupportedOperationException(String.format("Segment size is not a multiple of %d. Size: %d", elemSize, length));
+        }
+        long arraySize = length / elemSize;
+        if (arraySize > (Integer.MAX_VALUE - 8)) { //conservative check
             throw new UnsupportedOperationException(String.format("Segment is too large to wrap as %s. Size: %d", typeName, length));
         }
+        return (int)arraySize;
     }
 
     private void checkBounds(long offset, long length) {

--- a/test/jdk/java/foreign/TestArrays.java
+++ b/test/jdk/java/foreign/TestArrays.java
@@ -24,7 +24,7 @@
 
 /*
  * @test
- * @run testng TestArrays
+ * @run testng/othervm -Dforeign.restricted=permit TestArrays
  */
 
 import jdk.incubator.foreign.MemoryAddress;
@@ -36,7 +36,10 @@ import jdk.incubator.foreign.SequenceLayout;
 
 import java.lang.invoke.VarHandle;
 import java.util.function.BiConsumer;
+import java.util.function.BiFunction;
 import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.function.ToIntFunction;
 
 import org.testng.annotations.*;
 
@@ -87,49 +90,65 @@ public class TestArrays {
         }
     }
 
-    static void checkBytes(MemoryAddress base, SequenceLayout layout) {
-        long nBytes = layout.elementCount().getAsLong() * layout.elementLayout().byteSize();
-        byte[] arr = base.segment().toByteArray();
-        for (long i = 0 ; i < nBytes ; i++) {
-            byte expected = (byte)byteHandle.get(base, i);
-            byte found = arr[(int)i];
+    static void checkBytes(MemoryAddress base, SequenceLayout layout, Function<MemorySegment, Object> arrayFactory, BiFunction<MemoryAddress, Long, Object> handleGetter) {
+        int nelems = (int)layout.elementCount().getAsLong();
+        Object arr = arrayFactory.apply(base.segment());
+        for (int i = 0; i < nelems; i++) {
+            Object found = handleGetter.apply(base, (long) i);
+            Object expected = java.lang.reflect.Array.get(arr, i);
             assertEquals(expected, found);
         }
     }
 
     @Test(dataProvider = "arrays")
-    public void testArrays(Consumer<MemoryAddress> init, SequenceLayout layout) {
+    public void testArrays(Consumer<MemoryAddress> init, Consumer<MemoryAddress> checker, MemoryLayout layout) {
         try (MemorySegment segment = MemorySegment.allocateNative(layout)) {
             init.accept(segment.baseAddress());
-            checkBytes(segment.baseAddress(), layout);
+            checker.accept(segment.baseAddress());
         }
     }
 
-    @Test(expectedExceptions = { UnsupportedOperationException.class,
-                                 IllegalArgumentException.class })
-    public void testTooBigForArray() {
-        MemorySegment.allocateNative((long) Integer.MAX_VALUE * 2).toByteArray();
+    @Test(dataProvider = "elemLayouts",
+          expectedExceptions = UnsupportedOperationException.class)
+    public void testTooBigForArray(MemoryLayout layout, Function<MemorySegment, Object> arrayFactory) {
+        MemoryLayout seq = MemoryLayout.ofSequence((Integer.MAX_VALUE * layout.byteSize()) + 1, layout);
+        //do not really allocate here, as it's way too much memory
+        try (MemorySegment segment = MemorySegment.ofNativeRestricted(MemoryAddress.NULL, seq.byteSize(), null, null, null)) {
+            arrayFactory.apply(segment);
+        }
     }
 
-    @Test(expectedExceptions = IllegalStateException.class)
-    public void testArrayFromClosedSegment() {
-        MemorySegment segment = MemorySegment.allocateNative(8);
+    @Test(dataProvider = "elemLayouts",
+          expectedExceptions = UnsupportedOperationException.class)
+    public void testBadSize(MemoryLayout layout, Function<MemorySegment, Object> arrayFactory) {
+        if (layout.byteSize() == 1) throw new UnsupportedOperationException(); //make it fail
+        try (MemorySegment segment = MemorySegment.allocateNative(layout.byteSize() + 1)) {
+            arrayFactory.apply(segment);
+        }
+    }
+
+    @Test(dataProvider = "elemLayouts",
+            expectedExceptions = IllegalStateException.class)
+    public void testArrayFromClosedSegment(MemoryLayout layout, Function<MemorySegment, Object> arrayFactory) {
+        MemorySegment segment = MemorySegment.allocateNative(layout);
         segment.close();
-        segment.toByteArray();
+        arrayFactory.apply(segment);
     }
 
-    @Test(expectedExceptions = UnsupportedOperationException.class)
-    public void testArrayFromHeapSegmentWithoutAccess() {
-        MemorySegment segment = MemorySegment.ofArray(new byte[8]);
-        segment = segment.withAccessModes(segment.accessModes() & ~READ);
-        segment.toByteArray();
+    @Test(dataProvider = "elemLayouts",
+          expectedExceptions = UnsupportedOperationException.class)
+    public void testArrayFromHeapSegmentWithoutAccess(MemoryLayout layout, Function<MemorySegment, Object> arrayFactory) {
+        MemorySegment segment = MemorySegment.ofArray(new byte[(int)layout.byteSize()]);
+        segment = segment.withAccessModes(MemorySegment.ALL_ACCESS & ~READ);
+        arrayFactory.apply(segment);
     }
 
-    @Test(expectedExceptions = UnsupportedOperationException.class)
-    public void testArrayFromNativeSegmentWithoutAccess() {
-        MemorySegment segment = MemorySegment.allocateNative(8);
-        segment = segment.withAccessModes(segment.accessModes() & ~READ);
-        segment.toByteArray();
+    @Test(dataProvider = "elemLayouts",
+            expectedExceptions = UnsupportedOperationException.class)
+    public void testArrayFromNativeSegmentWithoutAccess(MemoryLayout layout, Function<MemorySegment, Object> arrayFactory) {
+        try (MemorySegment segment = MemorySegment.allocateNative(layout).withAccessModes(MemorySegment.ALL_ACCESS & ~READ)) {
+            arrayFactory.apply(segment);
+        }
     }
 
     @DataProvider(name = "arrays")
@@ -149,14 +168,42 @@ public class TestArrays {
         Consumer<MemoryAddress> doubleInitializer =
                 (base) -> initBytes(base, doubles, (addr, pos) -> doubleHandle.set(addr, pos, (double)(long)pos));
 
+        Consumer<MemoryAddress> byteChecker =
+                (base) -> checkBytes(base, bytes, MemorySegment::toByteArray, (addr, pos) -> (byte)byteHandle.get(addr, pos));
+        Consumer<MemoryAddress> shortChecker =
+                (base) -> checkBytes(base, shorts, MemorySegment::toShortArray, (addr, pos) -> (short)shortHandle.get(addr, pos));
+        Consumer<MemoryAddress> charChecker =
+                (base) -> checkBytes(base, chars, MemorySegment::toCharArray, (addr, pos) -> (char)charHandle.get(addr, pos));
+        Consumer<MemoryAddress> intChecker =
+                (base) -> checkBytes(base, ints, MemorySegment::toIntArray, (addr, pos) -> (int)intHandle.get(addr, pos));
+        Consumer<MemoryAddress> floatChecker =
+                (base) -> checkBytes(base, floats, MemorySegment::toFloatArray, (addr, pos) -> (float)floatHandle.get(addr, pos));
+        Consumer<MemoryAddress> longChecker =
+                (base) -> checkBytes(base, longs, MemorySegment::toLongArray, (addr, pos) -> (long)longHandle.get(addr, pos));
+        Consumer<MemoryAddress> doubleChecker =
+                (base) -> checkBytes(base, doubles, MemorySegment::toDoubleArray, (addr, pos) -> (double)doubleHandle.get(addr, pos));
+
         return new Object[][]{
-                {byteInitializer, bytes},
-                {charInitializer, chars},
-                {shortInitializer, shorts},
-                {intInitializer, ints},
-                {floatInitializer, floats},
-                {longInitializer, longs},
-                {doubleInitializer, doubles}
+                {byteInitializer, byteChecker, bytes},
+                {charInitializer, charChecker, chars},
+                {shortInitializer, shortChecker, shorts},
+                {intInitializer, intChecker, ints},
+                {floatInitializer, floatChecker, floats},
+                {longInitializer, longChecker, longs},
+                {doubleInitializer, doubleChecker, doubles}
+        };
+    }
+
+    @DataProvider(name = "elemLayouts")
+    public Object[][] elemLayouts() {
+        return new Object[][] {
+                { MemoryLayouts.JAVA_BYTE, (Function<MemorySegment, Object>) MemorySegment::toByteArray },
+                { MemoryLayouts.JAVA_SHORT, (Function<MemorySegment, Object>) MemorySegment::toShortArray },
+                { MemoryLayouts.JAVA_CHAR, (Function<MemorySegment, Object>) MemorySegment::toCharArray },
+                { MemoryLayouts.JAVA_INT, (Function<MemorySegment, Object>) MemorySegment::toIntArray },
+                { MemoryLayouts.JAVA_FLOAT, (Function<MemorySegment, Object>) MemorySegment::toFloatArray },
+                { MemoryLayouts.JAVA_LONG, (Function<MemorySegment, Object>) MemorySegment::toLongArray },
+                { MemoryLayouts.JAVA_DOUBLE, (Function<MemorySegment, Object>) MemorySegment::toDoubleArray }
         };
     }
 }

--- a/test/jdk/java/foreign/TestByteBuffer.java
+++ b/test/jdk/java/foreign/TestByteBuffer.java
@@ -30,6 +30,7 @@
 
 
 import jdk.incubator.foreign.MappedMemorySegment;
+import jdk.incubator.foreign.MemoryAccess;
 import jdk.incubator.foreign.MemoryLayouts;
 import jdk.incubator.foreign.MemoryLayout;
 import jdk.incubator.foreign.MemoryAddress;
@@ -131,15 +132,6 @@ public class TestByteBuffer {
 
     static VarHandle indexHandle = tuples.varHandle(int.class, PathElement.sequenceElement(), PathElement.groupElement("index"));
     static VarHandle valueHandle = tuples.varHandle(float.class, PathElement.sequenceElement(), PathElement.groupElement("value"));
-
-    static VarHandle byteHandle = bytes.varHandle(byte.class, PathElement.sequenceElement());
-    static VarHandle charHandle = chars.varHandle(char.class, PathElement.sequenceElement());
-    static VarHandle shortHandle = shorts.varHandle(short.class, PathElement.sequenceElement());
-    static VarHandle intHandle = ints.varHandle(int.class, PathElement.sequenceElement());
-    static VarHandle floatHandle = floats.varHandle(float.class, PathElement.sequenceElement());
-    static VarHandle longHandle = longs.varHandle(long.class, PathElement.sequenceElement());
-    static VarHandle doubleHandle = doubles.varHandle(double.class, PathElement.sequenceElement());
-
 
     static void initTuples(MemoryAddress base, long count) {
         for (long i = 0; i < count ; i++) {
@@ -561,7 +553,7 @@ public class TestByteBuffer {
 
         s1.close(); // memory freed
 
-        intHandle.set(s2.baseAddress(), 0L, 10); // Dead access!
+        MemoryAccess.setInt(s2.baseAddress(), 0L, 10); // Dead access!
     }
 
     @DataProvider(name = "bufferOps")
@@ -622,34 +614,34 @@ public class TestByteBuffer {
     @DataProvider(name = "resizeOps")
     public Object[][] resizeOps() {
         Consumer<MemoryAddress> byteInitializer =
-                (base) -> initBytes(base, bytes, (addr, pos) -> byteHandle.set(addr, pos, (byte)(long)pos));
+                (base) -> initBytes(base, bytes, (addr, pos) -> MemoryAccess.setByte_BE(addr, pos, (byte)(long)pos));
         Consumer<MemoryAddress> charInitializer =
-                (base) -> initBytes(base, chars, (addr, pos) -> charHandle.set(addr, pos, (char)(long)pos));
+                (base) -> initBytes(base, chars, (addr, pos) -> MemoryAccess.setChar_BE(addr, pos * 2, (char)(long)pos));
         Consumer<MemoryAddress> shortInitializer =
-                (base) -> initBytes(base, shorts, (addr, pos) -> shortHandle.set(addr, pos, (short)(long)pos));
+                (base) -> initBytes(base, shorts, (addr, pos) -> MemoryAccess.setShort_BE(addr, pos * 2, (short)(long)pos));
         Consumer<MemoryAddress> intInitializer =
-                (base) -> initBytes(base, ints, (addr, pos) -> intHandle.set(addr, pos, (int)(long)pos));
+                (base) -> initBytes(base, ints, (addr, pos) -> MemoryAccess.setInt_BE(addr, pos * 4, (int)(long)pos));
         Consumer<MemoryAddress> floatInitializer =
-                (base) -> initBytes(base, floats, (addr, pos) -> floatHandle.set(addr, pos, (float)(long)pos));
+                (base) -> initBytes(base, floats, (addr, pos) -> MemoryAccess.setFloat_BE(addr, pos * 4, (float)(long)pos));
         Consumer<MemoryAddress> longInitializer =
-                (base) -> initBytes(base, longs, (addr, pos) -> longHandle.set(addr, pos, (long)pos));
+                (base) -> initBytes(base, longs, (addr, pos) -> MemoryAccess.setLong_BE(addr, pos * 8, (long)pos));
         Consumer<MemoryAddress> doubleInitializer =
-                (base) -> initBytes(base, doubles, (addr, pos) -> doubleHandle.set(addr, pos, (double)(long)pos));
+                (base) -> initBytes(base, doubles, (addr, pos) -> MemoryAccess.setDouble_BE(addr, pos * 8, (double)(long)pos));
 
         Consumer<MemoryAddress> byteChecker =
-                (base) -> checkBytes(base, bytes, Function.identity(), byteHandle::get, ByteBuffer::get);
+                (base) -> checkBytes(base, bytes, Function.identity(), MemoryAccess::getByte_BE, ByteBuffer::get);
         Consumer<MemoryAddress> charChecker =
-                (base) -> checkBytes(base, chars, ByteBuffer::asCharBuffer, charHandle::get, CharBuffer::get);
+                (base) -> checkBytes(base, chars, ByteBuffer::asCharBuffer, (addr, pos) -> MemoryAccess.getChar_BE(addr, pos * 2), CharBuffer::get);
         Consumer<MemoryAddress> shortChecker =
-                (base) -> checkBytes(base, shorts, ByteBuffer::asShortBuffer, shortHandle::get, ShortBuffer::get);
+                (base) -> checkBytes(base, shorts, ByteBuffer::asShortBuffer, (addr, pos) -> MemoryAccess.getShort_BE(addr, pos * 2), ShortBuffer::get);
         Consumer<MemoryAddress> intChecker =
-                (base) -> checkBytes(base, ints, ByteBuffer::asIntBuffer, intHandle::get, IntBuffer::get);
+                (base) -> checkBytes(base, ints, ByteBuffer::asIntBuffer, (addr, pos) -> MemoryAccess.getInt_BE(addr, pos * 4), IntBuffer::get);
         Consumer<MemoryAddress> floatChecker =
-                (base) -> checkBytes(base, floats, ByteBuffer::asFloatBuffer, floatHandle::get, FloatBuffer::get);
+                (base) -> checkBytes(base, floats, ByteBuffer::asFloatBuffer, (addr, pos) -> MemoryAccess.getFloat_BE(addr, pos * 4), FloatBuffer::get);
         Consumer<MemoryAddress> longChecker =
-                (base) -> checkBytes(base, longs, ByteBuffer::asLongBuffer, longHandle::get, LongBuffer::get);
+                (base) -> checkBytes(base, longs, ByteBuffer::asLongBuffer, (addr, pos) -> MemoryAccess.getLong_BE(addr, pos * 8), LongBuffer::get);
         Consumer<MemoryAddress> doubleChecker =
-                (base) -> checkBytes(base, doubles, ByteBuffer::asDoubleBuffer, doubleHandle::get, DoubleBuffer::get);
+                (base) -> checkBytes(base, doubles, ByteBuffer::asDoubleBuffer, (addr, pos) -> MemoryAccess.getDouble_BE(addr, pos * 8), DoubleBuffer::get);
 
         return new Object[][]{
                 {byteChecker, byteInitializer, bytes},

--- a/test/jdk/java/foreign/TestNativeScope.java
+++ b/test/jdk/java/foreign/TestNativeScope.java
@@ -34,12 +34,21 @@ import jdk.incubator.foreign.MemoryLayouts;
 import jdk.incubator.foreign.MemoryLayout;
 import jdk.incubator.foreign.MemoryAddress;
 
+import jdk.incubator.foreign.ValueLayout;
 import org.testng.annotations.*;
 
 import java.lang.invoke.VarHandle;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.DoubleBuffer;
+import java.nio.FloatBuffer;
+import java.nio.IntBuffer;
+import java.nio.LongBuffer;
+import java.nio.ShortBuffer;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.BiFunction;
 import java.util.function.Function;
 
 import static jdk.incubator.foreign.MemorySegment.CLOSE;
@@ -51,14 +60,14 @@ public class TestNativeScope {
     final static int ELEMS = 128;
 
     @Test(dataProvider = "nativeScopes")
-    public <Z> void testAllocation(Z value, ScopeFactory scopeFactory, MemoryLayout layout, Class<?> carrier, AllocationFunction<Z> allocationFunction, Function<MemoryLayout, VarHandle> handleFactory) {
-        MemoryLayout[] layouts = {
+    public <Z> void testAllocation(Z value, ScopeFactory scopeFactory, ValueLayout layout, AllocationFunction<Z> allocationFunction, Function<MemoryLayout, VarHandle> handleFactory) {
+        ValueLayout[] layouts = {
                 layout,
                 layout.withBitAlignment(layout.bitAlignment() * 2),
                 layout.withBitAlignment(layout.bitAlignment() * 4),
                 layout.withBitAlignment(layout.bitAlignment() * 8)
         };
-        for (MemoryLayout alignedLayout : layouts) {
+        for (ValueLayout alignedLayout : layouts) {
             List<MemoryAddress> addressList = new ArrayList<>();
             int elems = ELEMS / ((int)alignedLayout.byteAlignment() / (int)layout.byteAlignment());
             try (NativeScope scope = scopeFactory.make((int)alignedLayout.byteSize() * ELEMS)) {
@@ -195,108 +204,288 @@ public class TestNativeScope {
         assertFalse(registered.isAlive());
     }
 
+    @Test(dataProvider = "arrayScopes")
+    public <Z> void testArray(ScopeFactory scopeFactory, ValueLayout layout, AllocationFunction<Object> allocationFunction, ToArrayHelper<Z> arrayHelper) {
+        Z arr = arrayHelper.array();
+        try (NativeScope scope = scopeFactory.make(100)) {
+            MemoryAddress address = allocationFunction.allocate(scope, layout, arr);
+            Z found = arrayHelper.toArray(address.segment(), layout);
+            assertEquals(found, arr);
+        }
+    }
+
     @DataProvider(name = "nativeScopes")
     static Object[][] nativeScopes() {
         return new Object[][] {
-                { (byte)42, (ScopeFactory) NativeScope::boundedScope, MemoryLayouts.BITS_8_BE, byte.class,
+                { (byte)42, (ScopeFactory) NativeScope::boundedScope, MemoryLayouts.BITS_8_BE,
                         (AllocationFunction<Byte>) NativeScope::allocate,
                         (Function<MemoryLayout, VarHandle>)l -> l.varHandle(byte.class) },
-                { (short)42, (ScopeFactory) NativeScope::boundedScope, MemoryLayouts.BITS_16_BE, short.class,
+                { (short)42, (ScopeFactory) NativeScope::boundedScope, MemoryLayouts.BITS_16_BE,
                         (AllocationFunction<Short>) NativeScope::allocate,
                         (Function<MemoryLayout, VarHandle>)l -> l.varHandle(short.class) },
                 { 42, (ScopeFactory) NativeScope::boundedScope,
-                        MemoryLayouts.BITS_32_BE, int.class,
+                        MemoryLayouts.BITS_32_BE,
                         (AllocationFunction<Integer>) NativeScope::allocate,
                         (Function<MemoryLayout, VarHandle>)l -> l.varHandle(int.class) },
-                { 42f, (ScopeFactory) NativeScope::boundedScope, MemoryLayouts.BITS_32_BE, float.class,
+                { 42f, (ScopeFactory) NativeScope::boundedScope, MemoryLayouts.BITS_32_BE,
                         (AllocationFunction<Float>) NativeScope::allocate,
                         (Function<MemoryLayout, VarHandle>)l -> l.varHandle(float.class) },
-                { 42L, (ScopeFactory) NativeScope::boundedScope, MemoryLayouts.BITS_64_BE, long.class,
+                { 42L, (ScopeFactory) NativeScope::boundedScope, MemoryLayouts.BITS_64_BE,
                         (AllocationFunction<Long>) NativeScope::allocate,
                         (Function<MemoryLayout, VarHandle>)l -> l.varHandle(long.class) },
-                { 42d, (ScopeFactory) NativeScope::boundedScope, MemoryLayouts.BITS_64_BE, double.class,
+                { 42d, (ScopeFactory) NativeScope::boundedScope, MemoryLayouts.BITS_64_BE,
                         (AllocationFunction<Double>) NativeScope::allocate,
                         (Function<MemoryLayout, VarHandle>)l -> l.varHandle(double.class) },
-                { MemoryAddress.ofLong(42), (ScopeFactory) NativeScope::boundedScope, MemoryLayouts.BITS_64_BE, MemoryAddress.class,
-                        (AllocationFunction<MemoryAddress>) NativeScope::allocate,
-                        (Function<MemoryLayout, VarHandle>)l -> MemoryHandles.asAddressVarHandle(l.varHandle(long.class)) },
 
-                { (byte)42, (ScopeFactory) NativeScope::boundedScope, MemoryLayouts.BITS_8_LE, byte.class,
+                { (byte)42, (ScopeFactory) NativeScope::boundedScope, MemoryLayouts.BITS_8_LE,
                         (AllocationFunction<Byte>) NativeScope::allocate,
                         (Function<MemoryLayout, VarHandle>)l -> l.varHandle(byte.class) },
-                { (short)42, (ScopeFactory) NativeScope::boundedScope, MemoryLayouts.BITS_16_LE, short.class,
+                { (short)42, (ScopeFactory) NativeScope::boundedScope, MemoryLayouts.BITS_16_LE,
                         (AllocationFunction<Short>) NativeScope::allocate,
                         (Function<MemoryLayout, VarHandle>)l -> l.varHandle(short.class) },
                 { 42, (ScopeFactory) NativeScope::boundedScope,
-                        MemoryLayouts.BITS_32_LE, int.class,
+                        MemoryLayouts.BITS_32_LE,
                         (AllocationFunction<Integer>) NativeScope::allocate,
                         (Function<MemoryLayout, VarHandle>)l -> l.varHandle(int.class) },
-                { 42f, (ScopeFactory) NativeScope::boundedScope, MemoryLayouts.BITS_32_LE, float.class,
+                { 42f, (ScopeFactory) NativeScope::boundedScope, MemoryLayouts.BITS_32_LE,
                         (AllocationFunction<Float>) NativeScope::allocate,
                         (Function<MemoryLayout, VarHandle>)l -> l.varHandle(float.class) },
-                { 42L, (ScopeFactory) NativeScope::boundedScope, MemoryLayouts.BITS_64_LE, long.class,
+                { 42L, (ScopeFactory) NativeScope::boundedScope, MemoryLayouts.BITS_64_LE,
                         (AllocationFunction<Long>) NativeScope::allocate,
                         (Function<MemoryLayout, VarHandle>)l -> l.varHandle(long.class) },
-                { 42d, (ScopeFactory) NativeScope::boundedScope, MemoryLayouts.BITS_64_LE, double.class,
+                { 42d, (ScopeFactory) NativeScope::boundedScope, MemoryLayouts.BITS_64_LE,
                         (AllocationFunction<Double>) NativeScope::allocate,
                         (Function<MemoryLayout, VarHandle>)l -> l.varHandle(double.class) },
-                { MemoryAddress.ofLong(42), (ScopeFactory) NativeScope::boundedScope, MemoryLayouts.BITS_64_LE, MemoryAddress.class,
-                        (AllocationFunction<MemoryAddress>) NativeScope::allocate,
-                        (Function<MemoryLayout, VarHandle>)l -> MemoryHandles.asAddressVarHandle(l.varHandle(long.class)) },
 
-                { (byte)42, (ScopeFactory)size -> NativeScope.unboundedScope(), MemoryLayouts.BITS_8_BE, byte.class,
+                { (byte)42, (ScopeFactory)size -> NativeScope.unboundedScope(), MemoryLayouts.BITS_8_BE,
                         (AllocationFunction<Byte>) NativeScope::allocate,
                         (Function<MemoryLayout, VarHandle>)l -> l.varHandle(byte.class) },
-                { (short)42, (ScopeFactory)size -> NativeScope.unboundedScope(), MemoryLayouts.BITS_16_BE, short.class,
+                { (short)42, (ScopeFactory)size -> NativeScope.unboundedScope(), MemoryLayouts.BITS_16_BE,
                         (AllocationFunction<Short>) NativeScope::allocate,
                         (Function<MemoryLayout, VarHandle>)l -> l.varHandle(short.class) },
                 { 42, (ScopeFactory)size -> NativeScope.unboundedScope(),
-                        MemoryLayouts.BITS_32_BE, int.class,
+                        MemoryLayouts.BITS_32_BE,
                         (AllocationFunction<Integer>) NativeScope::allocate,
                         (Function<MemoryLayout, VarHandle>)l -> l.varHandle(int.class) },
-                { 42f, (ScopeFactory)size -> NativeScope.unboundedScope(), MemoryLayouts.BITS_32_BE, float.class,
+                { 42f, (ScopeFactory)size -> NativeScope.unboundedScope(), MemoryLayouts.BITS_32_BE,
                         (AllocationFunction<Float>) NativeScope::allocate,
                         (Function<MemoryLayout, VarHandle>)l -> l.varHandle(float.class) },
-                { 42L, (ScopeFactory)size -> NativeScope.unboundedScope(), MemoryLayouts.BITS_64_BE, long.class,
+                { 42L, (ScopeFactory)size -> NativeScope.unboundedScope(), MemoryLayouts.BITS_64_BE,
                         (AllocationFunction<Long>) NativeScope::allocate,
                         (Function<MemoryLayout, VarHandle>)l -> l.varHandle(long.class) },
-                { 42d, (ScopeFactory)size -> NativeScope.unboundedScope(), MemoryLayouts.BITS_64_BE, double.class,
+                { 42d, (ScopeFactory)size -> NativeScope.unboundedScope(), MemoryLayouts.BITS_64_BE,
                         (AllocationFunction<Double>) NativeScope::allocate,
                         (Function<MemoryLayout, VarHandle>)l -> l.varHandle(double.class) },
-                { MemoryAddress.ofLong(42), (ScopeFactory)size -> NativeScope.unboundedScope(), MemoryLayouts.BITS_64_BE, MemoryAddress.class,
-                        (AllocationFunction<MemoryAddress>) NativeScope::allocate,
-                        (Function<MemoryLayout, VarHandle>)l -> MemoryHandles.asAddressVarHandle(l.varHandle(long.class)) },
 
-                { (byte)42, (ScopeFactory)size -> NativeScope.unboundedScope(), MemoryLayouts.BITS_8_LE, byte.class,
+                { (byte)42, (ScopeFactory)size -> NativeScope.unboundedScope(), MemoryLayouts.BITS_8_LE,
                         (AllocationFunction<Byte>) NativeScope::allocate,
                         (Function<MemoryLayout, VarHandle>)l -> l.varHandle(byte.class) },
-                { (short)42, (ScopeFactory)size -> NativeScope.unboundedScope(), MemoryLayouts.BITS_16_LE, short.class,
+                { (short)42, (ScopeFactory)size -> NativeScope.unboundedScope(), MemoryLayouts.BITS_16_LE,
                         (AllocationFunction<Short>) NativeScope::allocate,
                         (Function<MemoryLayout, VarHandle>)l -> l.varHandle(short.class) },
                 { 42, (ScopeFactory)size -> NativeScope.unboundedScope(),
-                        MemoryLayouts.BITS_32_LE, int.class,
+                        MemoryLayouts.BITS_32_LE,
                         (AllocationFunction<Integer>) NativeScope::allocate,
                         (Function<MemoryLayout, VarHandle>)l -> l.varHandle(int.class) },
-                { 42f, (ScopeFactory)size -> NativeScope.unboundedScope(), MemoryLayouts.BITS_32_LE, float.class,
+                { 42f, (ScopeFactory)size -> NativeScope.unboundedScope(), MemoryLayouts.BITS_32_LE,
                         (AllocationFunction<Float>) NativeScope::allocate,
                         (Function<MemoryLayout, VarHandle>)l -> l.varHandle(float.class) },
-                { 42L, (ScopeFactory)size -> NativeScope.unboundedScope(), MemoryLayouts.BITS_64_LE, long.class,
+                { 42L, (ScopeFactory)size -> NativeScope.unboundedScope(), MemoryLayouts.BITS_64_LE,
                         (AllocationFunction<Long>) NativeScope::allocate,
                         (Function<MemoryLayout, VarHandle>)l -> l.varHandle(long.class) },
-                { 42d, (ScopeFactory)size -> NativeScope.unboundedScope(), MemoryLayouts.BITS_64_LE, double.class,
+                { 42d, (ScopeFactory)size -> NativeScope.unboundedScope(), MemoryLayouts.BITS_64_LE,
                         (AllocationFunction<Double>) NativeScope::allocate,
                         (Function<MemoryLayout, VarHandle>)l -> l.varHandle(double.class) },
-                { MemoryAddress.ofLong(42), (ScopeFactory)size -> NativeScope.unboundedScope(), MemoryLayouts.BITS_64_LE, MemoryAddress.class,
-                        (AllocationFunction<MemoryAddress>) NativeScope::allocate,
-                        (Function<MemoryLayout, VarHandle>)l -> MemoryHandles.asAddressVarHandle(l.varHandle(long.class)) },
         };
     }
 
+    @DataProvider(name = "arrayScopes")
+    static Object[][] arrayScopes() {
+        return new Object[][] {
+                { (ScopeFactory) NativeScope::boundedScope, MemoryLayouts.BITS_8_LE,
+                        (AllocationFunction<byte[]>) NativeScope::allocateArray,
+                        ToArrayHelper.toByteArray },
+                { (ScopeFactory) NativeScope::boundedScope, MemoryLayouts.BITS_16_LE,
+                        (AllocationFunction<short[]>) NativeScope::allocateArray,
+                        ToArrayHelper.toShortArray },
+                { (ScopeFactory) NativeScope::boundedScope,
+                        MemoryLayouts.BITS_32_LE,
+                        (AllocationFunction<int[]>) NativeScope::allocateArray,
+                        ToArrayHelper.toIntArray },
+                { (ScopeFactory) NativeScope::boundedScope, MemoryLayouts.BITS_32_LE,
+                        (AllocationFunction<float[]>) NativeScope::allocateArray,
+                        ToArrayHelper.toFloatArray },
+                { (ScopeFactory) NativeScope::boundedScope, MemoryLayouts.BITS_64_LE,
+                        (AllocationFunction<long[]>) NativeScope::allocateArray,
+                        ToArrayHelper.toLongArray },
+                { (ScopeFactory) NativeScope::boundedScope, MemoryLayouts.BITS_64_LE,
+                        (AllocationFunction<double[]>) NativeScope::allocateArray,
+                        ToArrayHelper.toDoubleArray },
+                
+                
+                { (ScopeFactory) NativeScope::boundedScope, MemoryLayouts.BITS_8_BE,
+                        (AllocationFunction<byte[]>) NativeScope::allocateArray,
+                        ToArrayHelper.toByteArray },
+                { (ScopeFactory) NativeScope::boundedScope, MemoryLayouts.BITS_16_BE,
+                        (AllocationFunction<short[]>) NativeScope::allocateArray,
+                        ToArrayHelper.toShortArray },
+                { (ScopeFactory) NativeScope::boundedScope,
+                        MemoryLayouts.BITS_32_BE,
+                        (AllocationFunction<int[]>) NativeScope::allocateArray,
+                        ToArrayHelper.toIntArray },
+                { (ScopeFactory) NativeScope::boundedScope, MemoryLayouts.BITS_32_BE,
+                        (AllocationFunction<float[]>) NativeScope::allocateArray,
+                        ToArrayHelper.toFloatArray },
+                { (ScopeFactory) NativeScope::boundedScope, MemoryLayouts.BITS_64_BE,
+                        (AllocationFunction<long[]>) NativeScope::allocateArray,
+                        ToArrayHelper.toLongArray },
+                { (ScopeFactory) NativeScope::boundedScope, MemoryLayouts.BITS_64_BE,
+                        (AllocationFunction<double[]>) NativeScope::allocateArray,
+                        ToArrayHelper.toDoubleArray },
+
+                { (ScopeFactory) size -> NativeScope.unboundedScope(), MemoryLayouts.BITS_8_LE,
+                        (AllocationFunction<byte[]>) NativeScope::allocateArray,
+                        ToArrayHelper.toByteArray },
+                { (ScopeFactory) size -> NativeScope.unboundedScope(), MemoryLayouts.BITS_16_LE,
+                        (AllocationFunction<short[]>) NativeScope::allocateArray,
+                        ToArrayHelper.toShortArray },
+                { (ScopeFactory) size -> NativeScope.unboundedScope(),
+                        MemoryLayouts.BITS_32_LE,
+                        (AllocationFunction<int[]>) NativeScope::allocateArray,
+                        ToArrayHelper.toIntArray },
+                { (ScopeFactory) size -> NativeScope.unboundedScope(), MemoryLayouts.BITS_32_LE,
+                        (AllocationFunction<float[]>) NativeScope::allocateArray,
+                        ToArrayHelper.toFloatArray },
+                { (ScopeFactory) size -> NativeScope.unboundedScope(), MemoryLayouts.BITS_64_LE,
+                        (AllocationFunction<long[]>) NativeScope::allocateArray,
+                        ToArrayHelper.toLongArray },
+                { (ScopeFactory) size -> NativeScope.unboundedScope(), MemoryLayouts.BITS_64_LE,
+                        (AllocationFunction<double[]>) NativeScope::allocateArray,
+                        ToArrayHelper.toDoubleArray },
+
+
+                { (ScopeFactory) size -> NativeScope.unboundedScope(), MemoryLayouts.BITS_8_BE,
+                        (AllocationFunction<byte[]>) NativeScope::allocateArray,
+                        ToArrayHelper.toByteArray },
+                { (ScopeFactory) size -> NativeScope.unboundedScope(), MemoryLayouts.BITS_16_BE,
+                        (AllocationFunction<short[]>) NativeScope::allocateArray,
+                        ToArrayHelper.toShortArray },
+                { (ScopeFactory) size -> NativeScope.unboundedScope(),
+                        MemoryLayouts.BITS_32_BE,
+                        (AllocationFunction<int[]>) NativeScope::allocateArray,
+                        ToArrayHelper.toIntArray },
+                { (ScopeFactory) size -> NativeScope.unboundedScope(), MemoryLayouts.BITS_32_BE,
+                        (AllocationFunction<float[]>) NativeScope::allocateArray,
+                        ToArrayHelper.toFloatArray },
+                { (ScopeFactory) size -> NativeScope.unboundedScope(), MemoryLayouts.BITS_64_BE,
+                        (AllocationFunction<long[]>) NativeScope::allocateArray,
+                        ToArrayHelper.toLongArray },
+                { (ScopeFactory) size -> NativeScope.unboundedScope(), MemoryLayouts.BITS_64_BE,
+                        (AllocationFunction<double[]>) NativeScope::allocateArray,
+                        ToArrayHelper.toDoubleArray },
+        };
+    }
+        
     interface AllocationFunction<X> {
-        MemoryAddress allocate(NativeScope scope, MemoryLayout layout, X value);
+        MemoryAddress allocate(NativeScope scope, ValueLayout layout, X value);
     }
 
     interface ScopeFactory {
         NativeScope make(int size);
+    }
+    
+    interface ToArrayHelper<T> {
+        T array();
+        T toArray(MemorySegment segment, ValueLayout layout);
+        
+        ToArrayHelper<byte[]> toByteArray = new ToArrayHelper<>() {
+            @Override
+            public byte[] array() {
+                return new byte[] { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 };
+            }
+
+            @Override
+            public byte[] toArray(MemorySegment segment, ValueLayout layout) {
+                ByteBuffer buffer = segment.asByteBuffer().order(layout.order());
+                byte[] found = new byte[buffer.limit()];
+                buffer.get(found);
+                return found;
+            }
+        };
+
+        ToArrayHelper<short[]> toShortArray = new ToArrayHelper<>() {
+            @Override
+            public short[] array() {
+                return new short[] { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 };
+            }
+
+            @Override
+            public short[] toArray(MemorySegment segment, ValueLayout layout) {
+                ShortBuffer buffer = segment.asByteBuffer().order(layout.order()).asShortBuffer();
+                short[] found = new short[buffer.limit()];
+                buffer.get(found);
+                return found;
+            }
+        };
+
+        ToArrayHelper<int[]> toIntArray = new ToArrayHelper<>() {
+            @Override
+            public int[] array() {
+                return new int[] { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 };
+            }
+
+            @Override
+            public int[] toArray(MemorySegment segment, ValueLayout layout) {
+                IntBuffer buffer = segment.asByteBuffer().order(layout.order()).asIntBuffer();
+                int[] found = new int[buffer.limit()];
+                buffer.get(found);
+                return found;
+            }
+        };
+
+        ToArrayHelper<float[]> toFloatArray = new ToArrayHelper<>() {
+            @Override
+            public float[] array() {
+                return new float[] { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 };
+            }
+
+            @Override
+            public float[] toArray(MemorySegment segment, ValueLayout layout) {
+                FloatBuffer buffer = segment.asByteBuffer().order(layout.order()).asFloatBuffer();
+                float[] found = new float[buffer.limit()];
+                buffer.get(found);
+                return found;
+            }
+        };
+
+        ToArrayHelper<long[]> toLongArray = new ToArrayHelper<>() {
+            @Override
+            public long[] array() {
+                return new long[] { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 };
+            }
+
+            @Override
+            public long[] toArray(MemorySegment segment, ValueLayout layout) {
+                LongBuffer buffer = segment.asByteBuffer().order(layout.order()).asLongBuffer();
+                long[] found = new long[buffer.limit()];
+                buffer.get(found);
+                return found;
+            }
+        };
+
+        ToArrayHelper<double[]> toDoubleArray = new ToArrayHelper<>() {
+            @Override
+            public double[] array() {
+                return new double[] { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 };
+            }
+
+            @Override
+            public double[] toArray(MemorySegment segment, ValueLayout layout) {
+                DoubleBuffer buffer = segment.asByteBuffer().order(layout.order()).asDoubleBuffer();
+                double[] found = new double[buffer.limit()];
+                buffer.get(found);
+                return found;
+            }
+        };
     }
 }

--- a/test/jdk/java/foreign/TestNativeScope.java
+++ b/test/jdk/java/foreign/TestNativeScope.java
@@ -321,8 +321,8 @@ public class TestNativeScope {
                 { (ScopeFactory) NativeScope::boundedScope, MemoryLayouts.BITS_64_LE,
                         (AllocationFunction<double[]>) NativeScope::allocateArray,
                         ToArrayHelper.toDoubleArray },
-                
-                
+
+
                 { (ScopeFactory) NativeScope::boundedScope, MemoryLayouts.BITS_8_BE,
                         (AllocationFunction<byte[]>) NativeScope::allocateArray,
                         ToArrayHelper.toByteArray },
@@ -385,7 +385,7 @@ public class TestNativeScope {
                         ToArrayHelper.toDoubleArray },
         };
     }
-        
+
     interface AllocationFunction<X> {
         MemoryAddress allocate(NativeScope scope, ValueLayout layout, X value);
     }
@@ -393,11 +393,11 @@ public class TestNativeScope {
     interface ScopeFactory {
         NativeScope make(int size);
     }
-    
+
     interface ToArrayHelper<T> {
         T array();
         T toArray(MemorySegment segment, ValueLayout layout);
-        
+
         ToArrayHelper<byte[]> toByteArray = new ToArrayHelper<>() {
             @Override
             public byte[] array() {

--- a/test/jdk/java/foreign/TestSegments.java
+++ b/test/jdk/java/foreign/TestSegments.java
@@ -340,6 +340,12 @@ public class TestSegments {
                 "copyFrom",
                 "mismatch",
                 "toByteArray",
+                "toCharArray",
+                "toShortArray",
+                "toIntArray",
+                "toFloatArray",
+                "toLongArray",
+                "toDoubleArray",
                 "withOwnerThread"
         );
 

--- a/test/micro/org/openjdk/bench/jdk/incubator/foreign/LoopOverNonConstant.java
+++ b/test/micro/org/openjdk/bench/jdk/incubator/foreign/LoopOverNonConstant.java
@@ -22,6 +22,7 @@
  */
 package org.openjdk.bench.jdk.incubator.foreign;
 
+import jdk.incubator.foreign.MemoryAccess;
 import jdk.incubator.foreign.MemoryAddress;
 import jdk.incubator.foreign.MemoryLayout;
 import jdk.incubator.foreign.MemorySegment;
@@ -111,6 +112,15 @@ public class LoopOverNonConstant {
         int res = 0;
         for (int i = 0; i < ELEM_SIZE; i ++) {
             res += unsafe.getInt(unsafe_addr + (i * CARRIER_SIZE));
+        }
+        return res;
+    }
+
+    @Benchmark
+    public int segment_loop_static() {
+        int res = 0;
+        for (int i = 0; i < ELEM_SIZE; i ++) {
+            res += MemoryAccess.getInt(segment.baseAddress(), i * CARRIER_SIZE);
         }
         return res;
     }

--- a/test/micro/org/openjdk/bench/jdk/incubator/foreign/LoopOverNonConstantHeap.java
+++ b/test/micro/org/openjdk/bench/jdk/incubator/foreign/LoopOverNonConstantHeap.java
@@ -22,6 +22,7 @@
  */
 package org.openjdk.bench.jdk.incubator.foreign;
 
+import jdk.incubator.foreign.MemoryAccess;
 import jdk.incubator.foreign.MemoryAddress;
 import jdk.incubator.foreign.MemoryLayout;
 import jdk.incubator.foreign.MemorySegment;
@@ -116,6 +117,15 @@ public class LoopOverNonConstantHeap {
             sum += (int) VH_int.get(base, (long) i);
         }
         return sum;
+    }
+
+    @Benchmark
+    public int segment_loop_static() {
+        int res = 0;
+        for (int i = 0; i < ELEM_SIZE; i ++) {
+            res += MemoryAccess.getInt(segment.baseAddress(), i * CARRIER_SIZE);
+        }
+        return res;
     }
 
     @Benchmark

--- a/test/micro/org/openjdk/bench/jdk/incubator/foreign/LoopOverNonConstantMapped.java
+++ b/test/micro/org/openjdk/bench/jdk/incubator/foreign/LoopOverNonConstantMapped.java
@@ -22,6 +22,7 @@
  */
 package org.openjdk.bench.jdk.incubator.foreign;
 
+import jdk.incubator.foreign.MemoryAccess;
 import jdk.incubator.foreign.MemoryAddress;
 import jdk.incubator.foreign.MemoryLayout;
 import jdk.incubator.foreign.MemorySegment;
@@ -140,6 +141,15 @@ public class LoopOverNonConstantMapped {
             sum += (int) VH_int.get(base, (long) i);
         }
         return sum;
+    }
+
+    @Benchmark
+    public int segment_loop_static() {
+        int res = 0;
+        for (int i = 0; i < ELEM_SIZE; i ++) {
+            res += MemoryAccess.getInt(segment.baseAddress(), i * CARRIER_SIZE);
+        }
+        return res;
     }
 
     @Benchmark


### PR DESCRIPTION
This patch adds methods to NativeScope which allow clients to allocate off-heap arrays from Java on-heap arrays.

While in most cases the code for copying is straightforward, we have to take into account endianness mismatches (in case the user wants to store the array elements off-heap in an endianness that doesn't match that of the platform).

To allow for that, I've added a new implementation method in AbstractMemorySegmentImpl, which is the same as `copyFrom`, but adds the byte swap (a wrapper around `Unsafe::copySwapMemory`).
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [JDK-8248499](https://bugs.openjdk.java.net/browse/JDK-8248499): Add methods to allocate off heap arrays from Java arrays


### Reviewers
 * Athijegannathan Sundararajan ([sundar](@sundararajana) - Committer) ⚠️ Review applies to ac6e37dc7c3eb91f4640db892096421d1a9f48f3
 * Jorn Vernee ([jvernee](@JornVernee) - Committer) ⚠️ Review applies to 38c81345427b02034d063d824ab6f982434f544a
 * Paul Sandoz ([psandoz](@PaulSandoz) - Committer) ⚠️ Review applies to 86c572f3281a16f5fa405f8e8027b71158d5f482
 * Henry Jen ([henryjen](@slowhog) - Committer) ⚠️ Review applies to 86c572f3281a16f5fa405f8e8027b71158d5f482


### Download
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/222/head:pull/222`
`$ git checkout pull/222`
