### PR TITLE
8253390: jextract should quote string literals

### DIFF
--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/SourceConstantHelper.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/SourceConstantHelper.java
@@ -457,7 +457,7 @@ class SourceConstantHelper implements ConstantHelper {
         append("MemorySegment ");
         append(fieldName);
         append(" = CLinker.toCString(\"");
-        append(Objects.toString(value));
+        append(Utils.quote(Objects.toString(value)));
         append("\");\n");
         decrAlign();
         return fieldName;

--- a/test/jdk/tools/jextract/test8253390/LibTest8253390Test.java
+++ b/test/jdk/tools/jextract/test8253390/LibTest8253390Test.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import org.testng.annotations.Test;
+import static org.testng.Assert.assertEquals;
+import static jdk.incubator.foreign.CLinker.toJavaString;
+import static test.jextract.test8253390.test8253390_h.*;
+
+/*
+ * @test id=classes
+ * @library ..
+ * @modules jdk.incubator.jextract
+ * @bug 8253390
+ * @summary jextract should quote string literals
+ * @run driver JtregJextract -t test.jextract.test8253390 -- test8253390.h
+ * @run testng/othervm -Dforeign.restricted=permit LibTest8253390Test
+ */
+/*
+ * @test id=sources
+ * @library ..
+ * @modules jdk.incubator.jextract
+ * @bug 8253390
+ * @summary jextract should quote string literals
+ * @run driver JtregJextractSources -t test.jextract.test8253390 -- test8253390.h
+ * @run testng/othervm -Dforeign.restricted=permit LibTest8253390Test
+ */
+public class LibTest8253390Test {
+    @Test
+    public void testSquare() {
+        assertEquals(toJavaString(GREETING()), "hello\nworld");
+        assertEquals(toJavaString(GREETING2()), "hello\tworld");
+    }
+}

--- a/test/jdk/tools/jextract/test8253390/test8253390.h
+++ b/test/jdk/tools/jextract/test8253390/test8253390.h
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+#ifdef __cplusplus
+extern "C" {
+#endif // __cplusplus
+
+#ifdef _WIN64
+#define EXPORT __declspec(dllexport)
+#else
+#define EXPORT
+#endif
+
+#define GREETING "hello\nworld"
+#define GREETING2 "hello\tworld"
+
+#ifdef __cplusplus
+}
+#endif // __cplusplus


### PR DESCRIPTION
String literals are escaped.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [JDK-8253390](https://bugs.openjdk.java.net/browse/JDK-8253390): jextract should quote string literals


### Reviewers
 * [Jorn Vernee](https://openjdk.java.net/census#jvernee) (@JornVernee - Committer)
 * [Maurizio Cimadamore](https://openjdk.java.net/census#mcimadamore) (@mcimadamore - Committer)


### Download
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/351/head:pull/351`
`$ git checkout pull/351`
