### PR TITLE
AArch64 build fixes

### DIFF
--- a/src/hotspot/cpu/aarch64/aarch64.ad
+++ b/src/hotspot/cpu/aarch64/aarch64.ad
@@ -1509,6 +1509,11 @@ int MachCallRuntimeNode::ret_addr_offset() {
   }
 }
 
+int MachCallNativeNode::ret_addr_offset() {
+  ShouldNotReachHere();
+  return -1;
+}
+
 // Indicate if the safepoint node needs the polling page as an input
 
 // the shared code plants the oop data at the start of the generated

--- a/src/hotspot/cpu/aarch64/sharedRuntime_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/sharedRuntime_aarch64.cpp
@@ -3046,3 +3046,10 @@ void OptoRuntime::generate_exception_blob() {
   _exception_blob =  ExceptionBlob::create(&buffer, oop_maps, SimpleRuntimeFrame::framesize >> 1);
 }
 #endif // COMPILER2
+
+address SharedRuntime::make_native_invoker(address call_target,
+                                           int shadow_space_bytes,
+                                           const GrowableArray<VMReg>& input_registers,
+                                           const GrowableArray<VMReg>& output_registers) {
+  return NULL;
+}

--- a/src/hotspot/cpu/aarch64/vmreg_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/vmreg_aarch64.cpp
@@ -26,7 +26,7 @@
 #include "precompiled.hpp"
 #include "asm/assembler.hpp"
 #include "code/vmreg.hpp"
-
+#include "vmreg_aarch64.inline.hpp"
 
 
 void VMRegImpl::set_regName() {
@@ -50,4 +50,18 @@ void VMRegImpl::set_regName() {
   for ( ; i < ConcreteRegisterImpl::number_of_registers ; i ++ ) {
     regName[i] = "NON-GPR-FPR";
   }
+}
+
+#define INTEGER_TYPE 0
+#define VECTOR_TYPE 1
+#define X87_TYPE 2
+#define STACK_TYPE 3
+
+VMReg VMRegImpl::vmStorageToVMReg(int type, int index) {
+  switch(type) {
+    case INTEGER_TYPE: return ::as_Register(index)->as_VMReg();
+    case VECTOR_TYPE: return ::as_FloatRegister(index)->as_VMReg();
+    case STACK_TYPE: return VMRegImpl::stack2reg(index LP64_ONLY(* 2)); // numbering on x64 goes per 64-bits
+  }
+  return VMRegImpl::Bad();
 }

--- a/src/hotspot/cpu/aarch64/vmreg_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/vmreg_aarch64.cpp
@@ -61,7 +61,7 @@ VMReg VMRegImpl::vmStorageToVMReg(int type, int index) {
   switch(type) {
     case INTEGER_TYPE: return ::as_Register(index)->as_VMReg();
     case VECTOR_TYPE: return ::as_FloatRegister(index)->as_VMReg();
-    case STACK_TYPE: return VMRegImpl::stack2reg(index LP64_ONLY(* 2)); // numbering on x64 goes per 64-bits
+    case STACK_TYPE: return VMRegImpl::stack2reg(index LP64_ONLY(* 2));
   }
   return VMRegImpl::Bad();
 }

--- a/src/hotspot/share/opto/callGenerator.cpp
+++ b/src/hotspot/share/opto/callGenerator.cpp
@@ -862,6 +862,7 @@ JVMState* NativeCallGenerator::generate(JVMState* jvms) {
   GraphKit kit(jvms);
 
   Node* call = kit.make_native_call(tf(), method()->arg_size(), _nep); // -fallback, - nep
+  if (call == NULL) return NULL;
 
   kit.C->print_inlining_update(this);
   address addr = _nep->entry_point();

--- a/src/hotspot/share/opto/graphKit.cpp
+++ b/src/hotspot/share/opto/graphKit.cpp
@@ -2628,6 +2628,7 @@ Node* GraphKit::make_native_call(const TypeFunc* call_type, uint nargs, ciNative
     call_addr = SharedRuntime::make_native_invoker(call_addr,
                                                    nep->shadow_space(),
                                                    arg_regs, ret_regs);
+    if (call_addr == NULL) return NULL;
     C->add_native_stub(call_addr);
   }
   assert(call_addr != NULL, "sanity");


### PR DESCRIPTION
Hi,

This patch fixes several linker errors observed when building on aarch64, due to missing implementations of methods added for the C2 down call intrinsics.

Currently C2 compilation will just bail out when trying to generate a the native call, but I think another strategy is possible where we generate a call to the fallback MethodHandle instead. This patch is just fixing the build.

Thanks,
Jorn
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * Paul Sandoz ([psandoz](@PaulSandoz) - Committer) ⚠️ Review applies to 1e8bfe3b4109024ed5e8ef4904a94d6ba6d011dc


### Download
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/238/head:pull/238`
`$ git checkout pull/238`
