### PR TITLE
8251047: GC stackwalking doesn't work when intrinsics are enabled

### DIFF
--- a/src/hotspot/cpu/x86/frame_x86.cpp
+++ b/src/hotspot/cpu/x86/frame_x86.cpp
@@ -343,6 +343,11 @@ frame frame::sender_for_entry_frame(RegisterMap* map) const {
   assert(map->include_argument_oops(), "should be set by clear");
   vmassert(jfa->last_Java_pc() != NULL, "not walkable");
   frame fr(jfa->last_Java_sp(), jfa->last_Java_fp(), jfa->last_Java_pc());
+
+  if (jfa->saved_rbp_address()) {
+    update_map_with_saved_link(map, jfa->saved_rbp_address());
+  }
+
   return fr;
 }
 

--- a/src/hotspot/cpu/x86/javaFrameAnchor_x86.hpp
+++ b/src/hotspot/cpu/x86/javaFrameAnchor_x86.hpp
@@ -30,6 +30,9 @@ private:
   // FP value associated with _last_Java_sp:
   intptr_t* volatile        _last_Java_fp;           // pointer is volatile not what it points to
 
+  // (Optional) location of saved RBP register, which GCs want to inspect
+  intptr_t** volatile _saved_rbp_address;
+
 public:
   // Each arch must define reset, save, restore
   // These are used by objects that only care about:
@@ -43,6 +46,7 @@ public:
     // fence?
     _last_Java_fp = NULL;
     _last_Java_pc = NULL;
+    _saved_rbp_address = NULL;
   }
 
   void copy(JavaFrameAnchor* src) {
@@ -60,6 +64,8 @@ public:
     _last_Java_pc = src->_last_Java_pc;
     // Must be last so profiler will always see valid frame if has_last_frame() is true
     _last_Java_sp = src->_last_Java_sp;
+
+    _saved_rbp_address = src->_saved_rbp_address;
   }
 
   bool walkable(void)                            { return _last_Java_sp != NULL && _last_Java_pc != NULL; }
@@ -70,9 +76,12 @@ public:
 
   address last_Java_pc(void)                     { return _last_Java_pc; }
 
+  intptr_t** saved_rbp_address(void) const       { return _saved_rbp_address; }
+
 private:
 
   static ByteSize last_Java_fp_offset()          { return byte_offset_of(JavaFrameAnchor, _last_Java_fp); }
+  static ByteSize saved_rbp_address_offset()     { return byte_offset_of(JavaFrameAnchor, _saved_rbp_address); }
 
 public:
 

--- a/src/hotspot/cpu/x86/macroAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/macroAssembler_x86.cpp
@@ -2678,6 +2678,7 @@ void MacroAssembler::reset_last_Java_frame(Register java_thread, bool clear_fp) 
   }
   // Always clear the pc because it could have been set by make_walkable()
   movslq(Address(java_thread, JavaThread::last_Java_pc_offset()), NULL_WORD);
+  movslq(Address(java_thread, JavaThread::saved_rbp_address_offset()), NULL_WORD);
   vzeroupper();
 }
 

