### PR TITLE
8250518: Jextract should process macros in bulk

### DIFF
--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/MacroParserImpl.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/MacroParserImpl.java
@@ -188,11 +188,11 @@ class MacroParserImpl implements JextractTask.ConstantParser {
                 return "jextract$macro$" + name;
             }
 
-            Success success(Type type, Object value) {
+            Entry success(Type type, Object value) {
                 throw new IllegalStateException();
             }
 
-            RecoverableFailure failure(Type type) {
+            Entry failure(Type type) {
                 throw new IllegalStateException();
             }
 
@@ -205,6 +205,10 @@ class MacroParserImpl implements JextractTask.ConstantParser {
             boolean isUnparsed() {
                 return false;
             }
+
+            void update() {
+                macrosByMangledName.put(mangledName(), this);
+            }
         }
 
         class Unparsed extends Entry {
@@ -213,20 +217,25 @@ class MacroParserImpl implements JextractTask.ConstantParser {
             }
 
             @Override
-            Success success(Type type, Object value) {
+            Entry success(Type type, Object value) {
                 return new Success(name, tokens, cursor, type, value);
             }
 
             @Override
-            RecoverableFailure failure(Type type) {
+            Entry failure(Type type) {
                 return type != null ?
                         new RecoverableFailure(name, tokens, cursor, type) :
-                        null;
+                        new UnparseableMacro(name, tokens, cursor);
             }
 
             @Override
             boolean isUnparsed() {
                 return true;
+            }
+
+            @Override
+            void update() {
+                throw new IllegalStateException();
             }
         }
 
@@ -240,13 +249,13 @@ class MacroParserImpl implements JextractTask.ConstantParser {
             }
 
             @Override
-            Success success(Type type, Object value) {
+            Entry success(Type type, Object value) {
                 return new Success(name, tokens, cursor, this.type, value);
             }
 
             @Override
-            RecoverableFailure failure(Type type) {
-                return null;
+            Entry failure(Type type) {
+                return new UnparseableMacro(name, tokens, cursor);
             }
 
             @Override
@@ -275,6 +284,18 @@ class MacroParserImpl implements JextractTask.ConstantParser {
             }
         }
 
+        class UnparseableMacro extends Entry {
+
+            UnparseableMacro(String name, String[] tokens, Cursor cursor) {
+                super(name, tokens, cursor);
+            }
+
+            @Override
+            void update() {
+                macrosByMangledName.remove(mangledName());
+            }
+        };
+
         void enterMacro(String name, String[] tokens, Cursor cursor) {
             Unparsed unparsed = new Unparsed(name, tokens, cursor);
             macrosByMangledName.put(unparsed.mangledName(), unparsed);
@@ -299,35 +320,27 @@ class MacroParserImpl implements JextractTask.ConstantParser {
         void updateTable(TypeMaker typeMaker, Cursor decl) {
             String mangledName = decl.spelling();
             Entry entry = macrosByMangledName.get(mangledName);
-            Entry newEntry;
             try (EvalResult result = decl.eval()) {
-                switch (result.getKind()) {
-                    case Integral: {
+                Entry newEntry = switch (result.getKind()) {
+                    case Integral -> {
                         long value = result.getAsInt();
-                        newEntry = entry.success(typeMaker.makeType(decl.type()), value);
-                        break;
+                        yield entry.success(typeMaker.makeType(decl.type()), value);
                     }
-                    case FloatingPoint: {
+                    case FloatingPoint -> {
                         double value = result.getAsFloat();
-                        newEntry = entry.success(typeMaker.makeType(decl.type()), value);
-                        break;
+                        yield entry.success(typeMaker.makeType(decl.type()), value);
                     }
-                    case StrLiteral: {
+                    case StrLiteral -> {
                         String value = result.getAsString();
-                        newEntry = entry.success(typeMaker.makeType(decl.type()), value);
-                        break;
+                        yield entry.success(typeMaker.makeType(decl.type()), value);
                     }
-                    default: {
+                    default -> {
                         Type type = decl.type().equals(decl.type().canonicalType()) ?
                                 null : typeMaker.makeType(decl.type());
-                        newEntry = entry.failure(type);
+                        yield entry.failure(type);
                     }
-                }
-            }
-            if (newEntry != null) {
-                macrosByMangledName.put(newEntry.mangledName(), newEntry);
-            } else {
-                macrosByMangledName.remove(entry.mangledName());
+                };
+                newEntry.update();
             }
         }
 

--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/Parser.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/Parser.java
@@ -108,7 +108,7 @@ class Parser {
             });
 
         if (constantParser instanceof MacroParserImpl) {
-            decls.addAll(((MacroParserImpl)constantParser).reparseConstants());
+            decls.addAll(((MacroParserImpl)constantParser).macroTable.reparseConstants());
         }
         Declaration.Scoped rv = treeMaker.createHeader(tuCursor, decls);
         treeMaker.freeze();

--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/TreeMaker.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/TreeMaker.java
@@ -170,9 +170,9 @@ class TreeMaker {
                 params.toArray(new Declaration.Variable[0]));
     }
 
-    public Declaration.Constant createMacro(Cursor c, MacroParserImpl.Macro parsedMacro) {
+    public Declaration.Constant createMacro(Cursor c, String name, Type type, Object value) {
         checkCursorAny(c, CursorKind.MacroDefinition);
-        return Declaration.constant(toPos(c), c.spelling(), parsedMacro.value, parsedMacro.type());
+        return Declaration.constant(toPos(c), name, value, type);
     }
 
     public Declaration.Constant createEnumConstant(Cursor c) {

--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/TreeMaker.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/TreeMaker.java
@@ -170,14 +170,9 @@ class TreeMaker {
                 params.toArray(new Declaration.Variable[0]));
     }
 
-    public Declaration.Constant createMacro(Cursor c, Optional<MacroParserImpl.Macro> macro) {
+    public Declaration.Constant createMacro(Cursor c, MacroParserImpl.Macro parsedMacro) {
         checkCursorAny(c, CursorKind.MacroDefinition);
-        if (macro.isEmpty()) {
-            return null;
-        } else {
-            MacroParserImpl.Macro parsedMacro = macro.get();
-            return Declaration.constant(toPos(c), c.spelling(), parsedMacro.value, parsedMacro.type());
-        }
+        return Declaration.constant(toPos(c), c.spelling(), parsedMacro.value, parsedMacro.type());
     }
 
     public Declaration.Constant createEnumConstant(Cursor c) {

--- a/test/jdk/java/jextract/TestMacros.java
+++ b/test/jdk/java/jextract/TestMacros.java
@@ -57,7 +57,7 @@ public class TestMacros extends JextractApiTestBase {
             Type.pointer(Type.function(false, Type.void_(), C_INT)),
             0L);
         // Record type in macro definition are erased to void
-        checkConstant(badMacro, "NO_FOO", Type.pointer(Type.void_()), 0L);
+        checkConstant(badMacro, "NO_FOO", Type.pointer(Type.declared(foo)), 0L);
         checkConstant(badMacro, "INVALID_INT_ARRAY_PTR", Type.pointer(Type.pointer(C_INT)), 0L);
     }
 


### PR DESCRIPTION
This patch adds bulk processing of macros; that is, instead of having a reparsing step for every macro constant, this patch tweaks jextract so that all unparsed macros are processed in one go.

The logic is quite convoluted and this work led to a major refactoring of MacroParserImpl; there is now a *table* where unparsed macros are kept - elements in this table are reparsed, and, based on the contents of the reparsed cursors, the table state is updated accordingly (the code has quite a bit of doc documenting the possible state transitions).

This results in some 2x performance boost in some of the heaviest extraction runs.

One thing to notice is that one of the test required some tweaks, as the new code seems to be able to infer a sharper type for a macro - e.g. `foo*` instead of `void*`. I suspect this is related to `TypeMaker::resolveTypeReferences` but I'm not 100% sure - @slowhog  can you please take a look?
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [JDK-8250518](https://bugs.openjdk.java.net/browse/JDK-8250518): Jextract should process macros in bulk


### Reviewers
 * Jorn Vernee ([jvernee](@JornVernee) - Committer)
 * Athijegannathan Sundararajan ([sundar](@sundararajana) - Committer)


### Download
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/264/head:pull/264`
`$ git checkout pull/264`
