### PR TITLE
8253305: The threshold for the shared segment handshake stackwalk is too low

### DIFF
--- a/src/hotspot/share/prims/scopedMemoryAccess.cpp
+++ b/src/hotspot/share/prims/scopedMemoryAccess.cpp
@@ -87,7 +87,7 @@ public:
       Deoptimization::deoptimize(jt, last_frame);
     }
 
-    const int max_critical_stack_depth = 5;
+    const int max_critical_stack_depth = 10;
     int depth = 0;
     vframeStream stream(jt);
     for (; !stream.at_end(); stream.next()) {


### PR DESCRIPTION
This patch slightly increases the threshold for the stack walk during the shared segment handshake.
We found instances (MemorySegment::copy) where more than 5 frames were inserted beteween top of stack and first scoped frame.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8253305](https://bugs.openjdk.java.net/browse/JDK-8253305): The threshold for the shared segment handshake stackwalk is too low


### Reviewers
 * [Paul Sandoz](https://openjdk.java.net/census#psandoz) (@PaulSandoz - Committer)


### Download
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/337/head:pull/337`
`$ git checkout pull/337`
