### PR TITLE
8252872: NativeScope should take Addressable instead of MemoryAddress

### DIFF
--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/CSupport.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/CSupport.java
@@ -225,11 +225,16 @@ public class CSupport {
 
         /**
          * Constructs a new {@code VaList} instance out of a memory address pointing to an existing C {@code va_list}.
+         * <p>
+         * This method is <em>restricted</em>. Restricted method are unsafe, and, if used incorrectly, their use might crash
+         * the JVM or, worse, silently result in memory corruption. Thus, clients should refrain from depending on
+         * restricted methods, and use safe and supported functionalities, where possible.
          *
          * @param address a memory address pointing to an existing C {@code va_list}.
          * @return a new {@code VaList} instance backed by the C {@code va_list} at {@code address}.
          */
-        static VaList ofAddress(MemoryAddress address) {
+        static VaList ofAddressRestricted(MemoryAddress address) {
+            Utils.checkRestrictedAccess("VaList.ofAddressRestricted");
             return SharedUtils.newVaListOfAddress(address);
         }
 
@@ -299,7 +304,7 @@ public class CSupport {
              * @return this builder.
              * @throws IllegalArgumentException if the given memory layout is not compatible with {@code int}
              */
-            Builder vargFromInt(MemoryLayout layout, int value);
+            Builder vargFromInt(ValueLayout layout, int value);
 
             /**
              * Adds a native value represented as a {@code long} to the C {@code va_list} being constructed.
@@ -309,7 +314,7 @@ public class CSupport {
              * @return this builder.
              * @throws IllegalArgumentException if the given memory layout is not compatible with {@code long}
              */
-            Builder vargFromLong(MemoryLayout layout, long value);
+            Builder vargFromLong(ValueLayout layout, long value);
 
             /**
              * Adds a native value represented as a {@code double} to the C {@code va_list} being constructed.
@@ -319,17 +324,17 @@ public class CSupport {
              * @return this builder.
              * @throws IllegalArgumentException if the given memory layout is not compatible with {@code double}
              */
-            Builder vargFromDouble(MemoryLayout layout, double value);
+            Builder vargFromDouble(ValueLayout layout, double value);
 
             /**
              * Adds a native value represented as a {@code MemoryAddress} to the C {@code va_list} being constructed.
              *
              * @param layout the native layout of the value.
-             * @param value the value, represented as a {@code MemoryAddress}.
+             * @param value the value, represented as a {@code Addressable}.
              * @return this builder.
              * @throws IllegalArgumentException if the given memory layout is not compatible with {@code MemoryAddress}
              */
-            Builder vargFromAddress(MemoryLayout layout, MemoryAddress value);
+            Builder vargFromAddress(ValueLayout layout, Addressable value);
 
             /**
              * Adds a native value represented as a {@code MemorySegment} to the C {@code va_list} being constructed.
@@ -339,7 +344,7 @@ public class CSupport {
              * @return this builder.
              * @throws IllegalArgumentException if the given memory layout is not compatible with {@code MemorySegment}
              */
-            Builder vargFromSegment(MemoryLayout layout, MemorySegment value);
+            Builder vargFromSegment(GroupLayout layout, MemorySegment value);
         }
     }
 
@@ -891,6 +896,10 @@ public class CSupport {
 
     /**
      * Allocate memory of given size using malloc.
+     * <p>
+     * This method is <em>restricted</em>. Restricted method are unsafe, and, if used incorrectly, their use might crash
+     * the JVM or, worse, silently result in memory corruption. Thus, clients should refrain from depending on
+     * restricted methods, and use safe and supported functionalities, where possible.
      *
      * @param size memory size to be allocated
      * @return addr memory address of the allocated memory
@@ -902,6 +911,10 @@ public class CSupport {
 
     /**
      * Free the memory pointed by the given memory address.
+     * <p>
+     * This method is <em>restricted</em>. Restricted method are unsafe, and, if used incorrectly, their use might crash
+     * the JVM or, worse, silently result in memory corruption. Thus, clients should refrain from depending on
+     * restricted methods, and use safe and supported functionalities, where possible.
      *
      * @param addr memory address of the native memory to be freed
      */

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/aarch64/AArch64VaList.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/aarch64/AArch64VaList.java
@@ -25,13 +25,7 @@
  */
 package jdk.internal.foreign.abi.aarch64;
 
-import jdk.incubator.foreign.CSupport;
-import jdk.incubator.foreign.GroupLayout;
-import jdk.incubator.foreign.MemoryAddress;
-import jdk.incubator.foreign.MemoryHandles;
-import jdk.incubator.foreign.MemoryLayout;
-import jdk.incubator.foreign.MemorySegment;
-import jdk.incubator.foreign.NativeScope;
+import jdk.incubator.foreign.*;
 import jdk.internal.foreign.NativeMemorySegmentImpl;
 import jdk.internal.foreign.Utils;
 import jdk.internal.foreign.abi.SharedUtils;
@@ -444,27 +438,27 @@ public class AArch64VaList implements VaList {
         }
 
         @Override
-        public Builder vargFromInt(MemoryLayout layout, int value) {
+        public Builder vargFromInt(ValueLayout layout, int value) {
             return arg(int.class, layout, value);
         }
 
         @Override
-        public Builder vargFromLong(MemoryLayout layout, long value) {
+        public Builder vargFromLong(ValueLayout layout, long value) {
             return arg(long.class, layout, value);
         }
 
         @Override
-        public Builder vargFromDouble(MemoryLayout layout, double value) {
+        public Builder vargFromDouble(ValueLayout layout, double value) {
             return arg(double.class, layout, value);
         }
 
         @Override
-        public Builder vargFromAddress(MemoryLayout layout, MemoryAddress value) {
-            return arg(MemoryAddress.class, layout, value);
+        public Builder vargFromAddress(ValueLayout layout, Addressable value) {
+            return arg(MemoryAddress.class, layout, value.address());
         }
 
         @Override
-        public Builder vargFromSegment(MemoryLayout layout, MemorySegment value) {
+        public Builder vargFromSegment(GroupLayout layout, MemorySegment value) {
             return arg(MemorySegment.class, layout, value);
         }
 

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/x64/sysv/SysVVaList.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/x64/sysv/SysVVaList.java
@@ -25,13 +25,7 @@
  */
 package jdk.internal.foreign.abi.x64.sysv;
 
-import jdk.incubator.foreign.CSupport;
-import jdk.incubator.foreign.GroupLayout;
-import jdk.incubator.foreign.MemoryAddress;
-import jdk.incubator.foreign.MemoryHandles;
-import jdk.incubator.foreign.MemoryLayout;
-import jdk.incubator.foreign.MemorySegment;
-import jdk.incubator.foreign.NativeScope;
+import jdk.incubator.foreign.*;
 import jdk.internal.foreign.NativeMemorySegmentImpl;
 import jdk.internal.foreign.Utils;
 import jdk.internal.foreign.abi.SharedUtils;
@@ -375,27 +369,27 @@ public class SysVVaList implements VaList {
         }
 
         @Override
-        public Builder vargFromInt(MemoryLayout layout, int value) {
+        public Builder vargFromInt(ValueLayout layout, int value) {
             return arg(int.class, layout, value);
         }
 
         @Override
-        public Builder vargFromLong(MemoryLayout layout, long value) {
+        public Builder vargFromLong(ValueLayout layout, long value) {
             return arg(long.class, layout, value);
         }
 
         @Override
-        public Builder vargFromDouble(MemoryLayout layout, double value) {
+        public Builder vargFromDouble(ValueLayout layout, double value) {
             return arg(double.class, layout, value);
         }
 
         @Override
-        public Builder vargFromAddress(MemoryLayout layout, MemoryAddress value) {
-            return arg(MemoryAddress.class, layout, value);
+        public Builder vargFromAddress(ValueLayout layout, Addressable value) {
+            return arg(MemoryAddress.class, layout, value.address());
         }
 
         @Override
-        public Builder vargFromSegment(MemoryLayout layout, MemorySegment value) {
+        public Builder vargFromSegment(GroupLayout layout, MemorySegment value) {
             return arg(MemorySegment.class, layout, value);
         }
 

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/x64/windows/WinVaList.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/x64/windows/WinVaList.java
@@ -25,13 +25,8 @@
  */
 package jdk.internal.foreign.abi.x64.windows;
 
-import jdk.incubator.foreign.CSupport;
+import jdk.incubator.foreign.*;
 import jdk.incubator.foreign.CSupport.VaList;
-import jdk.incubator.foreign.MemoryAddress;
-import jdk.incubator.foreign.MemoryHandles;
-import jdk.incubator.foreign.MemoryLayout;
-import jdk.incubator.foreign.MemorySegment;
-import jdk.incubator.foreign.NativeScope;
 import jdk.internal.foreign.abi.SharedUtils;
 import jdk.internal.foreign.abi.SharedUtils.SimpleVaArg;
 
@@ -206,27 +201,27 @@ class WinVaList implements VaList {
         }
 
         @Override
-        public Builder vargFromInt(MemoryLayout layout, int value) {
+        public Builder vargFromInt(ValueLayout layout, int value) {
             return arg(int.class, layout, value);
         }
 
         @Override
-        public Builder vargFromLong(MemoryLayout layout, long value) {
+        public Builder vargFromLong(ValueLayout layout, long value) {
             return arg(long.class, layout, value);
         }
 
         @Override
-        public Builder vargFromDouble(MemoryLayout layout, double value) {
+        public Builder vargFromDouble(ValueLayout layout, double value) {
             return arg(double.class, layout, value);
         }
 
         @Override
-        public Builder vargFromAddress(MemoryLayout layout, MemoryAddress value) {
-            return arg(MemoryAddress.class, layout, value);
+        public Builder vargFromAddress(ValueLayout layout, Addressable value) {
+            return arg(MemoryAddress.class, layout, value.address());
         }
 
         @Override
-        public Builder vargFromSegment(MemoryLayout layout, MemorySegment value) {
+        public Builder vargFromSegment(GroupLayout layout, MemorySegment value) {
             return arg(MemorySegment.class, layout, value);
         }
 

--- a/test/jdk/java/foreign/StdLibTest.java
+++ b/test/jdk/java/foreign/StdLibTest.java
@@ -44,15 +44,7 @@ import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import jdk.incubator.foreign.CSupport;
-import jdk.incubator.foreign.ForeignLinker;
-import jdk.incubator.foreign.FunctionDescriptor;
-import jdk.incubator.foreign.LibraryLookup;
-import jdk.incubator.foreign.MemoryAddress;
-import jdk.incubator.foreign.MemoryLayout;
-import jdk.incubator.foreign.MemorySegment;
-import jdk.incubator.foreign.NativeScope;
-import jdk.incubator.foreign.SequenceLayout;
+import jdk.incubator.foreign.*;
 
 import static jdk.incubator.foreign.MemoryAccess.*;
 
@@ -426,14 +418,14 @@ public class StdLibTest extends NativeTestHelper {
         DOUBLE(double.class, asVarArg(C_DOUBLE), "%.4f", 1.2345d, 1.2345d, VaList.Builder::vargFromDouble);
 
         final Class<?> carrier;
-        final MemoryLayout layout;
+        final ValueLayout layout;
         final String format;
         final Object nativeValue;
         final Object javaValue;
         @SuppressWarnings("rawtypes")
         final VaListBuilderCall builderCall;
 
-        <Z> PrintfArg(Class<?> carrier, MemoryLayout layout, String format, Z nativeValue, Object javaValue, VaListBuilderCall<Z> builderCall) {
+        <Z> PrintfArg(Class<?> carrier, ValueLayout layout, String format, Z nativeValue, Object javaValue, VaListBuilderCall<Z> builderCall) {
             this.carrier = carrier;
             this.layout = layout;
             this.format = format;
@@ -449,7 +441,7 @@ public class StdLibTest extends NativeTestHelper {
         }
 
         interface VaListBuilderCall<V> {
-            void build(VaList.Builder builder, MemoryLayout layout, V value);
+            void build(VaList.Builder builder, ValueLayout layout, V value);
         }
     }
 

--- a/test/jdk/java/foreign/valist/VaListTest.java
+++ b/test/jdk/java/foreign/valist/VaListTest.java
@@ -31,20 +31,11 @@
  * @run testng/othervm -Dforeign.restricted=permit VaListTest
  */
 
-import jdk.incubator.foreign.CSupport;
+import jdk.incubator.foreign.*;
 import jdk.incubator.foreign.CSupport.AArch64;
 import jdk.incubator.foreign.CSupport.SysV;
 import jdk.incubator.foreign.CSupport.VaList;
 import jdk.incubator.foreign.CSupport.Win64;
-import jdk.incubator.foreign.ForeignLinker;
-import jdk.incubator.foreign.FunctionDescriptor;
-import jdk.incubator.foreign.GroupLayout;
-import jdk.incubator.foreign.LibraryLookup;
-import jdk.incubator.foreign.MemoryAccess;
-import jdk.incubator.foreign.MemoryAddress;
-import jdk.incubator.foreign.MemoryLayout;
-import jdk.incubator.foreign.MemorySegment;
-import jdk.incubator.foreign.NativeScope;
 import jdk.internal.foreign.abi.SharedUtils;
 import jdk.internal.foreign.abi.aarch64.AArch64Linker;
 import jdk.internal.foreign.abi.x64.sysv.SysVx64Linker;
@@ -156,7 +147,7 @@ public class VaListTest {
     @Test(dataProvider = "sumInts")
     public void testIntSum(Function<Consumer<VaList.Builder>, VaList> vaListFactory,
                            BiFunction<Integer, VaList, Integer> sumInts,
-                           MemoryLayout intLayout) {
+                           ValueLayout intLayout) {
         try (VaList vaList = vaListFactory.apply(b ->
                 b.vargFromInt(intLayout, 10)
                         .vargFromInt(intLayout, 15)
@@ -184,7 +175,7 @@ public class VaListTest {
     @Test(dataProvider = "sumDoubles")
     public void testDoubleSum(Function<Consumer<VaList.Builder>, VaList> vaListFactory,
                               BiFunction<Integer, VaList, Double> sumDoubles,
-                              MemoryLayout doubleLayout) {
+                              ValueLayout doubleLayout) {
         try (VaList vaList = vaListFactory.apply(b ->
                 b.vargFromDouble(doubleLayout, 3.0D)
                         .vargFromDouble(doubleLayout, 4.0D)
@@ -214,7 +205,7 @@ public class VaListTest {
     @Test(dataProvider = "pointers")
     public void testVaListMemoryAddress(Function<Consumer<VaList.Builder>, VaList> vaListFactory,
                                         Function<VaList, Integer> getFromPointer,
-                                        MemoryLayout pointerLayout) {
+                                        ValueLayout pointerLayout) {
         try (MemorySegment msInt = MemorySegment.allocateNative(JAVA_INT)) {
             MemoryAccess.setInt(msInt, 10);
             try (VaList vaList = vaListFactory.apply(b -> b.vargFromAddress(pointerLayout, msInt.address()))) {
@@ -267,7 +258,7 @@ public class VaListTest {
     @Test(dataProvider = "structs")
     public void testStruct(Function<Consumer<VaList.Builder>, VaList> vaListFactory,
                            Function<VaList, Integer> sumStruct,
-                           MemoryLayout Point_LAYOUT, VarHandle VH_Point_x, VarHandle VH_Point_y) {
+                           GroupLayout Point_LAYOUT, VarHandle VH_Point_x, VarHandle VH_Point_y) {
         try (MemorySegment struct = MemorySegment.allocateNative(Point_LAYOUT)) {
             VH_Point_x.set(struct, 5);
             VH_Point_y.set(struct, 10);
@@ -318,7 +309,7 @@ public class VaListTest {
     @Test(dataProvider = "bigStructs")
     public void testBigStruct(Function<Consumer<VaList.Builder>, VaList> vaListFactory,
                               Function<VaList, Long> sumBigStruct,
-                              MemoryLayout BigPoint_LAYOUT, VarHandle VH_BigPoint_x, VarHandle VH_BigPoint_y) {
+                              GroupLayout BigPoint_LAYOUT, VarHandle VH_BigPoint_x, VarHandle VH_BigPoint_y) {
         try (MemorySegment struct = MemorySegment.allocateNative(BigPoint_LAYOUT)) {
             VH_BigPoint_x.set(struct, 5);
             VH_BigPoint_y.set(struct, 10);
@@ -369,7 +360,7 @@ public class VaListTest {
     @Test(dataProvider = "floatStructs")
     public void testFloatStruct(Function<Consumer<VaList.Builder>, VaList> vaListFactory,
                                 Function<VaList, Float> sumFloatStruct,
-                                MemoryLayout FloatPoint_LAYOUT,
+                                GroupLayout FloatPoint_LAYOUT,
                                 VarHandle VH_FloatPoint_x, VarHandle VH_FloatPoint_y) {
         try (MemorySegment struct = MemorySegment.allocateNative(FloatPoint_LAYOUT)) {
             VH_FloatPoint_x.set(struct, 1.234f);
@@ -429,7 +420,7 @@ public class VaListTest {
     @Test(dataProvider = "hugeStructs")
     public void testHugeStruct(Function<Consumer<VaList.Builder>, VaList> vaListFactory,
                                Function<VaList, Long> sumHugeStruct,
-                               MemoryLayout HugePoint_LAYOUT,
+                               GroupLayout HugePoint_LAYOUT,
                                VarHandle VH_HugePoint_x, VarHandle VH_HugePoint_y, VarHandle VH_HugePoint_z) {
         // On AArch64 a struct needs to be larger than 16 bytes to be
         // passed by reference.
@@ -482,8 +473,8 @@ public class VaListTest {
     @Test(dataProvider = "sumStack")
     public void testStack(Function<Consumer<VaList.Builder>, VaList> vaListFactory,
                           SumStackFunc sumStack,
-                          MemoryLayout longLayout,
-                          MemoryLayout doubleLayout) {
+                          ValueLayout longLayout,
+                          ValueLayout doubleLayout) {
         try (MemorySegment longSum = MemorySegment.allocateNative(longLayout);
              MemorySegment doubleSum = MemorySegment.allocateNative(doubleLayout)) {
             MemoryAccess.setLong(longSum, 0L);
@@ -555,7 +546,7 @@ public class VaListTest {
     @Test(dataProvider = "sumIntsScoped")
     public void testScopedVaList(BiFunction<Consumer<VaList.Builder>, NativeScope, VaList> vaListFactory,
                                  BiFunction<Integer, VaList, Integer> sumInts,
-                                 MemoryLayout intLayout) {
+                                 ValueLayout intLayout) {
         VaList listLeaked;
         try (NativeScope scope = NativeScope.unboundedScope()) {
             VaList list = vaListFactory.apply(b -> b.vargFromInt(intLayout, 4)
@@ -571,7 +562,7 @@ public class VaListTest {
     @Test(dataProvider = "structs")
     public void testScopeMSRead(Function<Consumer<VaList.Builder>, VaList> vaListFactory,
                                 Function<VaList, Integer> sumStruct, // ignored
-                                MemoryLayout Point_LAYOUT, VarHandle VH_Point_x, VarHandle VH_Point_y) {
+                                GroupLayout Point_LAYOUT, VarHandle VH_Point_x, VarHandle VH_Point_y) {
         MemorySegment pointOut;
         try (NativeScope scope = NativeScope.unboundedScope()) {
             try (MemorySegment pointIn = MemorySegment.allocateNative(Point_LAYOUT)) {
@@ -599,7 +590,7 @@ public class VaListTest {
     }
 
     @Test(dataProvider = "copy")
-    public void testCopy(Function<Consumer<VaList.Builder>, VaList> vaListFactory, MemoryLayout intLayout) {
+    public void testCopy(Function<Consumer<VaList.Builder>, VaList> vaListFactory, ValueLayout intLayout) {
         try (VaList list = vaListFactory.apply(b -> b.vargFromInt(intLayout, 4)
                 .vargFromInt(intLayout, 8))) {
             VaList  copy = list.copy();
@@ -615,7 +606,7 @@ public class VaListTest {
     }
 
     @Test(dataProvider = "copy")
-    public void testScopedCopy(Function<Consumer<VaList.Builder>, VaList> vaListFactory, MemoryLayout intLayout) {
+    public void testScopedCopy(Function<Consumer<VaList.Builder>, VaList> vaListFactory, ValueLayout intLayout) {
         try (VaList list = vaListFactory.apply(b -> b.vargFromInt(intLayout, 4)
                 .vargFromInt(intLayout, 8))) {
             VaList copy;
@@ -635,7 +626,7 @@ public class VaListTest {
     @Test(dataProvider = "copy",
             expectedExceptions = IllegalStateException.class)
     public void testCopyUnusableAfterOriginalClosed(Function<Consumer<VaList.Builder>, VaList> vaListFactory,
-                                                    MemoryLayout intLayout) {
+                                                    ValueLayout intLayout) {
         VaList list = vaListFactory.apply(b -> b.vargFromInt(intLayout, 4)
                 .vargFromInt(intLayout, 8));
         try (VaList copy = list.copy()) {
@@ -648,7 +639,7 @@ public class VaListTest {
     @Test(dataProvider = "copy",
             expectedExceptions = IllegalStateException.class)
     public void testCopyUnusableAfterOriginalClosedScope(Function<Consumer<VaList.Builder>, VaList> vaListFactory,
-                                                         MemoryLayout intLayout) {
+                                                         ValueLayout intLayout) {
         VaList list = vaListFactory.apply(b -> b.vargFromInt(intLayout, 4)
                 .vargFromInt(intLayout, 8));
         try (NativeScope scope = NativeScope.unboundedScope()) {


### PR DESCRIPTION
The routines for creating a memory segment initialized to a given initial MemoryAddress value should be updated to allow clients to pass any Addressable.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [JDK-8252872](https://bugs.openjdk.java.net/browse/JDK-8252872): NativeScope should take Addressable instead of MemoryAddress


### Reviewers
 * [Athijegannathan Sundararajan](https://openjdk.java.net/census#sundar) (@sundararajana - Committer) ⚠️ Review applies to 832126822645fc4f2a712339bc62bd269544ed73
 * [Jorn Vernee](https://openjdk.java.net/census#jvernee) (@JornVernee - Committer)


### Download
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/311/head:pull/311`
`$ git checkout pull/311`
