### PR TITLE
JDK-8248809: Consider supporting address dereference/allocation for platforms where pointers are not 64 bits

### DIFF
--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/CSupport.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/CSupport.java
@@ -488,7 +488,7 @@ public class CSupport {
         /**
          * The {@code T*} native type.
          */
-        public static final ValueLayout C_POINTER = MemoryLayouts.BITS_64_LE
+        public static final ValueLayout C_POINTER = MemoryLayouts.ADDRESS
                 .withAttribute(CLASS_ATTRIBUTE_NAME, ArgumentClass.POINTER);
 
         /**
@@ -593,7 +593,7 @@ public class CSupport {
         /**
          * The {@code T*} native type.
          */
-        public static final ValueLayout C_POINTER = MemoryLayouts.BITS_64_LE
+        public static final ValueLayout C_POINTER = MemoryLayouts.ADDRESS
                 .withAttribute(CLASS_ATTRIBUTE_NAME, ArgumentClass.POINTER);
 
         /**
@@ -702,7 +702,7 @@ public class CSupport {
         /**
          * The {@code T*} native type.
          */
-        public static final ValueLayout C_POINTER = MemoryLayouts.BITS_64_LE
+        public static final ValueLayout C_POINTER = MemoryLayouts.ADDRESS
                 .withAttribute(CLASS_ATTRIBUTE_NAME, ArgumentClass.POINTER);
 
         /**

--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/MemoryAccess.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/MemoryAccess.java
@@ -42,7 +42,16 @@ public final class MemoryAccess {
     private static final VarHandle float_BE_handle = indexedHandle(MemoryLayouts.BITS_32_BE, float.class);
     private static final VarHandle long_BE_handle = indexedHandle(MemoryLayouts.BITS_64_BE, long.class);
     private static final VarHandle double_BE_handle = indexedHandle(MemoryLayouts.BITS_64_BE, double.class);
-    private static final VarHandle address_handle = MemoryHandles.asAddressVarHandle((ByteOrder.nativeOrder() == ByteOrder.BIG_ENDIAN) ? long_BE_handle : long_LE_handle);
+    private static final VarHandle address_handle;
+
+    static {
+        Class<?> carrier = switch ((int) MemoryLayouts.ADDRESS.byteSize()) {
+            case 4 -> int.class;
+            case 8 -> long.class;
+            default -> throw new ExceptionInInitializerError("Unsupported pointer size: " + MemoryLayouts.ADDRESS.byteSize());
+        };
+        address_handle = MemoryHandles.asAddressVarHandle(indexedHandle(MemoryLayouts.ADDRESS, carrier));
+    }
 
     /**
      * Read a byte from given segment and offset, with byte order set to {@link ByteOrder#LITTLE_ENDIAN}.

--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/MemoryLayouts.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/MemoryLayouts.java
@@ -26,6 +26,8 @@
 
 package jdk.incubator.foreign;
 
+import jdk.internal.misc.Unsafe;
+
 import java.nio.ByteOrder;
 
 /**
@@ -135,4 +137,9 @@ public final class MemoryLayouts {
      * A value layout constant whose size is the same as that of a Java {@code double}, and byte order set to {@link ByteOrder#nativeOrder()}.
      */
     public static final ValueLayout JAVA_DOUBLE = MemoryLayout.ofValueBits(64, ByteOrder.nativeOrder());
+
+    /**
+     * A value layout constant whose size is the same as that of a machine address (e.g. {@code size_t}), and byte order set to {@link ByteOrder#nativeOrder()}.
+     */
+    public static final ValueLayout ADDRESS = MemoryLayout.ofValueBits(Unsafe.ADDRESS_SIZE * 8, ByteOrder.nativeOrder());
 }

