### PR TITLE
8253841: jextract --source mode is broken

### DIFF
--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/MultiFileConstantHelper.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/MultiFileConstantHelper.java
@@ -65,16 +65,16 @@ public class MultiFileConstantHelper implements ConstantHelper {
 
     private void checkNewConstantsClass() {
         if (constantCount > constantsPerClass) {
-            newConstantsClass(false, null);
+            newConstantsClass(false);
         }
         constantCount++;
     }
 
-    private void newConstantsClass(boolean isFinal, String nameOverride) {
+    private void newConstantsClass(boolean isFinal) {
         finishedClasses.addAll(delegate.build());
         String currentClassName = getConstantClassName();
         constantClassCount++;
-        String newClassName = nameOverride != null ? nameOverride : getConstantClassName();
+        String newClassName = getConstantClassName();
         delegate = delegateFactory.make(newClassName, currentClassName, isFinal);
         this.constantCount = 0;
     }
@@ -123,7 +123,7 @@ public class MultiFileConstantHelper implements ConstantHelper {
 
     @Override
     public List<JavaFileObject> build() {
-        newConstantsClass(true, headerClassName + "$constants");
+        newConstantsClass(true);
         return new ArrayList<>(finishedClasses);
     }
 }

--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/SourceConstantHelper.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/SourceConstantHelper.java
@@ -187,6 +187,11 @@ class SourceConstantHelper extends JavaSourceBuilder implements ConstantHelper {
         return List.of(result);
     }
 
+    @Override
+    protected String getClassModifiers() {
+        return "";
+    }
+
     protected void classBegin() {
         super.classBegin();
         if (superClass() == null) { // only for the first one


### PR DESCRIPTION
* left constant name is specially modified which is problematic.
* access flags for source constant classes should not be just ""

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [JDK-8253841](https://bugs.openjdk.java.net/browse/JDK-8253841): jextract --source mode is broken


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.java.net/census#mcimadamore) (@mcimadamore - Committer)


### Download
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/362/head:pull/362`
`$ git checkout pull/362`
