### PR TITLE
8253373: Add package-level javadoc for foreign linker support

### DIFF
--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/package-info.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/package-info.java
@@ -108,7 +108,7 @@ try (MemorySegment segment = MemorySegment.allocateNative(10 * 4)) {
  *
  * <pre>{@code
 MethodHandle strlen = CLinker.getInstance().downcallHandle(
-        LibraryLookup.ofDefault().lookup("strlen"),
+        LibraryLookup.ofDefault().lookup("strlen").get(),
         MethodType.methodType(long.class, MemoryAddress.class),
         FunctionDescriptor.of(CLinker.C_LONG, CLinker.C_POINTER)
 );

--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/package-info.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/package-info.java
@@ -230,7 +230,7 @@ MemorySegment comparFunc = CLinker.getInstance().upcallStub(
  * <li>{@code deny}: issues a runtime exception on each restricted call. This is the default value;</li>
  * <li>{@code permit}: allows restricted calls;</li>
  * <li>{@code warn}: like permit, but also prints a one-line warning on each restricted call;</li>
- * <li>{@code debug}: like permit, but also dumps the stack corresponding to any given restricted.</li>
+ * <li>{@code debug}: like permit, but also dumps the stack corresponding to any given restricted call.</li>
  * </ul>
  */
 package jdk.incubator.foreign;

--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/package-info.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/package-info.java
@@ -98,10 +98,10 @@ try (MemorySegment segment = MemorySegment.allocateNative(10 * 4)) {
  *
  * <h2>Foreign function access</h2>
  * The key abstractions introduced to support foreign function access are {@link jdk.incubator.foreign.LibraryLookup} and {@link jdk.incubator.foreign.CLinker}.
- * The first is used to load foreign libraries, as well as to lookup symbols inside said libraries; the latter
+ * The former is used to load foreign libraries, as well as to lookup symbols inside said libraries; the latter
  * provides linking capabilities which allow to model foreign functions as {@link jdk.incubator.foreign.MemoryHandles} instance,
- * so that clients can perform foreign function calls directly in Java, with no need to introduce intermediate
- * layers of native code (as it's the case with the <a href="{@docRoot}/../specs/jni/index.html">Java Native Interface (JNI)</a>).
+ * so that clients can perform foreign function calls directly in Java, without the need for intermediate layers of native
+ * code (as it's the case with the <a href="{@docRoot}/../specs/jni/index.html">Java Native Interface (JNI)</a>).
  * <p>
  * For example, to compute the length of a string using the C standard library function {@code strlen} on a Linux x64 platform,
  * we can use the following code:

--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/package-info.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/package-info.java
@@ -25,9 +25,12 @@
  */
 
 /**
- * <p> Classes to support low-level, safe and efficient memory access.
+ * <p> Classes to support low-level and efficient foreign memory/function access, directly from Java.
+ *
+ * <h2>Foreign memory access</h2>
+ *
  * <p>
- * The key abstractions introduced by this package are {@link jdk.incubator.foreign.MemorySegment} and {@link jdk.incubator.foreign.MemoryAddress}.
+ * The key abstractions introduced to support foreign memory access are {@link jdk.incubator.foreign.MemorySegment} and {@link jdk.incubator.foreign.MemoryAddress}.
  * The first models a contiguous memory region, which can reside either inside or outside the Java heap; the latter models an address - which also can
  * reside either inside or outside the Java heap (and can sometimes be expressed as an offset into a given segment).
  * A memory segment represents the main access coordinate of a memory access var handle, which can be obtained
@@ -61,7 +64,7 @@ try (MemorySegment segment = MemorySegment.allocateNative(10 * 4)) {
  * {@code s[i]}, where {@code 0 <= i < 10}, where the size of each slot is exactly 4 bytes, the initialization logic above will set each slot
  * so that {@code s[i] = i}, again where {@code 0 <= i < 10}.
  *
- * <h2><a id="deallocation"></a>Deterministic deallocation</h2>
+ * <h3><a id="deallocation"></a>Deterministic deallocation</h3>
  *
  * When writing code that manipulates memory segments, especially if backed by memory which resides outside the Java heap, it is
  * crucial that the resources associated with a memory segment are released when the segment is no longer in use, by calling the {@link jdk.incubator.foreign.MemorySegment#close()}
@@ -75,7 +78,7 @@ try (MemorySegment segment = MemorySegment.allocateNative(10 * 4)) {
  * models such as this can be very convenient - clients do not have to remember to <em>close</em> a direct buffer - such models can also make it
  * hard for clients to ensure that the memory associated with a direct buffer has indeed been released.
  *
- * <h2><a id="safety"></a>Safety</h2>
+ * <h3><a id="safety"></a>Safety</h3>
  *
  * This API provides strong safety guarantees when it comes to memory access. First, when dereferencing a memory segment,
  * the access coordinates are validated (upon access), to make sure that access does not occur at an address which resides
@@ -92,5 +95,140 @@ try (MemorySegment segment = MemorySegment.allocateNative(10 * 4)) {
  * <p>
  * Together, spatial and temporal safety ensure that each memory access operation either succeeds - and accesses a valid
  * memory location - or fails.
+ *
+ * <h2>Foreign function access</h2>
+ * The key abstractions introduced to support foreign function access are {@link jdk.incubator.foreign.LibraryLookup} and {@link jdk.incubator.foreign.CLinker}.
+ * The first is used to load foreign libraries, as well as to lookup symbols inside said libraries; the latter
+ * provides linking capabilities which allow to model foreign functions as {@link jdk.incubator.foreign.MemoryHandles} instance,
+ * so that clients can perform foreign function calls directly in Java, with no need to introduce intermediate
+ * layers of native code (as it's the case with the <a href="{@docRoot}/../specs/jni/index.html">Java Native Interface (JNI)</a>).
+ * <p>
+ * For example, to compute the length of a string using the C standard library function {@code strlen} on a Linux x64 platform,
+ * we can use the following code:
+ *
+ * <pre>{@code
+MethodHandle strlen = CLinker.getInstance().downcallHandle(
+        LibraryLookup.ofDefault().lookup("strlen"),
+        MethodType.methodType(long.class, MemoryAddress.class),
+        FunctionDescriptor.of(CLinker.C_LONG, CLinker.C_POINTER)
+);
+
+long len = strlen.invokeExact(CLinker.toCString("Hello").address()) // 5
+ * }</pre>
+ *
+ * Here, we lookup the {@code strlen} symbol in the <em>default</em> library lookup (see {@link jdk.incubator.foreign.LibraryLookup#ofDefault()}.
+ * Then, we obtain a linker instance (see {@link jdk.incubator.foreign.CLinker#getInstance()}) and we use it to
+ * obtain a method handle which targets the {@code strlen} library symbol. To complete the linking successfully,
+ * we must provide (i) a {@link java.lang.invoke.MethodType} instance, describing the type of the resulting method handle
+ * and (ii) a {@link jdk.incubator.foreign.FunctionDescriptor} instance, describing the signature of the {@code strlen}
+ * function. From this information, the linker will uniquely determine the sequence of steps which will turn
+ * the method handle invocation (here performed using {@link java.lang.invoke.MethodHandle#invokeExact(java.lang.Object...)})
+ * into a foreign function call, according to the rules specified by the platform C ABI. The {@link jdk.incubator.foreign.CLinker}
+ * class also provides many useful methods for interacting with native code, such as converting Java strings into
+ * native strings and viceversa (see {@link jdk.incubator.foreign.CLinker#toCString(java.lang.String)} and
+ * {@link jdk.incubator.foreign.CLinker#toJavaString(jdk.incubator.foreign.MemorySegment)}, respectively), as
+ * demonstrated in the above example.
+ *
+ * <h3>Foreign addresses</h3>
+ *
+ * When a memory segment is created from Java code, the segment properties (spatial bounds, temporal bounds and confinement)
+ * are fully known at segment creation. But when interacting with native libraries, clients will often receive <em>raw</em> pointers;
+ * such pointers have no spatial bounds (example: does the C type {@code char*} refer to a single {@code char} value,
+ * or an array of {@code char} values, of given size?), no notion of temporal bounds, nor thread-confinement.
+ * <p>
+ * When clients receive a {@link jdk.incubator.foreign.MemoryAddress} instance from a foreign function call, it might be
+ * necessary to obtain a {@link jdk.incubator.foreign.MemorySegment} instance to dereference the memory pointed to by that address.
+ * To do that, clients can proceed in three different ways, described below.
+ * <p>
+ * First, if the memory address is known to belong to a segment the client already owns, a <em>rebase</em> operation can be performed;
+ * in other words, the client can ask the address what its offset relative to a given segment is, and, then, proceed to dereference
+ * the original segment accordingly, as follows:
+ *
+ * <pre>{@code
+MemorySegment segment = MemorySegment.allocateNative(100);
+...
+MemoryAddress addr = ... //obtain address from native code
+int x = MemoryAccess.getIntAtOffset(segment, addr.segmentOffset(segment));
+ * }</pre>
+ *
+ * Secondly, if the client does <em>not</em> have a segment which contains a given memory address, it can create one <em>unsafely</em>,
+ * using the {@link jdk.incubator.foreign.MemoryAddress#asSegmentRestricted(long)} factory. This allows the client to
+ * inject extra knowledge about spatial bounds which might, for instance, be available in the documentation of the foreign function
+ * which produced the native address. Here is how an unsafe segment can be created from a native address:
+ *
+ * <pre>{@code
+MemoryAddress addr = ... //obtain address from native code
+MemorySegment segment = addr.asSegmentRestricted(4); // segment is 4 bytes long
+int x = MemoryAccess.getInt(segment);
+ * }</pre>
+ *
+ * Alternatively, the client can fall back to use the so called <em>everything</em> segment - that is, a primordial segment
+ * which covers the entire native heap. This segment can be obtained by calling the {@link jdk.incubator.foreign.MemorySegment#ofNativeRestricted()}
+ * method, so that dereference can happen without the need of creating any additional segment instances:
+ *
+ * <pre>{@code
+MemoryAddress addr = ... //obtain address from native code
+int x = MemoryAccess.getIntAtOffset(MemorySegment.ofNativeRestricted(), addr.toRawLongValue());
+ * }</pre>
+ *
+ * <h3>Upcalls</h3>
+ * The {@link jdk.incubator.foreign.CLinker} class also allows to turn an existing method handles (which might point
+ * to a Java method) into a native memory segment (see {@link jdk.incubator.foreign.MemorySegment}), so that Java code
+ * can effectively be passed to other foreign functions. For instance, we can write a method that compares two
+ * integer values, as follows:
+ *
+ * <pre>{@code
+class IntComparator {
+    static int intCompare(MemoryAddress addr1, MemoryAddress addr2) {
+        return MemoryAccess.getIntAtOffset(MemorySegment.ofNativeRestricted(), addr1.toRawLongValue()) -
+               MemoryAccess.getIntAtOffset(MemorySegment.ofNativeRestricted(), addr2.toRawLongValue());
+    }
+}
+ * }</pre>
+ *
+ * The above method dereferences two memory addresses containing an integer value, and performs a simple comparison
+ * by returning the difference between such values. We can then obtain a method handle which targets the above static
+ * method, as follows:
+ *
+ * <pre>{@code
+MethodHandle intCompareHandle = MethodHandles.lookup().findStatic(IntComparator.class,
+                                                   "intCompare",
+                                                   MethodType.methodType(int.class, MemoryAddress.class, MemoryAddress.class));
+ * }</pre>
+ *
+ * Now that we have a method handle instance, we can link it into a fresh native memory segment, using the {@link jdk.incubator.foreign.CLinker} class, as follows:
+ *
+ * <pre>{@code
+MemorySegment comparFunc = CLinker.getInstance().upcallStub(
+     intCompareHandle,
+     FunctionDescriptor.of(C_INT, C_POINTER, C_POINTER)
+);
+ * }</pre>
+ *
+ * As before, we need to provide a {@link jdk.incubator.foreign.FunctionDescriptor} instance describing the signature
+ * of the function pointer we want to create; as before, this, coupled with the method handle type, uniquely determines the
+ * sequence of steps which will allow foreign code to call the {@code intCompareHandle} according to the rules specified
+ * by the platform C ABI.
+ *
+ * <h2>Restricted methods</h2>
+ * Some methods in this package are considered <em>restricted</em>. Restricted methods are typically used to bind native
+ * foreign data and/or functions to first-class Java API elements which can then be used directly by client. For instance
+ * the restricted method {@link jdk.incubator.foreign.MemoryAddress#asSegmentRestricted(long)} can be used to create
+ * a fresh segment with given spatial bounds out of a native address.
+ * <p>
+ * Binding foreign data and/or functions is generally unsafe and, if done incorrectly, can result in VM crashes, or memory corruption when the bound Java API element is accessed.
+ * For instance, in the case of {@link jdk.incubator.foreign.MemoryAddress#asSegmentRestricted(long)}, if the provided
+ * spatial bounds are incorrect, a client of the segment returned by that method might crash the VM, or corrupt
+ * memory when attempting to dereference said segment. For these reasons, it is crucial for code that calls a restricted method
+ * to never pass arguments that might causes incorrect binding of foreign data and/or functions to a Java API.
+ * <p>
+ * Access to restricted method is <em>disabled</em> by default; to enable restricted methods, the JDK property
+ * {@code foreign.restricted} must be set to a value other than {@code deny}. The possible values for this property are:
+ * <ul>
+ * <li>{@code deny}: issues a runtime exception on each restricted call. This is the default value;</li>
+ * <li>{@code permit}: allows restricted calls;</li>
+ * <li>{@code warn}: like permit, but also prints a one-line warning on each restricted call;</li>
+ * <li>{@code debug}: like permit, but also dumps the stack corresponding to any given restricted.</li>
+ * </ul>
  */
 package jdk.incubator.foreign;

--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/package-info.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/package-info.java
@@ -174,7 +174,7 @@ int x = MemoryAccess.getIntAtOffset(MemorySegment.ofNativeRestricted(), addr.toR
  * }</pre>
  *
  * <h3>Upcalls</h3>
- * The {@link jdk.incubator.foreign.CLinker} class also allows to turn an existing method handles (which might point
+ * The {@link jdk.incubator.foreign.CLinker} class also allows to turn an existing method handle (which might point
  * to a Java method) into a native memory segment (see {@link jdk.incubator.foreign.MemorySegment}), so that Java code
  * can effectively be passed to other foreign functions. For instance, we can write a method that compares two
  * integer values, as follows:

--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/package-info.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/package-info.java
@@ -222,7 +222,7 @@ MemorySegment comparFunc = CLinker.getInstance().upcallStub(
  * For instance, in the case of {@link jdk.incubator.foreign.MemoryAddress#asSegmentRestricted(long)}, if the provided
  * spatial bounds are incorrect, a client of the segment returned by that method might crash the VM, or corrupt
  * memory when attempting to dereference said segment. For these reasons, it is crucial for code that calls a restricted method
- * to never pass arguments that might causes incorrect binding of foreign data and/or functions to a Java API.
+ * to never pass arguments that might cause incorrect binding of foreign data and/or functions to a Java API.
  * <p>
  * Access to restricted method is <em>disabled</em> by default; to enable restricted methods, the JDK property
  * {@code foreign.restricted} must be set to a value other than {@code deny}. The possible values for this property are:

--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/package-info.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/package-info.java
@@ -113,7 +113,9 @@ MethodHandle strlen = CLinker.getInstance().downcallHandle(
         FunctionDescriptor.of(CLinker.C_LONG, CLinker.C_POINTER)
 );
 
-long len = strlen.invokeExact(CLinker.toCString("Hello").address()) // 5
+try (var cString = CLinker.toCString("Hello")) {
+    long len = strlen.invokeExact(cString.address()) // 5
+}
  * }</pre>
  *
  * Here, we lookup the {@code strlen} symbol in the <em>default</em> library lookup (see {@link jdk.incubator.foreign.LibraryLookup#ofDefault()}.

--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/package-info.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/package-info.java
@@ -224,7 +224,7 @@ MemorySegment comparFunc = CLinker.getInstance().upcallStub(
  * memory when attempting to dereference said segment. For these reasons, it is crucial for code that calls a restricted method
  * to never pass arguments that might cause incorrect binding of foreign data and/or functions to a Java API.
  * <p>
- * Access to restricted method is <em>disabled</em> by default; to enable restricted methods, the JDK property
+ * Access to restricted methods is <em>disabled</em> by default; to enable restricted methods, the JDK property
  * {@code foreign.restricted} must be set to a value other than {@code deny}. The possible values for this property are:
  * <ul>
  * <li>{@code deny}: issues a runtime exception on each restricted call. This is the default value;</li>


### PR DESCRIPTION
This patch modifies the toplevel javadoc of jdk.incubator.foreign to add details about the ABI support.

I've decided to split the javadoc into two main sections - one about memory access, and one about foreign function access; they have subsections for more detailed info.

There's also a trailing toplevel section on "restricted method". I'm still wordsmithing the definition of "what's it like to be a restricted method" together with Alex, but this is a first attempt.
It is likely that, once we have this done, we can have the various restrcited definitions inside the API refer bakc to this section.

Link to javadoc:
http://cr.openjdk.java.net/~mcimadamore/panama/foreign-linker-javadoc/javadoc/jdk/incubator/foreign/package-summary.html
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [JDK-8253373](https://bugs.openjdk.java.net/browse/JDK-8253373): Add package-level javadoc for foreign linker support


### Reviewers
 * [Athijegannathan Sundararajan](https://openjdk.java.net/census#sundar) (@sundararajana - Committer) ⚠️ Review applies to eb09b53f8a5ba81a0b789eaee73fc4bef4bb77fb
 * [Jorn Vernee](https://openjdk.java.net/census#jvernee) (@JornVernee - Committer) ⚠️ Review applies to eb09b53f8a5ba81a0b789eaee73fc4bef4bb77fb


### Download
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/346/head:pull/346`
`$ git checkout pull/346`
