### PR TITLE
Fix wrong ret_addr_offset value for some native calls.

### DIFF
--- a/src/hotspot/cpu/x86/x86_64.ad
+++ b/src/hotspot/cpu/x86/x86_64.ad
@@ -461,6 +461,7 @@ int MachCallRuntimeNode::ret_addr_offset() {
 
 int MachCallNativeNode::ret_addr_offset() {
   int offset = 13; // movq r10,#addr; callq (r10)
+  offset += clear_avx_size();
   return offset;
 }
 //
@@ -12569,9 +12570,7 @@ instruct CallNativeDirect(method meth)
 
   ins_cost(300);
   format %{ "call_native " %}
-  ins_encode %{
-    __ call(RuntimeAddress((address) $meth$$method));
-  %}
+  ins_encode(clear_avx, Java_To_Runtime(meth));
   ins_pipe(pipe_slow);
 %}
 

--- a/src/hotspot/share/opto/output.cpp
+++ b/src/hotspot/share/opto/output.cpp
@@ -1605,6 +1605,8 @@ void PhaseOutput::fill_buffer(CodeBuffer* cb, uint* blk_starts) {
       n->emit(*cb, C->regalloc());
       current_offset  = cb->insts_size();
 
+      assert(!is_mcall || (call_returns[block->_pre_order] == current_offset), "ret_addr_offset() did not match size of emitted code");
+
       // Above we only verified that there is enough space in the instruction section.
       // However, the instruction may emit stubs that cause code buffer expansion.
       // Bail out here if expansion failed due to a lack of code cache space.


### PR DESCRIPTION
Hi,

This patch fixes a problem observed when running some of the jextract samples with intrinsics enabled.

The problem is that safepoint information is stored based on code offsets in C2, and for native calls, the code offset was wrong sometimes due to the assembler emitting different code for near and far calls.

The fix is to force the emission of a far call, so that the code offset is always correct. This follows what currently happens for normal runtime calls as well.

The patch also adds an assertion to verify that the given code offset is correct when emitting code. The assertion correctly fires on the current intrinsics tests without the fix.

Thanks,
Jorn
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * Maurizio Cimadamore ([mcimadamore](@mcimadamore) - Committer)


### Download
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/269/head:pull/269`
`$ git checkout pull/269`
