### PR TITLE
8253055: ScopedAccessException should be an Error

### DIFF
--- a/src/hotspot/share/prims/scopedMemoryAccess.cpp
+++ b/src/hotspot/share/prims/scopedMemoryAccess.cpp
@@ -1,3 +1,4 @@
+
 #include "precompiled.hpp"
 #include "jni.h"
 #include "jvm.h"
@@ -86,7 +87,7 @@ public:
       Deoptimization::deoptimize(jt, last_frame);
     }
 
-    const int max_critical_stack_depth = 5;
+    const int max_critical_stack_depth = 45;
     int depth = 0;
     vframeStream stream(jt);
     for (; !stream.at_end(); stream.next()) {
@@ -136,13 +137,13 @@ JVM_ENTRY(void, ScopedMemoryAccess_closeScope(JNIEnv *env, jobject receiver, job
 
 #define MEMACCESS "ScopedMemoryAccess"
 #define SCOPE LANG MEMACCESS "$Scope;"
-#define SCOPED_EXC LANG MEMACCESS "$Scope$ScopedAccessException;"
+#define SCOPED_ERR LANG MEMACCESS "$Scope$ScopedAccessError;"
 
 #define CC (char*)  /*cast a literal from (const char*)*/
 #define FN_PTR(f) CAST_FROM_FN_PTR(void*, &f)
 
 static JNINativeMethod jdk_internal_misc_ScopedMemoryAccess_methods[] = {
-    {CC "closeScope0",   CC "(" SCOPE SCOPED_EXC ")V",           FN_PTR(ScopedMemoryAccess_closeScope)},
+    {CC "closeScope0",   CC "(" SCOPE SCOPED_ERR ")V",           FN_PTR(ScopedMemoryAccess_closeScope)},
 };
 
 #undef CC

--- a/src/hotspot/share/prims/scopedMemoryAccess.cpp
+++ b/src/hotspot/share/prims/scopedMemoryAccess.cpp
@@ -87,7 +87,7 @@ public:
       Deoptimization::deoptimize(jt, last_frame);
     }
 
-    const int max_critical_stack_depth = 45;
+    const int max_critical_stack_depth = 5;
     int depth = 0;
     vframeStream stream(jt);
     for (; !stream.at_end(); stream.next()) {

--- a/src/java.base/share/classes/jdk/internal/misc/X-ScopedMemoryAccess-bin.java.template
+++ b/src/java.base/share/classes/jdk/internal/misc/X-ScopedMemoryAccess-bin.java.template
@@ -2,7 +2,7 @@
     public $type$ get$Type$(Scope scope, Object base, long offset) {
         try {
             return get$Type$Internal(scope, base, offset);
-        } catch (Scope.ScopedAccessException ex) {
+        } catch (Scope.ScopedAccessError ex) {
             throw new IllegalStateException("This segment is already closed");
         }
     }
@@ -23,7 +23,7 @@
     public void put$Type$(Scope scope, Object base, long offset, $type$ value) {
         try {
             put$Type$Internal(scope, base, offset, value);
-        } catch (Scope.ScopedAccessException ex) {
+        } catch (Scope.ScopedAccessError ex) {
             throw new IllegalStateException("This segment is already closed");
         }
     }
@@ -45,7 +45,7 @@
     public $type$ get$Type$Unaligned(Scope scope, Object base, long offset, boolean be) {
         try {
             return get$Type$UnalignedInternal(scope, base, offset, be);
-        } catch (Scope.ScopedAccessException ex) {
+        } catch (Scope.ScopedAccessError ex) {
             throw new IllegalStateException("This segment is already closed");
         }
     }
@@ -66,7 +66,7 @@
     public void put$Type$Unaligned(Scope scope, Object base, long offset, $type$ value, boolean be) {
         try {
             put$Type$UnalignedInternal(scope, base, offset, value, be);
-        } catch (Scope.ScopedAccessException ex) {
+        } catch (Scope.ScopedAccessError ex) {
             throw new IllegalStateException("This segment is already closed");
         }
     }
@@ -88,7 +88,7 @@
     public $type$ get$Type$Volatile(Scope scope, Object base, long offset) {
         try {
             return get$Type$VolatileInternal(scope, base, offset);
-        } catch (Scope.ScopedAccessException ex) {
+        } catch (Scope.ScopedAccessError ex) {
             throw new IllegalStateException("This segment is already closed");
         }
     }
@@ -109,7 +109,7 @@
     public void put$Type$Volatile(Scope scope, Object base, long offset, $type$ value) {
         try {
             put$Type$VolatileInternal(scope, base, offset, value);
-        } catch (Scope.ScopedAccessException ex) {
+        } catch (Scope.ScopedAccessError ex) {
             throw new IllegalStateException("This segment is already closed");
         }
     }
@@ -130,7 +130,7 @@
     public $type$ get$Type$Acquire(Scope scope, Object base, long offset) {
         try {
             return get$Type$AcquireInternal(scope, base, offset);
-        } catch (Scope.ScopedAccessException ex) {
+        } catch (Scope.ScopedAccessError ex) {
             throw new IllegalStateException("This segment is already closed");
         }
     }
@@ -151,7 +151,7 @@
     public void put$Type$Release(Scope scope, Object base, long offset, $type$ value) {
         try {
             put$Type$ReleaseInternal(scope, base, offset, value);
-        } catch (Scope.ScopedAccessException ex) {
+        } catch (Scope.ScopedAccessError ex) {
             throw new IllegalStateException("This segment is already closed");
         }
     }
@@ -172,7 +172,7 @@
     public $type$ get$Type$Opaque(Scope scope, Object base, long offset) {
         try {
             return get$Type$OpaqueInternal(scope, base, offset);
-        } catch (Scope.ScopedAccessException ex) {
+        } catch (Scope.ScopedAccessError ex) {
             throw new IllegalStateException("This segment is already closed");
         }
     }
@@ -192,7 +192,7 @@
     public void put$Type$Opaque(Scope scope, Object base, long offset, $type$ value) {
         try {
             put$Type$OpaqueInternal(scope, base, offset, value);
-        } catch (Scope.ScopedAccessException ex) {
+        } catch (Scope.ScopedAccessError ex) {
             throw new IllegalStateException("This segment is already closed");
         }
     }
@@ -213,7 +213,7 @@
     public boolean compareAndSet$Type$(Scope scope, Object base, long offset, $type$ expected, $type$ value) {
         try {
             return compareAndSet$Type$Internal(scope, base, offset, expected, value);
-        } catch (Scope.ScopedAccessException ex) {
+        } catch (Scope.ScopedAccessError ex) {
             throw new IllegalStateException("This segment is already closed");
         }
     }
@@ -234,7 +234,7 @@
     public $type$ compareAndExchange$Type$(Scope scope, Object base, long offset, $type$ expected, $type$ value) {
         try {
             return compareAndExchange$Type$Internal(scope, base, offset, expected, value);
-        } catch (Scope.ScopedAccessException ex) {
+        } catch (Scope.ScopedAccessError ex) {
             throw new IllegalStateException("This segment is already closed");
         }
     }
@@ -255,7 +255,7 @@
     public $type$ compareAndExchange$Type$Acquire(Scope scope, Object base, long offset, $type$ expected, $type$ value) {
         try {
             return compareAndExchange$Type$AcquireInternal(scope, base, offset, expected, value);
-        } catch (Scope.ScopedAccessException ex) {
+        } catch (Scope.ScopedAccessError ex) {
             throw new IllegalStateException("This segment is already closed");
         }
     }
@@ -276,7 +276,7 @@
     public $type$ compareAndExchange$Type$Release(Scope scope, Object base, long offset, $type$ expected, $type$ value) {
         try {
             return compareAndExchange$Type$ReleaseInternal(scope, base, offset, expected, value);
-        } catch (Scope.ScopedAccessException ex) {
+        } catch (Scope.ScopedAccessError ex) {
             throw new IllegalStateException("This segment is already closed");
         }
     }
@@ -297,7 +297,7 @@
     public boolean weakCompareAndSet$Type$Plain(Scope scope, Object base, long offset, $type$ expected, $type$ value) {
         try {
             return weakCompareAndSet$Type$PlainInternal(scope, base, offset, expected, value);
-        } catch (Scope.ScopedAccessException ex) {
+        } catch (Scope.ScopedAccessError ex) {
             throw new IllegalStateException("This segment is already closed");
         }
     }
@@ -318,7 +318,7 @@
     public boolean weakCompareAndSet$Type$(Scope scope, Object base, long offset, $type$ expected, $type$ value) {
         try {
             return weakCompareAndSet$Type$Internal(scope, base, offset, expected, value);
-        } catch (Scope.ScopedAccessException ex) {
+        } catch (Scope.ScopedAccessError ex) {
             throw new IllegalStateException("This segment is already closed");
         }
     }
@@ -339,7 +339,7 @@
     public boolean weakCompareAndSet$Type$Acquire(Scope scope, Object base, long offset, $type$ expected, $type$ value) {
         try {
             return weakCompareAndSet$Type$AcquireInternal(scope, base, offset, expected, value);
-        } catch (Scope.ScopedAccessException ex) {
+        } catch (Scope.ScopedAccessError ex) {
             throw new IllegalStateException("This segment is already closed");
         }
     }
@@ -360,7 +360,7 @@
     public boolean weakCompareAndSet$Type$Release(Scope scope, Object base, long offset, $type$ expected, $type$ value) {
         try {
             return weakCompareAndSet$Type$ReleaseInternal(scope, base, offset, expected, value);
-        } catch (Scope.ScopedAccessException ex) {
+        } catch (Scope.ScopedAccessError ex) {
             throw new IllegalStateException("This segment is already closed");
         }
     }
@@ -381,7 +381,7 @@
     public $type$ getAndSet$Type$(Scope scope, Object base, long offset, $type$ value) {
         try {
             return getAndSet$Type$Internal(scope, base, offset, value);
-        } catch (Scope.ScopedAccessException ex) {
+        } catch (Scope.ScopedAccessError ex) {
             throw new IllegalStateException("This segment is already closed");
         }
     }
@@ -402,7 +402,7 @@
     public $type$ getAndSet$Type$Acquire(Scope scope, Object base, long offset, $type$ value) {
         try {
             return getAndSet$Type$AcquireInternal(scope, base, offset, value);
-        } catch (Scope.ScopedAccessException ex) {
+        } catch (Scope.ScopedAccessError ex) {
             throw new IllegalStateException("This segment is already closed");
         }
     }
@@ -423,7 +423,7 @@
     public $type$ getAndSet$Type$Release(Scope scope, Object base, long offset, $type$ value) {
         try {
             return getAndSet$Type$ReleaseInternal(scope, base, offset, value);
-        } catch (Scope.ScopedAccessException ex) {
+        } catch (Scope.ScopedAccessError ex) {
             throw new IllegalStateException("This segment is already closed");
         }
     }
@@ -446,7 +446,7 @@
     public $type$ getAndAdd$Type$(Scope scope, Object base, long offset, $type$ delta) {
         try {
             return getAndAdd$Type$Internal(scope, base, offset, delta);
-        } catch (Scope.ScopedAccessException ex) {
+        } catch (Scope.ScopedAccessError ex) {
             throw new IllegalStateException("This segment is already closed");
         }
     }
@@ -467,7 +467,7 @@
     public $type$ getAndAdd$Type$Acquire(Scope scope, Object base, long offset, $type$ delta) {
         try {
             return getAndAdd$Type$AcquireInternal(scope, base, offset, delta);
-        } catch (Scope.ScopedAccessException ex) {
+        } catch (Scope.ScopedAccessError ex) {
             throw new IllegalStateException("This segment is already closed");
         }
     }
@@ -488,7 +488,7 @@
     public $type$ getAndAdd$Type$Release(Scope scope, Object base, long offset, $type$ delta) {
         try {
             return getAndAdd$Type$ReleaseInternal(scope, base, offset, delta);
-        } catch (Scope.ScopedAccessException ex) {
+        } catch (Scope.ScopedAccessError ex) {
             throw new IllegalStateException("This segment is already closed");
         }
     }
@@ -511,7 +511,7 @@
     public $type$ getAndBitwiseOr$Type$(Scope scope, Object base, long offset, $type$ value) {
         try {
             return getAndBitwiseOr$Type$Internal(scope, base, offset, value);
-        } catch (Scope.ScopedAccessException ex) {
+        } catch (Scope.ScopedAccessError ex) {
             throw new IllegalStateException("This segment is already closed");
         }
     }
@@ -532,7 +532,7 @@
     public $type$ getAndBitwiseOr$Type$Acquire(Scope scope, Object base, long offset, $type$ value) {
         try {
             return getAndBitwiseOr$Type$AcquireInternal(scope, base, offset, value);
-        } catch (Scope.ScopedAccessException ex) {
+        } catch (Scope.ScopedAccessError ex) {
             throw new IllegalStateException("This segment is already closed");
         }
     }
@@ -553,7 +553,7 @@
     public $type$ getAndBitwiseOr$Type$Release(Scope scope, Object base, long offset, $type$ value) {
         try {
             return getAndBitwiseOr$Type$ReleaseInternal(scope, base, offset, value);
-        } catch (Scope.ScopedAccessException ex) {
+        } catch (Scope.ScopedAccessError ex) {
             throw new IllegalStateException("This segment is already closed");
         }
     }
@@ -574,7 +574,7 @@
     public $type$ getAndBitwiseAnd$Type$(Scope scope, Object base, long offset, $type$ value) {
         try {
             return getAndBitwiseAnd$Type$Internal(scope, base, offset, value);
-        } catch (Scope.ScopedAccessException ex) {
+        } catch (Scope.ScopedAccessError ex) {
             throw new IllegalStateException("This segment is already closed");
         }
     }
@@ -595,7 +595,7 @@
     public $type$ getAndBitwiseAnd$Type$Acquire(Scope scope, Object base, long offset, $type$ value) {
         try {
             return getAndBitwiseAnd$Type$AcquireInternal(scope, base, offset, value);
-        } catch (Scope.ScopedAccessException ex) {
+        } catch (Scope.ScopedAccessError ex) {
             throw new IllegalStateException("This segment is already closed");
         }
     }
@@ -616,7 +616,7 @@
     public $type$ getAndBitwiseAnd$Type$Release(Scope scope, Object base, long offset, $type$ value) {
         try {
             return getAndBitwiseAnd$Type$ReleaseInternal(scope, base, offset, value);
-        } catch (Scope.ScopedAccessException ex) {
+        } catch (Scope.ScopedAccessError ex) {
             throw new IllegalStateException("This segment is already closed");
         }
     }
@@ -637,7 +637,7 @@
     public $type$ getAndBitwiseXor$Type$(Scope scope, Object base, long offset, $type$ value) {
         try {
             return getAndBitwiseXor$Type$Internal(scope, base, offset, value);
-        } catch (Scope.ScopedAccessException ex) {
+        } catch (Scope.ScopedAccessError ex) {
             throw new IllegalStateException("This segment is already closed");
         }
     }
@@ -658,7 +658,7 @@
     public $type$ getAndBitwiseXor$Type$Acquire(Scope scope, Object base, long offset, $type$ value) {
         try {
             return getAndBitwiseXor$Type$AcquireInternal(scope, base, offset, value);
-        } catch (Scope.ScopedAccessException ex) {
+        } catch (Scope.ScopedAccessError ex) {
             throw new IllegalStateException("This segment is already closed");
         }
     }
@@ -679,7 +679,7 @@
     public $type$ getAndBitwiseXor$Type$Release(Scope scope, Object base, long offset, $type$ value) {
         try {
             return getAndBitwiseXor$Type$ReleaseInternal(scope, base, offset, value);
-        } catch (Scope.ScopedAccessException ex) {
+        } catch (Scope.ScopedAccessError ex) {
             throw new IllegalStateException("This segment is already closed");
         }
     }

--- a/src/java.base/share/classes/jdk/internal/misc/X-ScopedMemoryAccess.java.template
+++ b/src/java.base/share/classes/jdk/internal/misc/X-ScopedMemoryAccess.java.template
@@ -52,7 +52,7 @@ import jdk.internal.vm.annotation.ForceInline;
  * {@link #closeScope(jdk.internal.misc.ScopedMemoryAccess.Scope)} method provided by this class. This method initiates
  * thread-local handshakes with all the other VM threads, which are then stopped one by one. If any thread is found
  * accessing memory that is associated to the very scope object being closed, that thread execution is asynchronously
- * interrupted with a {@link Scope.ScopedAccessException}.
+ * interrupted with a {@link Scope.ScopedAccessError}.
  * <p>
  * This synchronization strategy relies on the idea that accessing memory is atomic with respect to checking the
  * validity of the scope associated with that memory region - that is, a thread that wants to perform memory access will be
@@ -77,10 +77,10 @@ public class ScopedMemoryAccess {
     }
 
     public void closeScope(Scope scope) {
-        closeScope0(scope, Scope.ScopedAccessException.INSTANCE);
+        closeScope0(scope, Scope.ScopedAccessError.INSTANCE);
     }
 
-    native void closeScope0(Scope scope, Scope.ScopedAccessException exception);
+    native void closeScope0(Scope scope, Scope.ScopedAccessError exception);
 
     private ScopedMemoryAccess() {}
 
@@ -98,17 +98,19 @@ public class ScopedMemoryAccess {
         void checkValidState();
 
         /**
-         * Exception thrown when memory access fails because the memory has already been released.
+         * Error thrown when memory access fails because the memory has already been released.
          * Note: for performance reasons, this exception is never created by client; instead a shared instance
-         * is thrown (sometimes, this instance can be thrown asynchronosuly inside VM code). For this reason,
+         * is thrown (sometimes, this instance can be thrown asynchronously inside VM code). For this reason,
          * it is important for clients to always catch this exception and throw a regular exception instead
          * (which contains full stack information).
          */
-        final class ScopedAccessException extends RuntimeException {
-            private ScopedAccessException() { }
+        final class ScopedAccessError extends Error {
+            private ScopedAccessError() {
+                super("Attempt to access an already released memory resource", null, false, false);
+            }
             static final long serialVersionUID = 1L;
 
-            public static final ScopedAccessException INSTANCE = new ScopedAccessException();
+            public static final ScopedAccessError INSTANCE = new ScopedAccessError();
         }
     }
 
@@ -125,7 +127,7 @@ public class ScopedMemoryAccess {
                                    long bytes) {
           try {
               copyMemoryInternal(srcScope, dstScope, srcBase, srcOffset, destBase, destOffset, bytes);
-          } catch (Scope.ScopedAccessException ex) {
+          } catch (Scope.ScopedAccessError ex) {
               throw new IllegalStateException("This segment is already closed");
           }
     }
@@ -156,7 +158,7 @@ public class ScopedMemoryAccess {
                                    long bytes, long elemSize) {
           try {
               copySwapMemoryInternal(srcScope, dstScope, srcBase, srcOffset, destBase, destOffset, bytes, elemSize);
-          } catch (Scope.ScopedAccessException ex) {
+          } catch (Scope.ScopedAccessError ex) {
               throw new IllegalStateException("This segment is already closed");
           }
     }
@@ -184,7 +186,7 @@ public class ScopedMemoryAccess {
     public void setMemory(Scope scope, Object o, long offset, long bytes, byte value) {
         try {
             setMemoryInternal(scope, o, offset, bytes, value);
-        } catch (Scope.ScopedAccessException ex) {
+        } catch (Scope.ScopedAccessError ex) {
             throw new IllegalStateException("This segment is already closed");
         }
     }
@@ -209,7 +211,7 @@ public class ScopedMemoryAccess {
                                              int log2ArrayIndexScale) {
         try {
             return vectorizedMismatchInternal(aScope, bScope, a, aOffset, b, bOffset, length, log2ArrayIndexScale);
-        } catch (Scope.ScopedAccessException ex) {
+        } catch (Scope.ScopedAccessError ex) {
             throw new IllegalStateException("This segment is already closed");
         }
     }

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/AbstractMemorySegmentImpl.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/AbstractMemorySegmentImpl.java
@@ -369,7 +369,7 @@ public abstract class AbstractMemorySegmentImpl implements MemorySegment, Memory
     private void checkValidState() {
         try {
             scope.checkValidState();
-        } catch (ScopedMemoryAccess.Scope.ScopedAccessException ex) {
+        } catch (ScopedMemoryAccess.Scope.ScopedAccessError ex) {
             throw new IllegalStateException("This segment is already closed");
         }
     }

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/MemoryScope.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/MemoryScope.java
@@ -163,12 +163,12 @@ abstract class MemoryScope implements ScopedMemoryAccess.Scope {
     /**
      * Checks that this scope is still alive (see {@link #isAlive()}), by performing
      * a quick, plain access. As such, this method should be used with care.
-     * @throws ScopedAccessException if this scope is already closed.
+     * @throws ScopedAccessError if this scope is already closed.
      */
     @ForceInline
     private static void checkAliveRaw(MemoryScope scope) {
         if (scope.closed) {
-            throw ScopedAccessException.INSTANCE;
+            throw ScopedAccessError.INSTANCE;
         }
     }
 


### PR DESCRIPTION
This patch turns scoped access exceptions into an error. This was suggested by @PaulSandoz, and is, I think a very good idea; after all these exceptions are never meant to be exposed to the user, and, if that happens, it is always because of obscure cases where the async exception raised during the handshake could not be delivered on time.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [JDK-8253055](https://bugs.openjdk.java.net/browse/JDK-8253055): ScopedAccessException should be an Error


### Reviewers
 * [Paul Sandoz](https://openjdk.java.net/census#psandoz) (@PaulSandoz - Committer)


### Download
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/322/head:pull/322`
`$ git checkout pull/322`
