### PR TITLE
8250798: [Test] Cleanup @modules jtreg directives for jdk_foreign tests

### DIFF
--- a/test/jdk/java/foreign/StdLibTest.java
+++ b/test/jdk/java/foreign/StdLibTest.java
@@ -23,10 +23,6 @@
 
 /*
  * @test
-  * @modules jdk.incubator.foreign/jdk.incubator.foreign.unsafe
- *          jdk.incubator.foreign/jdk.internal.foreign
- *          jdk.incubator.foreign/jdk.internal.foreign.abi
- *          java.base/sun.security.action
  * @build NativeTestHelper StdLibTest
  * @run testng/othervm -Dforeign.restricted=permit StdLibTest
  */

--- a/test/jdk/java/foreign/TestAdaptVarHandles.java
+++ b/test/jdk/java/foreign/TestAdaptVarHandles.java
@@ -24,7 +24,6 @@
 
 /*
  * @test
- * @modules jdk.incubator.foreign
  * @run testng/othervm -Djava.lang.invoke.VarHandle.VAR_HANDLE_GUARDS=true -Djava.lang.invoke.VarHandle.VAR_HANDLE_IDENTITY_ADAPT=false -Xverify:all TestAdaptVarHandles
  * @run testng/othervm -Djava.lang.invoke.VarHandle.VAR_HANDLE_GUARDS=true -Djava.lang.invoke.VarHandle.VAR_HANDLE_IDENTITY_ADAPT=true -Xverify:all TestAdaptVarHandles
  * @run testng/othervm -Djava.lang.invoke.VarHandle.VAR_HANDLE_GUARDS=false -Djava.lang.invoke.VarHandle.VAR_HANDLE_IDENTITY_ADAPT=false -Xverify:all TestAdaptVarHandles

--- a/test/jdk/java/foreign/TestCircularInit1.java
+++ b/test/jdk/java/foreign/TestCircularInit1.java
@@ -23,7 +23,6 @@
 
 /*
  * @test
- * @modules jdk.incubator.foreign
  * @run testng/othervm TestCircularInit1
  */
 

--- a/test/jdk/java/foreign/TestCircularInit2.java
+++ b/test/jdk/java/foreign/TestCircularInit2.java
@@ -23,7 +23,6 @@
 
 /*
  * @test
- * @modules jdk.incubator.foreign
  * @run testng/othervm TestCircularInit2
  */
 

--- a/test/jdk/java/foreign/TestDowncall.java
+++ b/test/jdk/java/foreign/TestDowncall.java
@@ -24,10 +24,6 @@
 
 /*
  * @test
- * @modules jdk.incubator.foreign/jdk.incubator.foreign.unsafe
- *          jdk.incubator.foreign/jdk.internal.foreign
- *          jdk.incubator.foreign/jdk.internal.foreign.abi
- *          java.base/sun.security.action
  * @build NativeTestHelper CallGeneratorHelper TestDowncall
  *
  * @run testng/othervm

--- a/test/jdk/java/foreign/TestIntrinsics.java
+++ b/test/jdk/java/foreign/TestIntrinsics.java
@@ -23,10 +23,6 @@
 
 /*
  * @test
- * @modules jdk.incubator.foreign/jdk.incubator.foreign.unsafe
- *          jdk.incubator.foreign/jdk.internal.foreign
- *          jdk.incubator.foreign/jdk.internal.foreign.abi
- *          java.base/sun.security.action
  * @build NativeTestHelper
  * @run testng/othervm
  *   -Djdk.internal.foreign.ProgrammableInvoker.USE_SPEC=true

--- a/test/jdk/java/foreign/TestNative.java
+++ b/test/jdk/java/foreign/TestNative.java
@@ -24,7 +24,6 @@
 
 /*
  * @test
- * @modules jdk.incubator.foreign/jdk.internal.foreign
  * @run testng/othervm -Dforeign.restricted=permit TestNative
  */
 

