### PR TITLE
8249790: Add Addressable abstraction

### DIFF
--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/Addressable.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/Addressable.java
@@ -1,0 +1,21 @@
+package jdk.incubator.foreign;
+
+/**
+ * Represents a type which is <em>addressable</em>. An addressable type is one which can projected down to
+ * a memory address instance (see {@link #address()}. Examples of addressable types are {@link MemorySegment},
+ * and {@link MemoryAddress}.
+ *
+ * @apiNote In the future, if the Java language permits, {@link Addressable}
+ * may become a {@code sealed} interface, which would prohibit subclassing except by
+ * explicitly permitted types, such as {@link MemorySegment} and {@link MemoryAddress}.
+ *
+ * @implSpec
+ * Implementations of this interface <a href="{@docRoot}/java.base/java/lang/doc-files/ValueBased.html">value-based</a>.
+ */
+public interface Addressable {
+    /**
+     * Map this object into a {@link MemoryAddress} instance.
+     * @return the {@link MemoryAddress} instance associated with this object.
+     */
+    MemoryAddress address();
+}

--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/Addressable.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/Addressable.java
@@ -1,7 +1,32 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
 package jdk.incubator.foreign;
 
 /**
- * Represents a type which is <em>addressable</em>. An addressable type is one which can projected down to
+ * Represents a type which is <em>addressable</em>. An addressable type is one which can be projected down to
  * a memory address instance (see {@link #address()}). Examples of addressable types are {@link MemorySegment},
  * and {@link MemoryAddress}.
  *

--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/Addressable.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/Addressable.java
@@ -2,7 +2,7 @@ package jdk.incubator.foreign;
 
 /**
  * Represents a type which is <em>addressable</em>. An addressable type is one which can projected down to
- * a memory address instance (see {@link #address()}. Examples of addressable types are {@link MemorySegment},
+ * a memory address instance (see {@link #address()}). Examples of addressable types are {@link MemorySegment},
  * and {@link MemoryAddress}.
  *
  * @apiNote In the future, if the Java language permits, {@link Addressable}

--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/MemoryAddress.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/MemoryAddress.java
@@ -30,7 +30,7 @@ import jdk.internal.foreign.MemoryAddressImpl;
 
 /**
  * A memory address models a reference into a memory location. Memory addresses are typically obtained using the
- * {@link MemorySegment#baseAddress()} method; such addresses are said to be <em>checked</em>, and can be expressed
+ * {@link MemorySegment#address()} method; such addresses are said to be <em>checked</em>, and can be expressed
  * as <em>offsets</em> into some underlying memory segment (see {@link #segment()} and {@link #segmentOffset()}).
  * Since checked memory addresses feature both spatial and temporal bounds, these addresses can <em>safely</em> be
  * dereferenced using a memory access var handle (see {@link MemoryHandles}).
@@ -54,7 +54,13 @@ import jdk.internal.foreign.MemoryAddressImpl;
  * @implSpec
  * Implementations of this interface are immutable, thread-safe and <a href="{@docRoot}/java.base/java/lang/doc-files/ValueBased.html">value-based</a>.
  */
