### PR TITLE
8252838: Panama foreign-abi branch fails to build

### DIFF
--- a/src/java.base/share/classes/java/lang/invoke/NativeMethodHandle.java
+++ b/src/java.base/share/classes/java/lang/invoke/NativeMethodHandle.java
@@ -29,6 +29,7 @@ import jdk.internal.vm.annotation.ForceInline;
 import jdk.internal.invoke.NativeEntryPoint;
 
 import static java.lang.invoke.LambdaForm.*;
+import static java.lang.invoke.MethodHandleNatives.Constants.LM_TRUSTED;
 import static java.lang.invoke.MethodHandleNatives.Constants.REF_invokeStatic;
 import static java.lang.invoke.MethodHandleStatics.newInternalError;
 
@@ -87,7 +88,7 @@ import static java.lang.invoke.MethodHandleStatics.newInternalError;
                 .appendParameterTypes(Object.class);
         MemberName linker = new MemberName(MethodHandle.class, "linkToNative", linkerType, REF_invokeStatic);
         try {
-            linker = IMPL_NAMES.resolveOrFail(REF_invokeStatic, linker, null, NoSuchMethodException.class);
+            linker = IMPL_NAMES.resolveOrFail(REF_invokeStatic, linker, null, LM_TRUSTED, NoSuchMethodException.class);
         } catch (ReflectiveOperationException ex) {
             throw newInternalError(ex);
         }


### PR DESCRIPTION
sync'ing with the changes done via bug fix 8244090
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [JDK-8252838](https://bugs.openjdk.java.net/browse/JDK-8252838): Panama foreign-abi branch fails to build


### Reviewers
 * [Jorn Vernee](https://openjdk.java.net/census#jvernee) (@JornVernee - Committer)


### Download
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/309/head:pull/309`
`$ git checkout pull/309`
