### PR TITLE
8252686: All jextract tests should be run in both classes and sources mode

### DIFF
--- a/test/jdk/tools/jextract/JtregJextractSources.java
+++ b/test/jdk/tools/jextract/JtregJextractSources.java
@@ -21,6 +21,7 @@
  * questions.
  */
 
+import java.io.File;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.lang.reflect.Array;
@@ -32,9 +33,14 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 public class JtregJextractSources {
+    private static Path getJextractSourcePath() {
+        Path testSrc = Path.of(System.getProperty("test.file"));
+        return Path.of(testSrc.toFile().getName() + "_sources");
+    }
 
     public static int main(String[] args) throws IOException {
-        Path sourcePath = Path.of("sources");
+        System.err.println("jextract --source mode");
+        Path sourcePath = getJextractSourcePath();
         JtregJextract jj =  new JtregJextract(null, sourcePath);
         String[] newArgs = new String[args.length + 1];
         newArgs[0] = "--source";
@@ -47,6 +53,7 @@ public class JtregJextractSources {
                 .map(p -> p.toAbsolutePath().toString())
                 .collect(Collectors.toList());
 
+        System.err.println("compiling jextracted sources @ " + sourcePath.toAbsolutePath());
         List<String> commands = new ArrayList<>();
         commands.add(Paths.get(System.getProperty("test.jdk"), "bin", "javac").toString());
         commands.add("--add-modules");

--- a/test/jdk/tools/jextract/test8239918/LibTest8239918Test.java
+++ b/test/jdk/tools/jextract/test8239918/LibTest8239918Test.java
@@ -26,12 +26,21 @@ import static org.testng.Assert.assertEquals;
 import static test.jextract.test8239918.test8239918_h.*;
 
 /*
- * @test
- * @library ..
- * @modules jdk.incubator.jextract
+ * @test id=classes
  * @bug 8239918
  * @summary jextract generates uncompilable code for no argument C function
+ * @library ..
+ * @modules jdk.incubator.jextract
  * @run driver JtregJextract -l Test8239918 -t test.jextract.test8239918 -- test8239918.h
+ * @run testng/othervm -Dforeign.restricted=permit LibTest8239918Test
+ */
+/*
+ * @test id=sources
+ * @bug 8239918
+ * @summary jextract generates uncompilable code for no argument C function
+ * @library ..
+ * @modules jdk.incubator.jextract
+ * @run driver JtregJextractSources -l Test8239918 -t test.jextract.test8239918 -- test8239918.h
  * @run testng/othervm -Dforeign.restricted=permit LibTest8239918Test
  */
 public class LibTest8239918Test {

--- a/test/jdk/tools/jextract/test8244412/LibTest8244412Test.java
+++ b/test/jdk/tools/jextract/test8244412/LibTest8244412Test.java
@@ -32,12 +32,21 @@ import static org.testng.Assert.assertTrue;
 import static test.jextract.test8244412.test8244412_h.*;
 
 /*
- * @test
+ * @test id=classes
  * @library ..
  * @modules jdk.incubator.jextract
  * @bug 8244412
  * @summary jextract should generate static utils class for primitive typedefs
  * @run driver JtregJextract -t test.jextract.test8244412 -- test8244412.h
+ * @run testng/othervm -Dforeign.restricted=permit LibTest8244412Test
+ */
+/*
+ * @test id=sources
+ * @library ..
+ * @modules jdk.incubator.jextract
+ * @bug 8244412
+ * @summary jextract should generate static utils class for primitive typedefs
+ * @run driver JtregJextractSources -t test.jextract.test8244412 -- test8244412.h
  * @run testng/othervm -Dforeign.restricted=permit LibTest8244412Test
  */
 public class LibTest8244412Test {

--- a/test/jdk/tools/jextract/test8244938/Test8244938.java
+++ b/test/jdk/tools/jextract/test8244938/Test8244938.java
@@ -26,12 +26,22 @@ import static org.testng.Assert.assertEquals;
 import static test.jextract.test8244938.test8244938_h.*;
 
 /*
- * @test
+ * @test id=classes
  * @bug 8244938
  * @summary Crash in foreign ABI CallArranger class when a test native function returns a nested struct
  * @library ..
  * @modules jdk.incubator.jextract
  * @run driver JtregJextract -l Test8244938 -t test.jextract.test8244938 -- test8244938.h
+ * @run testng/othervm -Dforeign.restricted=permit Test8244938
+ */
+
+/*
+ * @test id=sources
+ * @bug 8244938
+ * @summary Crash in foreign ABI CallArranger class when a test native function returns a nested struct
+ * @library ..
+ * @modules jdk.incubator.jextract
+ * @run driver JtregJextractSources -l Test8244938 -t test.jextract.test8244938 -- test8244938.h
  * @run testng/othervm -Dforeign.restricted=permit Test8244938
  */
 public class Test8244938 {

--- a/test/jdk/tools/jextract/test8244959/Test8244959.java
+++ b/test/jdk/tools/jextract/test8244959/Test8244959.java
@@ -30,10 +30,21 @@ import static test.jextract.printf.printf_h.*;
 import static jdk.incubator.foreign.CSupport.*;
 
 /*
- * @test
+ * @test id=classes
+ * @bug 8244959
+ * @summary Jextract's VarargsInvoker fails to link functions when passing integer types other than long
  * @library ..
  * @modules jdk.incubator.jextract
  * @run driver JtregJextract -t test.jextract.printf -l Printf -- printf.h
+ * @run testng/othervm -Dforeign.restricted=permit Test8244959
+ */
+/*
+ * @test id=sources
+ * @bug 8244959
+ * @summary Jextract's VarargsInvoker fails to link functions when passing integer types other than long
+ * @library ..
+ * @modules jdk.incubator.jextract
+ * @run driver JtregJextractSources -t test.jextract.printf -l Printf -- printf.h
  * @run testng/othervm -Dforeign.restricted=permit Test8244959
  */
 public class Test8244959 {

--- a/test/jdk/tools/jextract/test8245003/Test8245003.java
+++ b/test/jdk/tools/jextract/test8245003/Test8245003.java
@@ -30,12 +30,21 @@ import static test.jextract.test8245003.test8245003_h.*;
 import static jdk.incubator.foreign.CSupport.*;
 
 /*
- * @test
+ * @test id=classes
  * @bug 8245003
  * @summary jextract does not generate accessor for MemorySegement typed values
  * @library ..
  * @modules jdk.incubator.jextract
  * @run driver JtregJextract -l Test8245003 -t test.jextract.test8245003 -- test8245003.h
+ * @run testng/othervm -Dforeign.restricted=permit Test8245003
+ */
+/*
+ * @test id=sources
+ * @bug 8245003
+ * @summary jextract does not generate accessor for MemorySegement typed values
+ * @library ..
+ * @modules jdk.incubator.jextract
+ * @run driver JtregJextractSources -l Test8245003 -t test.jextract.test8245003 -- test8245003.h
  * @run testng/othervm -Dforeign.restricted=permit Test8245003
  */
 public class Test8245003 {

--- a/test/jdk/tools/jextract/test8246341/LibTest8246341Test.java
+++ b/test/jdk/tools/jextract/test8246341/LibTest8246341Test.java
@@ -32,13 +32,21 @@ import static test.jextract.test8246341.test8246341_h.*;
 import static jdk.incubator.foreign.CSupport.*;
 
 /*
- * @test
- * @library ..
- * @modules jdk.incubator.jextract
- * @modules jdk.incubator.foreign
+ * @test id=classes
  * @bug 8246341
  * @summary jextract should generate Cpointer utilities class
+ * @library ..
+ * @modules jdk.incubator.jextract
  * @run driver JtregJextract -l Test8246341 -t test.jextract.test8246341 -- test8246341.h
+ * @run testng/othervm -Dforeign.restricted=permit LibTest8246341Test
+ */
+/*
+ * @test id=sources
+ * @bug 8246341
+ * @summary jextract should generate Cpointer utilities class
+ * @library ..
+ * @modules jdk.incubator.jextract
+ * @run driver JtregJextractSources -l Test8246341 -t test.jextract.test8246341 -- test8246341.h
  * @run testng/othervm -Dforeign.restricted=permit LibTest8246341Test
  */
 public class LibTest8246341Test {

--- a/test/jdk/tools/jextract/test8246400/LibTest8246400Test.java
+++ b/test/jdk/tools/jextract/test8246400/LibTest8246400Test.java
@@ -32,12 +32,21 @@ import static test.jextract.test8246400.test8246400_h.*;
 import static test.jextract.test8246400.RuntimeHelper.*;
 
 /*
- * @test
- * @library ..
- * @modules jdk.incubator.jextract
+ * @test id=classes
  * @bug 8246400
  * @summary jextract should generate a utility to manage mutliple MemorySegments
+ * @library ..
+ * @modules jdk.incubator.jextract
  * @run driver JtregJextract -l Test8246400 -t test.jextract.test8246400 -- test8246400.h
+ * @run testng/othervm -Dforeign.restricted=permit LibTest8246400Test
+ */
+/*
+ * @test id=sources
+ * @bug 8246400
+ * @summary jextract should generate a utility to manage mutliple MemorySegments
+ * @library ..
+ * @modules jdk.incubator.jextract
+ * @run driver JtregJextractSources -l Test8246400 -t test.jextract.test8246400 -- test8246400.h
  * @run testng/othervm -Dforeign.restricted=permit LibTest8246400Test
  */
 public class LibTest8246400Test {

--- a/test/jdk/tools/jextract/test8249757/LibTest8249757Test.java
+++ b/test/jdk/tools/jextract/test8249757/LibTest8249757Test.java
@@ -26,12 +26,21 @@ import static org.testng.Assert.assertEquals;
 import static test.jextract.test8249757.test8249757_h.*;
 
 /*
- * @test
+ * @test id=classes
  * @library ..
  * @modules jdk.incubator.jextract
  * @bug 8249757
  * @summary jextract should expose a way to load library from a given absolute path
  * @run driver JtregJextract -libpath Test8249757 -t test.jextract.test8249757 -- test8249757.h
+ * @run testng/othervm -Dforeign.restricted=permit LibTest8249757Test
+ */
+/*
+ * @test id=sources
+ * @library ..
+ * @modules jdk.incubator.jextract
+ * @bug 8249757
+ * @summary jextract should expose a way to load library from a given absolute path
+ * @run driver JtregJextractSources -libpath Test8249757 -t test.jextract.test8249757 -- test8249757.h
  * @run testng/othervm -Dforeign.restricted=permit LibTest8249757Test
  */
 public class LibTest8249757Test {

--- a/test/jdk/tools/jextract/test8252016/Test8252016.java
+++ b/test/jdk/tools/jextract/test8252016/Test8252016.java
@@ -30,10 +30,21 @@ import static test.jextract.vsprintf.vsprintf_h.*;
 import static jdk.incubator.foreign.CSupport.*;
 
 /*
- * @test
+ * @test id=classes
+ * @bug 8252016
+ * @summary jextract should handle va_list
  * @library ..
  * @modules jdk.incubator.jextract
  * @run driver JtregJextract -t test.jextract.vsprintf -l VSPrintf -- vsprintf.h
+ * @run testng/othervm -Dforeign.restricted=permit Test8252016
+ */
+/*
+ * @test id=sources
+ * @bug 8252016
+ * @summary jextract should handle va_list
+ * @library ..
+ * @modules jdk.incubator.jextract
+ * @run driver JtregJextractSources -t test.jextract.vsprintf -l VSPrintf -- vsprintf.h
  * @run testng/othervm -Dforeign.restricted=permit Test8252016
  */
 public class Test8252016 {

--- a/test/jdk/tools/jextract/test8252121/Test8252121.java
+++ b/test/jdk/tools/jextract/test8252121/Test8252121.java
@@ -31,12 +31,21 @@ import static org.testng.Assert.assertEquals;
 import static test.jextract.arrayparam.arrayparam_h.*;
 
 /*
- * @test
+ * @test id=classes
  * @bug 8252121
  * @summary jextract generated code fails with ABI for typedefed array type parameters
  * @library ..
  * @modules jdk.incubator.jextract
  * @run driver JtregJextract -t test.jextract.arrayparam -l Arrayparam -- arrayparam.h
+ * @run testng/othervm -Dforeign.restricted=permit Test8252121
+ */
+/*
+ * @test id=sources
+ * @bug 8252121
+ * @summary jextract generated code fails with ABI for typedefed array type parameters
+ * @library ..
+ * @modules jdk.incubator.jextract
+ * @run driver JtregJextractSources -t test.jextract.arrayparam -l Arrayparam -- arrayparam.h
  * @run testng/othervm -Dforeign.restricted=permit Test8252121
  */
 public class Test8252121 {

--- a/test/jdk/tools/jextract/test8252465/LibTest8252465Test.java
+++ b/test/jdk/tools/jextract/test8252465/LibTest8252465Test.java
@@ -27,12 +27,21 @@ import static org.testng.Assert.assertEquals;
 import static test.jextract.test8252465.test8252465_h.*;
 
 /*
- * @test
- * @library ..
- * @modules jdk.incubator.jextract
+ * @test id=classes
  * @bug 8252465
  * @summary jextract generates wrong layout and varhandle when different structs have same named field
+ * @library ..
+ * @modules jdk.incubator.jextract
  * @run driver JtregJextract -t test.jextract.test8252465 -- test8252465.h
+ * @run testng/othervm -Dforeign.restricted=permit LibTest8252465Test
+ */
+/*
+ * @test id=sources
+ * @bug 8252465
+ * @summary jextract generates wrong layout and varhandle when different structs have same named field
+ * @library ..
+ * @modules jdk.incubator.jextract
+ * @run driver JtregJextractSources -t test.jextract.test8252465 -- test8252465.h
  * @run testng/othervm -Dforeign.restricted=permit LibTest8252465Test
  */
 public class LibTest8252465Test {

--- a/test/jdk/tools/jextract/testFunctionPointer/LibFuncPtrTest.java
+++ b/test/jdk/tools/jextract/testFunctionPointer/LibFuncPtrTest.java
@@ -28,10 +28,17 @@ import static org.testng.Assert.assertEquals;
 import static test.jextract.fp.funcPtr_h.*;
 
 /*
- * @test
+ * @test id=classes
  * @library ..
  * @modules jdk.incubator.jextract
  * @run driver JtregJextract -l FuncPtr -t test.jextract.fp -- funcPtr.h
+ * @run testng/othervm -Dforeign.restricted=permit LibFuncPtrTest
+ */
+/*
+ * @test id=sources
+ * @library ..
+ * @modules jdk.incubator.jextract
+ * @run driver JtregJextractSources -l FuncPtr -t test.jextract.fp -- funcPtr.h
  * @run testng/othervm -Dforeign.restricted=permit LibFuncPtrTest
  */
 public class LibFuncPtrTest {


### PR DESCRIPTION
adding --source mode for all jextract tests
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [JDK-8252686](https://bugs.openjdk.java.net/browse/JDK-8252686): All jextract tests should be run in both classes and sources mode


### Reviewers
 * Jorn Vernee ([jvernee](@JornVernee) - Committer)


### Download
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/301/head:pull/301`
`$ git checkout pull/301`
