### PR TITLE
8253798: Simplify ClassConstantHelper

### DIFF
--- a/src/jdk.incubator.jextract/share/classes/jdk/incubator/jextract/Type.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/incubator/jextract/Type.java
@@ -30,7 +30,6 @@ import jdk.incubator.foreign.CLinker;
 import jdk.incubator.foreign.FunctionDescriptor;
 import jdk.incubator.foreign.MemoryLayout;
 import jdk.internal.jextract.impl.LayoutUtils;
-import jdk.internal.jextract.impl.LayoutUtils.CanonicalABIType;
 import jdk.internal.jextract.impl.TypeImpl;
 
 import java.util.List;
@@ -39,8 +38,6 @@ import java.util.OptionalLong;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-
-import static jdk.internal.jextract.impl.LayoutUtils.CANONICAL_FIELD;
 
 /**
  * Instances of this class are used to model types in the foreign language.
@@ -98,11 +95,11 @@ public interface Type {
             /**
              * {@code Bool} type.
              */
-            Bool("_Bool", CLinker.C_CHAR.withAttribute(CANONICAL_FIELD, CanonicalABIType.C_CHAR)),
+            Bool("_Bool", CLinker.C_CHAR),
             /**
              * {@code char} type.
              */
-            Char("char", CLinker.C_CHAR.withAttribute(CANONICAL_FIELD, CanonicalABIType.C_CHAR)),
+            Char("char", CLinker.C_CHAR),
             /**
              * {@code char16} type.
              */
