### PR TITLE
8252121: jextract generated code fails with ABI for typedefed array type parameters

### DIFF
--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/TypeMaker.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/TypeMaker.java
@@ -235,6 +235,14 @@ class TypeMaker {
         }
 
         @Override
+        public Type visitDelegated(Type.Delegated t, Void aVoid) {
+            if (t.kind() == Delegated.Kind.TYPEDEF && t.type() instanceof Type.Array) {
+                return visitArray((Type.Array)t.type(), aVoid);
+            }
+            return visitType(t, aVoid);
+        }
+
+        @Override
         public Type visitType(Type t, Void aVoid) {
             return t;
         }

--- a/test/jdk/tools/jextract/test8252121/Test8252121.java
+++ b/test/jdk/tools/jextract/test8252121/Test8252121.java
@@ -46,6 +46,7 @@ public class Test8252121 {
             int[] array = { 3, 5, 89, 34, -33 };
             MemorySegment seg = scope.allocateArray(CSupport.C_INT, array);
             assertEquals(IntStream.of(array).sum(), sum(seg));
-        } 
+            assertEquals(IntStream.of(array).reduce(1, (a,b) -> a*b), mul(seg));
+        }
     }
 }

--- a/test/jdk/tools/jextract/test8252121/Test8252121.java
+++ b/test/jdk/tools/jextract/test8252121/Test8252121.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import org.testng.annotations.Test;
+
+import java.util.stream.IntStream;
+import jdk.incubator.foreign.CSupport;
+import jdk.incubator.foreign.MemorySegment;
+import jdk.incubator.foreign.NativeScope;
+import static org.testng.Assert.assertEquals;
+import static test.jextract.arrayparam.arrayparam_h.*;
+
+/*
+ * @test
+ * @bug 8252121
+ * @summary jextract generated code fails with ABI for typedefed array type parameters
+ * @library ..
+ * @modules jdk.incubator.jextract
+ * @run driver JtregJextract -t test.jextract.arrayparam -l Arrayparam -- arrayparam.h
+ * @run testng/othervm -Dforeign.restricted=permit Test8252121
+ */
+public class Test8252121 {
+    @Test
+    public void test() {
+        try (NativeScope scope = NativeScope.unboundedScope()) {
+            int[] array = { 3, 5, 89, 34, -33 };
+            MemorySegment seg = scope.allocateArray(CSupport.C_INT, array);
+            assertEquals(IntStream.of(array).sum(), sum(seg));
+        } 
+    }
+}

--- a/test/jdk/tools/jextract/test8252121/arrayparam.h
+++ b/test/jdk/tools/jextract/test8252121/arrayparam.h
@@ -30,4 +30,7 @@
 #define NUM_ELEMENTS 5
 typedef int Array[NUM_ELEMENTS];
 
+typedef Array MyArray;
+
 EXPORT int sum(Array a);
+EXPORT int mul(MyArray a);

--- a/test/jdk/tools/jextract/test8252121/arrayparam.h
+++ b/test/jdk/tools/jextract/test8252121/arrayparam.h
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+#ifdef _WIN64
+#define EXPORT __declspec(dllexport)
+#else
+#define EXPORT
+#endif
+
+#define NUM_ELEMENTS 5
+typedef int Array[NUM_ELEMENTS];
+
+EXPORT int sum(Array a);

--- a/test/jdk/tools/jextract/test8252121/libArrayparam.c
+++ b/test/jdk/tools/jextract/test8252121/libArrayparam.c
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+#include "arrayparam.h"
+
+int sum(Array a) {
+    int res = 0;
+    for (int i = 0; i < NUM_ELEMENTS; i++) {
+        res += a[i];
+    }
+    return res;
+}

--- a/test/jdk/tools/jextract/test8252121/libArrayparam.c
+++ b/test/jdk/tools/jextract/test8252121/libArrayparam.c
@@ -30,3 +30,11 @@ int sum(Array a) {
     }
     return res;
 }
+
+int mul(MyArray a) {
+    int res = 1;
+    for (int i = 0; i < NUM_ELEMENTS; i++) {
+        res *= a[i];
+    }
+    return res;
+}


### PR DESCRIPTION
TypeMaker now special cases typedef'ed arrays for argument types for functions.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [JDK-8252121](https://bugs.openjdk.java.net/browse/JDK-8252121): jextract generated code fails with ABI for typedefed array type parameters


### Reviewers
 * Maurizio Cimadamore ([mcimadamore](@mcimadamore) - Committer)


### Download
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/287/head:pull/287`
`$ git checkout pull/287`
