### PR TITLE
Change error handling strategy in MacroParserImpl's constructor

### DIFF
--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/MacroParserImpl.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/MacroParserImpl.java
@@ -52,18 +52,18 @@ import java.util.stream.Stream;
 
 class MacroParserImpl implements JextractTask.ConstantParser {
 
-    private final Reparser reparser;
+    private final ClangReparser reparser;
     private final TreeMaker treeMaker;
     final MacroTable macroTable;
 
-    private MacroParserImpl(Reparser reparser, TreeMaker treeMaker) {
+    private MacroParserImpl(ClangReparser reparser, TreeMaker treeMaker) {
         this.reparser = reparser;
         this.treeMaker = treeMaker;
         this.macroTable = new MacroTable();
     }
 
     public static MacroParserImpl make(TreeMaker treeMaker, TranslationUnit tu, Collection<String> args) {
-        Reparser reparser;
+        ClangReparser reparser;
         try {
             reparser = new ClangReparser(tu, args);
         } catch (IOException | Index.ParsingFailedException ex) {
@@ -108,16 +108,12 @@ class MacroParserImpl implements JextractTask.ConstantParser {
         }
     }
 
-    interface Reparser {
-        Stream<Cursor> reparse(String snippet);
-    }
-
     /**
      * This class allows client to reparse a snippet of code against a given set of include files.
      * For performance reasons, the set of includes (which comes from the jextract parser) is compiled
      * into a precompiled header, so as to speed to incremental recompilation of the generated snippets.
      */
-    static class ClangReparser implements Reparser {
+    static class ClangReparser {
         final Path macro;
         final Index macroIndex = LibClang.createIndex(true);
         final TranslationUnit macroUnit;
@@ -148,7 +144,6 @@ class MacroParserImpl implements JextractTask.ConstantParser {
             }
         }
 
-        @Override
         public Stream<Cursor> reparse(String snippet) {
             macroUnit.reparse(this::processDiagnostics,
                     Index.UnsavedFile.of(macro, snippet));

--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/MacroParserImpl.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/MacroParserImpl.java
@@ -52,18 +52,25 @@ import java.util.stream.Stream;
 
 class MacroParserImpl implements JextractTask.ConstantParser {
 
-    private Reparser reparser;
-    TreeMaker treeMaker;
-    MacroTable macroTable;
+    private final Reparser reparser;
+    private final TreeMaker treeMaker;
+    final MacroTable macroTable;
 
-    public MacroParserImpl(TreeMaker treeMaker, TranslationUnit tu, Collection<String> args) {
+    private MacroParserImpl(Reparser reparser, TreeMaker treeMaker) {
+        this.reparser = reparser;
+        this.treeMaker = treeMaker;
+        this.macroTable = new MacroTable();
+    }
+
+    public static MacroParserImpl make(TreeMaker treeMaker, TranslationUnit tu, Collection<String> args) {
+        Reparser reparser;
         try {
-            this.reparser = new ClangReparser(tu, args);
-            this.treeMaker = treeMaker;
-            this.macroTable = new MacroTable();
+            reparser = new ClangReparser(tu, args);
         } catch (IOException | Index.ParsingFailedException ex) {
-            this.reparser = Reparser.DUMMY;
+            throw new RuntimeException(ex);
         }
+
+        return new MacroParserImpl(reparser, treeMaker);
     }
 
     /**
@@ -103,8 +110,6 @@ class MacroParserImpl implements JextractTask.ConstantParser {
 
     interface Reparser {
         Stream<Cursor> reparse(String snippet);
-
-        Reparser DUMMY = s -> Stream.empty();
     }
 
     /**

--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/Parser.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/Parser.java
@@ -68,7 +68,7 @@ class Parser {
             true, args.toArray(new String[0]));
 
         JextractTask.ConstantParser constantParser = this.constantParser != null ?
-                this.constantParser : new MacroParserImpl(treeMaker, tu, args);
+                this.constantParser : MacroParserImpl.make(treeMaker, tu, args);
 
         List<Declaration> decls = new ArrayList<>();
         Cursor tuCursor = tu.getCursor();


### PR DESCRIPTION
Hi,

This patch changes the error handling strategy in MacroParserImpl's constructor.

When running the tests I ran into cryptic NPEs. It turned out that this was caused due to a failure to create the default ClangReparser, which led to an exception, which led to the treeMaker and macroTable fields being left uninitialized.

This patch changes these fields to `final` to catch any future problems with not being initialized along all paths, as well as factoring out the constructor argument pre-processing into a static factory method, to more clearly show that argument pre-processing takes place when creating a MacroParserImpl instance. It also just propagates the exception thrown when creating the ClangReparser instead of trying to use a dummy reparser.

Thanks,
Jorn
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * Maurizio Cimadamore ([mcimadamore](@mcimadamore) - Committer)


### Download
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/273/head:pull/273`
`$ git checkout pull/273`
