### PR TITLE
Copy stubs from Compile arena to nmethod stub array

### DIFF
--- a/src/hotspot/share/opto/output.cpp
+++ b/src/hotspot/share/opto/output.cpp
@@ -3300,6 +3300,9 @@ void PhaseOutput::install_code(ciMethod*         target,
     if (!C->native_stubs()->is_empty()) {
       num_stubs = C->native_stubs()->length();
       native_stubs = NEW_C_HEAP_ARRAY(address, num_stubs, mtInternal);
+      for (int i = 0; i < num_stubs; i++) {
+        native_stubs[i] = C->native_stubs()->at(i);
+      }
     }
 
     C->env()->register_method(target,


### PR DESCRIPTION
Hi,

This is a small followup on the intrinsics patch (https://github.com/openjdk/panama-foreign/pull/219).

@slowhog was seeing a crash when native invoker stubs were being freed, and it turned out that this was due to not copying the stubs properly from the compile arena to the nmethod stub array when creating the nmethod. This patch fixes that.

I had wrongly assumed that this code path would be exercised by the current tests, but this is evidently not the case. I'll think of a way to add a test for this specific case, but in the mean time this is a stop-gap fix to resolve the crash.

Thanks,
Jorn
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * Henry Jen ([henryjen](@slowhog) - Committer)


### Download
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/227/head:pull/227`
`$ git checkout pull/227`
