### PR TITLE
8252899: jextract can't handle multiple extern declarations that have the same name, but a different type name

### DIFF
--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/OutputFactory.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/OutputFactory.java
@@ -57,7 +57,7 @@ public class OutputFactory implements Declaration.Visitor<Void, Declaration> {
     private static final String VA_LIST_TAG = "__va_list_tag";
     private final Set<String> constants = new HashSet<>();
     // To detect duplicate Variable and Function declarations.
-    private final Set<Declaration.Variable> variables = new HashSet<>();
+    private final Set<String> variables = new HashSet<>();
     private final Set<Declaration.Function> functions = new HashSet<>();
 
     protected final HeaderBuilder toplevelBuilder;
@@ -83,7 +83,7 @@ public class OutputFactory implements Declaration.Visitor<Void, Declaration> {
 
     // have we seen this Variable earlier?
     protected boolean variableSeen(Declaration.Variable tree) {
-        return !variables.add(tree);
+        return !variables.add(tree.name());
     }
 
     // have we seen this Function earlier?

--- a/test/jdk/tools/jextract/testGlobalRedefinition/TestGlobalRedefinition.java
+++ b/test/jdk/tools/jextract/testGlobalRedefinition/TestGlobalRedefinition.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import org.testng.annotations.Test;
+import test.jextract.redef.*;
+
+import java.lang.reflect.Method;
+
+import static org.testng.Assert.assertEquals;
+import static test.jextract.redef.redef_h.*;
+
+/*
+ * @test id=classes
+ * @library ..
+ * @modules jdk.incubator.jextract
+ * @run driver JtregJextract -t test.jextract.redef -- redef.h
+ * @run testng/othervm -Dforeign.restricted=permit TestGlobalRedefinition
+ */
+/*
+ * @test id=sources
+ * @library ..
+ * @modules jdk.incubator.jextract
+ * @run driver JtregJextractSources -t test.jextract.redef -- redef.h
+ * @run testng/othervm -Dforeign.restricted=permit TestGlobalRedefinition
+ */
+public class TestGlobalRedefinition {
+    @Test
+    public void test() throws Throwable {
+        Method mGet = redef_h.class.getMethod("x$get");
+        C c1 = mGet.getAnnotatedReturnType().getAnnotation(C.class);
+        assertEquals(c1.value(), "int");
+
+        Method mSet = redef_h.class.getMethod("x$set", int.class);
+        C c2 = mSet.getAnnotatedParameterTypes()[0].getAnnotation(C.class);
+        assertEquals(c2.value(), "int");
+    }
+}

--- a/test/jdk/tools/jextract/testGlobalRedefinition/redef.h
+++ b/test/jdk/tools/jextract/testGlobalRedefinition/redef.h
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+typedef int MyInt;
+
+extern const int x;
+extern const MyInt x;


### PR DESCRIPTION
Hi,

This PR let's jextract handle cases like the one described in the bug:

    typedef int MyInt;

    extern const int x;
    extern const MyInt x; 

Where the same global variable is re-declared, but slightly differently.

The current code is de-duping globals using the declaration. Changing this to de-duping by name allows use to also handle these cases.

Thanks,
Jorn
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [JDK-8252899](https://bugs.openjdk.java.net/browse/JDK-8252899): jextract can't handle multiple extern declarations that have the same name, but a different type name


### Reviewers
 * [Athijegannathan Sundararajan](https://openjdk.java.net/census#sundar) (@sundararajana - Committer)


### Download
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/313/head:pull/313`
`$ git checkout pull/313`
