### PR TITLE
8249790: Add Addressable abstraction

### DIFF
--- a/src/jdk.incubator.jextract/share/classes/jdk/incubator/jextract/ConstantHelper.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/incubator/jextract/ConstantHelper.java
@@ -96,7 +96,7 @@ public class ConstantHelper {
     private static final DirectMethodHandleDesc MH_MemorySegment_baseAddress = MethodHandleDesc.ofMethod(
             Kind.INTERFACE_VIRTUAL,
             desc(MemorySegment.class),
-            "baseAddress",
+            "address",
             desc(methodType(MemoryAddress.class))
     );
 

--- a/src/jdk.incubator.jextract/share/classes/jdk/incubator/jextract/HeaderBuilder.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/incubator/jextract/HeaderBuilder.java
@@ -167,7 +167,7 @@ public class HeaderBuilder extends JavaSourceBuilder {
         sb.append(PUB_MODS + "MemoryAddress allocate(" + className + " fi, NativeScope scope) {\n");
         incrAlign();
         indent();
-        sb.append("return scope.register(allocate(fi)).baseAddress();\n");
+        sb.append("return scope.register(allocate(fi)).address();\n");
         decrAlign();
         indent();
         sb.append("}\n");

--- a/src/jdk.incubator.jextract/share/classes/jdk/incubator/jextract/StructBuilder.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/incubator/jextract/StructBuilder.java
@@ -120,7 +120,7 @@ public class StructBuilder extends JavaSourceBuilder {
         sb.append(parentLayout.byteOffset(MemoryLayout.PathElement.groupElement(nativeName)));
         sb.append(", ");
         sb.append(layout.byteSize());
-        sb.append(").baseAddress();\n");
+        sb.append(").address();\n");
         decrAlign();
         indent();
         sb.append("}\n");

--- a/src/jdk.incubator.jextract/share/classes/jdk/incubator/jextract/resources/RuntimeHelper.java.template
+++ b/src/jdk.incubator.jextract/share/classes/jdk/incubator/jextract/resources/RuntimeHelper.java.template
@@ -60,7 +60,7 @@ public class RuntimeHelper {
         return lookup(LIBRARIES, name).map(a ->
             MemorySegment.ofNativeRestricted(
                  a, layout.byteSize(), null, null, a
-            ).withAccessModes(MemorySegment.READ | MemorySegment.WRITE).baseAddress()).orElse(null);
+            ).withAccessModes(MemorySegment.READ | MemorySegment.WRITE).address()).orElse(null);
     }
 
     public static final MethodHandle downcallHandle(LibraryLookup[] LIBRARIES, String name, String desc, FunctionDescriptor fdesc, boolean variadic) {
@@ -90,7 +90,7 @@ public class RuntimeHelper {
 
     public static MemoryAddress asArrayRestricted(MemoryAddress addr, MemoryLayout layout, int numElements) {
         return MemorySegment.ofNativeRestricted(addr, numElements * layout.byteSize(),
-               Thread.currentThread(), null, null).baseAddress();
+               Thread.currentThread(), null, null).address();
     }
 
     public static MemoryAddress asArray(MemoryAddress addr, MemoryLayout layout, int numElements) {
@@ -98,7 +98,7 @@ public class RuntimeHelper {
         if (seg == null) {
             throw new IllegalArgumentException("no underlying segment for the address");
         }
-        return seg.asSlice(addr.segmentOffset(), numElements * layout.byteSize()).baseAddress();
+        return seg.asSlice(addr.segmentOffset(), numElements * layout.byteSize()).address();
     }
 
     private static class VarargsInvoker {

--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/clang/Index.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/clang/Index.java
@@ -85,14 +85,14 @@ public class Index implements AutoCloseable {
              MemorySegment outAddress = MemorySegment.allocateNative(CSupport.C_POINTER)) {
             ErrorCode code = ErrorCode.valueOf(Index_h.clang_parseTranslationUnit2(
                     ptr,
-                    src.baseAddress(),
-                    cargs == null ? MemoryAddress.NULL : cargs.baseAddress(),
+                    src.address(),
+                    cargs == null ? MemoryAddress.NULL : cargs.address(),
                     args.length, MemoryAddress.NULL,
                     0,
                     options,
-                    outAddress.baseAddress()));
+                    outAddress.address()));
 
-            MemoryAddress tu = (MemoryAddress) VH_MemoryAddress.get(outAddress.baseAddress());
+            MemoryAddress tu = (MemoryAddress) VH_MemoryAddress.get(outAddress.address());
             TranslationUnit rv = new TranslationUnit(tu);
             // even if we failed to parse, we might still have diagnostics
             rv.processDiagnostics(dh);

--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/clang/LibClang.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/clang/LibClang.java
@@ -55,7 +55,7 @@ public class LibClang {
                 MethodHandle PUT_ENV = abi.downcallHandle(LibraryLookup.ofDefault().lookup(putenv),
                                 MethodType.methodType(int.class, MemoryAddress.class),
                                 FunctionDescriptor.of(CSupport.C_INT, CSupport.C_POINTER));
-                int res = (int) PUT_ENV.invokeExact(disableCrashRecovery.baseAddress());
+                int res = (int) PUT_ENV.invokeExact(disableCrashRecovery.address());
             } catch (Throwable ex) {
                 throw new ExceptionInInitializerError(ex);
             }

--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/clang/SourceLocation.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/clang/SourceLocation.java
@@ -55,16 +55,16 @@ public class SourceLocation {
              MemorySegment col = MemorySegment.allocateNative(CSupport.C_INT);
              MemorySegment offset = MemorySegment.allocateNative(CSupport.C_INT)) {
 
-            fn.get(loc, file.baseAddress(), line.baseAddress(), col.baseAddress(), offset.baseAddress());
-            MemoryAddress fname = Utils.getPointer(file.baseAddress());
+            fn.get(loc, file.address(), line.address(), col.address(), offset.address());
+            MemoryAddress fname = Utils.getPointer(file.address());
 
 
             String str = fname == MemoryAddress.NULL ?
                     null :
                     LibClang.CXStrToString(Index_h.clang_getFileName(fname));
 
-            return new Location(str, Utils.getInt(line.baseAddress()),
-                Utils.getInt(col.baseAddress()), Utils.getInt(offset.baseAddress()));
+            return new Location(str, Utils.getInt(line.address()),
+                Utils.getInt(col.address()), Utils.getInt(offset.address()));
         }
     }
 

--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/clang/TranslationUnit.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/clang/TranslationUnit.java
@@ -62,7 +62,7 @@ public class TranslationUnit implements AutoCloseable {
 
     public final void save(Path path) throws TranslationUnitSaveException {
         try (MemorySegment pathStr = Utils.toNativeString(path.toAbsolutePath().toString())) {
-            SaveError res = SaveError.valueOf(Index_h.clang_saveTranslationUnit(tu, pathStr.baseAddress(), 0));
+            SaveError res = SaveError.valueOf(Index_h.clang_saveTranslationUnit(tu, pathStr.address(), 0));
             if (res != SaveError.None) {
                 throw new TranslationUnitSaveException(path, res);
             }
@@ -86,15 +86,15 @@ public class TranslationUnit implements AutoCloseable {
                     null :
                     scope.track(MemorySegment.allocateNative(MemoryLayout.ofSequence(inMemoryFiles.length, Index_h.CXUnsavedFile$LAYOUT)));
             for (int i = 0; i < inMemoryFiles.length; i++) {
-                MemoryAddress start = files.baseAddress().addOffset(i * Index_h.CXUnsavedFile$LAYOUT.byteSize());
-                Utils.setPointer(start.addOffset(FILENAME_OFFSET), scope.track(Utils.toNativeString(inMemoryFiles[i].file)).baseAddress());
-                Utils.setPointer(start.addOffset(CONTENTS_OFFSET), scope.track(Utils.toNativeString(inMemoryFiles[i].contents)).baseAddress());
+                MemoryAddress start = files.address().addOffset(i * Index_h.CXUnsavedFile$LAYOUT.byteSize());
+                Utils.setPointer(start.addOffset(FILENAME_OFFSET), scope.track(Utils.toNativeString(inMemoryFiles[i].file)).address());
+                Utils.setPointer(start.addOffset(CONTENTS_OFFSET), scope.track(Utils.toNativeString(inMemoryFiles[i].contents)).address());
                 Utils.setLong(start.addOffset(LENGTH_OFFSET), inMemoryFiles[i].contents.length());
             }
             ErrorCode code = ErrorCode.valueOf(Index_h.clang_reparseTranslationUnit(
                         tu,
                         inMemoryFiles.length,
-                        files == null ? MemoryAddress.NULL : files.baseAddress(),
+                        files == null ? MemoryAddress.NULL : files.address(),
                         Index_h.clang_defaultReparseOptions(tu)));
 
             if (code != ErrorCode.Success) {
@@ -120,8 +120,8 @@ public class TranslationUnit implements AutoCloseable {
     public Tokens tokenize(SourceRange range) {
         MemorySegment p = MemorySegment.allocateNative(CSupport.C_POINTER);
         MemorySegment pCnt = MemorySegment.allocateNative(CSupport.C_INT);
-        Index_h.clang_tokenize(tu, range.range, p.baseAddress(), pCnt.baseAddress());
-        Tokens rv = new Tokens(Utils.getPointer(p.baseAddress()), Utils.getInt(pCnt.baseAddress()));
+        Index_h.clang_tokenize(tu, range.range, p.address(), pCnt.address());
+        Tokens rv = new Tokens(Utils.getPointer(p.address()), Utils.getInt(pCnt.address()));
         return rv;
     }
 

--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/clang/Type.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/clang/Type.java
@@ -109,7 +109,7 @@ public final class Type {
     // Struct/RecordType
     private long getOffsetOf0(String fieldName) {
         try (MemorySegment cfname = Utils.toNativeString(fieldName)) {
-            return Index_h.clang_Type_getOffsetOf(type, cfname.baseAddress());
+            return Index_h.clang_Type_getOffsetOf(type, cfname.address());
         }
     }
 

--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/clang/Utils.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/clang/Utils.java
@@ -76,7 +76,7 @@ public class Utils {
     static MemorySegment toNativeString(String value, int length) {
         MemoryLayout strLayout = MemoryLayout.ofSequence(length, CSupport.C_CHAR);
         MemorySegment segment = MemorySegment.allocateNative(strLayout);
-        MemoryAddress addr = segment.baseAddress();
+        MemoryAddress addr = segment.address();
         for (int i = 0 ; i < value.length() ; i++) {
             BYTE_ARR_VH.set(addr, i, (byte)value.charAt(i));
         }
@@ -95,7 +95,7 @@ public class Utils {
 
         MemorySegment segment = MemorySegment.allocateNative(MemoryLayout.ofSequence(ar.length, CSupport.C_POINTER));
         for (int i = 0; i < ar.length; i++) {
-            POINTER_ARR_VH.set(segment.baseAddress(), i, toNativeString(ar[i]).baseAddress());
+            POINTER_ARR_VH.set(segment.address(), i, toNativeString(ar[i]).address());
         }
 
         return segment;

--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/clang/libclang/Index_h.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/clang/libclang/Index_h.java
@@ -65,10 +65,10 @@ public final class Index_h {
     );
     public static final VarHandle CXString$private_flags = CXString$LAYOUT.varHandle(int.class, PathElement.groupElement("private_flags"));
     public static final int CXString$private_flags$get(MemorySegment seg) {
-        return (int)CXString$private_flags.get(seg.baseAddress());
+        return (int)CXString$private_flags.get(seg.address());
     }
     public static final void CXString$private_flags$set(MemorySegment seg, int x) {
-        CXString$private_flags.set(seg.baseAddress(), x);
+        CXString$private_flags.set(seg.address(), x);
     }
     public static final MemoryLayout CXStringSet$LAYOUT = MemoryLayout.ofStruct(
         CSupport.C_POINTER.withName("Strings"),
@@ -77,10 +77,10 @@ public final class Index_h {
     );
     public static final VarHandle CXStringSet$Count = CXStringSet$LAYOUT.varHandle(int.class, PathElement.groupElement("Count"));
     public static final int CXStringSet$Count$get(MemorySegment seg) {
-        return (int)CXStringSet$Count.get(seg.baseAddress());
+        return (int)CXStringSet$Count.get(seg.address());
     }
     public static final void CXStringSet$Count$set(MemorySegment seg, int x) {
-        CXStringSet$Count.set(seg.baseAddress(), x);
+        CXStringSet$Count.set(seg.address(), x);
     }
     public static final MethodHandle clang_getCString = RuntimeHelper.downcallHandle(
         LIBRARIES, "clang_getCString",
@@ -316,10 +316,10 @@ public final class Index_h {
     ).withName("CXUnsavedFile");
     public static final VarHandle CXUnsavedFile$Length = CXUnsavedFile$LAYOUT.varHandle(long.class, PathElement.groupElement("Length"));
     public static final long CXUnsavedFile$Length$get(MemorySegment seg) {
-        return (long)CXUnsavedFile$Length.get(seg.baseAddress());
+        return (long)CXUnsavedFile$Length.get(seg.address());
     }
     public static final void CXUnsavedFile$Length$set(MemorySegment seg, long x) {
-        CXUnsavedFile$Length.set(seg.baseAddress(), x);
+        CXUnsavedFile$Length.set(seg.address(), x);
     }
     public static final int CXAvailability_Available = (int)0L;
     public static final int CXAvailability_Deprecated = (int)1L;
@@ -332,24 +332,24 @@ public final class Index_h {
     ).withName("CXVersion");
     public static final VarHandle CXVersion$Major = CXVersion$LAYOUT.varHandle(int.class, PathElement.groupElement("Major"));
     public static final int CXVersion$Major$get(MemorySegment seg) {
-        return (int)CXVersion$Major.get(seg.baseAddress());
+        return (int)CXVersion$Major.get(seg.address());
     }
     public static final void CXVersion$Major$set(MemorySegment seg, int x) {
-        CXVersion$Major.set(seg.baseAddress(), x);
+        CXVersion$Major.set(seg.address(), x);
     }
     public static final VarHandle CXVersion$Minor = CXVersion$LAYOUT.varHandle(int.class, PathElement.groupElement("Minor"));
     public static final int CXVersion$Minor$get(MemorySegment seg) {
-        return (int)CXVersion$Minor.get(seg.baseAddress());
+        return (int)CXVersion$Minor.get(seg.address());
     }
     public static final void CXVersion$Minor$set(MemorySegment seg, int x) {
-        CXVersion$Minor.set(seg.baseAddress(), x);
+        CXVersion$Minor.set(seg.address(), x);
     }
     public static final VarHandle CXVersion$Subminor = CXVersion$LAYOUT.varHandle(int.class, PathElement.groupElement("Subminor"));
     public static final int CXVersion$Subminor$get(MemorySegment seg) {
-        return (int)CXVersion$Subminor.get(seg.baseAddress());
+        return (int)CXVersion$Subminor.get(seg.address());
     }
     public static final void CXVersion$Subminor$set(MemorySegment seg, int x) {
-        CXVersion$Subminor.set(seg.baseAddress(), x);
+        CXVersion$Subminor.set(seg.address(), x);
     }
     public static final int CXCursor_ExceptionSpecificationKind_None = (int)0L;
     public static final int CXCursor_ExceptionSpecificationKind_DynamicNone = (int)1L;
@@ -574,10 +574,10 @@ public final class Index_h {
     );
     public static final VarHandle CXSourceLocation$int_data = CXSourceLocation$LAYOUT.varHandle(int.class, PathElement.groupElement("int_data"));
     public static final int CXSourceLocation$int_data$get(MemorySegment seg) {
-        return (int)CXSourceLocation$int_data.get(seg.baseAddress());
+        return (int)CXSourceLocation$int_data.get(seg.address());
     }
     public static final void CXSourceLocation$int_data$set(MemorySegment seg, int x) {
-        CXSourceLocation$int_data.set(seg.baseAddress(), x);
+        CXSourceLocation$int_data.set(seg.address(), x);
     }
     public static final MemoryLayout CXSourceRange$LAYOUT = MemoryLayout.ofStruct(
         MemoryLayout.ofSequence(2, CSupport.C_POINTER).withName("ptr_data"),
@@ -586,17 +586,17 @@ public final class Index_h {
     );
     public static final VarHandle CXSourceRange$begin_int_data = CXSourceRange$LAYOUT.varHandle(int.class, PathElement.groupElement("begin_int_data"));
     public static final int CXSourceRange$begin_int_data$get(MemorySegment seg) {
-        return (int)CXSourceRange$begin_int_data.get(seg.baseAddress());
+        return (int)CXSourceRange$begin_int_data.get(seg.address());
     }
     public static final void CXSourceRange$begin_int_data$set(MemorySegment seg, int x) {
-        CXSourceRange$begin_int_data.set(seg.baseAddress(), x);
+        CXSourceRange$begin_int_data.set(seg.address(), x);
     }
     public static final VarHandle CXSourceRange$end_int_data = CXSourceRange$LAYOUT.varHandle(int.class, PathElement.groupElement("end_int_data"));
     public static final int CXSourceRange$end_int_data$get(MemorySegment seg) {
-        return (int)CXSourceRange$end_int_data.get(seg.baseAddress());
+        return (int)CXSourceRange$end_int_data.get(seg.address());
     }
     public static final void CXSourceRange$end_int_data$set(MemorySegment seg, int x) {
-        CXSourceRange$end_int_data.set(seg.baseAddress(), x);
+        CXSourceRange$end_int_data.set(seg.address(), x);
     }
     public static final MethodHandle clang_getNullLocation = RuntimeHelper.downcallHandle(
         LIBRARIES, "clang_getNullLocation",
@@ -958,10 +958,10 @@ public final class Index_h {
     );
     public static final VarHandle CXSourceRangeList$count = CXSourceRangeList$LAYOUT.varHandle(int.class, PathElement.groupElement("count"));
     public static final int CXSourceRangeList$count$get(MemorySegment seg) {
-        return (int)CXSourceRangeList$count.get(seg.baseAddress());
+        return (int)CXSourceRangeList$count.get(seg.address());
     }
     public static final void CXSourceRangeList$count$set(MemorySegment seg, int x) {
-        CXSourceRangeList$count.set(seg.baseAddress(), x);
+        CXSourceRangeList$count.set(seg.address(), x);
     }
     public static final MethodHandle clang_getSkippedRanges = RuntimeHelper.downcallHandle(
         LIBRARIES, "clang_getSkippedRanges",
@@ -1660,17 +1660,17 @@ public final class Index_h {
     ).withName("CXTUResourceUsageEntry");
     public static final VarHandle CXTUResourceUsageEntry$kind = CXTUResourceUsageEntry$LAYOUT.varHandle(int.class, PathElement.groupElement("kind"));
     public static final int CXTUResourceUsageEntry$kind$get(MemorySegment seg) {
-        return (int)CXTUResourceUsageEntry$kind.get(seg.baseAddress());
+        return (int)CXTUResourceUsageEntry$kind.get(seg.address());
     }
     public static final void CXTUResourceUsageEntry$kind$set(MemorySegment seg, int x) {
-        CXTUResourceUsageEntry$kind.set(seg.baseAddress(), x);
+        CXTUResourceUsageEntry$kind.set(seg.address(), x);
     }
     public static final VarHandle CXTUResourceUsageEntry$amount = CXTUResourceUsageEntry$LAYOUT.varHandle(long.class, PathElement.groupElement("amount"));
     public static final long CXTUResourceUsageEntry$amount$get(MemorySegment seg) {
-        return (long)CXTUResourceUsageEntry$amount.get(seg.baseAddress());
+        return (long)CXTUResourceUsageEntry$amount.get(seg.address());
     }
     public static final void CXTUResourceUsageEntry$amount$set(MemorySegment seg, long x) {
-        CXTUResourceUsageEntry$amount.set(seg.baseAddress(), x);
+        CXTUResourceUsageEntry$amount.set(seg.address(), x);
     }
     public static final MemoryLayout CXTUResourceUsage$LAYOUT = MemoryLayout.ofStruct(
         CSupport.C_POINTER.withName("data"),
@@ -1680,10 +1680,10 @@ public final class Index_h {
     ).withName("CXTUResourceUsage");
     public static final VarHandle CXTUResourceUsage$numEntries = CXTUResourceUsage$LAYOUT.varHandle(int.class, PathElement.groupElement("numEntries"));
     public static final int CXTUResourceUsage$numEntries$get(MemorySegment seg) {
-        return (int)CXTUResourceUsage$numEntries.get(seg.baseAddress());
+        return (int)CXTUResourceUsage$numEntries.get(seg.address());
     }
     public static final void CXTUResourceUsage$numEntries$set(MemorySegment seg, int x) {
-        CXTUResourceUsage$numEntries.set(seg.baseAddress(), x);
+        CXTUResourceUsage$numEntries.set(seg.address(), x);
     }
     public static final MethodHandle clang_getCXTUResourceUsage = RuntimeHelper.downcallHandle(
         LIBRARIES, "clang_getCXTUResourceUsage",
@@ -2045,17 +2045,17 @@ public final class Index_h {
     );
     public static final VarHandle CXCursor$kind = CXCursor$LAYOUT.varHandle(int.class, PathElement.groupElement("kind"));
     public static final int CXCursor$kind$get(MemorySegment seg) {
-        return (int)CXCursor$kind.get(seg.baseAddress());
+        return (int)CXCursor$kind.get(seg.address());
     }
     public static final void CXCursor$kind$set(MemorySegment seg, int x) {
-        CXCursor$kind.set(seg.baseAddress(), x);
+        CXCursor$kind.set(seg.address(), x);
     }
     public static final VarHandle CXCursor$xdata = CXCursor$LAYOUT.varHandle(int.class, PathElement.groupElement("xdata"));
     public static final int CXCursor$xdata$get(MemorySegment seg) {
-        return (int)CXCursor$xdata.get(seg.baseAddress());
+        return (int)CXCursor$xdata.get(seg.address());
     }
     public static final void CXCursor$xdata$set(MemorySegment seg, int x) {
-        CXCursor$xdata.set(seg.baseAddress(), x);
+        CXCursor$xdata.set(seg.address(), x);
     }
     public static final MethodHandle clang_getNullCursor = RuntimeHelper.downcallHandle(
         LIBRARIES, "clang_getNullCursor",
@@ -2423,10 +2423,10 @@ public final class Index_h {
     ).withName("CXPlatformAvailability");
     public static final VarHandle CXPlatformAvailability$Unavailable = CXPlatformAvailability$LAYOUT.varHandle(int.class, PathElement.groupElement("Unavailable"));
     public static final int CXPlatformAvailability$Unavailable$get(MemorySegment seg) {
-        return (int)CXPlatformAvailability$Unavailable.get(seg.baseAddress());
+        return (int)CXPlatformAvailability$Unavailable.get(seg.address());
     }
     public static final void CXPlatformAvailability$Unavailable$set(MemorySegment seg, int x) {
-        CXPlatformAvailability$Unavailable.set(seg.baseAddress(), x);
+        CXPlatformAvailability$Unavailable.set(seg.address(), x);
     }
     public static final MethodHandle clang_getCursorPlatformAvailability = RuntimeHelper.downcallHandle(
         LIBRARIES, "clang_getCursorPlatformAvailability",
@@ -2899,10 +2899,10 @@ public final class Index_h {
     );
     public static final VarHandle CXType$kind = CXType$LAYOUT.varHandle(int.class, PathElement.groupElement("kind"));
     public static final int CXType$kind$get(MemorySegment seg) {
-        return (int)CXType$kind.get(seg.baseAddress());
+        return (int)CXType$kind.get(seg.address());
     }
     public static final void CXType$kind$set(MemorySegment seg, int x) {
-        CXType$kind.set(seg.baseAddress(), x);
+        CXType$kind.set(seg.address(), x);
     }
     public static final MethodHandle clang_getCursorType = RuntimeHelper.downcallHandle(
         LIBRARIES, "clang_getCursorType",
@@ -5772,10 +5772,10 @@ public final class Index_h {
     );
     public static final VarHandle CXCompletionResult$CursorKind = CXCompletionResult$LAYOUT.varHandle(int.class, PathElement.groupElement("CursorKind"));
     public static final int CXCompletionResult$CursorKind$get(MemorySegment seg) {
-        return (int)CXCompletionResult$CursorKind.get(seg.baseAddress());
+        return (int)CXCompletionResult$CursorKind.get(seg.address());
     }
     public static final void CXCompletionResult$CursorKind$set(MemorySegment seg, int x) {
-        CXCompletionResult$CursorKind.set(seg.baseAddress(), x);
+        CXCompletionResult$CursorKind.set(seg.address(), x);
     }
     public static final int CXCompletionChunk_Optional = (int)0L;
     public static final int CXCompletionChunk_TypedText = (int)1L;
@@ -5984,10 +5984,10 @@ public final class Index_h {
     );
     public static final VarHandle CXCodeCompleteResults$NumResults = CXCodeCompleteResults$LAYOUT.varHandle(int.class, PathElement.groupElement("NumResults"));
     public static final int CXCodeCompleteResults$NumResults$get(MemorySegment seg) {
-        return (int)CXCodeCompleteResults$NumResults.get(seg.baseAddress());
+        return (int)CXCodeCompleteResults$NumResults.get(seg.address());
     }
     public static final void CXCodeCompleteResults$NumResults$set(MemorySegment seg, int x) {
-        CXCodeCompleteResults$NumResults.set(seg.baseAddress(), x);
+        CXCodeCompleteResults$NumResults.set(seg.address(), x);
     }
     public static final MethodHandle clang_getCompletionNumFixIts = RuntimeHelper.downcallHandle(
         LIBRARIES, "clang_getCompletionNumFixIts",
@@ -6537,10 +6537,10 @@ public final class Index_h {
     );
     public static final VarHandle CXIdxLoc$int_data = CXIdxLoc$LAYOUT.varHandle(int.class, PathElement.groupElement("int_data"));
     public static final int CXIdxLoc$int_data$get(MemorySegment seg) {
-        return (int)CXIdxLoc$int_data.get(seg.baseAddress());
+        return (int)CXIdxLoc$int_data.get(seg.address());
     }
     public static final void CXIdxLoc$int_data$set(MemorySegment seg, int x) {
-        CXIdxLoc$int_data.set(seg.baseAddress(), x);
+        CXIdxLoc$int_data.set(seg.address(), x);
     }
     public static final MemoryLayout CXIdxIncludedFileInfo$LAYOUT = MemoryLayout.ofStruct(
         MemoryLayout.ofStruct(
@@ -6557,24 +6557,24 @@ public final class Index_h {
     );
     public static final VarHandle CXIdxIncludedFileInfo$isImport = CXIdxIncludedFileInfo$LAYOUT.varHandle(int.class, PathElement.groupElement("isImport"));
     public static final int CXIdxIncludedFileInfo$isImport$get(MemorySegment seg) {
-        return (int)CXIdxIncludedFileInfo$isImport.get(seg.baseAddress());
+        return (int)CXIdxIncludedFileInfo$isImport.get(seg.address());
     }
     public static final void CXIdxIncludedFileInfo$isImport$set(MemorySegment seg, int x) {
-        CXIdxIncludedFileInfo$isImport.set(seg.baseAddress(), x);
+        CXIdxIncludedFileInfo$isImport.set(seg.address(), x);
     }
     public static final VarHandle CXIdxIncludedFileInfo$isAngled = CXIdxIncludedFileInfo$LAYOUT.varHandle(int.class, PathElement.groupElement("isAngled"));
     public static final int CXIdxIncludedFileInfo$isAngled$get(MemorySegment seg) {
-        return (int)CXIdxIncludedFileInfo$isAngled.get(seg.baseAddress());
+        return (int)CXIdxIncludedFileInfo$isAngled.get(seg.address());
     }
     public static final void CXIdxIncludedFileInfo$isAngled$set(MemorySegment seg, int x) {
-        CXIdxIncludedFileInfo$isAngled.set(seg.baseAddress(), x);
+        CXIdxIncludedFileInfo$isAngled.set(seg.address(), x);
     }
     public static final VarHandle CXIdxIncludedFileInfo$isModuleImport = CXIdxIncludedFileInfo$LAYOUT.varHandle(int.class, PathElement.groupElement("isModuleImport"));
     public static final int CXIdxIncludedFileInfo$isModuleImport$get(MemorySegment seg) {
-        return (int)CXIdxIncludedFileInfo$isModuleImport.get(seg.baseAddress());
+        return (int)CXIdxIncludedFileInfo$isModuleImport.get(seg.address());
     }
     public static final void CXIdxIncludedFileInfo$isModuleImport$set(MemorySegment seg, int x) {
-        CXIdxIncludedFileInfo$isModuleImport.set(seg.baseAddress(), x);
+        CXIdxIncludedFileInfo$isModuleImport.set(seg.address(), x);
     }
     public static final MemoryLayout CXIdxImportedASTFileInfo$LAYOUT = MemoryLayout.ofStruct(
         CSupport.C_POINTER.withName("file"),
@@ -6589,10 +6589,10 @@ public final class Index_h {
     );
     public static final VarHandle CXIdxImportedASTFileInfo$isImplicit = CXIdxImportedASTFileInfo$LAYOUT.varHandle(int.class, PathElement.groupElement("isImplicit"));
     public static final int CXIdxImportedASTFileInfo$isImplicit$get(MemorySegment seg) {
-        return (int)CXIdxImportedASTFileInfo$isImplicit.get(seg.baseAddress());
+        return (int)CXIdxImportedASTFileInfo$isImplicit.get(seg.address());
     }
     public static final void CXIdxImportedASTFileInfo$isImplicit$set(MemorySegment seg, int x) {
-        CXIdxImportedASTFileInfo$isImplicit.set(seg.baseAddress(), x);
+        CXIdxImportedASTFileInfo$isImplicit.set(seg.address(), x);
     }
     public static final int CXIdxEntity_Unexposed = (int)0L;
     public static final int CXIdxEntity_Typedef = (int)1L;
@@ -6650,10 +6650,10 @@ public final class Index_h {
     );
     public static final VarHandle CXIdxAttrInfo$kind = CXIdxAttrInfo$LAYOUT.varHandle(int.class, PathElement.groupElement("kind"));
     public static final int CXIdxAttrInfo$kind$get(MemorySegment seg) {
-        return (int)CXIdxAttrInfo$kind.get(seg.baseAddress());
+        return (int)CXIdxAttrInfo$kind.get(seg.address());
     }
     public static final void CXIdxAttrInfo$kind$set(MemorySegment seg, int x) {
-        CXIdxAttrInfo$kind.set(seg.baseAddress(), x);
+        CXIdxAttrInfo$kind.set(seg.address(), x);
     }
     public static final MemoryLayout CXIdxEntityInfo$LAYOUT = MemoryLayout.ofStruct(
         CSupport.C_INT.withName("kind"),
@@ -6673,31 +6673,31 @@ public final class Index_h {
     );
     public static final VarHandle CXIdxEntityInfo$kind = CXIdxEntityInfo$LAYOUT.varHandle(int.class, PathElement.groupElement("kind"));
     public static final int CXIdxEntityInfo$kind$get(MemorySegment seg) {
-        return (int)CXIdxEntityInfo$kind.get(seg.baseAddress());
+        return (int)CXIdxEntityInfo$kind.get(seg.address());
     }
     public static final void CXIdxEntityInfo$kind$set(MemorySegment seg, int x) {
-        CXIdxEntityInfo$kind.set(seg.baseAddress(), x);
+        CXIdxEntityInfo$kind.set(seg.address(), x);
     }
     public static final VarHandle CXIdxEntityInfo$templateKind = CXIdxEntityInfo$LAYOUT.varHandle(int.class, PathElement.groupElement("templateKind"));
     public static final int CXIdxEntityInfo$templateKind$get(MemorySegment seg) {
-        return (int)CXIdxEntityInfo$templateKind.get(seg.baseAddress());
+        return (int)CXIdxEntityInfo$templateKind.get(seg.address());
     }
     public static final void CXIdxEntityInfo$templateKind$set(MemorySegment seg, int x) {
-        CXIdxEntityInfo$templateKind.set(seg.baseAddress(), x);
+        CXIdxEntityInfo$templateKind.set(seg.address(), x);
     }
     public static final VarHandle CXIdxEntityInfo$lang = CXIdxEntityInfo$LAYOUT.varHandle(int.class, PathElement.groupElement("lang"));
     public static final int CXIdxEntityInfo$lang$get(MemorySegment seg) {
-        return (int)CXIdxEntityInfo$lang.get(seg.baseAddress());
+        return (int)CXIdxEntityInfo$lang.get(seg.address());
     }
     public static final void CXIdxEntityInfo$lang$set(MemorySegment seg, int x) {
-        CXIdxEntityInfo$lang.set(seg.baseAddress(), x);
+        CXIdxEntityInfo$lang.set(seg.address(), x);
     }
     public static final VarHandle CXIdxEntityInfo$numAttributes = CXIdxEntityInfo$LAYOUT.varHandle(int.class, PathElement.groupElement("numAttributes"));
     public static final int CXIdxEntityInfo$numAttributes$get(MemorySegment seg) {
-        return (int)CXIdxEntityInfo$numAttributes.get(seg.baseAddress());
+        return (int)CXIdxEntityInfo$numAttributes.get(seg.address());
     }
     public static final void CXIdxEntityInfo$numAttributes$set(MemorySegment seg, int x) {
-        CXIdxEntityInfo$numAttributes.set(seg.baseAddress(), x);
+        CXIdxEntityInfo$numAttributes.set(seg.address(), x);
     }
     public static final MemoryLayout CXIdxContainerInfo$LAYOUT = MemoryLayout.ofStruct(
         MemoryLayout.ofStruct(
@@ -6748,45 +6748,45 @@ public final class Index_h {
     );
     public static final VarHandle CXIdxDeclInfo$isRedeclaration = CXIdxDeclInfo$LAYOUT.varHandle(int.class, PathElement.groupElement("isRedeclaration"));
     public static final int CXIdxDeclInfo$isRedeclaration$get(MemorySegment seg) {
-        return (int)CXIdxDeclInfo$isRedeclaration.get(seg.baseAddress());
+        return (int)CXIdxDeclInfo$isRedeclaration.get(seg.address());
     }
     public static final void CXIdxDeclInfo$isRedeclaration$set(MemorySegment seg, int x) {
-        CXIdxDeclInfo$isRedeclaration.set(seg.baseAddress(), x);
+        CXIdxDeclInfo$isRedeclaration.set(seg.address(), x);
     }
     public static final VarHandle CXIdxDeclInfo$isDefinition = CXIdxDeclInfo$LAYOUT.varHandle(int.class, PathElement.groupElement("isDefinition"));
     public static final int CXIdxDeclInfo$isDefinition$get(MemorySegment seg) {
-        return (int)CXIdxDeclInfo$isDefinition.get(seg.baseAddress());
+        return (int)CXIdxDeclInfo$isDefinition.get(seg.address());
     }
     public static final void CXIdxDeclInfo$isDefinition$set(MemorySegment seg, int x) {
-        CXIdxDeclInfo$isDefinition.set(seg.baseAddress(), x);
+        CXIdxDeclInfo$isDefinition.set(seg.address(), x);
     }
     public static final VarHandle CXIdxDeclInfo$isContainer = CXIdxDeclInfo$LAYOUT.varHandle(int.class, PathElement.groupElement("isContainer"));
     public static final int CXIdxDeclInfo$isContainer$get(MemorySegment seg) {
-        return (int)CXIdxDeclInfo$isContainer.get(seg.baseAddress());
+        return (int)CXIdxDeclInfo$isContainer.get(seg.address());
     }
     public static final void CXIdxDeclInfo$isContainer$set(MemorySegment seg, int x) {
-        CXIdxDeclInfo$isContainer.set(seg.baseAddress(), x);
+        CXIdxDeclInfo$isContainer.set(seg.address(), x);
     }
     public static final VarHandle CXIdxDeclInfo$isImplicit = CXIdxDeclInfo$LAYOUT.varHandle(int.class, PathElement.groupElement("isImplicit"));
     public static final int CXIdxDeclInfo$isImplicit$get(MemorySegment seg) {
-        return (int)CXIdxDeclInfo$isImplicit.get(seg.baseAddress());
+        return (int)CXIdxDeclInfo$isImplicit.get(seg.address());
     }
     public static final void CXIdxDeclInfo$isImplicit$set(MemorySegment seg, int x) {
-        CXIdxDeclInfo$isImplicit.set(seg.baseAddress(), x);
+        CXIdxDeclInfo$isImplicit.set(seg.address(), x);
     }
     public static final VarHandle CXIdxDeclInfo$numAttributes = CXIdxDeclInfo$LAYOUT.varHandle(int.class, PathElement.groupElement("numAttributes"));
     public static final int CXIdxDeclInfo$numAttributes$get(MemorySegment seg) {
-        return (int)CXIdxDeclInfo$numAttributes.get(seg.baseAddress());
+        return (int)CXIdxDeclInfo$numAttributes.get(seg.address());
     }
     public static final void CXIdxDeclInfo$numAttributes$set(MemorySegment seg, int x) {
-        CXIdxDeclInfo$numAttributes.set(seg.baseAddress(), x);
+        CXIdxDeclInfo$numAttributes.set(seg.address(), x);
     }
     public static final VarHandle CXIdxDeclInfo$flags = CXIdxDeclInfo$LAYOUT.varHandle(int.class, PathElement.groupElement("flags"));
     public static final int CXIdxDeclInfo$flags$get(MemorySegment seg) {
-        return (int)CXIdxDeclInfo$flags.get(seg.baseAddress());
+        return (int)CXIdxDeclInfo$flags.get(seg.address());
     }
     public static final void CXIdxDeclInfo$flags$set(MemorySegment seg, int x) {
-        CXIdxDeclInfo$flags.set(seg.baseAddress(), x);
+        CXIdxDeclInfo$flags.set(seg.address(), x);
     }
     public static final int CXIdxObjCContainer_ForwardRef = (int)0L;
     public static final int CXIdxObjCContainer_Interface = (int)1L;
@@ -6798,10 +6798,10 @@ public final class Index_h {
     );
     public static final VarHandle CXIdxObjCContainerDeclInfo$kind = CXIdxObjCContainerDeclInfo$LAYOUT.varHandle(int.class, PathElement.groupElement("kind"));
     public static final int CXIdxObjCContainerDeclInfo$kind$get(MemorySegment seg) {
-        return (int)CXIdxObjCContainerDeclInfo$kind.get(seg.baseAddress());
+        return (int)CXIdxObjCContainerDeclInfo$kind.get(seg.address());
     }
     public static final void CXIdxObjCContainerDeclInfo$kind$set(MemorySegment seg, int x) {
-        CXIdxObjCContainerDeclInfo$kind.set(seg.baseAddress(), x);
+        CXIdxObjCContainerDeclInfo$kind.set(seg.address(), x);
     }
     public static final MemoryLayout CXIdxBaseClassInfo$LAYOUT = MemoryLayout.ofStruct(
         CSupport.C_POINTER.withName("base"),
@@ -6836,10 +6836,10 @@ public final class Index_h {
     );
     public static final VarHandle CXIdxObjCProtocolRefListInfo$numProtocols = CXIdxObjCProtocolRefListInfo$LAYOUT.varHandle(int.class, PathElement.groupElement("numProtocols"));
     public static final int CXIdxObjCProtocolRefListInfo$numProtocols$get(MemorySegment seg) {
-        return (int)CXIdxObjCProtocolRefListInfo$numProtocols.get(seg.baseAddress());
+        return (int)CXIdxObjCProtocolRefListInfo$numProtocols.get(seg.address());
     }
     public static final void CXIdxObjCProtocolRefListInfo$numProtocols$set(MemorySegment seg, int x) {
-        CXIdxObjCProtocolRefListInfo$numProtocols.set(seg.baseAddress(), x);
+        CXIdxObjCProtocolRefListInfo$numProtocols.set(seg.address(), x);
     }
     public static final MemoryLayout CXIdxObjCInterfaceDeclInfo$LAYOUT = MemoryLayout.ofStruct(
         CSupport.C_POINTER.withName("containerInfo"),
@@ -6874,10 +6874,10 @@ public final class Index_h {
     );
     public static final VarHandle CXIdxCXXClassDeclInfo$numBases = CXIdxCXXClassDeclInfo$LAYOUT.varHandle(int.class, PathElement.groupElement("numBases"));
     public static final int CXIdxCXXClassDeclInfo$numBases$get(MemorySegment seg) {
-        return (int)CXIdxCXXClassDeclInfo$numBases.get(seg.baseAddress());
+        return (int)CXIdxCXXClassDeclInfo$numBases.get(seg.address());
     }
     public static final void CXIdxCXXClassDeclInfo$numBases$set(MemorySegment seg, int x) {
-        CXIdxCXXClassDeclInfo$numBases.set(seg.baseAddress(), x);
+        CXIdxCXXClassDeclInfo$numBases.set(seg.address(), x);
     }
     public static final int CXIdxEntityRef_Direct = (int)1L;
     public static final int CXIdxEntityRef_Implicit = (int)2L;
@@ -6912,17 +6912,17 @@ public final class Index_h {
     );
     public static final VarHandle CXIdxEntityRefInfo$kind = CXIdxEntityRefInfo$LAYOUT.varHandle(int.class, PathElement.groupElement("kind"));
     public static final int CXIdxEntityRefInfo$kind$get(MemorySegment seg) {
-        return (int)CXIdxEntityRefInfo$kind.get(seg.baseAddress());
+        return (int)CXIdxEntityRefInfo$kind.get(seg.address());
     }
     public static final void CXIdxEntityRefInfo$kind$set(MemorySegment seg, int x) {
-        CXIdxEntityRefInfo$kind.set(seg.baseAddress(), x);
+        CXIdxEntityRefInfo$kind.set(seg.address(), x);
     }
     public static final VarHandle CXIdxEntityRefInfo$role = CXIdxEntityRefInfo$LAYOUT.varHandle(int.class, PathElement.groupElement("role"));
     public static final int CXIdxEntityRefInfo$role$get(MemorySegment seg) {
-        return (int)CXIdxEntityRefInfo$role.get(seg.baseAddress());
+        return (int)CXIdxEntityRefInfo$role.get(seg.address());
     }
     public static final void CXIdxEntityRefInfo$role$set(MemorySegment seg, int x) {
-        CXIdxEntityRefInfo$role.set(seg.baseAddress(), x);
+        CXIdxEntityRefInfo$role.set(seg.address(), x);
     }
     public static final MemoryLayout IndexerCallbacks$LAYOUT = MemoryLayout.ofStruct(
         CSupport.C_POINTER.withName("abortQuery"),

--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/clang/libclang/RuntimeHelper.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/clang/libclang/RuntimeHelper.java
@@ -90,7 +90,7 @@ public class RuntimeHelper {
         return lookup(LIBRARIES, name).map(a ->
             MemorySegment.ofNativeRestricted(
                 a, layout.byteSize(), null, null, a
-            ).withAccessModes(MemorySegment.READ | MemorySegment.WRITE).baseAddress()).orElse(null);
+            ).withAccessModes(MemorySegment.READ | MemorySegment.WRITE).address()).orElse(null);
     }
 
     public static final MethodHandle downcallHandle(LibraryLookup[] LIBRARIES, String name, String desc, FunctionDescriptor fdesc) {
@@ -101,7 +101,7 @@ public class RuntimeHelper {
     }
 
     public static final MemoryAddress upcallStub(MethodHandle handle, FunctionDescriptor fdesc) {
-        return ABI.upcallStub(handle, fdesc).baseAddress();
+        return ABI.upcallStub(handle, fdesc).address();
     }
 
     public static final <Z> MemoryAddress upcallStub(Class<Z> fi, Z z, FunctionDescriptor fdesc, String mtypeDesc) {

--- a/test/jdk/tools/jextract/test8244938/Test8244938.java
+++ b/test/jdk/tools/jextract/test8244938/Test8244938.java
@@ -39,7 +39,7 @@ public class Test8244938 {
     public void testNestedStructReturn() {
          var seg = func();
          assertEquals(seg.byteSize(), Point.sizeof());
-         var addr = seg.baseAddress();
+         var addr = seg.address();
          assertEquals(Point.k$get(addr), 44);
          var point2dAddr = Point.point2d$addr(addr);
          assertEquals(Point2D.i$get(point2dAddr), 567);

--- a/test/jdk/tools/jextract/test8244959/Test8244959.java
+++ b/test/jdk/tools/jextract/test8244959/Test8244959.java
@@ -40,10 +40,10 @@ public class Test8244959 {
     @Test
     public void testsPrintf() {
         try (MemorySegment s = MemorySegment.allocateNative(1024)) {
-            my_sprintf(s.baseAddress(),
-                toCString("%hhd %c %.2f %.2f %lld %lld %d %hd %d %d %lld %c").baseAddress(), 12,
+            my_sprintf(s.address(),
+                toCString("%hhd %c %.2f %.2f %lld %lld %d %hd %d %d %lld %c").address(), 12,
                 (byte) 1, 'b', -1.25f, 5.5d, -200L, Long.MAX_VALUE, (byte) -2, (short) 2, 3, (short) -4, 5L, 'a');
-            String str = toJavaString(s.baseAddress());
+            String str = toJavaString(s.address());
             assertEquals(str, "1 b -1.25 5.50 -200 " + Long.MAX_VALUE + " -2 2 3 -4 5 a");
         }
     }

--- a/test/jdk/tools/jextract/test8246341/LibTest8246341Test.java
+++ b/test/jdk/tools/jextract/test8246341/LibTest8246341Test.java
@@ -54,7 +54,7 @@ public class LibTest8246341Test {
             assertEquals(toJavaStringRestricted(MemoryAccess.getAddressAtIndex(addr, 2)), "javascript");
             assertEquals(toJavaStringRestricted(MemoryAccess.getAddressAtIndex(addr, 3)), "c++");
         })) {
-            func(callback.baseAddress());
+            func(callback.address());
         }
         assertTrue(callbackCalled[0]);
     }

--- a/test/jdk/tools/jextract/test8246400/LibTest8246400Test.java
+++ b/test/jdk/tools/jextract/test8246400/LibTest8246400Test.java
@@ -57,12 +57,12 @@ public class LibTest8246400Test {
             sum = add(v1.segment(), v2.segment());
             sum = scope.register(sum);
 
-            assertEquals(Vector.x$get(sum.baseAddress()), 1.0, 0.1);
-            assertEquals(Vector.y$get(sum.baseAddress()), 1.0, 0.1);
+            assertEquals(Vector.x$get(sum.address()), 1.0, 0.1);
+            assertEquals(Vector.y$get(sum.address()), 1.0, 0.1);
 
             callback = cosine_similarity$dot.allocate((a, b) -> {
-                return (Vector.x$get(a.baseAddress()) * Vector.x$get(b.baseAddress())) +
-                    (Vector.y$get(a.baseAddress()) * Vector.y$get(b.baseAddress()));
+                return (Vector.x$get(a.address()) * Vector.x$get(b.address())) +
+                    (Vector.y$get(a.address()) * Vector.y$get(b.address()));
             }, scope);
 
             var value = cosine_similarity(v1.segment(), v2.segment(), callback);

--- a/test/jdk/tools/jextract/testClassGen/TestClassGeneration.java
+++ b/test/jdk/tools/jextract/testClassGen/TestClassGeneration.java
@@ -182,7 +182,7 @@ public class TestClassGeneration extends JextractToolRunner {
         MemoryAddress addr = MemorySegment.ofNativeRestricted(
                 (MemoryAddress)addr_getter.invoke(null),
                 expectedLayout.byteSize(),
-                null, null, null).baseAddress();
+                null, null, null).address();
 
         Method vh_getter = checkMethod(cls, name + "$VH", VarHandle.class);
         VarHandle vh = (VarHandle) vh_getter.invoke(null);
@@ -207,7 +207,7 @@ public class TestClassGeneration extends JextractToolRunner {
 
             Method getter = checkMethod(structCls, memberName + "$get", expectedType, MemoryAddress.class);
             Method setter = checkMethod(structCls, memberName + "$set", void.class, MemoryAddress.class, expectedType);
-            MemoryAddress addr = struct.baseAddress();
+            MemoryAddress addr = struct.address();
             setter.invoke(null, addr, testValue);
             assertEquals(getter.invoke(null, addr), testValue);
         }

--- a/test/jdk/tools/jextract/testFunctionPointer/LibFuncPtrTest.java
+++ b/test/jdk/tools/jextract/testFunctionPointer/LibFuncPtrTest.java
@@ -38,7 +38,7 @@ public class LibFuncPtrTest {
     @Test
     public void test() {
         try (var handle = func$f.allocate(x -> x*x)) {
-            assertEquals(func(handle.baseAddress(), 35), 35 * 35 + 35);
+            assertEquals(func(handle.address(), 35), 35 * 35 + 35);
         } //deallocate
     }
 }

--- a/test/jdk/tools/jextract/testStruct/LibStructTest.java
+++ b/test/jdk/tools/jextract/testStruct/LibStructTest.java
@@ -41,7 +41,7 @@ public class LibStructTest {
     @Test
     public void testMakePoint() {
         try (var seg = makePoint(42, -39)) {
-            var addr = seg.baseAddress();
+            var addr = seg.address();
             assertEquals(Point.x$get(addr), 42);
             assertEquals(Point.y$get(addr), -39);
         }
@@ -50,7 +50,7 @@ public class LibStructTest {
     @Test
     public void testAllocate() {
         try (var seg = Point.allocate()) {
-            var addr = seg.baseAddress();
+            var addr = seg.address();
             Point.x$set(addr, 56);
             Point.y$set(addr, 65);
             assertEquals(Point.x$get(addr), 56);
@@ -61,7 +61,7 @@ public class LibStructTest {
     @Test
     public void testAllocateArray() {
         try (var seg = Point.allocateArray(3)) {
-            var addr = seg.baseAddress();
+            var addr = seg.address();
             for (int i = 0; i < 3; i++) {
                 Point.x$set(addr, i, 56 + i);
                 Point.y$set(addr, i, 65 + i);


### PR DESCRIPTION
Fixup various references to `MemorySegment::baseAddress()` throughout jextract sources and tests.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [JDK-8249790](https://bugs.openjdk.java.net/browse/JDK-8249790): Add Addressable abstraction


### Reviewers
 * Athijegannathan Sundararajan ([sundar](@sundararajana) - Committer)
 * Jorn Vernee ([jvernee](@JornVernee) - Committer)


### Download
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/254/head:pull/254`
`$ git checkout pull/254`
