### PR TITLE
8253290: Tweak jextract code to use new MemoryAddress::asSegmentRestricted

### DIFF
--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/clang/TranslationUnit.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/clang/TranslationUnit.java
@@ -158,7 +158,8 @@ public class TranslationUnit implements AutoCloseable {
 
         public MemorySegment getTokenSegment(int idx) {
             MemoryAddress p = ar.addOffset(idx * Index_h.CXToken.$LAYOUT().byteSize());
-            return MemorySegment.ofNativeRestricted(p, Index_h.CXToken.$LAYOUT().byteSize(), null, null, null);
+            return p.asSegmentRestricted(Index_h.CXToken.$LAYOUT().byteSize())
+                    .withOwnerThread(null);
         }
 
         public Token getToken(int index) {

--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/clang/libclang/RuntimeHelper.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/clang/libclang/RuntimeHelper.java
@@ -90,14 +90,14 @@ public class RuntimeHelper {
         return lookup(LIBRARIES, name).map(s ->
             nonCloseableNonTransferableSegment(s.address().asSegmentRestricted(layout.byteSize())
                     .withOwnerThread(null)
-                    .withCleanupAction(new RunnableHolder(s))
+                    .withCleanupAction(new SymbolHolder(s))
             )).orElse(null);
     }
 
-    static class RunnableHolder implements Runnable {
+    static class SymbolHolder implements Runnable {
         LibraryLookup.Symbol symbol;
 
-        RunnableHolder(LibraryLookup.Symbol symbol) {
+        SymbolHolder(LibraryLookup.Symbol symbol) {
             this.symbol = symbol;
         }
 

--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/resources/RuntimeHelper.java.template
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/resources/RuntimeHelper.java.template
@@ -63,14 +63,14 @@ public class RuntimeHelper {
             return lookup(LIBRARIES, name).map(s ->
                 nonCloseableNonTransferableSegment(s.address().asSegmentRestricted(layout.byteSize())
                         .withOwnerThread(null)
-                        .withCleanupAction(new RunnableHolder(s))
+                        .withCleanupAction(new SymbolHolder(s))
                 )).orElse(null);
     }
 
-    static class RunnableHolder implements Runnable {
+    static class SymbolHolder implements Runnable {
         LibraryLookup.Symbol symbol;
 
-        RunnableHolder(LibraryLookup.Symbol symbol) {
+        SymbolHolder(LibraryLookup.Symbol symbol) {
             this.symbol = symbol;
         }
 

--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/resources/RuntimeHelper.java.template
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/resources/RuntimeHelper.java.template
@@ -60,10 +60,24 @@ public class RuntimeHelper {
     }
 
     public static final MemorySegment lookupGlobalVariable(LibraryLookup[] LIBRARIES, String name, MemoryLayout layout) {
-        return lookup(LIBRARIES, name).map(s ->
-            nonCloseableNonTransferableSegment(MemorySegment.ofNativeRestricted(
-                 s.address(), layout.byteSize(), null, null, s
-            ))).orElse(null);
+            return lookup(LIBRARIES, name).map(s ->
+                nonCloseableNonTransferableSegment(s.address().asSegmentRestricted(layout.byteSize())
+                        .withOwnerThread(null)
+                        .withCleanupAction(new RunnableHolder(s))
+                )).orElse(null);
+    }
+
+    static class RunnableHolder implements Runnable {
+        LibraryLookup.Symbol symbol;
+
+        RunnableHolder(LibraryLookup.Symbol symbol) {
+            this.symbol = symbol;
+        }
+
+        @Override
+        public void run() {
+            // do nothing
+        }
     }
 
     public static final MemorySegment nonCloseableNonTransferableSegment(MemorySegment seg) {
@@ -100,8 +114,7 @@ public class RuntimeHelper {
     }
 
     public static MemorySegment asArrayRestricted(MemoryAddress addr, MemoryLayout layout, int numElements) {
-        return nonCloseableSegment(MemorySegment.ofNativeRestricted(addr, numElements * layout.byteSize(),
-               Thread.currentThread(), null, null));
+        return nonCloseableSegment(addr.asSegmentRestricted(numElements * layout.byteSize()));
     }
 
     public static MemorySegment asArray(MemorySegment seg, MemoryLayout layout, int numElements) {


### PR DESCRIPTION
This fixes references to the now-removed MemorySegment::ofNativeRestricted(...).

The only tricky issue is in RunimeHelper - which has to create an unchecked segment for a global variable and,
in doing so, it has to keep a reference of the lookup symbol in there, to prevent the library from being unloaded.

Since the new API doesn't have an explicit way to add an attachment, I've added a simple Runnable impl which wraps a symbol,
and pass that as a no-op cleanup action to the segment.

For the records, I believe that creating segments for global vars is tricky enough that there should be a blessed (restricted) way to do that in the LibraryLookup.Symbol API.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8253290](https://bugs.openjdk.java.net/browse/JDK-8253290): Tweak jextract code to use new MemoryAddress::asSegmentRestricted


### Reviewers
 * [Athijegannathan Sundararajan](https://openjdk.java.net/census#sundar) (@sundararajana - Committer) ⚠️ Review applies to e9b47df56d2222568ba71670435f39cd58889a4d


### Download
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/335/head:pull/335`
`$ git checkout pull/335`