--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/NativeScope.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/NativeScope.java
@@ -185,7 +185,7 @@ public interface NativeScope extends AutoCloseable {
     /**
      * Allocate a block of memory in this native scope with given layout and initialize it with given address value.
      * The address value might be narrowed according to the platform address size (see {@link MemoryLayouts#ADDRESS}).
-     * The segment returned by this method is associated with a segment which cannot be closed. Moreover, the returned
+     * The segment returned by this method cannot be closed. Moreover, the returned
      * segment must conform to the layout alignment constraints.
      * @param layout the layout of the block of memory to be allocated.
      * @param value the value to be set on the newly allocated memory block.

--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/NativeScope.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/NativeScope.java
@@ -36,6 +36,7 @@ import java.lang.reflect.Array;
 import java.nio.ByteOrder;
 import java.util.OptionalLong;
 import java.util.function.Function;
+import java.util.stream.Stream;
 
 /**
  * This class provides a scope of given size, within which several allocations can be performed. An native scope is backed
@@ -182,6 +183,29 @@ public interface NativeScope extends AutoCloseable {
     }
 
     /**
+     * Allocate a block of memory in this native scope with given layout and initialize it with given address value.
+     * The address value might be narrowed according to the platform address size (see {@link MemoryLayouts#ADDRESS}).
+     * The segment returned by this method is associated with a segment which cannot be closed. Moreover, the returned
+     * segment must conform to the layout alignment constraints.
+     * @param layout the layout of the block of memory to be allocated.
+     * @param value the value to be set on the newly allocated memory block.
+     * @return a segment for the newly allocated memory block.
+     * @throws OutOfMemoryError if there is not enough space left in this native scope, that is, if
+     * {@code limit() - size() < layout.byteSize()}.
+     * @throws IllegalArgumentException if {@code layout.byteSize() != MemoryLayouts.ADDRESS.byteSize()}.
+     */
+    default MemorySegment allocate(MemoryLayout layout, MemoryAddress value) {
+        if (MemoryLayouts.ADDRESS.byteSize() != layout.byteSize()) {
+            throw new IllegalArgumentException("Layout size mismatch - " + layout.byteSize() + " != " + MemoryLayouts.ADDRESS.byteSize());
+        }
+        switch ((int)layout.byteSize()) {
+            case 4: return allocate(layout, (int)value.toRawLongValue());
+            case 8: return allocate(layout, value.toRawLongValue());
+            default: throw new UnsupportedOperationException("Unsupported pointer size"); // should not get here
+        }
+    }
+
+    /**
      * Allocate a block of memory in this native scope with given layout and initialize it with given byte array.
      * The segment returned by this method is associated with a segment which cannot be closed. Moreover, the returned
      * segment must conform to the layout alignment constraints.
@@ -284,6 +308,33 @@ public interface NativeScope extends AutoCloseable {
      */
     default MemorySegment allocateArray(ValueLayout elementLayout, double[] array) {
         return copyArrayWithSwapIfNeeded(array, elementLayout, MemorySegment::ofArray);
+    }
+
+    /**
+     * Allocate a block of memory in this native scope with given layout and initialize it with given address array.
+     * The address value of each array element might be narrowed according to the platform address size (see {@link MemoryLayouts#ADDRESS}).
+     * The segment returned by this method is associated with a segment which cannot be closed. Moreover, the returned
+     * segment must conform to the layout alignment constraints.
+     * @param elementLayout the element layout of the array to be allocated.
+     * @param array the array to be copied on the newly allocated memory block.
+     * @return a segment for the newly allocated memory block.
+     * @throws OutOfMemoryError if there is not enough space left in this native scope, that is, if
+     * {@code limit() - size() < (elementLayout.byteSize() * array.length)}.
+     * @throws IllegalArgumentException if {@code layout.byteSize() != MemoryLayouts.ADDRESS.byteSize()}.
+     */
+    default MemorySegment allocateArray(ValueLayout elementLayout, MemoryAddress[] array) {
+        if (MemoryLayouts.ADDRESS.byteSize() != elementLayout.byteSize()) {
+            throw new IllegalArgumentException("Layout size mismatch - " + elementLayout.byteSize() + " != " + MemoryLayouts.ADDRESS.byteSize());
+        }
+        switch ((int)elementLayout.byteSize()) {
+            case 4: return copyArrayWithSwapIfNeeded(Stream.of(array)
+                            .mapToInt(a -> (int)a.toRawLongValue()).toArray(),
+                            elementLayout, MemorySegment::ofArray);
+            case 8: return copyArrayWithSwapIfNeeded(Stream.of(array)
+                            .mapToLong(MemoryAddress::toRawLongValue).toArray(),
+                            elementLayout, MemorySegment::ofArray);
+            default: throw new UnsupportedOperationException("Unsupported pointer size"); // should not get here
+        }
     }
 
     private <Z> MemorySegment copyArrayWithSwapIfNeeded(Z array, ValueLayout elementLayout,

--- a/test/jdk/java/foreign/TestNativeScope.java
+++ b/test/jdk/java/foreign/TestNativeScope.java
@@ -50,6 +50,8 @@ import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.BiFunction;
 import java.util.function.Function;
+import java.util.stream.IntStream;
+import java.util.stream.LongStream;
 
 import static jdk.incubator.foreign.MemorySegment.CLOSE;
 import static jdk.incubator.foreign.MemorySegment.HANDOFF;
@@ -236,6 +238,9 @@ public class TestNativeScope {
                 { 42d, (ScopeFactory) NativeScope::boundedScope, MemoryLayouts.BITS_64_BE,
                         (AllocationFunction<Double>) NativeScope::allocate,
                         (Function<MemoryLayout, VarHandle>)l -> l.varHandle(double.class) },
+                { MemoryAddress.ofLong(42), (ScopeFactory) NativeScope::boundedScope, MemoryLayouts.ADDRESS.withOrder(ByteOrder.BIG_ENDIAN),
+                        (AllocationFunction<MemoryAddress>) NativeScope::allocate,
+                        (Function<MemoryLayout, VarHandle>)l -> MemoryHandles.asAddressVarHandle(l.varHandle(long.class)) },
 
                 { (byte)42, (ScopeFactory) NativeScope::boundedScope, MemoryLayouts.BITS_8_LE,
                         (AllocationFunction<Byte>) NativeScope::allocate,
@@ -256,6 +261,9 @@ public class TestNativeScope {
                 { 42d, (ScopeFactory) NativeScope::boundedScope, MemoryLayouts.BITS_64_LE,
                         (AllocationFunction<Double>) NativeScope::allocate,
                         (Function<MemoryLayout, VarHandle>)l -> l.varHandle(double.class) },
+                { MemoryAddress.ofLong(42), (ScopeFactory) NativeScope::boundedScope, MemoryLayouts.ADDRESS.withOrder(ByteOrder.LITTLE_ENDIAN),
+                        (AllocationFunction<MemoryAddress>) NativeScope::allocate,
+                        (Function<MemoryLayout, VarHandle>)l -> MemoryHandles.asAddressVarHandle(l.varHandle(long.class)) },
 
                 { (byte)42, (ScopeFactory)size -> NativeScope.unboundedScope(), MemoryLayouts.BITS_8_BE,
                         (AllocationFunction<Byte>) NativeScope::allocate,
@@ -276,6 +284,9 @@ public class TestNativeScope {
                 { 42d, (ScopeFactory)size -> NativeScope.unboundedScope(), MemoryLayouts.BITS_64_BE,
                         (AllocationFunction<Double>) NativeScope::allocate,
                         (Function<MemoryLayout, VarHandle>)l -> l.varHandle(double.class) },
+                { MemoryAddress.ofLong(42), (ScopeFactory)size -> NativeScope.unboundedScope(), MemoryLayouts.ADDRESS.withOrder(ByteOrder.BIG_ENDIAN),
+                        (AllocationFunction<MemoryAddress>) NativeScope::allocate,
+                        (Function<MemoryLayout, VarHandle>)l -> MemoryHandles.asAddressVarHandle(l.varHandle(long.class)) },
 
                 { (byte)42, (ScopeFactory)size -> NativeScope.unboundedScope(), MemoryLayouts.BITS_8_LE,
                         (AllocationFunction<Byte>) NativeScope::allocate,
@@ -296,6 +307,9 @@ public class TestNativeScope {
                 { 42d, (ScopeFactory)size -> NativeScope.unboundedScope(), MemoryLayouts.BITS_64_LE,
                         (AllocationFunction<Double>) NativeScope::allocate,
                         (Function<MemoryLayout, VarHandle>)l -> l.varHandle(double.class) },
+                { MemoryAddress.ofLong(42), (ScopeFactory)size -> NativeScope.unboundedScope(), MemoryLayouts.ADDRESS.withOrder(ByteOrder.LITTLE_ENDIAN),
+                        (AllocationFunction<MemoryAddress>) NativeScope::allocate,
+                        (Function<MemoryLayout, VarHandle>)l -> MemoryHandles.asAddressVarHandle(l.varHandle(long.class)) },
         };
     }
 
@@ -321,6 +335,9 @@ public class TestNativeScope {
                 { (ScopeFactory) NativeScope::boundedScope, MemoryLayouts.BITS_64_LE,
                         (AllocationFunction<double[]>) NativeScope::allocateArray,
                         ToArrayHelper.toDoubleArray },
+                { (ScopeFactory) NativeScope::boundedScope, MemoryLayouts.ADDRESS.withOrder(ByteOrder.LITTLE_ENDIAN),
+                        (AllocationFunction<MemoryAddress[]>) NativeScope::allocateArray,
+                        ToArrayHelper.toAddressArray },
 
 
                 { (ScopeFactory) NativeScope::boundedScope, MemoryLayouts.BITS_8_BE,
@@ -342,6 +359,9 @@ public class TestNativeScope {
                 { (ScopeFactory) NativeScope::boundedScope, MemoryLayouts.BITS_64_BE,
                         (AllocationFunction<double[]>) NativeScope::allocateArray,
                         ToArrayHelper.toDoubleArray },
+                { (ScopeFactory) NativeScope::boundedScope, MemoryLayouts.ADDRESS.withOrder(ByteOrder.BIG_ENDIAN),
+                        (AllocationFunction<MemoryAddress[]>) NativeScope::allocateArray,
+                        ToArrayHelper.toAddressArray },
 
                 { (ScopeFactory) size -> NativeScope.unboundedScope(), MemoryLayouts.BITS_8_LE,
                         (AllocationFunction<byte[]>) NativeScope::allocateArray,
@@ -362,6 +382,9 @@ public class TestNativeScope {
                 { (ScopeFactory) size -> NativeScope.unboundedScope(), MemoryLayouts.BITS_64_LE,
                         (AllocationFunction<double[]>) NativeScope::allocateArray,
                         ToArrayHelper.toDoubleArray },
+                { (ScopeFactory)size -> NativeScope.unboundedScope(), MemoryLayouts.ADDRESS.withOrder(ByteOrder.LITTLE_ENDIAN),
+                        (AllocationFunction<MemoryAddress[]>) NativeScope::allocateArray,
+                        ToArrayHelper.toAddressArray },
 
 
                 { (ScopeFactory) size -> NativeScope.unboundedScope(), MemoryLayouts.BITS_8_BE,
@@ -383,6 +406,9 @@ public class TestNativeScope {
                 { (ScopeFactory) size -> NativeScope.unboundedScope(), MemoryLayouts.BITS_64_BE,
                         (AllocationFunction<double[]>) NativeScope::allocateArray,
                         ToArrayHelper.toDoubleArray },
+                { (ScopeFactory)size -> NativeScope.unboundedScope(), MemoryLayouts.ADDRESS.withOrder(ByteOrder.BIG_ENDIAN),
+                        (AllocationFunction<MemoryAddress[]>) NativeScope::allocateArray,
+                        ToArrayHelper.toAddressArray },
         };
     }
 
@@ -485,6 +511,34 @@ public class TestNativeScope {
                 double[] found = new double[buffer.limit()];
                 buffer.get(found);
                 return found;
+            }
+        };
+
+        ToArrayHelper<MemoryAddress[]> toAddressArray = new ToArrayHelper<>() {
+            @Override
+            public MemoryAddress[] array() {
+                return switch ((int)MemoryLayouts.ADDRESS.byteSize()) {
+                    case 4 -> wrap(toIntArray.array());
+                    case 8 -> wrap(toLongArray.array());
+                    default -> throw new IllegalStateException("Cannot get here");
+                };
+            }
+
+            @Override
+            public MemoryAddress[] toArray(MemorySegment segment, ValueLayout layout) {
+                return switch ((int)layout.byteSize()) {
+                    case 4 -> wrap(toIntArray.toArray(segment, layout));
+                    case 8 -> wrap(toLongArray.toArray(segment, layout));
+                    default -> throw new IllegalStateException("Cannot get here");
+                };
+            }
+
+            private MemoryAddress[] wrap(int[] ints) {
+                return IntStream.of(ints).mapToObj(MemoryAddress::ofLong).toArray(MemoryAddress[]::new);
+            }
+
+            private MemoryAddress[] wrap(long[] ints) {
+                return LongStream.of(ints).mapToObj(MemoryAddress::ofLong).toArray(MemoryAddress[]::new);
             }
         };
     }


### PR DESCRIPTION
This patch makes support for addresses more uniform, in a way that scales to platforms whose pointer size might be != 64 bits. After considering a number of alternatives, we settled on something which, I think is pleasing for a number of rteasons.

First, we added a new layout, namely `MemoryLayouts.ADDRESS`. This is the layout of a machine pointer, in the platform in which the JVM runs. This is a useful piece of information to have regardless.

This new layout is then used in two places:

* In MemoryAccess, to decide whether we need a 32 or a 64 dereference handle to get/set addresses

* In NativeScope, again, to decide to which NativeScope factory we should delegate (the long vs. the int one)

This should slightly generalize what we have and also adds some extra helper methods to NativeScope which were dropped in an earlier iteration, waiting for this issue to be addressed.

I've tweaked the NativeScope test in order to stress the new address-accepting factories.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [JDK-8248809](https://bugs.openjdk.java.net/browse/JDK-8248809): Consider supporting address dereference/allocation for platforms where pointers are not 64 bits


### Reviewers
 * [Paul Sandoz](https://openjdk.java.net/census#psandoz) (@PaulSandoz - Committer) ⚠️ Review applies to 4ac3aa43354dad968d608217e540b3a052c3a206
 * [Jorn Vernee](https://openjdk.java.net/census#jvernee) (@JornVernee - Committer) ⚠️ Review applies to 4ac3aa43354dad968d608217e540b3a052c3a206


### Download
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/308/head:pull/308`
`$ git checkout pull/308`
