### PR TITLE
8252700: jextract ignores typedef to undefined structs

### DIFF
--- a/test/jdk/tools/jextract/Test8245767.java
+++ b/test/jdk/tools/jextract/Test8245767.java
@@ -21,8 +21,9 @@
  * questions.
  */
 
+import java.lang.reflect.Method;
 import java.nio.file.Path;
-
+import jdk.incubator.foreign.NativeScope;
 import org.testng.annotations.Test;
 import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertNotNull;
@@ -47,9 +48,13 @@ public class Test8245767 extends JextractToolRunner {
             Class<?> cls = loader.loadClass("test8245767_h");
             assertNotNull(cls);
 
-            // no class should be generated for typedef on opaque struct
+            // class should be generated for typedef on opaque struct
             Class<?> fooCls = loader.loadClass("test8245767_h$Foo");
-            assertNull(fooCls);
+            assertNotNull(fooCls);
+            Method alloc = findMethod(fooCls, "allocatePointer");
+            assertNotNull(alloc);
+            alloc = findMethod(fooCls, "allocatePointer", NativeScope.class);
+            assertNotNull(alloc);
 
             // check Point_t
             Class<?> point_tCls = loader.loadClass("test8245767_h$Point_t");

--- a/test/jdk/tools/jextract/Test8252634.java
+++ b/test/jdk/tools/jextract/Test8252634.java
@@ -27,6 +27,7 @@ import java.lang.reflect.Method;
 import java.lang.reflect.Parameter;
 import jdk.incubator.foreign.MemoryAddress;
 import jdk.incubator.foreign.MemorySegment;
+import jdk.incubator.foreign.NativeScope;
 import java.nio.file.Path;
 import org.testng.annotations.Test;
 import static org.testng.Assert.assertEquals;
@@ -56,6 +57,10 @@ public class Test8252634 extends JextractToolRunner {
             Class<?> headerClass = loader.loadClass("test8252634_h");
             checkGlobalFunctions(headerClass);
             checkGlobalVariables(headerClass);
+
+            Class<?> fooTypedefClass = loader.loadClass("test8252634_h$Foo");
+            checkAnnotation(fooTypedefClass, "struct foo");
+            checkFooAllocatePointer(fooTypedefClass);
 
             Class<?> pointClass = loader.loadClass("test8252634_h$Point");
             checkPointGetters(pointClass);
@@ -117,8 +122,23 @@ public class Test8252634 extends JextractToolRunner {
     private void checkPointAllocate(Class<?> pointClass) throws Throwable {
         Method allocate = findMethod(pointClass, "allocate");
         checkAnnotation(allocate.getAnnotatedReturnType(), "struct Point");
+        allocate = findMethod(pointClass, "allocate", NativeScope.class);
+        checkAnnotation(allocate.getAnnotatedReturnType(), "struct Point");
         Method allocateArray = findMethod(pointClass, "allocateArray", int.class);
         checkAnnotation(allocateArray.getAnnotatedReturnType(), "struct Point[]");
+        allocateArray = findMethod(pointClass, "allocateArray", int.class, NativeScope.class);
+        checkAnnotation(allocateArray.getAnnotatedReturnType(), "struct Point[]");
+        Method allocatePointer = findMethod(pointClass, "allocatePointer");
+        checkAnnotation(allocatePointer.getAnnotatedReturnType(), "struct Point*");
+        allocatePointer = findMethod(pointClass, "allocatePointer", NativeScope.class);
+        checkAnnotation(allocatePointer.getAnnotatedReturnType(), "struct Point*");
+    }
+
+    private void checkFooAllocatePointer(Class<?> fooClass) throws Throwable {
+        Method allocatePointer = findMethod(fooClass, "allocatePointer");
+        checkAnnotation(allocatePointer.getAnnotatedReturnType(), "struct foo*");
+        allocatePointer = findMethod(fooClass, "allocatePointer", NativeScope.class);
+        checkAnnotation(allocatePointer.getAnnotatedReturnType(), "struct foo*");
     }
 
     private void checkAnnotation(AnnotatedElement ae, String expected) throws Throwable {

--- a/test/jdk/tools/jextract/test8252634.h
+++ b/test/jdk/tools/jextract/test8252634.h
@@ -36,6 +36,8 @@ void func(int (*callback)(int));
 typedef int* int_ptr;
 int_ptr p;
 
+typedef struct foo Foo;
+
 #ifdef __cplusplus
 }
 #endif // __cplusplus


### PR DESCRIPTION
A class with annotated allocatePointer methods is generated
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [JDK-8252700](https://bugs.openjdk.java.net/browse/JDK-8252700): jextract ignores typedef to undefined structs


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.java.net/census#mcimadamore) (@mcimadamore - Committer)


### Download
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/307/head:pull/307`
`$ git checkout pull/307`
