### PR TITLE
8248421: CSupport should have a way to free memory allocated outside Java

### DIFF
--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/CSupport.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/CSupport.java
@@ -882,4 +882,14 @@ public class CSupport {
         copy(addr, bytes);
         return addr;
     }
+
+    /**
+     * Free the memory pointed by the given memory address.
+     *
+     * @param addr memory address of the native memory to be freed
+     */
+    public static void freeMemoryRestricted(MemoryAddress addr) {
+        Utils.checkRestrictedAccess("CSupport.freeMemoryRestricted");
+        SharedUtils.freeMemoryInternal(addr);
+    }
 }

--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/CSupport.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/CSupport.java
@@ -884,6 +884,17 @@ public class CSupport {
     }
 
     /**
+     * Allocate memory of given size using malloc.
+     *
+     * @param size memory size to be allocated
+     * @return addr memory address of the allocated memory
+     */
+    public static MemoryAddress allocateMemoryRestricted(long size) {
+        Utils.checkRestrictedAccess("CSupport.allocateMemoryRestricted");
+        return SharedUtils.allocateMemoryInternal(size);
+    }
+
+    /**
      * Free the memory pointed by the given memory address.
      *
      * @param addr memory address of the native memory to be freed

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/SharedUtils.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/SharedUtils.java
@@ -269,13 +269,18 @@ public class SharedUtils {
         throw new IllegalArgumentException("String too large");
     }
 
-    // lazy init MH_FREE handle
-    private static class FreeHolder {
-        private static final MethodHandle MH_FREE;
+    // lazy init MH_ALLOC and MH_FREE handles
+    private static class AllocHolder {
+        static final MethodHandle MH_MALLOC;
+        static final MethodHandle MH_FREE;
 
         static {
             LibraryLookup lookup = LibraryLookup.ofDefault();
             try {
+                MH_MALLOC = getSystemLinker().downcallHandle(lookup.lookup("malloc"),
+                        MethodType.methodType(MemoryAddress.class, long.class),
+                        FunctionDescriptor.of(C_POINTER, C_LONGLONG));
+
                 MH_FREE = getSystemLinker().downcallHandle(lookup.lookup("free"),
                         MethodType.methodType(void.class, MemoryAddress.class),
                         FunctionDescriptor.ofVoid(C_POINTER));
@@ -285,9 +290,17 @@ public class SharedUtils {
         }
     }
 
+    public static MemoryAddress allocateMemoryInternal(long size) {
+        try {
+            return (MemoryAddress) AllocHolder.MH_MALLOC.invokeExact(size);
+        } catch (Throwable th) {
+            throw new RuntimeException(th);
+        }
+    }
+
     public static void freeMemoryInternal(MemoryAddress addr) {
         try {
-            FreeHolder.MH_FREE.invokeExact(addr);
+            AllocHolder.MH_FREE.invokeExact(addr);
         } catch (Throwable th) {
             throw new RuntimeException(th);
         }

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/SharedUtils.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/SharedUtils.java
@@ -33,6 +33,7 @@ import jdk.incubator.foreign.MemoryAddress;
 import jdk.incubator.foreign.MemoryHandles;
 import jdk.incubator.foreign.MemoryLayout;
 import jdk.incubator.foreign.MemorySegment;
+import jdk.incubator.foreign.LibraryLookup;
 import jdk.incubator.foreign.NativeScope;
 import jdk.incubator.foreign.SequenceLayout;
 import jdk.incubator.foreign.ValueLayout;
@@ -268,6 +269,29 @@ public class SharedUtils {
         throw new IllegalArgumentException("String too large");
     }
 
+    // lazy init MH_FREE handle
+    private static class FreeHolder {
+        private static final MethodHandle MH_FREE;
+
+        static {
+            LibraryLookup lookup = LibraryLookup.ofDefault();
+            try {
+                MH_FREE = getSystemLinker().downcallHandle(lookup.lookup("free"),
+                        MethodType.methodType(void.class, MemoryAddress.class),
+                        FunctionDescriptor.ofVoid(C_POINTER));
+            } catch (NoSuchMethodException nsme) {
+                throw new BootstrapMethodError(nsme);
+            }
+        }
+    }
+
+    public static void freeMemoryInternal(MemoryAddress addr) {
+        try {
+            FreeHolder.MH_FREE.invokeExact(addr);
+        } catch (Throwable th) {
+            throw new RuntimeException(th);
+        }
+    }
 
     public static VaList newVaList(Consumer<VaList.Builder> actions, Allocator allocator) {
         String name = CSupport.getSystemLinker().name();

--- a/test/jdk/java/foreign/TestFree.java
+++ b/test/jdk/java/foreign/TestFree.java
@@ -1,0 +1,64 @@
+/*
+ *  Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ *  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ *  This code is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License version 2 only, as
+ *  published by the Free Software Foundation.
+ *
+ *  This code is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ *  version 2 for more details (a copy is included in the LICENSE file that
+ *  accompanied this code).
+ *
+ *  You should have received a copy of the GNU General Public License version
+ *  2 along with this work; if not, write to the Free Software Foundation,
+ *  Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ *   Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ *  or visit www.oracle.com if you need additional information or have any
+ *  questions.
+ *
+ */
+
+/*
+ * @test
+ * @bug 8248421
+ * @summary CSupport should have a way to free memory allocated outside Java
+ * @run testng/othervm -Dforeign.restricted=permit TestFree
+ */
+
+import jdk.incubator.foreign.FunctionDescriptor;
+import jdk.incubator.foreign.LibraryLookup;
+import jdk.incubator.foreign.MemoryAccess;
+import jdk.incubator.foreign.MemoryAddress;
+import jdk.incubator.foreign.MemoryLayout;
+import jdk.incubator.foreign.MemorySegment;
+import jdk.incubator.foreign.ForeignLinker;
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodType;
+import static jdk.incubator.foreign.CSupport.*;
+import static org.testng.Assert.assertEquals;
+
+public class TestFree {
+    private static MemorySegment asArrayRestricted(MemoryAddress addr, MemoryLayout layout, int numElements) {
+        return MemorySegment.ofNativeRestricted(addr, numElements * layout.byteSize(),
+               Thread.currentThread(), null, null);
+    }
+
+    public void test() throws Throwable {
+        LibraryLookup lib = LibraryLookup.ofDefault();
+        ForeignLinker abi = getSystemLinker();
+        MethodHandle malloc = getSystemLinker().downcallHandle(lib.lookup("malloc"),
+                    MethodType.methodType(void.class, MemoryAddress.class),
+                    FunctionDescriptor.of(C_POINTER, C_INT));
+        String str = "hello world";
+        MemoryAddress addr = (MemoryAddress)malloc.invokeExact(str.length() + 1);
+        MemorySegment seg = asArrayRestricted(addr, C_CHAR, str.length() + 1);
+        seg.copyFrom(MemorySegment.ofArray(str.getBytes()));
+        MemoryAccess.setByteAtOffset(seg, str.length(), (byte)0);
+        assertEquals(str, toJavaString(seg));
+        freeMemoryRestricted(addr);
+    }
+}

