### PR TITLE
8250774: jextract does not close all files

### DIFF
--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/Writer.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/Writer.java
@@ -28,6 +28,7 @@ package jdk.internal.jextract.impl;
 
 import javax.tools.JavaFileObject;
 import java.io.IOException;
+import java.io.InputStream;
 import java.nio.file.FileAlreadyExistsException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -72,7 +73,9 @@ public final class Writer {
             String path = entry.getName();
             Path fullPath = destDir.resolve(path).normalize();
             Files.createDirectories(fullPath.getParent());
-            Files.write(fullPath, entry.openInputStream().readAllBytes());
+            try (InputStream is = entry.openInputStream()) {
+                Files.write(fullPath, is.readAllBytes());
+            }
         }
     }
 


### PR DESCRIPTION
Since when we switched to the new jextract implementation, we have observed spurious test failures on windows, caused by the fact that some of the files generated by jextract test runs are left opened and, therefore, cannot be deleted.

I have investigated this matter further (on Linux), by debugging one of the failing test (UnionDeclTest) and using `lsof` to keep track of the list of opened file descriptors associated with the test process. What I discovered was that calling `Writer::writeClassFiles` was causing the leak; upon closer inspection, I found this dubious code:

```
Files.write(fullPath, entry.openInputStream().readAllBytes());
```

In other words, the input stream was not being closed. As per javadoc, `readAllBytes` does _not_ close the stream when done. Fixing this (by using a try with resources) seems to get rid of the issues, and the leaked descriptors are no longer visible using `lsof`.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [JDK-8250774](https://bugs.openjdk.java.net/browse/JDK-8250774): jextract does not close all files


### Reviewers
 * Athijegannathan Sundararajan ([sundar](@sundararajana) - Committer)


### Download
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/271/head:pull/271`
`$ git checkout pull/271`
