### PR TITLE
8252704: Absolute library paths are not properly quoted

### DIFF
--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/SourceConstantHelper.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/SourceConstantHelper.java
@@ -635,12 +635,16 @@ class SourceConstantHelper implements ConstantHelper {
         for (String lib : libraryNames) {
             indent();
             append('\"');
-            append(lib);
+            append(quoteLibraryName(lib));
             append("\",\n");
         }
         decrAlign();
         indent();
         append("});\n\n");
         decrAlign();
+    }
+
+    private static String quoteLibraryName(String lib) {
+        return lib.replace("\\", "\\\\"); // double up slashes
     }
 }


### PR DESCRIPTION
Hi,

This PR fixes a minor issue where backslashes (`\`) in absolute library paths result in un-compilable sources on Windows.

Thanks,
Jorn
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [JDK-8252704](https://bugs.openjdk.java.net/browse/JDK-8252704): Absolute library paths are not properly quoted


### Reviewers
 * Athijegannathan Sundararajan ([sundar](@sundararajana) - Committer)


### Download
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/302/head:pull/302`
`$ git checkout pull/302`
