### PR TITLE
8239780: FunctionDescriptor factories and combinators should check whether return layout is null

### DIFF
--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/FunctionDescriptor.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/FunctionDescriptor.java
@@ -114,8 +114,11 @@ public final class FunctionDescriptor implements Constable {
      * @param resLayout the return
      * @param argLayouts the argument layouts.
      * @return the new function descriptor.
+     * @throws NullPointerException if any of the argument layouts, or the return layout is null
      */
     public static FunctionDescriptor of(MemoryLayout resLayout, MemoryLayout... argLayouts) {
+        Objects.requireNonNull(resLayout);
+        Arrays.stream(argLayouts).forEach(Objects::requireNonNull);
         return new FunctionDescriptor(resLayout, Map.of(), argLayouts);
     }
 
@@ -123,8 +126,10 @@ public final class FunctionDescriptor implements Constable {
      * Create a void function descriptor with given argument layouts.
      * @param argLayouts the argument layouts.
      * @return the new function descriptor.
+     * @throws NullPointerException if any of the argument layouts is null
      */
     public static FunctionDescriptor ofVoid(MemoryLayout... argLayouts) {
+        Arrays.stream(argLayouts).forEach(Objects::requireNonNull);
         return new FunctionDescriptor(null, Map.of(), argLayouts);
     }
 
@@ -133,8 +138,10 @@ public final class FunctionDescriptor implements Constable {
      * of this function descriptor.
      * @param addedLayouts the layouts to append
      * @return the new function descriptor
+     * @throws NullPointerException if any of the new argument layouts is null
      */
     public FunctionDescriptor appendArgumentLayouts(MemoryLayout... addedLayouts) {
+        Arrays.stream(addedLayouts).forEach(Objects::requireNonNull);
         MemoryLayout[] newLayouts = Arrays.copyOf(argLayouts, argLayouts.length + addedLayouts.length);
         System.arraycopy(addedLayouts, 0, newLayouts, argLayouts.length, addedLayouts.length);
         return new FunctionDescriptor(resLayout, attributes, newLayouts);
@@ -144,9 +151,19 @@ public final class FunctionDescriptor implements Constable {
      * Create a new function descriptor with the given memory layout as the new return layout.
      * @param newReturn the new return layout
      * @return the new function descriptor
+     * @throws NullPointerException if the new return layout is null
      */
     public FunctionDescriptor changeReturnLayout(MemoryLayout newReturn) {
+        Objects.requireNonNull(newReturn);
         return new FunctionDescriptor(newReturn, attributes, argLayouts);
+    }
+
+    /**
+     * Create a new function descriptor with the return layout dropped.
+     * @return the new function descriptor
+     */
+    public FunctionDescriptor dropReturnLayout() {
+        return new FunctionDescriptor(null, attributes, argLayouts);
     }
 
     /**

--- a/test/jdk/java/foreign/TestFunctionDescriptor.java
+++ b/test/jdk/java/foreign/TestFunctionDescriptor.java
@@ -1,0 +1,61 @@
+/*
+ *  Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ *  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ *  This code is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License version 2 only, as
+ *  published by the Free Software Foundation.
+ *
+ *  This code is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ *  version 2 for more details (a copy is included in the LICENSE file that
+ *  accompanied this code).
+ *
+ *  You should have received a copy of the GNU General Public License version
+ *  2 along with this work; if not, write to the Free Software Foundation,
+ *  Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ *   Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ *  or visit www.oracle.com if you need additional information or have any
+ *  questions.
+ *
+ */
+
+/*
+ * @test
+ * @run testng TestFunctionDescriptor
+ */
+
+import jdk.incubator.foreign.FunctionDescriptor;
+import org.testng.annotations.Test;
+
+import static jdk.incubator.foreign.CLinker.C_DOUBLE;
+import static jdk.incubator.foreign.CLinker.C_INT;
+import static jdk.incubator.foreign.CLinker.C_LONGLONG;
+
+public class TestFunctionDescriptor {
+
+    @Test(expectedExceptions = NullPointerException.class)
+    public void testNullArgumentLayout() {
+        FunctionDescriptor.ofVoid(C_INT, null, C_LONGLONG);
+    }
+
+    @Test(expectedExceptions = NullPointerException.class)
+    public void testNullReturnLayout() {
+        FunctionDescriptor.of(null, C_INT, C_LONGLONG);
+    }
+
+    @Test(expectedExceptions = NullPointerException.class)
+    public void testNullArgumentLayoutsAppend() {
+        FunctionDescriptor fd = FunctionDescriptor.ofVoid(C_INT, C_LONGLONG);
+        fd.appendArgumentLayouts(C_DOUBLE, null); // should throw
+    }
+
+    @Test(expectedExceptions = NullPointerException.class)
+    public void testNullReturnLayoutChange() {
+        FunctionDescriptor fd = FunctionDescriptor.ofVoid(C_INT, C_LONGLONG);
+        fd.changeReturnLayout(null); // should throw
+    }
+
+}


### PR DESCRIPTION
Hi,

I'm going through the foreign-abi JBS issues and taking care of some of the open ones.

This PR adds null checking to the MemoryLayouts passed to the FunctionDescriptor factories and adapter methods, together with a simple test.

I've also added an adapter for dropping the return layout, since with the null check, it is no longer possible to pass `null` to drop the return layout. I think having the explicit check, and a separate combinator for dropping the return layout instead will be better for avoiding accidental nulls being used.

Thanks,
Jorn
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8239780](https://bugs.openjdk.java.net/browse/JDK-8239780): FunctionDescriptor factories and combinators should check whether return layout is null


### Reviewers
 * [Athijegannathan Sundararajan](https://openjdk.java.net/census#sundar) (@sundararajana - Committer)


### Download
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/330/head:pull/330`
`$ git checkout pull/330`
