### PR TITLE
8252563: Field VarHandle generation in --source mode is missing the PathElement.groupElement argument

### DIFF
--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/ClassConstantHelper.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/ClassConstantHelper.java
@@ -193,7 +193,7 @@ class ClassConstantHelper implements ConstantHelper {
     }
 
     @Override
-    public DirectMethodHandleDesc addFieldVarHandle(String javaName, String nativeName, MemoryLayout layout, Class<?> type, String __, MemoryLayout parentLayout) {
+    public DirectMethodHandleDesc addFieldVarHandle(String javaName, String nativeName, MemoryLayout layout, Class<?> type, String ignored, MemoryLayout parentLayout) {
         return addVarHandle(javaName, nativeName, layout, type, parentLayout);
     }
 

--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/ClassConstantHelper.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/ClassConstantHelper.java
@@ -193,7 +193,16 @@ class ClassConstantHelper implements ConstantHelper {
     }
 
     @Override
-    public DirectMethodHandleDesc addVarHandle(String javaName, String nativeName, MemoryLayout layout, Class<?> type, MemoryLayout parentLayout) {
+    public DirectMethodHandleDesc addFieldVarHandle(String javaName, String nativeName, MemoryLayout layout, Class<?> type, String __, MemoryLayout parentLayout) {
+        return addVarHandle(javaName, nativeName, layout, type, parentLayout);
+    }
+
+    @Override
+    public DirectMethodHandleDesc addGlobalVarHandle(String javaName, String nativeName, MemoryLayout layout, Class<?> type) {
+        return addVarHandle(javaName, nativeName, layout, type, null);
+    }
+
+    private DirectMethodHandleDesc addVarHandle(String javaName, String nativeName, MemoryLayout layout, Class<?> type, MemoryLayout parentLayout) {
         return emitCondyGetter(javaName + "$VH", VarHandle.class, varHandleDesc(javaName, nativeName, layout, type, parentLayout));
     }
 

--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/ConstantHelper.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/ConstantHelper.java
@@ -35,7 +35,8 @@ import java.util.List;
 
 interface ConstantHelper {
     DirectMethodHandleDesc addLayout(String javaName, MemoryLayout layout);
-    DirectMethodHandleDesc addVarHandle(String javaName, String nativeName, MemoryLayout layout, Class<?> type, MemoryLayout parentLayout);
+    DirectMethodHandleDesc addFieldVarHandle(String javaName, String nativeName, MemoryLayout layout, Class<?> type, String parentJavaName, MemoryLayout parentLayout);
+    DirectMethodHandleDesc addGlobalVarHandle(String javaName, String nativeName, MemoryLayout layout, Class<?> type);
     DirectMethodHandleDesc addMethodHandle(String javaName, String nativeName, MethodType mtype, FunctionDescriptor desc, boolean varargs);
     DirectMethodHandleDesc addSegment(String javaName, String nativeName, MemoryLayout layout);
     DirectMethodHandleDesc addFunctionDesc(String javaName, FunctionDescriptor fDesc);

--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/JavaSourceBuilder.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/JavaSourceBuilder.java
@@ -106,15 +106,15 @@ abstract class JavaSourceBuilder {
         emitForwardGetter(constantHelper.addLayout(javaName, layout));
     }
 
-    void addVarHandleGetter(String javaName, String nativeName, MemoryLayout layout, Class<?> type, MemoryLayout parentLayout) {
-        emitForwardGetter(constantHelper.addVarHandle(javaName, nativeName, layout, type, parentLayout));
+    void addVarHandleGetter(String javaName, String nativeName, MemoryLayout layout, Class<?> type) {
+        emitForwardGetter(constantHelper.addGlobalVarHandle(javaName, nativeName, layout, type));
     }
 
     void addMethodHandleGetter(String javaName, String nativeName, MethodType mtype, FunctionDescriptor desc, boolean varargs) {
         emitForwardGetter(constantHelper.addMethodHandle(javaName, nativeName, mtype, desc, varargs));
     }
 
-    void addSegmentGetter(String javaName, String nativeName, MemoryLayout layout, MemoryLayout parentLayout) {
+    void addSegmentGetter(String javaName, String nativeName, MemoryLayout layout) {
         emitForwardGetter(constantHelper.addSegment(javaName, nativeName, layout));
     }
 
@@ -122,7 +122,7 @@ abstract class JavaSourceBuilder {
         emitForwardGetter(constantHelper.addConstant(javaName, type, value));
     }
 
-    void addGetter(String javaName, String nativeName, MemoryLayout layout, Class<?> type, MemoryLayout parentLayout) {
+    void addGetter(String javaName, String nativeName, MemoryLayout layout, Class<?> type) {
         incrAlign();
         indent();
         append(PUB_MODS + type.getName() + " " + javaName + "$get() {\n");
@@ -130,21 +130,21 @@ abstract class JavaSourceBuilder {
         indent();
         String vhParam = addressGetCallString(javaName, nativeName, layout);
         append("return (" + type.getName() + ")"
-                + varHandleGetCallString(javaName, nativeName, layout, type, null) + ".get(" + vhParam + ");\n");
+                + globalVarHandleGetCallString(javaName, nativeName, layout, type) + ".get(" + vhParam + ");\n");
         decrAlign();
         indent();
         append("}\n");
         decrAlign();
     }
 
-    void addSetter(String javaName, String nativeName, MemoryLayout layout, Class<?> type, MemoryLayout parentLayout) {
+    void addSetter(String javaName, String nativeName, MemoryLayout layout, Class<?> type) {
         incrAlign();
         indent();
         append(PUB_MODS + "void " + javaName + "$set(" + type.getName() + " x) {\n");
         incrAlign();
         indent();
         String vhParam = addressGetCallString(javaName, nativeName, layout);
-        append(varHandleGetCallString(javaName, nativeName, layout, type, null) + ".set(" + vhParam + ", x);\n");
+        append(globalVarHandleGetCallString(javaName, nativeName, layout, type) + ".set(" + vhParam + ", x);\n");
         decrAlign();
         indent();
         append("}\n");
@@ -202,8 +202,8 @@ abstract class JavaSourceBuilder {
         return getCallString(constantHelper.addMethodHandle(javaName, nativeName, mt, fDesc, varargs));
     }
 
-    protected String varHandleGetCallString(String javaName, String nativeName, MemoryLayout layout, Class<?> type, MemoryLayout parentLayout) {
-        return getCallString(constantHelper.addVarHandle(javaName, nativeName, layout, type, parentLayout));
+    private String globalVarHandleGetCallString(String javaName, String nativeName, MemoryLayout layout, Class<?> type) {
+        return getCallString(constantHelper.addGlobalVarHandle(javaName, nativeName, layout, type));
     }
 
     protected String addressGetCallString(String javaName, String nativeName, MemoryLayout layout) {
@@ -223,4 +223,5 @@ abstract class JavaSourceBuilder {
         name = Utils.javaSafeIdentifier(name);
         return nestedClassNames.add(name.toLowerCase()) ? name : (name + "$" + nestedClassNameCount++);
     }
+
 }

--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/OutputFactory.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/OutputFactory.java
@@ -205,11 +205,13 @@ public class OutputFactory implements Declaration.Visitor<Void, Declaration> {
                 case UNION: {
                     structClass = true;
                     String className = d.name().isEmpty() ? parent.name() : d.name();
-                    currentBuilder = new StructBuilder(currentBuilder, className, pkgName, constantHelper);
+                    MemoryLayout parentLayout = parentLayout(d);
+                    String parentLayoutFieldName = className + "$struct";
+                    currentBuilder = new StructBuilder(currentBuilder, className, parentLayoutFieldName, parentLayout, pkgName, constantHelper);
                     addStructDefinition(d, currentBuilder.className);
                     currentBuilder.incrAlign();
                     currentBuilder.classBegin();
-                    currentBuilder.addLayoutGetter(className, d.layout().get());
+                    currentBuilder.addLayoutGetter(parentLayoutFieldName, d.layout().get());
                     break;
                 }
             }
@@ -417,28 +419,27 @@ public class OutputFactory implements Declaration.Visitor<Void, Declaration> {
         }
         MemoryLayout treeLayout = tree.layout().orElseThrow();
         if (parent != null) { //struct field
-            MemoryLayout parentLayout = parentLayout(parent);
             if (isSegment) {
                 if (sizeAvailable) {
-                    currentBuilder.addSegmentGetter(fieldName, tree.name(), treeLayout, parentLayout);
+                    currentBuilder.addSegmentGetter(fieldName, tree.name(), treeLayout);
                 } else {
                     warn("Layout size not available for " + fieldName);
                 }
             } else {
-                currentBuilder.addVarHandleGetter(fieldName, tree.name(), treeLayout, clazz, parentLayout);
-                currentBuilder.addGetter(fieldName, tree.name(), treeLayout, clazz, parentLayout);
-                currentBuilder.addSetter(fieldName, tree.name(), treeLayout, clazz, parentLayout);
+                currentBuilder.addVarHandleGetter(fieldName, tree.name(), treeLayout, clazz);
+                currentBuilder.addGetter(fieldName, tree.name(), treeLayout, clazz);
+                currentBuilder.addSetter(fieldName, tree.name(), treeLayout, clazz);
             }
         } else {
             if (sizeAvailable) {
                 if (isSegment) {
-                    toplevelBuilder.addSegmentGetter(fieldName, tree.name(), treeLayout, null);
+                    toplevelBuilder.addSegmentGetter(fieldName, tree.name(), treeLayout);
                 } else {
                     toplevelBuilder.addLayoutGetter(fieldName, layout);
-                    toplevelBuilder.addVarHandleGetter(fieldName, tree.name(), treeLayout, clazz,null);
-                    toplevelBuilder.addSegmentGetter(fieldName, tree.name(), treeLayout, null);
-                    toplevelBuilder.addGetter(fieldName, tree.name(), treeLayout, clazz, null);
-                    toplevelBuilder.addSetter(fieldName, tree.name(), treeLayout, clazz, null);
+                    toplevelBuilder.addVarHandleGetter(fieldName, tree.name(), treeLayout, clazz);
+                    toplevelBuilder.addSegmentGetter(fieldName, tree.name(), treeLayout);
+                    toplevelBuilder.addGetter(fieldName, tree.name(), treeLayout, clazz);
+                    toplevelBuilder.addSetter(fieldName, tree.name(), treeLayout, clazz);
                 }
             } else {
                 warn("Layout size not available for " + fieldName);

--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/SourceConstantHelper.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/SourceConstantHelper.java
@@ -122,7 +122,7 @@ class SourceConstantHelper implements ConstantHelper {
     }
 
     @Override
-    public DirectMethodHandleDesc addFieldVarHandle(String javaName, String nativeName, MemoryLayout layout, Class<?> type, String parentJavaName, MemoryLayout __) {
+    public DirectMethodHandleDesc addFieldVarHandle(String javaName, String nativeName, MemoryLayout layout, Class<?> type, String parentJavaName, MemoryLayout ignored) {
         return addVarHandle(javaName, nativeName, layout, type, parentJavaName);
     }
 

--- a/test/jdk/tools/jextract/JtregJextractSources.java
+++ b/test/jdk/tools/jextract/JtregJextractSources.java
@@ -43,7 +43,7 @@ public class JtregJextractSources {
 
         Path outputDir = Paths.get(System.getProperty("test.classes", "."));
 
-        List<String> files = Files.find(sourcePath.toAbsolutePath(), 999, (path, __) -> path.toString().endsWith(".java"))
+        List<String> files = Files.find(sourcePath.toAbsolutePath(), 999, (path, ignored) -> path.toString().endsWith(".java"))
                 .map(p -> p.toAbsolutePath().toString())
                 .collect(Collectors.toList());
 

--- a/test/jdk/tools/jextract/JtregJextractSources.java
+++ b/test/jdk/tools/jextract/JtregJextractSources.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.lang.reflect.Array;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class JtregJextractSources {
+
+    public static int main(String[] args) throws IOException {
+        Path sourcePath = Path.of("sources");
+        JtregJextract jj =  new JtregJextract(null, sourcePath);
+        String[] newArgs = new String[args.length + 1];
+        newArgs[0] = "--source";
+        System.arraycopy(args, 0, newArgs, 1, args.length);
+        jj.jextract(newArgs);
+
+        Path outputDir = Paths.get(System.getProperty("test.classes", "."));
+
+        List<String> files = Files.find(sourcePath.toAbsolutePath(), 999, (path, __) -> path.toString().endsWith(".java"))
+                .map(p -> p.toAbsolutePath().toString())
+                .collect(Collectors.toList());
+
+        List<String> commands = new ArrayList<>();
+        commands.add(Paths.get(System.getProperty("test.jdk"), "bin", "javac").toString());
+        commands.add("--add-modules");
+        commands.add("jdk.incubator.foreign");
+        commands.add("-d");
+        commands.add(outputDir.toAbsolutePath().toString());
+        commands.addAll(files);
+
+        try {
+            Process proc = new ProcessBuilder(commands).inheritIO().start();
+            int result = proc.waitFor();
+            if (result != 0) {
+                throw new RuntimeException("javac returns non-zero value: " + result);
+            }
+            return result;
+        } catch (IOException ioExp) {
+            throw new UncheckedIOException(ioExp);
+        } catch (InterruptedException intExp) {
+            throw new RuntimeException(intExp);
+        }
+    }
+}

--- a/test/jdk/tools/jextract/testStruct/LibStructTest.java
+++ b/test/jdk/tools/jextract/testStruct/LibStructTest.java
@@ -31,12 +31,22 @@ import static org.testng.Assert.assertEquals;
 import static test.jextract.struct.struct_h.*;
 
 /*
- * @test
+ * @test id=classes
  * @library ..
  * @modules jdk.incubator.jextract
  * @run driver JtregJextract -l Struct -t test.jextract.struct -- struct.h
  * @run testng/othervm -Dforeign.restricted=permit LibStructTest
  */
+
+/*
+ * @test id=sources
+ * @library ..
+ * @modules jdk.incubator.jextract
+ *
+ * @run driver JtregJextractSources -l Struct -t test.jextract.struct -- struct.h
+ * @run testng/othervm -Dforeign.restricted=permit LibStructTest
+ */
+
 public class LibStructTest {
     @Test
     public void testMakePoint() {


### PR DESCRIPTION
Hi,

This PR fixes an issue where var handles in structs were not being created based on the layout of the parent struct, and were not using a PathElement.groupElement(...) argument to look up the right struct field, in --source mode, resulting in the created var handle not having the right offset. The core change is found in SourceConstantHelper#emitVarHandleField.

To try and clear things up a bit, I've also split the addVarHandle method in ConstantHelper into addGlobalVarHandle, and addFieldVarHandle with only the applicable parameter types, at least at the ConstantHelper level, so that calling code doesn't have to pass a bunch of nulls when calling addVarHandle for a global variable (the nulls being for the parent layout and field name).

To test this change, I've re-used the existing LibStructTest by running the test twice; once under the existing jtreg jextract driver that uses the binary constant helper, and once under a new jtreg jextract driver that first generates sources and then compiles them.

Thanks,
Jorn
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [JDK-8252563](https://bugs.openjdk.java.net/browse/JDK-8252563): Field VarHandle generation in --source mode is missing the PathElement.groupElement argument


### Reviewers
 * Athijegannathan Sundararajan ([sundar](@sundararajana) - Committer) ⚠️ Review applies to 72071c025818b9b2073c29eb16ce5cc1f2cd2281


### Download
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/297/head:pull/297`
`$ git checkout pull/297`
