### PR TITLE
8253430: Improve the LibraryLookup API

### DIFF
--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/LibraryLookup.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/LibraryLookup.java
@@ -108,12 +108,17 @@ public interface LibraryLookup {
 
     /**
      * Obtain a library lookup object corresponding to a library identified by given path.
-     * @param path the library path.
+     * @param path the library absolute path.
      * @return a library lookup object for given path.
+     * @throws IllegalArgumentException if the specified path does not correspond to an absolute path,
+     * e.g. if {@code !path.isAbsolute()}.
      */
     static LibraryLookup ofPath(Path path) {
         Objects.requireNonNull(path);
-        String absolutePath = path.toAbsolutePath().toString();
+        if (!path.isAbsolute()) {
+            throw new IllegalArgumentException("Not an absolute path: " + path.toString());
+        }
+        String absolutePath = path.toString();
         SecurityManager security = System.getSecurityManager();
         if (security != null) {
             security.checkLink(absolutePath);

--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/LibraryLookup.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/LibraryLookup.java
@@ -29,7 +29,9 @@ import jdk.internal.foreign.LibrariesHelper;
 
 import java.io.File;
 import java.lang.invoke.MethodType;
+import java.nio.file.Path;
 import java.util.Objects;
+import java.util.Optional;
 
 /**
  * A native library lookup. Exposes lookup operation for searching symbols, see {@link LibraryLookup#lookup(String)}.
@@ -89,9 +91,8 @@ public interface LibraryLookup {
      * Lookups a symbol with given name in this library. The returned symbol maintains a strong reference to this lookup object.
      * @param name the symbol name.
      * @return the library symbol (if any).
-     * @throws NoSuchMethodException if no symbol with given name could be found.
      */
-    Symbol lookup(String name) throws NoSuchMethodException;
+    Optional<Symbol> lookup(String name);
 
     /**
      * Obtain a default library lookup object.
@@ -110,17 +111,14 @@ public interface LibraryLookup {
      * @param path the library path.
      * @return a library lookup object for given path.
      */
-    static LibraryLookup ofPath(String path) {
+    static LibraryLookup ofPath(Path path) {
         Objects.requireNonNull(path);
+        String absolutePath = path.toAbsolutePath().toString();
         SecurityManager security = System.getSecurityManager();
         if (security != null) {
-            security.checkLink(path);
+            security.checkLink(absolutePath);
         }
-        if (!(new File(path).isAbsolute())) {
-            throw new UnsatisfiedLinkError(
-                    "Expecting an absolute path of the library: " + path);
-        }
-        return LibrariesHelper.load(path);
+        return LibrariesHelper.load(absolutePath);
     }
 
     /**

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/LibrariesHelper.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/LibrariesHelper.java
@@ -115,19 +115,23 @@ public final class LibrariesHelper {
         }
 
         @Override
-        public Symbol lookup(String name) throws NoSuchMethodException {
-            MemoryAddress addr = MemoryAddress.ofLong(library.lookup(name));
-            return new Symbol() { // inner class - retains a link to enclosing lookup
-                @Override
-                public String name() {
-                    return name;
-                }
+        public Optional<Symbol> lookup(String name) {
+            try {
+                MemoryAddress addr = MemoryAddress.ofLong(library.lookup(name));
+                return Optional.of(new Symbol() { // inner class - retains a link to enclosing lookup
+                    @Override
+                    public String name() {
+                        return name;
+                    }
 
-                @Override
-                public MemoryAddress address() {
-                    return addr;
-                }
-            };
+                    @Override
+                    public MemoryAddress address() {
+                        return addr;
+                    }
+                });
+            } catch (NoSuchMethodException ex) {
+                return Optional.empty();
+            }
         }
 
         static LibraryLookup DEFAULT_LOOKUP = new LibraryLookupImpl(NativeLibraries.defaultLibrary);

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/SharedUtils.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/SharedUtils.java
@@ -264,23 +264,16 @@ public class SharedUtils {
 
     // lazy init MH_ALLOC and MH_FREE handles
     private static class AllocHolder {
-        static final MethodHandle MH_MALLOC;
-        static final MethodHandle MH_FREE;
 
-        static {
-            LibraryLookup lookup = LibraryLookup.ofDefault();
-            try {
-                MH_MALLOC = getSystemLinker().downcallHandle(lookup.lookup("malloc"),
+        final static LibraryLookup LOOKUP = LibraryLookup.ofDefault();
+
+        final static MethodHandle MH_MALLOC = getSystemLinker().downcallHandle(LOOKUP.lookup("malloc").get(),
                         MethodType.methodType(MemoryAddress.class, long.class),
-                        FunctionDescriptor.of(C_POINTER, C_LONGLONG));
+                FunctionDescriptor.of(C_POINTER, C_LONGLONG));
 
-                MH_FREE = getSystemLinker().downcallHandle(lookup.lookup("free"),
+        final static MethodHandle MH_FREE = getSystemLinker().downcallHandle(LOOKUP.lookup("free").get(),
                         MethodType.methodType(void.class, MemoryAddress.class),
-                        FunctionDescriptor.ofVoid(C_POINTER));
-            } catch (NoSuchMethodException nsme) {
-                throw new BootstrapMethodError(nsme);
-            }
-        }
+                FunctionDescriptor.ofVoid(C_POINTER));
     }
 
     public static MemoryAddress allocateMemoryInternal(long size) {

--- a/test/jdk/java/foreign/StdLibTest.java
+++ b/test/jdk/java/foreign/StdLibTest.java
@@ -152,65 +152,54 @@ public class StdLibTest {
 
     static class StdLibHelper {
 
-        final static MethodHandle strcat;
-        final static MethodHandle strcmp;
-        final static MethodHandle puts;
-        final static MethodHandle strlen;
-        final static MethodHandle gmtime;
-        final static MethodHandle qsort;
+        static final LibraryLookup lookup = LibraryLookup.ofDefault();
+
+        final static MethodHandle strcat = abi.downcallHandle(lookup.lookup("strcat").get(),
+                MethodType.methodType(MemoryAddress.class, MemoryAddress.class, MemoryAddress.class),
+                FunctionDescriptor.of(C_POINTER, C_POINTER, C_POINTER));
+
+        final static MethodHandle strcmp = abi.downcallHandle(lookup.lookup("strcmp").get(),
+                MethodType.methodType(int.class, MemoryAddress.class, MemoryAddress.class),
+                FunctionDescriptor.of(C_INT, C_POINTER, C_POINTER));
+
+        final static MethodHandle puts = abi.downcallHandle(lookup.lookup("puts").get(),
+                MethodType.methodType(int.class, MemoryAddress.class),
+                FunctionDescriptor.of(C_INT, C_POINTER));
+
+        final static MethodHandle strlen = abi.downcallHandle(lookup.lookup("strlen").get(),
+                MethodType.methodType(int.class, MemoryAddress.class),
+                FunctionDescriptor.of(C_INT, C_POINTER));
+
+        final static MethodHandle gmtime = abi.downcallHandle(lookup.lookup("gmtime").get(),
+                MethodType.methodType(MemoryAddress.class, MemoryAddress.class),
+                FunctionDescriptor.of(C_POINTER, C_POINTER));
+
+        final static MethodHandle qsort = abi.downcallHandle(lookup.lookup("qsort").get(),
+                MethodType.methodType(void.class, MemoryAddress.class, long.class, long.class, MemoryAddress.class),
+                FunctionDescriptor.ofVoid(C_POINTER, C_LONGLONG, C_LONGLONG, C_POINTER));
+
+        final static FunctionDescriptor qsortComparFunction = FunctionDescriptor.of(C_INT, C_POINTER, C_POINTER);
+
         final static MethodHandle qsortCompar;
-        final static FunctionDescriptor qsortComparFunction;
-        final static MethodHandle rand;
-        final static MethodHandle vprintf;
-        final static LibraryLookup.Symbol printfAddr;
-        final static FunctionDescriptor printfBase;
+
+        final static MethodHandle rand = abi.downcallHandle(lookup.lookup("rand").get(),
+                MethodType.methodType(int.class),
+                FunctionDescriptor.of(C_INT));
+
+        final static MethodHandle vprintf = abi.downcallHandle(lookup.lookup("vprintf").get(),
+                MethodType.methodType(int.class, MemoryAddress.class, VaList.class),
+                FunctionDescriptor.of(C_INT, C_POINTER, C_VA_LIST));
+
+        final static LibraryLookup.Symbol printfAddr = lookup.lookup("printf").get();
+
+        final static FunctionDescriptor printfBase = FunctionDescriptor.of(C_INT, C_POINTER);
 
         static {
             try {
-                LibraryLookup lookup = LibraryLookup.ofDefault();
-
-                strcat = abi.downcallHandle(lookup.lookup("strcat"),
-                        MethodType.methodType(MemoryAddress.class, MemoryAddress.class, MemoryAddress.class),
-                        FunctionDescriptor.of(C_POINTER, C_POINTER, C_POINTER));
-
-                strcmp = abi.downcallHandle(lookup.lookup("strcmp"),
-                        MethodType.methodType(int.class, MemoryAddress.class, MemoryAddress.class),
-                        FunctionDescriptor.of(C_INT, C_POINTER, C_POINTER));
-
-                puts = abi.downcallHandle(lookup.lookup("puts"),
-                        MethodType.methodType(int.class, MemoryAddress.class),
-                        FunctionDescriptor.of(C_INT, C_POINTER));
-
-                strlen = abi.downcallHandle(lookup.lookup("strlen"),
-                        MethodType.methodType(int.class, MemoryAddress.class),
-                        FunctionDescriptor.of(C_INT, C_POINTER));
-
-                gmtime = abi.downcallHandle(lookup.lookup("gmtime"),
-                        MethodType.methodType(MemoryAddress.class, MemoryAddress.class),
-                        FunctionDescriptor.of(C_POINTER, C_POINTER));
-
-                qsortComparFunction = FunctionDescriptor.of(C_INT, C_POINTER, C_POINTER);
-
-                qsort = abi.downcallHandle(lookup.lookup("qsort"),
-                        MethodType.methodType(void.class, MemoryAddress.class, long.class, long.class, MemoryAddress.class),
-                        FunctionDescriptor.ofVoid(C_POINTER, C_LONGLONG, C_LONGLONG, C_POINTER));
-
                 //qsort upcall handle
                 qsortCompar = MethodHandles.lookup().findStatic(StdLibTest.StdLibHelper.class, "qsortCompare",
                         MethodType.methodType(int.class, MemorySegment.class, MemoryAddress.class, MemoryAddress.class));
-
-                rand = abi.downcallHandle(lookup.lookup("rand"),
-                        MethodType.methodType(int.class),
-                        FunctionDescriptor.of(C_INT));
-
-                vprintf = abi.downcallHandle(lookup.lookup("vprintf"),
-                        MethodType.methodType(int.class, MemoryAddress.class, VaList.class),
-                        FunctionDescriptor.of(C_INT, C_POINTER, C_VA_LIST));
-
-                printfAddr = lookup.lookup("printf");
-
-                printfBase = FunctionDescriptor.of(C_INT, C_POINTER);
-            } catch (Throwable ex) {
+            } catch (ReflectiveOperationException ex) {
                 throw new IllegalStateException(ex);
             }
         }

--- a/test/jdk/java/foreign/TestDowncall.java
+++ b/test/jdk/java/foreign/TestDowncall.java
@@ -73,7 +73,7 @@ public class TestDowncall extends CallGeneratorHelper {
     public void testDowncall(String fName, Ret ret, List<ParamType> paramTypes, List<StructFieldType> fields) throws Throwable {
         List<Consumer<Object>> checks = new ArrayList<>();
         List<MemorySegment> segments = new ArrayList<>();
-        LibraryLookup.Symbol addr = lib.lookup(fName);
+        LibraryLookup.Symbol addr = lib.lookup(fName).get();
         MethodHandle mh = abi.downcallHandle(addr, methodType(ret, paramTypes, fields), function(ret, paramTypes, fields));
         Object[] args = makeArgs(paramTypes, fields, checks, segments);
         mh = mh.asSpreader(Object[].class, paramTypes.size());

--- a/test/jdk/java/foreign/TestIntrinsics.java
+++ b/test/jdk/java/foreign/TestIntrinsics.java
@@ -63,7 +63,7 @@ public class TestIntrinsics {
 
     private static MethodHandle linkIndentity(String name, Class<?> carrier, MemoryLayout layout)
             throws NoSuchMethodException {
-        LibraryLookup.Symbol ma = lookup.lookup(name);
+        LibraryLookup.Symbol ma = lookup.lookup(name).get();
         MethodType mt = methodType(carrier, carrier);
         FunctionDescriptor fd = FunctionDescriptor.of(layout, layout);
         return abi.downcallHandle(ma, mt, fd);
@@ -72,7 +72,7 @@ public class TestIntrinsics {
     static {
         try {
             {
-                LibraryLookup.Symbol ma = lookup.lookup("empty");
+                LibraryLookup.Symbol ma = lookup.lookup("empty").get();
                 MethodType mt = methodType(void.class);
                 FunctionDescriptor fd = FunctionDescriptor.ofVoid();
                 MH_empty = abi.downcallHandle(ma, mt, fd);
@@ -84,14 +84,14 @@ public class TestIntrinsics {
             MH_identity_float = linkIndentity("identity_float", float.class, C_FLOAT);
             MH_identity_double = linkIndentity("identity_double", double.class, C_DOUBLE);
             {
-                LibraryLookup.Symbol ma = lookup.lookup("identity_va");
+                LibraryLookup.Symbol ma = lookup.lookup("identity_va").get();
                 MethodType mt = methodType(int.class, int.class, double.class, int.class, float.class, long.class);
                 FunctionDescriptor fd = FunctionDescriptor.of(C_INT, C_INT, asVarArg(C_DOUBLE),
                         asVarArg(C_INT), asVarArg(C_FLOAT), asVarArg(C_LONGLONG));
                 MH_identity_va = abi.downcallHandle(ma, mt, fd);
             }
             {
-                LibraryLookup.Symbol ma = lookup.lookup("invoke_consumer");
+                LibraryLookup.Symbol ma = lookup.lookup("invoke_consumer").get();
                 MethodType mt = methodType(void.class, int.class, double.class, long.class, float.class, byte.class,
                         short.class, char.class);
                 FunctionDescriptor fd = FunctionDescriptor.ofVoid(C_INT, C_DOUBLE, C_LONGLONG, C_FLOAT, C_CHAR,

--- a/test/jdk/java/foreign/TestLibraryLookup.java
+++ b/test/jdk/java/foreign/TestLibraryLookup.java
@@ -43,14 +43,19 @@ import static org.testng.Assert.*;
 
 public class TestLibraryLookup {
 
-    @Test(expectedExceptions = IllegalArgumentException.class)
+    @Test(expectedExceptions = IllegalArgumentException.class, expectedExceptionsMessageRegExp = "Library not found.*")
     public void testInvalidLookupName() {
         LibraryLookup.ofLibrary("NonExistent");
     }
 
-    @Test(expectedExceptions = IllegalArgumentException.class)
-    public void testInvalidLookupPath() {
+    @Test(expectedExceptions = IllegalArgumentException.class, expectedExceptionsMessageRegExp = "Not an absolute path.*")
+    public void testNoAbsoluteLookupPath() {
         LibraryLookup.ofPath(Path.of("NonExistent"));
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class, expectedExceptionsMessageRegExp = "Library not found.*")
+    public void testInvalidLookupPath() {
+        LibraryLookup.ofPath(Path.of("NonExistent").toAbsolutePath());
     }
 
     @Test

--- a/test/jdk/java/foreign/TestLibraryLookup.java
+++ b/test/jdk/java/foreign/TestLibraryLookup.java
@@ -50,15 +50,26 @@ public class TestLibraryLookup {
 
     @Test(expectedExceptions = IllegalArgumentException.class)
     public void testInvalidLookupPath() {
-        LibraryLookup.ofPath(Path.of("NonExistent").toAbsolutePath().toString());
+        LibraryLookup.ofPath(Path.of("NonExistent"));
     }
 
     @Test
     public void testSimpleLookup() throws Throwable {
         LibraryLookup.Symbol symbol = null;
         LibraryLookup lookup = LibraryLookup.ofLibrary("LookupTest");
-        symbol = lookup.lookup("f");
+        symbol = lookup.lookup("f").get();
         assertEquals(symbol.name(), "f");
+        assertEquals(LibrariesHelper.numLoadedLibraries(), 1);
+        lookup = null;
+        symbol = null;
+        waitUnload();
+    }
+
+    @Test
+    public void testInvalidSymbolLookup() throws Throwable {
+        LibraryLookup.Symbol symbol = null;
+        LibraryLookup lookup = LibraryLookup.ofLibrary("LookupTest");
+        assertTrue(lookup.lookup("nonExistent").isEmpty());
         assertEquals(LibrariesHelper.numLoadedLibraries(), 1);
         lookup = null;
         symbol = null;
@@ -71,7 +82,7 @@ public class TestLibraryLookup {
         List<LibraryLookup> lookups = new ArrayList<>();
         for (int i = 0 ; i < 5 ; i++) {
             LibraryLookup lookup = LibraryLookup.ofLibrary("LookupTest");
-            LibraryLookup.Symbol symbol = lookup.lookup("f");
+            LibraryLookup.Symbol symbol = lookup.lookup("f").get();
             lookups.add(lookup);
             symbols.add(symbol);
             assertEquals(LibrariesHelper.numLoadedLibraries(), 1);
@@ -134,7 +145,7 @@ public class TestLibraryLookup {
         static {
             try {
                 lookup = LibraryLookup.ofLibrary("LookupTest");
-                symbol = lookup.lookup("f");
+                symbol = lookup.lookup("f").get();
             } catch (Throwable ex) {
                 throw new ExceptionInInitializerError();
             }

--- a/test/jdk/java/foreign/TestUpcall.java
+++ b/test/jdk/java/foreign/TestUpcall.java
@@ -108,7 +108,7 @@ public class TestUpcall extends CallGeneratorHelper {
         List<MemorySegment> segments = new ArrayList<>();
         List<Consumer<Object>> returnChecks = new ArrayList<>();
         List<Consumer<Object[]>> argChecks = new ArrayList<>();
-        LibraryLookup.Symbol addr = lib.lookup(fName);
+        LibraryLookup.Symbol addr = lib.lookup(fName).get();
         MethodHandle mh = abi.downcallHandle(addr, methodType(ret, paramTypes, fields), function(ret, paramTypes, fields));
         Object[] args = makeArgs(ret, paramTypes, fields, returnChecks, argChecks, segments);
         mh = mh.asSpreader(Object[].class, paramTypes.size() + 1);

--- a/test/jdk/java/foreign/TestUpcallHighArity.java
+++ b/test/jdk/java/foreign/TestUpcallHighArity.java
@@ -85,7 +85,7 @@ public class TestUpcallHighArity extends CallGeneratorHelper {
         try {
             LibraryLookup lookup = LibraryLookup.ofLibrary("TestUpcallHighArity");
             MH_do_upcall = LINKER.downcallHandle(
-                lookup.lookup("do_upcall"),
+                lookup.lookup("do_upcall").get(),
                 MethodType.methodType(void.class, MemoryAddress.class,
                     MemorySegment.class, int.class, double.class, MemoryAddress.class,
                     MemorySegment.class, int.class, double.class, MemoryAddress.class,

--- a/test/jdk/java/foreign/TestVarArgs.java
+++ b/test/jdk/java/foreign/TestVarArgs.java
@@ -59,15 +59,8 @@ public class TestVarArgs {
     static final VarHandle VH_IntArray = MemoryLayout.ofSequence(C_INT).varHandle(int.class, sequenceElement());
 
     static final CLinker abi = CLinker.getInstance();
-    static final LibraryLookup.Symbol varargsAddr;
-
-    static {
-        try {
-            varargsAddr = LibraryLookup.ofLibrary("VarArgs").lookup("varargs");
-        } catch (NoSuchMethodException e) {
-            throw new BootstrapMethodError(e);
-        }
-    }
+    static final LibraryLookup.Symbol varargsAddr = LibraryLookup.ofLibrary("VarArgs")
+            .lookup("varargs").get();
 
     static final int WRITEBACK_BYTES_PER_ARG = 8;
 

--- a/test/jdk/java/foreign/stackwalk/TestStackWalk.java
+++ b/test/jdk/java/foreign/stackwalk/TestStackWalk.java
@@ -73,7 +73,7 @@ public class TestStackWalk {
         try {
             LibraryLookup lookup = LibraryLookup.ofLibrary("StackWalk");
             MH_foo = linker.downcallHandle(
-                    lookup.lookup("foo"),
+                    lookup.lookup("foo").get(),
                     MethodType.methodType(void.class, MemoryAddress.class),
                     FunctionDescriptor.ofVoid(C_POINTER));
             MH_m = lookup().findStatic(TestStackWalk.class, "m", MethodType.methodType(void.class));

--- a/test/jdk/java/foreign/valist/VaListTest.java
+++ b/test/jdk/java/foreign/valist/VaListTest.java
@@ -96,11 +96,7 @@ public class VaListTest {
             FunctionDescriptor.ofVoid(C_POINTER, C_POINTER, C_VA_LIST));
 
     private static MethodHandle link(String symbol, MethodType mt, FunctionDescriptor fd) {
-        try {
-            return abi.downcallHandle(lookup.lookup(symbol), mt, fd);
-        } catch (NoSuchMethodException e) {
-            throw new NoSuchMethodError(e.getMessage());
-        }
+        return abi.downcallHandle(lookup.lookup(symbol).get(), mt, fd);
     }
 
     private static MethodHandle linkVaListCB(String symbol) {

--- a/test/micro/org/openjdk/bench/jdk/incubator/foreign/CallOverhead.java
+++ b/test/micro/org/openjdk/bench/jdk/incubator/foreign/CallOverhead.java
@@ -55,6 +55,7 @@ import static jdk.incubator.foreign.CLinker.C_POINTER;
 public class CallOverhead {
 
     static final CLinker abi = CLinker.getInstance();
+
     static final MethodHandle func;
     static final MethodHandle identity;
     static final MethodHandle identity_struct;
@@ -73,39 +74,35 @@ public class CallOverhead {
     static {
         System.loadLibrary("CallOverheadJNI");
 
-        try {
-            LibraryLookup ll = LibraryLookup.ofLibrary("CallOverhead");
-            {
-                LibraryLookup.Symbol addr = ll.lookup("func");
-                MethodType mt = MethodType.methodType(void.class);
-                FunctionDescriptor fd = FunctionDescriptor.ofVoid();
-                func = abi.downcallHandle(addr, mt, fd);
-                func_trivial = abi.downcallHandle(addr, mt, fd.withAttribute(FunctionDescriptor.TRIVIAL_ATTRIBUTE_NAME, true));
-            }
-            {
-                LibraryLookup.Symbol addr = ll.lookup("identity");
-                MethodType mt = MethodType.methodType(int.class, int.class);
-                FunctionDescriptor fd = FunctionDescriptor.of(C_INT, C_INT);
-                identity = abi.downcallHandle(addr, mt, fd);
-                identity_trivial = abi.downcallHandle(addr, mt, fd.withAttribute(FunctionDescriptor.TRIVIAL_ATTRIBUTE_NAME, true));
-            }
-            identity_struct = abi.downcallHandle(ll.lookup("identity_struct"),
-                    MethodType.methodType(MemorySegment.class, MemorySegment.class),
-                    FunctionDescriptor.of(POINT_LAYOUT, POINT_LAYOUT));
-            identity_memory_address = abi.downcallHandle(ll.lookup("identity_memory_address"),
-                    MethodType.methodType(MemoryAddress.class, MemoryAddress.class),
-                    FunctionDescriptor.of(C_POINTER, C_POINTER));
-            args5 = abi.downcallHandle(ll.lookup("args5"),
-                    MethodType.methodType(void.class, long.class, double.class, long.class, double.class, long.class),
-                    FunctionDescriptor.ofVoid(C_LONGLONG, C_DOUBLE, C_LONGLONG, C_DOUBLE, C_LONGLONG));
-            args10 = abi.downcallHandle(ll.lookup("args10"),
-                    MethodType.methodType(void.class, long.class, double.class, long.class, double.class, long.class,
-                                                      double.class, long.class, double.class, long.class, double.class),
-                    FunctionDescriptor.ofVoid(C_LONGLONG, C_DOUBLE, C_LONGLONG, C_DOUBLE, C_LONGLONG,
-                                              C_DOUBLE, C_LONGLONG, C_DOUBLE, C_LONGLONG, C_DOUBLE));
-        } catch (NoSuchMethodException e) {
-            throw new BootstrapMethodError(e);
+        LibraryLookup ll = LibraryLookup.ofLibrary("CallOverhead");
+        {
+            LibraryLookup.Symbol addr = ll.lookup("func").get();
+            MethodType mt = MethodType.methodType(void.class);
+            FunctionDescriptor fd = FunctionDescriptor.ofVoid();
+            func = abi.downcallHandle(addr, mt, fd);
+            func_trivial = abi.downcallHandle(addr, mt, fd.withAttribute(FunctionDescriptor.TRIVIAL_ATTRIBUTE_NAME, true));
         }
+        {
+            LibraryLookup.Symbol addr = ll.lookup("identity").get();
+            MethodType mt = MethodType.methodType(int.class, int.class);
+            FunctionDescriptor fd = FunctionDescriptor.of(C_INT, C_INT);
+            identity = abi.downcallHandle(addr, mt, fd);
+            identity_trivial = abi.downcallHandle(addr, mt, fd.withAttribute(FunctionDescriptor.TRIVIAL_ATTRIBUTE_NAME, true));
+        }
+        identity_struct = abi.downcallHandle(ll.lookup("identity_struct").get(),
+                MethodType.methodType(MemorySegment.class, MemorySegment.class),
+                FunctionDescriptor.of(POINT_LAYOUT, POINT_LAYOUT));
+        identity_memory_address = abi.downcallHandle(ll.lookup("identity_memory_address").get(),
+                MethodType.methodType(MemoryAddress.class, MemoryAddress.class),
+                FunctionDescriptor.of(C_POINTER, C_POINTER));
+        args5 = abi.downcallHandle(ll.lookup("args5").get(),
+                MethodType.methodType(void.class, long.class, double.class, long.class, double.class, long.class),
+                FunctionDescriptor.ofVoid(C_LONGLONG, C_DOUBLE, C_LONGLONG, C_DOUBLE, C_LONGLONG));
+        args10 = abi.downcallHandle(ll.lookup("args10").get(),
+                MethodType.methodType(void.class, long.class, double.class, long.class, double.class, long.class,
+                                                  double.class, long.class, double.class, long.class, double.class),
+                FunctionDescriptor.ofVoid(C_LONGLONG, C_DOUBLE, C_LONGLONG, C_DOUBLE, C_LONGLONG,
+                                          C_DOUBLE, C_LONGLONG, C_DOUBLE, C_LONGLONG, C_DOUBLE));
     }
 
     static native void blank();

--- a/test/micro/org/openjdk/bench/jdk/incubator/foreign/Upcalls.java
+++ b/test/micro/org/openjdk/bench/jdk/incubator/foreign/Upcalls.java
@@ -71,7 +71,7 @@ public class Upcalls {
         try {
             LibraryLookup ll = LibraryLookup.ofLibrary("Upcalls");
             {
-                LibraryLookup.Symbol addr = ll.lookup("blank");
+                LibraryLookup.Symbol addr = ll.lookup("blank").get();
                 MethodType mt = MethodType.methodType(void.class, MemoryAddress.class);
                 FunctionDescriptor fd = FunctionDescriptor.ofVoid(C_POINTER);
                 blank = abi.downcallHandle(addr, mt, fd);
@@ -82,7 +82,7 @@ public class Upcalls {
                 ).address();
             }
             {
-                LibraryLookup.Symbol addr = ll.lookup("identity");
+                LibraryLookup.Symbol addr = ll.lookup("identity").get();
                 MethodType mt = MethodType.methodType(int.class, int.class, MemoryAddress.class);
                 FunctionDescriptor fd = FunctionDescriptor.of(C_INT, C_INT, C_POINTER);
                 identity = abi.downcallHandle(addr, mt, fd);

--- a/test/micro/org/openjdk/bench/jdk/incubator/foreign/VaList.java
+++ b/test/micro/org/openjdk/bench/jdk/incubator/foreign/VaList.java
@@ -59,16 +59,12 @@ public class VaList {
     static final MethodHandle MH_vaList;
 
     static {
-        try {
-            MH_ellipsis = linker.downcallHandle(lookup.lookup("ellipsis"),
-                    MethodType.methodType(void.class, int.class, int.class, double.class, long.class),
-                    FunctionDescriptor.ofVoid(C_INT, asVarArg(C_INT), asVarArg(C_DOUBLE), asVarArg(C_LONGLONG)));
-            MH_vaList = linker.downcallHandle(lookup.lookup("vaList"),
-                    MethodType.methodType(void.class, int.class, VaList.class),
-                    FunctionDescriptor.ofVoid(C_INT, C_VA_LIST));
-        } catch (NoSuchMethodException e) {
-            throw new InternalError(e);
-        }
+        MH_ellipsis = linker.downcallHandle(lookup.lookup("ellipsis").get(),
+                MethodType.methodType(void.class, int.class, int.class, double.class, long.class),
+                FunctionDescriptor.ofVoid(C_INT, asVarArg(C_INT), asVarArg(C_DOUBLE), asVarArg(C_LONGLONG)));
+        MH_vaList = linker.downcallHandle(lookup.lookup("vaList").get(),
+                MethodType.methodType(void.class, int.class, VaList.class),
+                FunctionDescriptor.ofVoid(C_INT, C_VA_LIST));
     }
 
     @Benchmark

--- a/test/micro/org/openjdk/bench/jdk/incubator/foreign/points/support/PanamaPoint.java
+++ b/test/micro/org/openjdk/bench/jdk/incubator/foreign/points/support/PanamaPoint.java
@@ -49,22 +49,18 @@ public class PanamaPoint implements AutoCloseable {
     private static final MethodHandle MH_distance_ptrs;
 
     static {
-        try {
-            CLinker abi = CLinker.getInstance();
-            LibraryLookup lookup = LibraryLookup.ofLibrary("Point");
-            MH_distance = abi.downcallHandle(
-                lookup.lookup("distance"),
-                methodType(double.class, MemorySegment.class, MemorySegment.class),
-                FunctionDescriptor.of(C_DOUBLE, LAYOUT, LAYOUT)
-            );
-            MH_distance_ptrs = abi.downcallHandle(
-                lookup.lookup("distance_ptrs"),
-                methodType(double.class, MemoryAddress.class, MemoryAddress.class),
-                FunctionDescriptor.of(C_DOUBLE, C_POINTER, C_POINTER)
-            );
-        } catch (NoSuchMethodException e) {
-            throw new BootstrapMethodError(e);
-        }
+        CLinker abi = CLinker.getInstance();
+        LibraryLookup lookup = LibraryLookup.ofLibrary("Point");
+        MH_distance = abi.downcallHandle(
+            lookup.lookup("distance").get(),
+            methodType(double.class, MemorySegment.class, MemorySegment.class),
+            FunctionDescriptor.of(C_DOUBLE, LAYOUT, LAYOUT)
+        );
+        MH_distance_ptrs = abi.downcallHandle(
+            lookup.lookup("distance_ptrs").get(),
+            methodType(double.class, MemoryAddress.class, MemoryAddress.class),
+            FunctionDescriptor.of(C_DOUBLE, C_POINTER, C_POINTER)
+        );
     }
 
     private final MemorySegment segment;


### PR DESCRIPTION
This patch implements a couple of suggestion which were made a couple of weeks ago by @BlueGoliath - here:

https://mail.openjdk.java.net/pipermail/panama-dev/2020-July/010140.html

Two ideas here:
* Change the signature of `LibraryLookup::ofPath` to actually take a `Path` (rathar than a `String`)
* Tweak `LibraryLookup::lookup` to return `Optional` (rather than throw)

Both suggestions seem to change the API for the better. The second one is probably more controversial: on the one hand it removes the need for having exception handling logic and makes it for more composable logic. On the other hand clients have to manually call `get` on the lookup result. But overall seems a win.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [JDK-8253430](https://bugs.openjdk.java.net/browse/JDK-8253430): Improve the LibraryLookup API


### Reviewers
 * [Jorn Vernee](https://openjdk.java.net/census#jvernee) (@JornVernee - Committer)
 * [Athijegannathan Sundararajan](https://openjdk.java.net/census#sundar) (@sundararajana - Committer)


### Download
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/348/head:pull/348`
`$ git checkout pull/348`
