### PR TITLE
Fix javadoc issues in foreign-abi

### DIFF
--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/CSupport.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/CSupport.java
@@ -302,17 +302,30 @@ public class CSupport {
         }
 
         /**
-         * The name of the SysV linker ({@see ForeignLinker#name})
+         * The name of the SysV linker
+         * @see ForeignLinker#name
          */
         public static final String NAME = "SysV";
 
+        /**
+         * The name of the layout attribute (see {@link MemoryLayout#attributes()} used for ABI classification. The
+         * attribute value must be an enum constant from {@link ArgumentClass}.
+         */
         public final static String CLASS_ATTRIBUTE_NAME = "abi/sysv/class";
 
+        /**
+         * Constants used for ABI classification. They are referred to by the layout attribute {@link #CLASS_ATTRIBUTE_NAME}.
+         */
         public enum ArgumentClass {
+            /** Classification constant for integral values */
             INTEGER,
+            /** Classification constant for floating point values */
             SSE,
+            /** Classification constant for x87 floating point values */
             X87,
+            /** Classification constant for {@code complex long double} values */
             COMPLEX_87,
+            /** Classification constant for machine pointer values */
             POINTER;
         }
 
@@ -398,17 +411,32 @@ public class CSupport {
         }
 
         /**
-         * The name of the Windows linker ({@see ForeignLinker#name})
+         * The name of the Windows linker
+         * @see ForeignLinker#name
          */
         public final static String NAME = "Windows";
 
+        /**
+         * The name of the layout attribute (see {@link MemoryLayout#attributes()} used to mark variadic parameters. The
+         * attribute value must be a boolean.
+         */
         public final static String VARARGS_ATTRIBUTE_NAME = "abi/windows/varargs";
 
+        /**
+         * The name of the layout attribute (see {@link MemoryLayout#attributes()} used for ABI classification. The
+         * attribute value must be an enum constant from {@link ArgumentClass}.
+         */
         public final static String CLASS_ATTRIBUTE_NAME = "abi/windows/class";
 
+        /**
+         * Constants used for ABI classification. They are referred to by the layout attribute {@link #CLASS_ATTRIBUTE_NAME}.
+         */
         public enum ArgumentClass {
+            /** Classification constant for integral values */
             INTEGER,
+            /** Classification constant for floating point values */
             FLOAT,
+            /** Classification constant for machine pointer values */
             POINTER;
         }
 
