### PR TITLE
8252302: jextract should compile generated java code with -parameters and -g:lines option

### DIFF
--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/SourceConstantHelper.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/SourceConstantHelper.java
@@ -230,6 +230,16 @@ class SourceConstantHelper implements ConstantHelper {
     }
 
     // Internals only below this point
+    private void emitConstructor() {
+        // emit private constructor to prevent construction objects
+        incrAlign();
+        indent();
+        append("private ");
+        append(constantClassName);
+        append("() {}\n");
+        decrAlign();
+    }
+
     private void classBegin(String[] libraryNames, String baseClassName, boolean leafClass) {
         addPackagePrefix(pkgName);
         addImportSection();
@@ -244,6 +254,7 @@ class SourceConstantHelper implements ConstantHelper {
             append(baseClassName);
         }
         append(" {\n");
+        emitConstructor();
         if (libraryNames != null) {
             emitLibraries(libraryNames);
         }

--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/Writer.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/Writer.java
@@ -49,8 +49,9 @@ public final class Writer {
         if (sources.isEmpty()) {
             return List.of();
         } else {
-            return InMemoryJavaCompiler.compile(sources, 
+            return InMemoryJavaCompiler.compile(sources,
                 "--add-modules", "jdk.incubator.foreign",
+                "-parameters", "-g:lines",
                 "-d", dest.toAbsolutePath().toString(),
                 "-cp", dest.toAbsolutePath().toString());
         }

--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/resources/RuntimeHelper.java.template
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/resources/RuntimeHelper.java.template
@@ -22,6 +22,8 @@ import static ${C_LANG}.*;
 
 public class RuntimeHelper {
 
+    private RuntimeHelper() {}
+
     private final static ForeignLinker ABI = CSupport.getSystemLinker();
 
     private final static ClassLoader LOADER = RuntimeHelper.class.getClassLoader();

--- a/test/jdk/tools/jextract/Test8252302.java
+++ b/test/jdk/tools/jextract/Test8252302.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.lang.reflect.Method;
+import java.lang.reflect.Parameter;
+import java.nio.file.Path;
+import org.testng.annotations.Test;
+import static org.testng.Assert.assertEquals;
+
+/*
+ * @test
+ * @library /test/lib
+ * @modules jdk.incubator.jextract
+ * @build JextractToolRunner
+ * @bug 8252302
+ * @summary jextract should compile generated java code with -parameters and -g:lines option
+ * @run testng/othervm -Dforeign.restricted=permit Test8252302
+ */
+public class Test8252302 extends JextractToolRunner {
+    @Test
+    public void test() {
+        Path outputPath = getOutputFilePath("output8252302");
+        Path headerFile = getInputFilePath("test8252302.h");
+        run("-d", outputPath.toString(), headerFile.toString()).checkSuccess();
+        try(Loader loader = classLoader(outputPath)) {
+            Class<?> headerClass = loader.loadClass("test8252302_h");
+            Method m = findMethod(headerClass, "func", int.class, int.class);
+            Parameter[] params = m.getParameters();
+            assertEquals(params[0].getName(), "x");
+            assertEquals(params[1].getName(), "y");
+        } finally {
+            deleteDir(outputPath);
+        }
+    }
+}

--- a/test/jdk/tools/jextract/test8252302.h
+++ b/test/jdk/tools/jextract/test8252302.h
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+#ifdef __cplusplus
+extern "C" {
+#endif // __cplusplus
+
+void func(int x, int y);
+
+#ifdef __cplusplus
+}
+#endif // __cplusplus


### PR DESCRIPTION
adding -parameters and -g:lines option to javac compilation
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [JDK-8252302](https://bugs.openjdk.java.net/browse/JDK-8252302): jextract should compile generated java code with -parameters and -g:lines option


### Reviewers
 * Jorn Vernee ([jvernee](@JornVernee) - Committer)


### Download
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/291/head:pull/291`
`$ git checkout pull/291`
