### PR TITLE
Turn on downcall intrinsics by default

### DIFF
--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/ProgrammableInvoker.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/ProgrammableInvoker.java
@@ -161,7 +161,8 @@ public class ProgrammableInvoker {
                                             .asType(leafType);
 
         boolean isSimple = !(retMoves.length > 1);
-        if (USE_INTRINSICS && isSimple) {
+        boolean usesStackArgs = stackArgsBytes != 0;
+        if (USE_INTRINSICS && isSimple && !usesStackArgs) {
             NativeEntryPoint nep = NativeEntryPoint.make(
                 addr.address().toRawLongValue(),
                 "native_call",

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/ProgrammableInvoker.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/ProgrammableInvoker.java
@@ -68,7 +68,7 @@ public class ProgrammableInvoker {
     private static final boolean USE_SPEC = Boolean.parseBoolean(
         GetPropertyAction.privilegedGetProperty("jdk.internal.foreign.ProgrammableInvoker.USE_SPEC", "true"));
     private static final boolean USE_INTRINSICS = Boolean.parseBoolean(
-        GetPropertyAction.privilegedGetProperty("jdk.internal.foreign.ProgrammableInvoker.USE_INTRINSICS", "false"));
+        GetPropertyAction.privilegedGetProperty("jdk.internal.foreign.ProgrammableInvoker.USE_INTRINSICS", "true"));
 
     private static final JavaLangInvokeAccess JLIA = SharedSecrets.getJavaLangInvokeAccess();
 

--- a/test/jdk/java/foreign/TestIntrinsics.java
+++ b/test/jdk/java/foreign/TestIntrinsics.java
@@ -53,9 +53,8 @@ public class TestIntrinsics {
     static final CLinker abi = CLinker.getInstance();
     static final LibraryLookup lookup = LibraryLookup.ofLibrary("Intrinsics");
 
-    private static MethodHandle linkIndentity(String name, Class<?> carrier, MemoryLayout layout, boolean trivial)
-            throws NoSuchMethodException {
-        LibraryLookup.Symbol ma = lookup.lookup(name).get();
+    private static MethodHandle linkIndentity(String name, Class<?> carrier, MemoryLayout layout, boolean trivial) {
+        LibraryLookup.Symbol ma = lookup.lookup(name).orElseThrow();
         MethodType mt = methodType(carrier, carrier);
         FunctionDescriptor fd = FunctionDescriptor.of(layout, layout);
         if (trivial) {
@@ -80,7 +79,7 @@ public class TestIntrinsics {
     }
 
     @DataProvider
-    public Object[][] tests() throws NoSuchMethodException {
+    public Object[][] tests() {
         List<RunnableX> testsList = new ArrayList<>();
         AddTest tests = (mh, expectedResult, args) -> testsList.add(() -> {
             Object actual = mh.invokeWithArguments(args);
@@ -88,7 +87,7 @@ public class TestIntrinsics {
         });
 
         { // empty
-            LibraryLookup.Symbol ma = lookup.lookup("empty");
+            LibraryLookup.Symbol ma = lookup.lookup("empty").orElseThrow();
             MethodType mt = methodType(void.class);
             FunctionDescriptor fd = FunctionDescriptor.ofVoid();
             tests.add(abi.downcallHandle(ma, mt, fd), null);
@@ -109,7 +108,7 @@ public class TestIntrinsics {
         tests.add(linkIndentity("identity_double", double.class, C_DOUBLE, true), 10D, 10D);
 
         { // identity_va
-            LibraryLookup.Symbol ma = lookup.lookup("identity_va");
+            LibraryLookup.Symbol ma = lookup.lookup("identity_va").orElseThrow();
             MethodType mt = methodType(int.class, int.class, double.class, int.class, float.class, long.class);
             FunctionDescriptor fd = FunctionDescriptor.of(C_INT, C_INT, asVarArg(C_DOUBLE),
                     asVarArg(C_INT), asVarArg(C_FLOAT), asVarArg(C_LONGLONG));
@@ -124,7 +123,7 @@ public class TestIntrinsics {
                     C_SHORT, C_SHORT);
             Object[] args = {1, 10D, 2L, 3F, (byte) 0, (short) 13, 'a'};
             for (int i = 0; i < args.length; i++) {
-                LibraryLookup.Symbol ma = lookup.lookup("invoke_high_arity" + i);
+                LibraryLookup.Symbol ma = lookup.lookup("invoke_high_arity" + i).orElseThrow();
                 MethodType mt = baseMT.changeReturnType(baseMT.parameterType(i));
                 FunctionDescriptor fd = baseFD.changeReturnLayout(baseFD.argumentLayouts().get(i));
                 Object expected = args[i];

--- a/test/jdk/java/foreign/libIntrinsics.c
+++ b/test/jdk/java/foreign/libIntrinsics.c
@@ -59,5 +59,24 @@ EXPORT int identity_va(int x, ...) {
     return x;
 }
 
-EXPORT void invoke_consumer(int x, double d, long long l, float f, char c, short s1, short s2) {
+EXPORT int invoke_high_arity0(int x, double d, long long l, float f, char c, short s1, short s2) {
+    return x;
+}
+EXPORT double invoke_high_arity1(int x, double d, long long l, float f, char c, short s1, short s2) {
+    return d;
+}
+EXPORT long long invoke_high_arity2(int x, double d, long long l, float f, char c, short s1, short s2) {
+    return l;
+}
+EXPORT float invoke_high_arity3(int x, double d, long long l, float f, char c, short s1, short s2) {
+    return f;
+}
+EXPORT char invoke_high_arity4(int x, double d, long long l, float f, char c, short s1, short s2) {
+    return c;
+}
+EXPORT short invoke_high_arity5(int x, double d, long long l, float f, char c, short s1, short s2) {
+    return s1;
+}
+EXPORT short invoke_high_arity6(int x, double d, long long l, float f, char c, short s1, short s2) {
+    return s2;
 }


### PR DESCRIPTION
Hi,

This PR turns on down call intrinsics by default.

Since the time they were turned off some fixes have been done in the area of GC handling of optimized native calls, and no further problems in that area have been found. What currently works is:

1. All TestDowncall and TestUpcall tests, where each function is invoked in a 20_000 iteration loop with -Xbatch, making sure these calls are intrinsified.
2. TestIntrinsics tests which intrinsifies calls the same way.
3. All jextract samples with intrinsics turned on, which from the logs also leads to calls being intrinsified, especially on large extraction runs like Windows.h.

There is one more case that is known to be problematic: TestUpcallHighArity crashes/fails when the call is intrinsified (using same method as 1 and 2). This seems to be caused by a known problem with the handling on stack arguments for intrinsified calls. So, for now, intrinsification of calls that pass arguments on the stack will be turned off.

If there are other cases you would like to make sure work, please take the test for a spin.

Thanks,
Jorn
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [Maurizio Cimadamore](https://openjdk.java.net/census#mcimadamore) (@mcimadamore - Committer)


### Download
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/354/head:pull/354`
`$ git checkout pull/354`
