### PR TITLE
8251049: revisit address accessors for struct fields/global variables

### DIFF
--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/ConstantHelper.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/ConstantHelper.java
@@ -201,8 +201,8 @@ public class ConstantHelper {
         return emitCondyGetter(javaName + "$MH", MethodHandle.class, methodHandleDesc(nativeName, mtype, desc, varargs));
     }
 
-    public DirectMethodHandleDesc addAddress(String javaName, String nativeName, MemoryLayout layout) {
-        return emitCondyGetter(javaName + "$ADDR", MemorySegment.class, globalVarAddressDesc(nativeName, layout));
+    public DirectMethodHandleDesc addSegment(String javaName, String nativeName, MemoryLayout layout) {
+        return emitCondyGetter(javaName + "$SEGMENT", MemorySegment.class, globalVarAddressDesc(nativeName, layout));
     }
 
     public DirectMethodHandleDesc addFunctionDesc(String javaName, FunctionDescriptor fDesc) {

--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/JavaSourceBuilder.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/JavaSourceBuilder.java
@@ -116,8 +116,8 @@ abstract class JavaSourceBuilder {
         emitForwardGetter(constantHelper.addMethodHandle(javaName, nativeName, mtype, desc, varargs));
     }
 
-    void addAddressGetter(String javaName, String nativeName, MemoryLayout layout, MemoryLayout parentLayout) {
-        emitForwardGetter(constantHelper.addAddress(javaName, nativeName, layout));
+    void addSegmentGetter(String javaName, String nativeName, MemoryLayout layout, MemoryLayout parentLayout) {
+        emitForwardGetter(constantHelper.addSegment(javaName, nativeName, layout));
     }
 
     void addConstantGetter(String javaName, Class<?> type, Object value) {
@@ -209,7 +209,7 @@ abstract class JavaSourceBuilder {
     }
 
     protected String addressGetCallString(String javaName, String nativeName, MemoryLayout layout) {
-        return getCallString(constantHelper.addAddress(javaName, nativeName, layout));
+        return getCallString(constantHelper.addSegment(javaName, nativeName, layout));
     }
 
     /*

--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/OutputFactory.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/OutputFactory.java
@@ -360,7 +360,7 @@ public class OutputFactory implements Declaration.Visitor<Void, Declaration> {
         if (parent != null) { //struct field
             MemoryLayout parentLayout = parentLayout(parent);
             if (isSegment) {
-                currentBuilder.addAddressGetter(fieldName, tree.name(), treeLayout, parentLayout);
+                currentBuilder.addSegmentGetter(fieldName, tree.name(), treeLayout, parentLayout);
             } else {
                 currentBuilder.addVarHandleGetter(fieldName, tree.name(), treeLayout, clazz, parentLayout);
                 currentBuilder.addGetter(fieldName, tree.name(), treeLayout, clazz, parentLayout);
@@ -368,11 +368,11 @@ public class OutputFactory implements Declaration.Visitor<Void, Declaration> {
             }
         } else {
             if (isSegment) {
-                toplevelBuilder.addAddressGetter(fieldName, tree.name(), treeLayout, null);
+                toplevelBuilder.addSegmentGetter(fieldName, tree.name(), treeLayout, null);
             } else {
                 toplevelBuilder.addLayoutGetter(fieldName, layout);
                 toplevelBuilder.addVarHandleGetter(fieldName, tree.name(), treeLayout, clazz,null);
-                toplevelBuilder.addAddressGetter(fieldName, tree.name(), treeLayout, null);
+                toplevelBuilder.addSegmentGetter(fieldName, tree.name(), treeLayout, null);
                 toplevelBuilder.addGetter(fieldName, tree.name(), treeLayout, clazz, null);
                 toplevelBuilder.addSetter(fieldName, tree.name(), treeLayout, clazz, null);
             }

--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/StructBuilder.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/StructBuilder.java
@@ -117,11 +117,11 @@ class StructBuilder extends JavaSourceBuilder {
     void addGetter(String javaName, String nativeName, MemoryLayout layout, Class<?> type, MemoryLayout parentLayout) {
         incrAlign();
         indent();
-        append(PUB_MODS + type.getName() + " " + javaName + "$get(MemorySegment addr) {\n");
+        append(PUB_MODS + type.getName() + " " + javaName + "$get(MemorySegment seg) {\n");
         incrAlign();
         indent();
         append("return (" + type.getName() + ")"
-                + varHandleGetCallString(javaName, nativeName, layout, type, parentLayout) + ".get(addr);\n");
+                + varHandleGetCallString(javaName, nativeName, layout, type, parentLayout) + ".get(seg);\n");
         decrAlign();
         indent();
         append("}\n");
@@ -134,11 +134,11 @@ class StructBuilder extends JavaSourceBuilder {
     void addSetter(String javaName, String nativeName, MemoryLayout layout, Class<?> type, MemoryLayout parentLayout) {
         incrAlign();
         indent();
-        String param = MemorySegment.class.getName() + " addr";
+        String param = MemorySegment.class.getName() + " seg";
         append(PUB_MODS + "void " + javaName + "$set(" + param + ", " + type.getName() + " x) {\n");
         incrAlign();
         indent();
-        append(varHandleGetCallString(javaName, nativeName, layout, type, null) + ".set(addr, x);\n");
+        append(varHandleGetCallString(javaName, nativeName, layout, type, null) + ".set(seg, x);\n");
         decrAlign();
         indent();
         append("}\n");
@@ -148,17 +148,17 @@ class StructBuilder extends JavaSourceBuilder {
     }
 
     @Override
-    void addAddressGetter(String javaName, String nativeName, MemoryLayout layout, MemoryLayout parentLayout) {
+    void addSegmentGetter(String javaName, String nativeName, MemoryLayout layout, MemoryLayout parentLayout) {
         incrAlign();
         indent();
-        append(PUB_MODS + "MemorySegment " + javaName + "$addr(MemorySegment addr) {\n");
+        append(PUB_MODS + "MemorySegment " + javaName + "$slice(MemorySegment seg) {\n");
         incrAlign();
         indent();
-        append("return addr.asSlice(");
+        append("return RuntimeHelper.nonCloseableNonTransferableSegment(seg.asSlice(");
         append(parentLayout.byteOffset(MemoryLayout.PathElement.groupElement(nativeName)));
         append(", ");
         append(layout.byteSize());
-        append(");\n");
+        append("));\n");
         decrAlign();
         indent();
         append("}\n");

--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/resources/RuntimeHelper.java.template
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/resources/RuntimeHelper.java.template
@@ -60,9 +60,13 @@ public class RuntimeHelper {
 
     public static final MemorySegment lookupGlobalVariable(LibraryLookup[] LIBRARIES, String name, MemoryLayout layout) {
         return lookup(LIBRARIES, name).map(s ->
-            MemorySegment.ofNativeRestricted(
+            nonCloseableNonTransferableSegment(MemorySegment.ofNativeRestricted(
                  s.address(), layout.byteSize(), null, null, s
-            ).withAccessModes(MemorySegment.READ | MemorySegment.WRITE)).orElse(null);
+            ))).orElse(null);
+    }
+
+    public static final MemorySegment nonCloseableNonTransferableSegment(MemorySegment seg) {
+        return seg.withAccessModes(seg.accessModes() &  ~MemorySegment.CLOSE & ~MemorySegment.HANDOFF);
     }
 
     public static final MethodHandle downcallHandle(LibraryLookup[] LIBRARIES, String name, String desc, FunctionDescriptor fdesc, boolean variadic) {

--- a/test/jdk/tools/jextract/test8244938/Test8244938.java
+++ b/test/jdk/tools/jextract/test8244938/Test8244938.java
@@ -40,8 +40,8 @@ public class Test8244938 {
          var seg = func();
          assertEquals(seg.byteSize(), Point.sizeof());
          assertEquals(Point.k$get(seg), 44);
-         var point2dAddr = Point.point2d$addr(seg);
-         assertEquals(Point2D.i$get(point2dAddr), 567);
-         assertEquals(Point2D.j$get(point2dAddr), 33);
+         var point2dSeg = Point.point2d$slice(seg);
+         assertEquals(Point2D.i$get(point2dSeg), 567);
+         assertEquals(Point2D.j$get(point2dSeg), 33);
     }
 }

--- a/test/jdk/tools/jextract/test8245003/Test8245003.java
+++ b/test/jdk/tools/jextract/test8245003/Test8245003.java
@@ -22,8 +22,10 @@
  */
 
 import org.testng.annotations.Test;
+import jdk.incubator.foreign.MemorySegment;
 import test.jextract.test8245003.*;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
 import static test.jextract.test8245003.test8245003_h.*;
 import static jdk.incubator.foreign.CSupport.*;
 
@@ -37,27 +39,34 @@ import static jdk.incubator.foreign.CSupport.*;
  * @run testng/othervm -Dforeign.restricted=permit Test8245003
  */
 public class Test8245003 {
+    private void checkAccess(MemorySegment seg) {
+        assertFalse(seg.hasAccessModes(MemorySegment.CLOSE | MemorySegment.HANDOFF));
+    }
+
     @Test
     public void testStructAccessor() {
-        var addr = special_pt$ADDR();
-        assertEquals(addr.byteSize(), Point.sizeof());
-        assertEquals(Point.x$get(addr), 56);
-        assertEquals(Point.y$get(addr), 75);
+        var seg = special_pt$SEGMENT();
+        checkAccess(seg);
+        assertEquals(seg.byteSize(), Point.sizeof());
+        assertEquals(Point.x$get(seg), 56);
+        assertEquals(Point.y$get(seg), 75);
 
-        addr = special_pt3d$ADDR();
-        assertEquals(addr.byteSize(), Point3D.sizeof());
-        assertEquals(Point3D.z$get(addr), 35);
-        var pointAddr = Point3D.p$addr(addr);
-        assertEquals(pointAddr.byteSize(), Point.sizeof());
-        assertEquals(Point.x$get(pointAddr), 43);
-        assertEquals(Point.y$get(pointAddr), 45);
+        seg = special_pt3d$SEGMENT();
+        checkAccess(seg);
+        assertEquals(seg.byteSize(), Point3D.sizeof());
+        assertEquals(Point3D.z$get(seg), 35);
+        var pointSeg = Point3D.p$slice(seg);
+        assertEquals(pointSeg.byteSize(), Point.sizeof());
+        assertEquals(Point.x$get(pointSeg), 43);
+        assertEquals(Point.y$get(pointSeg), 45);
+        checkAccess(pointSeg);
     }
 
     @Test
     public void testArrayAccessor() {
-        var addr = iarr$ADDR();
-        assertEquals(addr.byteSize(), C_INT.byteSize()*5);
-        int[] arr = addr.toIntArray();
+        var seg = iarr$SEGMENT();
+        assertEquals(seg.byteSize(), C_INT.byteSize()*5);
+        int[] arr = seg.toIntArray();
         assertEquals(arr.length, 5);
         assertEquals(arr[0], 2);
         assertEquals(arr[1], -2);
@@ -65,10 +74,10 @@ public class Test8245003 {
         assertEquals(arr[3], -42);
         assertEquals(arr[4], 345);
 
-        addr = foo$ADDR();
-        assertEquals(addr.byteSize(), Foo.sizeof());
-        assertEquals(Foo.count$get(addr), 37);
-        var greeting = Foo.greeting$addr(addr);
+        seg = foo$SEGMENT();
+        assertEquals(seg.byteSize(), Foo.sizeof());
+        assertEquals(Foo.count$get(seg), 37);
+        var greeting = Foo.greeting$slice(seg);
         byte[] barr = greeting.toByteArray();
         assertEquals(new String(barr), "hello");
     }

--- a/test/jdk/tools/jextract/testClassGen/TestClassGeneration.java
+++ b/test/jdk/tools/jextract/testClassGen/TestClassGeneration.java
@@ -178,7 +178,7 @@ public class TestClassGeneration extends JextractToolRunner {
         Method layout_getter = checkMethod(cls, name + "$LAYOUT", MemoryLayout.class);
         assertEquals(layout_getter.invoke(null), expectedLayout);
 
-        Method addr_getter = checkMethod(cls, name + "$ADDR", MemorySegment.class);
+        Method addr_getter = checkMethod(cls, name + "$SEGMENT", MemorySegment.class);
         MemorySegment segment = (MemorySegment)addr_getter.invoke(null);
 
         Method vh_getter = checkMethod(cls, name + "$VH", VarHandle.class);


### PR DESCRIPTION
* Non-cloneable, non-transferable segments are returned now
* $ADDR/$addr methods renamed as $SEGMENT/$slice respectively
* Existing test is modified to add check for segment access mode
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [JDK-8251049](https://bugs.openjdk.java.net/browse/JDK-8251049): revisit address accessors for struct fields/global variables


### Reviewers
 * Maurizio Cimadamore ([mcimadamore](@mcimadamore) - Committer)


### Download
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/282/head:pull/282`
`$ git checkout pull/282`