--- a/test/jdk/java/foreign/TestFree.java
+++ b/test/jdk/java/foreign/TestFree.java
@@ -29,15 +29,10 @@
  * @run testng/othervm -Dforeign.restricted=permit TestFree
  */
 
-import jdk.incubator.foreign.FunctionDescriptor;
-import jdk.incubator.foreign.LibraryLookup;
 import jdk.incubator.foreign.MemoryAccess;
 import jdk.incubator.foreign.MemoryAddress;
 import jdk.incubator.foreign.MemoryLayout;
 import jdk.incubator.foreign.MemorySegment;
-import jdk.incubator.foreign.ForeignLinker;
-import java.lang.invoke.MethodHandle;
-import java.lang.invoke.MethodType;
 import static jdk.incubator.foreign.CSupport.*;
 import static org.testng.Assert.assertEquals;
 
@@ -48,13 +43,8 @@ public class TestFree {
     }
 
     public void test() throws Throwable {
-        LibraryLookup lib = LibraryLookup.ofDefault();
-        ForeignLinker abi = getSystemLinker();
-        MethodHandle malloc = getSystemLinker().downcallHandle(lib.lookup("malloc"),
-                    MethodType.methodType(void.class, MemoryAddress.class),
-                    FunctionDescriptor.of(C_POINTER, C_INT));
         String str = "hello world";
-        MemoryAddress addr = (MemoryAddress)malloc.invokeExact(str.length() + 1);
+        MemoryAddress addr = allocateMemoryRestricted(str.length() + 1);
         MemorySegment seg = asArrayRestricted(addr, C_CHAR, str.length() + 1);
         seg.copyFrom(MemorySegment.ofArray(str.getBytes()));
         MemoryAccess.setByteAtOffset(seg, str.length(), (byte)0);

--- a/test/jdk/java/foreign/libNativeAccess.c
+++ b/test/jdk/java/foreign/libNativeAccess.c
@@ -115,13 +115,3 @@ JNIEXPORT jlong JNICALL
 Java_TestNative_getCapacity(JNIEnv *env, jclass cls, jobject buf) {
     return (*env)->GetDirectBufferCapacity(env, buf);
 }
-
-JNIEXPORT jlong JNICALL
-Java_TestNative_allocate(JNIEnv *env, jclass cls, jint size) {
-    return (jlong)(uintptr_t)malloc(size);
-}
-
-JNIEXPORT void JNICALL
-Java_TestNative_free(JNIEnv *env, jclass cls, jlong ptr) {
-    free((void*)(uintptr_t)ptr);
-}


### PR DESCRIPTION
Added CSupport.freeMemoryRestricted utility method.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [JDK-8248421](https://bugs.openjdk.java.net/browse/JDK-8248421): CSupport should have a way to free memory allocated outside Java


### Reviewers
 * Maurizio Cimadamore ([mcimadamore](@mcimadamore) - Committer)


### Download
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/281/head:pull/281`
`$ git checkout pull/281`