@@ -114,19 +111,19 @@ public interface Type {
             /**
              * {@code short} type.
              */
-            Short("short", CLinker.C_SHORT.withAttribute(CANONICAL_FIELD, CanonicalABIType.C_SHORT)),
+            Short("short", CLinker.C_SHORT),
             /**
              * {@code int} type.
              */
-            Int("int", CLinker.C_INT.withAttribute(CANONICAL_FIELD, CanonicalABIType.C_INT)),
+            Int("int", CLinker.C_INT),
             /**
              * {@code long} type.
              */
-            Long("long", CLinker.C_LONG.withAttribute(CANONICAL_FIELD, CanonicalABIType.C_LONG)),
+            Long("long", CLinker.C_LONG),
             /**
              * {@code long long} type.
              */
-            LongLong("long long", CLinker.C_LONGLONG.withAttribute(CANONICAL_FIELD, CanonicalABIType.C_LONGLONG)),
+            LongLong("long long", CLinker.C_LONGLONG),
             /**
              * {@code int128} type.
              */
@@ -134,15 +131,15 @@ public interface Type {
             /**
              * {@code float} type.
              */
-            Float("float", CLinker.C_FLOAT.withAttribute(CANONICAL_FIELD, CanonicalABIType.C_FLOAT)),
+            Float("float", CLinker.C_FLOAT),
             /**
              * {@code double} type.
              */
-            Double("double",CLinker.C_DOUBLE.withAttribute(CANONICAL_FIELD, CanonicalABIType.C_DOUBLE)),
+            Double("double",CLinker.C_DOUBLE),
             /**
              * {@code long double} type.
              */
-            LongDouble("long double", CLinker.C_LONGDOUBLE.withAttribute(CANONICAL_FIELD, CanonicalABIType.C_LONGDOUBLE)),
+            LongDouble("long double", CLinker.C_LONGDOUBLE),
             /**
              * {@code float128} type.
              */

--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/ClassConstantHelper.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/ClassConstantHelper.java
@@ -25,15 +25,11 @@
 package jdk.internal.jextract.impl;
 
 import jdk.incubator.foreign.FunctionDescriptor;
-import jdk.incubator.foreign.GroupLayout;
 import jdk.incubator.foreign.LibraryLookup;
 import jdk.incubator.foreign.MemoryAddress;
 import jdk.incubator.foreign.MemoryHandles;
 import jdk.incubator.foreign.MemoryLayout;
 import jdk.incubator.foreign.MemorySegment;
-import jdk.incubator.foreign.SequenceLayout;
-import jdk.incubator.foreign.ValueLayout;
-import jdk.internal.jextract.impl.LayoutUtils.CanonicalABIType;
 import jdk.internal.org.objectweb.asm.ClassWriter;
 import jdk.internal.org.objectweb.asm.ConstantDynamic;
 import jdk.internal.org.objectweb.asm.Handle;
@@ -44,7 +40,6 @@ import javax.tools.JavaFileObject;
 import java.lang.constant.ClassDesc;
 import java.lang.constant.Constable;
 import java.lang.constant.ConstantDesc;
-import java.lang.constant.ConstantDescs;
 import java.lang.constant.DirectMethodHandleDesc;
 import java.lang.constant.DirectMethodHandleDesc.Kind;
 import java.lang.constant.DynamicConstantDesc;
@@ -54,19 +49,14 @@ import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodType;
 import java.lang.invoke.VarHandle;
 import java.net.URI;
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.function.Consumer;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import static java.lang.constant.ConstantDescs.*;
 import static java.lang.invoke.MethodHandleInfo.*;
 import static java.lang.invoke.MethodType.methodType;
-import static jdk.internal.jextract.impl.LayoutUtils.CANONICAL_FIELD;
 import static jdk.internal.org.objectweb.asm.Opcodes.*;
 
 // generates ConstantHelper as java .class directly
@@ -75,11 +65,6 @@ class ClassConstantHelper implements ConstantHelper {
     private static final String INTR_OBJECT = Type.getInternalName(Object.class);
 
     private static final ClassDesc CD_LIBRARIES = desc(LibraryLookup[].class);
-    private static final ClassDesc CD_MEMORY_LAYOUT = desc(MemoryLayout.class);
-    private static final ClassDesc CD_Constable = desc(Constable.class);
-    private static final ClassDesc CD_GROUP_LAYOUT = desc(GroupLayout.class);
-    private static final ClassDesc CD_SEQUENCE_LAYOUT = desc(SequenceLayout.class);
-    private static final ClassDesc CD_FUNCTION_DESC = desc(FunctionDescriptor.class);
 
     private static final DirectMethodHandleDesc MH_MemoryLayout_varHandle = MethodHandleDesc.ofMethod(
             Kind.INTERFACE_VIRTUAL,
@@ -307,127 +292,7 @@ class ClassConstantHelper implements ConstantHelper {
 
     @SuppressWarnings("unchecked")
     private static <T extends ConstantDesc> T desc(Constable constable) {
-        if (constable instanceof MemoryLayout) {
-            return (T) describeLayout((MemoryLayout) constable);
-        } else if (constable instanceof FunctionDescriptor) {
-            return (T) describeDescriptor((FunctionDescriptor) constable);
-        }
-
         return (T) constable.describeConstable().orElseThrow();
-    }
-
-    private static final MethodHandleDesc MH_VOID_FUNCTION
-        = MethodHandleDesc.ofMethod(DirectMethodHandleDesc.Kind.STATIC, CD_FUNCTION_DESC, "ofVoid",
-                MethodTypeDesc.of(CD_FUNCTION_DESC, CD_MEMORY_LAYOUT.arrayType()));
-
-    private static final MethodHandleDesc MH_FUNCTION
-        = MethodHandleDesc.ofMethod(DirectMethodHandleDesc.Kind.STATIC, CD_FUNCTION_DESC, "of",
-                MethodTypeDesc.of(CD_FUNCTION_DESC, CD_MEMORY_LAYOUT, CD_MEMORY_LAYOUT.arrayType()));
-
-    private static ConstantDesc describeDescriptor(FunctionDescriptor descriptor) {
-        List<ConstantDesc> constants = new ArrayList<>();
-        boolean hasReturn = descriptor.returnLayout().isPresent();
-        constants.add(hasReturn ? MH_FUNCTION : MH_VOID_FUNCTION);
-        if (hasReturn) {
-            constants.add(describeLayout(descriptor.returnLayout().get()));
-        }
-        for (MemoryLayout argLayout : descriptor.argumentLayouts()) {
-            constants.add(describeLayout(argLayout));
-        }
-        return DynamicConstantDesc.ofNamed(
-            ConstantDescs.BSM_INVOKE, "function", CD_FUNCTION_DESC, constants.toArray(ConstantDesc[]::new));
-    }
-
-    private static ConstantDesc describeLayout(MemoryLayout layout) {
-        if (layout instanceof GroupLayout) {
-            return describeGroupLayout((GroupLayout) layout);
-        } else if (layout instanceof SequenceLayout) {
-            return describeSequenceLayout((SequenceLayout) layout);
-        } else if(layout instanceof ValueLayout) {
-            return describeValueLayout((ValueLayout) layout);
-        }
-
-        return layout.describeConstable().orElseThrow();
-    }
-
-    private static final MethodHandleDesc MH_WITH_BIT_ALIGNMENT
-        = MethodHandleDesc.ofMethod(DirectMethodHandleDesc.Kind.INTERFACE_VIRTUAL, CD_MEMORY_LAYOUT, "withBitAlignment",
-                MethodTypeDesc.of(CD_MEMORY_LAYOUT, CD_long));
-
-    private static final MethodHandleDesc MH_WITH_ATTRIBUTE
-        = MethodHandleDesc.ofMethod(DirectMethodHandleDesc.Kind.INTERFACE_VIRTUAL, CD_MEMORY_LAYOUT, "withAttribute",
-                MethodTypeDesc.of(CD_MEMORY_LAYOUT, CD_String, CD_Constable));
-
-    private static <T> DynamicConstantDesc<T> decorateLayoutConstant(MemoryLayout layout, DynamicConstantDesc<T> desc) {
-        return decorateLayoutConstant(layout, desc, layout.attributes());
-    }
-
-    private static <T> DynamicConstantDesc<T> decorateLayoutConstant(MemoryLayout layout, DynamicConstantDesc<T> desc,
-                                                                     Stream<String> attributes) {
-        if (!hasNaturalAlignment(layout)) {
-            desc = DynamicConstantDesc.ofNamed(BSM_INVOKE, "withBitAlignment", desc.constantType(), MH_WITH_BIT_ALIGNMENT,
-                    desc, layout.bitAlignment());
-        }
-        for (String name : attributes.collect(Collectors.toList())) {
-            Constable value = layout.attribute(name).get();
-            desc = DynamicConstantDesc.ofNamed(BSM_INVOKE, "withAttribute", desc.constantType(), MH_WITH_ATTRIBUTE,
-                    desc, name, value.describeConstable().orElseThrow());
-        }
-
-        return desc;
-    }
-
-    private static boolean hasNaturalAlignment(MemoryLayout layout) {
-        return layout.hasSize() && layout.bitSize() == layout.bitAlignment();
-    }
-
-    private static final MethodHandleDesc MH_STRUCT
-        = MethodHandleDesc.ofMethod(DirectMethodHandleDesc.Kind.INTERFACE_STATIC, CD_MEMORY_LAYOUT, "ofStruct",
-                MethodTypeDesc.of(CD_GROUP_LAYOUT, CD_MEMORY_LAYOUT.arrayType()));
-
-    private static final MethodHandleDesc MH_UNION
-        = MethodHandleDesc.ofMethod(DirectMethodHandleDesc.Kind.INTERFACE_STATIC, CD_MEMORY_LAYOUT, "ofUnion",
-                MethodTypeDesc.of(CD_GROUP_LAYOUT, CD_MEMORY_LAYOUT.arrayType()));
-
-    private static ConstantDesc describeGroupLayout(GroupLayout layout) {
-        List<MemoryLayout> elements = layout.memberLayouts();
-        ConstantDesc[] constants = new ConstantDesc[1 + elements.size()];
-        constants[0] = layout.isStruct() ? MH_STRUCT : MH_UNION;
-        for (int i = 0 ; i < elements.size() ; i++) {
-            constants[i + 1] = describeLayout(elements.get(i));
-        }
-        return decorateLayoutConstant(layout, DynamicConstantDesc.ofNamed(
-                ConstantDescs.BSM_INVOKE, layout.isStruct() ? "struct" : "union",
-                CD_GROUP_LAYOUT, constants));
-    }
-
-    private static final MethodHandleDesc MH_SIZED_SEQUENCE
-        = MethodHandleDesc.ofMethod(DirectMethodHandleDesc.Kind.INTERFACE_STATIC, CD_MEMORY_LAYOUT, "ofSequence",
-                MethodTypeDesc.of(CD_SEQUENCE_LAYOUT, CD_long, CD_MEMORY_LAYOUT));
-
-    private static final MethodHandleDesc MH_UNSIZED_SEQUENCE
-         = MethodHandleDesc.ofMethod(DirectMethodHandleDesc.Kind.INTERFACE_STATIC, CD_MEMORY_LAYOUT, "ofSequence",
-                MethodTypeDesc.of(CD_SEQUENCE_LAYOUT, CD_MEMORY_LAYOUT));
-
-    private static ConstantDesc describeSequenceLayout(SequenceLayout layout) {
-        return decorateLayoutConstant(layout, layout.elementCount().isPresent() ?
-            DynamicConstantDesc.ofNamed(ConstantDescs.BSM_INVOKE, "value",
-                    CD_SEQUENCE_LAYOUT, MH_SIZED_SEQUENCE,
-                    layout.elementCount().getAsLong(), describeLayout(layout.elementLayout())) :
-            DynamicConstantDesc.ofNamed(ConstantDescs.BSM_INVOKE, "value",
-                    CD_SEQUENCE_LAYOUT, MH_UNSIZED_SEQUENCE,
-                    describeLayout(layout.elementLayout())));
-    }
-
-    private static ConstantDesc describeValueLayout(ValueLayout layout) {
-        Optional<Constable> constantNameOp = layout.attribute(CANONICAL_FIELD);
-        if (constantNameOp.isPresent()) {
-            CanonicalABIType canonicalABIType = (CanonicalABIType) constantNameOp.get();
-            return decorateLayoutConstant(layout, canonicalABIType.descriptor(),
-                layout.attributes().filter(attr -> !CANONICAL_FIELD.equals(attr) && !attr.startsWith("abi/")));
-        }
-
-        return layout.describeConstable().orElseThrow();
     }
 
     // ASM helpers

--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/LayoutUtils.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/LayoutUtils.java
@@ -26,28 +26,21 @@
 
 package jdk.internal.jextract.impl;
 
-import jdk.incubator.foreign.CLinker;
 import jdk.incubator.foreign.FunctionDescriptor;
 import jdk.incubator.foreign.MemoryLayout;
-import jdk.incubator.foreign.ValueLayout;
 import jdk.incubator.jextract.Type.Primitive;
 import jdk.internal.clang.Cursor;
 import jdk.internal.clang.Type;
 
-import java.lang.constant.DynamicConstantDesc;
 import java.util.Optional;
 import java.util.function.Supplier;
 
-import static java.lang.constant.ConstantDescs.BSM_GET_STATIC_FINAL;
+import static jdk.incubator.foreign.CLinker.C_POINTER;
 
 /**
  * General Layout utility functions
  */
 public final class LayoutUtils {
-    public static final String CANONICAL_FIELD = "jextract/constant_name";
-    private static final ValueLayout POINTER_LAYOUT = CLinker.C_POINTER
-            .withAttribute(CANONICAL_FIELD, CanonicalABIType.C_POINTER);
-
     private LayoutUtils() {}
 
     public static String getName(Type type) {
@@ -115,7 +108,7 @@ public final class LayoutUtils {
                 return getLayout(t.canonicalType());
             case Pointer:
             case BlockPointer:
-                return POINTER_LAYOUT;
+                return C_POINTER;
             default:
                 throw new UnsupportedOperationException("unsupported: " + t.kind());
         }
@@ -142,7 +135,7 @@ public final class LayoutUtils {
         @Override
         public MemoryLayout visitDelegated(jdk.incubator.jextract.Type.Delegated t, Void _ignored) {
             if (t.kind() == jdk.incubator.jextract.Type.Delegated.Kind.POINTER) {
-                return POINTER_LAYOUT;
+                return C_POINTER;
             } else {
                 return t.type().accept(this, null);
             }
@@ -213,36 +206,5 @@ public final class LayoutUtils {
             case 64 -> Primitive.Kind.LongLong;
             default -> throw new IllegalStateException("Cannot infer container layout");
         };
-    }
-
-    public enum CanonicalABIType {
-        C_CHAR(canonicalLayoutConstantDesc("C_CHAR")),
-        C_SHORT(canonicalLayoutConstantDesc("C_SHORT")),
-        C_INT(canonicalLayoutConstantDesc("C_INT")),
-        C_LONG(canonicalLayoutConstantDesc("C_LONG")),
-        C_LONGLONG(canonicalLayoutConstantDesc("C_LONGLONG")),
-        C_FLOAT(canonicalLayoutConstantDesc("C_FLOAT")),
-        C_DOUBLE(canonicalLayoutConstantDesc("C_DOUBLE")),
-        C_LONGDOUBLE(canonicalLayoutConstantDesc("C_LONGDOUBLE")),
-        C_POINTER(canonicalLayoutConstantDesc("C_POINTER"));
-
-        private final DynamicConstantDesc<ValueLayout> descriptor;
-
-        CanonicalABIType(DynamicConstantDesc<ValueLayout> descriptor) {
-            this.descriptor = descriptor;
-        }
-
-        public DynamicConstantDesc<ValueLayout> descriptor() {
-            return descriptor;
-        }
-
-        private static DynamicConstantDesc<ValueLayout> canonicalLayoutConstantDesc(String name) {
-            return DynamicConstantDesc.ofNamed(
-                BSM_GET_STATIC_FINAL,
-                name,
-                ValueLayout.class.describeConstable().orElseThrow(),
-                CLinker.class.describeConstable().orElseThrow()
-            );
-        }
     }
 }


### PR DESCRIPTION
Hi,

This patch removes a whole bunch of workarounds in jextract code, which are made possible by upstream changes to foreign-abi.

ClassConstantHelper no longer has to manually canonicalize MemoryLayout constant that represent layout constants in CLinker. This is now handled by the CValueLayout.describeConstable() override.

Making CValueLayout public also means we can remove the CanonicalField enum from jextract, and rely on the CValueLayout.Kind instead. (note that since the enum was internal, complex recursive filtering would be needed if we had kept it).

Thanks,
Jorn

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [JDK-8253798](https://bugs.openjdk.java.net/browse/JDK-8253798): Simplify ClassConstantHelper


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.java.net/census#mcimadamore) (@mcimadamore - Committer)


### Download
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/360/head:pull/360`
`$ git checkout pull/360`
