### PR TITLE
8248420: Add a variant of VaList::make which takes a NativeScope

### DIFF
--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/CSupport.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/CSupport.java
@@ -56,6 +56,8 @@ public class CSupport {
     /**
      * An interface that models a C {@code va_list}.
      *
+     * A va list is a stateful cursor used to iterate over a set of variadic arguments.
+     *
      * Per the C specification (see C standard 6.5.2.2 Function calls - item 6),
      * arguments to variadic calls are erased by way of 'default argument promotions',
      * which erases integral types by way of integer promotion (see C standard 6.3.1.1 - item 2),
@@ -67,7 +69,7 @@ public class CSupport {
     public interface VaList extends AutoCloseable {
 
         /**
-         * Reads a value into an {@code int}
+         * Reads the next value into an {@code int} and advances this va list's position.
          *
          * @param layout the layout of the value
          * @return the value read as an {@code int}
@@ -77,7 +79,7 @@ public class CSupport {
         int vargAsInt(MemoryLayout layout);
 
         /**
-         * Reads a value into a {@code long}
+         * Reads the next value into a {@code long} and advances this va list's position.
          *
          * @param layout the layout of the value
          * @return the value read as an {@code long}
@@ -87,7 +89,7 @@ public class CSupport {
         long vargAsLong(MemoryLayout layout);
 
         /**
-         * Reads a value into a {@code double}
+         * Reads the next value into a {@code double} and advances this va list's position.
          *
          * @param layout the layout of the value
          * @return the value read as an {@code double}
@@ -97,7 +99,7 @@ public class CSupport {
         double vargAsDouble(MemoryLayout layout);
 
         /**
-         * Reads a value into a {@code MemoryAddress}
+         * Reads the next value into a {@code MemoryAddress} and advances this va list's position.
          *
          * @param layout the layout of the value
          * @return the value read as an {@code MemoryAddress}
@@ -107,7 +109,10 @@ public class CSupport {
         MemoryAddress vargAsAddress(MemoryLayout layout);
 
         /**
-         * Reads a value into a {@code MemorySegment}
+         * Reads the next value into a {@code MemorySegment}, and advances this va list's position.
+         *
+         * The memory segment returned by this method will be allocated using
+         * {@link MemorySegment#allocateNative(long, long)}, and will have to be closed separately.
          *
          * @param layout the layout of the value
          * @return the value read as an {@code MemorySegment}
@@ -117,7 +122,9 @@ public class CSupport {
         MemorySegment vargAsSegment(MemoryLayout layout);
 
         /**
-         * Reads a value into a {@code MemorySegment}, using the given {@code NativeScope} to allocate said segment.
+         * Reads the next value into a {@code MemorySegment}, and advances this va list's position.
+         *
+         * The memory segment returned by this method will be allocated using the given {@code NativeScope}.
          *
          * @param layout the layout of the value
          * @param scope the scope to allocate the segment in
@@ -128,7 +135,7 @@ public class CSupport {
         MemorySegment vargAsSegment(MemoryLayout layout, NativeScope scope);
 
         /**
-         * Skips a number of va arguments with the given memory layouts.
+         * Skips a number of arguments with the given memory layouts, and advancing this va list's position.
          *
          * @param layouts the layout of the value
          * @throws IllegalStateException if the C {@code va_list} associated with this instance is no longer valid
@@ -138,8 +145,7 @@ public class CSupport {
 
         /**
          * A predicate used to check if the memory associated with the C {@code va_list} modelled
-         * by this instance is still valid; or, in other words, if {@code close()} has been called on this
-         * instance.
+         * by this instance is still valid to use.
          *
          * @return true, if the memory associated with the C {@code va_list} modelled by this instance is still valid
          * @see #close()
@@ -147,19 +153,30 @@ public class CSupport {
         boolean isAlive();
 
         /**
-         * Releases the underlying C {@code va_list} modelled by this instance. As a result, subsequent attempts to call
-         * operations on this instance (e.g. {@link #copy()} will fail with an exception.
+         * Releases the underlying C {@code va_list} modelled by this instance, and any native memory that is attached
+         * to this va list that holds its elements (see {@link VaList#make(Consumer)}).
+         *
+         * For some {@code VaList} instances, calling this method will have no effect. For instance: on Windows, a copy
+         * of a va list does not need any native memory, so nothing has to be released. After calling {@code close()} on
+         * such an instance {@link #isAlive()} will still return {@code true}.
          *
          * @see #isAlive()
          */
         void close();
 
         /**
-         * Copies this C {@code va_list}.
+         * Copies this C {@code va_list} at its current position. Copying is useful to traverse the va list's elements
+         * starting from the current position, without affecting the state of the original va list, essentially
+         * allowing the elements to be traversed multiple times.
          *
-         * @apiNote that this method only copies the va list 'view' and not any argument space it may manage.
-         * That means that if this va list was created with the {@link #make(Consumer)} method, closing
-         * this va list will also free the argument space, and make the copy unusable.
+         * If this method needs to allocate native memory for the copy, it will use
+         * {@link MemorySegment#allocateNative(long, long)} to do so. {@link #close()} will have to be called on the
+         * returned va list instance to release the allocated memory.
+         *
+         * This method only copies the va list cursor itself and not the memory that may be attached to the
+         * va list which holds its elements. That means that if this va list was created with the
+         * {@link #make(Consumer)} method, closing this va list will also release the native memory that holds its
+         * elements, making the copy unusable.
          *
          * @return a copy of this C {@code va_list}.
          * @throws IllegalStateException if the C {@code va_list} associated with this instance is no longer valid
@@ -168,11 +185,17 @@ public class CSupport {
         VaList copy();
 
         /**
-         * Copies this C {@code va_list}, using the given {@code NativeScope} to allocate the copy (if needed).
+         * Copies this C {@code va_list} at its current position. Copying is useful to traverse the va list's elements
+         * starting from the current position, without affecting the state of the original va list, essentially
+         * allowing the elements to be traversed multiple times.
          *
-         * @apiNote this method only copies the va list 'view' and not any argument space it may manage.
-         * That means that if this va list was created with the {@link #make(Consumer)} method, closing
-         * this va list will also free the argument space, and make the copy unusable.
+         * If this method needs to allocate native memory for the copy, it will use
+         * the given {@code NativeScope} to do so.
+         *
+         * This method only copies the va list cursor itself and not the memory that may be attached to the
+         * va list which holds its elements. That means that if this va list was created with the
+         * {@link #make(Consumer)} method, closing this va list will also release the native memory that holds its
+         * elements, making the copy unusable.
          *
          * @param scope the scope to allocate the copy in
          * @return a copy of this C {@code va_list}.
@@ -201,13 +224,17 @@ public class CSupport {
         /**
          * Constructs a new {@code VaList} using a builder (see {@link Builder}).
          *
-         * Note that when there are no arguments added to the created va list,
+         * If this method needs to allocate native memory for the va list, it will use
+         * {@link MemorySegment#allocateNative(long, long)} to do so.
+         *
+         * This method will allocate native memory to hold the elements in the va list. This memory
+         * will be 'attached' to the returned va list instance, and will be released when {@link VaList#close()}
+         * is called.
+         *
+         * Note that when there are no elements added to the created va list,
          * this method will return the same as {@linkplain #empty()}.
          *
-         * Va lists created with this method also implicitly manage an off-heap 'argument space' that holds
-         * the arguments in the va list. Closing the returned va list will also free the argument space.
-         *
-         * @param actions a consumer for a builder (see {@link Builder}) which can be used to specify the contents
+         * @param actions a consumer for a builder (see {@link Builder}) which can be used to specify the elements
          *                of the underlying C {@code va_list}.
          * @return a new {@code VaList} instance backed by a fresh C {@code va_list}.
          */
@@ -216,13 +243,18 @@ public class CSupport {
         }
 
         /**
-         * Constructs a new {@code VaList} using a builder (see {@link Builder}), and using the given
-         * {@code NativeScope} to do all needed allocations.
+         * Constructs a new {@code VaList} using a builder (see {@link Builder}).
          *
-         * Note that when there are no arguments added to the created va list,
+         * If this method needs to allocate native memory for the va list, it will use
+         * the given {@code NativeScope} to do so.
+         *
+         * This method will allocate native memory to hold the elements in the va list. This memory
+         * will be managed by the given {@code NativeScope}, and will be released when the scope is closed.
+         *
+         * Note that when there are no elements added to the created va list,
          * this method will return the same as {@linkplain #empty()}.
          *
-         * @param actions a consumer for a builder (see {@link Builder}) which can be used to specify the contents
+         * @param actions a consumer for a builder (see {@link Builder}) which can be used to specify the elements
          *                of the underlying C {@code va_list}.
          * @return a new {@code VaList} instance backed by a fresh C {@code va_list}.
          */

--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/CSupport.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/CSupport.java
@@ -55,62 +55,66 @@ public class CSupport {
 
     /**
      * An interface that models a C {@code va_list}.
-     *
+     * <p>
      * A va list is a stateful cursor used to iterate over a set of variadic arguments.
-     *
+     * <p>
      * Per the C specification (see C standard 6.5.2.2 Function calls - item 6),
      * arguments to variadic calls are erased by way of 'default argument promotions',
      * which erases integral types by way of integer promotion (see C standard 6.3.1.1 - item 2),
      * and which erases all {@code float} arguments to {@code double}.
-     *
+     * <p>
      * As such, this interface only supports reading {@code int}, {@code double},
      * and any other type that fits into a {@code long}.
      */
     public interface VaList extends AutoCloseable {
 
         /**
-         * Reads the next value into an {@code int} and advances this va list's position.
+         * Reads the next value as an {@code int} and advances this va list's position.
          *
          * @param layout the layout of the value
          * @return the value read as an {@code int}
          * @throws IllegalStateException if the C {@code va_list} associated with this instance is no longer valid
          * (see {@link #close()}).
+         * @throws IllegalArgumentException if the given memory layout is not compatible with {@code int}
          */
         int vargAsInt(MemoryLayout layout);
 
         /**
-         * Reads the next value into a {@code long} and advances this va list's position.
+         * Reads the next value as a {@code long} and advances this va list's position.
          *
          * @param layout the layout of the value
          * @return the value read as an {@code long}
          * @throws IllegalStateException if the C {@code va_list} associated with this instance is no longer valid
          * (see {@link #close()}).
+         * @throws IllegalArgumentException if the given memory layout is not compatible with {@code long}
          */
         long vargAsLong(MemoryLayout layout);
 
         /**
-         * Reads the next value into a {@code double} and advances this va list's position.
+         * Reads the next value as a {@code double} and advances this va list's position.
          *
          * @param layout the layout of the value
          * @return the value read as an {@code double}
          * @throws IllegalStateException if the C {@code va_list} associated with this instance is no longer valid
          * (see {@link #close()}).
+         * @throws IllegalArgumentException if the given memory layout is not compatible with {@code double}
          */
         double vargAsDouble(MemoryLayout layout);
 
         /**
-         * Reads the next value into a {@code MemoryAddress} and advances this va list's position.
+         * Reads the next value as a {@code MemoryAddress} and advances this va list's position.
          *
          * @param layout the layout of the value
          * @return the value read as an {@code MemoryAddress}
          * @throws IllegalStateException if the C {@code va_list} associated with this instance is no longer valid
          * (see {@link #close()}).
+         * @throws IllegalArgumentException if the given memory layout is not compatible with {@code MemoryAddress}
          */
         MemoryAddress vargAsAddress(MemoryLayout layout);
 
         /**
-         * Reads the next value into a {@code MemorySegment}, and advances this va list's position.
-         *
+         * Reads the next value as a {@code MemorySegment}, and advances this va list's position.
+         * <p>
          * The memory segment returned by this method will be allocated using
          * {@link MemorySegment#allocateNative(long, long)}, and will have to be closed separately.
          *
@@ -118,12 +122,13 @@ public class CSupport {
          * @return the value read as an {@code MemorySegment}
          * @throws IllegalStateException if the C {@code va_list} associated with this instance is no longer valid
          * (see {@link #close()}).
+         * @throws IllegalArgumentException if the given memory layout is not compatible with {@code MemorySegment}
          */
         MemorySegment vargAsSegment(MemoryLayout layout);
 
         /**
-         * Reads the next value into a {@code MemorySegment}, and advances this va list's position.
-         *
+         * Reads the next value as a {@code MemorySegment}, and advances this va list's position.
+         * <p>
          * The memory segment returned by this method will be allocated using the given {@code NativeScope}.
          *
          * @param layout the layout of the value
@@ -131,6 +136,7 @@ public class CSupport {
          * @return the value read as an {@code MemorySegment}
          * @throws IllegalStateException if the C {@code va_list} associated with this instance is no longer valid
          * (see {@link #close()}).
+         * @throws IllegalArgumentException if the given memory layout is not compatible with {@code MemorySegment}
          */
         MemorySegment vargAsSegment(MemoryLayout layout, NativeScope scope);
 
@@ -155,7 +161,7 @@ public class CSupport {
         /**
          * Releases the underlying C {@code va_list} modelled by this instance, and any native memory that is attached
          * to this va list that holds its elements (see {@link VaList#make(Consumer)}).
-         *
+         * <p>
          * For some {@code VaList} instances, calling this method will have no effect. For instance: on Windows, a copy
          * of a va list does not need any native memory, so nothing has to be released. After calling {@code close()} on
          * such an instance {@link #isAlive()} will still return {@code true}.
@@ -168,11 +174,11 @@ public class CSupport {
          * Copies this C {@code va_list} at its current position. Copying is useful to traverse the va list's elements
          * starting from the current position, without affecting the state of the original va list, essentially
          * allowing the elements to be traversed multiple times.
-         *
+         * <p>
          * If this method needs to allocate native memory for the copy, it will use
          * {@link MemorySegment#allocateNative(long, long)} to do so. {@link #close()} will have to be called on the
          * returned va list instance to release the allocated memory.
-         *
+         * <p>
          * This method only copies the va list cursor itself and not the memory that may be attached to the
          * va list which holds its elements. That means that if this va list was created with the
          * {@link #make(Consumer)} method, closing this va list will also release the native memory that holds its
@@ -188,10 +194,10 @@ public class CSupport {
          * Copies this C {@code va_list} at its current position. Copying is useful to traverse the va list's elements
          * starting from the current position, without affecting the state of the original va list, essentially
          * allowing the elements to be traversed multiple times.
-         *
+         * <p>
          * If this method needs to allocate native memory for the copy, it will use
          * the given {@code NativeScope} to do so.
-         *
+         * <p>
          * This method only copies the va list cursor itself and not the memory that may be attached to the
          * va list which holds its elements. That means that if this va list was created with the
          * {@link #make(Consumer)} method, closing this va list will also release the native memory that holds its
@@ -223,14 +229,14 @@ public class CSupport {
 
         /**
          * Constructs a new {@code VaList} using a builder (see {@link Builder}).
-         *
+         * <p>
          * If this method needs to allocate native memory for the va list, it will use
          * {@link MemorySegment#allocateNative(long, long)} to do so.
-         *
+         * <p>
          * This method will allocate native memory to hold the elements in the va list. This memory
          * will be 'attached' to the returned va list instance, and will be released when {@link VaList#close()}
          * is called.
-         *
+         * <p>
          * Note that when there are no elements added to the created va list,
          * this method will return the same as {@linkplain #empty()}.
          *
@@ -244,13 +250,13 @@ public class CSupport {
 
         /**
          * Constructs a new {@code VaList} using a builder (see {@link Builder}).
-         *
+         * <p>
          * If this method needs to allocate native memory for the va list, it will use
          * the given {@code NativeScope} to do so.
-         *
+         * <p>
          * This method will allocate native memory to hold the elements in the va list. This memory
          * will be managed by the given {@code NativeScope}, and will be released when the scope is closed.
-         *
+         * <p>
          * Note that when there are no elements added to the created va list,
          * this method will return the same as {@linkplain #empty()}.
          *
@@ -264,7 +270,7 @@ public class CSupport {
 
         /**
          * Returns an empty C {@code va_list} constant.
-         *
+         * <p>
          * The returned {@code VaList} can not be closed.
          *
          * @return a {@code VaList} modelling an empty C {@code va_list}.
@@ -284,6 +290,7 @@ public class CSupport {
              * @param layout the native layout of the value.
              * @param value the value, represented as an {@code int}.
              * @return this builder.
+             * @throws IllegalArgumentException if the given memory layout is not compatible with {@code int}
              */
             Builder vargFromInt(MemoryLayout layout, int value);
 
@@ -293,6 +300,7 @@ public class CSupport {
              * @param layout the native layout of the value.
              * @param value the value, represented as a {@code long}.
              * @return this builder.
+             * @throws IllegalArgumentException if the given memory layout is not compatible with {@code long}
              */
             Builder vargFromLong(MemoryLayout layout, long value);
 
@@ -302,6 +310,7 @@ public class CSupport {
              * @param layout the native layout of the value.
              * @param value the value, represented as a {@code double}.
              * @return this builder.
+             * @throws IllegalArgumentException if the given memory layout is not compatible with {@code double}
              */
             Builder vargFromDouble(MemoryLayout layout, double value);
 
@@ -311,6 +320,7 @@ public class CSupport {
              * @param layout the native layout of the value.
              * @param value the value, represented as a {@code MemoryAddress}.
              * @return this builder.
+             * @throws IllegalArgumentException if the given memory layout is not compatible with {@code MemoryAddress}
              */
             Builder vargFromAddress(MemoryLayout layout, MemoryAddress value);
 
@@ -320,6 +330,7 @@ public class CSupport {
              * @param layout the native layout of the value.
              * @param value the value, represented as a {@code MemorySegment}.
              * @return this builder.
+             * @throws IllegalArgumentException if the given memory layout is not compatible with {@code MemorySegment}
              */
             Builder vargFromSegment(MemoryLayout layout, MemorySegment value);
         }

--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/CSupport.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/CSupport.java
@@ -29,7 +29,6 @@ import jdk.internal.foreign.AbstractMemorySegmentImpl;
 import jdk.internal.foreign.Utils;
 import jdk.internal.foreign.abi.SharedUtils;
 
-import java.lang.invoke.VarHandle;
 import java.nio.ByteOrder;
 import java.nio.charset.Charset;
 import java.util.Objects;
@@ -118,6 +117,17 @@ public class CSupport {
         MemorySegment vargAsSegment(MemoryLayout layout);
 
         /**
+         * Reads a value into a {@code MemorySegment}, using the given {@code NativeScope} to allocate said segment.
+         *
+         * @param layout the layout of the value
+         * @param scope the scope to allocate the segment in
+         * @return the value read as an {@code MemorySegment}
+         * @throws IllegalStateException if the C {@code va_list} associated with this instance is no longer valid
+         * (see {@link #close()}).
+         */
+        MemorySegment vargAsSegment(MemoryLayout layout, NativeScope scope);
+
+        /**
          * Skips a number of va arguments with the given memory layouts.
          *
          * @param layouts the layout of the value
@@ -147,11 +157,29 @@ public class CSupport {
         /**
          * Copies this C {@code va_list}.
          *
+         * @apiNote that this method only copies the va list 'view' and not any argument space it may manage.
+         * That means that if this va list was created with the {@link #make(Consumer)} method, closing
+         * this va list will also free the argument space, and make the copy unusable.
+         *
          * @return a copy of this C {@code va_list}.
          * @throws IllegalStateException if the C {@code va_list} associated with this instance is no longer valid
          * (see {@link #close()}).
          */
         VaList copy();
+
+        /**
+         * Copies this C {@code va_list}, using the given {@code NativeScope} to allocate the copy (if needed).
+         *
+         * @apiNote this method only copies the va list 'view' and not any argument space it may manage.
+         * That means that if this va list was created with the {@link #make(Consumer)} method, closing
+         * this va list will also free the argument space, and make the copy unusable.
+         *
+         * @param scope the scope to allocate the copy in
+         * @return a copy of this C {@code va_list}.
+         * @throws IllegalStateException if the C {@code va_list} associated with this instance is no longer valid
+         * (see {@link #close()}).
+         */
+        VaList copy(NativeScope scope);
 
         /**
          * Returns the memory address of the C {@code va_list} associated with this instance.
@@ -176,12 +204,30 @@ public class CSupport {
          * Note that when there are no arguments added to the created va list,
          * this method will return the same as {@linkplain #empty()}.
          *
+         * Va lists created with this method also implicitly manage an off-heap 'argument space' that holds
+         * the arguments in the va list. Closing the returned va list will also free the argument space.
+         *
          * @param actions a consumer for a builder (see {@link Builder}) which can be used to specify the contents
          *                of the underlying C {@code va_list}.
          * @return a new {@code VaList} instance backed by a fresh C {@code va_list}.
          */
         static VaList make(Consumer<VaList.Builder> actions) {
-            return SharedUtils.newVaList(actions);
+            return SharedUtils.newVaList(actions, MemorySegment::allocateNative);
+        }
+
+        /**
+         * Constructs a new {@code VaList} using a builder (see {@link Builder}), and using the given
+         * {@code NativeScope} to do all needed allocations.
+         *
+         * Note that when there are no arguments added to the created va list,
+         * this method will return the same as {@linkplain #empty()}.
+         *
+         * @param actions a consumer for a builder (see {@link Builder}) which can be used to specify the contents
+         *                of the underlying C {@code va_list}.
+         * @return a new {@code VaList} instance backed by a fresh C {@code va_list}.
+         */
+        static VaList make(Consumer<VaList.Builder> actions, NativeScope scope) {
+            return SharedUtils.newVaList(actions, SharedUtils.Allocator.ofScope(scope));
         }
 
         /**

--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/CSupport.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/CSupport.java
@@ -162,9 +162,8 @@ public class CSupport {
          * Releases the underlying C {@code va_list} modelled by this instance, and any native memory that is attached
          * to this va list that holds its elements (see {@link VaList#make(Consumer)}).
          * <p>
-         * For some {@code VaList} instances, calling this method will have no effect. For instance: on Windows, a copy
-         * of a va list does not need any native memory, so nothing has to be released. After calling {@code close()} on
-         * such an instance {@link #isAlive()} will still return {@code true}.
+         * After calling this method, {@link #isAlive()} will return {@code false} and further attempts to read values
+         * from this va list will result in an exception.
          *
          * @see #isAlive()
          */

--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/CSupport.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/CSupport.java
@@ -135,7 +135,7 @@ public class CSupport {
         MemorySegment vargAsSegment(MemoryLayout layout, NativeScope scope);
 
         /**
-         * Skips a number of arguments with the given memory layouts, and advancing this va list's position.
+         * Skips a number of elements with the given memory layouts, and advances this va list's position.
          *
          * @param layouts the layout of the value
          * @throws IllegalStateException if the C {@code va_list} associated with this instance is no longer valid

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/aarch64/AArch64Linker.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/aarch64/AArch64Linker.java
@@ -95,8 +95,8 @@ public class AArch64Linker implements ForeignLinker {
         return (AArch64.ArgumentClass)layout.attribute(AArch64.CLASS_ATTRIBUTE_NAME).get();
     }
 
-    public static VaList newVaList(Consumer<VaList.Builder> actions) {
-        AArch64VaList.Builder builder = AArch64VaList.builder();
+    public static VaList newVaList(Consumer<VaList.Builder> actions, SharedUtils.Allocator allocator) {
+        AArch64VaList.Builder builder = AArch64VaList.builder(allocator);
         actions.accept(builder);
         return builder.build();
     }

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/aarch64/AArch64VaList.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/aarch64/AArch64VaList.java
@@ -31,6 +31,7 @@ import jdk.incubator.foreign.MemoryAddress;
 import jdk.incubator.foreign.MemoryHandles;
 import jdk.incubator.foreign.MemoryLayout;
 import jdk.incubator.foreign.MemorySegment;
+import jdk.incubator.foreign.NativeScope;
 import jdk.internal.foreign.NativeMemorySegmentImpl;
 import jdk.internal.foreign.Utils;
 import jdk.internal.foreign.abi.SharedUtils;
@@ -106,23 +107,27 @@ public class AArch64VaList implements VaList {
         = new SharedUtils.EmptyVaList(emptyListAddress());
 
     private final MemorySegment segment;
-    private final List<MemorySegment> slices = new ArrayList<>();
-    private final MemorySegment fpRegsArea;
     private final MemorySegment gpRegsArea;
+    private final MemorySegment fpRegsArea;
+    private final List<MemorySegment> slices;
 
-    AArch64VaList(MemorySegment segment) {
+    private AArch64VaList(MemorySegment segment, MemorySegment gpRegsArea, MemorySegment fpRegsArea,
+                          List<MemorySegment>  slices) {
         this.segment = segment;
+        this.gpRegsArea = gpRegsArea;
+        this.fpRegsArea = fpRegsArea;
+        this.slices = slices;
+    }
 
-        gpRegsArea = MemorySegment.ofNativeRestricted(
-            grTop().addOffset(-MAX_GP_OFFSET), MAX_GP_OFFSET,
+    private static AArch64VaList readFromSegment(MemorySegment segment) {
+        MemorySegment gpRegsArea = MemorySegment.ofNativeRestricted(
+            grTop(segment).addOffset(-MAX_GP_OFFSET), MAX_GP_OFFSET,
             segment.ownerThread(), null, null);
 
-        fpRegsArea = MemorySegment.ofNativeRestricted(
-            vrTop().addOffset(-MAX_FP_OFFSET), MAX_FP_OFFSET,
+        MemorySegment fpRegsArea = MemorySegment.ofNativeRestricted(
+            vrTop(segment).addOffset(-MAX_FP_OFFSET), MAX_FP_OFFSET,
             segment.ownerThread(), null, null);
-
-        slices.add(gpRegsArea);
-        slices.add(fpRegsArea);
+        return new AArch64VaList(segment, gpRegsArea, fpRegsArea, List.of(gpRegsArea, fpRegsArea));
     }
 
     private static MemoryAddress emptyListAddress() {
@@ -145,10 +150,18 @@ public class AArch64VaList implements VaList {
     }
 
     private MemoryAddress grTop() {
+        return grTop(segment);
+    }
+
+    private static MemoryAddress grTop(MemorySegment segment) {
         return (MemoryAddress) VH_gr_top.get(segment.baseAddress());
     }
 
     private MemoryAddress vrTop() {
+        return vrTop(segment);
+    }
+
+    private static MemoryAddress vrTop(MemorySegment segment) {
         return (MemoryAddress) VH_vr_top.get(segment.baseAddress());
     }
 
@@ -233,7 +246,16 @@ public class AArch64VaList implements VaList {
         return (MemorySegment) read(MemorySegment.class, layout);
     }
 
+    @Override
+    public MemorySegment vargAsSegment(MemoryLayout layout, NativeScope scope) {
+        return (MemorySegment) read(MemorySegment.class, layout, SharedUtils.Allocator.ofScope(scope));
+    }
+
     private Object read(Class<?> carrier, MemoryLayout layout) {
+        return read(carrier, layout, MemorySegment::allocateNative);
+    }
+
+    private Object read(Class<?> carrier, MemoryLayout layout, SharedUtils.Allocator allocator) {
         checkCompatibleType(carrier, layout, AArch64Linker.ADDRESS_SIZE);
 
         TypeClass typeClass = TypeClass.classifyLayout(layout);
@@ -244,7 +266,7 @@ public class AArch64VaList implements VaList {
                     try (MemorySegment slice = MemorySegment.ofNativeRestricted(
                              stackPtr(), layout.byteSize(),
                              segment.ownerThread(), null, null)) {
-                        MemorySegment seg = MemorySegment.allocateNative(layout);
+                        MemorySegment seg = allocator.allocate(layout);
                         seg.copyFrom(slice);
                         postAlignStack(layout);
                         yield seg;
@@ -265,7 +287,7 @@ public class AArch64VaList implements VaList {
             return switch (typeClass) {
                 case STRUCT_REGISTER -> {
                     // Struct is passed packed in integer registers.
-                    MemorySegment value = MemorySegment.allocateNative(layout);
+                    MemorySegment value = allocator.allocate(layout);
                     long offset = 0;
                     while (offset < layout.byteSize()) {
                         final long copy = Math.min(layout.byteSize() - offset, 8);
@@ -279,7 +301,7 @@ public class AArch64VaList implements VaList {
                 case STRUCT_HFA -> {
                     // Struct is passed with each element in a separate floating
                     // point register.
-                    MemorySegment value = MemorySegment.allocateNative(layout);
+                    MemorySegment value = allocator.allocate(layout);
                     GroupLayout group = (GroupLayout)layout;
                     long offset = 0;
                     for (MemoryLayout elem : group.memberLayouts()) {
@@ -302,7 +324,7 @@ public class AArch64VaList implements VaList {
 
                     try (MemorySegment slice = MemorySegment.ofNativeRestricted(
                              ptr, layout.byteSize(), segment.ownerThread(), null, null)) {
-                        MemorySegment seg = MemorySegment.allocateNative(layout);
+                        MemorySegment seg = allocator.allocate(layout);
                         seg.copyFrom(slice);
                         yield seg;
                     }
@@ -340,13 +362,12 @@ public class AArch64VaList implements VaList {
         }
     }
 
-    static AArch64VaList.Builder builder() {
-        return new AArch64VaList.Builder();
+    static AArch64VaList.Builder builder(SharedUtils.Allocator allocator) {
+        return new AArch64VaList.Builder(allocator);
     }
 
     public static VaList ofAddress(MemoryAddress ma) {
-        return new AArch64VaList(
-            MemorySegment.ofNativeRestricted(
+        return readFromSegment(MemorySegment.ofNativeRestricted(
                 ma, LAYOUT.byteSize(), Thread.currentThread(), null, null));
     }
 
@@ -363,9 +384,18 @@ public class AArch64VaList implements VaList {
 
     @Override
     public VaList copy() {
-        MemorySegment copy = MemorySegment.allocateNative(LAYOUT.byteSize());
+        return copy(MemorySegment::allocateNative);
+    }
+
+    @Override
+    public VaList copy(NativeScope scope) {
+        return copy(SharedUtils.Allocator.ofScope(scope));
+    }
+
+    private VaList copy(SharedUtils.Allocator allocator) {
+        MemorySegment copy = allocator.allocate(LAYOUT);
         copy.copyFrom(segment);
-        return new AArch64VaList(copy);
+        return readFromSegment(copy);
     }
 
     @Override
@@ -400,14 +430,19 @@ public class AArch64VaList implements VaList {
     }
 
     static class Builder implements CSupport.VaList.Builder {
-        private final MemorySegment gpRegs
-            = MemorySegment.allocateNative(LAYOUT_GP_REGS);
-        private final MemorySegment fpRegs
-            = MemorySegment.allocateNative(LAYOUT_FP_REGS);
+        private final SharedUtils.Allocator allocator;
+        private final MemorySegment gpRegs;
+        private final MemorySegment fpRegs;
 
         private long currentGPOffset = 0;
         private long currentFPOffset = 0;
         private final List<SimpleVaArg> stackArgs = new ArrayList<>();
+
+        Builder(SharedUtils.Allocator allocator) {
+            this.allocator = allocator;
+            this.gpRegs = allocator.allocate(LAYOUT_GP_REGS);
+            this.fpRegs = allocator.allocate(LAYOUT_FP_REGS);
+        }
 
         @Override
         public Builder vargFromInt(MemoryLayout layout, int value) {
@@ -503,14 +538,13 @@ public class AArch64VaList implements VaList {
                 return EMPTY;
             }
 
-            MemorySegment vaListSegment = MemorySegment.allocateNative(LAYOUT.byteSize());
-            AArch64VaList res = new AArch64VaList(vaListSegment);
-
+            MemorySegment vaListSegment = allocator.allocate(LAYOUT);
+            List<MemorySegment> slices = new ArrayList<>();
             MemoryAddress stackArgsPtr = MemoryAddress.NULL;
             if (!stackArgs.isEmpty()) {
                 long stackArgsSize = stackArgs.stream()
                     .reduce(0L, (acc, e) -> acc + Utils.alignUp(e.layout.byteSize(), 8), Long::sum);
-                MemorySegment stackArgsSegment = MemorySegment.allocateNative(stackArgsSize, 16);
+                MemorySegment stackArgsSegment = allocator.allocate(stackArgsSize, 16);
                 MemoryAddress maStackArea = stackArgsSegment.baseAddress();
                 for (SimpleVaArg arg : stackArgs) {
                     final long alignedSize = Utils.alignUp(arg.layout.byteSize(), 8);
@@ -520,7 +554,7 @@ public class AArch64VaList implements VaList {
                     maStackArea = maStackArea.addOffset(alignedSize);
                 }
                 stackArgsPtr = stackArgsSegment.baseAddress();
-                res.slices.add(stackArgsSegment);
+                slices.add(stackArgsSegment);
             }
 
             MemoryAddress vaListAddr = vaListSegment.baseAddress();
@@ -530,11 +564,11 @@ public class AArch64VaList implements VaList {
             VH_gr_offs.set(vaListAddr, -MAX_GP_OFFSET);
             VH_vr_offs.set(vaListAddr, -MAX_FP_OFFSET);
 
-            res.slices.add(gpRegs);
-            res.slices.add(fpRegs);
+            slices.add(gpRegs);
+            slices.add(fpRegs);
             assert gpRegs.ownerThread() == vaListSegment.ownerThread();
             assert fpRegs.ownerThread() == vaListSegment.ownerThread();
-            return res;
+            return new AArch64VaList(vaListSegment, gpRegs, fpRegs, slices);
         }
     }
 }

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/x64/sysv/SysVVaList.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/x64/sysv/SysVVaList.java
@@ -31,6 +31,7 @@ import jdk.incubator.foreign.MemoryAddress;
 import jdk.incubator.foreign.MemoryHandles;
 import jdk.incubator.foreign.MemoryLayout;
 import jdk.incubator.foreign.MemorySegment;
+import jdk.incubator.foreign.NativeScope;
 import jdk.internal.foreign.NativeMemorySegmentImpl;
 import jdk.internal.foreign.Utils;
 import jdk.internal.foreign.abi.SharedUtils;
@@ -120,13 +121,18 @@ public class SysVVaList implements VaList {
     private static final CSupport.VaList EMPTY = new SharedUtils.EmptyVaList(emptyListAddress());
 
     private final MemorySegment segment;
-    private final List<MemorySegment> slices = new ArrayList<>();
     private final MemorySegment regSaveArea;
+    private final List<MemorySegment> slices;
 
-    SysVVaList(MemorySegment segment) {
+    private SysVVaList(MemorySegment segment, MemorySegment regSaveArea, List<MemorySegment> slices) {
         this.segment = segment;
-        regSaveArea = regSaveArea();
-        slices.add(regSaveArea);
+        this.regSaveArea = regSaveArea;
+        this.slices = slices;
+    }
+
+    private static SysVVaList readFromSegment(MemorySegment segment) {
+        MemorySegment regSaveArea = getRegSaveArea(segment);
+        return new SysVVaList(segment, regSaveArea, List.of(regSaveArea));
     }
 
     private static MemoryAddress emptyListAddress() {
@@ -171,6 +177,10 @@ public class SysVVaList implements VaList {
     }
 
     private MemorySegment regSaveArea() {
+        return getRegSaveArea(segment);
+    }
+
+    private static MemorySegment getRegSaveArea(MemorySegment segment) {
         return MemorySegment.ofNativeRestricted((MemoryAddress) VH_reg_save_area.get(segment.baseAddress()),
             LAYOUT_REG_SAVE_AREA.byteSize(), segment.ownerThread(), null, null);
     }
@@ -210,7 +220,16 @@ public class SysVVaList implements VaList {
         return (MemorySegment) read(MemorySegment.class, layout);
     }
 
+    @Override
+    public MemorySegment vargAsSegment(MemoryLayout layout, NativeScope scope) {
+        return (MemorySegment) read(MemorySegment.class, layout, SharedUtils.Allocator.ofScope(scope));
+    }
+
     private Object read(Class<?> carrier, MemoryLayout layout) {
+        return read(carrier, layout, MemorySegment::allocateNative);
+    }
+
+    private Object read(Class<?> carrier, MemoryLayout layout, SharedUtils.Allocator allocator) {
         checkCompatibleType(carrier, layout, SysVx64Linker.ADDRESS_SIZE);
         TypeClass typeClass = TypeClass.classifyLayout(layout);
         if (isRegOverflow(currentGPOffset(), currentFPOffset(), typeClass)
@@ -220,7 +239,7 @@ public class SysVVaList implements VaList {
                 case STRUCT -> {
                     try (MemorySegment slice = MemorySegment.ofNativeRestricted(stackPtr(), layout.byteSize(),
                                                                                 segment.ownerThread(), null, null)) {
-                        MemorySegment seg = MemorySegment.allocateNative(layout);
+                        MemorySegment seg = allocator.allocate(layout);
                         seg.copyFrom(slice);
                         postAlignStack(layout);
                         yield seg;
@@ -239,7 +258,7 @@ public class SysVVaList implements VaList {
         } else {
             return switch (typeClass.kind()) {
                 case STRUCT -> {
-                    MemorySegment value = MemorySegment.allocateNative(layout);
+                    MemorySegment value = allocator.allocate(layout);
                     int classIdx = 0;
                     long offset = 0;
                     while (offset < layout.byteSize()) {
@@ -287,12 +306,14 @@ public class SysVVaList implements VaList {
         }
     }
 
-    static SysVVaList.Builder builder() {
-        return new SysVVaList.Builder();
+    static SysVVaList.Builder builder(SharedUtils.Allocator allocator) {
+        return new SysVVaList.Builder(allocator);
     }
 
     public static VaList ofAddress(MemoryAddress ma) {
-        return new SysVVaList(MemorySegment.ofNativeRestricted(ma, LAYOUT.byteSize(), Thread.currentThread(), null, null));
+        MemorySegment vaListSegment
+            = MemorySegment.ofNativeRestricted(ma, LAYOUT.byteSize(), Thread.currentThread(), null, null);
+        return readFromSegment(vaListSegment);
     }
 
     @Override
@@ -308,9 +329,18 @@ public class SysVVaList implements VaList {
 
     @Override
     public VaList copy() {
-        MemorySegment copy = MemorySegment.allocateNative(LAYOUT.byteSize());
+        return copy(MemorySegment::allocateNative);
+    }
+
+    @Override
+    public VaList copy(NativeScope scope) {
+        return copy(SharedUtils.Allocator.ofScope(scope));
+    }
+
+    private VaList copy(SharedUtils.Allocator allocator) {
+        MemorySegment copy = allocator.allocate(LAYOUT);
         copy.copyFrom(segment);
-        return new SysVVaList(copy);
+        return SysVVaList.readFromSegment(copy);
     }
 
     @Override
@@ -334,10 +364,16 @@ public class SysVVaList implements VaList {
     }
 
     static class Builder implements CSupport.VaList.Builder {
-        private final MemorySegment reg_save_area = MemorySegment.allocateNative(LAYOUT_REG_SAVE_AREA);
+        private final SharedUtils.Allocator allocator;
+        private final MemorySegment reg_save_area;
         private long currentGPOffset = 0;
         private long currentFPOffset = FP_OFFSET;
         private final List<SimpleVaArg> stackArgs = new ArrayList<>();
+
+        public Builder(SharedUtils.Allocator allocator) {
+            this.allocator = allocator;
+            this.reg_save_area = allocator.allocate(LAYOUT_REG_SAVE_AREA);
+        }
 
         @Override
         public Builder vargFromInt(MemoryLayout layout, int value) {
@@ -415,12 +451,12 @@ public class SysVVaList implements VaList {
                 return EMPTY;
             }
 
-            MemorySegment vaListSegment = MemorySegment.allocateNative(LAYOUT.byteSize());
-            SysVVaList res = new SysVVaList(vaListSegment);
+            MemorySegment vaListSegment = allocator.allocate(LAYOUT);
+            List<MemorySegment> slices = new ArrayList<>();
             MemoryAddress stackArgsPtr = MemoryAddress.NULL;
             if (!stackArgs.isEmpty()) {
                 long stackArgsSize = stackArgs.stream().reduce(0L, (acc, e) -> acc + e.layout.byteSize(), Long::sum);
-                MemorySegment stackArgsSegment = MemorySegment.allocateNative(stackArgsSize, 16);
+                MemorySegment stackArgsSegment = allocator.allocate(stackArgsSize, 16);
                 MemoryAddress maOverflowArgArea = stackArgsSegment.baseAddress();
                 for (SimpleVaArg arg : stackArgs) {
                     if (arg.layout.byteSize() > 8) {
@@ -437,16 +473,16 @@ public class SysVVaList implements VaList {
                     maOverflowArgArea = maOverflowArgArea.addOffset(arg.layout.byteSize());
                 }
                 stackArgsPtr = stackArgsSegment.baseAddress();
-                res.slices.add(stackArgsSegment);
+                slices.add(stackArgsSegment);
             }
 
             MemoryAddress vaListAddr = vaListSegment.baseAddress();
             VH_fp_offset.set(vaListAddr, (int) FP_OFFSET);
             VH_overflow_arg_area.set(vaListAddr, stackArgsPtr);
             VH_reg_save_area.set(vaListAddr, reg_save_area.baseAddress());
-            res.slices.add(reg_save_area);
+            slices.add(reg_save_area);
             assert reg_save_area.ownerThread() == vaListSegment.ownerThread();
-            return res;
+            return new SysVVaList(vaListSegment, reg_save_area, slices);
         }
     }
 }

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/x64/sysv/SysVx64Linker.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/x64/sysv/SysVx64Linker.java
@@ -77,8 +77,8 @@ public class SysVx64Linker implements ForeignLinker {
         return instance;
     }
 
-    public static VaList newVaList(Consumer<VaList.Builder> actions) {
-        SysVVaList.Builder builder = SysVVaList.builder();
+    public static VaList newVaList(Consumer<VaList.Builder> actions, SharedUtils.Allocator allocator) {
+        SysVVaList.Builder builder = SysVVaList.builder(allocator);
         actions.accept(builder);
         return builder.build();
     }

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/x64/windows/Windowsx64Linker.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/x64/windows/Windowsx64Linker.java
@@ -78,8 +78,8 @@ public class Windowsx64Linker implements ForeignLinker {
         return instance;
     }
 
-    public static VaList newVaList(Consumer<VaList.Builder> actions) {
-        WinVaList.Builder builder = WinVaList.builder();
+    public static VaList newVaList(Consumer<VaList.Builder> actions, SharedUtils.Allocator allocator) {
+        WinVaList.Builder builder = WinVaList.builder(allocator);
         actions.accept(builder);
         return builder.build();
     }

--- a/test/jdk/java/foreign/valist/VaListTest.java
+++ b/test/jdk/java/foreign/valist/VaListTest.java
@@ -318,12 +318,15 @@ public class VaListTest {
     public void testScopedCopy() {
         try (VaList list = VaList.make(b -> b.vargFromInt(C_INT, 4)
                                              .vargFromInt(C_INT, 8))) {
+            VaList copy;
             try (NativeScope scope = NativeScope.unboundedScope()) {
-                VaList copy = list.copy(scope);
+                copy = list.copy(scope);
 
                 assertEquals(copy.vargAsInt(C_INT), 4);
                 assertEquals(copy.vargAsInt(C_INT), 8);
             }
+            assertFalse(copy.isAlive());
+
             assertEquals(list.vargAsInt(C_INT), 4);
             assertEquals(list.vargAsInt(C_INT), 8);
         }

--- a/test/jdk/java/foreign/valist/VaListTest.java
+++ b/test/jdk/java/foreign/valist/VaListTest.java
@@ -313,6 +313,22 @@ public class VaListTest {
         }
         assertFalse(pointOut.isAlive()); // after scope freed
     }
+    
+    @Test
+    public void testCopy() {
+        try (VaList list = VaList.make(b -> b.vargFromInt(C_INT, 4)
+                                             .vargFromInt(C_INT, 8))) {
+            VaList  copy = list.copy();
+            assertEquals(copy.vargAsInt(C_INT), 4);
+            assertEquals(copy.vargAsInt(C_INT), 8);
+            copy.close();
+
+            assertFalse(copy.isAlive());
+
+            assertEquals(list.vargAsInt(C_INT), 4);
+            assertEquals(list.vargAsInt(C_INT), 8);
+        }
+    }
 
     @Test
     public void testScopedCopy() {

--- a/test/jdk/java/foreign/valist/VaListTest.java
+++ b/test/jdk/java/foreign/valist/VaListTest.java
@@ -329,6 +329,29 @@ public class VaListTest {
         }
     }
 
+    @Test(expectedExceptions = IllegalStateException.class)
+    public void testCopyUnusableAfterOriginalClosed() {
+        VaList list = VaList.make(b -> b.vargFromInt(C_INT, 4)
+                                        .vargFromInt(C_INT, 8));
+        try (VaList copy = list.copy()) {
+            list.close();
+
+            copy.vargAsInt(C_INT); // should throw
+        }
+    }
+
+    @Test(expectedExceptions = IllegalStateException.class)
+    public void testCopyUnusableAfterOriginalClosedScope() {
+        VaList list = VaList.make(b -> b.vargFromInt(C_INT, 4)
+                                        .vargFromInt(C_INT, 8));
+        try (NativeScope scope = NativeScope.unboundedScope()) {
+            VaList copy = list.copy(scope);
+            list.close();
+
+            copy.vargAsInt(C_INT); // should throw
+        }
+    }
+
     @DataProvider
     public static Object[][] upcalls() {
         return new Object[][]{

--- a/test/jdk/java/foreign/valist/VaListTest.java
+++ b/test/jdk/java/foreign/valist/VaListTest.java
@@ -36,6 +36,7 @@ import jdk.incubator.foreign.LibraryLookup;
 import jdk.incubator.foreign.MemoryAddress;
 import jdk.incubator.foreign.MemoryLayout;
 import jdk.incubator.foreign.MemorySegment;
+import jdk.incubator.foreign.NativeScope;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
@@ -53,6 +54,8 @@ import static jdk.incubator.foreign.CSupport.C_VA_LIST;
 import static jdk.incubator.foreign.CSupport.Win64.asVarArg;
 import static jdk.incubator.foreign.MemoryLayout.PathElement.groupElement;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
 
 public class VaListTest {
 
@@ -276,6 +279,54 @@ public class VaListTest {
     public void testEmptyVaListFromBuilderNotCloseable() {
         VaList list = VaList.make(b -> {});
         list.close();
+    }
+
+    @Test
+    public void testScopedVaList() throws Throwable {
+        VaList listLeaked;
+        try (NativeScope scope = NativeScope.unboundedScope()) {
+            VaList list = CSupport.VaList.make(b -> b.vargFromInt(C_INT, 4)
+                                                     .vargFromInt(C_INT, 8),
+                                               scope);
+            int x = (int) MH_sumInts.invokeExact(2, list);
+            assertEquals(x, 12);
+            listLeaked = list;
+        }
+        assertFalse(listLeaked.isAlive());
+    }
+
+    @Test
+    public void testScopeMSRead() {
+        MemorySegment pointOut;
+        try (NativeScope scope = NativeScope.unboundedScope()) {
+            try (MemorySegment pointIn = MemorySegment.allocateNative(Point_LAYOUT)) {
+                VH_Point_x.set(pointIn.baseAddress(), 3);
+                VH_Point_y.set(pointIn.baseAddress(), 6);
+                try (VaList list = CSupport.VaList.make(b -> b.vargFromSegment(Point_LAYOUT, pointIn))) {
+                    pointOut = list.vargAsSegment(Point_LAYOUT, scope);
+                    assertEquals((int) VH_Point_x.get(pointOut.baseAddress()), 3);
+                    assertEquals((int) VH_Point_y.get(pointOut.baseAddress()), 6);
+                }
+                assertTrue(pointOut.isAlive()); // after VaList freed
+            }
+            assertTrue(pointOut.isAlive()); // after input MS freed
+        }
+        assertFalse(pointOut.isAlive()); // after scope freed
+    }
+
+    @Test
+    public void testScopedCopy() {
+        try (VaList list = VaList.make(b -> b.vargFromInt(C_INT, 4)
+                                             .vargFromInt(C_INT, 8))) {
+            try (NativeScope scope = NativeScope.unboundedScope()) {
+                VaList copy = list.copy(scope);
+
+                assertEquals(copy.vargAsInt(C_INT), 4);
+                assertEquals(copy.vargAsInt(C_INT), 8);
+            }
+            assertEquals(list.vargAsInt(C_INT), 4);
+            assertEquals(list.vargAsInt(C_INT), 8);
+        }
     }
 
     @DataProvider

--- a/test/jdk/java/foreign/valist/VaListTest.java
+++ b/test/jdk/java/foreign/valist/VaListTest.java
@@ -313,7 +313,7 @@ public class VaListTest {
         }
         assertFalse(pointOut.isAlive()); // after scope freed
     }
-    
+
     @Test
     public void testCopy() {
         try (VaList list = VaList.make(b -> b.vargFromInt(C_INT, 4)


### PR DESCRIPTION
Hi,

This patch adds overloads to several VaList related methods that might need to do allocations, namely, VaList::make, VaList::vargAsSegment, and VaList::copy.

In order to share the existing code, I've added an `Allocator` helper interface that can wrap either a NativeScope, or be used as a functional interface to bind to MemorySegment::allocateNative.

While testing this patch, I've also discovered a bug in the SysV implementation; The VaList::Builder was allocating a MemorySegment for the VaList, then creating the SysVVaList object wrapping that segment, and then filling in some of the contents of the segment. But, the SysVVaList constructor was also trying to read from the segment as well, and as a result was reading uninitialized fields. This is a problem when creating a VaList in Java, and then trying to read from it also in Java.

I've restructured the code a bit to fix this problem, moving the reading logic from the constructor to a static factory called readFromSegment, so that it's clear that only a fully initialized segment should be passed. The builder still calls the constructor directly, but it now requires all field values to be passed in explicitly.

There was a similar problem in the AArch64 implementation, which I've tried to fix. Unfortunately I was not able to fully test this change since there was a failure elsewhere in the testing infrastructure, and I currently don't have direct access to an aarch64 machine to be able to debug that. I did end up fixing some build failures on aarch64 in the process though, which I will submit another PR for.

Thanks,
Jorn
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [JDK-8248420](https://bugs.openjdk.java.net/browse/JDK-8248420): Add a variant of VaList::make which takes a NativeScope


### Reviewers
 * Paul Sandoz ([psandoz](@PaulSandoz) - Committer)


### Download
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/237/head:pull/237`
`$ git checkout pull/237`
