### PR TITLE
8253243: Investigate ways to make MemorySegment::ofNativeRestricted more composable

### DIFF
--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/MemoryAddress.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/MemoryAddress.java
@@ -93,6 +93,11 @@ public interface MemoryAddress extends Addressable {
      * (often as a plain {@code long} value). The returned segment will feature all <a href="#access-modes">access modes</a>
      * (see {@link MemorySegment#ALL_ACCESS}), and its confinement thread is the current thread (see {@link Thread#currentThread()}).
      * <p>
+     * Calling {@link MemorySegment#close()} on the returned segment will <em>not</em> result in releasing any
+     * memory resources which might implicitly be associated with the segment. If the client wants to specify
+     * a cleanup action to be executed when the returned segment is closed, the {@link MemorySegment#withCleanupAction(Runnable)}
+     * method should be used.
+     * <p>
      * This method is <em>restricted</em>. Restricted methods are unsafe, and, if used incorrectly, their use might crash
      * the JVM or, worse, silently result in memory corruption. Thus, clients should refrain from depending on
      * restricted methods, and use safe and supported functionalities, where possible.
@@ -105,10 +110,10 @@ public interface MemoryAddress extends Addressable {
      * {@code permit}, {@code warn} or {@code debug} (the default value is set to {@code deny}).
      */
     default MemorySegment asSegmentRestricted(long bytesSize) {
+        Utils.checkRestrictedAccess("MemoryAddress.asSegmentRestricted");
         if (bytesSize <= 0) {
             throw new IllegalArgumentException("Invalid size : " + bytesSize);
         }
-        Utils.checkRestrictedAccess("MemoryAddress.ofSegmentRestricted");
         return NativeMemorySegmentImpl.makeNativeSegmentUnchecked(this, bytesSize);
     }
 

--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/MemoryAddress.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/MemoryAddress.java
@@ -27,6 +27,10 @@
 package jdk.incubator.foreign;
 
 import jdk.internal.foreign.MemoryAddressImpl;
+import jdk.internal.foreign.NativeMemorySegmentImpl;
+import jdk.internal.foreign.Utils;
+
+import java.util.Objects;
 
 /**
  * A memory address models a reference into a memory location. Memory addresses are typically obtained using the
@@ -83,9 +87,35 @@ public interface MemoryAddress extends Addressable {
     long segmentOffset(MemorySegment segment);
 
     /**
-     * Returns the raw long value associated to this memory address.
-     * @return The raw long value associated to this memory address.
-     * @throws UnsupportedOperationException if this memory address is associated with an heap segment.
+     * Returns a new confined native memory segment with given size, and whose base address is this address; the returned segment has its own temporal
+     * bounds, and can therefore be closed. This method can be very useful when interacting with custom native memory sources (e.g. custom allocators),
+     * where an address to some underlying memory region is typically obtained from native code
+     * (often as a plain {@code long} value). The returned segment will feature all <a href="#access-modes">access modes</a>
+     * (see {@link MemorySegment#ALL_ACCESS}), and its confinement thread is the current thread (see {@link Thread#currentThread()}).
+     * <p>
+     * This method is <em>restricted</em>. Restricted methods are unsafe, and, if used incorrectly, their use might crash
+     * the JVM or, worse, silently result in memory corruption. Thus, clients should refrain from depending on
+     * restricted methods, and use safe and supported functionalities, where possible.
+     *
+     * @param bytesSize the desired size.
+     * @return a new confined native memory segment with given base address and size.
+     * @throws IllegalArgumentException if {@code bytesSize <= 0}.
+     * @throws UnsupportedOperationException if this address is an heap address.
+     * @throws IllegalAccessError if the runtime property {@code foreign.restricted} is not set to either
+     * {@code permit}, {@code warn} or {@code debug} (the default value is set to {@code deny}).
+     */
+    default MemorySegment asSegmentRestricted(long bytesSize) {
+        if (bytesSize <= 0) {
+            throw new IllegalArgumentException("Invalid size : " + bytesSize);
+        }
+        Utils.checkRestrictedAccess("MemoryAddress.ofSegmentRestricted");
+        return NativeMemorySegmentImpl.makeNativeSegmentUnchecked(this, bytesSize);
+    }
+
+    /**
+     * Returns the raw long value associated with this memory address.
+     * @return The raw long value associated with this memory address.
+     * @throws UnsupportedOperationException if this memory address is an heap address.
      */
     long toRawLongValue();
 

--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/MemorySegment.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/MemorySegment.java
@@ -257,12 +257,31 @@ public interface MemorySegment extends Addressable, AutoCloseable {
      * be either a confined segment ({@code newOwner != null}) or a shared segment ({@code newOwner == null}).
      * @throws IllegalStateException if this segment is not <em>alive</em>, or if access occurs from a thread other than the
      * thread owning this segment.
-     * thread (see {@link #spliterator(MemorySegment, SequenceLayout)}).
      * @throws IllegalArgumentException if the segment is already a confined segment owner by {@code newOnwer}
      * @throws UnsupportedOperationException if {@code newOwner != null} and this segment does not support the {@link #HANDOFF} access mode,
      * or if {@code newOwner == null} and this segment does not support the {@link #SHARE} access mode.
      */
     MemorySegment withOwnerThread(Thread newOwner);
+
+    /**
+     * Obtains a new memory segment backed by the same underlying memory region as this segment, and featuring
+     * the same confinement thread (see {@link #ownerThread()} and access modes (see {@link #accessModes()}),
+     * but with a different cleanup action. More specifically, the cleanup action associated with the returned segment will
+     * first call the user-provided action, before delegating back to the original cleanup action associated with
+     * this segment.
+     * <p>
+     * As a side-effect, this segment will be marked as <em>not alive</em>,
+     * and subsequent operations on this segment will result in runtime errors.
+     *
+     * @param action the new cleanup action
+     * @return a new memory segment backed by the same underlying memory region as this segment; the cleanup action
+     * associated with the new segment is the result of composing this segment's cleanup action with the
+     * supplied {@code action}.
+     * @throws IllegalStateException if this segment is not <em>alive</em>, or if access occurs from a thread other than the
+     * thread owning this segment.
+     * @throws NullPointerException if {@code action == null}
+     */
+    MemorySegment withCleanupAction(Runnable action);
 
     /**
      * The size (in bytes) of this memory segment.
@@ -521,123 +540,124 @@ for (long l = 0; l < segment.byteSize(); l++) {
     double[] toDoubleArray();
 
     /**
-     * Creates a new buffer memory segment that models the memory associated with the given byte
+     * Creates a new confined buffer memory segment that models the memory associated with the given byte
      * buffer. The segment starts relative to the buffer's position (inclusive)
      * and ends relative to the buffer's limit (exclusive).
      * <p>
      * The segment will feature all <a href="#access-modes">access modes</a> (see {@link #ALL_ACCESS}),
      * unless the given buffer is {@linkplain ByteBuffer#isReadOnly() read-only} in which case the segment will
-     * not feature the {@link #WRITE} access mode.
+     * not feature the {@link #WRITE} access mode, and its confinement thread is the current thread (see {@link Thread#currentThread()}).
      * <p>
      * The resulting memory segment keeps a reference to the backing buffer, to ensure it remains <em>reachable</em>
      * for the life-time of the segment.
      *
      * @param bb the byte buffer backing the buffer memory segment.
-     * @return a new buffer memory segment.
+     * @return a new confined buffer memory segment.
      */
     static MemorySegment ofByteBuffer(ByteBuffer bb) {
         return AbstractMemorySegmentImpl.ofBuffer(bb);
     }
 
     /**
-     * Creates a new array memory segment that models the memory associated with a given heap-allocated byte array.
+     * Creates a new confined array memory segment that models the memory associated with a given heap-allocated byte array.
      * <p>
      * The resulting memory segment keeps a reference to the backing array, to ensure it remains <em>reachable</em>
      * for the life-time of the segment. The segment will feature all <a href="#access-modes">access modes</a>
-     * (see {@link #ALL_ACCESS}).
+     * (see {@link #ALL_ACCESS}), and its confinement thread is the current thread (see {@link Thread#currentThread()}).
      *
      * @param arr the primitive array backing the array memory segment.
-     * @return a new array memory segment.
+     * @return a new confined array memory segment.
      */
     static MemorySegment ofArray(byte[] arr) {
         return HeapMemorySegmentImpl.makeArraySegment(arr);
     }
 
     /**
-     * Creates a new array memory segment that models the memory associated with a given heap-allocated char array.
+     * Creates a new confined array memory segment that models the memory associated with a given heap-allocated char array.
      * <p>
      * The resulting memory segment keeps a reference to the backing array, to ensure it remains <em>reachable</em>
      * for the life-time of the segment. The segment will feature all <a href="#access-modes">access modes</a>
-     * (see {@link #ALL_ACCESS}).
+     * (see {@link #ALL_ACCESS}), and its confinement thread is the current thread (see {@link Thread#currentThread()}).
      *
      * @param arr the primitive array backing the array memory segment.
-     * @return a new array memory segment.
+     * @return a new confined array memory segment.
      */
     static MemorySegment ofArray(char[] arr) {
         return HeapMemorySegmentImpl.makeArraySegment(arr);
     }
 
     /**
-     * Creates a new array memory segment that models the memory associated with a given heap-allocated short array.
+     * Creates a new confined array memory segment that models the memory associated with a given heap-allocated short array.
      * <p>
      * The resulting memory segment keeps a reference to the backing array, to ensure it remains <em>reachable</em>
      * for the life-time of the segment. The segment will feature all <a href="#access-modes">access modes</a>
-     * (see {@link #ALL_ACCESS}).
+     * (see {@link #ALL_ACCESS}), and its confinement thread is the current thread (see {@link Thread#currentThread()}).
      *
      * @param arr the primitive array backing the array memory segment.
-     * @return a new array memory segment.
+     * @return a new confined array memory segment.
      */
     static MemorySegment ofArray(short[] arr) {
         return HeapMemorySegmentImpl.makeArraySegment(arr);
     }
 
     /**
-     * Creates a new array memory segment that models the memory associated with a given heap-allocated int array.
+     * Creates a new confined array memory segment that models the memory associated with a given heap-allocated int array.
      * <p>
      * The resulting memory segment keeps a reference to the backing array, to ensure it remains <em>reachable</em>
-     * for the life-time of the segment. The segment will feature all <a href="#access-modes">access modes</a>.
+     * for the life-time of the segment. The segment will feature all <a href="#access-modes">access modes</a>
+     * (see {@link #ALL_ACCESS}), and its confinement thread is the current thread (see {@link Thread#currentThread()}).
      *
      * @param arr the primitive array backing the array memory segment.
-     * @return a new array memory segment.
+     * @return a new confined array memory segment.
      */
     static MemorySegment ofArray(int[] arr) {
         return HeapMemorySegmentImpl.makeArraySegment(arr);
     }
 
     /**
-     * Creates a new array memory segment that models the memory associated with a given heap-allocated float array.
+     * Creates a new confined array memory segment that models the memory associated with a given heap-allocated float array.
      * <p>
      * The resulting memory segment keeps a reference to the backing array, to ensure it remains <em>reachable</em>
      * for the life-time of the segment. The segment will feature all <a href="#access-modes">access modes</a>
-     * (see {@link #ALL_ACCESS}).
+     * (see {@link #ALL_ACCESS}), and its confinement thread is the current thread (see {@link Thread#currentThread()}).
      *
      * @param arr the primitive array backing the array memory segment.
-     * @return a new array memory segment.
+     * @return a new confined array memory segment.
      */
     static MemorySegment ofArray(float[] arr) {
         return HeapMemorySegmentImpl.makeArraySegment(arr);
     }
 
     /**
-     * Creates a new array memory segment that models the memory associated with a given heap-allocated long array.
+     * Creates a new confined array memory segment that models the memory associated with a given heap-allocated long array.
      * <p>
      * The resulting memory segment keeps a reference to the backing array, to ensure it remains <em>reachable</em>
      * for the life-time of the segment. The segment will feature all <a href="#access-modes">access modes</a>
-     * (see {@link #ALL_ACCESS}).
+     * (see {@link #ALL_ACCESS}), and its confinement thread is the current thread (see {@link Thread#currentThread()}).
      *
      * @param arr the primitive array backing the array memory segment.
-     * @return a new array memory segment.
+     * @return a new confined array memory segment.
      */
     static MemorySegment ofArray(long[] arr) {
         return HeapMemorySegmentImpl.makeArraySegment(arr);
     }
 
     /**
-     * Creates a new array memory segment that models the memory associated with a given heap-allocated double array.
+     * Creates a new confined array memory segment that models the memory associated with a given heap-allocated double array.
      * <p>
      * The resulting memory segment keeps a reference to the backing array, to ensure it remains <em>reachable</em>
      * for the life-time of the segment. The segment will feature all <a href="#access-modes">access modes</a>
      * (see {@link #ALL_ACCESS}).
      *
      * @param arr the primitive array backing the array memory segment.
-     * @return a new array memory segment.
+     * @return a new confined array memory segment.
      */
     static MemorySegment ofArray(double[] arr) {
         return HeapMemorySegmentImpl.makeArraySegment(arr);
     }
 
     /**
-     * Creates a new native memory segment that models a newly allocated block of off-heap memory with given layout.
+     * Creates a new confined native memory segment that models a newly allocated block of off-heap memory with given layout.
      * <p>
      * This is equivalent to the following code:
      * <blockquote><pre>{@code
@@ -657,7 +677,7 @@ for (long l = 0; l < segment.byteSize(); l++) {
     }
 
     /**
-     * Creates a new native memory segment that models a newly allocated block of off-heap memory with given size (in bytes).
+     * Creates a new confined native memory segment that models a newly allocated block of off-heap memory with given size (in bytes).
      * <p>
      * This is equivalent to the following code:
      * <blockquote><pre>{@code
@@ -669,7 +689,7 @@ allocateNative(bytesSize, 1);
      * to make sure the backing off-heap memory block is deallocated accordingly. Failure to do so will result in off-heap memory leaks.
      *
      * @param bytesSize the size (in bytes) of the off-heap memory block backing the native memory segment.
-     * @return a new native memory segment.
+     * @return a new confined native memory segment.
      * @throws IllegalArgumentException if {@code bytesSize < 0}.
      */
     static MemorySegment allocateNative(long bytesSize) {
@@ -677,11 +697,11 @@ allocateNative(bytesSize, 1);
     }
 
     /**
-     * Creates a new mapped memory segment that models a memory-mapped region of a file from a given path.
+     * Creates a new confined mapped memory segment that models a memory-mapped region of a file from a given path.
      * <p>
      * The segment will feature all <a href="#access-modes">access modes</a> (see {@link #ALL_ACCESS}),
      * unless the given mapping mode is {@linkplain FileChannel.MapMode#READ_ONLY READ_ONLY}, in which case
-     * the segment will not feature the {@link #WRITE} access mode.
+     * the segment will not feature the {@link #WRITE} access mode, and its confinement thread is the current thread (see {@link Thread#currentThread()}).
      *
      * @implNote When obtaining a mapped segment from a newly created file, the initialization state of the contents of the block
      * of mapped memory associated with the returned mapped memory segment is unspecified and should not be relied upon.
@@ -691,7 +711,7 @@ allocateNative(bytesSize, 1);
      * @param bytesSize the size (in bytes) of the mapped memory backing the memory segment.
      * @param mapMode a file mapping mode, see {@link FileChannel#map(FileChannel.MapMode, long, long)}; the chosen mapping mode
      *                might affect the behavior of the returned memory mapped segment (see {@link MappedMemorySegment#force()}).
-     * @return a new mapped memory segment.
+     * @return a new confined mapped memory segment.
      * @throws IllegalArgumentException if {@code bytesOffset < 0}.
      * @throws IllegalArgumentException if {@code bytesSize < 0}.
      * @throws UnsupportedOperationException if an unsupported map mode is specified.
@@ -702,9 +722,9 @@ allocateNative(bytesSize, 1);
     }
 
     /**
-     * Creates a new native memory segment that models a newly allocated block of off-heap memory with given size and
+     * Creates a new confined native memory segment that models a newly allocated block of off-heap memory with given size and
      * alignment constraint (in bytes). The segment will feature all <a href="#access-modes">access modes</a>
-     * (see {@link #ALL_ACCESS}).
+     * (see {@link #ALL_ACCESS}), and its confinement thread is the current thread (see {@link Thread#currentThread()}).
      *
      * @implNote The block of off-heap memory associated with the returned native memory segment is initialized to zero.
      * Moreover, a client is responsible to call the {@link MemorySegment#close()} on a native memory segment,
@@ -712,7 +732,7 @@ allocateNative(bytesSize, 1);
      *
      * @param bytesSize the size (in bytes) of the off-heap memory block backing the native memory segment.
      * @param alignmentBytes the alignment constraint (in bytes) of the off-heap memory block backing the native memory segment.
-     * @return a new native memory segment.
+     * @return a new confined native memory segment.
      * @throws IllegalArgumentException if {@code bytesSize < 0}, {@code alignmentBytes < 0}, or if {@code alignmentBytes}
      * is not a power of 2.
      */
@@ -730,12 +750,13 @@ allocateNative(bytesSize, 1);
     }
 
     /**
-     * Returns a native memory segment whose base address is {@link MemoryAddress#NULL} and whose size is {@link Long#MAX_VALUE}.
+     * Returns a shared native memory segment whose base address is {@link MemoryAddress#NULL} and whose size is {@link Long#MAX_VALUE}.
      * This method can be very useful when dereferencing memory addresses obtained when interacting with native libraries.
      * The segment will feature the {@link #READ} and {@link #WRITE} <a href="#access-modes">access modes</a>.
      * Equivalent to (but likely more efficient than) the following code:
      * <pre>{@code
-    MemorySegment.ofNativeRestricted(MemoryAddress.NULL, Long.MAX_VALUE, null, null, null)
+    MemoryAddress.NULL.asSegmentRestricted(Long.MAX_VALUE)
+                 .withOwnerThread(null)
                  .withAccessModes(READ | WRITE);
      * }</pre>
      * <p>
@@ -750,42 +771,6 @@ allocateNative(bytesSize, 1);
     static MemorySegment ofNativeRestricted() {
         Utils.checkRestrictedAccess("MemorySegment.ofNativeRestricted");
         return NativeMemorySegmentImpl.EVERYTHING;
-    }
-
-    /**
-     * Returns a new native memory segment with given base address and size; the returned segment has its own temporal
-     * bounds, and can therefore be closed; closing such a segment can optionally result in calling an user-provided cleanup
-     * action. This method can be very useful when interacting with custom native memory sources (e.g. custom allocators,
-     * GPU memory, etc.), where an address to some underlying memory region is typically obtained from native code
-     * (often as a plain {@code long} value). The segment will feature all <a href="#access-modes">access modes</a>
-     * (see {@link #ALL_ACCESS}).
-     * <p>
-     * This method is <em>restricted</em>. Restricted methods are unsafe, and, if used incorrectly, their use might crash
-     * the JVM or, worse, silently result in memory corruption. Thus, clients should refrain from depending on
-     * restricted methods, and use safe and supported functionalities, where possible.
-     *
-     * @param addr the desired base address
-     * @param bytesSize the desired size.
-     * @param owner the desired owner thread. If {@code owner == null}, the returned segment is <em>not</em> confined.
-     * @param cleanup a cleanup action to be executed when the {@link MemorySegment#close()} method is called on the
-     *                returned segment. If {@code cleanup == null}, no cleanup action is executed.
-     * @param attachment an object that must be kept alive by the returned segment; this can be useful when
-     *                   the returned segment depends on memory which could be released if a certain object
-     *                   is determined to be unreacheable. In most cases this will be set to {@code null}.
-     * @return a new native memory segment with given base address, size, owner, cleanup action and object attachment.
-     * @throws IllegalArgumentException if {@code bytesSize <= 0}.
-     * @throws UnsupportedOperationException if {@code addr} is associated with an heap segment.
-     * @throws IllegalAccessError if the runtime property {@code foreign.restricted} is not set to either
-     * {@code permit}, {@code warn} or {@code debug} (the default value is set to {@code deny}).
-     * @throws NullPointerException if {@code addr == null}.
-     */
-    static MemorySegment ofNativeRestricted(MemoryAddress addr, long bytesSize, Thread owner, Runnable cleanup, Object attachment) {
-        Objects.requireNonNull(addr);
-        if (bytesSize <= 0) {
-            throw new IllegalArgumentException("Invalid size : " + bytesSize);
-        }
-        Utils.checkRestrictedAccess("MemorySegment.ofNativeRestricted");
-        return NativeMemorySegmentImpl.makeNativeSegmentUnchecked(addr, bytesSize, owner, cleanup, attachment);
     }
 
     // access mode masks

--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/MemorySegment.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/MemorySegment.java
@@ -268,7 +268,7 @@ public interface MemorySegment extends Addressable, AutoCloseable {
      * the same confinement thread (see {@link #ownerThread()} and access modes (see {@link #accessModes()}),
      * but with a different cleanup action. More specifically, the cleanup action associated with the returned segment will
      * first call the user-provided action, before delegating back to the original cleanup action associated with
-     * this segment. Any exception thrown by the user-provided action will be discarded, and will not prevent the
+     * this segment (if any). Any errors and/or exceptions thrown by the user-provided action will be discarded, and will not prevent the
      * release of any memory resources associated with this segment.
      * <p>
      * As a side-effect, this segment will be marked as <em>not alive</em>,

--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/MemorySegment.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/MemorySegment.java
@@ -268,7 +268,8 @@ public interface MemorySegment extends Addressable, AutoCloseable {
      * the same confinement thread (see {@link #ownerThread()} and access modes (see {@link #accessModes()}),
      * but with a different cleanup action. More specifically, the cleanup action associated with the returned segment will
      * first call the user-provided action, before delegating back to the original cleanup action associated with
-     * this segment.
+     * this segment. Any exception thrown by the user-provided action will be discarded, and will not prevent the
+     * release of any memory resources associated with this segment.
      * <p>
      * As a side-effect, this segment will be marked as <em>not alive</em>,
      * and subsequent operations on this segment will result in runtime errors.

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/AbstractMemorySegmentImpl.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/AbstractMemorySegmentImpl.java
@@ -296,6 +296,12 @@ public abstract class AbstractMemorySegmentImpl implements MemorySegment, Memory
     }
 
     @Override
+    public MemorySegment withCleanupAction(Runnable action) {
+        checkValidState();
+        return dup(0L, length, mask, scope.wrapAction(action));
+    }
+
+    @Override
     public void registerCleaner(Cleaner cleaner) {
         checkAccessModes(CLOSE);
         checkValidState();

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/MemoryScope.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/MemoryScope.java
@@ -63,17 +63,7 @@ abstract class MemoryScope implements ScopedMemoryAccess.Scope {
      * @return a confined memory scope
      */
     static MemoryScope createConfined(Object ref, CleanupAction cleanupAction) {
-        return createConfined(Thread.currentThread(), ref, cleanupAction);
-    }
-
-    /**
-     * Creates a confined memory scope with given attachment, cleanup action and owner thread.
-     * @param ref           an optional reference to an instance that needs to be kept reachable
-     * @param cleanupAction a cleanup action to be executed when returned scope is closed
-     * @return a confined memory scope
-     */
-    static MemoryScope createConfined(Thread owner, Object ref, CleanupAction cleanupAction) {
-        return new ConfinedScope(owner, ref, cleanupAction);
+        return new ConfinedScope(Thread.currentThread(), ref, cleanupAction);
     }
 
     /**
@@ -142,6 +132,17 @@ abstract class MemoryScope implements ScopedMemoryAccess.Scope {
         try {
             justClose();
             return new SharedScope(ref, cleanupAction.dup());
+        } finally {
+            Reference.reachabilityFence(this);
+        }
+    }
+
+    final MemoryScope wrapAction(Runnable runnable) {
+        try {
+            justClose();
+            return ownerThread() == null ?
+                    new SharedScope(ref, cleanupAction.wrap(runnable)) :
+                    new ConfinedScope(ownerThread(), ref, cleanupAction.wrap(runnable));
         } finally {
             Reference.reachabilityFence(this);
         }
@@ -274,6 +275,7 @@ abstract class MemoryScope implements ScopedMemoryAccess.Scope {
     interface CleanupAction extends Runnable {
         void cleanup();
         CleanupAction dup();
+        CleanupAction wrap(Runnable runnable);
 
         @Override
         default void run() {
@@ -290,6 +292,11 @@ abstract class MemoryScope implements ScopedMemoryAccess.Scope {
             @Override
             public CleanupAction dup() {
                 return this;
+            }
+
+            @Override
+            public CleanupAction wrap(Runnable runnable) {
+                return AtMostOnceOnly.of(runnable);
             }
         };
 
@@ -323,6 +330,14 @@ abstract class MemoryScope implements ScopedMemoryAccess.Scope {
             public CleanupAction dup() {
                 disable();
                 return new DupAction(this);
+            }
+
+            @Override
+            public CleanupAction wrap(Runnable runnable) {
+                disable();
+                return AtMostOnceOnly.of(() -> {
+                    runnable.run(); doCleanup();
+                });
             }
 
             //where

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/MemoryScope.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/MemoryScope.java
@@ -336,7 +336,13 @@ abstract class MemoryScope implements ScopedMemoryAccess.Scope {
             public CleanupAction wrap(Runnable runnable) {
                 disable();
                 return AtMostOnceOnly.of(() -> {
-                    runnable.run(); doCleanup();
+                    try {
+                        runnable.run();
+                    } catch (Throwable t) {
+                        // ignore
+                    } finally {
+                        doCleanup();
+                    }
                 });
             }
 

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/NativeMemorySegmentImpl.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/NativeMemorySegmentImpl.java
@@ -41,8 +41,9 @@ import java.nio.ByteBuffer;
  */
 public class NativeMemorySegmentImpl extends AbstractMemorySegmentImpl {
 
-    public static final MemorySegment EVERYTHING = NativeMemorySegmentImpl.makeNativeSegmentUnchecked(MemoryAddress.NULL,
-            Long.MAX_VALUE, null, null, null).withAccessModes(READ | WRITE);
+    public static final MemorySegment EVERYTHING = makeNativeSegmentUnchecked(MemoryAddress.NULL, Long.MAX_VALUE)
+            .withOwnerThread(null)
+            .withAccessModes(READ | WRITE);
 
     private static final Unsafe unsafe = Unsafe.getUnsafe();
 
@@ -113,12 +114,8 @@ public class NativeMemorySegmentImpl extends AbstractMemorySegmentImpl {
         return segment;
     }
 
-    public static MemorySegment makeNativeSegmentUnchecked(MemoryAddress min, long bytesSize, Thread owner, Runnable cleanup, Object attachment) {
-        MemoryScope.CleanupAction cleanupAction = cleanup != null ?
-                MemoryScope.CleanupAction.AtMostOnceOnly.of(cleanup) : MemoryScope.CleanupAction.DUMMY;
-        MemoryScope scope = owner == null ?
-                MemoryScope.createShared(attachment, cleanupAction) :
-                MemoryScope.createConfined(owner, attachment, cleanupAction);
-        return new NativeMemorySegmentImpl(min.toRawLongValue(), bytesSize, defaultAccessModes(bytesSize), scope);
+    public static MemorySegment makeNativeSegmentUnchecked(MemoryAddress min, long bytesSize) {
+        return new NativeMemorySegmentImpl(min.toRawLongValue(), bytesSize, defaultAccessModes(bytesSize),
+                MemoryScope.createConfined(null, MemoryScope.CleanupAction.DUMMY));
     }
 }

--- a/test/jdk/java/foreign/TestArrays.java
+++ b/test/jdk/java/foreign/TestArrays.java
@@ -39,7 +39,6 @@ import java.util.function.BiConsumer;
 import java.util.function.BiFunction;
 import java.util.function.Consumer;
 import java.util.function.Function;
-import java.util.function.ToIntFunction;
 
 import org.testng.annotations.*;
 
@@ -113,7 +112,7 @@ public class TestArrays {
     public void testTooBigForArray(MemoryLayout layout, Function<MemorySegment, Object> arrayFactory) {
         MemoryLayout seq = MemoryLayout.ofSequence((Integer.MAX_VALUE * layout.byteSize()) + 1, layout);
         //do not really allocate here, as it's way too much memory
-        try (MemorySegment segment = MemorySegment.ofNativeRestricted(MemoryAddress.NULL, seq.byteSize(), null, null, null)) {
+        try (MemorySegment segment = MemoryAddress.NULL.asSegmentRestricted(seq.byteSize())) {
             arrayFactory.apply(segment);
         }
     }

--- a/test/jdk/java/foreign/TestNative.java
+++ b/test/jdk/java/foreign/TestNative.java
@@ -167,8 +167,8 @@ public class TestNative {
     @Test
     public void testDefaultAccessModes() {
         MemoryAddress addr = MemoryAddress.ofLong(allocate(12));
-        MemorySegment mallocSegment = MemorySegment.ofNativeRestricted(addr, 12, null,
-                () -> free(addr.toRawLongValue()), null);
+        MemorySegment mallocSegment = addr.asSegmentRestricted(12)
+                .withCleanupAction(() -> free(addr.toRawLongValue()));
         try (MemorySegment segment = mallocSegment) {
             assertTrue(segment.hasAccessModes(ALL_ACCESS));
             assertEquals(segment.accessModes(), ALL_ACCESS);
@@ -185,8 +185,8 @@ public class TestNative {
     @Test
     public void testMallocSegment() {
         MemoryAddress addr = MemoryAddress.ofLong(allocate(12));
-        MemorySegment mallocSegment = MemorySegment.ofNativeRestricted(addr, 12, null,
-                () -> free(addr.toRawLongValue()), null);
+        MemorySegment mallocSegment = addr.asSegmentRestricted(12)
+                .withCleanupAction(() -> free(addr.toRawLongValue()));
         assertEquals(mallocSegment.byteSize(), 12);
         mallocSegment.close(); //free here
         assertTrue(!mallocSegment.isAlive());
@@ -204,13 +204,8 @@ public class TestNative {
     @Test(expectedExceptions = IllegalArgumentException.class)
     public void testBadResize() {
         try (MemorySegment segment = MemorySegment.allocateNative(4)) {
-            MemorySegment.ofNativeRestricted(segment.address(), 0, null, null, null);
+            segment.address().asSegmentRestricted(0);
         }
-    }
-
-    @Test(expectedExceptions = NullPointerException.class)
-    public void testNullUnsafeSegment() {
-        MemorySegment.ofNativeRestricted(null, 10, null, null, null);
     }
 
     static {

--- a/test/jdk/java/foreign/TestNoForeignUnsafeOverride.java
+++ b/test/jdk/java/foreign/TestNoForeignUnsafeOverride.java
@@ -29,8 +29,8 @@
  */
 
 import jdk.incubator.foreign.MemoryAddress;
-import jdk.incubator.foreign.MemorySegment;
 
+import jdk.incubator.foreign.MemorySegment;
 import org.testng.annotations.Test;
 
 public class TestNoForeignUnsafeOverride {
@@ -40,6 +40,6 @@ public class TestNoForeignUnsafeOverride {
 
     @Test(expectedExceptions = IllegalAccessError.class)
     public void testUnsafeAccess() {
-        MemorySegment.ofNativeRestricted(MemoryAddress.ofLong(42), 10, null, null, null);
+        MemorySegment.ofNativeRestricted();
     }
 }

--- a/test/jdk/java/foreign/TestSegments.java
+++ b/test/jdk/java/foreign/TestSegments.java
@@ -336,7 +336,8 @@ public class TestSegments {
                 "toLongArray",
                 "toDoubleArray",
                 "withOwnerThread",
-                "registerCleaner"
+                "registerCleaner",
+                "withCleanupAction"
         );
 
         public SegmentMember(Method method, Object[] params) {

--- a/test/jdk/java/foreign/TestSharedAccess.java
+++ b/test/jdk/java/foreign/TestSharedAccess.java
@@ -27,10 +27,7 @@
  * @run testng/othervm -Dforeign.restricted=permit TestSharedAccess
  */
 
-import jdk.incubator.foreign.MemoryLayout;
-import jdk.incubator.foreign.MemorySegment;
-import jdk.incubator.foreign.MemoryLayouts;
-import jdk.incubator.foreign.SequenceLayout;
+import jdk.incubator.foreign.*;
 import org.testng.annotations.*;
 
 import java.lang.invoke.VarHandle;
@@ -127,8 +124,8 @@ public class TestSharedAccess {
             setInt(s, 42);
             assertEquals(getInt(s), 42);
             List<Thread> threads = new ArrayList<>();
-            MemorySegment sharedSegment = MemorySegment.ofNativeRestricted(
-                    s.address(), s.byteSize(), null, null, null);
+            MemorySegment sharedSegment = s.address().asSegmentRestricted(s.byteSize())
+                    .withOwnerThread(null);
             for (int i = 0 ; i < 1000 ; i++) {
                 threads.add(new Thread(() -> {
                     assertEquals(getInt(sharedSegment), 42);


### PR DESCRIPTION
This patch simplifies the MemorySegment::ofNativeRestricted API, based on a number of observations:

* now that we have shared segment support, passing an explicit owner thread isn't that useful (e.g. this is no longer an escape hatch, and can - and should - be done with public, safe API)
* if we had a public safe API to add cleanup action to existing segments, we could also get rid of the cleanup parameter
* if a custom cleanup action embedded some other object, that object will be kept reachable, so no attachment API is needed
* if we moved the method to MemoryAddress, we would streamline uses of this API quite a bit, as in `address.asSegmentRestricted(100)` - e.g. only size is needed

Adding the new API for attaching cleanup action is relatively straightforward - as usual we have to dup the segment and the scope, and create a new segment, with a new scope whose cleanup action calls the custom runnable before the original action (that original action should still be called, since otherwise we would fail to free/unmap memory).
Any exception thrown by the cleanup action is caught and ignored, so as not to mess with the critical cleanup which has to occur.

A nice consequence of this work is that the surface for unsafety is much reduced, and the various methods compose much better. For instance, the "everything" segment can be expressed as follows:

```
MemoryAddress.NULL
    .asSegmentRestricted(Long.MAX_VALUE)
    .withOwnerThread(null)
    .withAccessModes(READ | WRITE);
```

Which is, I think, much nicer. The changes in tests also suggest that the new API is easier on clients, and in one case (TestCleaner) the need for opting into unsafe operation actually vanished.

I also did a bit of cleaning on the javadoc, which appeared to be off-sync when it comes to confinement.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8253243](https://bugs.openjdk.java.net/browse/JDK-8253243): Investigate ways to make MemorySegment::ofNativeRestricted more composable


### Reviewers
 * [Athijegannathan Sundararajan](https://openjdk.java.net/census#sundar) (@sundararajana - Committer) ⚠️ Review applies to 3a186d46a27ba4da4b51d70e6c45df3626eb3662
 * [Paul Sandoz](https://openjdk.java.net/census#psandoz) (@PaulSandoz - Committer) ⚠️ Review applies to 3a186d46a27ba4da4b51d70e6c45df3626eb3662
 * [Jorn Vernee](https://openjdk.java.net/census#jvernee) (@JornVernee - Committer)


### Download
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/328/head:pull/328`
`$ git checkout pull/328`
