### PR TITLE
8249300: jextract does not handle empty parameter list of a function pointer parameters

### DIFF
--- a/src/jdk.incubator.jextract/share/classes/jdk/incubator/jextract/tool/HeaderBuilder.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/incubator/jextract/tool/HeaderBuilder.java
@@ -40,6 +40,12 @@ class HeaderBuilder extends JavaSourceBuilder {
         super(className, pkgName, constantHelper);
     }
 
+    private String getArrayTypeName(Class<?> type) {
+        assert type.isArray();
+        Class<?> elemType = type.getComponentType();
+        return elemType.isArray()? getArrayTypeName(elemType) + "[]" : elemType.getName() + "[]";
+    }
+
     public void addFunctionalInterface(String name, MethodType mtype,  FunctionDescriptor fDesc) {
         incrAlign();
         indent();
@@ -48,8 +54,13 @@ class HeaderBuilder extends JavaSourceBuilder {
         indent();
         sb.append(mtype.returnType().getName() + " apply(");
         String delim = "";
-        for (int i = 0 ; i < mtype.parameterCount() ; i++) {
-            sb.append(delim + mtype.parameterType(i).getName() + " x" + i);
+        for (int i = 0 ; i < mtype.parameterCount(); i++) {
+            Class<?> paramType = mtype.parameterType(i);
+            if (paramType.isArray()) {
+                sb.append(delim + getArrayTypeName(paramType) + " x" + i);
+            } else {
+                sb.append(delim + paramType.getName() + " x" + i);
+            }
             delim = ", ";
         }
         sb.append(");\n");
@@ -74,7 +85,8 @@ class HeaderBuilder extends JavaSourceBuilder {
                 pName = "x" + i;
             }
             pNames.add(pName);
-            sb.append(delim + mtype.parameterType(i).getName() + " " + pName);
+            Class<?> paramType = mtype.parameterType(i);
+            sb.append(delim + (paramType.isArray()? getArrayTypeName(paramType) : paramType.getName()) + " " + pName);
             delim = ", ";
         }
         if (varargs) {

--- a/src/jdk.incubator.jextract/share/classes/jdk/incubator/jextract/tool/HeaderBuilder.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/incubator/jextract/tool/HeaderBuilder.java
@@ -40,12 +40,6 @@ class HeaderBuilder extends JavaSourceBuilder {
         super(className, pkgName, constantHelper);
     }
 
-    private String getArrayTypeName(Class<?> type) {
-        assert type.isArray();
-        Class<?> elemType = type.getComponentType();
-        return elemType.isArray()? getArrayTypeName(elemType) + "[]" : elemType.getName() + "[]";
-    }
-
     public void addFunctionalInterface(String name, MethodType mtype,  FunctionDescriptor fDesc) {
         incrAlign();
         indent();
@@ -55,12 +49,7 @@ class HeaderBuilder extends JavaSourceBuilder {
         sb.append(mtype.returnType().getName() + " apply(");
         String delim = "";
         for (int i = 0 ; i < mtype.parameterCount(); i++) {
-            Class<?> paramType = mtype.parameterType(i);
-            if (paramType.isArray()) {
-                sb.append(delim + getArrayTypeName(paramType) + " x" + i);
-            } else {
-                sb.append(delim + paramType.getName() + " x" + i);
-            }
+            sb.append(delim + mtype.parameterType(i).getName() + " x" + i);
             delim = ", ";
         }
         sb.append(");\n");
@@ -85,8 +74,7 @@ class HeaderBuilder extends JavaSourceBuilder {
                 pName = "x" + i;
             }
             pNames.add(pName);
-            Class<?> paramType = mtype.parameterType(i);
-            sb.append(delim + (paramType.isArray()? getArrayTypeName(paramType) : paramType.getName()) + " " + pName);
+            sb.append(delim + mtype.parameterType(i).getName() + " " + pName);
             delim = ", ";
         }
         if (varargs) {

--- a/src/jdk.incubator.jextract/share/classes/jdk/incubator/jextract/tool/OutputFactory.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/incubator/jextract/tool/OutputFactory.java
@@ -267,7 +267,10 @@ public class OutputFactory implements Declaration.Visitor<Void, Declaration> {
                 String name = funcTree.name() + "$" + (param.name().isEmpty() ? "x" + i : param.name());
                 name = Utils.javaSafeIdentifier(name);
                 //generate functional interface
-                MethodType fitype = typeTranslator.getMethodType(f);
+                if (f.varargs()) {
+                    System.err.println("WARNING: varargs in callbacks is not supported");
+                }
+                MethodType fitype = typeTranslator.getMethodType(f, false);
                 builder.addFunctionalInterface(name, fitype, Type.descriptorFor(f).orElseThrow());
                 i++;
             }

--- a/src/jdk.incubator.jextract/share/classes/jdk/incubator/jextract/tool/TypeTranslator.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/incubator/jextract/tool/TypeTranslator.java
@@ -127,11 +127,15 @@ public class TypeTranslator implements Type.Visitor<Class<?>, Void> {
     }
 
     MethodType getMethodType(Type.Function type) {
+        return getMethodType(type, true);
+    }
+
+    MethodType getMethodType(Type.Function type, boolean varargsCheck) {
         MethodType mtype = MethodType.methodType(getJavaType(type.returnType()));
         for (Type arg : type.argumentTypes()) {
             mtype = mtype.appendParameterTypes(getJavaType(arg));
         }
-        if (type.varargs()) {
+        if (varargsCheck && type.varargs()) {
             mtype = mtype.appendParameterTypes(Object[].class);
         }
         return mtype;

--- a/test/jdk/tools/jextract/Test8249300.java
+++ b/test/jdk/tools/jextract/Test8249300.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.nio.file.Path;
+import jdk.incubator.foreign.MemoryAddress;
+import org.testng.annotations.Test;
+
+/*
+ * @test
+ * @library /test/lib
+ * @modules jdk.incubator.jextract
+ * @build JextractToolRunner
+ * @bug 8249300
+ * @summary jextract does not handle empty parameter list of a function pointer parameters
+ * @run testng/othervm -Dforeign.restricted=permit Test8249300
+ */
+public class Test8249300 extends JextractToolRunner {
+    @Test
+    public void testVoidTypedef() {
+        Path outputPath = getOutputFilePath("output8249300");
+        Path headerFile = getInputFilePath("test8249300.h");
+        run("-d", outputPath.toString(), headerFile.toString()).checkSuccess();
+        try(Loader loader = classLoader(outputPath)) {
+            Class<?> headerClass = loader.loadClass("test8249300_h");
+            checkMethod(headerClass, "func", void.class, MemoryAddress.class);
+            Class<?> fiClass = loader.loadClass("test8249300_h$func$f");
+            checkMethod(fiClass, "apply", void.class, Object[].class);
+        } finally {
+            deleteDir(outputPath);
+        }
+    }
+}

--- a/test/jdk/tools/jextract/Test8249300.java
+++ b/test/jdk/tools/jextract/Test8249300.java
@@ -44,7 +44,7 @@ public class Test8249300 extends JextractToolRunner {
             Class<?> headerClass = loader.loadClass("test8249300_h");
             checkMethod(headerClass, "func", void.class, MemoryAddress.class);
             Class<?> fiClass = loader.loadClass("test8249300_h$func$f");
-            checkMethod(fiClass, "apply", void.class, Object[].class);
+            checkMethod(fiClass, "apply", void.class);
         } finally {
             deleteDir(outputPath);
         }

--- a/test/jdk/tools/jextract/test8249300.h
+++ b/test/jdk/tools/jextract/test8249300.h
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+#ifdef __cplusplus
+extern "C" {
+#endif // __cplusplus
+
+#ifdef _WIN64
+#define EXPORT __declspec(dllexport)
+#else
+#define EXPORT
+#endif
+
+typedef void MyVoid;
+EXPORT void func(MyVoid (*f)());
+
+#ifdef __cplusplus
+}
+#endif // __cplusplus


### PR DESCRIPTION
Array type parameter in function callback is handled properly
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [JDK-8249300](https://bugs.openjdk.java.net/browse/JDK-8249300): jextract does not handle empty parameter list of a function pointer parameters


### Reviewers
 * Henry Jen ([henryjen](@slowhog) - Committer) ⚠️ Review applies to 6e6c762541fa402e5c69b169c59754a719e60d52
 * Jorn Vernee ([jvernee](@JornVernee) - Committer)


### Download
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/244/head:pull/244`
`$ git checkout pull/244`