--- a/src/hotspot/cpu/x86/sharedRuntime_x86_64.cpp
+++ b/src/hotspot/cpu/x86/sharedRuntime_x86_64.cpp
@@ -3766,14 +3766,15 @@ void NativeInvokerGenerator::generate() {
   MacroAssembler* masm = _masm;
   __ enter();
 
-  Address java_pc(r15_thread,
-                  JavaThread::frame_anchor_offset() + JavaFrameAnchor::last_Java_pc_offset());
+  Address java_pc(r15_thread, JavaThread::last_Java_pc_offset());
   __ movptr(rscratch1, Address(rsp, 8)); // read return address from stack
   __ movptr(java_pc, rscratch1);
 
   __ movptr(rscratch1, rsp);
-  __ addptr(rscratch1, 16);
+  __ addptr(rscratch1, 16); // skip return and frame
   __ movptr(Address(r15_thread, JavaThread::last_Java_sp_offset()), rscratch1);
+
+  __ movptr(Address(r15_thread, JavaThread::saved_rbp_address_offset()), rsp); // rsp points at saved RBP
 
     // State transition
   __ movl(Address(r15_thread, JavaThread::thread_state_offset()), _thread_in_native);

--- a/src/hotspot/share/c1/c1_IR.hpp
+++ b/src/hotspot/share/c1/c1_IR.hpp
@@ -244,7 +244,7 @@ class IRScopeDebugInfo: public CompilationResourceObj {
     bool reexecute = topmost ? should_reexecute() : false;
     bool return_oop = false; // This flag will be ignored since it used only for C2 with escape analysis.
     bool rethrow_exception = false;
-    recorder->describe_scope(pc_offset, methodHandle(), scope()->method(), bci(), reexecute, rethrow_exception, is_method_handle_invoke, return_oop, locvals, expvals, monvals);
+    recorder->describe_scope(pc_offset, methodHandle(), scope()->method(), bci(), reexecute, rethrow_exception, is_method_handle_invoke, false /* is opt native */, return_oop, locvals, expvals, monvals);
   }
 };
 

