### PR TITLE
8249290: jextract does not handle void typedef in function pointer argument

### DIFF
--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/LayoutUtils.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/LayoutUtils.java
@@ -174,16 +174,27 @@ public final class LayoutUtils {
         return RecordLayoutComputer.compute(0, type, type);
     }
 
+    private static boolean isVoidType(jdk.incubator.jextract.Type type) {
+        if (type instanceof jdk.incubator.jextract.Type.Primitive) {
+            jdk.incubator.jextract.Type.Primitive pt = (jdk.incubator.jextract.Type.Primitive)type;
+            return pt.kind() == jdk.incubator.jextract.Type.Primitive.Kind.Void;
+        } else if (type instanceof jdk.incubator.jextract.Type.Delegated) {
+            jdk.incubator.jextract.Type.Delegated dt = (jdk.incubator.jextract.Type.Delegated)type;
+            return dt.kind() == jdk.incubator.jextract.Type.Delegated.Kind.TYPEDEF? isVoidType(dt.type()) : false;
+        }
+        return false;
+    }
+
     public static Optional<FunctionDescriptor> getDescriptor(jdk.incubator.jextract.Type.Function t) {
         try {
             MemoryLayout[] args = t.argumentTypes().stream()
                     .map(LayoutUtils::getLayoutInternal)
                     .toArray(MemoryLayout[]::new);
-            if (t.returnType() instanceof jdk.incubator.jextract.Type.Primitive &&
-                    ((jdk.incubator.jextract.Type.Primitive) t.returnType()).kind() == jdk.incubator.jextract.Type.Primitive.Kind.Void) {
+            jdk.incubator.jextract.Type retType = t.returnType();
+            if (isVoidType(retType)) {
                 return Optional.of(FunctionDescriptor.ofVoid(args));
             } else {
-                return Optional.of(FunctionDescriptor.of(getLayoutInternal(t.returnType()), args));
+                return Optional.of(FunctionDescriptor.of(getLayoutInternal(retType), args));
             }
         } catch (Throwable ex) {
             return Optional.empty();

--- a/test/jdk/tools/jextract/Test8249290.java
+++ b/test/jdk/tools/jextract/Test8249290.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.nio.file.Path;
+import jdk.incubator.foreign.MemoryAddress;
+import org.testng.annotations.Test;
+
+/*
+ * @test
+ * @library /test/lib
+ * @modules jdk.incubator.jextract
+ * @build JextractToolRunner
+ * @bug 8249290
+ * @summary jextract does not handle void typedef in function pointer argument
+ * @run testng/othervm -Dforeign.restricted=permit Test8249290
+ */
+public class Test8249290 extends JextractToolRunner {
+    @Test
+    public void testVoidTypedef() {
+        Path outputPath = getOutputFilePath("output8249290");
+        Path headerFile = getInputFilePath("test8249290.h");
+        run("-d", outputPath.toString(), headerFile.toString()).checkSuccess();
+        try(Loader loader = classLoader(outputPath)) {
+            Class<?> headerClass = loader.loadClass("test8249290_h");
+            checkMethod(headerClass, "func", void.class, MemoryAddress.class);
+            Class<?> fiClass = loader.loadClass("test8249290_h$func$f");
+            checkMethod(fiClass, "apply", void.class);
+        } finally {
+            deleteDir(outputPath);
+        }
+    }
+}

--- a/test/jdk/tools/jextract/test8249290.h
+++ b/test/jdk/tools/jextract/test8249290.h
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+#ifdef __cplusplus
+extern "C" {
+#endif // __cplusplus
+
+#ifdef _WIN64
+#define EXPORT __declspec(dllexport)
+#else
+#define EXPORT
+#endif
+
+typedef void MyVoid;
+EXPORT void func(MyVoid (*f)(MyVoid));
+
+#ifdef __cplusplus
+}
+#endif // __cplusplus


### PR DESCRIPTION
void typedefs are handled to check the return type.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [JDK-8249290](https://bugs.openjdk.java.net/browse/JDK-8249290): jextract does not handle void typedef in function pointer argument


### Reviewers
 * Jorn Vernee ([jvernee](@JornVernee) - Committer)


### Download
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/243/head:pull/243`
`$ git checkout pull/243`
