### PR TITLE
8253306: jcheck should not be too picky about PR messages on panama-foreign

### DIFF
--- a/.jcheck/conf
+++ b/.jcheck/conf
@@ -3,7 +3,7 @@ project=panama
 jbs=JDK
 
 [checks]
-error=author,committer,reviewers,merge,issues,executable,symlink,message,hg-tag,whitespace
+error=author,committer,reviewers,merge,executable,symlink,message,hg-tag,whitespace
 
 [repository]
 tags=(?:jdk-(?:[1-9]([0-9]*)(?:\\.(?:0|[1-9][0-9]*)){0,4})(?:\\+(?:(?:[0-9]+))|(?:-ga)))|(?:jdk[4-9](?:u\\d{1,3})?-(?:(?:b\\d{2,3})|(?:ga)))|(?:hs\\d\\d(?:\\.\\d{1,2})?-b\\d\\d)
@@ -24,6 +24,3 @@ committers=1
 
 [checks "committer"]
 role=committer
-
-[checks "issues"]
-pattern=^([124-8][0-9]{6}): (\S.*)$


### PR DESCRIPTION
What the subject says :-)
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8253306](https://bugs.openjdk.java.net/browse/JDK-8253306): jcheck should not be too picky about PR messages on panama-foreign


### Reviewers
 * [Henry Jen](https://openjdk.java.net/census#henryjen) (@slowhog - Committer)


### Download
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/338/head:pull/338`
`$ git checkout pull/338`
