### PR TITLE
8252770: MemorySegment::allocateNative should honor direct memory limits

### DIFF
--- a/src/java.base/share/classes/java/nio/Bits.java
+++ b/src/java.base/share/classes/java/nio/Bits.java
@@ -106,7 +106,7 @@ class Bits {                            // package-private
     // These methods should be called whenever direct memory is allocated or
     // freed.  They allow the user to control the amount of direct memory
     // which a process may access.  All sizes are specified in bytes.
-    static void reserveMemory(long size, int cap) {
+    static void reserveMemory(long size, long cap) {
 
         if (!MEMORY_LIMIT_SET && VM.initLevel() >= 1) {
             MAX_MEMORY = VM.maxDirectMemory();
@@ -185,7 +185,7 @@ class Bits {                            // package-private
         }
     }
 
-    private static boolean tryReserveMemory(long size, int cap) {
+    private static boolean tryReserveMemory(long size, long cap) {
 
         // -XX:MaxDirectMemorySize limits the total capacity rather than the
         // actual memory usage, which will differ when buffers are page
@@ -203,7 +203,7 @@ class Bits {                            // package-private
     }
 
 
-    static void unreserveMemory(long size, int cap) {
+    static void unreserveMemory(long size, long cap) {
         long cnt = COUNT.decrementAndGet();
         long reservedMem = RESERVED_MEMORY.addAndGet(-size);
         long totalCap = TOTAL_CAPACITY.addAndGet(-cap);

--- a/src/java.base/share/classes/java/nio/Buffer.java
+++ b/src/java.base/share/classes/java/nio/Buffer.java
@@ -827,6 +827,21 @@ public abstract class Buffer {
                 public boolean isLoaded(long address, boolean isSync, long size) {
                     return MappedMemoryUtils.isLoaded(address, isSync, size);
                 }
+
+                @Override
+                public void reserveMemory(long size, long cap) {
+                    Bits.reserveMemory(size, cap);
+                }
+
+                @Override
+                public void unreserveMemory(long size, long cap) {
+                    Bits.unreserveMemory(size, cap);
+                }
+
+                @Override
+                public int pageSize() {
+                    return Bits.pageSize();
+                }
             });
     }
 

--- a/src/java.base/share/classes/jdk/internal/access/JavaNioAccess.java
+++ b/src/java.base/share/classes/jdk/internal/access/JavaNioAccess.java
@@ -104,4 +104,19 @@ public interface JavaNioAccess {
      * Used by {@code jdk.internal.foreign.MappedMemorySegmentImpl} and byte buffer var handle views.
      */
     boolean isLoaded(long address, boolean isSync, long size);
+
+    /**
+     * Used by {@code jdk.internal.foreign.NativeMemorySegmentImpl}.
+     */
+    void reserveMemory(long size, long cap);
+
+    /**
+     * Used by {@code jdk.internal.foreign.NativeMemorySegmentImpl}.
+     */
+    void unreserveMemory(long size, long cap);
+
+    /**
+     * Used by {@code jdk.internal.foreign.NativeMemorySegmentImpl}.
+     */
+    int pageSize();
 }

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/MappedMemorySegmentImpl.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/MappedMemorySegmentImpl.java
@@ -55,7 +55,6 @@ public class MappedMemorySegmentImpl extends NativeMemorySegmentImpl implements 
 
     @Override
     ByteBuffer makeByteBuffer() {
-        JavaNioAccess nioAccess = SharedSecrets.getJavaNioAccess();
         return nioAccess.newMappedByteBuffer(unmapper, min, (int)length, null, this);
     }
 

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/NativeMemorySegmentImpl.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/NativeMemorySegmentImpl.java
@@ -48,7 +48,7 @@ public class NativeMemorySegmentImpl extends AbstractMemorySegmentImpl {
 
     // The maximum alignment supported by malloc - typically 16 on
     // 64-bit platforms and 8 on 32-bit platforms.
-    private final static long MAX_ALIGN = Unsafe.ADDRESS_SIZE == 4 ? 8 : 16;
+    private final static long MAX_MALLOC_ALIGN = Unsafe.ADDRESS_SIZE == 4 ? 8 : 16;
 
     private static final boolean skipZeroMemory = GetBooleanAction.privilegedGetProperty("jdk.internal.foreign.skipZeroMemory");
 
@@ -86,7 +86,7 @@ public class NativeMemorySegmentImpl extends AbstractMemorySegmentImpl {
         if (VM.isDirectMemoryPageAligned()) {
             alignmentBytes = Math.max(alignmentBytes, nioAccess.pageSize());
         }
-        long alignedSize = alignmentBytes > MAX_ALIGN ?
+        long alignedSize = alignmentBytes > MAX_MALLOC_ALIGN ?
                 bytesSize + (alignmentBytes - 1) :
                 bytesSize;
 

--- a/test/jdk/java/foreign/TestByteBuffer.java
+++ b/test/jdk/java/foreign/TestByteBuffer.java
@@ -25,7 +25,7 @@
  * @test
  * @modules java.base/sun.nio.ch
  *          jdk.incubator.foreign/jdk.internal.foreign
- * @run testng TestByteBuffer
+ * @run testng/othervm -XX:MaxDirectMemorySize=3000000000 TestByteBuffer
  */
 
 

--- a/test/jdk/java/foreign/TestMismatch.java
+++ b/test/jdk/java/foreign/TestMismatch.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @run testng TestMismatch
+ * @run testng/othervm -XX:MaxDirectMemorySize=5000000000 TestMismatch
  */
 
 import java.lang.invoke.VarHandle;


### PR DESCRIPTION
Currently, `MemorySegment::allocateNative` does not honor the memory limits set for direct buffers (`-XX:MaxDirectMemorySize` and `-XX:+PageAlignDirectMemory`).This patch rectifies that. The changes are pretty simple, the main issue was that most of the methods are defined away in the `Bits` class which belongs to the nio package, so the usual access dance was necessary.

Since segments can already be allocated with an alignment, I slightly tweaked the alignment logic to compute the max between page size and requested alignment, in case the option for aligning direct memory chunks to page boundaries is set.


Tweak NativeMemorySegmentImpl to respect direct memory settings
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [JDK-8252770](https://bugs.openjdk.java.net/browse/JDK-8252770): MemorySegment::allocateNative should honor direct memory limits


### Reviewers
 * [Paul Sandoz](https://openjdk.java.net/census#psandoz) (@PaulSandoz - Committer) ⚠️ Review applies to 015ee74868ce9c13494f3cc17938a9fb240293f0


### Download
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/306/head:pull/306`
`$ git checkout pull/306`
