### PR TITLE
8249949: jextract libclang Cursor children iteration creates a new up call stub every time

### DIFF
--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/clang/Cursor.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/clang/Cursor.java
@@ -335,15 +335,26 @@ public final class Cursor {
         return new Cursor(Index_h.clang_getSpecializedCursorTemplate(cursor));
     }
 
-    public Stream<Cursor> children() {
-        final ArrayList<Cursor> ar = new ArrayList<>();
-        // FIXME: need a way to pass ar down as user data
-        Index_h.clang_visitChildren(cursor, Index_h.clang_visitChildren$visitor$make((c, p, d) -> {
+    private static class CursorChildren {
+        private static final ArrayList<Cursor> children = new ArrayList<>();
+        private static final MemoryAddress callback = Index_h.clang_visitChildren$visitor$allocate((c, p, d) -> {
             Cursor cursor = new Cursor(c);
-            ar.add(cursor);
+            children.add(cursor);
             return Index_h.CXChildVisit_Continue;
-        }), MemoryAddress.NULL);
-        return ar.stream();
+        });
+
+        synchronized static Stream<Cursor> get(Cursor c) {
+            try {
+                Index_h.clang_visitChildren(c.cursor, callback, MemoryAddress.NULL);
+                return new ArrayList<Cursor>(children).stream();
+            } finally {
+                children.clear();
+            }
+        }
+    }
+
+    public Stream<Cursor> children() {
+        return CursorChildren.get(this);
     }
 
     public Stream<Cursor> allChildren() {

--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/clang/libclang/Index_h.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/clang/libclang/Index_h.java
@@ -4340,7 +4340,7 @@ public final class Index_h {
     public interface clang_visitChildren$visitor {
         int apply(MemorySegment x0, MemorySegment x1, MemoryAddress x2);
     }
-    public static final MemoryAddress clang_visitChildren$visitor$make(clang_visitChildren$visitor fi) {
+    public static final MemoryAddress clang_visitChildren$visitor$allocate(clang_visitChildren$visitor fi) {
         return RuntimeHelper.upcallStub(clang_visitChildren$visitor.class, fi, clang_visitChildren$visitor$DESC, "(Ljdk/incubator/foreign/MemorySegment;Ljdk/incubator/foreign/MemorySegment;Ljdk/incubator/foreign/MemoryAddress;)I");
     }
     public static final MethodHandle clang_getCursorUSR = RuntimeHelper.downcallHandle(


### PR DESCRIPTION
Avoiding repeated upcall stub creation by caching. The array list updated is updated in a synchroinzed method.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8249949](https://bugs.openjdk.java.net/browse/JDK-8249949): jextract libclang Cursor children iteration creates a new up call stub every time


### Download
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/261/head:pull/261`
`$ git checkout pull/261`
