### PR TITLE
8252866: MemoryAccess.setAddress should take Addressable, not MemoryAddress (follow up)

### DIFF
--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/MemoryAccess.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/MemoryAccess.java
@@ -782,7 +782,7 @@ public final class MemoryAccess {
      * @param value the memory address to be written (expressed as an {@link Addressable} instance).
      */
     public static void setAddressAtOffset(MemorySegment segment, long offset, Addressable value) {
-        address_handle.set(segment, offset, value);
+        address_handle.set(segment, offset, value.address());
     }
 
     private static VarHandle indexedHandle(ValueLayout elementLayout, Class<?> carrier) {


### PR DESCRIPTION
This small patch fixes an oversight - MemoryAccess.setAddressAtOffset should call address() on the incoming value, before dispatching on the var handle.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [JDK-8252866](https://bugs.openjdk.java.net/browse/JDK-8252866): MemoryAccess.setAddress should take Addressable, not MemoryAddress ⚠️ Title mismatch between PR and JBS.


### Reviewers
 * [Athijegannathan Sundararajan](https://openjdk.java.net/census#sundar) (@sundararajana - Committer)


### Download
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/315/head:pull/315`
`$ git checkout pull/315`