--- a/src/hotspot/share/code/compiledMethod.cpp
+++ b/src/hotspot/share/code/compiledMethod.cpp
@@ -357,6 +357,7 @@ void CompiledMethod::preserve_callee_argument_oops(frame fr, const RegisterMap *
   if (method() != NULL && !method()->is_native()) {
     address pc = fr.pc();
     SimpleScopeDesc ssd(this, pc);
+    if (ssd.is_optimized_linkToNative()) return; // call was replaced
     Bytecode_invoke call(methodHandle(Thread::current(), ssd.method()), ssd.bci());
     bool has_receiver = call.has_receiver();
     bool has_appendix = call.has_appendix();

--- a/src/hotspot/share/code/debugInfoRec.cpp
+++ b/src/hotspot/share/code/debugInfoRec.cpp
@@ -286,6 +286,7 @@ void DebugInformationRecorder::describe_scope(int         pc_offset,
                                               bool        reexecute,
                                               bool        rethrow_exception,
                                               bool        is_method_handle_invoke,
+                                              bool        is_optimized_linkToNative,
                                               bool        return_oop,
                                               DebugToken* locals,
                                               DebugToken* expressions,
@@ -302,6 +303,7 @@ void DebugInformationRecorder::describe_scope(int         pc_offset,
   last_pd->set_should_reexecute(reexecute);
   last_pd->set_rethrow_exception(rethrow_exception);
   last_pd->set_is_method_handle_invoke(is_method_handle_invoke);
+  last_pd->set_is_optimized_linkToNative(is_optimized_linkToNative);
   last_pd->set_return_oop(return_oop);
 
   // serialize sender stream offest

--- a/src/hotspot/share/code/debugInfoRec.hpp
+++ b/src/hotspot/share/code/debugInfoRec.hpp
@@ -104,6 +104,7 @@ class DebugInformationRecorder: public ResourceObj {
                       bool        reexecute,
                       bool        rethrow_exception = false,
                       bool        is_method_handle_invoke = false,
+                      bool        is_optimized_linkToNative = false,
                       bool        return_oop = false,
                       DebugToken* locals      = NULL,
                       DebugToken* expressions = NULL,

--- a/src/hotspot/share/code/pcDesc.hpp
+++ b/src/hotspot/share/code/pcDesc.hpp
@@ -39,10 +39,11 @@ class PcDesc {
   int _obj_decode_offset;
 
   enum {
-    PCDESC_reexecute               = 1 << 0,
-    PCDESC_is_method_handle_invoke = 1 << 1,
-    PCDESC_return_oop              = 1 << 2,
-    PCDESC_rethrow_exception       = 1 << 3
+    PCDESC_reexecute                 = 1 << 0,
+    PCDESC_is_method_handle_invoke   = 1 << 1,
+    PCDESC_return_oop                = 1 << 2,
+    PCDESC_rethrow_exception         = 1 << 3,
+    PCDESC_is_optimized_linkToNative = 1 << 4
   };
 
   int _flags;
@@ -85,6 +86,9 @@ class PcDesc {
 
   bool     is_method_handle_invoke()       const { return (_flags & PCDESC_is_method_handle_invoke) != 0;     }
   void set_is_method_handle_invoke(bool z)       { set_flag(PCDESC_is_method_handle_invoke, z); }
+
+  bool     is_optimized_linkToNative()     const { return (_flags & PCDESC_is_optimized_linkToNative) != 0;     }
+  void set_is_optimized_linkToNative(bool z)     { set_flag(PCDESC_is_optimized_linkToNative, z); }
 
   bool     return_oop()                    const { return (_flags & PCDESC_return_oop) != 0;     }
   void set_return_oop(bool z)                    { set_flag(PCDESC_return_oop, z); }

--- a/src/hotspot/share/code/scopeDesc.hpp
+++ b/src/hotspot/share/code/scopeDesc.hpp
@@ -39,11 +39,14 @@ class SimpleScopeDesc : public StackObj {
  private:
   Method* _method;
   int _bci;
+  bool _is_optimized_linkToNative;
 
  public:
   SimpleScopeDesc(CompiledMethod* code, address pc) {
     PcDesc* pc_desc = code->pc_desc_at(pc);
     assert(pc_desc != NULL, "Must be able to find matching PcDesc");
+    // save this here so we only have to look up the PcDesc once
+    _is_optimized_linkToNative = pc_desc->is_optimized_linkToNative();
     DebugInfoReadStream buffer(code, pc_desc->scope_decode_offset());
     int ignore_sender = buffer.read_int();
     _method           = buffer.read_method();
@@ -52,6 +55,7 @@ class SimpleScopeDesc : public StackObj {
 
   Method* method() { return _method; }
   int bci() { return _bci; }
+  bool is_optimized_linkToNative() { return _is_optimized_linkToNative; }
 };
 
 // ScopeDescs contain the information that makes source-level debugging of

--- a/src/hotspot/share/jvmci/jvmciCodeInstaller.cpp
+++ b/src/hotspot/share/jvmci/jvmciCodeInstaller.cpp
@@ -1181,7 +1181,7 @@ void CodeInstaller::record_scope(jint pc_offset, JVMCIObject position, ScopeMode
     throw_exception = jvmci_env()->get_BytecodeFrame_rethrowException(frame) == JNI_TRUE;
   }
 
-  _debug_recorder->describe_scope(pc_offset, method, NULL, bci, reexecute, throw_exception, false, return_oop,
+  _debug_recorder->describe_scope(pc_offset, method, NULL, bci, reexecute, throw_exception, false, false, return_oop,
                                   locals_token, expressions_token, monitors_token);
 }
 

--- a/src/hotspot/share/opto/lcm.cpp
+++ b/src/hotspot/share/opto/lcm.cpp
@@ -878,7 +878,14 @@ uint PhaseCFG::sched_call(Block* block, uint node_cnt, Node_List& worklist, Grow
   // done for oops since idealreg2debugmask takes care of debug info
   // references but there no way to handle oops differently than other
   // pointers as far as the kill mask goes.
-  bool exclude_soe = op == Op_CallRuntime || op == Op_CallNative;
+  //
+  // Also, native callees can not save oops, so we kill the SOE registers
+  // here in case a native call has a safepoint. This doesn't work for
+  // RBP though, which seems to be special-cased elsewhere to always be
+  // treated as alive, so we instead manually save the location of RBP
+  // before doing the native call (see NativeInvokerGenerator::generate).
+  bool exclude_soe = op == Op_CallRuntime
+    || (op == Op_CallNative && mcall->guaranteed_safepoint());
 
   // If the call is a MethodHandle invoke, we need to exclude the
   // register which is used to save the SP value over MH invokes from

--- a/src/hotspot/share/opto/lcm.cpp
+++ b/src/hotspot/share/opto/lcm.cpp
@@ -878,7 +878,7 @@ uint PhaseCFG::sched_call(Block* block, uint node_cnt, Node_List& worklist, Grow
   // done for oops since idealreg2debugmask takes care of debug info
   // references but there no way to handle oops differently than other
   // pointers as far as the kill mask goes.
-  bool exclude_soe = op == Op_CallRuntime;
+  bool exclude_soe = op == Op_CallRuntime || op == Op_CallNative;
 
   // If the call is a MethodHandle invoke, we need to exclude the
   // register which is used to save the SP value over MH invokes from

--- a/src/hotspot/share/opto/output.cpp
+++ b/src/hotspot/share/opto/output.cpp
@@ -1068,7 +1068,20 @@ void PhaseOutput::Process_OopMap_Node(MachNode *mach, int current_offset) {
     // Now we can describe the scope.
     methodHandle null_mh;
     bool rethrow_exception = false;
-    C->debug_info()->describe_scope(safepoint_pc_offset, null_mh, scope_method, jvms->bci(), jvms->should_reexecute(), rethrow_exception, is_method_handle_invoke, return_oop, locvals, expvals, monvals);
+    C->debug_info()->describe_scope(
+      safepoint_pc_offset,
+      null_mh,
+      scope_method,
+      jvms->bci(),
+      jvms->should_reexecute(),
+      rethrow_exception,
+      is_method_handle_invoke,
+      mach->is_MachCallNative(),
+      return_oop,
+      locvals,
+      expvals,
+      monvals
+    );
   } // End jvms loop
 
   // Mark the end of the scope set.

--- a/src/hotspot/share/runtime/frame.cpp
+++ b/src/hotspot/share/runtime/frame.cpp
@@ -939,6 +939,7 @@ class CompiledArgumentOopFinder: public SignatureIterator {
     // In LP64-land, the high-order bits are valid but unhelpful.
     VMReg reg = _regs[_offset].first();
     oop *loc = _fr.oopmapreg_to_location(reg, _reg_map);
+    assert(loc != NULL, "missing register map entry");
     _f->do_oop(loc);
   }
 

--- a/src/hotspot/share/runtime/thread.hpp
+++ b/src/hotspot/share/runtime/thread.hpp
@@ -1792,6 +1792,10 @@ class JavaThread: public Thread {
   static ByteSize frame_anchor_offset() {
     return byte_offset_of(JavaThread, _anchor);
   }
+  static ByteSize saved_rbp_address_offset() {
+    return byte_offset_of(JavaThread, _anchor) + JavaFrameAnchor::saved_rbp_address_offset();
+  }
+
   static ByteSize callee_target_offset()         { return byte_offset_of(JavaThread, _callee_target); }
   static ByteSize vm_result_offset()             { return byte_offset_of(JavaThread, _vm_result); }
   static ByteSize vm_result_2_offset()           { return byte_offset_of(JavaThread, _vm_result_2); }


### PR DESCRIPTION
Hi,

This patch fixes GC stack walking for optimized native calls.

For calls in compiled frames, the callee argument oops are processed using special case code in `CompiledMethod::preserve_callee_argument_oops`. This code relies on the original bytecode to find the signature of the callee, but for optimized native calls this doesn't make sense, since the original call is replaced, and some of the arguments (notably some that are oops) are discarded. In the case of an optimized native call, we can skip all callee argument oop processing, since we can't pass any oops to native calls any ways.

Since the current code was already looking at debug info to find the signature of the callee, I piggy-backed on that to add a flag for optimized native calls. If the flag is set, we return early, skipping any processing.

(I left in the assert I used to debug this, since it gives the failure a better error message, should we run into this again in the future)

Thanks,
Jorn
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [JDK-8251047](https://bugs.openjdk.java.net/browse/JDK-8251047): GC stackwalking doesn't work when intrinsics are enabled


### Reviewers
 * Maurizio Cimadamore ([mcimadamore](@mcimadamore) - Committer) ⚠️ Review applies to 67d7c0a5384ea4e3ad94f4bb27c8d9600b66c017


### Download
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/279/head:pull/279`
`$ git checkout pull/279`
