### PR TITLE
JDK-8249753: Add restricted factory to access everything segment

### DIFF
--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/MemorySegment.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/MemorySegment.java
@@ -679,6 +679,29 @@ allocateNative(bytesSize, 1);
     }
 
     /**
+     * Returns a native memory segment whose base address is {@link MemoryAddress#NULL} and whose size is {@link Long#MAX_VALUE}.
+     * This method can be very useful when dereferencing memory addresses obtained when interacting with native libraries.
+     * The segment will feature the {@link #READ} and {@link #WRITE} <a href="#access-modes">access modes</a>.
+     * Equivalent to (but likely more efficient than) the following code:
+     * <pre>{@code
+    MemorySegment.ofNativeRestricted(MemoryAddress.NULL, Long.MAX_VALUE, null, null, null)
+                 .withAccessModes(READ | WRITE);
+     * }</pre>
+     * <p>
+     * This method is <em>restricted</em>. Restricted methods are unsafe, and, if used incorrectly, their use might crash
+     * the JVM or, worse, silently result in memory corruption. Thus, clients should refrain from depending on
+     * restricted methods, and use safe and supported functionalities, where possible.
+     *
+     * @return a memory segment whose base address is {@link MemoryAddress#NULL} and whose size is {@link Long#MAX_VALUE}.
+     * @throws IllegalAccessError if the runtime property {@code foreign.restricted} is not set to either
+     * {@code permit}, {@code warn} or {@code debug} (the default value is set to {@code deny}).
+     */
+    static MemorySegment ofNativeRestricted() {
+        Utils.checkRestrictedAccess("MemorySegment.ofNativeRestricted");
+        return NativeMemorySegmentImpl.EVERYTHING;
+    }
+
+    /**
      * Returns a new native memory segment with given base address and size; the returned segment has its own temporal
      * bounds, and can therefore be closed; closing such a segment can optionally result in calling an user-provided cleanup
      * action. This method can be very useful when interacting with custom native memory sources (e.g. custom allocators,

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/NativeMemorySegmentImpl.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/NativeMemorySegmentImpl.java
@@ -42,6 +42,9 @@ import java.nio.ByteBuffer;
  */
 public class NativeMemorySegmentImpl extends AbstractMemorySegmentImpl {
 
+    public static final MemorySegment EVERYTHING = NativeMemorySegmentImpl.makeNativeSegmentUnchecked(MemoryAddress.NULL,
+            Long.MAX_VALUE, null, null, null).withAccessModes(READ | WRITE);
+
     private static final Unsafe unsafe = Unsafe.getUnsafe();
 
     // The maximum alignment supported by malloc - typically 16 on

--- a/test/jdk/java/foreign/TestNative.java
+++ b/test/jdk/java/foreign/TestNative.java
@@ -29,6 +29,7 @@
  * @run testng/othervm -Dforeign.restricted=permit TestNative
  */
 
+import jdk.incubator.foreign.MemoryAccess;
 import jdk.incubator.foreign.MemoryAddress;
 import jdk.incubator.foreign.MemoryLayout;
 import jdk.incubator.foreign.MemoryLayout.PathElement;
@@ -184,6 +185,13 @@ public class TestNative {
     }
 
     @Test
+    public void testDefaultAccessModesEverthing() {
+        MemorySegment everything = MemorySegment.ofNativeRestricted();
+        assertTrue(everything.hasAccessModes(READ | WRITE));
+        assertEquals(everything.accessModes(), READ | WRITE);
+    }
+
+    @Test
     public void testMallocSegment() {
         MemoryAddress addr = MemoryAddress.ofLong(allocate(12));
         assertNull(addr.segment());
@@ -192,6 +200,17 @@ public class TestNative {
         assertEquals(mallocSegment.byteSize(), 12);
         mallocSegment.close(); //free here
         assertTrue(!mallocSegment.isAlive());
+    }
+
+    @Test
+    public void testEverythingSegment() {
+        MemoryAddress addr = MemoryAddress.ofLong(allocate(4));
+        assertNull(addr.segment());
+        MemorySegment everything = MemorySegment.ofNativeRestricted();
+        MemoryAddress ptr = addr.rebase(everything);
+        MemoryAccess.setInt(ptr, 42);
+        assertEquals(MemoryAccess.getInt(ptr), 42);
+        free(addr.toRawLongValue());
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class)


### PR DESCRIPTION
This patch adds another restricted factory, namely `MemorySegment::ofRestrictedNative()`. The new factory takes no arguments and return a segment that has the following characteristics:

* its base address is `MemoryAddress::NULL`
* its size is `Long.MAX_VALUE`
* it is non-closeable
* it is not confined

Note that this is not *exactly* the _everything_ segment, since, at least in principle, addressable space goes up to `2 ^ 64 - 1` while `Long::MAX_VALUE` is "only" `2^63 -1`. In other words, there is a possibility for some addresses to show up as *negative* long values, which will then be rejeced during dereference.

That said, for all intent and purposes, the segment returned by the new factory is a close enough approximation to the everything segment; we'd prefer to start with that and expand later (with some concrete use cases) rather than adding a new kind of memory segment which might not be needed.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [JDK-8249753](https://bugs.openjdk.java.net/browse/JDK-8249753): Add restricted factory to access everything segment


### Reviewers
 * Jorn Vernee ([jvernee](@JornVernee) - Committer)


### Download
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/249/head:pull/249`
`$ git checkout pull/249`
