### PR TITLE
8248480: Switch isVarArg layout attribute to Boolean

### DIFF
--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/CSupport.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/CSupport.java
@@ -512,7 +512,7 @@ public class CSupport {
          * which is set to {@code true}.
          */
         public static ValueLayout asVarArg(ValueLayout layout) {
-            return layout.withAttribute(VARARGS_ATTRIBUTE_NAME, "true");
+            return layout.withAttribute(VARARGS_ATTRIBUTE_NAME, true);
         }
     }
 

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/x64/windows/TypeClass.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/x64/windows/TypeClass.java
@@ -63,8 +63,7 @@ enum TypeClass {
             return POINTER;
         } else if (clazz == CSupport.Win64.ArgumentClass.FLOAT) {
             if (type.attribute(VARARGS_ATTRIBUTE_NAME)
-                    .map(String.class::cast)
-                    .map(Boolean::parseBoolean).orElse(false)) {
+                    .map(Boolean.class::cast).orElse(false)) {
                 return VARARG_FLOAT;
             }
             return FLOAT;


### PR DESCRIPTION
Hi,

This trivial patch switches the type of the Windows var arg layout attribute from String to boolean.

Thanks,
Jorn
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [JDK-8248480](https://bugs.openjdk.java.net/browse/JDK-8248480): Switch isVarArg layout attribute to Boolean


### Reviewers
 * Maurizio Cimadamore ([mcimadamore](@mcimadamore) - Committer)


### Download
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/231/head:pull/231`
`$ git checkout pull/231`
