### PR TITLE
Add missing codeCache.hpp include to upcallStubs.cpp

### DIFF
--- a/src/hotspot/share/prims/upcallStubs.cpp
+++ b/src/hotspot/share/prims/upcallStubs.cpp
@@ -24,6 +24,7 @@
 #include "precompiled.hpp"
 #include "runtime/jniHandles.inline.hpp"
 #include "runtime/interfaceSupport.inline.hpp"
+#include "code/codeCache.hpp"
 
 JVM_ENTRY(static jboolean, UH_FreeUpcallStub0(JNIEnv *env, jobject _unused, jlong addr))
   //acquire code cache lock


### PR DESCRIPTION
Hi,

This patch adds a missing codeCache.hpp include to upcallStubs.cpp, which was causing a failure in our CI pipeline.

Thanks,
Jorn
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * Paul Sandoz ([psandoz](@PaulSandoz) - Committer)


### Download
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/242/head:pull/242`
`$ git checkout pull/242`
