### PR TITLE
8252931: Extend multiple constant classes support to ClassConstantHelper

### DIFF
--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/ConstantHelper.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/ConstantHelper.java
@@ -33,6 +33,9 @@ import java.lang.constant.DirectMethodHandleDesc;
 import java.lang.invoke.MethodType;
 import java.util.List;
 
+import static jdk.internal.jextract.impl.MultiFileConstantHelper.CONSTANTS_PER_CLASS_CLASSES;
+import static jdk.internal.jextract.impl.MultiFileConstantHelper.CONSTANTS_PER_CLASS_SOURCES;
+
 interface ConstantHelper {
     DirectMethodHandleDesc addLayout(String javaName, MemoryLayout layout);
     DirectMethodHandleDesc addFieldVarHandle(String javaName, String nativeName, MemoryLayout layout, Class<?> type, String parentJavaName, MemoryLayout parentLayout);
@@ -48,6 +51,7 @@ interface ConstantHelper {
         return new MultiFileConstantHelper(headerClassName,
             (simpleClassName, baseClassName, isFinal) -> source
                 ? SourceConstantHelper.make(packageName, simpleClassName, libraryNames, baseClassName, isFinal)
-                : ClassConstantHelper.make(packageName, simpleClassName, runtimeHelper, cString, libraryNames, baseClassName, isFinal));
+                : ClassConstantHelper.make(packageName, simpleClassName, runtimeHelper, cString, libraryNames, baseClassName, isFinal),
+            source ? CONSTANTS_PER_CLASS_SOURCES : CONSTANTS_PER_CLASS_CLASSES);
     }
 }

