### PR TITLE
8253355: Add some overloads to memory access API

### DIFF
--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/MemoryAddress.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/MemoryAddress.java
@@ -88,10 +88,46 @@ public interface MemoryAddress extends Addressable {
 
     /**
      * Returns a new confined native memory segment with given size, and whose base address is this address; the returned segment has its own temporal
-     * bounds, and can therefore be closed. This method can be very useful when interacting with custom native memory sources (e.g. custom allocators),
+     * bounds, and can therefore be closed. This method can be useful when interacting with custom native memory sources (e.g. custom allocators),
      * where an address to some underlying memory region is typically obtained from native code
      * (often as a plain {@code long} value). The returned segment will feature all <a href="#access-modes">access modes</a>
      * (see {@link MemorySegment#ALL_ACCESS}), and its confinement thread is the current thread (see {@link Thread#currentThread()}).
+     * <p>
+     * Calling {@link MemorySegment#close()} on the returned segment will <em>not</em> result in releasing any
+     * memory resources which might implicitly be associated with the segment. If the client wants to specify
+     * a cleanup action to be executed when the returned segment is closed, the {@link MemorySegment#withCleanupAction(Runnable)}
+     * method should be used.
+     * <p>
+     * Equivalent to the following code:
+     * <pre>{@code
+    asSegmentRestricted(byteSize, null);
+     * }</pre>
+     * <p>
+     * This method is <em>restricted</em>. Restricted methods are unsafe, and, if used incorrectly, their use might crash
+     * the JVM or, worse, silently result in memory corruption. Thus, clients should refrain from depending on
+     * restricted methods, and use safe and supported functionalities, where possible.
+     *
+     * @see #asSegmentRestricted(long, Object)
+     *
+     * @param bytesSize the desired size.
+     * @return a new confined native memory segment with given base address and size.
+     * @throws IllegalArgumentException if {@code bytesSize <= 0}.
+     * @throws UnsupportedOperationException if this address is an heap address.
+     * @throws IllegalAccessError if the runtime property {@code foreign.restricted} is not set to either
+     * {@code permit}, {@code warn} or {@code debug} (the default value is set to {@code deny}).
+     */
+    default MemorySegment asSegmentRestricted(long bytesSize) {
+        return asSegmentRestricted(bytesSize, null);
+    }
+
+    /**
+     * Returns a new confined native memory segment with given size, and whose base address is this address; the returned segment has its own temporal
+     * bounds, and can therefore be closed. This method can be useful when interacting with custom native memory sources (e.g. custom allocators),
+     * where an address to some underlying memory region is typically obtained from native code
+     * (often as a plain {@code long} value). The returned segment will feature all <a href="#access-modes">access modes</a>
+     * (see {@link MemorySegment#ALL_ACCESS}), and its confinement thread is the current thread (see {@link Thread#currentThread()}).
+     * Moreover, the returned segment will keep a strong reference to the supplied attachment object, which can
+     * be useful in cases where the lifecycle of the segment is dependent on that of some other external resource.
      * <p>
      * Calling {@link MemorySegment#close()} on the returned segment will <em>not</em> result in releasing any
      * memory resources which might implicitly be associated with the segment. If the client wants to specify
@@ -103,13 +139,14 @@ public interface MemoryAddress extends Addressable {
      * restricted methods, and use safe and supported functionalities, where possible.
      *
      * @param bytesSize the desired size.
+     * @param attachment an attachment object that will be kept strongly reachable by the returned segment; can be {@code null}.
      * @return a new confined native memory segment with given base address and size.
      * @throws IllegalArgumentException if {@code bytesSize <= 0}.
      * @throws UnsupportedOperationException if this address is an heap address.
      * @throws IllegalAccessError if the runtime property {@code foreign.restricted} is not set to either
      * {@code permit}, {@code warn} or {@code debug} (the default value is set to {@code deny}).
      */
-    default MemorySegment asSegmentRestricted(long bytesSize) {
+    default MemorySegment asSegmentRestricted(long bytesSize, Object attachment) {
         Utils.checkRestrictedAccess("MemoryAddress.asSegmentRestricted");
         if (bytesSize <= 0) {
             throw new IllegalArgumentException("Invalid size : " + bytesSize);

--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/MemoryAddress.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/MemoryAddress.java
@@ -93,6 +93,10 @@ public interface MemoryAddress extends Addressable {
      * (often as a plain {@code long} value). The returned segment will feature all <a href="#access-modes">access modes</a>
      * (see {@link MemorySegment#ALL_ACCESS}), and its confinement thread is the current thread (see {@link Thread#currentThread()}).
      * <p>
+     * Clients should ensure that the address and bounds refers to a valid region of memory that is accessible for reading and,
+     * if appropriate, writing; an attempt to access an invalid memory location from Java code will either return an arbitrary value,
+     * have no visible effect, or cause an unspecified exception to be thrown.
+     * <p>
      * Calling {@link MemorySegment#close()} on the returned segment will <em>not</em> result in releasing any
      * memory resources which might implicitly be associated with the segment. If the client wants to specify
      * a cleanup action to be executed when the returned segment is closed, the {@link MemorySegment#withCleanupAction(Runnable)}
@@ -124,7 +128,13 @@ public interface MemoryAddress extends Addressable {
      * Returns a new confined native memory segment with given size, and whose base address is this address; the returned segment has its own temporal
      * bounds, and can therefore be closed. This method can be useful when interacting with custom native memory sources (e.g. custom allocators),
      * where an address to some underlying memory region is typically obtained from native code
-     * (often as a plain {@code long} value). The returned segment will feature all <a href="#access-modes">access modes</a>
+     * (often as a plain {@code long} value).
+     * <p>
+     * Clients should ensure that the address and bounds refers to a valid region of memory that is accessible for reading and,
+     * if appropriate, writing; an attempt to access an invalid memory location from Java code will either return an arbitrary value,
+     * have no visible effect, or cause an unspecified exception to be thrown.
+     * <p>
+     * The returned segment will feature all <a href="#access-modes">access modes</a>
      * (see {@link MemorySegment#ALL_ACCESS}), and its confinement thread is the current thread (see {@link Thread#currentThread()}).
      * Moreover, the returned segment will keep a strong reference to the supplied attachment object, which can
      * be useful in cases where the lifecycle of the segment is dependent on that of some other external resource.
@@ -151,7 +161,7 @@ public interface MemoryAddress extends Addressable {
         if (bytesSize <= 0) {
             throw new IllegalArgumentException("Invalid size : " + bytesSize);
         }
-        return NativeMemorySegmentImpl.makeNativeSegmentUnchecked(this, bytesSize);
+        return NativeMemorySegmentImpl.makeNativeSegmentUnchecked(this, bytesSize, attachment);
     }
 
     /**

--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/MemorySegment.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/MemorySegment.java
@@ -320,6 +320,11 @@ public interface MemorySegment extends Addressable, AutoCloseable {
     /**
      * Obtains a new memory segment view whose base address is the same as the base address of this segment plus a given offset,
      * and whose new size is specified by the given argument.
+     *
+     * @see #asSlice(long)
+     * @see #asSlice(MemoryAddress)
+     * @see #asSlice(MemoryAddress, long)
+     *
      * @param offset The new segment base offset (relative to the current segment base address), specified in bytes.
      * @param newSize The new segment size, specified in bytes.
      * @return a new memory segment view with updated base/limit addresses.
@@ -328,24 +333,70 @@ public interface MemorySegment extends Addressable, AutoCloseable {
     MemorySegment asSlice(long offset, long newSize);
 
     /**
+     * Obtains a new memory segment view whose base address is the given address, and whose new size is specified by the given argument.
+     * <p>
+     * Equivalent to the following code:
+     * <pre>{@code
+    asSlice(newBase.segmentOffset(this), newSize);
+     * }</pre>
+     *
+     * @see #asSlice(long)
+     * @see #asSlice(MemoryAddress)
+     * @see #asSlice(long, long)
+     *
+     * @param newBase The new segment base address.
+     * @param newSize The new segment size, specified in bytes.
+     * @return a new memory segment view with updated base/limit addresses.
+     * @throws NullPointerException if {@code newBase == null}.
+     * @throws IndexOutOfBoundsException if {@code offset < 0}, {@code offset > byteSize()}, {@code newSize < 0}, or {@code newSize > byteSize() - offset}
+     */
+    default MemorySegment asSlice(MemoryAddress newBase, long newSize) {
+        Objects.requireNonNull(newBase);
+        return asSlice(newBase.segmentOffset(this), newSize);
+    }
+
+    /**
      * Obtains a new memory segment view whose base address is the same as the base address of this segment plus a given offset,
      * and whose new size is computed by subtracting the specified offset from this segment size.
+     * <p>
+     * Equivalent to the following code:
+     * <pre>{@code
+    asSlice(offset, byteSize() - offset);
+     * }</pre>
+     *
+     * @see #asSlice(MemoryAddress)
+     * @see #asSlice(MemoryAddress, long)
+     * @see #asSlice(long, long)
+     *
      * @param offset The new segment base offset (relative to the current segment base address), specified in bytes.
      * @return a new memory segment view with updated base/limit addresses.
      * @throws IndexOutOfBoundsException if {@code offset < 0}, or {@code offset > byteSize()}.
      */
-    MemorySegment asSlice(long offset);
+    default MemorySegment asSlice(long offset) {
+        return asSlice(offset, byteSize() - offset);
+    }
 
     /**
-     * Obtains a new memory segment view whose base address is the address passed as argument,
-     * and whose new size is computed by subtracting the address offset relative to this segment
-     * (see {@link MemoryAddress#segmentOffset(MemorySegment)}) from this segment size.
-     * @param address The new segment base offset (relative to the current segment base address), specified in bytes.
+     * Obtains a new memory segment view whose base address is the given address, and whose new size is computed by subtracting
+     * the address offset relative to this segment (see {@link MemoryAddress#segmentOffset(MemorySegment)}) from this segment size.
+     * <p>
+     * Equivalent to the following code:
+     * <pre>{@code
+    asSlice(newBase.segmentOffset(this));
+     * }</pre>
+     *
+     * @see #asSlice(long)
+     * @see #asSlice(MemoryAddress, long)
+     * @see #asSlice(long, long)
+     *
+     * @param newBase The new segment base offset (relative to the current segment base address), specified in bytes.
      * @return a new memory segment view with updated base/limit addresses.
+     * @throws NullPointerException if {@code newBase == null}.
      * @throws IndexOutOfBoundsException if {@code address.segmentOffset(this) < 0}, or {@code address.segmentOffset(this) > byteSize()}.
      */
-    default MemorySegment asSlice(MemoryAddress address) {
-        return asSlice(address.segmentOffset(this));
+    default MemorySegment asSlice(MemoryAddress newBase) {
+        Objects.requireNonNull(newBase);
+        return asSlice(newBase.segmentOffset(this));
     }
 
     /**

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/NativeMemorySegmentImpl.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/NativeMemorySegmentImpl.java
@@ -41,7 +41,7 @@ import java.nio.ByteBuffer;
  */
 public class NativeMemorySegmentImpl extends AbstractMemorySegmentImpl {
 
-    public static final MemorySegment EVERYTHING = makeNativeSegmentUnchecked(MemoryAddress.NULL, Long.MAX_VALUE)
+    public static final MemorySegment EVERYTHING = makeNativeSegmentUnchecked(MemoryAddress.NULL, Long.MAX_VALUE, null)
             .withOwnerThread(null)
             .withAccessModes(READ | WRITE);
 
@@ -114,8 +114,8 @@ public class NativeMemorySegmentImpl extends AbstractMemorySegmentImpl {
         return segment;
     }
 
-    public static MemorySegment makeNativeSegmentUnchecked(MemoryAddress min, long bytesSize) {
+    public static MemorySegment makeNativeSegmentUnchecked(MemoryAddress min, long bytesSize, Object attachment) {
         return new NativeMemorySegmentImpl(min.toRawLongValue(), bytesSize, defaultAccessModes(bytesSize),
-                MemoryScope.createConfined(null, MemoryScope.CleanupAction.DUMMY));
+                MemoryScope.createConfined(attachment, MemoryScope.CleanupAction.DUMMY));
     }
 }


### PR DESCRIPTION
This patch adds two overload:

* MemoryAddress::asSegmentRestricted which takes an Object attachment
* MemorySegment::asSlice which takes a MemoryAddress base and a new length

These overloads make the API slightly more usable.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [JDK-8253355](https://bugs.openjdk.java.net/browse/JDK-8253355): Add some overloads to memory access API


### Reviewers
 * [Athijegannathan Sundararajan](https://openjdk.java.net/census#sundar) (@sundararajana - Committer)
 * [Jorn Vernee](https://openjdk.java.net/census#jvernee) (@JornVernee - Committer) ⚠️ Review applies to dc0270944082545c32c691a900584c86db6ad535


### Download
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/341/head:pull/341`
`$ git checkout pull/341`
