### PR TITLE
Fix some tests failing jextract on Windows

### DIFF
--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/OutputFactory.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/OutputFactory.java
@@ -239,7 +239,8 @@ public class OutputFactory implements Declaration.Visitor<Void, Declaration> {
     }
 
     private static boolean isLongDouble(MemoryLayout layout) {
-        return CSupport.C_LONGDOUBLE.equals(layout);
+        return CSupport.C_LONGDOUBLE.bitSize() == 128
+            && CSupport.C_LONGDOUBLE.equals(layout);
     }
 
     private static boolean usesLongDouble(FunctionDescriptor desc) {

--- a/test/jdk/tools/jextract/test8252016/Test8252016.java
+++ b/test/jdk/tools/jextract/test8252016/Test8252016.java
@@ -33,7 +33,7 @@ import static jdk.incubator.foreign.CSupport.*;
  * @test
  * @library ..
  * @modules jdk.incubator.jextract
- * @run driver JtregJextract -t test.jextract.vsprintf -- vsprintf.h
+ * @run driver JtregJextract -t test.jextract.vsprintf -l VSPrintf -- vsprintf.h
  * @run testng/othervm -Dforeign.restricted=permit Test8252016
  */
 public class Test8252016 {
@@ -46,7 +46,7 @@ public class Test8252016 {
                 b.vargFromLong(C_LONGLONG, -200L);
                 b.vargFromLong(C_LONGLONG, Long.MAX_VALUE);
             })) {
-                vsprintf(s, toCString("%hhd %.2f %lld %lld"), vaList);
+                my_vsprintf(s, toCString("%hhd %.2f %lld %lld"), vaList);
                 String str = toJavaString(s);
                 assertEquals(str, "12 5.50 -200 " + Long.MAX_VALUE);
             }

--- a/test/jdk/tools/jextract/test8252016/libVSPrintf.c
+++ b/test/jdk/tools/jextract/test8252016/libVSPrintf.c
@@ -21,12 +21,11 @@
  * questions.
  */
 
-#ifdef _WIN64
-#define EXPORT __declspec(dllexport)
-#else
-#define EXPORT
-#endif
+#include "vsprintf.h"
 
+#include <stdio.h>
 #include <stdarg.h>
 
-EXPORT int my_vsprintf(char *s, const char* format, va_list arg);
+EXPORT int my_vsprintf(char *s, const char* format, va_list arg) {
+    return vsprintf(s, format, arg);
+}


### PR DESCRIPTION
Hi,

This PR fixes some tests that were failing on Windows;

1. The new test for `long double` layouts gives a false positive on Windows for the `double` layout, since both are 64 bits. I've added another check to see that the `long double` layout is actually 128 bits. (Since it's 64 bits on Windows, it would be allowed there, but it behaves the same as `double` so that should be fine).

2. A test using vsprintf was failing. It was depending on the default library to load the standard c library function, but this doesn't work reliably on Windows. I've put a wrapper around the vsprintf function, and called that instead. When building this wrapper the correct vsprintf is picked up.

Thanks,
Jorn
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * Athijegannathan Sundararajan ([sundar](@sundararajana) - Committer)


### Download
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/293/head:pull/293`
`$ git checkout pull/293`
