### PR TITLE
8253003: jextract clang wrapper code should avoid Addressable.address() call as much as possible

### DIFF
--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/clang/Index.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/clang/Index.java
@@ -87,17 +87,17 @@ public class Index implements AutoCloseable {
             MemorySegment src = CSupport.toCString(file, scope);
             MemorySegment cargs = scope.allocateArray(CSupport.C_POINTER, args.length);
             for (int i = 0 ; i < args.length ; i++) {
-                MemoryAccess.setAddressAtIndex(cargs, i, CSupport.toCString(args[i], scope).address());
+                MemoryAccess.setAddressAtIndex(cargs, i, CSupport.toCString(args[i], scope));
             }
             MemorySegment outAddress = scope.allocate(CSupport.C_POINTER);
             ErrorCode code = ErrorCode.valueOf(Index_h.clang_parseTranslationUnit2(
                     ptr,
-                    src.address(),
-                    cargs == null ? MemoryAddress.NULL : cargs.address(),
+                    src,
+                    cargs == null ? MemoryAddress.NULL : cargs,
                     args.length, MemoryAddress.NULL,
                     0,
                     options,
-                    outAddress.address()));
+                    outAddress));
 
             MemoryAddress tu = (MemoryAddress) VH_MemoryAddress.get(outAddress);
             TranslationUnit rv = new TranslationUnit(tu);

--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/clang/SourceLocation.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/clang/SourceLocation.java
@@ -25,6 +25,7 @@
  */
 package jdk.internal.clang;
 
+import jdk.incubator.foreign.Addressable;
 import jdk.incubator.foreign.CSupport;
 import jdk.incubator.foreign.MemoryAccess;
 import jdk.incubator.foreign.MemoryAddress;
@@ -45,8 +46,8 @@ public class SourceLocation {
 
     @FunctionalInterface
     private interface LocationFactory {
-        void get(MemorySegment loc, MemoryAddress file,
-                 MemoryAddress line, MemoryAddress column, MemoryAddress offset);
+        void get(MemorySegment loc, Addressable file,
+                 Addressable line, Addressable column, Addressable offset);
     }
 
     @SuppressWarnings("unchecked")
@@ -56,7 +57,7 @@ public class SourceLocation {
              MemorySegment col = MemorySegment.allocateNative(CSupport.C_INT);
              MemorySegment offset = MemorySegment.allocateNative(CSupport.C_INT)) {
 
-            fn.get(loc, file.address(), line.address(), col.address(), offset.address());
+            fn.get(loc, file, line, col, offset);
             MemoryAddress fname = MemoryAccess.getAddress(file);
 
 

--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/clang/Type.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/clang/Type.java
@@ -110,7 +110,7 @@ public final class Type {
     // Struct/RecordType
     private long getOffsetOf0(String fieldName) {
         try (MemorySegment cfname = CSupport.toCString(fieldName)) {
-            return Index_h.clang_Type_getOffsetOf(type, cfname.address());
+            return Index_h.clang_Type_getOffsetOf(type, cfname);
         }
     }
 


### PR DESCRIPTION
removed .address calls in libclang wrapper code.
