### PR TITLE
8253255: Investigate replacing ABI layout attributes with custom subtypes of ValueLayout

### DIFF
--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/AbstractLayout.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/AbstractLayout.java
@@ -43,6 +43,7 @@ import java.util.OptionalLong;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import static java.lang.constant.ConstantDescs.BSM_GET_STATIC_FINAL;
 import static java.lang.constant.ConstantDescs.BSM_INVOKE;
 import static java.lang.constant.ConstantDescs.CD_String;
 import static java.lang.constant.ConstantDescs.CD_long;
@@ -149,7 +150,7 @@ abstract class AbstractLayout implements MemoryLayout {
         return s;
     }
 
-    <T> DynamicConstantDesc<T> decorateLayoutConstant(DynamicConstantDesc<T> desc) {
+    protected <T> DynamicConstantDesc<T> decorateLayoutConstant(DynamicConstantDesc<T> desc) {
         if (!hasNaturalAlignment()) {
             desc = DynamicConstantDesc.ofNamed(BSM_INVOKE, "withBitAlignment", desc.constantType(), MH_WITH_BIT_ALIGNMENT,
                     desc, bitAlignment());
@@ -162,7 +163,7 @@ abstract class AbstractLayout implements MemoryLayout {
         return desc;
     }
 
-    boolean hasNaturalAlignment() {
+    protected boolean hasNaturalAlignment() {
         return size.isPresent() && size.getAsLong() == alignment;
     }
 
@@ -192,10 +193,6 @@ abstract class AbstractLayout implements MemoryLayout {
 
     /*** Helper constants for implementing Layout::describeConstable ***/
 
-    static final DirectMethodHandleDesc BSM_GET_STATIC_FINAL
-            = ConstantDescs.ofConstantBootstrap(ConstantDescs.CD_ConstantBootstraps, "getStaticFinal",
-            ConstantDescs.CD_Object, ConstantDescs.CD_Class);
-
     static final ClassDesc CD_MEMORY_LAYOUT = MemoryLayout.class.describeConstable().get();
 
     static final ClassDesc CD_VALUE_LAYOUT = ValueLayout.class.describeConstable().get();
@@ -213,10 +210,6 @@ abstract class AbstractLayout implements MemoryLayout {
     static final ConstantDesc BIG_ENDIAN = DynamicConstantDesc.ofNamed(BSM_GET_STATIC_FINAL, "BIG_ENDIAN", CD_BYTEORDER, CD_BYTEORDER);
 
     static final ConstantDesc LITTLE_ENDIAN = DynamicConstantDesc.ofNamed(BSM_GET_STATIC_FINAL, "LITTLE_ENDIAN", CD_BYTEORDER, CD_BYTEORDER);
-
-    static final ConstantDesc TRUE = DynamicConstantDesc.ofNamed(BSM_GET_STATIC_FINAL, "TRUE", ConstantDescs.CD_Boolean, ConstantDescs.CD_Boolean);
-
-    static final ConstantDesc FALSE = DynamicConstantDesc.ofNamed(BSM_GET_STATIC_FINAL, "FALSE", ConstantDescs.CD_Boolean, ConstantDescs.CD_Boolean);
 
     static final MethodHandleDesc MH_PADDING = MethodHandleDesc.ofMethod(DirectMethodHandleDesc.Kind.INTERFACE_STATIC, CD_MEMORY_LAYOUT, "ofPaddingBits",
                 MethodTypeDesc.of(CD_MEMORY_LAYOUT, CD_long));

--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/GroupLayout.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/GroupLayout.java
@@ -171,12 +171,12 @@ public final class GroupLayout extends AbstractLayout {
     }
 
     @Override
-    GroupLayout dup(long alignment, Map<String, Constable> attributes) {
+    protected GroupLayout dup(long alignment, Map<String, Constable> attributes) {
         return new GroupLayout(kind, elements, alignment, attributes);
     }
 
     @Override
-    boolean hasNaturalAlignment() {
+    protected boolean hasNaturalAlignment() {
         return alignment == kind.alignof(elements);
     }
 

--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/SequenceLayout.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/SequenceLayout.java
@@ -252,12 +252,12 @@ public final class SequenceLayout extends AbstractLayout {
     }
 
     @Override
-    SequenceLayout dup(long alignment, Map<String, Constable> attributes) {
+    protected SequenceLayout dup(long alignment, Map<String, Constable> attributes) {
         return new SequenceLayout(elementCount(), elementLayout, alignment, attributes);
     }
 
     @Override
-    boolean hasNaturalAlignment() {
+    protected boolean hasNaturalAlignment() {
         return alignment == elementLayout.bitAlignment();
     }
 

--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/ValueLayout.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/ValueLayout.java
@@ -92,10 +92,10 @@ public class ValueLayout extends AbstractLayout implements MemoryLayout {
         if (this == other) {
             return true;
         }
-        if (!super.equals(other)) {
+        if (other == null || getClass() != other.getClass()) {
             return false;
         }
-        if (!(other instanceof ValueLayout)) {
+        if (!super.equals(other)) {
             return false;
         }
         ValueLayout v = (ValueLayout)other;

--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/ValueLayout.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/ValueLayout.java
@@ -48,15 +48,15 @@ import java.util.OptionalLong;
  * @implSpec
  * This class is immutable and thread-safe.
  */
-public final class ValueLayout extends AbstractLayout implements MemoryLayout {
+public class ValueLayout extends AbstractLayout implements MemoryLayout {
 
     private final ByteOrder order;
 
-    ValueLayout(ByteOrder order, long size) {
+    protected ValueLayout(ByteOrder order, long size) {
         this(order, size, size, Map.of());
     }
 
-    ValueLayout(ByteOrder order, long size, long alignment, Map<String, Constable> attributes) {
+    protected ValueLayout(ByteOrder order, long size, long alignment, Map<String, Constable> attributes) {
         super(OptionalLong.of(size), alignment, attributes);
         this.order = order;
     }
@@ -110,7 +110,7 @@ public final class ValueLayout extends AbstractLayout implements MemoryLayout {
     }
 
     @Override
-    ValueLayout dup(long alignment, Map<String, Constable> attributes) {
+    protected ValueLayout dup(long alignment, Map<String, Constable> attributes) {
         return new ValueLayout(order, bitSize(), alignment, attributes);
     }
 

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/CValueLayout.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/CValueLayout.java
@@ -1,3 +1,28 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
 package jdk.internal.foreign;
 
 import jdk.incubator.foreign.CLinker;

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/CValueLayout.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/CValueLayout.java
@@ -32,6 +32,7 @@ import java.lang.constant.Constable;
 import java.lang.constant.DynamicConstantDesc;
 import java.nio.ByteOrder;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 
 import static java.lang.constant.ConstantDescs.BSM_GET_STATIC_FINAL;
@@ -154,5 +155,25 @@ public class CValueLayout extends ValueLayout {
     @Override
     public Optional<DynamicConstantDesc<ValueLayout>> describeConstable() {
         return Optional.of(decorateLayoutConstant(kind.bsm()));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (this == other) {
+            return true;
+        }
+        if (other == null || getClass() != other.getClass()) {
+            return false;
+        }
+        if (!super.equals(other)) {
+            return false;
+        }
+        CValueLayout that = (CValueLayout) other;
+        return kind == that.kind;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), kind);
     }
 }

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/CValueLayout.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/CValueLayout.java
@@ -1,0 +1,133 @@
+package jdk.internal.foreign;
+
+import jdk.incubator.foreign.CLinker;
+import jdk.incubator.foreign.ValueLayout;
+
+import java.lang.constant.Constable;
+import java.lang.constant.DynamicConstantDesc;
+import java.nio.ByteOrder;
+import java.util.Map;
+import java.util.Optional;
+
+import static java.lang.constant.ConstantDescs.BSM_GET_STATIC_FINAL;
+
+public class CValueLayout extends ValueLayout {
+
+    public enum Kind {
+        CHAR(findBSM("C_CHAR"), true),
+        SHORT(findBSM("C_SHORT"), true),
+        INT(findBSM("C_INT"), true),
+        LONG(findBSM("C_LONG"), true),
+        LONGLONG(findBSM("C_LONGLONG"), true),
+        FLOAT(findBSM("C_FLOAT"), false),
+        DOUBLE(findBSM("C_DOUBLE"), false),
+        LONGDOUBLE(findBSM("C_LONGDOUBLE"), false),
+        POINTER(findBSM("C_POINTER"), false);
+
+        private final DynamicConstantDesc<ValueLayout> bsm;
+        private final boolean isIntegral;
+
+        Kind(DynamicConstantDesc<ValueLayout> bsm, boolean isIntegral) {
+            this.bsm = bsm;
+            this.isIntegral = isIntegral;
+        }
+
+        public DynamicConstantDesc<ValueLayout> bsm() {
+            return bsm;
+        }
+
+        public boolean isIntergral() {
+            return isIntegral;
+        }
+
+        public boolean isPointer() {
+            return this == POINTER;
+        }
+
+        private static DynamicConstantDesc<ValueLayout> findBSM(String fieldName) {
+            return DynamicConstantDesc.ofNamed(
+                BSM_GET_STATIC_FINAL,
+                fieldName,
+                ValueLayout.class.describeConstable().orElseThrow(),
+                CLinker.class.describeConstable().orElseThrow()
+            );
+        }
+    }
+
+    private final Kind kind;
+
+    private CValueLayout(Kind kind, ByteOrder order, long size, long alignment, Map<String, Constable> attributes) {
+        super(order, size, alignment, attributes);
+        this.kind = kind;
+    }
+
+    static CValueLayout ofChar(ByteOrder order, long bitSize) {
+        return new CValueLayout(Kind.CHAR, order, bitSize, bitSize, Map.of());
+    }
+
+    static CValueLayout ofShort(ByteOrder order, long bitSize) {
+        return new CValueLayout(Kind.SHORT, order, bitSize, bitSize, Map.of());
+    }
+
+    static CValueLayout ofInt(ByteOrder order, long bitSize) {
+        return new CValueLayout(Kind.INT, order, bitSize, bitSize, Map.of());
+    }
+
+    static CValueLayout ofLong(ByteOrder order, long bitSize) {
+        return new CValueLayout(Kind.LONG, order, bitSize, bitSize, Map.of());
+    }
+
+    static CValueLayout ofLongLong(ByteOrder order, long bitSize) {
+        return new CValueLayout(Kind.LONGLONG, order, bitSize, bitSize, Map.of());
+    }
+
+    static CValueLayout ofFloat(ByteOrder order, long bitSize) {
+        return new CValueLayout(Kind.FLOAT, order, bitSize, bitSize, Map.of());
+    }
+
+    static CValueLayout ofDouble(ByteOrder order, long bitSize) {
+        return new CValueLayout(Kind.DOUBLE, order, bitSize, bitSize, Map.of());
+    }
+
+    static CValueLayout ofLongDouble(ByteOrder order, long bitSize) {
+        return new CValueLayout(Kind.LONGDOUBLE, order, bitSize, bitSize, Map.of());
+    }
+
+    static CValueLayout ofPointer(ByteOrder order, long bitSize) {
+        return new CValueLayout(Kind.POINTER, order, bitSize, bitSize, Map.of());
+    }
+
+    public Kind kind() {
+        return kind;
+    }
+
+    @Override
+    public CValueLayout withOrder(ByteOrder order) {
+        return (CValueLayout) super.withOrder(order);
+    }
+
+    @Override
+    public CValueLayout withName(String name) {
+        return (CValueLayout) super.withName(name);
+    }
+
+    @Override
+    public CValueLayout withBitAlignment(long alignmentBits) {
+        return (CValueLayout) super.withBitAlignment(alignmentBits);
+    }
+
+    @Override
+    public CValueLayout withAttribute(String name, Constable value) {
+        return (CValueLayout) super.withAttribute(name, value);
+    }
+
+    @Override
+    protected CValueLayout dup(long alignment, Map<String, Constable> attributes) {
+        return new CValueLayout(kind, order(), bitSize(), alignment, attributes);
+    }
+
+    @Override
+    public Optional<DynamicConstantDesc<ValueLayout>> describeConstable() {
+        return Optional.of(decorateLayoutConstant(kind.bsm()));
+    }
+}

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/PlatformLayouts.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/PlatformLayouts.java
@@ -25,12 +25,11 @@
  */
 package jdk.internal.foreign;
 
-import jdk.incubator.foreign.GroupLayout;
 import jdk.incubator.foreign.MemoryLayout;
-import jdk.incubator.foreign.MemoryLayouts;
 import jdk.incubator.foreign.ValueLayout;
 
-import java.nio.ByteOrder;
+import static java.nio.ByteOrder.LITTLE_ENDIAN;
+import static jdk.incubator.foreign.MemoryLayouts.ADDRESS;
 
 public class PlatformLayouts {
     public static <Z extends MemoryLayout> Z pick(Z sysv, Z win64, Z aarch64) {
@@ -57,86 +56,49 @@ public class PlatformLayouts {
         }
 
         /**
-         * The name of the layout attribute (see {@link MemoryLayout#attributes()} used for ABI classification. The
-         * attribute value must be an enum constant from {@link ArgumentClass}.
-         */
-        public final static String CLASS_ATTRIBUTE_NAME = "abi/sysv/class";
-
-        /**
-         * Constants used for ABI classification. They are referred to by the layout attribute {@link #CLASS_ATTRIBUTE_NAME}.
-         */
-        public enum ArgumentClass {
-            /** Classification constant for integral values */
-            INTEGER,
-            /** Classification constant for floating point values */
-            SSE,
-            /** Classification constant for x87 floating point values */
-            X87,
-            /** Classification constant for {@code complex long double} values */
-            COMPLEX_87,
-            /** Classification constant for machine pointer values */
-            POINTER;
-        }
-
-        /**
          * The {@code char} native type.
          */
-        public static final ValueLayout C_CHAR = MemoryLayouts.BITS_8_LE
-                .withAttribute(CLASS_ATTRIBUTE_NAME, ArgumentClass.INTEGER);
+        public static final ValueLayout C_CHAR = CValueLayout.ofChar(LITTLE_ENDIAN, 8);
 
         /**
          * The {@code short} native type.
          */
-        public static final ValueLayout C_SHORT = MemoryLayouts.BITS_16_LE
-                .withAttribute(CLASS_ATTRIBUTE_NAME, ArgumentClass.INTEGER);
+        public static final ValueLayout C_SHORT = CValueLayout.ofShort(LITTLE_ENDIAN, 16);
 
         /**
          * The {@code int} native type.
          */
-        public static final ValueLayout C_INT = MemoryLayouts.BITS_32_LE
-                .withAttribute(CLASS_ATTRIBUTE_NAME, ArgumentClass.INTEGER);
+        public static final ValueLayout C_INT = CValueLayout.ofInt(LITTLE_ENDIAN, 32);
 
         /**
          * The {@code long} native type.
          */
-        public static final ValueLayout C_LONG = MemoryLayouts.BITS_64_LE
-                .withAttribute(CLASS_ATTRIBUTE_NAME, ArgumentClass.INTEGER);
+        public static final ValueLayout C_LONG = CValueLayout.ofLong(LITTLE_ENDIAN, 64);
 
         /**
          * The {@code long long} native type.
          */
-        public static final ValueLayout C_LONGLONG = MemoryLayouts.BITS_64_LE
-                .withAttribute(CLASS_ATTRIBUTE_NAME, ArgumentClass.INTEGER);
+        public static final ValueLayout C_LONGLONG = CValueLayout.ofLongLong(LITTLE_ENDIAN, 64);
 
         /**
          * The {@code float} native type.
          */
-        public static final ValueLayout C_FLOAT = MemoryLayouts.BITS_32_LE
-                .withAttribute(CLASS_ATTRIBUTE_NAME, ArgumentClass.SSE);
+        public static final ValueLayout C_FLOAT = CValueLayout.ofFloat(LITTLE_ENDIAN, 32);
 
         /**
          * The {@code double} native type.
          */
-        public static final ValueLayout C_DOUBLE = MemoryLayouts.BITS_64_LE
-                .withAttribute(CLASS_ATTRIBUTE_NAME, ArgumentClass.SSE);
+        public static final ValueLayout C_DOUBLE = CValueLayout.ofDouble(LITTLE_ENDIAN, 64);
 
         /**
          * The {@code long double} native type.
          */
-        public static final ValueLayout C_LONGDOUBLE = MemoryLayout.ofValueBits(128, ByteOrder.LITTLE_ENDIAN)
-                .withAttribute(CLASS_ATTRIBUTE_NAME, ArgumentClass.X87);
-
-        /**
-         * The {@code complex long double} native type.
-         */
-        public static final GroupLayout C_COMPLEX_LONGDOUBLE = MemoryLayout.ofStruct(C_LONGDOUBLE, C_LONGDOUBLE)
-                .withAttribute(CLASS_ATTRIBUTE_NAME, ArgumentClass.COMPLEX_87);
+        public static final ValueLayout C_LONGDOUBLE = CValueLayout.ofLongDouble(LITTLE_ENDIAN, 128);
 
         /**
          * The {@code T*} native type.
          */
-        public static final ValueLayout C_POINTER = MemoryLayouts.ADDRESS
-                .withAttribute(CLASS_ATTRIBUTE_NAME, ArgumentClass.POINTER);
+        public static final ValueLayout C_POINTER = CValueLayout.ofPointer(LITTLE_ENDIAN, ADDRESS.bitSize());
 
         /**
          * The {@code va_list} native type, as it is passed to a function.
@@ -160,76 +122,48 @@ public class PlatformLayouts {
         public final static String VARARGS_ATTRIBUTE_NAME = "abi/windows/varargs";
 
         /**
-         * The name of the layout attribute (see {@link MemoryLayout#attributes()} used for ABI classification. The
-         * attribute value must be an enum constant from {@link ArgumentClass}.
-         */
-        public final static String CLASS_ATTRIBUTE_NAME = "abi/windows/class";
-
-        /**
-         * Constants used for ABI classification. They are referred to by the layout attribute {@link #CLASS_ATTRIBUTE_NAME}.
-         */
-        public enum ArgumentClass {
-            /** Classification constant for integral values */
-            INTEGER,
-            /** Classification constant for floating point values */
-            FLOAT,
-            /** Classification constant for machine pointer values */
-            POINTER;
-        }
-
-        /**
          * The {@code char} native type.
          */
-        public static final ValueLayout C_CHAR = MemoryLayouts.BITS_8_LE
-                .withAttribute(CLASS_ATTRIBUTE_NAME, ArgumentClass.INTEGER);
+        public static final ValueLayout C_CHAR = CValueLayout.ofChar(LITTLE_ENDIAN, 8);
 
         /**
          * The {@code short} native type.
          */
-        public static final ValueLayout C_SHORT = MemoryLayouts.BITS_16_LE
-                .withAttribute(CLASS_ATTRIBUTE_NAME, ArgumentClass.INTEGER);
+        public static final ValueLayout C_SHORT = CValueLayout.ofShort(LITTLE_ENDIAN, 16);
 
         /**
          * The {@code int} native type.
          */
-        public static final ValueLayout C_INT = MemoryLayouts.BITS_32_LE
-                .withAttribute(CLASS_ATTRIBUTE_NAME, ArgumentClass.INTEGER);
-
+        public static final ValueLayout C_INT = CValueLayout.ofInt(LITTLE_ENDIAN, 32);
         /**
          * The {@code long} native type.
          */
-        public static final ValueLayout C_LONG = MemoryLayouts.BITS_32_LE
-                .withAttribute(CLASS_ATTRIBUTE_NAME, ArgumentClass.INTEGER);
+        public static final ValueLayout C_LONG = CValueLayout.ofLong(LITTLE_ENDIAN, 32);
 
         /**
          * The {@code long long} native type.
          */
-        public static final ValueLayout C_LONGLONG = MemoryLayouts.BITS_64_LE
-                .withAttribute(CLASS_ATTRIBUTE_NAME, ArgumentClass.INTEGER);
+        public static final ValueLayout C_LONGLONG = CValueLayout.ofLongLong(LITTLE_ENDIAN, 64);
 
         /**
          * The {@code float} native type.
          */
-        public static final ValueLayout C_FLOAT = MemoryLayouts.BITS_32_LE
-                .withAttribute(CLASS_ATTRIBUTE_NAME, ArgumentClass.FLOAT);
+        public static final ValueLayout C_FLOAT = CValueLayout.ofFloat(LITTLE_ENDIAN, 32);
 
         /**
          * The {@code double} native type.
          */
-        public static final ValueLayout C_DOUBLE = MemoryLayouts.BITS_64_LE
-                .withAttribute(CLASS_ATTRIBUTE_NAME, ArgumentClass.FLOAT);
+        public static final ValueLayout C_DOUBLE = CValueLayout.ofDouble(LITTLE_ENDIAN, 64);
 
         /**
          * The {@code long double} native type.
          */
-        public static final ValueLayout C_LONGDOUBLE = MemoryLayouts.BITS_64_LE
-                .withAttribute(CLASS_ATTRIBUTE_NAME, ArgumentClass.FLOAT);
+        public static final ValueLayout C_LONGDOUBLE = CValueLayout.ofLongDouble(LITTLE_ENDIAN, 64);
 
         /**
          * The {@code T*} native type.
          */
-        public static final ValueLayout C_POINTER = MemoryLayouts.ADDRESS
-                .withAttribute(CLASS_ATTRIBUTE_NAME, ArgumentClass.POINTER);
+        public static final ValueLayout C_POINTER = CValueLayout.ofPointer(LITTLE_ENDIAN, ADDRESS.bitSize());
 
         /**
          * The {@code va_list} native type, as it is passed to a function.
@@ -257,76 +191,49 @@ public class PlatformLayouts {
         }
 
         /**
-         * The name of the layout attribute (see {@link MemoryLayout#attributes()} used for ABI classification. The
-         * attribute value must be an enum constant from {@link ArgumentClass}.
-         */
-        public static final String CLASS_ATTRIBUTE_NAME = "abi/aarch64/class";
-
-        /**
-         * Constants used for ABI classification. They are referred to by the layout attribute {@link #CLASS_ATTRIBUTE_NAME}.
-         */
-        public enum ArgumentClass {
-            /** Classification constant for machine integral values */
-            INTEGER,
-            /** Classification constant for machine floating point values */
-            VECTOR,
-            /** Classification constant for machine pointer values */
-            POINTER;
-        }
-
-        /**
          * The {@code char} native type.
          */
-        public static final ValueLayout C_CHAR = MemoryLayouts.BITS_8_LE
-                .withAttribute(CLASS_ATTRIBUTE_NAME, ArgumentClass.INTEGER);
+        public static final ValueLayout C_CHAR = CValueLayout.ofChar(LITTLE_ENDIAN, 8);
 
         /**
          * The {@code short} native type.
          */
-        public static final ValueLayout C_SHORT = MemoryLayouts.BITS_16_LE
-                .withAttribute(CLASS_ATTRIBUTE_NAME, ArgumentClass.INTEGER);
+        public static final ValueLayout C_SHORT = CValueLayout.ofShort(LITTLE_ENDIAN, 16);
 
         /**
          * The {@code int} native type.
          */
-        public static final ValueLayout C_INT = MemoryLayouts.BITS_32_LE
-                .withAttribute(CLASS_ATTRIBUTE_NAME, ArgumentClass.INTEGER);
+        public static final ValueLayout C_INT = CValueLayout.ofInt(LITTLE_ENDIAN, 32);
 
         /**
          * The {@code long} native type.
          */
-        public static final ValueLayout C_LONG = MemoryLayouts.BITS_64_LE
-                .withAttribute(CLASS_ATTRIBUTE_NAME, ArgumentClass.INTEGER);
+        public static final ValueLayout C_LONG = CValueLayout.ofLong(LITTLE_ENDIAN, 64);
 
         /**
          * The {@code long long} native type.
          */
-        public static final ValueLayout C_LONGLONG = MemoryLayouts.BITS_64_LE
-                .withAttribute(CLASS_ATTRIBUTE_NAME, ArgumentClass.INTEGER);
+        public static final ValueLayout C_LONGLONG = CValueLayout.ofLongLong(LITTLE_ENDIAN, 64);
 
         /**
          * The {@code float} native type.
          */
-        public static final ValueLayout C_FLOAT = MemoryLayouts.BITS_32_LE
-                .withAttribute(CLASS_ATTRIBUTE_NAME, ArgumentClass.VECTOR);
+        public static final ValueLayout C_FLOAT = CValueLayout.ofFloat(LITTLE_ENDIAN, 32);
 
         /**
          * The {@code double} native type.
          */
-        public static final ValueLayout C_DOUBLE = MemoryLayouts.BITS_64_LE
-                .withAttribute(CLASS_ATTRIBUTE_NAME, ArgumentClass.VECTOR);
+        public static final ValueLayout C_DOUBLE = CValueLayout.ofDouble(LITTLE_ENDIAN, 64);
 
         /**
          * The {@code long double} native type.
          */
-        public static final ValueLayout C_LONGDOUBLE = MemoryLayout.ofValueBits(128, ByteOrder.LITTLE_ENDIAN)
-                .withAttribute(CLASS_ATTRIBUTE_NAME, ArgumentClass.VECTOR);
+        public static final ValueLayout C_LONGDOUBLE = CValueLayout.ofLongDouble(LITTLE_ENDIAN, 128);
 
         /**
          * The {@code T*} native type.
          */
-        public static final ValueLayout C_POINTER = MemoryLayouts.ADDRESS
-                .withAttribute(CLASS_ATTRIBUTE_NAME, ArgumentClass.POINTER);
+        public static final ValueLayout C_POINTER = CValueLayout.ofPointer(LITTLE_ENDIAN, ADDRESS.bitSize());
 
         /**
          * The {@code va_list} native type, as it is passed to a function.

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/aarch64/AArch64Linker.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/aarch64/AArch64Linker.java
@@ -86,10 +86,6 @@ public class AArch64Linker implements CLinker {
         return UpcallStubs.upcallAddress(CallArranger.arrangeUpcall(target, target.type(), function));
     }
 
-    static AArch64.ArgumentClass argumentClassFor(MemoryLayout layout) {
-        return (AArch64.ArgumentClass)layout.attribute(AArch64.CLASS_ATTRIBUTE_NAME).get();
-    }
-
     public static VaList newVaList(Consumer<VaList.Builder> actions, SharedUtils.Allocator allocator) {
         AArch64VaList.Builder builder = AArch64VaList.builder(allocator);
         actions.accept(builder);

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/aarch64/TypeClass.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/aarch64/TypeClass.java
@@ -29,10 +29,7 @@ import jdk.incubator.foreign.GroupLayout;
 import jdk.incubator.foreign.MemoryLayout;
 import jdk.incubator.foreign.SequenceLayout;
 import jdk.incubator.foreign.ValueLayout;
-import jdk.internal.foreign.PlatformLayouts;
-
-import static jdk.internal.foreign.PlatformLayouts.*;
-import static jdk.internal.foreign.abi.aarch64.AArch64Linker.argumentClassFor;
+import jdk.internal.foreign.CValueLayout;
 
 enum TypeClass {
     STRUCT_REGISTER,
@@ -45,20 +42,15 @@ enum TypeClass {
     private static final int MAX_AGGREGATE_REGS_SIZE = 2;
 
     private static TypeClass classifyValueType(ValueLayout type) {
-        AArch64.ArgumentClass clazz = argumentClassFor(type);
-        if (clazz == null) {
-            //padding not allowed here
+        if (!(type instanceof CValueLayout)) {
             throw new IllegalStateException("Unexpected value layout: could not determine ABI class");
         }
 
-        if (clazz == AArch64.ArgumentClass.INTEGER) {
-            return INTEGER;
-        } else if(clazz == AArch64.ArgumentClass.POINTER) {
-            return POINTER;
-        } else if (clazz == AArch64.ArgumentClass.VECTOR) {
-            return FLOAT;
-        }
-        throw new IllegalArgumentException("Unknown ABI class: " + clazz);
+        return switch (((CValueLayout) type).kind()) {
+            case CHAR, SHORT, INT, LONG, LONGLONG -> INTEGER;
+            case POINTER -> POINTER;
+            case FLOAT, DOUBLE, LONGDOUBLE -> FLOAT;
+        };
     }
 
     static boolean isRegisterAggregate(MemoryLayout type) {
@@ -80,15 +72,15 @@ enum TypeClass {
         if (!(baseType instanceof ValueLayout))
             return false;
 
-        AArch64.ArgumentClass baseArgClass = argumentClassFor(baseType);
-        if (baseArgClass != AArch64.ArgumentClass.VECTOR)
+        TypeClass baseArgClass = classifyValueType((ValueLayout) baseType);
+        if (baseArgClass != FLOAT)
            return false;
 
         for (MemoryLayout elem : groupLayout.memberLayouts()) {
             if (!(elem instanceof ValueLayout))
                 return false;
 
-            AArch64.ArgumentClass argClass = argumentClassFor(elem);
+            TypeClass argClass = classifyValueType((ValueLayout) elem);
             if (elem.bitSize() != baseType.bitSize() ||
                     elem.bitAlignment() != baseType.bitAlignment() ||
                     baseArgClass != argClass) {

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/x64/sysv/SysVx64Linker.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/x64/sysv/SysVx64Linker.java
@@ -97,20 +97,6 @@ public class SysVx64Linker implements CLinker {
         return UpcallStubs.upcallAddress(CallArranger.arrangeUpcall(target, target.type(), function));
     }
 
-    static Optional<ArgumentClassImpl> argumentClassFor(MemoryLayout layout) {
-        @SuppressWarnings({"unchecked", "rawtypes"})
-        Optional<SysV.ArgumentClass> argClassOpt =
-                (Optional<SysV.ArgumentClass>)(Optional)layout.attribute(SysV.CLASS_ATTRIBUTE_NAME);
-        return argClassOpt.map(argClass -> switch (argClass) {
-            case INTEGER -> ArgumentClassImpl.INTEGER;
-            case SSE -> ArgumentClassImpl.SSE;
-            case X87 -> ArgumentClassImpl.X87;
-            case COMPLEX_87 -> ArgumentClassImpl.COMPLEX_X87;
-            case POINTER -> ArgumentClassImpl.POINTER;
-            default -> null;
-        });
-    }
-
     public static VaList newVaListOfAddress(MemoryAddress ma) {
         return SysVVaList.ofAddress(ma);
     }

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/x64/sysv/TypeClass.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/x64/sysv/TypeClass.java
@@ -28,14 +28,13 @@ import jdk.incubator.foreign.GroupLayout;
 import jdk.incubator.foreign.MemoryLayout;
 import jdk.incubator.foreign.SequenceLayout;
 import jdk.incubator.foreign.ValueLayout;
+import jdk.internal.foreign.CValueLayout;
 import jdk.internal.foreign.Utils;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
-
-import static jdk.internal.foreign.abi.x64.sysv.SysVx64Linker.argumentClassFor;
 
 class TypeClass {
     enum Kind {
@@ -55,14 +54,13 @@ class TypeClass {
 
     public static TypeClass ofValue(ValueLayout layout) {
         final Kind kind;
-        ArgumentClassImpl argClass = classifyValueType(layout);
-        switch (argClass) {
-            case POINTER: kind = Kind.POINTER; break;
-            case INTEGER: kind = Kind.INTEGER; break;
-            case SSE: kind = Kind.FLOAT; break;
-            default:
-                throw new IllegalStateException();
-        }
+        ArgumentClassImpl argClass = argumentClassFor(layout);
+        kind = switch (argClass) {
+            case POINTER -> Kind.POINTER;
+            case INTEGER -> Kind.INTEGER;
+            case SSE -> Kind.FLOAT;
+            default -> throw new IllegalStateException("Unexpected argument class: " + argClass);
+        };
         return new TypeClass(kind, List.of(argClass));
     }
 
@@ -108,24 +106,21 @@ class TypeClass {
                 .collect(Collectors.toCollection(ArrayList::new));
     }
 
-    // TODO: handle '__int128' and 'long double'
-    private static ArgumentClassImpl classifyValueType(ValueLayout type) {
-        if (type.byteSize() > 8) {
-            throw new IllegalStateException("");
+    private static ArgumentClassImpl argumentClassFor(MemoryLayout layout) {
+        if (!(layout instanceof CValueLayout)) {
+            throw new IllegalStateException("Unexpected value layout: could not determine ABI class");
         }
-        ArgumentClassImpl clazz = SysVx64Linker.argumentClassFor(type)
-                .orElseThrow(() -> new IllegalStateException("Unexpected value layout: could not determine ABI class"));
-        return clazz;
+
+        return switch (((CValueLayout) layout).kind()) {
+            case CHAR, SHORT, INT, LONG, LONGLONG -> ArgumentClassImpl.INTEGER;
+            case FLOAT, DOUBLE -> ArgumentClassImpl.SSE;
+            case LONGDOUBLE -> ArgumentClassImpl.X87;
+            case POINTER -> ArgumentClassImpl.POINTER;
+        };
     }
 
     // TODO: handle zero length arrays
     private static List<ArgumentClassImpl> classifyStructType(GroupLayout type) {
-        if (argumentClassFor(type)
-                .filter(argClass -> argClass == ArgumentClassImpl.COMPLEX_X87)
-                .isPresent()) {
-            return COMPLEX_X87_CLASSES;
-        }
-
         List<ArgumentClassImpl>[] eightbytes = groupByEightBytes(type);
         long nWords = eightbytes.length;
         if (nWords > MAX_AGGREGATE_REGS_SIZE) {
@@ -230,7 +225,7 @@ class TypeClass {
             }
             // if the aggregate contains unaligned fields, it has class MEMORY
             ArgumentClassImpl argumentClass = (offset % l.byteAlignment()) == 0 ?
-                    classifyValueType((ValueLayout)l) :
+                    argumentClassFor(l) :
                     ArgumentClassImpl.MEMORY;
             layouts.add(argumentClass);
         } else {

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/x64/windows/Windowsx64Linker.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/x64/windows/Windowsx64Linker.java
@@ -98,10 +98,6 @@ public class Windowsx64Linker implements CLinker {
         return UpcallStubs.upcallAddress(CallArranger.arrangeUpcall(target, target.type(), function));
     }
 
-    static Win64.ArgumentClass argumentClassFor(MemoryLayout layout) {
-        return (Win64.ArgumentClass)layout.attribute(Win64.CLASS_ATTRIBUTE_NAME).get();
-    }
-
     public static VaList newVaListOfAddress(MemoryAddress ma) {
         return WinVaList.ofAddress(ma);
     }

--- a/test/jdk/java/foreign/NativeTestHelper.java
+++ b/test/jdk/java/foreign/NativeTestHelper.java
@@ -23,27 +23,15 @@
  */
 
 import jdk.incubator.foreign.MemoryLayout;
-import jdk.internal.foreign.CABI;
-
-import static jdk.internal.foreign.PlatformLayouts.*;
+import jdk.internal.foreign.CValueLayout;
 
 public class NativeTestHelper {
 
-    public static final CABI ABI = CABI.current();
-
     public static boolean isIntegral(MemoryLayout layout) {
-        return switch (ABI) {
-            case SysV -> layout.attribute(SysV.CLASS_ATTRIBUTE_NAME).get() == SysV.ArgumentClass.INTEGER;
-            case Win64 -> layout.attribute(Win64.CLASS_ATTRIBUTE_NAME).get() == Win64.ArgumentClass.INTEGER;
-            case AArch64 -> layout.attribute(AArch64.CLASS_ATTRIBUTE_NAME).get() == AArch64.ArgumentClass.INTEGER;
-        };
+        return ((CValueLayout) layout).kind().isIntergral();
     }
 
     public static boolean isPointer(MemoryLayout layout) {
-        return switch (ABI) {
-            case SysV -> layout.attribute(SysV.CLASS_ATTRIBUTE_NAME).get() == SysV.ArgumentClass.POINTER;
-            case Win64 -> layout.attribute(Win64.CLASS_ATTRIBUTE_NAME).get() == Win64.ArgumentClass.POINTER;
-            case AArch64 -> layout.attribute(AArch64.CLASS_ATTRIBUTE_NAME).get() == AArch64.ArgumentClass.POINTER;
-        };
+        return ((CValueLayout) layout).kind().isPointer();
     }
 }

--- a/test/jdk/java/foreign/TestCondy.java
+++ b/test/jdk/java/foreign/TestCondy.java
@@ -1,0 +1,86 @@
+/*
+ *  Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ *  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ *  This code is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License version 2 only, as
+ *  published by the Free Software Foundation.
+ *
+ *  This code is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ *  version 2 for more details (a copy is included in the LICENSE file that
+ *  accompanied this code).
+ *
+ *  You should have received a copy of the GNU General Public License version
+ *  2 along with this work; if not, write to the Free Software Foundation,
+ *  Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ *  Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ *  or visit www.oracle.com if you need additional information or have any
+ *  questions.
+ */
+
+/*
+ * @test
+ *
+ * @run testng TestCondy
+ */
+
+import jdk.incubator.foreign.FunctionDescriptor;
+import jdk.incubator.foreign.MemoryLayout;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.lang.constant.Constable;
+import java.lang.constant.ConstantDesc;
+import java.lang.invoke.MethodHandles;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static jdk.incubator.foreign.CLinker.*;
+import static org.testng.Assert.assertEquals;
+
+public class TestCondy {
+
+    @Test(dataProvider = "constables")
+    public void testPublicResolve(Constable constable) throws ReflectiveOperationException {
+        ConstantDesc desc = constable.describeConstable().orElseThrow();
+        Object result = desc.resolveConstantDesc(MethodHandles.publicLookup());
+        assertEquals(result, constable);
+    }
+
+
+    private static final MemoryLayout[] constants = {
+        C_CHAR,
+        C_SHORT,
+        C_INT,
+        C_LONG,
+        C_LONGLONG,
+        C_FLOAT,
+        C_DOUBLE,
+        C_LONGDOUBLE,
+        C_POINTER
+    };
+
+    @DataProvider
+    public static Object[][] constables() {
+        List<Constable> testValues = new ArrayList<>();
+
+        testValues.addAll(Arrays.asList(constants));
+
+        testValues.add(MemoryLayout.ofStruct(constants));
+        testValues.add(MemoryLayout.ofUnion(constants));
+
+        for (MemoryLayout ml : constants) {
+            testValues.add(MemoryLayout.ofSequence(ml));
+            testValues.add(MemoryLayout.ofSequence(10, ml));
+        }
+
+        testValues.add(FunctionDescriptor.ofVoid(constants));
+        testValues.add(FunctionDescriptor.of(C_CHAR, constants));
+
+        return testValues.stream().map(e -> new Object[] { e }).toArray(Object[][]::new);
+    }
+}

--- a/test/jdk/java/foreign/TestLayoutEquality.java
+++ b/test/jdk/java/foreign/TestLayoutEquality.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+/*
+ * @test
+ * @modules jdk.incubator.foreign/jdk.internal.foreign
+ *
+ * @run testng TestLayoutEquality
+ */
+
+import jdk.incubator.foreign.MemoryLayout;
+import jdk.incubator.foreign.ValueLayout;
+import jdk.internal.foreign.PlatformLayouts;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.testng.Assert.*;
+
+public class TestLayoutEquality {
+
+    @Test(dataProvider = "layoutConstants")
+    public void testReconstructedEquality(ValueLayout layout) {
+        ValueLayout newLayout = MemoryLayout.ofValueBits(layout.bitSize(), layout.order());
+
+        // properties should be equal
+        assertEquals(newLayout.bitSize(), layout.bitSize());
+        assertEquals(newLayout.bitAlignment(), layout.bitAlignment());
+        assertEquals(newLayout.name(), layout.name());
+        assertEquals(newLayout.attributes().toArray().length, 0);
+        assertEquals(layout.attributes().toArray().length, 0);
+
+        // but equals should return false, because one is a CValueLayout
+        assertNotEquals(newLayout, layout);
+    }
+
+    @DataProvider
+    public static Object[][] layoutConstants() throws ReflectiveOperationException {
+        List<ValueLayout> testValues = new ArrayList<>();
+
+        addLayoutConstants(testValues, PlatformLayouts.SysV.class);
+        addLayoutConstants(testValues, PlatformLayouts.Win64.class);
+        addLayoutConstants(testValues, PlatformLayouts.AArch64.class);
+
+        return testValues.stream().map(e -> new Object[]{ e }).toArray(Object[][]::new);
+    }
+
+    private static void addLayoutConstants(List<ValueLayout> testValues, Class<?> cls) throws ReflectiveOperationException {
+        for (Field f : cls.getFields()) {
+            if (f.getName().startsWith("C_"))
+                testValues.add((ValueLayout) f.get(null));
+        }
+    }
+
+}


### PR DESCRIPTION
Hi,

This patch removes ABI attributes, and replaces them with a custom ValueLayout subtype, called CValueLayout.

This, for one, allows us to override the describeConstable method to return a dynamic constant descriptor that will load the public constant field in CLinker. This avoids getting illegal access errors when trying to resolve the internal ABI attributes. The illegal access error was forcing clients, like jextract, to basically re-implement the describeConstable methods for FunctionDescriptor, GroupLayout, SequenceLayout and ValueLayout in order the 'cannonicalize' these constant descriptors to reference the fields.

Most of the needed changes were in the TypeClass classes, which now need to map the CValueLayout.Kind into the appropriate ABI classes (though doing this was pretty straight forward).

I've also added a test to make sure it is possible to resolve constant descriptors with these CValueLayouts inside with a public Lookup object.

Thanks,
Jorn

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [JDK-8253255](https://bugs.openjdk.java.net/browse/JDK-8253255): Investigate replacing ABI layout attributes with custom subtypes of ValueLayout


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.java.net/census#mcimadamore) (@mcimadamore - Committer)


### Download
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/358/head:pull/358`
`$ git checkout pull/358`
