### PR TITLE
8251943: jextract should not generate MemorySegment typed fields for variables, struct fields if layout size info is not available

### DIFF
--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/OutputFactory.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/OutputFactory.java
@@ -250,7 +250,7 @@ public class OutputFactory implements Declaration.Visitor<Void, Declaration> {
                 name = Utils.javaSafeIdentifier(name);
                 //generate functional interface
                 if (f.varargs()) {
-                    System.err.println("WARNING: varargs in callbacks is not supported");
+                    warn("varargs in callbacks is not supported");
                 }
                 MethodType fitype = typeTranslator.getMethodType(f, false);
                 toplevelBuilder.addFunctionalInterface(name, fitype, Type.descriptorFor(f).orElseThrow());
@@ -351,25 +351,40 @@ public class OutputFactory implements Declaration.Visitor<Void, Declaration> {
         }
 
         boolean isSegment = clazz == MemorySegment.class;
+        boolean sizeAvailable;
+        try {
+            layout.byteSize();
+            sizeAvailable = true;
+        } catch (Exception ignored) {
+            sizeAvailable = false;
+        }
         MemoryLayout treeLayout = tree.layout().orElseThrow();
         if (parent != null) { //struct field
             MemoryLayout parentLayout = parentLayout(parent);
             if (isSegment) {
-                currentBuilder.addSegmentGetter(fieldName, tree.name(), treeLayout, parentLayout);
+                if (sizeAvailable) {
+                    currentBuilder.addSegmentGetter(fieldName, tree.name(), treeLayout, parentLayout);
+                } else {
+                    warn("Layout size not available for " + fieldName);
+                }
             } else {
                 currentBuilder.addVarHandleGetter(fieldName, tree.name(), treeLayout, clazz, parentLayout);
                 currentBuilder.addGetter(fieldName, tree.name(), treeLayout, clazz, parentLayout);
                 currentBuilder.addSetter(fieldName, tree.name(), treeLayout, clazz, parentLayout);
             }
         } else {
-            if (isSegment) {
-                toplevelBuilder.addSegmentGetter(fieldName, tree.name(), treeLayout, null);
+            if (sizeAvailable) {
+                if (isSegment) {
+                    toplevelBuilder.addSegmentGetter(fieldName, tree.name(), treeLayout, null);
+                } else {
+                    toplevelBuilder.addLayoutGetter(fieldName, layout);
+                    toplevelBuilder.addVarHandleGetter(fieldName, tree.name(), treeLayout, clazz,null);
+                    toplevelBuilder.addSegmentGetter(fieldName, tree.name(), treeLayout, null);
+                    toplevelBuilder.addGetter(fieldName, tree.name(), treeLayout, clazz, null);
+                    toplevelBuilder.addSetter(fieldName, tree.name(), treeLayout, clazz, null);
+                }
             } else {
-                toplevelBuilder.addLayoutGetter(fieldName, layout);
-                toplevelBuilder.addVarHandleGetter(fieldName, tree.name(), treeLayout, clazz,null);
-                toplevelBuilder.addSegmentGetter(fieldName, tree.name(), treeLayout, null);
-                toplevelBuilder.addGetter(fieldName, tree.name(), treeLayout, clazz, null);
-                toplevelBuilder.addSetter(fieldName, tree.name(), treeLayout, clazz, null);
+                warn("Layout size not available for " + fieldName);
             }
         }
 
@@ -399,5 +414,9 @@ public class OutputFactory implements Declaration.Visitor<Void, Declaration> {
             throw new IllegalArgumentException("Unexpected parent declaration");
         }
         // case like `typedef struct { ... } Foo`
+    }
+
+    private void warn(String msg) {
+        System.err.println("WARNING: " + msg);
     }
 }

--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/SourceConstantHelper.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/SourceConstantHelper.java
@@ -80,8 +80,8 @@ class SourceConstantHelper implements ConstantHelper {
     public DirectMethodHandleDesc addLayout(String javaName, MemoryLayout layout) {
         String layoutName = javaName + "$LAYOUT";
         if (namesGenerated.add(layoutName)) {
-            emitLayoutField(javaName, layout);
-            return emitGetter(layoutName, MemoryLayout.class, getLayoutFieldName(javaName));
+            String fieldName = emitLayoutField(javaName, layout);
+            return emitGetter(layoutName, MemoryLayout.class, fieldName);
         } else {
             return getGetterDesc(layoutName, MethodHandle.class);
         }
@@ -303,13 +303,15 @@ class SourceConstantHelper implements ConstantHelper {
         return javaName + "$LAYOUT_";
     }
 
-    private void emitLayoutField(String javaName, MemoryLayout layout) {
+    private String emitLayoutField(String javaName, MemoryLayout layout) {
+        String fieldName = getLayoutFieldName(javaName);
         incrAlign();
         indent();
-        append(PRIVATE_MODS + "MemoryLayout " + getLayoutFieldName(javaName) + " = ");
+        append(PRIVATE_MODS + "MemoryLayout " + fieldName + " = ");
         emitLayoutString(layout);
         append(";\n");
         decrAlign();
+        return fieldName;
     }
 
     private void emitLayoutString(MemoryLayout l) {

--- a/test/jdk/tools/jextract/Test8251943.java
+++ b/test/jdk/tools/jextract/Test8251943.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.nio.file.Path;
+import jdk.incubator.foreign.MemoryAddress;
+import jdk.incubator.foreign.MemorySegment;
+import org.testng.annotations.Test;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertNotNull;
+
+/*
+ * @test
+ * @library /test/lib
+ * @modules jdk.incubator.jextract
+ * @build JextractToolRunner
+ * @bug 8251943
+ * @summary jextract should not generate MemorySegment typed fields for variables, struct fields if layout size info is not available
+ * @run testng/othervm -Dforeign.restricted=permit Test8251943
+ */
+public class Test8251943 extends JextractToolRunner {
+
+    @Test
+    public void test() {
+        Path outputPath = getOutputFilePath("output");
+        Path headerFile = getInputFilePath("test8251943.h");
+        run("-d", outputPath.toString(), headerFile.toString()).checkSuccess();
+        try(Loader loader = classLoader(outputPath)) {
+            Class<?> headerClass = loader.loadClass("test8251943_h");
+            assertNull(findMethod(headerClass, "tzname$SEGMENT"));
+
+            Class<?> fooClass = loader.loadClass("test8251943_h$Foo");
+            assertNotNull(findMethod(fooClass, "bar$get", MemorySegment.class));
+            assertNull(findMethod(fooClass, "names$get", MemorySegment.class));
+        } finally {
+            deleteDir(outputPath);
+        }
+    }
+}

--- a/test/jdk/tools/jextract/test8251943.h
+++ b/test/jdk/tools/jextract/test8251943.h
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+extern char* tzname[];
+
+struct Foo {
+   int bar;
+   char* names[];
+};


### PR DESCRIPTION
problematic variables, struct/union fields are ignored with a warning.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [JDK-8251943](https://bugs.openjdk.java.net/browse/JDK-8251943): jextract should not generate MemorySegment typed fields for variables, struct fields if layout size info is not available


### Reviewers
 * Maurizio Cimadamore ([mcimadamore](@mcimadamore) - Committer)


### Download
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/284/head:pull/284`
`$ git checkout pull/284`
