### PR TITLE
8253472: Hotspot code should special case ScopedAccessError

### DIFF
--- a/src/hotspot/share/classfile/systemDictionary.hpp
+++ b/src/hotspot/share/classfile/systemDictionary.hpp
@@ -226,6 +226,8 @@ class TableStatistics;
   /* support for records */                                                                                     \
   do_klass(RecordComponent_klass,                       java_lang_reflect_RecordComponent                     ) \
                                                                                                                 \
+  /* support for Panama */                                                                                      \
+  do_klass(ScopedAccessError_klass,                     jdk_internal_misc_ScopedMemoryAccess_Scope_ScopedAccessError) \
   /*end*/
 
 class SystemDictionary : AllStatic {

--- a/src/hotspot/share/classfile/vmSymbols.hpp
+++ b/src/hotspot/share/classfile/vmSymbols.hpp
@@ -129,6 +129,7 @@
   template(sun_net_www_ParseUtil,                     "sun/net/www/ParseUtil")                    \
   template(java_util_Iterator,                        "java/util/Iterator")                       \
   template(java_lang_Record,                          "java/lang/Record")                         \
+  template(jdk_internal_misc_ScopedMemoryAccess_Scope_ScopedAccessError, "jdk/internal/misc/ScopedMemoryAccess$Scope$ScopedAccessError") \
                                                                                                   \
   template(jdk_internal_loader_NativeLibraries,       "jdk/internal/loader/NativeLibraries")      \
   template(jdk_internal_loader_BuiltinClassLoader,    "jdk/internal/loader/BuiltinClassLoader")   \

--- a/src/hotspot/share/utilities/exceptions.cpp
+++ b/src/hotspot/share/utilities/exceptions.cpp
@@ -73,6 +73,7 @@ void ThreadShadow::clear_pending_exception() {
 void ThreadShadow::clear_pending_nonasync_exception() {
   // Do not clear probable async exceptions.
   if (!_pending_exception->is_a(SystemDictionary::ThreadDeath_klass()) &&
+       _pending_exception->klass() != SystemDictionary::ScopedAccessError_klass() &&
       (_pending_exception->klass() != SystemDictionary::InternalError_klass() ||
        java_lang_InternalError::during_unsafe_access(_pending_exception) != JNI_TRUE)) {
     clear_pending_exception();


### PR DESCRIPTION
There are a number of places where compiled code clears all pending exception; this operation did not take into account async exception and a recent fix has been introduced to rectify this: JDK-8249451. The fix checks for the type of the pending exception and disables the clearing for a selectd subbset of exception types. We should add ScopedAccessError to the list, to future-proof the shared memory segment support.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [JDK-8253472](https://bugs.openjdk.java.net/browse/JDK-8253472): Hotspot code should special case ScopedAccessError


### Reviewers
 * [Erik Österlund](https://openjdk.java.net/census#eosterlund) (@fisk - no project role)
 * [Jorn Vernee](https://openjdk.java.net/census#jvernee) (@JornVernee - Committer)
 * [Athijegannathan Sundararajan](https://openjdk.java.net/census#sundar) (@sundararajana - Committer)


### Download
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/353/head:pull/353`
`$ git checkout pull/353`
