### PR TITLE
8252866: MemoryAccess.setAddress should take Addressable, not MemoryAddress

### DIFF
--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/MemoryAccess.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/MemoryAccess.java
@@ -1,3 +1,28 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
 package jdk.incubator.foreign;
 
 import jdk.internal.access.foreign.MemorySegmentProxy;
@@ -42,7 +67,16 @@ public final class MemoryAccess {
     private static final VarHandle float_BE_handle = indexedHandle(MemoryLayouts.BITS_32_BE, float.class);
     private static final VarHandle long_BE_handle = indexedHandle(MemoryLayouts.BITS_64_BE, long.class);
     private static final VarHandle double_BE_handle = indexedHandle(MemoryLayouts.BITS_64_BE, double.class);
-    private static final VarHandle address_handle = MemoryHandles.asAddressVarHandle((ByteOrder.nativeOrder() == ByteOrder.BIG_ENDIAN) ? long_BE_handle : long_LE_handle);
+    private static final VarHandle address_handle;
+
+    static {
+        Class<?> carrier = switch ((int) MemoryLayouts.ADDRESS.byteSize()) {
+            case 4 -> int.class;
+            case 8 -> long.class;
+            default -> throw new ExceptionInInitializerError("Unsupported pointer size: " + MemoryLayouts.ADDRESS.byteSize());
+        };
+        address_handle = MemoryHandles.asAddressVarHandle(indexedHandle(MemoryLayouts.ADDRESS, carrier));
+    }
 
     /**
      * Read a byte from given segment and offset, with byte order set to {@link ByteOrder#LITTLE_ENDIAN}.
@@ -741,13 +775,13 @@ public final class MemoryAccess {
      * This is equivalent to the following code:
      * <blockquote><pre>{@code
     VarHandle handle = MemoryHandles.asAddressHandle(MemoryHandles.withStride(JAVA_LONG.withBitAlignment(8).varHandle(long.class), 1L));
-    handle.set(segment, offset, value);
+    handle.set(segment, offset, value.address());
      * }</pre></blockquote>
      * @param segment the segment to be dereferenced.
      * @param offset offset (relative to {@code segment}). The final address of this read operation can be expressed as {@code segment.address().addOffset(offset)}.
-     * @param value the memory address to be written.
+     * @param value the memory address to be written (expressed as an {@link Addressable} instance).
      */
-    public static void setAddressAtOffset(MemorySegment segment, long offset, MemoryAddress value) {
+    public static void setAddressAtOffset(MemorySegment segment, long offset, Addressable value) {
         address_handle.set(segment, offset, value);
     }
 
@@ -1368,9 +1402,9 @@ public final class MemoryAccess {
     setAddressAtOffset(segment, 0L, value);
      * }</pre></blockquote>
      * @param segment the segment to be dereferenced.
-     * @param value the memory address to be written.
+     * @param value the memory address to be written (expressed as an {@link Addressable} instance).
      */
-    public static void setAddress(MemorySegment segment, MemoryAddress value) {
+    public static void setAddress(MemorySegment segment, Addressable value) {
         setAddressAtOffset(segment, 0L, value);
     }
 
@@ -2031,9 +2065,9 @@ public final class MemoryAccess {
      * }</pre></blockquote>
      * @param segment the segment to be dereferenced.
      * @param index element index (relative to {@code segment}). The final address of this read operation can be expressed as {@code segment.address().addOffset(index * 8)}.
-     * @param value the memory address to be written.
+     * @param value the memory address to be written (expressed as an {@link Addressable} instance).
      */
-    public static void setAddressAtIndex(MemorySegment segment, long index, MemoryAddress value) {
+    public static void setAddressAtIndex(MemorySegment segment, long index, Addressable value) {
         setAddressAtOffset(segment, scale(segment, index, 8), value);
     }
 

--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/MemoryLayouts.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/MemoryLayouts.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ *  Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
  *  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  *  This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,8 @@
  */
 
 package jdk.incubator.foreign;
+
+import jdk.internal.misc.Unsafe;
 
 import java.nio.ByteOrder;
 
@@ -135,4 +137,9 @@ public final class MemoryLayouts {
      * A value layout constant whose size is the same as that of a Java {@code double}, and byte order set to {@link ByteOrder#nativeOrder()}.
      */
     public static final ValueLayout JAVA_DOUBLE = MemoryLayout.ofValueBits(64, ByteOrder.nativeOrder());
+
+    /**
+     * A value layout constant whose size is the same as that of a machine address (e.g. {@code size_t}), and byte order set to {@link ByteOrder#nativeOrder()}.
+     */
+    public static final ValueLayout ADDRESS = MemoryLayout.ofValueBits(Unsafe.ADDRESS_SIZE * 8, ByteOrder.nativeOrder());
 }


### PR DESCRIPTION
`MemoryAccess::setAddress` should be made more flexible by accepting an `Addressable` instance. This reflects the API design principle of *Be liberal in what you accept, and conservative in what you send*.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [JDK-8252866](https://bugs.openjdk.java.net/browse/JDK-8252866): MemoryAccess.setAddress should take Addressable, not MemoryAddress


### Reviewers
 * [Athijegannathan Sundararajan](https://openjdk.java.net/census#sundar) (@sundararajana - Committer)


### Download
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/310/head:pull/310`
`$ git checkout pull/310`