-public interface MemoryAddress {
+public interface MemoryAddress extends Addressable {
+
+    @Override
+    default MemoryAddress address() {
+        return this;
+    }
+
     /**
      * Creates a new memory address with given offset (in bytes), which might be negative, from current one.
      * @param offset specified offset (in bytes), relative to this address, which should be used to create the new address.

--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/MemorySegment.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/MemorySegment.java
@@ -169,15 +169,16 @@ int sum = StreamSupport.stream(MemorySegment.spliterator(segment, SEQUENCE_LAYOU
  * @implSpec
  * Implementations of this interface are immutable, thread-safe and <a href="{@docRoot}/java.base/java/lang/doc-files/ValueBased.html">value-based</a>.
  */
-public interface MemorySegment extends AutoCloseable {
+public interface MemorySegment extends Addressable, AutoCloseable {
 
     /**
      * The base memory address associated with this memory segment. The returned address is
-     * a <em>checked</em> memory address and can therefore be used in derefrence operations
+     * a <em>checked</em> memory address and can therefore be used in dereference operations
      * (see {@link MemoryAddress}).
      * @return The base memory address.
      */
-    MemoryAddress baseAddress();
+    @Override
+    MemoryAddress address();
 
     /**
      * Returns a spliterator for the given memory segment. The returned spliterator reports {@link Spliterator#SIZED},
@@ -349,7 +350,7 @@ for (long l = 0; l < segment.byteSize(); l++) {
     /**
      * Finds and returns the offset, in bytes, of the first mismatch between
      * this segment and a given other segment. The offset is relative to the
-     * {@link #baseAddress() base address} of each segment and will be in the
+     * {@link #address() base address} of each segment and will be in the
      * range of 0 (inclusive) up to the {@link #byteSize() size} (in bytes) of
      * the smaller memory segment (exclusive).
      * <p>

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/AbstractMemorySegmentImpl.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/AbstractMemorySegmentImpl.java
@@ -151,7 +151,7 @@ public abstract class AbstractMemorySegmentImpl implements MemorySegment, Memory
 
         long i = 0;
         if (length > 7) {
-            if ((byte) BYTE_HANDLE.get(this.baseAddress(), 0) != (byte) BYTE_HANDLE.get(that.baseAddress(), 0)) {
+            if ((byte) BYTE_HANDLE.get(this.address(), 0) != (byte) BYTE_HANDLE.get(that.address(), 0)) {
                 return 0;
             }
             i = ArraysSupport.vectorizedMismatchLargeForBytes(
@@ -165,8 +165,8 @@ public abstract class AbstractMemorySegmentImpl implements MemorySegment, Memory
             assert remaining < 8 : "remaining greater than 7: " + remaining;
             i = length - remaining;
         }
-        MemoryAddress thisAddress = this.baseAddress();
-        MemoryAddress thatAddress = that.baseAddress();
+        MemoryAddress thisAddress = this.address();
+        MemoryAddress thatAddress = that.address();
         for (; i < length; i++) {
             if ((byte) BYTE_HANDLE.get(thisAddress, i) != (byte) BYTE_HANDLE.get(thatAddress, i)) {
                 return i;
@@ -177,7 +177,7 @@ public abstract class AbstractMemorySegmentImpl implements MemorySegment, Memory
 
     @Override
     @ForceInline
-    public final MemoryAddress baseAddress() {
+    public final MemoryAddress address() {
         return new MemoryAddressImpl(this, 0);
     }
 

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/MemoryAddressImpl.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/MemoryAddressImpl.java
@@ -90,7 +90,7 @@ public final class MemoryAddressImpl implements MemoryAddress, MemoryAddressProx
             throw new IllegalArgumentException("Invalid rebase target: " + segment);
         }
         return new MemoryAddressImpl((AbstractMemorySegmentImpl)segment,
-                unsafeGetOffset() - ((MemoryAddressImpl)segment.baseAddress()).unsafeGetOffset());
+                unsafeGetOffset() - ((MemoryAddressImpl)segment.address()).unsafeGetOffset());
     }
 
     // MemoryAddressProxy methods

--- a/test/jdk/java/foreign/TestAdaptVarHandles.java
+++ b/test/jdk/java/foreign/TestAdaptVarHandles.java
@@ -92,16 +92,16 @@ public class TestAdaptVarHandles {
         MemorySegment segment = MemorySegment.allocateNative(layout);
         VarHandle intHandle = layout.varHandle(int.class);
         VarHandle i2SHandle = MemoryHandles.filterValue(intHandle, S2I, I2S);
-        i2SHandle.set(segment.baseAddress(), "1");
-        String oldValue = (String)i2SHandle.getAndAdd(segment.baseAddress(), "42");
+        i2SHandle.set(segment.address(), "1");
+        String oldValue = (String)i2SHandle.getAndAdd(segment.address(), "42");
         assertEquals(oldValue, "1");
-        String value = (String)i2SHandle.get(segment.baseAddress());
+        String value = (String)i2SHandle.get(segment.address());
         assertEquals(value, "43");
-        boolean swapped = (boolean)i2SHandle.compareAndSet(segment.baseAddress(), "43", "12");
+        boolean swapped = (boolean)i2SHandle.compareAndSet(segment.address(), "43", "12");
         assertTrue(swapped);
-        oldValue = (String)i2SHandle.compareAndExchange(segment.baseAddress(), "12", "42");
+        oldValue = (String)i2SHandle.compareAndExchange(segment.address(), "12", "42");
         assertEquals(oldValue, "12");
-        value = (String)i2SHandle.toMethodHandle(VarHandle.AccessMode.GET).invokeExact(segment.baseAddress());
+        value = (String)i2SHandle.toMethodHandle(VarHandle.AccessMode.GET).invokeExact(segment.address());
         assertEquals(value, "42");
     }
 
@@ -113,16 +113,16 @@ public class TestAdaptVarHandles {
         MethodHandle CTX_S2I = MethodHandles.dropArguments(S2I, 0, String.class, String.class);
         VarHandle i2SHandle = MemoryHandles.filterValue(intHandle, CTX_S2I, CTX_I2S);
         i2SHandle = MemoryHandles.insertCoordinates(i2SHandle, 1, "a", "b");
-        i2SHandle.set(segment.baseAddress(), "1");
-        String oldValue = (String)i2SHandle.getAndAdd(segment.baseAddress(), "42");
+        i2SHandle.set(segment.address(), "1");
+        String oldValue = (String)i2SHandle.getAndAdd(segment.address(), "42");
         assertEquals(oldValue, "ab1");
-        String value = (String)i2SHandle.get(segment.baseAddress());
+        String value = (String)i2SHandle.get(segment.address());
         assertEquals(value, "ab43");
-        boolean swapped = (boolean)i2SHandle.compareAndSet(segment.baseAddress(), "43", "12");
+        boolean swapped = (boolean)i2SHandle.compareAndSet(segment.address(), "43", "12");
         assertTrue(swapped);
-        oldValue = (String)i2SHandle.compareAndExchange(segment.baseAddress(), "12", "42");
+        oldValue = (String)i2SHandle.compareAndExchange(segment.address(), "12", "42");
         assertEquals(oldValue, "ab12");
-        value = (String)i2SHandle.toMethodHandle(VarHandle.AccessMode.GET).invokeExact(segment.baseAddress());
+        value = (String)i2SHandle.toMethodHandle(VarHandle.AccessMode.GET).invokeExact(segment.address());
         assertEquals(value, "ab42");
     }
 
@@ -132,16 +132,16 @@ public class TestAdaptVarHandles {
         MemorySegment segment = MemorySegment.allocateNative(layout);
         VarHandle intHandle = layout.varHandle(int.class);
         VarHandle i2SHandle = MemoryHandles.filterValue(intHandle, O2I, I2O);
-        i2SHandle.set(segment.baseAddress(), "1");
-        String oldValue = (String)i2SHandle.getAndAdd(segment.baseAddress(), "42");
+        i2SHandle.set(segment.address(), "1");
+        String oldValue = (String)i2SHandle.getAndAdd(segment.address(), "42");
         assertEquals(oldValue, "1");
-        String value = (String)i2SHandle.get(segment.baseAddress());
+        String value = (String)i2SHandle.get(segment.address());
         assertEquals(value, "43");
-        boolean swapped = (boolean)i2SHandle.compareAndSet(segment.baseAddress(), "43", "12");
+        boolean swapped = (boolean)i2SHandle.compareAndSet(segment.address(), "43", "12");
         assertTrue(swapped);
-        oldValue = (String)i2SHandle.compareAndExchange(segment.baseAddress(), "12", "42");
+        oldValue = (String)i2SHandle.compareAndExchange(segment.address(), "12", "42");
         assertEquals(oldValue, "12");
-        value = (String)(Object)i2SHandle.toMethodHandle(VarHandle.AccessMode.GET).invokeExact(segment.baseAddress());
+        value = (String)(Object)i2SHandle.toMethodHandle(VarHandle.AccessMode.GET).invokeExact(segment.address());
         assertEquals(value, "42");
     }
 
@@ -277,7 +277,7 @@ public class TestAdaptVarHandles {
         ValueLayout layout = MemoryLayouts.JAVA_INT;
         MemorySegment segment = MemorySegment.allocateNative(layout);
         VarHandle intHandle = MemoryHandles.withStride(layout.varHandle(int.class), 4);
-        VarHandle intHandle_longIndex = MemoryHandles.insertCoordinates(intHandle, 0, segment.baseAddress(), 0L);
+        VarHandle intHandle_longIndex = MemoryHandles.insertCoordinates(intHandle, 0, segment.address(), 0L);
         intHandle_longIndex.set(1);
         int oldValue = (int)intHandle_longIndex.getAndAdd(42);
         assertEquals(oldValue, 1);
@@ -333,16 +333,16 @@ public class TestAdaptVarHandles {
         VarHandle intHandle = MemoryHandles.withStride(layout.varHandle(int.class), 4);
         VarHandle intHandle_swap = MemoryHandles.permuteCoordinates(intHandle,
                 List.of(long.class, MemoryAddress.class), 1, 0);
-        intHandle_swap.set(0L, segment.baseAddress(), 1);
-        int oldValue = (int)intHandle_swap.getAndAdd(0L, segment.baseAddress(), 42);
+        intHandle_swap.set(0L, segment.address(), 1);
+        int oldValue = (int)intHandle_swap.getAndAdd(0L, segment.address(), 42);
         assertEquals(oldValue, 1);
-        int value = (int)intHandle_swap.get(0L, segment.baseAddress());
+        int value = (int)intHandle_swap.get(0L, segment.address());
         assertEquals(value, 43);
-        boolean swapped = (boolean)intHandle_swap.compareAndSet(0L, segment.baseAddress(), 43, 12);
+        boolean swapped = (boolean)intHandle_swap.compareAndSet(0L, segment.address(), 43, 12);
         assertTrue(swapped);
-        oldValue = (int)intHandle_swap.compareAndExchange(0L, segment.baseAddress(), 12, 42);
+        oldValue = (int)intHandle_swap.compareAndExchange(0L, segment.address(), 12, 42);
         assertEquals(oldValue, 12);
-        value = (int)intHandle_swap.toMethodHandle(VarHandle.AccessMode.GET).invokeExact(0L, segment.baseAddress());
+        value = (int)intHandle_swap.toMethodHandle(VarHandle.AccessMode.GET).invokeExact(0L, segment.address());
         assertEquals(value, 42);
     }
 
@@ -393,16 +393,16 @@ public class TestAdaptVarHandles {
         MemorySegment segment = MemorySegment.allocateNative(layout);
         VarHandle intHandle = MemoryHandles.withStride(layout.varHandle(int.class), 4);
         VarHandle intHandle_sum = MemoryHandles.collectCoordinates(intHandle, 1, SUM_OFFSETS);
-        intHandle_sum.set(segment.baseAddress(), -2L, 2L, 1);
-        int oldValue = (int)intHandle_sum.getAndAdd(segment.baseAddress(), -2L, 2L, 42);
+        intHandle_sum.set(segment.address(), -2L, 2L, 1);
+        int oldValue = (int)intHandle_sum.getAndAdd(segment.address(), -2L, 2L, 42);
         assertEquals(oldValue, 1);
-        int value = (int)intHandle_sum.get(segment.baseAddress(), -2L, 2L);
+        int value = (int)intHandle_sum.get(segment.address(), -2L, 2L);
         assertEquals(value, 43);
-        boolean swapped = (boolean)intHandle_sum.compareAndSet(segment.baseAddress(), -2L, 2L, 43, 12);
+        boolean swapped = (boolean)intHandle_sum.compareAndSet(segment.address(), -2L, 2L, 43, 12);
         assertTrue(swapped);
-        oldValue = (int)intHandle_sum.compareAndExchange(segment.baseAddress(), -2L, 2L, 12, 42);
+        oldValue = (int)intHandle_sum.compareAndExchange(segment.address(), -2L, 2L, 12, 42);
         assertEquals(oldValue, 12);
-        value = (int)intHandle_sum.toMethodHandle(VarHandle.AccessMode.GET).invokeExact(segment.baseAddress(), -2L, 2L);
+        value = (int)intHandle_sum.toMethodHandle(VarHandle.AccessMode.GET).invokeExact(segment.address(), -2L, 2L);
         assertEquals(value, 42);
     }
 
@@ -453,16 +453,16 @@ public class TestAdaptVarHandles {
         MemorySegment segment = MemorySegment.allocateNative(layout);
         VarHandle intHandle = MemoryHandles.withStride(layout.varHandle(int.class), 4);
         VarHandle intHandle_dummy = MemoryHandles.dropCoordinates(intHandle, 1, float.class, String.class);
-        intHandle_dummy.set(segment.baseAddress(), 1f, "hello", 0L, 1);
-        int oldValue = (int)intHandle_dummy.getAndAdd(segment.baseAddress(), 1f, "hello", 0L, 42);
+        intHandle_dummy.set(segment.address(), 1f, "hello", 0L, 1);
+        int oldValue = (int)intHandle_dummy.getAndAdd(segment.address(), 1f, "hello", 0L, 42);
         assertEquals(oldValue, 1);
-        int value = (int)intHandle_dummy.get(segment.baseAddress(), 1f, "hello", 0L);
+        int value = (int)intHandle_dummy.get(segment.address(), 1f, "hello", 0L);
         assertEquals(value, 43);
-        boolean swapped = (boolean)intHandle_dummy.compareAndSet(segment.baseAddress(), 1f, "hello", 0L, 43, 12);
+        boolean swapped = (boolean)intHandle_dummy.compareAndSet(segment.address(), 1f, "hello", 0L, 43, 12);
         assertTrue(swapped);
-        oldValue = (int)intHandle_dummy.compareAndExchange(segment.baseAddress(), 1f, "hello", 0L, 12, 42);
+        oldValue = (int)intHandle_dummy.compareAndExchange(segment.address(), 1f, "hello", 0L, 12, 42);
         assertEquals(oldValue, 12);
-        value = (int)intHandle_dummy.toMethodHandle(VarHandle.AccessMode.GET).invokeExact(segment.baseAddress(), 1f, "hello", 0L);
+        value = (int)intHandle_dummy.toMethodHandle(VarHandle.AccessMode.GET).invokeExact(segment.address(), 1f, "hello", 0L);
         assertEquals(value, 42);
     }
 
@@ -508,7 +508,7 @@ public class TestAdaptVarHandles {
     }
 
     static MemoryAddress baseAddress(MemorySegment segment) {
-        return segment.baseAddress();
+        return segment.address();
     }
 
     static long sumOffsets(long l1, long l2) {

--- a/test/jdk/java/foreign/TestAddressHandle.java
+++ b/test/jdk/java/foreign/TestAddressHandle.java
@@ -64,9 +64,9 @@ public class TestAddressHandle {
         VarHandle longHandle = MemoryHandles.varHandle(long.class, ByteOrder.nativeOrder());
         try (MemorySegment segment = MemorySegment.allocateNative(8)) {
             MemoryAddress target = ByteOrder.nativeOrder() == ByteOrder.BIG_ENDIAN ?
-                    segment.baseAddress().addOffset(8 - byteSize) :
-                    segment.baseAddress();
-            longHandle.set(segment.baseAddress(), 42L);
+                    segment.address().addOffset(8 - byteSize) :
+                    segment.address();
+            longHandle.set(segment.address(), 42L);
             MemoryAddress address = (MemoryAddress)addrHandle.get(target);
             assertEquals(address.toRawLongValue(), 42L);
             try {
@@ -76,7 +76,7 @@ public class TestAddressHandle {
                 assertTrue(true);
             }
             addrHandle.set(target, address.addOffset(1));
-            long result = (long)longHandle.get(segment.baseAddress());
+            long result = (long)longHandle.get(segment.address());
             assertEquals(43L, result);
         }
     }
@@ -85,8 +85,8 @@ public class TestAddressHandle {
     public void testNull(VarHandle addrHandle, int byteSize) {
         VarHandle longHandle = MemoryHandles.varHandle(long.class, ByteOrder.nativeOrder());
         try (MemorySegment segment = MemorySegment.allocateNative(8)) {
-            longHandle.set(segment.baseAddress(), 0L);
-            MemoryAddress address = (MemoryAddress)addrHandle.get(segment.baseAddress());
+            longHandle.set(segment.address(), 0L);
+            MemoryAddress address = (MemoryAddress)addrHandle.get(segment.address());
             assertTrue(address == MemoryAddress.NULL);
         }
     }

--- a/test/jdk/java/foreign/TestArrays.java
+++ b/test/jdk/java/foreign/TestArrays.java
@@ -39,7 +39,6 @@ import java.util.function.BiConsumer;
 import java.util.function.BiFunction;
 import java.util.function.Consumer;
 import java.util.function.Function;
-import java.util.function.ToIntFunction;
 
 import org.testng.annotations.*;
 
@@ -103,8 +102,8 @@ public class TestArrays {
     @Test(dataProvider = "arrays")
     public void testArrays(Consumer<MemoryAddress> init, Consumer<MemoryAddress> checker, MemoryLayout layout) {
         try (MemorySegment segment = MemorySegment.allocateNative(layout)) {
-            init.accept(segment.baseAddress());
-            checker.accept(segment.baseAddress());
+            init.accept(segment.address());
+            checker.accept(segment.address());
         }
     }
 

--- a/test/jdk/java/foreign/TestByteBuffer.java
+++ b/test/jdk/java/foreign/TestByteBuffer.java
@@ -170,7 +170,7 @@ public class TestByteBuffer {
             ByteBuffer bb = resizedSegment.asByteBuffer();
             Z z = bufFactory.apply(bb);
             for (long j = i ; j < limit ; j++) {
-                Object handleValue = handleExtractor.apply(resizedSegment.baseAddress(), j - i);
+                Object handleValue = handleExtractor.apply(resizedSegment.address(), j - i);
                 Object bufferValue = bufferExtractor.apply(z);
                 if (handleValue instanceof Number) {
                     assertEquals(((Number)handleValue).longValue(), j);
@@ -186,7 +186,7 @@ public class TestByteBuffer {
     @Test
     public void testOffheap() {
         try (MemorySegment segment = MemorySegment.allocateNative(tuples)) {
-            MemoryAddress base = segment.baseAddress();
+            MemoryAddress base = segment.address();
             initTuples(base, tuples.elementCount().getAsLong());
 
             ByteBuffer bb = segment.asByteBuffer();
@@ -198,7 +198,7 @@ public class TestByteBuffer {
     public void testHeap() {
         byte[] arr = new byte[(int) tuples.byteSize()];
         MemorySegment region = MemorySegment.ofArray(arr);
-        MemoryAddress base = region.baseAddress();
+        MemoryAddress base = region.address();
         initTuples(base, tuples.elementCount().getAsLong());
 
         ByteBuffer bb = region.asByteBuffer();
@@ -215,7 +215,7 @@ public class TestByteBuffer {
         try (FileChannel channel = FileChannel.open(f.toPath(), StandardOpenOption.READ, StandardOpenOption.WRITE)) {
             withMappedBuffer(channel, FileChannel.MapMode.READ_WRITE, 0, tuples.byteSize(), mbb -> {
                 MemorySegment segment = MemorySegment.ofByteBuffer(mbb);
-                MemoryAddress base = segment.baseAddress();
+                MemoryAddress base = segment.address();
                 initTuples(base, tuples.elementCount().getAsLong());
                 mbb.force();
             });
@@ -225,7 +225,7 @@ public class TestByteBuffer {
         try (FileChannel channel = FileChannel.open(f.toPath(), StandardOpenOption.READ)) {
             withMappedBuffer(channel, FileChannel.MapMode.READ_ONLY, 0, tuples.byteSize(), mbb -> {
                 MemorySegment segment = MemorySegment.ofByteBuffer(mbb);
-                MemoryAddress base = segment.baseAddress();
+                MemoryAddress base = segment.address();
                 checkTuples(base, mbb, tuples.elementCount().getAsLong());
             });
         }
@@ -252,14 +252,14 @@ public class TestByteBuffer {
 
         //write to channel
         try (MappedMemorySegment segment = MemorySegment.mapFromPath(f.toPath(), 0L, tuples.byteSize(), FileChannel.MapMode.READ_WRITE)) {
-            MemoryAddress base = segment.baseAddress();
+            MemoryAddress base = segment.address();
             initTuples(base, tuples.elementCount().getAsLong());
             segment.force();
         }
 
         //read from channel
         try (MemorySegment segment = MemorySegment.mapFromPath(f.toPath(), 0L, tuples.byteSize(), FileChannel.MapMode.READ_ONLY)) {
-            MemoryAddress base = segment.baseAddress();
+            MemoryAddress base = segment.address();
             checkTuples(base, segment.asByteBuffer(), tuples.elementCount().getAsLong());
         }
     }
@@ -276,7 +276,7 @@ public class TestByteBuffer {
         for (int i = 0 ; i < tuples.byteSize() ; i += tupleLayout.byteSize()) {
             //write to channel
             try (MappedMemorySegment segment = MemorySegment.mapFromPath(f.toPath(), i, tuples.byteSize(), FileChannel.MapMode.READ_WRITE)) {
-                MemoryAddress base = segment.baseAddress();
+                MemoryAddress base = segment.address();
                 initTuples(base, 1);
                 segment.force();
             }
@@ -286,7 +286,7 @@ public class TestByteBuffer {
         for (int i = 0 ; i < tuples.byteSize() ; i += tupleLayout.byteSize()) {
             //read from channel
             try (MemorySegment segment = MemorySegment.mapFromPath(f.toPath(), 0L, tuples.byteSize(), FileChannel.MapMode.READ_ONLY)) {
-                MemoryAddress base = segment.baseAddress();
+                MemoryAddress base = segment.address();
                 checkTuples(base, segment.asByteBuffer(), 1);
             }
         }
@@ -315,7 +315,7 @@ public class TestByteBuffer {
     public void testScopedBuffer(Function<ByteBuffer, Buffer> bufferFactory, Map<Method, Object[]> members) {
         Buffer bb;
         try (MemorySegment segment = MemorySegment.allocateNative(bytes)) {
-            MemoryAddress base = segment.baseAddress();
+            MemoryAddress base = segment.address();
             bb = bufferFactory.apply(segment.asByteBuffer());
         }
         //outside of scope!!
@@ -381,7 +381,7 @@ public class TestByteBuffer {
     @Test(dataProvider = "bufferOps")
     public void testDirectBuffer(Function<ByteBuffer, Buffer> bufferFactory, Map<Method, Object[]> members) {
         try (MemorySegment segment = MemorySegment.allocateNative(bytes)) {
-            MemoryAddress base = segment.baseAddress();
+            MemoryAddress base = segment.address();
             Buffer bb = bufferFactory.apply(segment.asByteBuffer());
             assertTrue(bb.isDirect());
             DirectBuffer directBuffer = ((DirectBuffer)bb);
@@ -394,7 +394,7 @@ public class TestByteBuffer {
     @Test(dataProvider="resizeOps")
     public void testResizeOffheap(Consumer<MemoryAddress> checker, Consumer<MemoryAddress> initializer, SequenceLayout seq) {
         try (MemorySegment segment = MemorySegment.allocateNative(seq)) {
-            MemoryAddress base = segment.baseAddress();
+            MemoryAddress base = segment.address();
             initializer.accept(base);
             checker.accept(base);
         }
@@ -404,7 +404,7 @@ public class TestByteBuffer {
     public void testResizeHeap(Consumer<MemoryAddress> checker, Consumer<MemoryAddress> initializer, SequenceLayout seq) {
         checkByteArrayAlignment(seq.elementLayout());
         int capacity = (int)seq.byteSize();
-        MemoryAddress base = MemorySegment.ofArray(new byte[capacity]).baseAddress();
+        MemoryAddress base = MemorySegment.ofArray(new byte[capacity]).address();
         initializer.accept(base);
         checker.accept(base);
     }
@@ -413,7 +413,7 @@ public class TestByteBuffer {
     public void testResizeBuffer(Consumer<MemoryAddress> checker, Consumer<MemoryAddress> initializer, SequenceLayout seq) {
         checkByteArrayAlignment(seq.elementLayout());
         int capacity = (int)seq.byteSize();
-        MemoryAddress base = MemorySegment.ofByteBuffer(ByteBuffer.wrap(new byte[capacity])).baseAddress();
+        MemoryAddress base = MemorySegment.ofByteBuffer(ByteBuffer.wrap(new byte[capacity])).address();
         initializer.accept(base);
         checker.accept(base);
     }
@@ -424,18 +424,18 @@ public class TestByteBuffer {
         int capacity = (int)seq.byteSize();
         byte[] arr = new byte[capacity];
         MemorySegment segment = MemorySegment.ofArray(arr);
-        MemoryAddress first = segment.baseAddress();
+        MemoryAddress first = segment.address();
         initializer.accept(first);
-        MemoryAddress second = MemorySegment.ofByteBuffer(segment.asByteBuffer()).baseAddress();
+        MemoryAddress second = MemorySegment.ofByteBuffer(segment.asByteBuffer()).address();
         checker.accept(second);
     }
 
     @Test(dataProvider="resizeOps")
     public void testResizeRoundtripNative(Consumer<MemoryAddress> checker, Consumer<MemoryAddress> initializer, SequenceLayout seq) {
         try (MemorySegment segment = MemorySegment.allocateNative(seq)) {
-            MemoryAddress first = segment.baseAddress();
+            MemoryAddress first = segment.address();
             initializer.accept(first);
-            MemoryAddress second = MemorySegment.ofByteBuffer(segment.asByteBuffer()).baseAddress();
+            MemoryAddress second = MemorySegment.ofByteBuffer(segment.asByteBuffer()).address();
             checker.accept(second);
         }
     }
@@ -489,9 +489,9 @@ public class TestByteBuffer {
         int bytes = (int)seq.byteSize();
         try (MemorySegment nativeArray = MemorySegment.allocateNative(bytes);
              MemorySegment heapArray = MemorySegment.ofArray(new byte[bytes])) {
-            initializer.accept(heapArray.baseAddress());
+            initializer.accept(heapArray.address());
             nativeArray.copyFrom(heapArray);
-            checker.accept(nativeArray.baseAddress());
+            checker.accept(nativeArray.address());
         }
     }
 
@@ -501,9 +501,9 @@ public class TestByteBuffer {
         int bytes = (int)seq.byteSize();
         try (MemorySegment nativeArray = MemorySegment.allocateNative(seq);
              MemorySegment heapArray = MemorySegment.ofArray(new byte[bytes])) {
-            initializer.accept(nativeArray.baseAddress());
+            initializer.accept(nativeArray.address());
             heapArray.copyFrom(nativeArray);
-            checker.accept(heapArray.baseAddress());
+            checker.accept(heapArray.address());
         }
     }
 
@@ -555,7 +555,7 @@ public class TestByteBuffer {
 
         s1.close(); // memory freed
 
-        MemoryAccess.setInt(s2.baseAddress(), 10); // Dead access!
+        MemoryAccess.setInt(s2.address(), 10); // Dead access!
     }
 
     @DataProvider(name = "bufferOps")

--- a/test/jdk/java/foreign/TestLayouts.java
+++ b/test/jdk/java/foreign/TestLayouts.java
@@ -64,14 +64,14 @@ public class TestLayouts {
                 MemoryLayout.PathElement.sequenceElement());
         try (MemorySegment segment = MemorySegment.allocateNative(
                 layout.map(l -> ((SequenceLayout)l).withElementCount(4), MemoryLayout.PathElement.groupElement("arr")))) {
-            size_handle.set(segment.baseAddress(), 4);
+            size_handle.set(segment.address(), 4);
             for (int i = 0 ; i < 4 ; i++) {
-                array_elem_handle.set(segment.baseAddress(), i, (double)i);
+                array_elem_handle.set(segment.address(), i, (double)i);
             }
             //check
-            assertEquals(4, (int)size_handle.get(segment.baseAddress()));
+            assertEquals(4, (int)size_handle.get(segment.address()));
             for (int i = 0 ; i < 4 ; i++) {
-                assertEquals((double)i, (double)array_elem_handle.get(segment.baseAddress(), i));
+                assertEquals((double)i, (double)array_elem_handle.get(segment.address(), i));
             }
         }
     }
@@ -90,14 +90,14 @@ public class TestLayouts {
                 MemoryLayout.PathElement.sequenceElement());
         try (MemorySegment segment = MemorySegment.allocateNative(
                 layout.map(l -> ((SequenceLayout)l).withElementCount(4), MemoryLayout.PathElement.groupElement("arr"), MemoryLayout.PathElement.sequenceElement()))) {
-            size_handle.set(segment.baseAddress(), 4);
+            size_handle.set(segment.address(), 4);
             for (int i = 0 ; i < 4 ; i++) {
-                array_elem_handle.set(segment.baseAddress(), i, (double)i);
+                array_elem_handle.set(segment.address(), i, (double)i);
             }
             //check
-            assertEquals(4, (int)size_handle.get(segment.baseAddress()));
+            assertEquals(4, (int)size_handle.get(segment.address()));
             for (int i = 0 ; i < 4 ; i++) {
-                assertEquals((double)i, (double)array_elem_handle.get(segment.baseAddress(), i));
+                assertEquals((double)i, (double)array_elem_handle.get(segment.address(), i));
             }
         }
     }
@@ -109,13 +109,13 @@ public class TestLayouts {
             VarHandle indexHandle = seq.varHandle(int.class, MemoryLayout.PathElement.sequenceElement());
             // init segment
             for (int i = 0 ; i < 10 ; i++) {
-                indexHandle.set(segment.baseAddress(), (long)i, i);
+                indexHandle.set(segment.address(), (long)i, i);
             }
             //check statically indexed handles
             for (int i = 0 ; i < 10 ; i++) {
                 VarHandle preindexHandle = seq.varHandle(int.class, MemoryLayout.PathElement.sequenceElement(i));
-                int expected = (int)indexHandle.get(segment.baseAddress(), (long)i);
-                int found = (int)preindexHandle.get(segment.baseAddress());
+                int expected = (int)indexHandle.get(segment.address(), (long)i);
+                int found = (int)preindexHandle.get(segment.address());
                 assertEquals(expected, found);
             }
         }

--- a/test/jdk/java/foreign/TestMemoryAccess.java
+++ b/test/jdk/java/foreign/TestMemoryAccess.java
@@ -85,7 +85,7 @@ public class TestMemoryAccess {
         MemoryAddress outer_address;
         try (MemorySegment segment = viewFactory.apply(MemorySegment.allocateNative(layout))) {
             boolean isRO = !segment.hasAccessModes(MemorySegment.WRITE);
-            MemoryAddress addr = segment.baseAddress();
+            MemoryAddress addr = segment.address();
             try {
                 checker.check(handle, addr);
                 if (isRO) {
@@ -117,7 +117,7 @@ public class TestMemoryAccess {
         MemoryAddress outer_address;
         try (MemorySegment segment = viewFactory.apply(MemorySegment.allocateNative(seq))) {
             boolean isRO = !segment.hasAccessModes(MemorySegment.WRITE);
-            MemoryAddress addr = segment.baseAddress();
+            MemoryAddress addr = segment.address();
             try {
                 for (int i = 0; i < seq.elementCount().getAsLong(); i++) {
                     checker.check(handle, addr, i);
@@ -186,7 +186,7 @@ public class TestMemoryAccess {
         MemoryAddress outer_address;
         try (MemorySegment segment = viewFactory.apply(MemorySegment.allocateNative(seq))) {
             boolean isRO = !segment.hasAccessModes(MemorySegment.WRITE);
-            MemoryAddress addr = segment.baseAddress();
+            MemoryAddress addr = segment.address();
             try {
                 for (int i = 0; i < seq.elementCount().getAsLong(); i++) {
                     for (int j = 0; j < ((SequenceLayout) seq.elementLayout()).elementCount().getAsLong(); j++) {

--- a/test/jdk/java/foreign/TestMemoryAlignment.java
+++ b/test/jdk/java/foreign/TestMemoryAlignment.java
@@ -51,7 +51,7 @@ public class TestMemoryAlignment {
         assertEquals(aligned.bitAlignment(), align); //unreasonable alignment here, to make sure access throws
         VarHandle vh = aligned.varHandle(int.class);
         try (MemorySegment segment = MemorySegment.allocateNative(aligned)) {
-            MemoryAddress addr = segment.baseAddress();
+            MemoryAddress addr = segment.address();
             vh.set(addr, -42);
             int val = (int)vh.get(addr);
             assertEquals(val, -42);
@@ -67,7 +67,7 @@ public class TestMemoryAlignment {
         assertEquals(alignedGroup.bitAlignment(), align);
         VarHandle vh = aligned.varHandle(int.class);
         try (MemorySegment segment = MemorySegment.allocateNative(alignedGroup)) {
-            MemoryAddress addr = segment.baseAddress();
+            MemoryAddress addr = segment.address();
             vh.set(addr.addOffset(1L), -42);
             assertEquals(align, 8); //this is the only case where access is aligned
         } catch (IllegalStateException ex) {
@@ -94,7 +94,7 @@ public class TestMemoryAlignment {
         try {
             VarHandle vh = layout.varHandle(int.class, PathElement.sequenceElement());
             try (MemorySegment segment = MemorySegment.allocateNative(layout)) {
-                MemoryAddress addr = segment.baseAddress();
+                MemoryAddress addr = segment.address();
                 for (long i = 0 ; i < 5 ; i++) {
                     vh.set(addr, i, -42);
                 }
@@ -118,7 +118,7 @@ public class TestMemoryAlignment {
         VarHandle vh_s = g.varHandle(short.class, PathElement.groupElement("b"));
         VarHandle vh_i = g.varHandle(int.class, PathElement.groupElement("c"));
         try (MemorySegment segment = MemorySegment.allocateNative(g)) {
-            MemoryAddress addr = segment.baseAddress();
+            MemoryAddress addr = segment.address();
             vh_c.set(addr, Byte.MIN_VALUE);
             assertEquals(vh_c.get(addr), Byte.MIN_VALUE);
             vh_s.set(addr, Short.MIN_VALUE);

--- a/test/jdk/java/foreign/TestMemoryCopy.java
+++ b/test/jdk/java/foreign/TestMemoryCopy.java
@@ -46,8 +46,8 @@ public class TestMemoryCopy {
 
     @Test(dataProvider = "slices")
     public void testCopy(SegmentSlice s1, SegmentSlice s2) {
-        MemoryAddress addr1 = s1.segment.baseAddress();
-        MemoryAddress addr2 = s2.segment.baseAddress();
+        MemoryAddress addr1 = s1.segment.address();
+        MemoryAddress addr2 = s2.segment.address();
         int size = Math.min(s1.size(), s2.size());
         //prepare source and target segments
         for (int i = 0 ; i < size ; i++) {

--- a/test/jdk/java/foreign/TestMemoryHandleAsUnsigned.java
+++ b/test/jdk/java/foreign/TestMemoryHandleAsUnsigned.java
@@ -59,10 +59,10 @@ public class TestMemoryHandleAsUnsigned {
         VarHandle intHandle = MemoryHandles.asUnsigned(byteHandle, int.class);
 
         try (MemorySegment segment = MemorySegment.allocateNative(layout)) {
-            intHandle.set(segment.baseAddress(), intValue);
+            intHandle.set(segment.address(), intValue);
             int expectedIntValue = Byte.toUnsignedInt(byteValue);
-            assertEquals((int) intHandle.get(segment.baseAddress()), expectedIntValue);
-            assertEquals((byte) byteHandle.get(segment.baseAddress()), byteValue);
+            assertEquals((int) intHandle.get(segment.address()), expectedIntValue);
+            assertEquals((byte) byteHandle.get(segment.address()), byteValue);
         }
     }
 
@@ -81,10 +81,10 @@ public class TestMemoryHandleAsUnsigned {
         VarHandle longHandle = MemoryHandles.asUnsigned(byteHandle, long.class);
 
         try (MemorySegment segment = MemorySegment.allocateNative(layout)) {
-            longHandle.set(segment.baseAddress(), longValue);
+            longHandle.set(segment.address(), longValue);
             long expectedLongValue = Byte.toUnsignedLong(byteValue);
-            assertEquals((long) longHandle.get(segment.baseAddress()), expectedLongValue);
-            assertEquals((byte) byteHandle.get(segment.baseAddress()), byteValue);
+            assertEquals((long) longHandle.get(segment.address()), expectedLongValue);
+            assertEquals((byte) byteHandle.get(segment.address()), byteValue);
         }
     }
 
@@ -103,10 +103,10 @@ public class TestMemoryHandleAsUnsigned {
         VarHandle intHandle = MemoryHandles.asUnsigned(shortHandle, int.class);
 
         try (MemorySegment segment = MemorySegment.allocateNative(layout)) {
-            intHandle.set(segment.baseAddress(), intValue);
+            intHandle.set(segment.address(), intValue);
             int expectedIntValue = Short.toUnsignedInt(shortValue);
-            assertEquals((int) intHandle.get(segment.baseAddress()), expectedIntValue);
-            assertEquals((short) shortHandle.get(segment.baseAddress()), shortValue);
+            assertEquals((int) intHandle.get(segment.address()), expectedIntValue);
+            assertEquals((short) shortHandle.get(segment.address()), shortValue);
         }
     }
 
@@ -125,10 +125,10 @@ public class TestMemoryHandleAsUnsigned {
         VarHandle longHandle = MemoryHandles.asUnsigned(shortHandle, long.class);
 
         try (MemorySegment segment = MemorySegment.allocateNative(layout)) {
-            longHandle.set(segment.baseAddress(), longValue);
+            longHandle.set(segment.address(), longValue);
             long expectedLongValue = Short.toUnsignedLong(shortValue);
-            assertEquals((long) longHandle.get(segment.baseAddress()), expectedLongValue);
-            assertEquals((short) shortHandle.get(segment.baseAddress()), shortValue);
+            assertEquals((long) longHandle.get(segment.address()), expectedLongValue);
+            assertEquals((short) shortHandle.get(segment.address()), shortValue);
         }
     }
 
@@ -151,10 +151,10 @@ public class TestMemoryHandleAsUnsigned {
         VarHandle longHandle = MemoryHandles.asUnsigned(intHandle, long.class);
 
         try (MemorySegment segment = MemorySegment.allocateNative(layout)) {
-            longHandle.set(segment.baseAddress(), longValue);
+            longHandle.set(segment.address(), longValue);
             long expectedLongValue = Integer.toUnsignedLong(intValue);
-            assertEquals((long) longHandle.get(segment.baseAddress()), expectedLongValue);
-            assertEquals((int) intHandle.get(segment.baseAddress()), intValue);
+            assertEquals((long) longHandle.get(segment.address()), expectedLongValue);
+            assertEquals((int) intHandle.get(segment.address()), intValue);
         }
     }
 
@@ -165,10 +165,10 @@ public class TestMemoryHandleAsUnsigned {
         VarHandle intHandle = MemoryHandles.asUnsigned(byteHandle, int.class);
 
         try (MemorySegment segment = MemorySegment.allocateNative(layout)) {
-            intHandle.set(segment.baseAddress(), 0L, (int) -1);
-            assertEquals((int) intHandle.get(segment.baseAddress(), 0L), 255);
-            intHandle.set(segment.baseAddress(), 1L, (int) 200);
-            assertEquals((int) intHandle.get(segment.baseAddress(), 1L), 200);
+            intHandle.set(segment.address(), 0L, (int) -1);
+            assertEquals((int) intHandle.get(segment.address(), 0L), 255);
+            intHandle.set(segment.address(), 1L, (int) 200);
+            assertEquals((int) intHandle.get(segment.address(), 1L), 200);
         }
     }
 
@@ -176,7 +176,7 @@ public class TestMemoryHandleAsUnsigned {
     public void testCoordinatesStride() {
         byte[] arr = { 0, 0, (byte) 129, 0 };
         MemorySegment segment = MemorySegment.ofArray(arr);
-        MemoryAddress addr = segment.baseAddress();
+        MemoryAddress addr = segment.address();
 
         {
             VarHandle byteHandle = MemoryHandles.varHandle(byte.class, ByteOrder.nativeOrder());

--- a/test/jdk/java/foreign/TestMismatch.java
+++ b/test/jdk/java/foreign/TestMismatch.java
@@ -47,7 +47,7 @@ public class TestMismatch {
 
     // stores a increasing sequence of values into the memory of the given segment
     static MemorySegment initializeSegment(MemorySegment segment) {
-        MemoryAddress addr = segment.baseAddress();
+        MemoryAddress addr = segment.address();
         for (int i = 0 ; i < segment.byteSize() ; i++) {
             BYTE_HANDLE.set(addr.addOffset(i), (byte)i);
         }
@@ -81,7 +81,7 @@ public class TestMismatch {
 
         for (long i = s2.byteSize() -1 ; i >= 0; i--) {
             long expectedMismatchOffset = i;
-            BYTE_HANDLE.set(s2.baseAddress().addOffset(i), (byte) 0xFF);
+            BYTE_HANDLE.set(s2.address().addOffset(i), (byte) 0xFF);
 
             if (s1.byteSize() == s2.byteSize()) {
                 assertEquals(s1.mismatch(s2), expectedMismatchOffset);
@@ -135,7 +135,7 @@ public class TestMismatch {
 
     private void testLargeMismatchAcrossMaxBoundary(MemorySegment s1, MemorySegment s2) {
         for (long i = s2.byteSize() -1 ; i >= Integer.MAX_VALUE - 10L; i--) {
-            BYTE_HANDLE.set(s2.baseAddress().addOffset(i), (byte) 0xFF);
+            BYTE_HANDLE.set(s2.address().addOffset(i), (byte) 0xFF);
             long expectedMismatchOffset = i;
             assertEquals(s1.mismatch(s2), expectedMismatchOffset);
             assertEquals(s2.mismatch(s1), expectedMismatchOffset);

--- a/test/jdk/java/foreign/TestNative.java
+++ b/test/jdk/java/foreign/TestNative.java
@@ -155,7 +155,7 @@ public class TestNative {
     @Test(dataProvider="nativeAccessOps")
     public void testNativeAccess(Consumer<MemoryAddress> checker, Consumer<MemoryAddress> initializer, SequenceLayout seq) {
         try (MemorySegment segment = MemorySegment.allocateNative(seq)) {
-            MemoryAddress address = segment.baseAddress();
+            MemoryAddress address = segment.address();
             initializer.accept(address);
             checker.accept(address);
         }
@@ -216,7 +216,7 @@ public class TestNative {
     @Test(expectedExceptions = IllegalArgumentException.class)
     public void testBadResize() {
         try (MemorySegment segment = MemorySegment.allocateNative(4)) {
-            MemorySegment.ofNativeRestricted(segment.baseAddress(), 0, null, null, null);
+            MemorySegment.ofNativeRestricted(segment.address(), 0, null, null, null);
         }
     }
 

--- a/test/jdk/java/foreign/TestRebase.java
+++ b/test/jdk/java/foreign/TestRebase.java
@@ -50,7 +50,7 @@ public class TestRebase {
     public void testRebase(SegmentSlice s1, SegmentSlice s2) {
         if (s1.contains(s2)) {
             //check that an address and its rebased counterpart point to same element
-            MemoryAddress base = s2.segment.baseAddress();
+            MemoryAddress base = s2.segment.address();
             MemoryAddress rebased = base.rebase(s1.segment);
             for (int i = 0; i < s2.size(); i++) {
                 int expected = (int) BYTE_VH.get(base.addOffset(i));
@@ -60,14 +60,14 @@ public class TestRebase {
         } else if (s1.kind != s2.kind) {
             // check that rebase s1 to s2 fails
             try {
-                s1.segment.baseAddress().rebase(s2.segment);
+                s1.segment.address().rebase(s2.segment);
                 fail("Rebase unexpectedly passed!");
             } catch (IllegalArgumentException ex) {
                 assertTrue(true);
             }
         } else if (!s2.contains(s1)) {
             //disjoint segments - check that rebased address is out of bounds
-            MemoryAddress base = s2.segment.baseAddress();
+            MemoryAddress base = s2.segment.address();
             MemoryAddress rebased = base.rebase(s1.segment);
             for (int i = 0; i < s2.size(); i++) {
                 BYTE_VH.get(base.addOffset(i));
@@ -129,7 +129,7 @@ public class TestRebase {
             //init root segment
             MemorySegment segment = kind.makeSegment(16);
             for (int i = 0 ; i < 16 ; i++) {
-                BYTE_VH.set(segment.baseAddress().addOffset(i), (byte)i);
+                BYTE_VH.set(segment.address().addOffset(i), (byte)i);
             }
             //compute all slices
             for (int size : sizes) {

--- a/test/jdk/java/foreign/TestSegments.java
+++ b/test/jdk/java/foreign/TestSegments.java
@@ -94,7 +94,7 @@ public class TestSegments {
                 .varHandle(byte.class, MemoryLayout.PathElement.sequenceElement());
         try (MemorySegment segment = MemorySegment.allocateNative(1000)) {
             for (long i = 0 ; i < segment.byteSize() ; i++) {
-                assertEquals(0, (byte)byteHandle.get(segment.baseAddress(), i));
+                assertEquals(0, (byte)byteHandle.get(segment.address(), i));
             }
         }
     }
@@ -127,17 +127,17 @@ public class TestSegments {
         try (MemorySegment segment = MemorySegment.allocateNative(10)) {
             //init
             for (byte i = 0 ; i < segment.byteSize() ; i++) {
-                byteHandle.set(segment.baseAddress(), (long)i, i);
+                byteHandle.set(segment.address(), (long)i, i);
             }
             long start = 0;
-            MemoryAddress base = segment.baseAddress();
+            MemoryAddress base = segment.address();
             MemoryAddress last = base.addOffset(10);
             while (!base.equals(last)) {
                 MemorySegment slice = segment.asSlice(base.segmentOffset(), 10 - start);
                 for (long i = start ; i < 10 ; i++) {
                     assertEquals(
-                            byteHandle.get(segment.baseAddress(), i),
-                            byteHandle.get(slice.baseAddress(), i - start)
+                            byteHandle.get(segment.address(), i),
+                            byteHandle.get(slice.address(), i - start)
                     );
                 }
                 base = base.addOffset(1);
@@ -197,20 +197,20 @@ public class TestSegments {
             try (MemorySegment segment = memorySegmentSupplier.get()) {
                 segment.fill(value);
                 for (long l = 0; l < segment.byteSize(); l++) {
-                    assertEquals((byte) byteHandle.get(segment.baseAddress(), l), value);
+                    assertEquals((byte) byteHandle.get(segment.address(), l), value);
                 }
 
                 // fill a slice
                 var sliceSegment = segment.asSlice(1, segment.byteSize() - 2).fill((byte) ~value);
                 for (long l = 0; l < sliceSegment.byteSize(); l++) {
-                    assertEquals((byte) byteHandle.get(sliceSegment.baseAddress(), l), ~value);
+                    assertEquals((byte) byteHandle.get(sliceSegment.address(), l), ~value);
                 }
                 // assert enclosing slice
-                assertEquals((byte) byteHandle.get(segment.baseAddress(), 0L), value);
+                assertEquals((byte) byteHandle.get(segment.address(), 0L), value);
                 for (long l = 1; l < segment.byteSize() - 2; l++) {
-                    assertEquals((byte) byteHandle.get(segment.baseAddress(), l), (byte) ~value);
+                    assertEquals((byte) byteHandle.get(segment.address(), l), (byte) ~value);
                 }
-                assertEquals((byte) byteHandle.get(segment.baseAddress(), segment.byteSize() - 1L), value);
+                assertEquals((byte) byteHandle.get(segment.address(), segment.byteSize() - 1L), value);
             }
         }
     }
@@ -436,13 +436,13 @@ public class TestSegments {
         READ(MemorySegment.READ) {
             @Override
             void run(MemorySegment segment) {
-                INT_HANDLE.get(segment.baseAddress());
+                INT_HANDLE.get(segment.address());
             }
         },
         WRITE(MemorySegment.WRITE) {
             @Override
             void run(MemorySegment segment) {
-                INT_HANDLE.set(segment.baseAddress(), 42);
+                INT_HANDLE.set(segment.address(), 42);
             }
         },
         HANDOFF(MemorySegment.HANDOFF) {

--- a/test/jdk/java/foreign/TestSharedAccess.java
+++ b/test/jdk/java/foreign/TestSharedAccess.java
@@ -41,7 +41,6 @@ import java.util.List;
 import java.util.Spliterator;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
@@ -59,12 +58,12 @@ public class TestSharedAccess {
         Thread owner = Thread.currentThread();
         MemorySegment s = MemorySegment.allocateNative(4);
         AtomicReference<MemorySegment> confined = new AtomicReference<>(s);
-        setInt(s.baseAddress(), 42);
-        assertEquals(getInt(s.baseAddress()), 42);
+        setInt(s.address(), 42);
+        assertEquals(getInt(s.address()), 42);
         List<Thread> threads = new ArrayList<>();
         for (int i = 0 ; i < 1000 ; i++) {
             threads.add(new Thread(() -> {
-                assertEquals(getInt(confined.get().baseAddress()), 42);
+                assertEquals(getInt(confined.get().address()), 42);
                 confined.set(confined.get().withOwnerThread(owner));
             }));
         }
@@ -85,7 +84,7 @@ public class TestSharedAccess {
         SequenceLayout layout = MemoryLayout.ofSequence(1024, MemoryLayouts.JAVA_INT);
         try (MemorySegment s = MemorySegment.allocateNative(layout)) {
             for (int i = 0 ; i < layout.elementCount().getAsLong() ; i++) {
-                setInt(s.baseAddress().addOffset(i * 4), 42);
+                setInt(s.address().addOffset(i * 4), 42);
             }
             List<Thread> threads = new ArrayList<>();
             List<Spliterator<MemorySegment>> spliterators = new ArrayList<>();
@@ -108,7 +107,7 @@ public class TestSharedAccess {
             for (Spliterator<MemorySegment> spliterator : spliterators) {
                 threads.add(new Thread(() -> {
                     spliterator.tryAdvance(local -> {
-                        assertEquals(getInt(local.baseAddress()), 42);
+                        assertEquals(getInt(local.address()), 42);
                         accessCount.incrementAndGet();
                     });
                 }));
@@ -128,14 +127,14 @@ public class TestSharedAccess {
     @Test
     public void testSharedUnsafe() throws Throwable {
         try (MemorySegment s = MemorySegment.allocateNative(4)) {
-            setInt(s.baseAddress(), 42);
-            assertEquals(getInt(s.baseAddress()), 42);
+            setInt(s.address(), 42);
+            assertEquals(getInt(s.address()), 42);
             List<Thread> threads = new ArrayList<>();
             MemorySegment sharedSegment = MemorySegment.ofNativeRestricted(
-                    s.baseAddress(), s.byteSize(), null, null, null);
+                    s.address(), s.byteSize(), null, null, null);
             for (int i = 0 ; i < 1000 ; i++) {
                 threads.add(new Thread(() -> {
-                    assertEquals(getInt(sharedSegment.baseAddress()), 42);
+                    assertEquals(getInt(sharedSegment.address()), 42);
                 }));
             }
             threads.forEach(Thread::start);
@@ -228,7 +227,7 @@ public class TestSharedAccess {
                     } catch (InterruptedException e) {
                     }
 
-                    MemoryAddress base = s2.baseAddress();
+                    MemoryAddress base = s2.address();
                     setInt(base.addOffset(4), -42);
                     fail();
                 } catch (IllegalStateException ex) {
@@ -237,7 +236,7 @@ public class TestSharedAccess {
             });
 
             a.await();
-            MemoryAddress base = s1.baseAddress();
+            MemoryAddress base = s1.address();
             setInt(base.addOffset(4), 42);
         }
 

--- a/test/jdk/java/foreign/TestSlices.java
+++ b/test/jdk/java/foreign/TestSlices.java
@@ -52,7 +52,7 @@ public class TestSlices {
             //init
             for (long i = 0 ; i < 2 ; i++) {
                 for (long j = 0 ; j < 5 ; j++) {
-                    VH_ALL.set(segment.baseAddress(), i, j, (int)j + 1 + ((int)i * 5));
+                    VH_ALL.set(segment.address(), i, j, (int)j + 1 + ((int)i * 5));
                 }
             }
 
@@ -64,7 +64,7 @@ public class TestSlices {
         int index = 0;
         for (long i = 0 ; i < i_max ; i++) {
             for (long j = 0 ; j < j_max ; j++) {
-                int x = (int) handle.get(segment.baseAddress(), i, j);
+                int x = (int) handle.get(segment.address(), i, j);
                 assertEquals(x, values[index++]);
             }
         }

--- a/test/jdk/java/foreign/TestSpliterator.java
+++ b/test/jdk/java/foreign/TestSpliterator.java
@@ -63,7 +63,7 @@ public class TestSpliterator {
         //setup
         MemorySegment segment = MemorySegment.allocateNative(layout);
         for (int i = 0; i < layout.elementCount().getAsLong(); i++) {
-            INT_HANDLE.set(segment.baseAddress(), (long) i, i);
+            INT_HANDLE.set(segment.address(), (long) i, i);
         }
         long expected = LongStream.range(0, layout.elementCount().getAsLong()).sum();
         //serial
@@ -88,7 +88,7 @@ public class TestSpliterator {
         //setup
         MemorySegment segment = MemorySegment.allocateNative(layout);
         for (int i = 0; i < layout.elementCount().getAsLong(); i++) {
-            INT_HANDLE.set(segment.baseAddress(), (long) i, i);
+            INT_HANDLE.set(segment.address(), (long) i, i);
         }
         long expected = LongStream.range(0, layout.elementCount().getAsLong()).sum();
 
@@ -100,12 +100,12 @@ public class TestSpliterator {
     }
 
     static long sumSingle(long acc, MemorySegment segment) {
-        return acc + (int)INT_HANDLE.get(segment.baseAddress(), 0L);
+        return acc + (int)INT_HANDLE.get(segment.address(), 0L);
     }
 
     static long sum(long start, MemorySegment segment) {
         long sum = start;
-        MemoryAddress base = segment.baseAddress();
+        MemoryAddress base = segment.address();
         int length = (int)segment.byteSize();
         for (int i = 0 ; i < length / CARRIER_SIZE ; i++) {
             sum += (int)INT_HANDLE.get(base, (long)i);

--- a/test/jdk/java/foreign/TestVarHandleCombinators.java
+++ b/test/jdk/java/foreign/TestVarHandleCombinators.java
@@ -49,7 +49,7 @@ public class TestVarHandleCombinators {
 
         byte[] arr = { 0, 0, -1, 0 };
         MemorySegment segment = MemorySegment.ofArray(arr);
-        MemoryAddress addr = segment.baseAddress();
+        MemoryAddress addr = segment.address();
 
         assertEquals((byte) vh.get(addr, 2), (byte) -1);
     }
@@ -59,7 +59,7 @@ public class TestVarHandleCombinators {
         VarHandle vh = MemoryHandles.varHandle(byte.class, 4, ByteOrder.nativeOrder());
         vh = MemoryHandles.withStride(vh, 2);
         MemorySegment segment = MemorySegment.ofArray(new byte[4]);
-        vh.get(segment.baseAddress(), 1L); //should throw
+        vh.get(segment.address(), 1L); //should throw
     }
 
     public void testZeroStrideElement() {
@@ -67,7 +67,7 @@ public class TestVarHandleCombinators {
         VarHandle strided_vh = MemoryHandles.withStride(vh, 0);
         MemorySegment segment = MemorySegment.ofArray(new int[] { 42 });
         for (int i = 0 ; i < 100 ; i++) {
-            assertEquals((int)vh.get(segment.baseAddress()), strided_vh.get(segment.baseAddress(), (long)i));
+            assertEquals((int)vh.get(segment.address()), strided_vh.get(segment.address(), (long)i));
         }
     }
 
@@ -92,7 +92,7 @@ public class TestVarHandleCombinators {
         VarHandle vh = MemoryHandles.varHandle(byte.class, 2, ByteOrder.nativeOrder());
 
         MemorySegment segment = MemorySegment.allocateNative(1, 2);
-        MemoryAddress address = segment.baseAddress();
+        MemoryAddress address = segment.address();
 
         vh.set(address, (byte) 10); // fine, memory region is aligned
         assertEquals((byte) vh.get(address), (byte) 10);
@@ -104,7 +104,7 @@ public class TestVarHandleCombinators {
         vh = MemoryHandles.withOffset(vh, 1); // offset by 1 byte
 
         MemorySegment segment = MemorySegment.allocateNative(2, 2);
-        MemoryAddress address = segment.baseAddress();
+        MemoryAddress address = segment.address();
 
         vh.set(address, (byte) 10); // should be bad align
     }
@@ -114,7 +114,7 @@ public class TestVarHandleCombinators {
         VarHandle offset_vh = MemoryHandles.withOffset(vh, 0);
         MemorySegment segment = MemorySegment.ofArray(new int[] { 42 });
         for (int i = 0 ; i < 100 ; i++) {
-            assertEquals((int)vh.get(segment.baseAddress()), offset_vh.get(segment.baseAddress(), (long)i));
+            assertEquals((int)vh.get(segment.address()), offset_vh.get(segment.address(), (long)i));
         }
     }
 
@@ -129,7 +129,7 @@ public class TestVarHandleCombinators {
         VarHandle vh = MemoryHandles.varHandle(byte.class, 4, ByteOrder.nativeOrder());
         vh = MemoryHandles.withOffset(vh, 2);
         MemorySegment segment = MemorySegment.ofArray(new byte[4]);
-        vh.get(segment.baseAddress()); //should throw
+        vh.get(segment.address()); //should throw
     }
 
     @Test
@@ -138,7 +138,7 @@ public class TestVarHandleCombinators {
         vh = MemoryHandles.withOffset(vh, 1);
 
         MemorySegment segment = MemorySegment.ofArray(new byte[2]);
-        MemoryAddress address = segment.baseAddress();
+        MemoryAddress address = segment.address();
 
         vh.set(address, (byte) 10);
         assertEquals((byte) vh.get(address), (byte) 10);
@@ -149,7 +149,7 @@ public class TestVarHandleCombinators {
         VarHandle vh = MemoryHandles.varHandle(short.class, 2, ByteOrder.LITTLE_ENDIAN);
         byte[] arr = new byte[2];
         MemorySegment segment = MemorySegment.ofArray(arr);
-        MemoryAddress address = segment.baseAddress();
+        MemoryAddress address = segment.address();
 
         vh.set(address, (short) 0xFF);
         assertEquals(arr[0], (byte) 0xFF);
@@ -161,7 +161,7 @@ public class TestVarHandleCombinators {
         VarHandle vh = MemoryHandles.varHandle(short.class, 2, ByteOrder.BIG_ENDIAN);
         byte[] arr = new byte[2];
         MemorySegment segment = MemorySegment.ofArray(arr);
-        MemoryAddress address = segment.baseAddress();
+        MemoryAddress address = segment.address();
 
         vh.set(address, (short) 0xFF);
         assertEquals(arr[0], (byte) 0);
@@ -183,9 +183,9 @@ public class TestVarHandleCombinators {
         try (MemorySegment segment = MemorySegment.allocateNative(inner_size * outer_size * 8)) {
             for (long i = 0; i < outer_size; i++) {
                 for (long j = 0; j < inner_size; j++) {
-                    outer_vh.set(segment.baseAddress(), i, j, count);
+                    outer_vh.set(segment.address(), i, j, count);
                     assertEquals(
-                            (int)inner_vh.get(segment.baseAddress().addOffset(i * inner_size * 8), j),
+                            (int)inner_vh.get(segment.address().addOffset(i * inner_size * 8), j),
                             count);
                     count++;
                 }

--- a/test/micro/org/openjdk/bench/jdk/incubator/foreign/LoopOverConstant.java
+++ b/test/micro/org/openjdk/bench/jdk/incubator/foreign/LoopOverConstant.java
@@ -72,7 +72,7 @@ public class LoopOverConstant {
 
     //setup native memory segment
 
-    static final MemoryAddress segment_addr = MemorySegment.allocateNative(ALLOC_SIZE).baseAddress();
+    static final MemoryAddress segment_addr = MemorySegment.allocateNative(ALLOC_SIZE).address();
     static final VarHandle VH_int = MemoryLayout.ofSequence(JAVA_INT).varHandle(int.class, sequenceElement());
 
     static {

--- a/test/micro/org/openjdk/bench/jdk/incubator/foreign/LoopOverNew.java
+++ b/test/micro/org/openjdk/bench/jdk/incubator/foreign/LoopOverNew.java
@@ -22,7 +22,6 @@
  */
 package org.openjdk.bench.jdk.incubator.foreign;
 
-import jdk.incubator.foreign.MemoryAddress;
 import jdk.incubator.foreign.MemoryLayout;
 import jdk.incubator.foreign.MemorySegment;
 import org.openjdk.jmh.annotations.Benchmark;
@@ -74,7 +73,7 @@ public class LoopOverNew {
     public void segment_loop() {
         MemorySegment segment = MemorySegment.allocateNative(ALLOC_SIZE);
         for (int i = 0; i < ELEM_SIZE; i++) {
-            VH_int.set(segment.baseAddress(), (long) i, i);
+            VH_int.set(segment.address(), (long) i, i);
         }
         segment.close();
     }

--- a/test/micro/org/openjdk/bench/jdk/incubator/foreign/LoopOverNonConstant.java
+++ b/test/micro/org/openjdk/bench/jdk/incubator/foreign/LoopOverNonConstant.java
@@ -74,7 +74,7 @@ public class LoopOverNonConstant {
         }
         segment = MemorySegment.allocateNative(ALLOC_SIZE);
         for (int i = 0; i < ELEM_SIZE; i++) {
-            VH_int.set(segment.baseAddress(), (long) i, i);
+            VH_int.set(segment.address(), (long) i, i);
         }
         byteBuffer = ByteBuffer.allocateDirect(ALLOC_SIZE).order(ByteOrder.nativeOrder());
         for (int i = 0; i < ELEM_SIZE; i++) {
@@ -98,7 +98,7 @@ public class LoopOverNonConstant {
     @Benchmark
     @OutputTimeUnit(TimeUnit.NANOSECONDS)
     public int segment_get() {
-        return (int) VH_int.get(segment.baseAddress(), 0L);
+        return (int) VH_int.get(segment.address(), 0L);
     }
 
     @Benchmark
@@ -120,7 +120,7 @@ public class LoopOverNonConstant {
     public int segment_loop_static() {
         int res = 0;
         for (int i = 0; i < ELEM_SIZE; i ++) {
-            res += MemoryAccess.getIntAtIndex(segment.baseAddress(), i);
+            res += MemoryAccess.getIntAtIndex(segment.address(), i);
         }
         return res;
     }
@@ -128,7 +128,7 @@ public class LoopOverNonConstant {
     @Benchmark
     public int segment_loop() {
         int sum = 0;
-        MemoryAddress base = segment.baseAddress();
+        MemoryAddress base = segment.address();
         for (int i = 0; i < ELEM_SIZE; i++) {
             sum += (int) VH_int.get(base, (long) i);
         }
@@ -138,7 +138,7 @@ public class LoopOverNonConstant {
     @Benchmark
     public int segment_loop_slice() {
         int sum = 0;
-        MemoryAddress base = segment.asSlice(0, segment.byteSize()).baseAddress();
+        MemoryAddress base = segment.asSlice(0, segment.byteSize()).address();
         for (int i = 0; i < ELEM_SIZE; i++) {
             sum += (int) VH_int.get(base, (long) i);
         }
@@ -148,7 +148,7 @@ public class LoopOverNonConstant {
     @Benchmark
     public int segment_loop_readonly() {
         int sum = 0;
-        MemoryAddress base = segment.withAccessModes(MemorySegment.READ).baseAddress();
+        MemoryAddress base = segment.withAccessModes(MemorySegment.READ).address();
         for (int i = 0; i < ELEM_SIZE; i++) {
             sum += (int) VH_int.get(base, (long) i);
         }

--- a/test/micro/org/openjdk/bench/jdk/incubator/foreign/LoopOverNonConstantHeap.java
+++ b/test/micro/org/openjdk/bench/jdk/incubator/foreign/LoopOverNonConstantHeap.java
@@ -91,7 +91,7 @@ public class LoopOverNonConstantHeap {
     @Benchmark
     @OutputTimeUnit(TimeUnit.NANOSECONDS)
     public int segment_get() {
-        return (int) VH_int.get(segment.baseAddress(), 0L);
+        return (int) VH_int.get(segment.address(), 0L);
     }
 
     @Benchmark
@@ -112,7 +112,7 @@ public class LoopOverNonConstantHeap {
     @Benchmark
     public int segment_loop() {
         int sum = 0;
-        MemoryAddress base = segment.baseAddress();
+        MemoryAddress base = segment.address();
         for (int i = 0; i < ELEM_SIZE; i++) {
             sum += (int) VH_int.get(base, (long) i);
         }
@@ -123,7 +123,7 @@ public class LoopOverNonConstantHeap {
     public int segment_loop_static() {
         int res = 0;
         for (int i = 0; i < ELEM_SIZE; i ++) {
-            res += MemoryAccess.getIntAtIndex(segment.baseAddress(), i);
+            res += MemoryAccess.getIntAtIndex(segment.address(), i);
         }
         return res;
     }
@@ -131,7 +131,7 @@ public class LoopOverNonConstantHeap {
     @Benchmark
     public int segment_loop_slice() {
         int sum = 0;
-        MemoryAddress base = segment.asSlice(0, segment.byteSize()).baseAddress();
+        MemoryAddress base = segment.asSlice(0, segment.byteSize()).address();
         for (int i = 0; i < ELEM_SIZE; i++) {
             sum += (int) VH_int.get(base, (long) i);
         }
@@ -141,7 +141,7 @@ public class LoopOverNonConstantHeap {
     @Benchmark
     public int segment_loop_readonly() {
         int sum = 0;
-        MemoryAddress base = segment.withAccessModes(MemorySegment.READ).baseAddress();
+        MemoryAddress base = segment.withAccessModes(MemorySegment.READ).address();
         for (int i = 0; i < ELEM_SIZE; i++) {
             sum += (int) VH_int.get(base, (long) i);
         }

--- a/test/micro/org/openjdk/bench/jdk/incubator/foreign/LoopOverNonConstantMapped.java
+++ b/test/micro/org/openjdk/bench/jdk/incubator/foreign/LoopOverNonConstantMapped.java
@@ -97,7 +97,7 @@ public class LoopOverNonConstantMapped {
             ((MappedByteBuffer)byteBuffer).force();
         }
         segment = MemorySegment.mapFromPath(tempPath, 0L, ALLOC_SIZE, FileChannel.MapMode.READ_WRITE);
-        unsafe_addr = segment.baseAddress().toRawLongValue();
+        unsafe_addr = segment.address().toRawLongValue();
     }
 
     @TearDown
@@ -115,7 +115,7 @@ public class LoopOverNonConstantMapped {
     @Benchmark
     @OutputTimeUnit(TimeUnit.NANOSECONDS)
     public int segment_get() {
-        return (int) VH_int.get(segment.baseAddress(), 0L);
+        return (int) VH_int.get(segment.address(), 0L);
     }
 
     @Benchmark
@@ -136,7 +136,7 @@ public class LoopOverNonConstantMapped {
     @Benchmark
     public int segment_loop() {
         int sum = 0;
-        MemoryAddress base = segment.baseAddress();
+        MemoryAddress base = segment.address();
         for (int i = 0; i < ELEM_SIZE; i++) {
             sum += (int) VH_int.get(base, (long) i);
         }
@@ -147,7 +147,7 @@ public class LoopOverNonConstantMapped {
     public int segment_loop_static() {
         int res = 0;
         for (int i = 0; i < ELEM_SIZE; i ++) {
-            res += MemoryAccess.getIntAtIndex(segment.baseAddress(), i);
+            res += MemoryAccess.getIntAtIndex(segment.address(), i);
         }
         return res;
     }
@@ -155,7 +155,7 @@ public class LoopOverNonConstantMapped {
     @Benchmark
     public int segment_loop_slice() {
         int sum = 0;
-        MemoryAddress base = segment.asSlice(0, segment.byteSize()).baseAddress();
+        MemoryAddress base = segment.asSlice(0, segment.byteSize()).address();
         for (int i = 0; i < ELEM_SIZE; i++) {
             sum += (int) VH_int.get(base, (long) i);
         }
@@ -165,7 +165,7 @@ public class LoopOverNonConstantMapped {
     @Benchmark
     public int segment_loop_readonly() {
         int sum = 0;
-        MemoryAddress base = segment.withAccessModes(MemorySegment.READ).baseAddress();
+        MemoryAddress base = segment.withAccessModes(MemorySegment.READ).address();
         for (int i = 0; i < ELEM_SIZE; i++) {
             sum += (int) VH_int.get(base, (long) i);
         }

--- a/test/micro/org/openjdk/bench/jdk/incubator/foreign/ParallelSum.java
+++ b/test/micro/org/openjdk/bench/jdk/incubator/foreign/ParallelSum.java
@@ -44,12 +44,10 @@ import java.lang.invoke.VarHandle;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Optional;
-import java.util.OptionalInt;
 import java.util.Spliterator;
 import java.util.concurrent.CountedCompleter;
 import java.util.concurrent.RecursiveTask;
 import java.util.concurrent.TimeUnit;
-import java.util.function.IntFunction;
 import java.util.function.Predicate;
 import java.util.function.ToIntFunction;
 import java.util.stream.StreamSupport;
@@ -87,7 +85,7 @@ public class ParallelSum {
         }
         segment = MemorySegment.allocateNative(ALLOC_SIZE);
         for (int i = 0; i < ELEM_SIZE; i++) {
-            VH_int.set(segment.baseAddress(), (long) i, i);
+            VH_int.set(segment.address(), (long) i, i);
         }
     }
 
@@ -100,7 +98,7 @@ public class ParallelSum {
     @Benchmark
     public int segment_serial() {
         int res = 0;
-        MemoryAddress base = segment.baseAddress();
+        MemoryAddress base = segment.address();
         for (int i = 0; i < ELEM_SIZE; i++) {
             res += (int)VH_int.get(base, (long) i);
         }
@@ -139,11 +137,11 @@ public class ParallelSum {
     }
 
     final static ToIntFunction<MemorySegment> SEGMENT_TO_INT = slice ->
-            (int) VH_int.get(slice.baseAddress(), 0L);
+            (int) VH_int.get(slice.address(), 0L);
 
     final static ToIntFunction<MemorySegment> SEGMENT_TO_INT_BULK = slice -> {
         int res = 0;
-        MemoryAddress base = slice.baseAddress();
+        MemoryAddress base = slice.address();
         for (int i = 0; i < BULK_FACTOR ; i++) {
             res += (int)VH_int.get(base, (long) i);
         }
@@ -179,10 +177,10 @@ public class ParallelSum {
     }
 
     final static Predicate<MemorySegment> FIND_SINGLE = slice ->
-            (int)VH_int.get(slice.baseAddress(), 0L) == (ELEM_SIZE - 1);
+            (int)VH_int.get(slice.address(), 0L) == (ELEM_SIZE - 1);
 
     final static Predicate<MemorySegment> FIND_BULK = slice -> {
-        MemoryAddress base = slice.baseAddress();
+        MemoryAddress base = slice.address();
         for (int i = 0; i < BULK_FACTOR ; i++) {
             if ((int)VH_int.get(base, (long)i) == (ELEM_SIZE - 1)) {
                 return true;

--- a/test/micro/org/openjdk/bench/jdk/incubator/foreign/TestAdaptVarHandles.java
+++ b/test/micro/org/openjdk/bench/jdk/incubator/foreign/TestAdaptVarHandles.java
@@ -144,7 +144,7 @@ public class TestAdaptVarHandles {
     @Benchmark
     public int segment_loop() throws Throwable {
         int sum = 0;
-        MemoryAddress baseAddress = segment.baseAddress();
+        MemoryAddress baseAddress = segment.address();
         for (int i = 0; i < ELEM_SIZE; i++) {
             sum += (int)VH_addr_int.get(baseAddress, (long)i);
         }
@@ -154,7 +154,7 @@ public class TestAdaptVarHandles {
     @Benchmark
     public int segment_box_loop() throws Throwable {
         int sum = 0;
-        MemoryAddress baseAddress = segment.baseAddress();
+        MemoryAddress baseAddress = segment.address();
         for (int i = 0; i < ELEM_SIZE; i++) {
             sum += ((IntBox)VH_addr_box_int.get(baseAddress, (long)i)).intValue();
         }

--- a/test/micro/org/openjdk/bench/jdk/incubator/foreign/points/support/PanamaPoint.java
+++ b/test/micro/org/openjdk/bench/jdk/incubator/foreign/points/support/PanamaPoint.java
@@ -58,19 +58,19 @@ public class PanamaPoint implements AutoCloseable {
     }
 
     public void setX(int x) {
-        VH_x.set(segment.baseAddress(), x);
+        VH_x.set(segment.address(), x);
     }
 
     public int getX() {
-        return (int) VH_x.get(segment.baseAddress());
+        return (int) VH_x.get(segment.address());
     }
 
     public void setY(int y) {
-        VH_y.set(segment.baseAddress(), y);
+        VH_y.set(segment.address(), y);
     }
 
     public int getY() {
-        return (int) VH_y.get(segment.baseAddress());
+        return (int) VH_y.get(segment.address());
     }
 
     @Override


### PR DESCRIPTION
This patch adds a new entity in the Foreign Memory Access API, namely `Addressable`. This is a simple functional interface which is implemented by all the entities which can be mapped onto a `MemoryAddress`. For now, only `MemoryAddress` and `MemorySegment` implements it (but on the foreign-abi branch we will repeat the exercise and add more implementations).
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [JDK-8249790](https://bugs.openjdk.java.net/browse/JDK-8249790): Add Addressable abstraction


### Reviewers
 * Athijegannathan Sundararajan ([sundar](@sundararajana) - Committer) ⚠️ Review applies to efceeed70af50502d1b0f0a9090ceebcc707468f
 * Jorn Vernee ([jvernee](@JornVernee) - Committer) ⚠️ Review applies to efceeed70af50502d1b0f0a9090ceebcc707468f


### Download
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/252/head:pull/252`
`$ git checkout pull/252`
