### PR TITLE
8253307: Simplify code in RuntimeHelper::lookupGlobalVariable

### DIFF
--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/clang/libclang/RuntimeHelper.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/clang/libclang/RuntimeHelper.java
@@ -89,22 +89,7 @@ public class RuntimeHelper {
     public static final MemorySegment lookupGlobalVariable(LibraryLookup[] LIBRARIES, String name, MemoryLayout layout) {
         return lookup(LIBRARIES, name).map(s ->
             nonCloseableNonTransferableSegment(s.address().asSegmentRestricted(layout.byteSize())
-                    .withOwnerThread(null)
-                    .withCleanupAction(new SymbolHolder(s))
-            )).orElse(null);
-    }
-
-    static class SymbolHolder implements Runnable {
-        LibraryLookup.Symbol symbol;
-
-        SymbolHolder(LibraryLookup.Symbol symbol) {
-            this.symbol = symbol;
-        }
-
-        @Override
-        public void run() {
-            // do nothing
-        }
+                    .withOwnerThread(null))).orElse(null);
     }
 
     public static final MemorySegment nonCloseableNonTransferableSegment(MemorySegment seg) {

--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/resources/RuntimeHelper.java.template
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/resources/RuntimeHelper.java.template
@@ -65,19 +65,6 @@ public class RuntimeHelper {
                     .withOwnerThread(null))).orElse(null);
     }
 
-    static class SymbolHolder implements Runnable {
-        LibraryLookup.Symbol symbol;
-
-        SymbolHolder(LibraryLookup.Symbol symbol) {
-            this.symbol = symbol;
-        }
-
-        @Override
-        public void run() {
-            // do nothing
-        }
-    }
-
     public static final MemorySegment nonCloseableNonTransferableSegment(MemorySegment seg) {
         return seg.withAccessModes(seg.accessModes() &  ~MemorySegment.CLOSE & ~MemorySegment.HANDOFF);
     }

--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/resources/RuntimeHelper.java.template
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/resources/RuntimeHelper.java.template
@@ -60,11 +60,9 @@ public class RuntimeHelper {
     }
 
     public static final MemorySegment lookupGlobalVariable(LibraryLookup[] LIBRARIES, String name, MemoryLayout layout) {
-            return lookup(LIBRARIES, name).map(s ->
-                nonCloseableNonTransferableSegment(s.address().asSegmentRestricted(layout.byteSize())
-                        .withOwnerThread(null)
-                        .withCleanupAction(new SymbolHolder(s))
-                )).orElse(null);
+        return lookup(LIBRARIES, name).map(s ->
+            nonCloseableNonTransferableSegment(s.address().asSegmentRestricted(layout.byteSize())
+                    .withOwnerThread(null))).orElse(null);
     }
 
     static class SymbolHolder implements Runnable {


### PR DESCRIPTION
Earlier today, I added a workaround on RuntimeHelper when I tweaked it to use the new MemoryAddress::asSegmentRestricted API.
The old code was adding the lookup symbol as an attachment to the returned segment, so I did a workaround to do just that under the new API.

Turns out that the workaround wasn't needed (I think). Upon more thinking, I realized that we always store an array of LibraryLookup inside the very constant holder class - either as a static field, or as a dynamically loaded constant.

I think in both cases that should be enough to prevent the lookup object from going unreachable.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [JDK-8253307](https://bugs.openjdk.java.net/browse/JDK-8253307): Simplify code in RuntimeHelper::lookupGlobalVariable


### Reviewers
 * [Henry Jen](https://openjdk.java.net/census#henryjen) (@slowhog - Committer)
 * [Jorn Vernee](https://openjdk.java.net/census#jvernee) (@JornVernee - Committer)
 * [Athijegannathan Sundararajan](https://openjdk.java.net/census#sundar) (@sundararajana - Committer)


### Download
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/339/head:pull/339`
`$ git checkout pull/339`
