### PR TITLE
Transition back to java on safepoint poll slow-path when returning from an optimized native call

### DIFF
--- a/src/hotspot/cpu/x86/sharedRuntime_x86_64.cpp
+++ b/src/hotspot/cpu/x86/sharedRuntime_x86_64.cpp
@@ -3810,10 +3810,11 @@ void NativeInvokerGenerator::generate() {
   __ safepoint_poll(L_safepoint_poll_slow_path, r15_thread, rscratch1);
   __ cmpl(Address(r15_thread, JavaThread::suspend_flags_offset()), 0);
   __ jcc(Assembler::notEqual, L_safepoint_poll_slow_path);
-  // change thread state
-  __ movl(Address(r15_thread, JavaThread::thread_state_offset()), _thread_in_Java);
 
   __ bind(L_after_safepoint_poll);
+
+  // change thread state
+  __ movl(Address(r15_thread, JavaThread::thread_state_offset()), _thread_in_Java);
 
   __ block_comment("reguard stack check");
   Label L_reguard;


### PR DESCRIPTION
Hi,

Due to a bug report last week, it was found that threads do not transition back to the _thread_in_java state on the safepoint poll slow path after returning from an optimized native call.

While I was not able to reproduce the crash in question so far, the current code is obviously wrong, since the thread state transition back only happens on the fast path.

This patch rectifies that issue.

Thanks,
Jorn

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [Maurizio Cimadamore](https://openjdk.java.net/census#mcimadamore) (@mcimadamore - Committer)


### Download
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/356/head:pull/356`
`$ git checkout pull/356`
