### PR TITLE
8233007: Add upcall tests that test stack arguments on Windows

### DIFF
--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/x64/windows/CallArranger.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/x64/windows/CallArranger.java
@@ -169,7 +169,7 @@ public class CallArranger {
                 stackOffset = Utils.alignUp(stackOffset, alignment);
 
                 VMStorage storage = X86_64Architecture.stackStorage((int) (stackOffset / STACK_SLOT_SIZE));
-                stackOffset += layout.byteSize();
+                stackOffset += STACK_SLOT_SIZE;
                 return storage;
             }
             return (forArguments

--- a/test/jdk/java/foreign/TestUpcall.java
+++ b/test/jdk/java/foreign/TestUpcall.java
@@ -51,7 +51,6 @@
 
 import jdk.incubator.foreign.CLinker;
 import jdk.incubator.foreign.FunctionDescriptor;
-import jdk.incubator.foreign.GroupLayout;
 import jdk.incubator.foreign.LibraryLookup;
 import jdk.incubator.foreign.MemoryAddress;
 import jdk.incubator.foreign.MemoryLayout;
@@ -64,7 +63,6 @@ import org.testng.annotations.Test;
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.MethodType;
-import java.lang.invoke.VarHandle;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
@@ -193,33 +191,6 @@ public class TestUpcall extends CallGeneratorHelper {
         MemorySegment stub = abi.upcallStub(mh, func);
         segments.add(stub);
         return stub.address();
-    }
-
-    private static void assertStructEquals(MemorySegment actual, MemorySegment expected, MemoryLayout layout) {
-        assertEquals(actual.byteSize(), expected.byteSize());
-        GroupLayout g = (GroupLayout) layout;
-        for (MemoryLayout field : g.memberLayouts()) {
-            if (field instanceof ValueLayout) {
-                VarHandle vh = g.varHandle(vhCarrier(field), MemoryLayout.PathElement.groupElement(field.name().orElseThrow()));
-                assertEquals(vh.get(actual), vh.get(expected));
-            }
-        }
-    }
-
-    private static Class<?> vhCarrier(MemoryLayout layout) {
-        if (layout instanceof ValueLayout) {
-            if (isIntegral(layout)) {
-                if (layout.bitSize() == 64) {
-                    return long.class;
-                }
-                return int.class;
-            } else if (layout.bitSize() == 32) {
-                return float.class;
-            }
-            return double.class;
-        } else {
-            throw new IllegalStateException("Unexpected layout: " + layout);
-        }
     }
 
     static Object passAndSave(Object[] o, AtomicReference<Object[]> ref) {

--- a/test/jdk/java/foreign/TestUpcallHighArity.java
+++ b/test/jdk/java/foreign/TestUpcallHighArity.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ *  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ *  This code is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License version 2 only, as
+ *  published by the Free Software Foundation.
+ *
+ *  This code is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ *  version 2 for more details (a copy is included in the LICENSE file that
+ *  accompanied this code).
+ *
+ *  You should have received a copy of the GNU General Public License version
+ *  2 along with this work; if not, write to the Free Software Foundation,
+ *  Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ *  Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ *  or visit www.oracle.com if you need additional information or have any
+ *  questions.
+ *
+ */
+
+/*
+ * @test
+ * @modules jdk.incubator.foreign/jdk.internal.foreign
+ * @build NativeTestHelper CallGeneratorHelper TestUpcallHighArity
+ *
+ * @run testng/othervm/native
+ *   -Dforeign.restricted=permit
+ *   -Djdk.internal.foreign.ProgrammableInvoker.USE_SPEC=false
+ *   -Djdk.internal.foreign.ProgrammableInvoker.USE_INTRINSICS=false
+ *   TestUpcallHighArity
+ * @run testng/othervm/native
+ *   -Dforeign.restricted=permit
+ *   -Djdk.internal.foreign.ProgrammableInvoker.USE_SPEC=true
+ *   -Djdk.internal.foreign.ProgrammableInvoker.USE_INTRINSICS=false
+ *   TestUpcallHighArity
+ * @run testng/othervm/native
+ *   -Dforeign.restricted=permit
+ *   -Djdk.internal.foreign.ProgrammableInvoker.USE_SPEC=false
+ *   -Djdk.internal.foreign.ProgrammableInvoker.USE_INTRINSICS=true
+ *   TestUpcallHighArity
+ * @run testng/othervm/native
+ *   -Dforeign.restricted=permit
+ *   -Djdk.internal.foreign.ProgrammableInvoker.USE_SPEC=true
+ *   -Djdk.internal.foreign.ProgrammableInvoker.USE_INTRINSICS=true
+ *   TestUpcallHighArity
+ */
+
+import jdk.incubator.foreign.CLinker;
+import jdk.incubator.foreign.FunctionDescriptor;
+import jdk.incubator.foreign.LibraryLookup;
+import jdk.incubator.foreign.MemoryAddress;
+import jdk.incubator.foreign.MemoryLayout;
+import jdk.incubator.foreign.MemorySegment;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
+
+import static jdk.incubator.foreign.CLinker.*;
+import static org.testng.Assert.assertEquals;
+
+public class TestUpcallHighArity extends CallGeneratorHelper {
+    static final MethodHandle MH_do_upcall;
+    static final MethodHandle MH_passAndSave;
+    static final CLinker LINKER = CLinker.getInstance();
+
+    // struct S_PDI { void* p0; double p1; int p2; };
+    static final MemoryLayout S_PDI_LAYOUT = MemoryLayout.ofStruct(
+        C_POINTER.withName("p0"),
+        C_DOUBLE.withName("p1"),
+        C_INT.withName("p2")
+    );
+
+    static {
+        try {
+            LibraryLookup lookup = LibraryLookup.ofLibrary("TestUpcallHighArity");
+            MH_do_upcall = LINKER.downcallHandle(
+                lookup.lookup("do_upcall"),
+                MethodType.methodType(void.class, MemoryAddress.class,
+                    MemorySegment.class, int.class, double.class, MemoryAddress.class,
+                    MemorySegment.class, int.class, double.class, MemoryAddress.class,
+                    MemorySegment.class, int.class, double.class, MemoryAddress.class,
+                    MemorySegment.class, int.class, double.class, MemoryAddress.class),
+                FunctionDescriptor.ofVoid(C_POINTER,
+                    S_PDI_LAYOUT, C_INT, C_DOUBLE, C_POINTER,
+                    S_PDI_LAYOUT, C_INT, C_DOUBLE, C_POINTER,
+                    S_PDI_LAYOUT, C_INT, C_DOUBLE, C_POINTER,
+                    S_PDI_LAYOUT, C_INT, C_DOUBLE, C_POINTER)
+            );
+            MH_passAndSave = MethodHandles.lookup().findStatic(TestUpcallHighArity.class, "passAndSave",
+                    MethodType.methodType(void.class, Object[].class, AtomicReference.class));
+        } catch (ReflectiveOperationException e) {
+            throw new InternalError(e);
+        }
+    }
+
+    static void passAndSave(Object[] o, AtomicReference<Object[]> ref) {
+        ref.set(o);
+    }
+
+    @Test(dataProvider = "args")
+    public void testUpcall(MethodHandle downcall, MethodType upcallType,
+                           FunctionDescriptor upcallDescriptor) throws Throwable {
+        AtomicReference<Object[]> capturedArgs = new AtomicReference<>();
+        MethodHandle target = MethodHandles.insertArguments(MH_passAndSave, 1, capturedArgs)
+                                         .asCollector(Object[].class, upcallType.parameterCount())
+                                         .asType(upcallType);
+        try (MemorySegment upcallStub = LINKER.upcallStub(target, upcallDescriptor)) {
+            List<MemorySegment> segments = new ArrayList<>();
+            Object[] args = new Object[upcallType.parameterCount() + 1];
+            args[0] = upcallStub.address();
+            List<MemoryLayout> argLayouts = upcallDescriptor.argumentLayouts();
+            for (int i = 1; i < args.length; i++) {
+                args[i] = makeArg(argLayouts.get(i - 1), null, false, segments);
+            }
+
+            downcall.invokeWithArguments(args);
+
+            Object[] capturedArgsArr = capturedArgs.get();
+            for (int i = 0; i < capturedArgsArr.length; i++) {
+                if (upcallType.parameterType(i) == MemorySegment.class) {
+                    assertStructEquals((MemorySegment) capturedArgsArr[i], (MemorySegment) args[i + 1], argLayouts.get(i));
+                } else {
+                    assertEquals(capturedArgsArr[i], args[i + 1]);
+                }
+            }
+            segments.forEach(MemorySegment::close);
+        }
+    }
+
+    @DataProvider
+    public static Object[][] args() {
+        return new Object[][]{
+            { MH_do_upcall,
+                MethodType.methodType(void.class,
+                    MemorySegment.class, int.class, double.class, MemoryAddress.class,
+                    MemorySegment.class, int.class, double.class, MemoryAddress.class,
+                    MemorySegment.class, int.class, double.class, MemoryAddress.class,
+                    MemorySegment.class, int.class, double.class, MemoryAddress.class),
+                FunctionDescriptor.ofVoid(
+                    S_PDI_LAYOUT, C_INT, C_DOUBLE, C_POINTER,
+                    S_PDI_LAYOUT, C_INT, C_DOUBLE, C_POINTER,
+                    S_PDI_LAYOUT, C_INT, C_DOUBLE, C_POINTER,
+                    S_PDI_LAYOUT, C_INT, C_DOUBLE, C_POINTER)
+            }
+        };
+    }
+
+}

--- a/test/jdk/java/foreign/callarranger/TestWindowsCallArranger.java
+++ b/test/jdk/java/foreign/callarranger/TestWindowsCallArranger.java
@@ -327,4 +327,47 @@ public class TestWindowsCallArranger extends CallArrangerTestBase {
 
         checkReturnBindings(callingSequence, new Binding[]{});
     }
+
+    @Test
+    public void testStackStruct() {
+        MemoryLayout struct = MemoryLayout.ofStruct(C_POINTER, C_DOUBLE, C_INT);
+
+        MethodType mt = MethodType.methodType(void.class,
+            MemorySegment.class, int.class, double.class, MemoryAddress.class,
+            MemorySegment.class, int.class, double.class, MemoryAddress.class,
+            MemorySegment.class, int.class, double.class, MemoryAddress.class,
+            MemorySegment.class, int.class, double.class, MemoryAddress.class);
+        FunctionDescriptor fd = FunctionDescriptor.ofVoid(
+            struct, C_INT, C_DOUBLE, C_POINTER,
+            struct, C_INT, C_DOUBLE, C_POINTER,
+            struct, C_INT, C_DOUBLE, C_POINTER,
+            struct, C_INT, C_DOUBLE, C_POINTER);
+        CallArranger.Bindings bindings = CallArranger.getBindings(mt, fd, false);
+
+        assertFalse(bindings.isInMemoryReturn);
+        CallingSequence callingSequence = bindings.callingSequence;
+        assertEquals(callingSequence.methodType(), mt);
+        assertEquals(callingSequence.functionDesc(), fd);
+
+        checkArgumentBindings(callingSequence, new Binding[][]{
+            { copy(struct), baseAddress(), convertAddress(), move(rcx, long.class) },
+            { move(rdx, int.class) },
+            { move(xmm2, double.class) },
+            { convertAddress(), move(r9, long.class) },
+            { copy(struct), baseAddress(), convertAddress(), move(stackStorage(0), long.class) },
+            { move(stackStorage(1), int.class) },
+            { move(stackStorage(2), double.class) },
+            { convertAddress(), move(stackStorage(3), long.class) },
+            { copy(struct), baseAddress(), convertAddress(), move(stackStorage(4), long.class) },
+            { move(stackStorage(5), int.class) },
+            { move(stackStorage(6), double.class) },
+            { convertAddress(), move(stackStorage(7), long.class) },
+            { copy(struct), baseAddress(), convertAddress(), move(stackStorage(8), long.class) },
+            { move(stackStorage(9), int.class) },
+            { move(stackStorage(10), double.class) },
+            { convertAddress(), move(stackStorage(11), long.class) },
+        });
+
+        checkReturnBindings(callingSequence, new Binding[]{});
+    }
 }

--- a/test/jdk/java/foreign/libTestUpcallHighArity.c
+++ b/test/jdk/java/foreign/libTestUpcallHighArity.c
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+#ifdef _WIN64
+#define EXPORT __declspec(dllexport)
+#else
+#define EXPORT
+#endif
+
+struct S_PDI { void* p0; double p1; int p2; };
+
+
+EXPORT void do_upcall(void (*cb)(struct S_PDI, int, double, void*, struct S_PDI, int, double, void*,
+                                 struct S_PDI, int, double, void*, struct S_PDI, int, double, void*),
+        struct S_PDI a0, int a1, double a2, void* a3, struct S_PDI a4, int a5, double a6, void* a7,
+        struct S_PDI a8, int a9, double a10, void* a11, struct S_PDI a12, int a13, double a14, void* a15) {
+    cb(a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15);
+}


### PR DESCRIPTION
Hi,

This PR adds a test for high-arity upcalls.

This actually uncovered a bug in the Windows CallArranger wrt passing structs by-value on the stack, which I've fixed. I've also added the particular test case to the CallArranger test.

Thanks,
Jorn
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [JDK-8233007](https://bugs.openjdk.java.net/browse/JDK-8233007): Add upcall tests that test stack arguments on Windows


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.java.net/census#mcimadamore) (@mcimadamore - Committer)


### Download
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/342/head:pull/342`
`$ git checkout pull/342`
