### PR TITLE
JDK-8252757: Add support for shared segments (followup)

### DIFF
--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/AbstractMemorySegmentImpl.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/AbstractMemorySegmentImpl.java
@@ -278,6 +278,7 @@ public abstract class AbstractMemorySegmentImpl implements MemorySegment, Memory
 
     @Override
     public MemorySegment withOwnerThread(Thread newOwner) {
+        checkValidState();
         int expectedMode = newOwner != null ? HANDOFF : SHARE;
         if (!isSet(expectedMode)) {
             throw unsupportedAccessMode(expectedMode);
@@ -295,13 +296,10 @@ public abstract class AbstractMemorySegmentImpl implements MemorySegment, Memory
 
     @Override
     public final void close() {
+        checkValidState();
         if (!isSet(CLOSE)) {
             throw unsupportedAccessMode(CLOSE);
         }
-        closeNoCheck();
-    }
-
-    private final void closeNoCheck() {
         scope.close();
     }
 

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/MemoryScope.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/MemoryScope.java
@@ -102,7 +102,6 @@ abstract class MemoryScope implements ScopedMemoryAccess.Scope {
      * a confined scope and this method is called outside of the owner thread.
      */
     final void close() {
-        checkValidState();
         justClose();
         if (cleanupAction != null) {
             cleanupAction.run();
@@ -119,7 +118,6 @@ abstract class MemoryScope implements ScopedMemoryAccess.Scope {
      * a confined scope and this method is called outside of the owner thread.
      */
     MemoryScope confineTo(Thread newOwner) {
-        checkValidState();
         justClose();
         return new ConfinedScope(newOwner, ref, cleanupAction);
     }
@@ -132,7 +130,6 @@ abstract class MemoryScope implements ScopedMemoryAccess.Scope {
      * or if this is already a shared scope.
      */
     MemoryScope share() {
-        checkValidState();
         justClose();
         return new SharedScope(ref, cleanupAction);
     }


### PR DESCRIPTION
I realized there's a small issue in the API code for shared segment support: the liveness test is always performed inside MemoryScope (e.g. on share(), confineTo() and close()). While this is ok, there is an usability issue, in that the `checkValidState` method inside MemoryScope throws raw scoped exceptions (as this routine is really meant only to be used during memory access).

A better solution is to move the liveness check outside the scope implementation for these operations, and do the check in AbstractMemorySegment, which correctly wraps the exception.

I've added a comprehensive test which checks that no raw exceptions are leaked from the segment API.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [JDK-8252757](https://bugs.openjdk.java.net/browse/JDK-8252757): Add support for shared segments ⚠️ Title mismatch between PR and JBS.


### Reviewers
 * [Jorn Vernee](https://openjdk.java.net/census#jvernee) (@JornVernee - Committer)


### Download
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/318/head:pull/318`
`$ git checkout pull/318`
