### PR TITLE
8249757: jextract should expose a way to load library from a given absolute path

### DIFF
--- a/src/jdk.incubator.jextract/share/classes/jdk/incubator/jextract/tool/Main.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/incubator/jextract/tool/Main.java
@@ -150,11 +150,17 @@ public class Main {
         if (librariesSpecified) {
             for (Object arg : optionSet.valuesOf("l")) {
                 String lib = (String)arg;
-                if (lib.indexOf(File.separatorChar) != -1) {
-                    err.println(format("l.name.should.not.be.path", lib));
-                    return OPTION_ERROR;
+                if (lib.indexOf(File.separatorChar) == -1) {
+                    builder.addLibraryName(lib);
+                } else {
+                    Path libPath = Paths.get(lib);
+                    if (libPath.isAbsolute() && Files.isRegularFile(libPath)) {
+                        builder.addLibraryName(lib);
+                    } else {
+                        err.println(format("l.option.value.invalid", lib));
+                        return OPTION_ERROR;
+                    }
                 }
-                builder.addLibraryName(lib);
             }
         }
 

--- a/src/jdk.incubator.jextract/share/classes/jdk/incubator/jextract/tool/resources/Messages.properties
+++ b/src/jdk.incubator.jextract/share/classes/jdk/incubator/jextract/tool/resources/Messages.properties
@@ -23,7 +23,7 @@
 
 # error message
 cannot.read.header.file=cannot read header file: {0}
-l.name.should.not.be.path=option value for -l option cannot be a path
+l.option.value.invalid=option value for -l option should be a name or an absolute path
 
 # help messages for options
 help.C=pass through argument for clang

--- a/src/jdk.incubator.jextract/share/classes/jdk/incubator/jextract/tool/resources/RuntimeHelper.java.template
+++ b/src/jdk.incubator.jextract/share/classes/jdk/incubator/jextract/tool/resources/RuntimeHelper.java.template
@@ -11,6 +11,7 @@ import jdk.incubator.foreign.MemorySegment;
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.MethodType;
+import java.io.File;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Optional;
@@ -30,7 +31,13 @@ public class RuntimeHelper {
             return new LibraryLookup[] { LibraryLookup.ofDefault() };
         } else {
             return Arrays.stream(libNames)
-                .map(libName -> LibraryLookup.ofLibrary(libName))
+                 .map(libName -> {
+                      if (libName.indexOf(File.separatorChar) != -1) {
+                          return LibraryLookup.ofPath(libName);
+                      } else {
+                          return LibraryLookup.ofLibrary(libName);
+                      }
+                 })
                 .toArray(LibraryLookup[]::new);
         }
     }

--- a/test/jdk/tools/jextract/JtregJextract.java
+++ b/test/jdk/tools/jextract/JtregJextract.java
@@ -22,6 +22,7 @@
  */
 
 import java.io.IOException;
+import java.io.File;
 import java.io.UncheckedIOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -62,6 +63,16 @@ public class JtregJextract {
             String opt = args[i++];
             if ("--".equals(opt)) {
                 break;
+            }
+
+            if ("-libpath".equals(opt)) {
+                String lib = args[i];
+                jextrOpts.add("-l");
+                String libpath = System.getProperty("test.nativepath") + File.separator + System.mapLibraryName(lib);
+                System.err.println("jextract driver libpath passed: " + libpath);
+                jextrOpts.add(libpath);
+                i++;
+                continue;
             }
 
             if ("-d".equals(opt)) {

--- a/test/jdk/tools/jextract/test8249757/LibTest8249757Test.java
+++ b/test/jdk/tools/jextract/test8249757/LibTest8249757Test.java
@@ -30,7 +30,7 @@ import static test.jextract.test8249757.test8249757_h.*;
  * @library ..
  * @modules jdk.incubator.jextract
  * @bug 8249757
- * @summary jextract should expose a way to load library from a given absolute path 
+ * @summary jextract should expose a way to load library from a given absolute path
  * @run driver JtregJextract -libpath Test8249757 -t test.jextract.test8249757 -- test8249757.h
  * @run testng/othervm -Dforeign.restricted=permit LibTest8249757Test
  */

--- a/test/jdk/tools/jextract/test8249757/LibTest8249757Test.java
+++ b/test/jdk/tools/jextract/test8249757/LibTest8249757Test.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import org.testng.annotations.Test;
+import static org.testng.Assert.assertEquals;
+import static test.jextract.test8249757.test8249757_h.*;
+
+/*
+ * @test
+ * @library ..
+ * @modules jdk.incubator.jextract
+ * @bug 8249757
+ * @summary jextract should expose a way to load library from a given absolute path 
+ * @run driver JtregJextract -libpath Test8249757 -t test.jextract.test8249757 -- test8249757.h
+ * @run testng/othervm -Dforeign.restricted=permit LibTest8249757Test
+ */
+public class LibTest8249757Test {
+    @Test
+    public void testSquare() {
+        assertEquals(square(5), 25);
+        assertEquals(square(16), 256);
+        assertEquals(square(20), 400);
+    }
+}

--- a/test/jdk/tools/jextract/test8249757/libTest8249757.c
+++ b/test/jdk/tools/jextract/test8249757/libTest8249757.c
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+#include "test8249757.h"
+
+EXPORT int square(int x) {
+    return x*x;
+}

--- a/test/jdk/tools/jextract/test8249757/test8249757.h
+++ b/test/jdk/tools/jextract/test8249757/test8249757.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+#ifdef __cplusplus
+extern "C" {
+#endif // __cplusplus
+
+#ifdef _WIN64
+#define EXPORT __declspec(dllexport)
+#else
+#define EXPORT
+#endif
+
+EXPORT int square(int);
+
+#ifdef __cplusplus
+}
+#endif // __cplusplus


### PR DESCRIPTION
-l option value is checked for path or simple name and handled accordingly
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [JDK-8249757](https://bugs.openjdk.java.net/browse/JDK-8249757): jextract should expose a way to load library from a given absolute path


### Reviewers
 * Maurizio Cimadamore ([mcimadamore](@mcimadamore) - Committer)


### Download
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/250/head:pull/250`
`$ git checkout pull/250`