--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/ConstantHelper.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/ConstantHelper.java
@@ -43,12 +43,11 @@ interface ConstantHelper {
     DirectMethodHandleDesc addConstant(String name, Class<?> type, Object value);
     List<JavaFileObject> getClasses();
 
-    static ConstantHelper make(boolean source, String parentClassName, ClassDesc runtimeHelper,
+    static ConstantHelper make(boolean source, String packageName, String headerClassName, ClassDesc runtimeHelper,
                                ClassDesc cString, String[] libraryNames) {
-        if (source) {
-            return new SourceConstantHelper(parentClassName, libraryNames);
-        } else {
-            return new ClassConstantHelper(parentClassName, runtimeHelper, cString, libraryNames);
-        }
+        return new MultiFileConstantHelper(headerClassName,
+            (simpleClassName, baseClassName, isFinal) -> source
+                ? SourceConstantHelper.make(packageName, simpleClassName, libraryNames, baseClassName, isFinal)
+                : ClassConstantHelper.make(packageName, simpleClassName, runtimeHelper, cString, libraryNames, baseClassName, isFinal));
     }
 }

--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/MultiFileConstantHelper.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/MultiFileConstantHelper.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package jdk.internal.jextract.impl;
+
+import jdk.incubator.foreign.FunctionDescriptor;
+import jdk.incubator.foreign.MemoryLayout;
+
+import javax.tools.JavaFileObject;
+import java.lang.constant.DirectMethodHandleDesc;
+import java.lang.invoke.MethodType;
+import java.util.ArrayList;
+import java.util.List;
+
+public class MultiFileConstantHelper implements ConstantHelper {
+
+    private static final int CONSTANTS_PER_CLASS = Integer.getInteger("jextract.constants.per.class", 1000);
+
+    @FunctionalInterface
+    interface ConstantHelperFunc {
+        ConstantHelper make(String simpleClassName, String baseClassName, boolean isFinal);
+    }
+
+    private final ConstantHelperFunc delegateFactory;
+    private final String headerClassName;
+
+    private int constantCount;
+    private int constantClassCount;
+    private ConstantHelper delegate;
+
+    private final List<JavaFileObject> finishedClasses = new ArrayList<>();
+
+    public MultiFileConstantHelper(String headerClassName, ConstantHelperFunc func) {
+        this.headerClassName = headerClassName;
+        this.delegateFactory = func;
+        this.delegate = delegateFactory.make(getConstantClassName(), null, false);
+    }
+
+    private String getConstantClassName() {
+        return headerClassName + "$constants$" + constantClassCount;
+    }
+
+    private void checkNewConstantsClass() {
+        if (constantCount > CONSTANTS_PER_CLASS) {
+            newConstantsClass(false, null);
+        }
+        constantCount++;
+    }
+
+    private void newConstantsClass(boolean isFinal, String nameOverride) {
+        finishedClasses.addAll(delegate.getClasses());
+        String currentClassName = getConstantClassName();
+        constantClassCount++;
+        String newClassName = nameOverride != null ? nameOverride : getConstantClassName();
+        delegate = delegateFactory.make(newClassName, currentClassName, isFinal);
+        this.constantCount = 0;
+    }
+
+    @Override
+    public DirectMethodHandleDesc addLayout(String javaName, MemoryLayout layout) {
+        checkNewConstantsClass();
+        return delegate.addLayout(javaName, layout);
+    }
+
+    @Override
+    public DirectMethodHandleDesc addFieldVarHandle(String javaName, String nativeName, MemoryLayout layout, Class<?> type, String parentJavaName, MemoryLayout parentLayout) {
+        checkNewConstantsClass();
+        return delegate.addFieldVarHandle(javaName, nativeName, layout, type, parentJavaName, parentLayout);
+    }
+
+    @Override
+    public DirectMethodHandleDesc addGlobalVarHandle(String javaName, String nativeName, MemoryLayout layout, Class<?> type) {
+        checkNewConstantsClass();
+        return delegate.addGlobalVarHandle(javaName, nativeName, layout, type);
+    }
+
+    @Override
+    public DirectMethodHandleDesc addMethodHandle(String javaName, String nativeName, MethodType mtype, FunctionDescriptor desc, boolean varargs) {
+        checkNewConstantsClass();
+        return delegate.addMethodHandle(javaName, nativeName, mtype, desc, varargs);
+    }
+
+    @Override
+    public DirectMethodHandleDesc addSegment(String javaName, String nativeName, MemoryLayout layout) {
+        checkNewConstantsClass();
+        return delegate.addSegment(javaName, nativeName, layout);
+    }
+
+    @Override
+    public DirectMethodHandleDesc addFunctionDesc(String javaName, FunctionDescriptor fDesc) {
+        checkNewConstantsClass();
+        return delegate.addFunctionDesc(javaName, fDesc);
+    }
+
+    @Override
+    public DirectMethodHandleDesc addConstant(String name, Class<?> type, Object value) {
+        checkNewConstantsClass();
+        return delegate.addConstant(name, type, value);
+    }
+
+    @Override
+    public List<JavaFileObject> getClasses() {
+        newConstantsClass(true, headerClassName + "$constants");
+        return new ArrayList<>(finishedClasses);
+    }
+}

--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/MultiFileConstantHelper.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/MultiFileConstantHelper.java
@@ -34,8 +34,8 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class MultiFileConstantHelper implements ConstantHelper {
-
-    private static final int CONSTANTS_PER_CLASS = Integer.getInteger("jextract.constants.per.class", 1000);
+    static final int CONSTANTS_PER_CLASS_SOURCES = Integer.getInteger("jextract.constants.per.class.source", 1000);
+    static final int CONSTANTS_PER_CLASS_CLASSES = Integer.getInteger("jextract.constants.per.class.binary", 10000);
 
     @FunctionalInterface
     interface ConstantHelperFunc {
@@ -44,6 +44,7 @@ public class MultiFileConstantHelper implements ConstantHelper {
 
     private final ConstantHelperFunc delegateFactory;
     private final String headerClassName;
+    private final int constantsPerClass;
 
     private int constantCount;
     private int constantClassCount;
@@ -51,9 +52,10 @@ public class MultiFileConstantHelper implements ConstantHelper {
 
     private final List<JavaFileObject> finishedClasses = new ArrayList<>();
 
-    public MultiFileConstantHelper(String headerClassName, ConstantHelperFunc func) {
+    public MultiFileConstantHelper(String headerClassName, ConstantHelperFunc func, int constantsPerClass) {
         this.headerClassName = headerClassName;
         this.delegateFactory = func;
+        this.constantsPerClass = constantsPerClass;
         this.delegate = delegateFactory.make(getConstantClassName(), null, false);
     }
 
@@ -62,7 +64,7 @@ public class MultiFileConstantHelper implements ConstantHelper {
     }
 
     private void checkNewConstantsClass() {
-        if (constantCount > CONSTANTS_PER_CLASS) {
+        if (constantCount > constantsPerClass) {
             newConstantsClass(false, null);
         }
         constantCount++;

--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/OutputFactory.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/OutputFactory.java
@@ -94,8 +94,7 @@ public class OutputFactory implements Declaration.Visitor<Void, Declaration> {
     public static JavaFileObject[] generateWrapped(Declaration.Scoped decl, String headerName, boolean source,
                 String pkgName, List<String> libraryNames) {
         String clsName = Utils.javaSafeIdentifier(headerName.replace(".h", "_h"), true);
-        String qualName = pkgName.isEmpty() ? clsName : pkgName + "." + clsName;
-        ConstantHelper constantHelper = ConstantHelper.make(source, qualName,
+        ConstantHelper constantHelper = ConstantHelper.make(source, pkgName, clsName,
                 ClassDesc.of(pkgName, "RuntimeHelper"), ClassDesc.of("jdk.incubator.foreign", "CSupport"),
                 libraryNames.toArray(String[]::new));
         AnnotationWriter annotationWriter = new AnnotationWriter();

--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/Utils.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/Utils.java
@@ -54,6 +54,10 @@ import java.util.stream.Stream;
  * General utility functions
  */
 class Utils {
+    public static String qualifiedClassName(String packageName, String simpleName) {
+        return (packageName.isEmpty() ? "" : packageName + ".") + simpleName;
+    }
+
     private static URI fileName(String pkgName, String clsName, String extension) {
         String pkgPrefix = pkgName.isEmpty() ? "" : pkgName.replaceAll("\\.", "/") + "/";
         return URI.create(pkgPrefix + clsName + extension);


### PR DESCRIPTION
Hi,

This PR extracts the multiple source file functionality from SourceConstantHelper into a decorator class, and then uses it for ClassConstantHelper as well.

(I've also done a minor cleanup where I simplified the way booleans are turned into constants, since we can now just call describeConstable() on a Boolean)

Thanks,
Jorn
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [JDK-8252931](https://bugs.openjdk.java.net/browse/JDK-8252931): Extend multiple constant classes support to ClassConstantHelper


### Reviewers
 * [Athijegannathan Sundararajan](https://openjdk.java.net/census#sundar) (@sundararajana - Committer)


### Download
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/314/head:pull/314`
`$ git checkout pull/314`
