### PR TITLE
8252756: jextract does not handle VLAs/Incomplete Arrays/Flexible arrays

### DIFF
--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/UnionLayoutComputer.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/UnionLayoutComputer.java
@@ -31,6 +31,7 @@ import jdk.incubator.foreign.MemoryLayout;
 import jdk.incubator.foreign.ValueLayout;
 import jdk.internal.clang.Cursor;
 import jdk.internal.clang.Type;
+import jdk.internal.clang.TypeKind;
 
 import java.util.List;
 
@@ -69,6 +70,9 @@ final class UnionLayoutComputer extends RecordLayoutComputer {
 
     @Override
     long fieldSize(Cursor c) {
+        if (c.type().kind() == TypeKind.IncompleteArray) {
+            return 0;
+        }
         return c.type().size() * 8;
     }
 

--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/Utils.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/Utils.java
@@ -201,26 +201,6 @@ class Utils {
                 .filter(cx -> cx.isAnonymousStruct() || cx.kind() == CursorKind.FieldDecl);
     }
 
-    static Optional<Cursor> lastChild(Cursor c) {
-        List<Cursor> children = flattenableChildren(c)
-                .collect(Collectors.toList());
-        return children.isEmpty() ? Optional.empty() : Optional.of(children.get(children.size() - 1));
-    }
-
-    static boolean hasIncompleteArray(Cursor c) {
-        switch (c.kind()) {
-            case FieldDecl:
-                return c.type().kind() == TypeKind.IncompleteArray;
-            case UnionDecl:
-                return flattenableChildren(c)
-                        .anyMatch(Utils::hasIncompleteArray);
-            case StructDecl:
-                return lastChild(c).map(Utils::hasIncompleteArray).orElse(false);
-            default:
-                throw new IllegalStateException("Unhandled cursor kind: " + c.kind());
-        }
-    }
-
     // return builtin Record types accessible from the given Type
     static Stream<Cursor> getBuiltinRecordTypes(Type type) {
         List<Cursor> recordTypes = new ArrayList<>();

--- a/test/jdk/tools/jextract/incompleteArray/IncompleteArrayTest.java
+++ b/test/jdk/tools/jextract/incompleteArray/IncompleteArrayTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @library .. /test/lib
+ * @modules jdk.incubator.jextract
+ *
+ * @run testng/othervm -Dforeign.restricted=permit IncompleteArrayTest
+ */
+
+import jdk.incubator.foreign.MemoryLayout;
+import org.testng.annotations.Test;
+
+import static jdk.incubator.foreign.CSupport.C_INT;
+import static jdk.incubator.foreign.CSupport.C_POINTER;
+import static org.testng.Assert.*;
+
+import java.nio.file.Path;
+
+public class IncompleteArrayTest extends JextractToolRunner {
+
+    @Test
+    public void testIncompleteArray() {
+        Path output = getOutputFilePath("incompleteArray_out");
+        Path input = getInputFilePath("incompleteArray.h");
+        run(
+            "-t", "org.jextract",
+            "-d", output,
+            "--",
+            input).checkSuccess();
+        try (Loader loader = classLoader(output)) {
+            Class<?> cls = loader.loadClass("org.jextract.incompleteArray_h$Foo");
+            assertNotNull(cls);
+
+            MemoryLayout actualLayout = findLayout(cls);
+            MemoryLayout expectedLayout = MemoryLayout.ofStruct(
+                C_INT.withName("size"),
+                MemoryLayout.ofPaddingBits(32),
+                MemoryLayout.ofSequence(C_POINTER).withName("data")
+            ).withName("Foo");
+            assertEquals(actualLayout, expectedLayout);
+        } finally {
+            //deleteDir(output);
+        }
+    }
+
+}

--- a/test/jdk/tools/jextract/incompleteArray/incompleteArray.h
+++ b/test/jdk/tools/jextract/incompleteArray/incompleteArray.h
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+struct Foo {
+    int size;
+    void* data[]; // incomplete array
+};


### PR DESCRIPTION
Hi,

This PR removes the variable length array workarounds that were needed pre-LLVM 9, and adds a test that verifies that the correct layout is generated for a struct containing a VLA.

Thanks,
Jorn
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [JDK-8252756](https://bugs.openjdk.java.net/browse/JDK-8252756): jextract does not handle VLAs/Incomplete Arrays/Flexible arrays


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.java.net/census#mcimadamore) (@mcimadamore - Committer)


### Download
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/305/head:pull/305`
`$ git checkout pull/305`
