### PR TITLE
8252465: jextract generates wrong layout and varhandle when different structs have same named field

### DIFF
--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/StructBuilder.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/StructBuilder.java
@@ -98,6 +98,25 @@ class StructBuilder extends JavaSourceBuilder {
         return super.classEnd();
     }
 
+    private String getQualifiedName(String fieldName) {
+        return className + "$" + fieldName;
+    }
+
+    @Override
+    void addVarHandleGetter(String javaName, String nativeName, MemoryLayout layout, Class<?> type, MemoryLayout parentLayout) {
+        var desc = constantHelper.addVarHandle(getQualifiedName(javaName), nativeName, layout, type, parentLayout);
+        incrAlign();
+        indent();
+        append(PUB_MODS + displayName(desc.invocationType().returnType()) + " " + javaName + "$VH() {\n");
+        incrAlign();
+        indent();
+        append("return " + getCallString(desc) + ";\n");
+        decrAlign();
+        indent();
+        append("}\n");
+        decrAlign();
+    }
+
     @Override
     void addLayoutGetter(String javaName, MemoryLayout layout) {
         var desc = constantHelper.addLayout(javaName + "$struct", layout);
@@ -121,7 +140,7 @@ class StructBuilder extends JavaSourceBuilder {
         incrAlign();
         indent();
         append("return (" + type.getName() + ")"
-                + varHandleGetCallString(javaName, nativeName, layout, type, parentLayout) + ".get(seg);\n");
+                + varHandleGetCallString(getQualifiedName(javaName), nativeName, layout, type, parentLayout) + ".get(seg);\n");
         decrAlign();
         indent();
         append("}\n");
@@ -138,7 +157,7 @@ class StructBuilder extends JavaSourceBuilder {
         append(PUB_MODS + "void " + javaName + "$set(" + param + ", " + type.getName() + " x) {\n");
         incrAlign();
         indent();
-        append(varHandleGetCallString(javaName, nativeName, layout, type, null) + ".set(seg, x);\n");
+        append(varHandleGetCallString(getQualifiedName(javaName), nativeName, layout, type, null) + ".set(seg, x);\n");
         decrAlign();
         indent();
         append("}\n");
@@ -223,7 +242,8 @@ class StructBuilder extends JavaSourceBuilder {
         incrAlign();
         indent();
         append("return (" + type.getName() + ")"
-                + varHandleGetCallString(javaName, nativeName, layout, type, parentLayout) + ".get(addr.asSlice(index*sizeof()));\n");
+                + varHandleGetCallString(getQualifiedName(javaName), nativeName, layout, type, parentLayout) +
+                ".get(addr.asSlice(index*sizeof()));\n");
         decrAlign();
         indent();
         append("}\n");
@@ -237,7 +257,8 @@ class StructBuilder extends JavaSourceBuilder {
         append(PUB_MODS + "void " + javaName + "$set(" + params + ") {\n");
         incrAlign();
         indent();
-        append(varHandleGetCallString(javaName, nativeName, layout, type, parentLayout) + ".set(addr.asSlice(index*sizeof()), x);\n");
+        append(varHandleGetCallString(getQualifiedName(javaName), nativeName, layout, type, parentLayout) +
+                ".set(addr.asSlice(index*sizeof()), x);\n");
         decrAlign();
         indent();
         append("}\n");

--- a/test/jdk/tools/jextract/test8252465/LibTest8252465Test.java
+++ b/test/jdk/tools/jextract/test8252465/LibTest8252465Test.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import org.testng.annotations.Test;
+import jdk.incubator.foreign.NativeScope;
+import static org.testng.Assert.assertEquals;
+import static test.jextract.test8252465.test8252465_h.*;
+
+/*
+ * @test
+ * @library ..
+ * @modules jdk.incubator.jextract
+ * @bug 8252465
+ * @summary jextract generates wrong layout and varhandle when different structs have same named field
+ * @run driver JtregJextract -t test.jextract.test8252465 -- test8252465.h
+ * @run testng/othervm -Dforeign.restricted=permit LibTest8252465Test
+ */
+public class LibTest8252465Test {
+    @Test
+    public void test() {
+        try (var scope = NativeScope.unboundedScope()) {
+            var foo = Foo.allocate(scope);
+            Foo.x$set(foo, 3.14f);
+            assertEquals(Foo.x$get(foo), 3.14f, 0.001f);
+            var bar = Bar.allocate(scope);
+            Bar.x$set(bar, -42);
+            assertEquals(Bar.x$get(bar), -42);
+        }
+    }
+}

--- a/test/jdk/tools/jextract/test8252465/test8252465.h
+++ b/test/jdk/tools/jextract/test8252465/test8252465.h
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+struct Foo {
+    float x;
+};
+
+struct Bar {
+    int x;
+};


### PR DESCRIPTION
all tests pass. all samples jextract and run fine on Mac.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [JDK-8252465](https://bugs.openjdk.java.net/browse/JDK-8252465): jextract generates wrong layout and varhandle when different structs have same named field


### Reviewers
 * Maurizio Cimadamore ([mcimadamore](@mcimadamore) - Committer)


### Download
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/295/head:pull/295`
`$ git checkout pull/295`
