### PR TITLE
8253102: jextract should emit address to segment utility method on struct classes

### DIFF
--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/StructBuilder.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/StructBuilder.java
@@ -110,6 +110,7 @@ class StructBuilder extends JavaSourceBuilder {
         emitScopeAllocateArray();
         emitAllocatePoiner();
         emitScopeAllocatePointer();
+        emitAsRestricted();
         return super.classEnd();
     }
 
@@ -277,6 +278,14 @@ class StructBuilder extends JavaSourceBuilder {
         decrAlign();
         indent();
         append("}\n");
+        decrAlign();
+    }
+
+    private void emitAsRestricted() {
+        incrAlign();
+        indent();
+        append(PUB_MODS);
+        append(structAnno + " MemorySegment ofAddressRestricted(MemoryAddress addr) { return RuntimeHelper.asArrayRestricted(addr, $LAYOUT(), 1); }\n");
         decrAlign();
     }
 

--- a/test/jdk/tools/jextract/test8253102/LibTest8253102Test.java
+++ b/test/jdk/tools/jextract/test8253102/LibTest8253102Test.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import org.testng.annotations.Test;
+import jdk.incubator.foreign.CSupport;
+import jdk.incubator.foreign.MemoryAddress;
+import jdk.incubator.foreign.MemorySegment;
+import static org.testng.Assert.assertEquals;
+import static test.jextract.test8253102.test8253102_h.*;
+
+/*
+ * @test id=classes
+ * @bug 8253102
+ * @summary jextract generates uncompilable code for no argument C function
+ * @library ..
+ * @modules jdk.incubator.jextract
+ * @run driver JtregJextract -l Test8253102 -t test.jextract.test8253102 -- test8253102.h
+ * @run testng/othervm -Dforeign.restricted=permit LibTest8253102Test
+ */
+/*
+ * @test id=sources
+ * @bug 8253102
+ * @summary jextract generates uncompilable code for no argument C function
+ * @library ..
+ * @modules jdk.incubator.jextract
+ * @run driver JtregJextractSources -l Test8253102 -t test.jextract.test8253102 -- test8253102.h
+ * @run testng/othervm -Dforeign.restricted=permit LibTest8253102Test
+ */
+public class LibTest8253102Test {
+    @Test
+    public void test() {
+        MemoryAddress addr = make(14, 99);
+        MemorySegment seg = Point.ofAddressRestricted(addr);
+        assertEquals(Point.x$get(seg), 14);
+        assertEquals(Point.y$get(seg), 99);
+        CSupport.freeMemoryRestricted(addr);
+    }
+}

--- a/test/jdk/tools/jextract/test8253102/libTest8253102.c
+++ b/test/jdk/tools/jextract/test8253102/libTest8253102.c
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+#include "test8253102.h"
+#include <stdlib.h>
+
+EXPORT Point* make(int x, int y) {
+    Point* p = (Point*)malloc(sizeof(Point));
+    p->x = x; p->y = y;
+    return p;
+}

--- a/test/jdk/tools/jextract/test8253102/test8253102.h
+++ b/test/jdk/tools/jextract/test8253102/test8253102.h
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+#ifdef __cplusplus
+extern "C" {
+#endif // __cplusplus
+
+#ifdef _WIN64
+#define EXPORT __declspec(dllexport)
+#else
+#define EXPORT
+#endif
+
+typedef struct Point {
+    int x;
+    int y;
+} Point;
+
+EXPORT Point* make(int x, int y);
+
+#ifdef __cplusplus
+}
+#endif // __cplusplus


### PR DESCRIPTION
added utility method to struct classes.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [JDK-8253102](https://bugs.openjdk.java.net/browse/JDK-8253102): jextract should emit address to segment utility method on struct classes


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.java.net/census#mcimadamore) (@mcimadamore - Committer)
 * [Jorn Vernee](https://openjdk.java.net/census#jvernee) (@JornVernee - Committer)


### Download
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/324/head:pull/324`
`$ git checkout pull/324`
