### PR TITLE
8253287: jcheck merge check is too strict

### DIFF
--- a/.jcheck/conf
+++ b/.jcheck/conf
@@ -17,7 +17,7 @@ domain=openjdk.org
 files=.*\.cpp|.*\.hpp|.*\.c|.*\.h|.*\.java
 
 [checks "merge"]
-message=Merge
+message=Merge .*
 
 [checks "reviewers"]
 committers=1


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Error
&nbsp;⚠️ The pull request body must not be empty.

### Issue
 * [JDK-8253287](https://bugs.openjdk.java.net/browse/JDK-8253287): jcheck merge check is too strict


### Download
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/334/head:pull/334`
`$ git checkout pull/334`
