### PR TITLE
Unsafe ParallelSum test is broken

### DIFF
--- a/test/micro/org/openjdk/bench/jdk/incubator/foreign/ParallelSum.java
+++ b/test/micro/org/openjdk/bench/jdk/incubator/foreign/ParallelSum.java
@@ -190,7 +190,7 @@ public class ParallelSum {
 
     @Benchmark
     public int unsafe_parallel() {
-        return new SumUnsafe(address, 0, ALLOC_SIZE).invoke();
+        return new SumUnsafe(address, 0, ALLOC_SIZE / CARRIER_SIZE).invoke();
     }
 
     static class SumUnsafe extends RecursiveTask<Integer> {
@@ -209,15 +209,19 @@ public class ParallelSum {
         @Override
         protected Integer compute() {
             if (length > SPLIT_THRESHOLD) {
-                SumUnsafe s1 = new SumUnsafe(address, start, length / 2);
-                SumUnsafe s2 = new SumUnsafe(address, length / 2, length / 2);
+                int rem = length % 2;
+                int split = length / 2;
+                int lobound = split;
+                int hibound = lobound + rem;
+                SumUnsafe s1 = new SumUnsafe(address, start, lobound);
+                SumUnsafe s2 = new SumUnsafe(address, start + lobound, hibound);
                 s1.fork();
                 s2.fork();
                 return s1.join() + s2.join();
             } else {
                 int res = 0;
-                for (int i = 0; i < length; i += CARRIER_SIZE) {
-                    res += unsafe.getInt(start + address + i);
+                for (int i = 0; i < length; i ++) {
+                    res += unsafe.getInt(address + (start + i) * CARRIER_SIZE);
                 }
                 return res;
             }


### PR DESCRIPTION
The numbers for the unsafe parallel sum tests are artificially low; after some debugging I realized that the test was not summing up all components.
I then plugged in the unsafe fork join action into our existing memory segment spliterator test, and verified that indeed that fork join action was violating all assertions.

I then fixed all the issues, verified that assertions were satisfied and then plugged the fixed action back into the microbenchmark.

Unsurprisingly, the perf numbers of the unsafe part are now in sync with those obtained from the segment counterpart.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * Jorn Vernee ([jvernee](@JornVernee) - Committer)
 * Athijegannathan Sundararajan ([sundar](@sundararajana) - Committer)


### Download
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/288/head:pull/288`
`$ git checkout pull/288`