--- a/test/jdk/java/foreign/TestNoForeignUnsafeOverride.java
+++ b/test/jdk/java/foreign/TestNoForeignUnsafeOverride.java
@@ -23,8 +23,6 @@
 
 /*
  * @test
- * @modules java.base/jdk.internal.misc
- *          jdk.incubator.foreign/jdk.internal.foreign
  * @run testng TestNoForeignUnsafeOverride
  */
 

--- a/test/jdk/java/foreign/TestUpcall.java
+++ b/test/jdk/java/foreign/TestUpcall.java
@@ -24,10 +24,6 @@
 
 /*
  * @test
-  * @modules jdk.incubator.foreign/jdk.incubator.foreign.unsafe
- *          jdk.incubator.foreign/jdk.internal.foreign
- *          jdk.incubator.foreign/jdk.internal.foreign.abi
- *          java.base/sun.security.action
  * @build NativeTestHelper CallGeneratorHelper TestUpcall
  *
  * @run testng/othervm

--- a/test/jdk/java/foreign/TestVarArgs.java
+++ b/test/jdk/java/foreign/TestVarArgs.java
@@ -24,10 +24,6 @@
 
 /*
  * @test
- * @modules jdk.incubator.foreign/jdk.incubator.foreign.unsafe
- *          jdk.incubator.foreign/jdk.internal.foreign
- *          jdk.incubator.foreign/jdk.internal.foreign.abi
- *          java.base/sun.security.action
  * @run testng/othervm -Dforeign.restricted=permit TestVarArgs
  */
 

--- a/test/jdk/java/foreign/callarranger/TestAarch64CallArranger.java
+++ b/test/jdk/java/foreign/callarranger/TestAarch64CallArranger.java
@@ -24,9 +24,7 @@
 
 /*
  * @test
- * @modules java.base/sun.nio.ch
- *          jdk.incubator.foreign/jdk.internal.foreign
- *          jdk.incubator.foreign/jdk.internal.foreign.abi
+ * @modules jdk.incubator.foreign/jdk.internal.foreign.abi
  *          jdk.incubator.foreign/jdk.internal.foreign.abi.aarch64
  * @build CallArrangerTestBase
  * @run testng TestAarch64CallArranger

--- a/test/jdk/java/foreign/callarranger/TestSysVCallArranger.java
+++ b/test/jdk/java/foreign/callarranger/TestSysVCallArranger.java
@@ -24,9 +24,7 @@
 
 /*
  * @test
- * @modules java.base/sun.nio.ch
- *          jdk.incubator.foreign/jdk.internal.foreign
- *          jdk.incubator.foreign/jdk.internal.foreign.abi
+ * @modules jdk.incubator.foreign/jdk.internal.foreign.abi
  *          jdk.incubator.foreign/jdk.internal.foreign.abi.x64
  *          jdk.incubator.foreign/jdk.internal.foreign.abi.x64.sysv
  * @build CallArrangerTestBase

--- a/test/jdk/java/foreign/callarranger/TestWindowsCallArranger.java
+++ b/test/jdk/java/foreign/callarranger/TestWindowsCallArranger.java
@@ -24,9 +24,7 @@
 
 /*
  * @test
- * @modules java.base/sun.nio.ch
- *          jdk.incubator.foreign/jdk.internal.foreign
- *          jdk.incubator.foreign/jdk.internal.foreign.abi
+ * @modules jdk.incubator.foreign/jdk.internal.foreign.abi
  *          jdk.incubator.foreign/jdk.internal.foreign.abi.x64
  *          jdk.incubator.foreign/jdk.internal.foreign.abi.x64.windows
  * @build CallArrangerTestBase


### PR DESCRIPTION
@module jdk.incubator.foreign is not needed as that's specified in test/jdk/java/foreign/TEST.properties.
Remove directives to export unused internal API.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [JDK-8250798](https://bugs.openjdk.java.net/browse/JDK-8250798): [Test] Cleanup @modules jtreg directives for jdk_foreign tests


### Reviewers
 * Athijegannathan Sundararajan ([sundar](@sundararajana) - Committer)


### Download
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/274/head:pull/274`
`$ git checkout pull/274`
