### PR TITLE
8248487: Add static helpers to access segments (continued)

### DIFF
--- a/test/jdk/tools/jextract/test8241925/LibTest8241925Test.java
+++ b/test/jdk/tools/jextract/test8241925/LibTest8241925Test.java
@@ -45,14 +45,14 @@ public class LibTest8241925Test {
     public void test() {
         try (var scope = NativeScope.unboundedScope()) {
             var addr = scope.allocate(C_INT, 12);
-            assertEquals(MemoryAccess.getInt(addr, 0), 12);
+            assertEquals(MemoryAccess.getInt(addr), 12);
             square(addr);
-            assertEquals(MemoryAccess.getInt(addr, 0), 144);
+            assertEquals(MemoryAccess.getInt(addr), 144);
 
             addr = scope.allocate(C_DOUBLE, 12.0);
-            assertEquals(MemoryAccess.getDouble(addr, 0), 12.0, 0.1);
+            assertEquals(MemoryAccess.getDouble(addr), 12.0, 0.1);
             square_fp(addr);
-            assertEquals(MemoryAccess.getDouble(addr, 0), 144.0, 0.1);
+            assertEquals(MemoryAccess.getDouble(addr), 144.0, 0.1);
 
             int[] intArray = { 34, 67, 78, 8 };
             addr = scope.allocateArray(C_INT, intArray);

--- a/test/jdk/tools/jextract/test8244412/LibTest8244412Test.java
+++ b/test/jdk/tools/jextract/test8244412/LibTest8244412Test.java
@@ -45,9 +45,9 @@ public class LibTest8244412Test {
     public void test() {
         try (var scope = NativeScope.unboundedScope()) {
             var addr = scope.allocate(mysize_t, 0L);
-            assertEquals(MemoryAccess.getLong(addr, 0), 0L);
-            MemoryAccess.setLong(addr, 0, 13455566L);
-            assertEquals(MemoryAccess.getLong(addr, 0), 13455566L);
+            assertEquals(MemoryAccess.getLong(addr), 0L);
+            MemoryAccess.setLong(addr, 13455566L);
+            assertEquals(MemoryAccess.getLong(addr), 13455566L);
         }
     }
 }

--- a/test/jdk/tools/jextract/test8246341/LibTest8246341Test.java
+++ b/test/jdk/tools/jextract/test8246341/LibTest8246341Test.java
@@ -42,10 +42,6 @@ import static jdk.incubator.foreign.CSupport.*;
  * @run testng/othervm -Dforeign.restricted=permit LibTest8246341Test
  */
 public class LibTest8246341Test {
-    private static MemoryAddress getPointerAt(MemoryAddress addr, int element) {
-        return MemoryAccess.getAddress(addr, element*C_POINTER.byteSize());
-    }
-
     @Test
     public void testPointerArray() {
         boolean[] callbackCalled = new boolean[1];
@@ -53,10 +49,10 @@ public class LibTest8246341Test {
             callbackCalled[0] = true;
             var addr = RuntimeHelper.asArrayRestricted(argv, C_POINTER, argc);
             assertEquals(argc, 4);
-            assertEquals(toJavaStringRestricted(getPointerAt(addr, 0)), "java");
-            assertEquals(toJavaStringRestricted(getPointerAt(addr, 1)), "python");
-            assertEquals(toJavaStringRestricted(getPointerAt(addr, 2)), "javascript");
-            assertEquals(toJavaStringRestricted(getPointerAt(addr, 3)), "c++");
+            assertEquals(toJavaStringRestricted(MemoryAccess.getAddressAtIndex(addr, 0)), "java");
+            assertEquals(toJavaStringRestricted(MemoryAccess.getAddressAtIndex(addr, 1)), "python");
+            assertEquals(toJavaStringRestricted(MemoryAccess.getAddressAtIndex(addr, 2)), "javascript");
+            assertEquals(toJavaStringRestricted(MemoryAccess.getAddressAtIndex(addr, 3)), "c++");
         })) {
             func(callback.baseAddress());
         }
@@ -67,9 +63,9 @@ public class LibTest8246341Test {
     public void testPointerAllocate() {
         try (var scope = NativeScope.boundedScope(C_POINTER.byteSize())) {
             var addr = scope.allocate(C_POINTER);
-            MemoryAccess.setAddress(addr, 0, MemoryAddress.NULL);
+            MemoryAccess.setAddress(addr, MemoryAddress.NULL);
             fillin(addr);
-            assertEquals(toJavaStringRestricted(getPointerAt(addr, 0)), "hello world");
+            assertEquals(toJavaStringRestricted(MemoryAccess.getAddress(addr)), "hello world");
         }
     }
 }


### PR DESCRIPTION
Fix jextract tests to use correct memory static accessors.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [JDK-8248487](https://bugs.openjdk.java.net/browse/JDK-8248487): Add static helpers to access segments ⚠️ Title mismatch between PR and JBS.


### Reviewers
 * Jorn Vernee ([jvernee](@JornVernee) - Committer)


### Download
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/235/head:pull/235`
`$ git checkout pull/235`
