### PR TITLE
8253159: RuntimeHelper.asArrayRestricted should create noncloseable segment

### DIFF
--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/resources/RuntimeHelper.java.template
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/resources/RuntimeHelper.java.template
@@ -96,9 +96,13 @@ public class RuntimeHelper {
         }
     }
 
+    public static final MemorySegment nonCloseableSegment(MemorySegment seg) {
+        return seg.withAccessModes(seg.accessModes() &  ~MemorySegment.CLOSE);
+    }
+
     public static MemorySegment asArrayRestricted(MemoryAddress addr, MemoryLayout layout, int numElements) {
-        return MemorySegment.ofNativeRestricted(addr, numElements * layout.byteSize(),
-               Thread.currentThread(), null, null);
+        return nonCloseableSegment(MemorySegment.ofNativeRestricted(addr, numElements * layout.byteSize(),
+               Thread.currentThread(), null, null));
     }
 
     public static MemorySegment asArray(MemorySegment seg, MemoryLayout layout, int numElements) {

--- a/test/jdk/tools/jextract/test8253159/LibTest8253159Test.java
+++ b/test/jdk/tools/jextract/test8253159/LibTest8253159Test.java
@@ -27,34 +27,38 @@ import jdk.incubator.foreign.MemoryAddress;
 import jdk.incubator.foreign.MemorySegment;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
-import static test.jextract.test8253102.test8253102_h.*;
+import test.jextract.test8253159.RuntimeHelper;
+import static test.jextract.test8253159.test8253159_h.*;
 
 /*
  * @test id=classes
- * @bug 8253102
- * @summary jextract should emit address to segment utility method on struct classes
+ * @bug 8253159
+ * @summary RuntimeHelper.asArrayRestricted should create noncloseable segment
  * @library ..
  * @modules jdk.incubator.jextract
- * @run driver JtregJextract -l Test8253102 -t test.jextract.test8253102 -- test8253102.h
- * @run testng/othervm -Dforeign.restricted=permit LibTest8253102Test
+ * @run driver JtregJextract -l Test8253159 -t test.jextract.test8253159 -- test8253159.h
+ * @run testng/othervm -Dforeign.restricted=permit LibTest8253159Test
  */
 /*
  * @test id=sources
- * @bug 8253102
- * @summary jextract should emit address to segment utility method on struct classes
+ * @bug 8253159
+ * @summary RuntimeHelper.asArrayRestricted should create noncloseable segment
  * @library ..
  * @modules jdk.incubator.jextract
- * @run driver JtregJextractSources -l Test8253102 -t test.jextract.test8253102 -- test8253102.h
- * @run testng/othervm -Dforeign.restricted=permit LibTest8253102Test
+ * @run driver JtregJextractSources -l Test8253159 -t test.jextract.test8253159 -- test8253159.h
+ * @run testng/othervm -Dforeign.restricted=permit LibTest8253159Test
  */
-public class LibTest8253102Test {
+public class LibTest8253159Test {
     @Test
     public void test() {
-        MemoryAddress addr = make(14, 99);
-        MemorySegment seg = Point.ofAddressRestricted(addr);
-        assertEquals(Point.x$get(seg), 14);
-        assertEquals(Point.y$get(seg), 99);
-        CSupport.freeMemoryRestricted(addr);
+        MemoryAddress addr = get_array();
+        MemorySegment seg = RuntimeHelper.asArrayRestricted(addr, CSupport.C_INT, 6);
+        int[] actual = seg.toIntArray();
+        int[] expected = new int[] { 2, 3, 5, 7, 11, 13};
+        assertEquals(actual.length, expected.length);
+        for (int i = 0; i < actual.length; i++) {
+            assertEquals(actual[i], expected[i]);
+        }
         boolean caughtException = false;
         try {
             seg.close();

--- a/test/jdk/tools/jextract/test8253159/libTest8253159.c
+++ b/test/jdk/tools/jextract/test8253159/libTest8253159.c
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+#include "test8253159.h"
+
+static int arr[] = {
+    2, 3, 5, 7, 11, 13
+};
+
+EXPORT int* get_array() {
+    return arr;
+}

--- a/test/jdk/tools/jextract/test8253159/test8253159.h
+++ b/test/jdk/tools/jextract/test8253159/test8253159.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+#ifdef __cplusplus
+extern "C" {
+#endif // __cplusplus
+
+#ifdef _WIN64
+#define EXPORT __declspec(dllexport)
+#else
+#define EXPORT
+#endif
+
+EXPORT int* get_array();
+
+#ifdef __cplusplus
+}
+#endif // __cplusplus


### PR DESCRIPTION
non-closeable segment is returned.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8253159](https://bugs.openjdk.java.net/browse/JDK-8253159): RuntimeHelper.asArrayRestricted should create noncloseable segment


### Reviewers
 * [Jorn Vernee](https://openjdk.java.net/census#jvernee) (@JornVernee - Committer)


### Download
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/326/head:pull/326`
`$ git checkout pull/326`
