### PR TITLE
8250222: ConstantsTest is broken

### DIFF
--- a/test/jdk/tools/jextract/constants.h
+++ b/test/jdk/tools/jextract/constants.h
@@ -64,3 +64,5 @@
 
 #define ZERO_PTR (void*)0;
 #define F_PTR (void*) 0xFFFFFFFFFFFFFFFFLL; // all 1s
+
+#define ARRAY { 0, 1, 2, 3, 4, 5 }

--- a/test/jdk/tools/jextract/constants_aux.h
+++ b/test/jdk/tools/jextract/constants_aux.h
@@ -22,5 +22,3 @@
  */
 
 #define SUP 5 //this is used by the main test header file
-
-#define UNUSED "unused" //this should not be used


### PR DESCRIPTION
This patch fixes ConstantsTest, which seems to be in an inconsistent state, especially when it comes to its test for missing constants; this test erroneosly looks for fields, not methods, so it always passes (as there are no fields!).

I've rectified the test, but also I've strengthened it, to make sure that we also check the values of the pointer constants (these were not checked before). I also added a test for an array constant (which should be dropped), and I've dropped the `UNUSED` constant in `constants_aux.h`, since its use was mostly targeted at some kind of filtering mechanism that we no longer have.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [JDK-8250222](https://bugs.openjdk.java.net/browse/JDK-8250222): ConstantsTest is broken


### Reviewers
 * Henry Jen ([henryjen](@slowhog) - Committer)


### Download
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/263/head:pull/263`
`$ git checkout pull/263`
