### PR TITLE
8253063: ScopedAccessError is sometimes thrown spuriously

### DIFF
--- a/src/hotspot/share/c1/c1_Runtime1.cpp
+++ b/src/hotspot/share/c1/c1_Runtime1.cpp
@@ -638,6 +638,7 @@ address Runtime1::exception_handler_for_pc(JavaThread* thread) {
   {
     // Enter VM mode by calling the helper
     ResetNoHandleMark rnhm;
+    ExceptionHandlingMark ehm(thread);
     continuation = exception_handler_for_pc_helper(thread, exception, pc, nm);
   }
   // Back in JAVA, use no oops DON'T safepoint

--- a/src/hotspot/share/jvmci/jvmciRuntime.cpp
+++ b/src/hotspot/share/jvmci/jvmciRuntime.cpp
@@ -375,6 +375,7 @@ address JVMCIRuntime::exception_handler_for_pc(JavaThread* thread) {
   {
     // Enter VM mode by calling the helper
     ResetNoHandleMark rnhm;
+    ExceptionHandlingMark ehm(thread);
     continuation = exception_handler_for_pc_helper(thread, exception, pc, cm);
   }
   // Back in JAVA, use no oops DON'T safepoint

--- a/src/hotspot/share/opto/runtime.cpp
+++ b/src/hotspot/share/opto/runtime.cpp
@@ -1420,6 +1420,7 @@ address OptoRuntime::handle_exception_C(JavaThread* thread) {
     // Enter the VM
 
     ResetNoHandleMark rnhm;
+    ExceptionHandlingMark ehm(thread);
     handler_address = handle_exception_C_helper(thread, nm);
   }
 

--- a/src/hotspot/share/prims/scopedMemoryAccess.cpp
+++ b/src/hotspot/share/prims/scopedMemoryAccess.cpp
@@ -1,3 +1,4 @@
+
 #include "precompiled.hpp"
 #include "jni.h"
 #include "jvm.h"
@@ -86,7 +87,7 @@ public:
       Deoptimization::deoptimize(jt, last_frame);
     }
 
-    const int max_critical_stack_depth = 5;
+    const int max_critical_stack_depth = 45;
     int depth = 0;
     vframeStream stream(jt);
     for (; !stream.at_end(); stream.next()) {
@@ -136,13 +137,13 @@ JVM_ENTRY(void, ScopedMemoryAccess_closeScope(JNIEnv *env, jobject receiver, job
 
 #define MEMACCESS "ScopedMemoryAccess"
 #define SCOPE LANG MEMACCESS "$Scope;"
-#define SCOPED_EXC LANG MEMACCESS "$Scope$ScopedAccessException;"
+#define SCOPED_ERR LANG MEMACCESS "$Scope$ScopedAccessError;"
 
 #define CC (char*)  /*cast a literal from (const char*)*/
 #define FN_PTR(f) CAST_FROM_FN_PTR(void*, &f)
 
 static JNINativeMethod jdk_internal_misc_ScopedMemoryAccess_methods[] = {
-    {CC "closeScope0",   CC "(" SCOPE SCOPED_EXC ")V",           FN_PTR(ScopedMemoryAccess_closeScope)},
+    {CC "closeScope0",   CC "(" SCOPE SCOPED_ERR ")V",           FN_PTR(ScopedMemoryAccess_closeScope)},
 };
 
 #undef CC

--- a/src/hotspot/share/prims/scopedMemoryAccess.cpp
+++ b/src/hotspot/share/prims/scopedMemoryAccess.cpp
@@ -87,7 +87,7 @@ public:
       Deoptimization::deoptimize(jt, last_frame);
     }
 
-    const int max_critical_stack_depth = 45;
+    const int max_critical_stack_depth = 5;
     int depth = 0;
     vframeStream stream(jt);
     for (; !stream.at_end(); stream.next()) {

--- a/src/hotspot/share/prims/scopedMemoryAccess.cpp
+++ b/src/hotspot/share/prims/scopedMemoryAccess.cpp
@@ -99,7 +99,7 @@ public:
           if (var->type() == T_OBJECT) {
             if (var->get_obj() == JNIHandles::resolve(_deopt)) {
               assert(depth < max_critical_stack_depth, "can't have more than %d critical frames", max_critical_stack_depth);
-              if (!thread->has_pending_exception()) {
+              if (!thread->has_pending_exception() && jt->exception_oop() != NULL) {
                 jt->install_async_exception(JNIHandles::resolve(_exception));
               }
               return;

--- a/src/hotspot/share/prims/scopedMemoryAccess.cpp
+++ b/src/hotspot/share/prims/scopedMemoryAccess.cpp
@@ -99,7 +99,7 @@ public:
           if (var->type() == T_OBJECT) {
             if (var->get_obj() == JNIHandles::resolve(_deopt)) {
               assert(depth < max_critical_stack_depth, "can't have more than %d critical frames", max_critical_stack_depth);
-              if (!thread->has_pending_exception() && jt->exception_oop() != NULL) {
+              if (!jt->is_exception_handling()) {
                 jt->install_async_exception(JNIHandles::resolve(_exception));
               }
               return;

--- a/src/hotspot/share/runtime/deoptimization.cpp
+++ b/src/hotspot/share/runtime/deoptimization.cpp
@@ -160,7 +160,10 @@ JRT_BLOCK_ENTRY(Deoptimization::UnrollBlock*, Deoptimization::fetch_unroll_info(
   }
   thread->inc_in_deopt_handler();
 
-  return fetch_unroll_info_helper(thread, exec_mode);
+  UnrollBlock* result = fetch_unroll_info_helper(thread, exec_mode);
+  thread->check_and_handle_async_exceptions(true);
+
+  return result;
 JRT_END
 
 #if COMPILER2_OR_JVMCI

--- a/src/hotspot/share/runtime/thread.cpp
+++ b/src/hotspot/share/runtime/thread.cpp
@@ -1712,6 +1712,7 @@ void JavaThread::initialize() {
   set_exception_oop(oop());
   _exception_pc  = 0;
   _exception_handler_pc = 0;
+  _is_exception_handling = false;
   _is_method_handle_return = 0;
   _jvmti_thread_state= NULL;
   _should_post_on_exceptions_flag = JNI_FALSE;

--- a/src/hotspot/share/runtime/thread.hpp
+++ b/src/hotspot/share/runtime/thread.hpp
@@ -1207,6 +1207,7 @@ class JavaThread: public Thread {
   volatile address _exception_pc;                // PC where exception happened
   volatile address _exception_handler_pc;        // PC for handler of exception
   volatile int     _is_method_handle_return;     // true (== 1) if the current exception PC is a MethodHandle call site.
+  bool             _is_exception_handling;
 
  private:
   // support for JNI critical regions
@@ -1586,6 +1587,9 @@ class JavaThread: public Thread {
   void set_exception_pc(address a)               { _exception_pc = a; }
   void set_exception_handler_pc(address a)       { _exception_handler_pc = a; }
   void set_is_method_handle_return(bool value)   { _is_method_handle_return = value ? 1 : 0; }
+
+  bool is_exception_handling() const             { return _is_exception_handling; }
+  void set_is_exception_handling(bool val)       { _is_exception_handling = val; }
 
   void clear_exception_oop_and_pc() {
     set_exception_oop(NULL);

--- a/src/hotspot/share/utilities/exceptions.cpp
+++ b/src/hotspot/share/utilities/exceptions.cpp
@@ -506,6 +506,16 @@ ExceptionMark::~ExceptionMark() {
   }
 }
 
+// Implementation of ExceptionHandlingMark
+
+ExceptionHandlingMark::ExceptionHandlingMark(JavaThread* jt) : _jt(jt) {
+  jt->set_is_exception_handling(true);
+}
+
+ExceptionHandlingMark::~ExceptionHandlingMark() {
+  _jt->set_is_exception_handling(false);
+}
+
 // ----------------------------------------------------------------------------------------
 
 // caller frees value_string if necessary

--- a/src/hotspot/share/utilities/exceptions.hpp
+++ b/src/hotspot/share/utilities/exceptions.hpp
@@ -52,6 +52,7 @@ class Thread;
 class Handle;
 class Symbol;
 class JavaCallArguments;
+class JavaThread;
 class methodHandle;
 
 // The ThreadShadow class is a helper class to access the _pending_exception
@@ -321,6 +322,15 @@ class ExceptionMark {
   ~ExceptionMark();
 };
 
+
+class ExceptionHandlingMark {
+private:
+  JavaThread* _jt;
+
+public:
+  ExceptionHandlingMark(JavaThread* jt);
+  ~ExceptionHandlingMark();
+};
 
 
 // Use an EXCEPTION_MARK for 'local' exceptions. EXCEPTION_MARK makes sure that no

--- a/src/java.base/share/classes/jdk/internal/misc/X-ScopedMemoryAccess-bin.java.template
+++ b/src/java.base/share/classes/jdk/internal/misc/X-ScopedMemoryAccess-bin.java.template
@@ -2,7 +2,7 @@
     public $type$ get$Type$(Scope scope, Object base, long offset) {
         try {
             return get$Type$Internal(scope, base, offset);
-        } catch (Scope.ScopedAccessException ex) {
+        } catch (Scope.ScopedAccessError ex) {
             throw new IllegalStateException("This segment is already closed");
         }
     }
@@ -23,7 +23,7 @@
     public void put$Type$(Scope scope, Object base, long offset, $type$ value) {
         try {
             put$Type$Internal(scope, base, offset, value);
-        } catch (Scope.ScopedAccessException ex) {
+        } catch (Scope.ScopedAccessError ex) {
             throw new IllegalStateException("This segment is already closed");
         }
     }
@@ -45,7 +45,7 @@
     public $type$ get$Type$Unaligned(Scope scope, Object base, long offset, boolean be) {
         try {
             return get$Type$UnalignedInternal(scope, base, offset, be);
-        } catch (Scope.ScopedAccessException ex) {
+        } catch (Scope.ScopedAccessError ex) {
             throw new IllegalStateException("This segment is already closed");
         }
     }
@@ -66,7 +66,7 @@
     public void put$Type$Unaligned(Scope scope, Object base, long offset, $type$ value, boolean be) {
         try {
             put$Type$UnalignedInternal(scope, base, offset, value, be);
-        } catch (Scope.ScopedAccessException ex) {
+        } catch (Scope.ScopedAccessError ex) {
             throw new IllegalStateException("This segment is already closed");
         }
     }
@@ -88,7 +88,7 @@
     public $type$ get$Type$Volatile(Scope scope, Object base, long offset) {
         try {
             return get$Type$VolatileInternal(scope, base, offset);
-        } catch (Scope.ScopedAccessException ex) {
+        } catch (Scope.ScopedAccessError ex) {
             throw new IllegalStateException("This segment is already closed");
         }
     }
@@ -109,7 +109,7 @@
     public void put$Type$Volatile(Scope scope, Object base, long offset, $type$ value) {
         try {
             put$Type$VolatileInternal(scope, base, offset, value);
-        } catch (Scope.ScopedAccessException ex) {
+        } catch (Scope.ScopedAccessError ex) {
             throw new IllegalStateException("This segment is already closed");
         }
     }
@@ -130,7 +130,7 @@
     public $type$ get$Type$Acquire(Scope scope, Object base, long offset) {
         try {
             return get$Type$AcquireInternal(scope, base, offset);
-        } catch (Scope.ScopedAccessException ex) {
+        } catch (Scope.ScopedAccessError ex) {
             throw new IllegalStateException("This segment is already closed");
         }
     }
@@ -151,7 +151,7 @@
     public void put$Type$Release(Scope scope, Object base, long offset, $type$ value) {
         try {
             put$Type$ReleaseInternal(scope, base, offset, value);
-        } catch (Scope.ScopedAccessException ex) {
+        } catch (Scope.ScopedAccessError ex) {
             throw new IllegalStateException("This segment is already closed");
         }
     }
@@ -172,7 +172,7 @@
     public $type$ get$Type$Opaque(Scope scope, Object base, long offset) {
         try {
             return get$Type$OpaqueInternal(scope, base, offset);
-        } catch (Scope.ScopedAccessException ex) {
+        } catch (Scope.ScopedAccessError ex) {
             throw new IllegalStateException("This segment is already closed");
         }
     }
@@ -192,7 +192,7 @@
     public void put$Type$Opaque(Scope scope, Object base, long offset, $type$ value) {
         try {
             put$Type$OpaqueInternal(scope, base, offset, value);
-        } catch (Scope.ScopedAccessException ex) {
+        } catch (Scope.ScopedAccessError ex) {
             throw new IllegalStateException("This segment is already closed");
         }
     }
@@ -213,7 +213,7 @@
     public boolean compareAndSet$Type$(Scope scope, Object base, long offset, $type$ expected, $type$ value) {
         try {
             return compareAndSet$Type$Internal(scope, base, offset, expected, value);
-        } catch (Scope.ScopedAccessException ex) {
+        } catch (Scope.ScopedAccessError ex) {
             throw new IllegalStateException("This segment is already closed");
         }
     }
@@ -234,7 +234,7 @@
     public $type$ compareAndExchange$Type$(Scope scope, Object base, long offset, $type$ expected, $type$ value) {
         try {
             return compareAndExchange$Type$Internal(scope, base, offset, expected, value);
-        } catch (Scope.ScopedAccessException ex) {
+        } catch (Scope.ScopedAccessError ex) {
             throw new IllegalStateException("This segment is already closed");
         }
     }
@@ -255,7 +255,7 @@
     public $type$ compareAndExchange$Type$Acquire(Scope scope, Object base, long offset, $type$ expected, $type$ value) {
         try {
             return compareAndExchange$Type$AcquireInternal(scope, base, offset, expected, value);
-        } catch (Scope.ScopedAccessException ex) {
+        } catch (Scope.ScopedAccessError ex) {
             throw new IllegalStateException("This segment is already closed");
         }
     }
@@ -276,7 +276,7 @@
     public $type$ compareAndExchange$Type$Release(Scope scope, Object base, long offset, $type$ expected, $type$ value) {
         try {
             return compareAndExchange$Type$ReleaseInternal(scope, base, offset, expected, value);
-        } catch (Scope.ScopedAccessException ex) {
+        } catch (Scope.ScopedAccessError ex) {
             throw new IllegalStateException("This segment is already closed");
         }
     }
@@ -297,7 +297,7 @@
     public boolean weakCompareAndSet$Type$Plain(Scope scope, Object base, long offset, $type$ expected, $type$ value) {
         try {
             return weakCompareAndSet$Type$PlainInternal(scope, base, offset, expected, value);
-        } catch (Scope.ScopedAccessException ex) {
+        } catch (Scope.ScopedAccessError ex) {
             throw new IllegalStateException("This segment is already closed");
         }
     }
@@ -318,7 +318,7 @@
     public boolean weakCompareAndSet$Type$(Scope scope, Object base, long offset, $type$ expected, $type$ value) {
         try {
             return weakCompareAndSet$Type$Internal(scope, base, offset, expected, value);
-        } catch (Scope.ScopedAccessException ex) {
+        } catch (Scope.ScopedAccessError ex) {
             throw new IllegalStateException("This segment is already closed");
         }
     }
@@ -339,7 +339,7 @@
     public boolean weakCompareAndSet$Type$Acquire(Scope scope, Object base, long offset, $type$ expected, $type$ value) {
         try {
             return weakCompareAndSet$Type$AcquireInternal(scope, base, offset, expected, value);
-        } catch (Scope.ScopedAccessException ex) {
+        } catch (Scope.ScopedAccessError ex) {
             throw new IllegalStateException("This segment is already closed");
         }
     }
@@ -360,7 +360,7 @@
     public boolean weakCompareAndSet$Type$Release(Scope scope, Object base, long offset, $type$ expected, $type$ value) {
         try {
             return weakCompareAndSet$Type$ReleaseInternal(scope, base, offset, expected, value);
-        } catch (Scope.ScopedAccessException ex) {
+        } catch (Scope.ScopedAccessError ex) {
             throw new IllegalStateException("This segment is already closed");
         }
     }
@@ -381,7 +381,7 @@
     public $type$ getAndSet$Type$(Scope scope, Object base, long offset, $type$ value) {
         try {
             return getAndSet$Type$Internal(scope, base, offset, value);
-        } catch (Scope.ScopedAccessException ex) {
+        } catch (Scope.ScopedAccessError ex) {
             throw new IllegalStateException("This segment is already closed");
         }
     }
@@ -402,7 +402,7 @@
     public $type$ getAndSet$Type$Acquire(Scope scope, Object base, long offset, $type$ value) {
         try {
             return getAndSet$Type$AcquireInternal(scope, base, offset, value);
-        } catch (Scope.ScopedAccessException ex) {
+        } catch (Scope.ScopedAccessError ex) {
             throw new IllegalStateException("This segment is already closed");
         }
     }
@@ -423,7 +423,7 @@
     public $type$ getAndSet$Type$Release(Scope scope, Object base, long offset, $type$ value) {
         try {
             return getAndSet$Type$ReleaseInternal(scope, base, offset, value);
-        } catch (Scope.ScopedAccessException ex) {
+        } catch (Scope.ScopedAccessError ex) {
             throw new IllegalStateException("This segment is already closed");
         }
     }
@@ -446,7 +446,7 @@
     public $type$ getAndAdd$Type$(Scope scope, Object base, long offset, $type$ delta) {
         try {
             return getAndAdd$Type$Internal(scope, base, offset, delta);
-        } catch (Scope.ScopedAccessException ex) {
+        } catch (Scope.ScopedAccessError ex) {
             throw new IllegalStateException("This segment is already closed");
         }
     }
@@ -467,7 +467,7 @@
     public $type$ getAndAdd$Type$Acquire(Scope scope, Object base, long offset, $type$ delta) {
         try {
             return getAndAdd$Type$AcquireInternal(scope, base, offset, delta);
-        } catch (Scope.ScopedAccessException ex) {
+        } catch (Scope.ScopedAccessError ex) {
             throw new IllegalStateException("This segment is already closed");
         }
     }
@@ -488,7 +488,7 @@
     public $type$ getAndAdd$Type$Release(Scope scope, Object base, long offset, $type$ delta) {
         try {
             return getAndAdd$Type$ReleaseInternal(scope, base, offset, delta);
-        } catch (Scope.ScopedAccessException ex) {
+        } catch (Scope.ScopedAccessError ex) {
             throw new IllegalStateException("This segment is already closed");
         }
     }
@@ -511,7 +511,7 @@
     public $type$ getAndBitwiseOr$Type$(Scope scope, Object base, long offset, $type$ value) {
         try {
             return getAndBitwiseOr$Type$Internal(scope, base, offset, value);
-        } catch (Scope.ScopedAccessException ex) {
+        } catch (Scope.ScopedAccessError ex) {
             throw new IllegalStateException("This segment is already closed");
         }
     }
@@ -532,7 +532,7 @@
     public $type$ getAndBitwiseOr$Type$Acquire(Scope scope, Object base, long offset, $type$ value) {
         try {
             return getAndBitwiseOr$Type$AcquireInternal(scope, base, offset, value);
-        } catch (Scope.ScopedAccessException ex) {
+        } catch (Scope.ScopedAccessError ex) {
             throw new IllegalStateException("This segment is already closed");
         }
     }
@@ -553,7 +553,7 @@
     public $type$ getAndBitwiseOr$Type$Release(Scope scope, Object base, long offset, $type$ value) {
         try {
             return getAndBitwiseOr$Type$ReleaseInternal(scope, base, offset, value);
-        } catch (Scope.ScopedAccessException ex) {
+        } catch (Scope.ScopedAccessError ex) {
             throw new IllegalStateException("This segment is already closed");
         }
     }
@@ -574,7 +574,7 @@
     public $type$ getAndBitwiseAnd$Type$(Scope scope, Object base, long offset, $type$ value) {
         try {
             return getAndBitwiseAnd$Type$Internal(scope, base, offset, value);
-        } catch (Scope.ScopedAccessException ex) {
+        } catch (Scope.ScopedAccessError ex) {
             throw new IllegalStateException("This segment is already closed");
         }
     }
@@ -595,7 +595,7 @@
     public $type$ getAndBitwiseAnd$Type$Acquire(Scope scope, Object base, long offset, $type$ value) {
         try {
             return getAndBitwiseAnd$Type$AcquireInternal(scope, base, offset, value);
-        } catch (Scope.ScopedAccessException ex) {
+        } catch (Scope.ScopedAccessError ex) {
             throw new IllegalStateException("This segment is already closed");
         }
     }
@@ -616,7 +616,7 @@
     public $type$ getAndBitwiseAnd$Type$Release(Scope scope, Object base, long offset, $type$ value) {
         try {
             return getAndBitwiseAnd$Type$ReleaseInternal(scope, base, offset, value);
-        } catch (Scope.ScopedAccessException ex) {
+        } catch (Scope.ScopedAccessError ex) {
             throw new IllegalStateException("This segment is already closed");
         }
     }
@@ -637,7 +637,7 @@
     public $type$ getAndBitwiseXor$Type$(Scope scope, Object base, long offset, $type$ value) {
         try {
             return getAndBitwiseXor$Type$Internal(scope, base, offset, value);
-        } catch (Scope.ScopedAccessException ex) {
+        } catch (Scope.ScopedAccessError ex) {
             throw new IllegalStateException("This segment is already closed");
         }
     }
@@ -658,7 +658,7 @@
     public $type$ getAndBitwiseXor$Type$Acquire(Scope scope, Object base, long offset, $type$ value) {
         try {
             return getAndBitwiseXor$Type$AcquireInternal(scope, base, offset, value);
-        } catch (Scope.ScopedAccessException ex) {
+        } catch (Scope.ScopedAccessError ex) {
             throw new IllegalStateException("This segment is already closed");
         }
     }
@@ -679,7 +679,7 @@
     public $type$ getAndBitwiseXor$Type$Release(Scope scope, Object base, long offset, $type$ value) {
         try {
             return getAndBitwiseXor$Type$ReleaseInternal(scope, base, offset, value);
-        } catch (Scope.ScopedAccessException ex) {
+        } catch (Scope.ScopedAccessError ex) {
             throw new IllegalStateException("This segment is already closed");
         }
     }

--- a/src/java.base/share/classes/jdk/internal/misc/X-ScopedMemoryAccess.java.template
+++ b/src/java.base/share/classes/jdk/internal/misc/X-ScopedMemoryAccess.java.template
@@ -52,7 +52,7 @@ import jdk.internal.vm.annotation.ForceInline;
  * {@link #closeScope(jdk.internal.misc.ScopedMemoryAccess.Scope)} method provided by this class. This method initiates
  * thread-local handshakes with all the other VM threads, which are then stopped one by one. If any thread is found
  * accessing memory that is associated to the very scope object being closed, that thread execution is asynchronously
- * interrupted with a {@link Scope.ScopedAccessException}.
+ * interrupted with a {@link Scope.ScopedAccessError}.
  * <p>
  * This synchronization strategy relies on the idea that accessing memory is atomic with respect to checking the
  * validity of the scope associated with that memory region - that is, a thread that wants to perform memory access will be
@@ -77,10 +77,10 @@ public class ScopedMemoryAccess {
     }
 
     public void closeScope(Scope scope) {
-        closeScope0(scope, Scope.ScopedAccessException.INSTANCE);
+        closeScope0(scope, Scope.ScopedAccessError.INSTANCE);
     }
 
-    native void closeScope0(Scope scope, Scope.ScopedAccessException exception);
+    native void closeScope0(Scope scope, Scope.ScopedAccessError exception);
 
     private ScopedMemoryAccess() {}
 
@@ -98,17 +98,19 @@ public class ScopedMemoryAccess {
         void checkValidState();
 
         /**
-         * Exception thrown when memory access fails because the memory has already been released.
+         * Error thrown when memory access fails because the memory has already been released.
          * Note: for performance reasons, this exception is never created by client; instead a shared instance
-         * is thrown (sometimes, this instance can be thrown asynchronosuly inside VM code). For this reason,
+         * is thrown (sometimes, this instance can be thrown asynchronously inside VM code). For this reason,
          * it is important for clients to always catch this exception and throw a regular exception instead
          * (which contains full stack information).
          */
-        final class ScopedAccessException extends RuntimeException {
-            private ScopedAccessException() { }
+        final class ScopedAccessError extends Error {
+            private ScopedAccessError() {
+                super("Attempt to access an already released memory resource", null, false, false);
+            }
             static final long serialVersionUID = 1L;
 
-            public static final ScopedAccessException INSTANCE = new ScopedAccessException();
+            public static final ScopedAccessError INSTANCE = new ScopedAccessError();
         }
     }
 
@@ -125,7 +127,7 @@ public class ScopedMemoryAccess {
                                    long bytes) {
           try {
               copyMemoryInternal(srcScope, dstScope, srcBase, srcOffset, destBase, destOffset, bytes);
-          } catch (Scope.ScopedAccessException ex) {
+          } catch (Scope.ScopedAccessError ex) {
               throw new IllegalStateException("This segment is already closed");
           }
     }
@@ -156,7 +158,7 @@ public class ScopedMemoryAccess {
                                    long bytes, long elemSize) {
           try {
               copySwapMemoryInternal(srcScope, dstScope, srcBase, srcOffset, destBase, destOffset, bytes, elemSize);
-          } catch (Scope.ScopedAccessException ex) {
+          } catch (Scope.ScopedAccessError ex) {
               throw new IllegalStateException("This segment is already closed");
           }
     }
@@ -184,7 +186,7 @@ public class ScopedMemoryAccess {
     public void setMemory(Scope scope, Object o, long offset, long bytes, byte value) {
         try {
             setMemoryInternal(scope, o, offset, bytes, value);
-        } catch (Scope.ScopedAccessException ex) {
+        } catch (Scope.ScopedAccessError ex) {
             throw new IllegalStateException("This segment is already closed");
         }
     }
@@ -209,7 +211,7 @@ public class ScopedMemoryAccess {
                                              int log2ArrayIndexScale) {
         try {
             return vectorizedMismatchInternal(aScope, bScope, a, aOffset, b, bOffset, length, log2ArrayIndexScale);
-        } catch (Scope.ScopedAccessException ex) {
+        } catch (Scope.ScopedAccessError ex) {
             throw new IllegalStateException("This segment is already closed");
         }
     }

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/AbstractMemorySegmentImpl.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/AbstractMemorySegmentImpl.java
@@ -369,7 +369,7 @@ public abstract class AbstractMemorySegmentImpl implements MemorySegment, Memory
     private void checkValidState() {
         try {
             scope.checkValidState();
-        } catch (ScopedMemoryAccess.Scope.ScopedAccessException ex) {
+        } catch (ScopedMemoryAccess.Scope.ScopedAccessError ex) {
             throw new IllegalStateException("This segment is already closed");
         }
     }

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/MemoryScope.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/MemoryScope.java
@@ -163,12 +163,12 @@ abstract class MemoryScope implements ScopedMemoryAccess.Scope {
     /**
      * Checks that this scope is still alive (see {@link #isAlive()}), by performing
      * a quick, plain access. As such, this method should be used with care.
-     * @throws ScopedAccessException if this scope is already closed.
+     * @throws ScopedAccessError if this scope is already closed.
      */
     @ForceInline
     private static void checkAliveRaw(MemoryScope scope) {
         if (scope.closed) {
-            throw ScopedAccessException.INSTANCE;
+            throw ScopedAccessError.INSTANCE;
         }
     }
 

--- a/test/jdk/java/foreign/TestHandshake.java
+++ b/test/jdk/java/foreign/TestHandshake.java
@@ -50,7 +50,7 @@ import static org.testng.Assert.*;
 
 public class TestHandshake {
 
-    static final int ITERATIONS = 5;
+    static final int ITERATIONS = 10;
     static final int SEGMENT_SIZE = 1_000_000;
     static final int MAX_DELAY_MILLIS = 500;
     static final int MAX_EXECUTOR_WAIT_SECONDS = 10;


### PR DESCRIPTION
After running the test for shared segment handshake during unrelated work, I noted that the test exhibit two kind of failure modes:

1. First, the test can sometimes fail with a raw ScopedAccessError
2. More rarely, the test sometimes even crash (this only happens in the vectorized mismatch test)

After some investigation carried out by @fisk, turns out that (2) was caused by the fact that when we exit from deoptimization we don't check for pending async exception (while we check for regulart ones). This condition was not triggered in other tests because, it seems, plain unsafe accesses are effectively atomic once intrinisfied - e.g. there can be no safepoint between check and access. But the vectorized mismatch routine is a biggie Java routine which gets some initial compilation (by C1) - and this is when the bug hit.

The problem (2) was more difficult to pinpoint - basically, there are some routines in the VM which are hostile w.r.t. async exceptions - and are marked with the special `JRT_ENTRY_NO_ASYNC` entry. One of those routines happens to be the one that throws exceptions, and this routine can safepoint too. Now, since the scope memory access can also throw (if the scope is not alive) it is possible to end up in a situation where we try to install an async exception while the VM code was already in the middle of installing one. We thought we covered this case by checking for *pending exceptions* - but the check we had was too weak. After trying with different approaches we agreed to address this more explicitly - by having the exception code set a flag on the running thread - so that we can precisely determine, when we do the handshake, as to whether the async exception should be installed or not.

With these fixes, the test passes and no more spurious failures can be observed (I left it running for a long time ;-)).
I've beefed up the test by always having it use max number of available processors, and also by lowering the delay time associated with the closing thread. The longer the wait, the less frequently transient issues such as (1) can be observed.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8253063](https://bugs.openjdk.java.net/browse/JDK-8253063): ScopedAccessError is sometimes thrown spuriously


### Reviewers
 * [Erik Österlund](https://openjdk.java.net/census#eosterlund) (@fisk - no project role)
 * [Paul Sandoz](https://openjdk.java.net/census#psandoz) (@PaulSandoz - Committer)


### Download
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/323/head:pull/323`
`$ git checkout pull/323`
