### PR TITLE
8253287: jcheck merge check is too strict

### DIFF
--- a/.jcheck/conf
+++ b/.jcheck/conf
@@ -17,7 +17,7 @@ domain=openjdk.org
 files=.*\.cpp|.*\.hpp|.*\.c|.*\.h|.*\.java
 
 [checks "merge"]
-message=Merge
+message=Merge .*
 
 [checks "reviewers"]
 committers=1


### PR DESCRIPTION
The regex for checking merge commits is too strict. This should relax that.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8253287](https://bugs.openjdk.java.net/browse/JDK-8253287): jcheck merge check is too strict


### Reviewers
 * [Jorn Vernee](https://openjdk.java.net/census#jvernee) (@JornVernee - Committer)


### Download
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/332/head:pull/332`
`$ git checkout pull/332`