@@ -477,8 +505,14 @@ public class CSupport {
          */
         public static final MemoryLayout C_VA_LIST = Win64.C_POINTER;
 
-        public static ValueLayout asVarArg(ValueLayout l) {
-            return l.withAttribute(VARARGS_ATTRIBUTE_NAME, "true");
+        /**
+         * Return a new memory layout which describes a variadic parameter to be passed to a function.
+         * @param layout the original parameter layout.
+         * @return a layout which is the same as {@code layout}, except for the extra attribute {@link #VARARGS_ATTRIBUTE_NAME},
+         * which is set to {@code true}.
+         */
+        public static ValueLayout asVarArg(ValueLayout layout) {
+            return layout.withAttribute(VARARGS_ATTRIBUTE_NAME, "true");
         }
     }
 
@@ -492,15 +526,26 @@ public class CSupport {
         }
 
         /**
-         * The name of the AArch64 linker ({@see ForeignLinker#name})
+         * The name of the AArch64 linker
+         * @see ForeignLinker#name
          */
         public final static String NAME = "AArch64";
 
+        /**
+         * The name of the layout attribute (see {@link MemoryLayout#attributes()} used for ABI classification. The
+         * attribute value must be an enum constant from {@link ArgumentClass}.
+         */
         public static final String CLASS_ATTRIBUTE_NAME = "abi/aarch64/class";
 
+        /**
+         * Constants used for ABI classification. They are referred to by the layout attribute {@link #CLASS_ATTRIBUTE_NAME}.
+         */
         public enum ArgumentClass {
+            /** Classification constant for machine integral values */
             INTEGER,
+            /** Classification constant for machine integral values */
             VECTOR,
+            /** Classification constant for machine pointer values */
             POINTER;
         }
 
@@ -700,7 +745,7 @@ public class CSupport {
      * @throws NullPointerException if {@code addr == null}
      * @throws IllegalArgumentException if the size of the native string is greater than {@code Integer.MAX_VALUE}.
      * @throws IllegalStateException if the size of the native string is greater than the size of the segment
-     * associated with {@code addr}, or if {@code addr} is associated with a segment that is </em>not alive<em>.
+     * associated with {@code addr}, or if {@code addr} is associated with a segment that is <em>not alive</em>.
      */
     public static String toJavaString(MemoryAddress addr) {
         return SharedUtils.toJavaStringInternal(addr, Charset.defaultCharset());
@@ -719,7 +764,7 @@ public class CSupport {
      * @throws NullPointerException if {@code addr == null}
      * @throws IllegalArgumentException if the size of the native string is greater than {@code Integer.MAX_VALUE}.
      * @throws IllegalStateException if the size of the native string is greater than the size of the segment
-     * associated with {@code addr}, or if {@code addr} is associated with a segment that is </em>not alive<em>.
+     * associated with {@code addr}, or if {@code addr} is associated with a segment that is <em>not alive</em>.
      */
     public static String toJavaString(MemoryAddress addr, Charset charset) {
         return SharedUtils.toJavaStringInternal(addr, charset);

--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/CSupport.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/CSupport.java
@@ -543,7 +543,7 @@ public class CSupport {
         public enum ArgumentClass {
             /** Classification constant for machine integral values */
             INTEGER,
-            /** Classification constant for machine integral values */
+            /** Classification constant for machine floating point values */
             VECTOR,
             /** Classification constant for machine pointer values */
             POINTER;

--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/FunctionDescriptor.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/FunctionDescriptor.java
@@ -44,7 +44,7 @@ import java.util.stream.Stream;
 public final class FunctionDescriptor implements Constable {
 
     /**
-     * The name of the function descriptor attribute (see {@link #attributes()} used to mark variadic parameters. The
+     * The name of the function descriptor attribute (see {@link #attributes()} used to mark trivial functions. The
      * attribute value must be a boolean.
      */
     public static final String TRIVIAL_ATTRIBUTE_NAME = "abi/trivial";

--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/FunctionDescriptor.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/FunctionDescriptor.java
@@ -42,7 +42,12 @@ import java.util.stream.Stream;
  * is used to model the signature of native functions.
  */
 public final class FunctionDescriptor implements Constable {
-    public static final String IS_TRIVIAL = "abi/is_trivial";
+
+    /**
+     * The name of the function descriptor attribute (see {@link #attributes()} used to mark variadic parameters. The
+     * attribute value must be a boolean.
+     */
+    public static final String TRIVIAL_ATTRIBUTE_NAME = "abi/trivial";
     
     private final MemoryLayout resLayout;
     private final MemoryLayout[] argLayouts;
@@ -54,14 +59,34 @@ public final class FunctionDescriptor implements Constable {
         this.argLayouts = argLayouts;
     }
 
+    /**
+     * Returns the attribute with the given name (if it exists).
+     *
+     * @param name the attribute name
+     * @return the attribute with the given name (if it exists).
+     */
     public Optional<Constable> attribute(String name) {
         return Optional.ofNullable(attributes.get(name));
     }
 
+    /**
+     * Returns a stream of the attribute names associated with this function descriptor.
+     *
+     * @return a stream of the attribute names associated with this function descriptor.
+     */
     public Stream<String> attributes() {
         return attributes.keySet().stream();
     }
 
+    /**
+     * Returns a new function descriptor which features the same attributes as this descriptor, plus the newly specified attribute.
+     * If this descriptor already contains an attribute with the same name, the existing attribute value is overwritten in the returned
+     * descriptor.
+     *
+     * @param name the attribute name.
+     * @param value the attribute value.
+     * @return a new function descriptor which features the same attributes as this descriptor, plus the newly specified attribute.
+     */
     public FunctionDescriptor withAttribute(String name, Constable value) {
         Map<String, Constable> newAttributes = new HashMap<>(attributes);
         newAttributes.put(name, value);

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/SharedUtils.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/SharedUtils.java
@@ -351,7 +351,7 @@ public class SharedUtils {
     }
 
     public static boolean isTrivial(FunctionDescriptor cDesc) {
-        return cDesc.attribute(FunctionDescriptor.IS_TRIVIAL)
+        return cDesc.attribute(FunctionDescriptor.TRIVIAL_ATTRIBUTE_NAME)
                 .map(Boolean.class::cast)
                 .orElse(false);
     }

--- a/test/micro/org/openjdk/bench/jdk/incubator/foreign/CallOverhead.java
+++ b/test/micro/org/openjdk/bench/jdk/incubator/foreign/CallOverhead.java
@@ -81,14 +81,14 @@ public class CallOverhead {
                 MethodType mt = MethodType.methodType(void.class);
                 FunctionDescriptor fd = FunctionDescriptor.ofVoid();
                 func = abi.downcallHandle(addr, mt, fd);
-                func_trivial = abi.downcallHandle(addr, mt, fd.withAttribute(FunctionDescriptor.IS_TRIVIAL, true));
+                func_trivial = abi.downcallHandle(addr, mt, fd.withAttribute(FunctionDescriptor.TRIVIAL_ATTRIBUTE_NAME, true));
             }
             {
                 MemoryAddress addr = ll.lookup("identity");
                 MethodType mt = MethodType.methodType(int.class, int.class);
                 FunctionDescriptor fd = FunctionDescriptor.of(C_INT, C_INT);
                 identity = abi.downcallHandle(addr, mt, fd);
-                identity_trivial = abi.downcallHandle(addr, mt, fd.withAttribute(FunctionDescriptor.IS_TRIVIAL, true));
+                identity_trivial = abi.downcallHandle(addr, mt, fd.withAttribute(FunctionDescriptor.TRIVIAL_ATTRIBUTE_NAME, true));
             }
             identity_struct = abi.downcallHandle(ll.lookup("identity_struct"),
                     MethodType.methodType(MemorySegment.class, MemorySegment.class),


### PR DESCRIPTION
This patch addresses several issues with foreign-abi javadoc, which are preventing javadoc to complete succesfully on the jdk.incubator.foreign package.

I added the various bits of missing documentation and fixed all relevant warnings - the comments will likely need a later pass, but at least now javadoc can be built w/o issues.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * Jorn Vernee ([jvernee](@JornVernee) - Committer) ⚠️ Review applies to 975bda3f1df522dfafb28d392158054c1ea0be36


### Download
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/230/head:pull/230`
`$ git checkout pull/230`
