### PR TITLE
Improve StdLibTest to use new helpers

### DIFF
--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/CSupport.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/CSupport.java
@@ -566,12 +566,6 @@ public class CSupport {
     }
 
     /**
-     * Byte array handle to read byte array from C char*
-     */
-    public final static VarHandle byteArrHandle =
-            MemoryLayout.ofSequence(C_CHAR).varHandle(byte.class, MemoryLayout.PathElement.sequenceElement());
-
-    /**
      * Convert a Java string into a null-terminated C string, using the
      * platform's default charset, storing the result into a new native memory segment.
      * <p>
@@ -734,7 +728,7 @@ public class CSupport {
     private static void copy(MemoryAddress addr, byte[] bytes) {
         var heapSegment = MemorySegment.ofArray(bytes);
         addr.segment().copyFrom(heapSegment);
-        byteArrHandle.set(addr, (long)bytes.length, (byte)0);
+        MemoryAccess.setByte(addr, bytes.length, (byte)0);
     }
 
     private static MemorySegment toCString(byte[] bytes) {

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/SharedUtils.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/SharedUtils.java
@@ -28,6 +28,7 @@ import jdk.incubator.foreign.CSupport;
 import jdk.incubator.foreign.ForeignLinker;
 import jdk.incubator.foreign.FunctionDescriptor;
 import jdk.incubator.foreign.GroupLayout;
+import jdk.incubator.foreign.MemoryAccess;
 import jdk.incubator.foreign.MemoryAddress;
 import jdk.incubator.foreign.MemoryHandles;
 import jdk.incubator.foreign.MemoryLayout;
@@ -269,7 +270,7 @@ public class SharedUtils {
     private static int strlen(MemoryAddress address) {
         // iterate until overflow (String can only hold a byte[], whose length can be expressed as an int)
         for (int offset = 0; offset >= 0; offset++) {
-            byte curr = (byte) CSupport.byteArrHandle.get(address, (long) offset);
+            byte curr = MemoryAccess.getByte(address, offset);
             if (curr == 0) {
                 return offset;
             }

--- a/test/jdk/java/foreign/StdLibTest.java
+++ b/test/jdk/java/foreign/StdLibTest.java
@@ -34,8 +34,6 @@
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.MethodType;
-import java.lang.invoke.VarHandle;
-import java.nio.ByteOrder;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
@@ -48,8 +46,6 @@ import java.util.List;
 import java.util.Set;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
-import java.util.stream.IntStream;
-import java.util.stream.LongStream;
 import java.util.stream.Stream;
 
 import jdk.incubator.foreign.CSupport;
@@ -57,10 +53,13 @@ import jdk.incubator.foreign.ForeignLinker;
 import jdk.incubator.foreign.FunctionDescriptor;
 import jdk.incubator.foreign.LibraryLookup;
 import jdk.incubator.foreign.MemoryAddress;
-import jdk.incubator.foreign.MemoryHandles;
 import jdk.incubator.foreign.MemoryLayout;
 import jdk.incubator.foreign.MemorySegment;
+import jdk.incubator.foreign.NativeScope;
 import jdk.incubator.foreign.SequenceLayout;
+
+import static jdk.incubator.foreign.MemoryAccess.*;
+
 import org.testng.annotations.*;
 
 import static jdk.incubator.foreign.CSupport.*;
@@ -70,17 +69,6 @@ import static org.testng.Assert.*;
 public class StdLibTest extends NativeTestHelper {
 
     final static ForeignLinker abi = CSupport.getSystemLinker();
-
-    final static VarHandle byteHandle = MemoryHandles.varHandle(byte.class, ByteOrder.nativeOrder());
-    final static VarHandle intHandle = MemoryHandles.varHandle(int.class, ByteOrder.nativeOrder());
-    final static VarHandle longHandle = MemoryHandles.varHandle(long.class, ByteOrder.nativeOrder());
-    final static VarHandle byteArrHandle = arrayHandle(C_CHAR, byte.class);
-    final static VarHandle intArrHandle = arrayHandle(C_INT, int.class);
-
-    static VarHandle arrayHandle(MemoryLayout elemLayout, Class<?> elemCarrier) {
-        return MemoryLayout.ofSequence(1, elemLayout)
-                .varHandle(elemCarrier, MemoryLayout.PathElement.sequenceElement());
-    }
 
     private StdLibHelper stdLibHelper = new StdLibHelper();
 
@@ -245,9 +233,9 @@ public class StdLibTest extends NativeTestHelper {
                  MemorySegment other = toCString(s2)) {
                 char[] chars = s1.toCharArray();
                 for (long i = 0 ; i < chars.length ; i++) {
-                    byteArrHandle.set(buf.baseAddress(), i, (byte)chars[(int)i]);
+                    setByte(buf.baseAddress(), i, (byte)chars[(int)i]);
                 }
-                byteArrHandle.set(buf.baseAddress(), (long)chars.length, (byte)'\0');
+                setByte(buf.baseAddress(), chars.length, (byte)'\0');
                 return toJavaStringRestricted(((MemoryAddress)strcat.invokeExact(buf.baseAddress(), other.baseAddress())));
             }
         }
@@ -273,7 +261,7 @@ public class StdLibTest extends NativeTestHelper {
 
         Tm gmtime(long arg) throws Throwable {
             try (MemorySegment time = MemorySegment.allocateNative(8)) {
-                longHandle.set(time.baseAddress(), arg);
+                setLong(time.baseAddress(), 0, arg);
                 return new Tm((MemoryAddress)gmtime.invokeExact(time.baseAddress()));
             }
         }
@@ -291,58 +279,55 @@ public class StdLibTest extends NativeTestHelper {
             }
 
             int sec() {
-                return (int)intHandle.get(base);
+                return getInt(base, 0);
             }
             int min() {
-                return (int)intHandle.get(base.addOffset(4));
+                return getInt(base, 4);
             }
             int hour() {
-                return (int)intHandle.get(base.addOffset(8));
+                return getInt(base, 8);
             }
             int mday() {
-                return (int)intHandle.get(base.addOffset(12));
+                return getInt(base, 12);
             }
             int mon() {
-                return (int)intHandle.get(base.addOffset(16));
+                return getInt(base, 16);
             }
             int year() {
-                return (int)intHandle.get(base.addOffset(20));
+                return getInt(base, 20);
             }
             int wday() {
-                return (int)intHandle.get(base.addOffset(24));
+                return getInt(base, 24);
             }
             int yday() {
-                return (int)intHandle.get(base.addOffset(28));
+                return getInt(base, 28);
             }
             boolean isdst() {
-                byte b = (byte)byteHandle.get(base.addOffset(32));
+                byte b = getByte(base, 32);
                 return b != 0;
             }
         }
 
         int[] qsort(int[] arr) throws Throwable {
             //init native array
-            SequenceLayout seq = MemoryLayout.ofSequence(arr.length, C_INT);
+            try (NativeScope scope = NativeScope.unboundedScope()) {
 
-            try (MemorySegment nativeArr = MemorySegment.allocateNative(seq)) {
-
-                IntStream.range(0, arr.length)
-                        .forEach(i -> intArrHandle.set(nativeArr.baseAddress(), i, arr[i]));
+                MemorySegment nativeArr = scope.allocateArray(C_INT, arr).segment();
 
                 //call qsort
-                try (MemorySegment qsortUpcallStub = abi.upcallStub(qsortCompar.bindTo(nativeArr), qsortComparFunction)) {
-                    qsort.invokeExact(nativeArr.baseAddress(), seq.elementCount().getAsLong(), C_INT.byteSize(), qsortUpcallStub.baseAddress());
-                }
+                MemorySegment qsortUpcallStub = abi.upcallStub(qsortCompar.bindTo(nativeArr), qsortComparFunction);
+                scope.register(qsortUpcallStub);
+
+                qsort.invokeExact(nativeArr.baseAddress(), (long)arr.length, C_INT.byteSize(), qsortUpcallStub.baseAddress());
 
                 //convert back to Java array
-                return LongStream.range(0, arr.length)
-                        .mapToInt(i -> (int)intArrHandle.get(nativeArr.baseAddress(), i))
-                        .toArray();
+                return nativeArr.toIntArray();
             }
         }
 
         static int qsortCompare(MemorySegment base, MemoryAddress addr1, MemoryAddress addr2) {
-            return (int)intHandle.get(addr1.rebase(base)) - (int)intHandle.get(addr2.rebase(base));
+            return getInt(base.baseAddress(), addr1.rebase(base).segmentOffset()) -
+                   getInt(base.baseAddress(), addr2.rebase(base).segmentOffset());
         }
 
         int rand() throws Throwable {


### PR DESCRIPTION
This patch improves StdLibTest to use the new static accessors in MemoryAccess, as well as some of the recently added improvements to NativeScope and MemorySegment (such as the ability to create off-heap segments from Java arrays and back).
As part of this change, as I saw that the test (probably inadvertently) depended on the var handle constant defined in CSupport (which has also been accidentally exposed), I applied minor rewrites to also use the static accessors in CSupport and SharedUtils.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * Athijegannathan Sundararajan ([sundar](@sundararajana) - Committer)
 * Jorn Vernee ([jvernee](@JornVernee) - Committer)


### Download
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/225/head:pull/225`
`$ git checkout pull/225`
