### PR TITLE
Investigate ways to make handoff-like operation more explicit (foreign-memacess edition)

### DIFF
--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/MemoryAddress.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/MemoryAddress.java
@@ -31,6 +31,8 @@ import jdk.internal.foreign.MemoryAddressImpl;
 import jdk.internal.foreign.NativeMemorySegmentImpl;
 import jdk.internal.foreign.Utils;
 
+import java.lang.ref.Cleaner;
+
 /**
  * A memory address models a reference into a memory location. Memory addresses are typically obtained using the
  * {@link MemorySegment#address()} method, and can refer to either off-heap or on-heap memory.
@@ -134,6 +136,9 @@ public interface MemoryAddress extends Addressable {
      * Calling {@link MemorySegment#close()} on the returned segment will <em>not</em> result in releasing any
      * memory resources which might implicitly be associated with the segment, but will result in calling the
      * provided cleanup action (if any).
+     * <p>
+     * Both the cleanup action and the attachment object (if any) will be preserved under terminal operations such as
+     * {@link MemorySegment#handoff(Thread)}, {@link MemorySegment#share()} and {@link MemorySegment#registerCleaner(Cleaner)}.
      * <p>
      * This method is <em>restricted</em>. Restricted methods are unsafe, and, if used incorrectly, their use might crash
      * the JVM or, worse, silently result in memory corruption. Thus, clients should refrain from depending on

--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/MemoryAddress.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/MemoryAddress.java
@@ -26,11 +26,10 @@
 
 package jdk.incubator.foreign;
 
+import jdk.internal.foreign.AbstractMemorySegmentImpl;
 import jdk.internal.foreign.MemoryAddressImpl;
 import jdk.internal.foreign.NativeMemorySegmentImpl;
 import jdk.internal.foreign.Utils;
-
-import java.util.Objects;
 
 /**
  * A memory address models a reference into a memory location. Memory addresses are typically obtained using the
@@ -89,8 +88,9 @@ public interface MemoryAddress extends Addressable {
     /**
      * Returns a new confined native memory segment with given size, and whose base address is this address; the returned segment has its own temporal
      * bounds, and can therefore be closed. This method can be useful when interacting with custom native memory sources (e.g. custom allocators),
-     * where an address to some underlying memory region is typically obtained from native code
-     * (often as a plain {@code long} value). The returned segment will feature all <a href="#access-modes">access modes</a>
+     * where an address to some underlying memory region is typically obtained from native code (often as a plain {@code long} value).
+     * <p>
+     * The returned segment will feature all <a href="#access-modes">access modes</a>
      * (see {@link MemorySegment#ALL_ACCESS}), and its confinement thread is the current thread (see {@link Thread#currentThread()}).
      * <p>
      * Clients should ensure that the address and bounds refers to a valid region of memory that is accessible for reading and,
@@ -98,20 +98,13 @@ public interface MemoryAddress extends Addressable {
      * have no visible effect, or cause an unspecified exception to be thrown.
      * <p>
      * Calling {@link MemorySegment#close()} on the returned segment will <em>not</em> result in releasing any
-     * memory resources which might implicitly be associated with the segment. If the client wants to specify
-     * a cleanup action to be executed when the returned segment is closed, the {@link MemorySegment#withCleanupAction(Runnable)}
-     * method should be used.
-     * <p>
-     * Equivalent to the following code:
+     * memory resources which might implicitly be associated with the segment. This method is equivalent to the following code:
      * <pre>{@code
-    asSegmentRestricted(byteSize, null);
+    asSegmentRestricted(byteSize, null, null);
      * }</pre>
-     * <p>
      * This method is <em>restricted</em>. Restricted methods are unsafe, and, if used incorrectly, their use might crash
      * the JVM or, worse, silently result in memory corruption. Thus, clients should refrain from depending on
      * restricted methods, and use safe and supported functionalities, where possible.
-     *
-     * @see #asSegmentRestricted(long, Object)
      *
      * @param bytesSize the desired size.
      * @return a new confined native memory segment with given base address and size.
@@ -121,34 +114,33 @@ public interface MemoryAddress extends Addressable {
      * {@code permit}, {@code warn} or {@code debug} (the default value is set to {@code deny}).
      */
     default MemorySegment asSegmentRestricted(long bytesSize) {
-        return asSegmentRestricted(bytesSize, null);
+        return asSegmentRestricted(bytesSize, null, null);
     }
 
     /**
      * Returns a new confined native memory segment with given size, and whose base address is this address; the returned segment has its own temporal
      * bounds, and can therefore be closed. This method can be useful when interacting with custom native memory sources (e.g. custom allocators),
-     * where an address to some underlying memory region is typically obtained from native code
-     * (often as a plain {@code long} value).
+     * where an address to some underlying memory region is typically obtained from native code (often as a plain {@code long} value).
+     * <p>
+     * The returned segment will feature all <a href="#access-modes">access modes</a>
+     * (see {@link MemorySegment#ALL_ACCESS}), and its confinement thread is the current thread (see {@link Thread#currentThread()}).
+     * Moreover, the returned segment will keep a strong reference to the supplied attachment object (if any), which can
+     * be useful in cases where the lifecycle of the segment is dependent on that of some other external resource.
      * <p>
      * Clients should ensure that the address and bounds refers to a valid region of memory that is accessible for reading and,
      * if appropriate, writing; an attempt to access an invalid memory location from Java code will either return an arbitrary value,
      * have no visible effect, or cause an unspecified exception to be thrown.
      * <p>
-     * The returned segment will feature all <a href="#access-modes">access modes</a>
-     * (see {@link MemorySegment#ALL_ACCESS}), and its confinement thread is the current thread (see {@link Thread#currentThread()}).
-     * Moreover, the returned segment will keep a strong reference to the supplied attachment object, which can
-     * be useful in cases where the lifecycle of the segment is dependent on that of some other external resource.
-     * <p>
      * Calling {@link MemorySegment#close()} on the returned segment will <em>not</em> result in releasing any
-     * memory resources which might implicitly be associated with the segment. If the client wants to specify
-     * a cleanup action to be executed when the returned segment is closed, the {@link MemorySegment#withCleanupAction(Runnable)}
-     * method should be used.
+     * memory resources which might implicitly be associated with the segment, but will result in calling the
+     * provided cleanup action (if any).
      * <p>
      * This method is <em>restricted</em>. Restricted methods are unsafe, and, if used incorrectly, their use might crash
      * the JVM or, worse, silently result in memory corruption. Thus, clients should refrain from depending on
      * restricted methods, and use safe and supported functionalities, where possible.
      *
      * @param bytesSize the desired size.
+     * @param cleanupAction the cleanup action; can be {@code null}.
      * @param attachment an attachment object that will be kept strongly reachable by the returned segment; can be {@code null}.
      * @return a new confined native memory segment with given base address and size.
      * @throws IllegalArgumentException if {@code bytesSize <= 0}.
@@ -156,13 +148,7 @@ public interface MemoryAddress extends Addressable {
      * @throws IllegalAccessError if the runtime property {@code foreign.restricted} is not set to either
      * {@code permit}, {@code warn} or {@code debug} (the default value is set to {@code deny}).
      */
-    default MemorySegment asSegmentRestricted(long bytesSize, Object attachment) {
-        Utils.checkRestrictedAccess("MemoryAddress.asSegmentRestricted");
-        if (bytesSize <= 0) {
-            throw new IllegalArgumentException("Invalid size : " + bytesSize);
-        }
-        return NativeMemorySegmentImpl.makeNativeSegmentUnchecked(this, bytesSize, attachment);
-    }
+    MemorySegment asSegmentRestricted(long bytesSize, Runnable cleanupAction, Object attachment);
 
     /**
      * Returns the raw long value associated with this memory address.

--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/MemorySegment.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/MemorySegment.java
@@ -408,7 +408,6 @@ public interface MemorySegment extends Addressable, AutoCloseable {
      *
      * @param thread the new owner thread
      * @return a new confined memory segment whose owner thread is set to {@code thread}.
-     * characteristics have been modified, according to the supplied {@code handoffTransform}.
      * @throws IllegalStateException if this segment is not <em>alive</em>, or if access occurs from a thread other than the
      * thread owning this segment.
      * @throws UnsupportedOperationException if this segment does not support the {@link #HANDOFF} access mode.
@@ -445,6 +444,9 @@ public interface MemorySegment extends Addressable, AutoCloseable {
      * <p>
      * This is a <em>terminal operation</em>; as a side-effect, this segment will be
      * marked as <em>not alive</em>, and subsequent operations on this segment will fail with {@link IllegalStateException}.
+     * <p>
+     * The implicit deallocation behavior associated with the returned segment will be preserved under terminal
+     * operations such as {@link #handoff(Thread)} and {@link #share()}.
      *
      * @param cleaner the cleaner object, responsible for implicit deallocation of the returned segment.
      * @return a new memory segment backed by the same underlying memory region as this segment, which features

--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/MemorySegment.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/MemorySegment.java
@@ -55,7 +55,7 @@ import java.util.function.Consumer;
  * <p>
  * Non-platform classes should not implement {@linkplain MemorySegment} directly.
  *
- * <h2>Constructing memory segments from different sources</h2>
+ * <h2>Constructing memory segments</h2>
  *
  * There are multiple ways to obtain a memory segment. First, memory segments backed by off-heap memory can
  * be allocated using one of the many factory methods provided (see {@link MemorySegment#allocateNative(MemoryLayout)},
@@ -85,7 +85,7 @@ import java.util.function.Consumer;
  * associated with such segments remain inaccessible, and that said memory sources are never aliased by more than one segment
  * at a time - e.g. so as to prevent concurrent modifications of the contents of an array, or buffer segment.
  *
- * <h2>Closing a memory segment</h2>
+ * <h2>Explicit deallocation</h2>
  *
  * Memory segments are closed explicitly (see {@link MemorySegment#close()}). When a segment is closed, it is no longer
  * <em>alive</em> (see {@link #isAlive()}, and subsequent operation on the segment (or on any {@link MemoryAddress} instance
@@ -102,10 +102,6 @@ import java.util.function.Consumer;
  *     these segments are discarded in a timely manner, so as not to prevent garbage collection to reclaim the underlying
  *     objects.</li>
  * </ul>
- *
- * Clients can register a memory segment against a {@link Cleaner}, to make sure that underlying resources associated with
- * that segment will be released when the segment becomes <em>unreachable</em> (see {@link #registerCleaner(Cleaner)});
- * this might be useful to prevent native memory leaks.
  *
  * <h2><a id = "access-modes">Access modes</a></h2>
  *
@@ -149,28 +145,65 @@ MemorySegment roSegment = segment.withAccessModes(segment.accessModes() & ~WRITE
  * the segment using a memory access var handle. Any attempt to perform such operations from a thread other than the
  * owner thread will result in a runtime failure.
  * <p>
- * Memory segments support <em>serial thread confinement</em>; that is, ownership of a memory segment can change (see
- * {@link #withOwnerThread(Thread)}). This allows, for instance, for two threads {@code A} and {@code B} to share
- * a segment in a controlled, cooperative and race-free fashion.
+ * The {@link #handoff(Thread)} method can be used to change the thread-confinement properties of a memory segment.
+ * This method is, like {@link #close()}, a <em>terminal operation</em> which marks the original segment as not alive
+ * (see {@link #isAlive()}) and creates a <em>new</em> segment with the desired thread-confinement properties. Calling
+ * {@link #handoff(Thread)} is only possible if the segment features the corresponding {@link #HANDOFF} access mode.
  * <p>
- * In some cases, it might be useful for multiple threads to process the contents of the same memory segment concurrently
- * (e.g. in the case of parallel processing); while memory segments provide strong confinement guarantees, it is possible
- * to derive a <em>shared</em> segment from a confined one. This can be done again, by calling {@link #withOwnerThread(Thread)},
- * and passing a {@code null} owner segment (this assumes that the access mode {@link #SHARE} of the original segment is set).
- * For instance, a client might obtain a {@link Spliterator} from a shared segment, which can then be used to slice the
- * segment and allow multiple thread to work in parallel on disjoint segment slices.
- * For instance, the following code can be used to sum all int values in a memory segment in parallel:
+ * For instance, if a client wants to transfer ownership of a segment to another (known) thread, it can do so as follows:
+ *
+ * <blockquote><pre>{@code
+MemorySegment segment = ...
+MemorySegment aSegment = segment.handoff(threadA);
+ * }</pre></blockquote>
+ *
+ * By doing so, the original segment is marked as not alive, and a new segment is returned whose owner thread
+ * is {@code threadA}; this allows, for instance, for two threads {@code A} and {@code B} to share
+ * a segment in a controlled, cooperative and race-free fashion (also known as <em>serial thread confinement</em>).
+ * <p>
+ * Alternatively, the {@link #share()} method can be used to remove thread ownership altogether; this is only possible
+ * if the segment features the corresponding {@link #SHARE} access mode. The following code shows how clients can
+ * obtain a shared segment:
+ *
+ * <blockquote><pre>{@code
+MemorySegment segment = ...
+MemorySegment sharedSegment = segment.share();
+ * }</pre></blockquote>
+ *
+ * Again here, the original segment is marked as not alive, and a new <em>shared</em> segment is returned which features no owner
+ * thread (e.g. {@link #ownerThread()} returns {@code null}). This might be useful when multiple threads need to process
+ * the contents of the same memory segment concurrently (e.g. in the case of parallel processing). For instance, a client
+ * might obtain a {@link Spliterator} from a shared segment, which can then be used to slice the segment and allow multiple
+ * threads to work in parallel on disjoint segment slices. The following code can be used to sum all int values in a memory segment in parallel:
+ *
  * <blockquote><pre>{@code
 SequenceLayout SEQUENCE_LAYOUT = MemoryLayout.ofSequence(1024, MemoryLayouts.JAVA_INT);
-try (MemorySegment segment = MemorySegment.allocateNative(SEQUENCE_LAYOUT).withOwnerThread(null)) {
+try (MemorySegment segment = MemorySegment.allocateNative(SEQUENCE_LAYOUT).share()) {
     VarHandle VH_int = SEQUENCE_LAYOUT.elementLayout().varHandle(int.class);
     int sum = StreamSupport.stream(MemorySegment.spliterator(segment, SEQUENCE_LAYOUT), true)
                            .mapToInt(s -> (int)VH_int.get(s.address()))
                            .sum();
 }
  * }</pre></blockquote>
- * Once shared, a segment can be claimed back by a given thread (see {@link #withOwnerThread(Thread)}); in fact, many threads
+ *
+ * Once shared, a segment can be claimed back by a given thread (again using {@link #handoff(Thread)}); in fact, many threads
  * can attempt to gain ownership of the same segment, concurrently, and only one of them is guaranteed to succeed.
+ *
+ * <h2>Implicit deallocation</h2>
+ *
+ * Clients can register a memory segment against a {@link Cleaner}, to make sure that underlying resources associated with
+ * that segment will be released when the segment becomes <em>unreachable</em>, which can be useful to prevent native memory
+ * leaks. This can be achieved using the {@link #registerCleaner(Cleaner)} method, as follows:
+ *
+ * <blockquote><pre>{@code
+MemorySegment segment = ...
+MemorySegment gcSegment = segment.registerCleaner(cleaner);
+ * }</pre></blockquote>
+ *
+ * Here, the original segment is marked as not alive, and a new segment is returned (the owner thread of the returned
+ * segment set is set to that of the current thread, see {@link #ownerThread()}); the new segment
+ * will also be registered with the the {@link Cleaner} instance provided to the {@link #registerCleaner(Cleaner)} method;
+ * as such, if not closed explicitly (see {@link #close()}), the new segment will be automatically closed by the cleaner.
  *
  * @apiNote In the future, if the Java language permits, {@link MemorySegment}
  * may become a {@code sealed} interface, which would prohibit subclassing except by
@@ -193,20 +226,6 @@ public interface MemorySegment extends Addressable, AutoCloseable {
     MemoryAddress address();
 
     /**
-     * Register this memory segment instance against a {@link Cleaner} object. This allows for the segment to be closed
-     * as soon as it becomes <em>unreachable</em>, which might be helpful in preventing native memory leaks.
-     * @apiNote Calling this method multiple times, even concurrently (from multiple threads, if this segment is shared)
-     * is allowed; the implementation guarantees that the memory resources associated with this segment will be released
-     * at most once. Also, in case the segment has been closed explicitly (see {@link #close}) no further action will be
-     * taken by the GC when the segment later becomes unreachable.
-     * @param cleaner the {@link Cleaner} object responsible for cleaning up this memory segment.
-     * @throws IllegalStateException if this segment is not <em>alive</em>, or if access occurs from a thread other than the
-     * thread owning this segment
-     * @throws UnsupportedOperationException if this segment does not feature the {@link #CLOSE} access mode.
-     */
-    void registerCleaner(Cleaner cleaner);
-
-    /**
      * Returns a spliterator for the given memory segment. The returned spliterator reports {@link Spliterator#SIZED},
      * {@link Spliterator#SUBSIZED}, {@link Spliterator#IMMUTABLE}, {@link Spliterator#NONNULL} and {@link Spliterator#ORDERED}
      * characteristics.
@@ -218,7 +237,7 @@ public interface MemorySegment extends Addressable, AutoCloseable {
      * <a href="#access-modes">access modes</a> as the given segment less the {@link #CLOSE} access mode.
      * <p>
      * The returned spliterator effectively allows to slice a segment into disjoint sub-segments, which can then
-     * be processed in parallel by multiple threads (if the access mode {@link #SHARE} is set).
+     * be processed in parallel by multiple threads (if the segment is shared).
      * While closing the segment (see {@link #close()}) during pending concurrent execution will generally
      * fail with an exception, it is possible to close a segment when a spliterator has been obtained but no thread
      * is actively working on it using {@link Spliterator#tryAdvance(Consumer)}; in such cases, any subsequent call
@@ -239,50 +258,6 @@ public interface MemorySegment extends Addressable, AutoCloseable {
      * @return the thread owning this segment.
      */
     Thread ownerThread();
-
-    /**
-     * Obtains a new memory segment backed by the same underlying memory region as this segment,
-     * but with different owner thread. As a side-effect, this segment will be marked as <em>not alive</em>,
-     * and subsequent operations on this segment will result in runtime errors.
-     *<p>If {@code newOwner} is {@code != null}, then the resulting segment will
-     * be a confined segment, whose owner thread is {@code newOwner}. Otherwise, the resulting segment will be
-     * a shared segment, and will be accessible concurrently from multiple threads.
-     * <p>
-     * Write accesses to the segment's content <a href="../../../java/util/concurrent/package-summary.html#MemoryVisibility"><i>happens-before</i></a>
-     * hand-over from the current owner thread to the new owner thread, which in turn <i>happens before</i> read accesses to the segment's contents on
-     * the new owner thread.
-     *
-     * @param newOwner the new owner thread (can be {@code null}).
-     * @return a new memory segment backed by the same underlying memory region as this segment; the new segment can
-     * be either a confined segment ({@code newOwner != null}) or a shared segment ({@code newOwner == null}).
-     * @throws IllegalStateException if this segment is not <em>alive</em>, or if access occurs from a thread other than the
-     * thread owning this segment.
-     * @throws IllegalArgumentException if the segment is already a confined segment owner by {@code newOnwer}
-     * @throws UnsupportedOperationException if {@code newOwner != null} and this segment does not support the {@link #HANDOFF} access mode,
-     * or if {@code newOwner == null} and this segment does not support the {@link #SHARE} access mode.
-     */
-    MemorySegment withOwnerThread(Thread newOwner);
-
-    /**
-     * Obtains a new memory segment backed by the same underlying memory region as this segment, and featuring
-     * the same confinement thread (see {@link #ownerThread()} and access modes (see {@link #accessModes()}),
-     * but with a different cleanup action. More specifically, the cleanup action associated with the returned segment will
-     * first call the user-provided action, before delegating back to the original cleanup action associated with
-     * this segment (if any). Any errors and/or exceptions thrown by the user-provided action will be discarded, and will not prevent the
-     * release of any memory resources associated with this segment.
-     * <p>
-     * As a side-effect, this segment will be marked as <em>not alive</em>,
-     * and subsequent operations on this segment will result in runtime errors.
-     *
-     * @param action the new cleanup action
-     * @return a new memory segment backed by the same underlying memory region as this segment; the cleanup action
-     * associated with the new segment is the result of composing this segment's cleanup action with the
-     * supplied {@code action}.
-     * @throws IllegalStateException if this segment is not <em>alive</em>, or if access occurs from a thread other than the
-     * thread owning this segment.
-     * @throws NullPointerException if {@code action == null}
-     */
-    MemorySegment withCleanupAction(Runnable action);
 
     /**
      * The size (in bytes) of this memory segment.
@@ -407,8 +382,8 @@ public interface MemorySegment extends Addressable, AutoCloseable {
     boolean isAlive();
 
     /**
-     * Closes this memory segment. Once a memory segment has been closed, any attempt to use the memory segment,
-     * or to access any {@link MemoryAddress} instance associated with it will fail with {@link IllegalStateException}.
+     * Closes this memory segment. This is a <em>terminal operation</em>; as a side-effect, this segment will be marked
+     * as <em>not alive</em>, and subsequent operations on this segment will fail with {@link IllegalStateException}.
      * Depending on the kind of memory segment being closed, calling this method further triggers deallocation of all the resources
      * associated with the memory segment.
      * @throws IllegalStateException if this segment is not <em>alive</em>, or if access occurs from a thread other than the
@@ -417,6 +392,69 @@ public interface MemorySegment extends Addressable, AutoCloseable {
      * @throws UnsupportedOperationException if this segment does not support the {@link #CLOSE} access mode.
      */
     void close();
+
+    /**
+     * Obtains a new confined memory segment backed by the same underlying memory region as this segment. The returned segment will
+     * be confined on the specified thread, and will feature the same spatial bounds and access modes (see {@link #accessModes()})
+     * as this segment.
+     * <p>
+     * This is a <em>terminal operation</em>; as a side-effect, this segment will be
+     * marked as <em>not alive</em>, and subsequent operations on this segment will fail with {@link IllegalStateException}.
+     * <p>
+     * In case where the owner thread of the returned segment differs from that of this segment, write accesses to this
+     * segment's content <a href="../../../java/util/concurrent/package-summary.html#MemoryVisibility"><i>happens-before</i></a>
+     * hand-over from the current owner thread to the new owner thread, which in turn <i>happens before</i> read accesses
+     * to the returned segment's contents on the new owner thread.
+     *
+     * @param thread the new owner thread
+     * @return a new confined memory segment whose owner thread is set to {@code thread}.
+     * characteristics have been modified, according to the supplied {@code handoffTransform}.
+     * @throws IllegalStateException if this segment is not <em>alive</em>, or if access occurs from a thread other than the
+     * thread owning this segment.
+     * @throws UnsupportedOperationException if this segment does not support the {@link #HANDOFF} access mode.
+     * @throws NullPointerException if {@code thread == null}
+     */
+    MemorySegment handoff(Thread thread);
+
+    /**
+     * Obtains a new shared memory segment backed by the same underlying memory region as this segment. The returned segment will
+     * not be confined on any thread and can therefore be accessed concurrently from multiple threads; moreover, the
+     * returned segment will feature the same spatial bounds and access modes (see {@link #accessModes()})
+     * as this segment.
+     * <p>
+     * This is a <em>terminal operation</em>; as a side-effect, this segment will be
+     * marked as <em>not alive</em>, and subsequent operations on this segment will fail with {@link IllegalStateException}.
+     * <p>
+     * Write accesses to this segment's content <a href="../../../java/util/concurrent/package-summary.html#MemoryVisibility"><i>happens-before</i></a>
+     * hand-over from the current owner thread to the new owner thread, which in turn <i>happens before</i> read accesses
+     * to the returned segment's contents on a new thread.
+     *
+     * @return a new memory shared segment backed by the same underlying memory region as this segment.
+     * @throws IllegalStateException if this segment is not <em>alive</em>, or if access occurs from a thread other than the
+     * thread owning this segment.
+     * @throws NullPointerException if {@code thread == null}
+     */
+    MemorySegment share();
+
+    /**
+     * Register this memory segment instance against a {@link Cleaner} object, by returning a new memory segment backed
+     * by the same underlying memory region as this segment. The returned segment will feature the same confinement,
+     * spatial bounds and access modes (see {@link #accessModes()}) as this segment. Moreover, the returned segment
+     * will be associated with the specified {@link Cleaner} object; this allows for the segment to be closed
+     * as soon as it becomes <em>unreachable</em>, which might be helpful in preventing native memory leaks.
+     * <p>
+     * This is a <em>terminal operation</em>; as a side-effect, this segment will be
+     * marked as <em>not alive</em>, and subsequent operations on this segment will fail with {@link IllegalStateException}.
+     *
+     * @param cleaner the cleaner object, responsible for implicit deallocation of the returned segment.
+     * @return a new memory segment backed by the same underlying memory region as this segment, which features
+     * implicit deallocation.
+     * @throws IllegalStateException if this segment is not <em>alive</em>, or if access occurs from a thread other than the
+     * thread owning this segment, or if this segment is already associated with a cleaner.
+     * @throws UnsupportedOperationException if this segment does not support the {@link #CLOSE} access mode.
+     * @throws NullPointerException if {@code thread == null}
+     */
+    MemorySegment registerCleaner(Cleaner cleaner);
 
     /**
      * Fills a value into this memory segment.
@@ -849,7 +887,7 @@ allocateNative(bytesSize, 1);
     int CLOSE = WRITE << 1;
 
     /**
-     * Share access mode; this segment support sharing with threads other than the owner thread (see {@link #withOwnerThread(Thread)}}).
+     * Share access mode; this segment support sharing with threads other than the owner thread (see {@link #share()}).
      * (see {@link #spliterator(MemorySegment, SequenceLayout)}).
      * @see MemorySegment#accessModes()
      * @see MemorySegment#withAccessModes(int)
@@ -858,7 +896,7 @@ allocateNative(bytesSize, 1);
 
     /**
      * Handoff access mode; this segment support serial thread-confinement via thread ownership changes
-     * (see {@link #withOwnerThread(Thread)}).
+     * (see {@link #handoff(Thread)}).
      * @see MemorySegment#accessModes()
      * @see MemorySegment#withAccessModes(int)
      */

--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/package-info.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/package-info.java
@@ -87,8 +87,8 @@ try (MemorySegment segment = MemorySegment.allocateNative(10 * 4)) {
  * the segment being accessed has not been closed prematurely. We call this guarantee <em>temporal safety</em>. Note that,
  * in the general case, guaranteeing temporal safety can be hard, as multiple threads could attempt to access and/or close
  * the same memory segment concurrently. The memory access API addresses this problem by imposing strong
- * <a href="MemorySegment.html#thread-confinement"><em>thread-confinement</em></a> guarantees on memory segments: each
- * memory segment is associated with an owner thread, which is the only thread that can either access or close the segment.
+ * <em>thread-confinement</em> guarantees on memory segments: upon creation, a memory segment is associated with an owner thread,
+ * which is the only thread that can either access or close the segment.
  * <p>
  * Together, spatial and temporal safety ensure that each memory access operation either succeeds - and accesses a valid
  * memory location - or fails.

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/HeapMemorySegmentImpl.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/HeapMemorySegmentImpl.java
@@ -121,7 +121,7 @@ public class HeapMemorySegmentImpl<H> extends AbstractMemorySegmentImpl {
 
     static <Z> HeapMemorySegmentImpl<Z> makeHeapSegment(Supplier<Z> obj, int length, int base, int scale) {
         int byteSize = length * scale;
-        MemoryScope scope = MemoryScope.createConfined(null, MemoryScope.CleanupAction.DUMMY);
+        MemoryScope scope = MemoryScope.createConfined(null, MemoryScope.DUMMY_CLEANUP_ACTION, null);
         return new HeapMemorySegmentImpl<>(base, obj, byteSize, defaultAccessModes(byteSize), scope);
     }
 }

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/MappedMemorySegmentImpl.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/MappedMemorySegmentImpl.java
@@ -101,12 +101,7 @@ public class MappedMemorySegmentImpl extends NativeMemorySegmentImpl implements 
         if (bytesOffset < 0) throw new IllegalArgumentException("Requested bytes offset must be >= 0.");
         try (FileChannelImpl channelImpl = (FileChannelImpl)FileChannel.open(path, openOptions(mapMode))) {
             UnmapperProxy unmapperProxy = channelImpl.mapInternal(mapMode, bytesOffset, bytesSize);
-            MemoryScope scope = MemoryScope.createConfined(null, new MemoryScope.CleanupAction.AtMostOnceOnly() {
-                @Override
-                void doCleanup() {
-                    unmapperProxy.unmap();
-                }
-            });
+            MemoryScope scope = MemoryScope.createConfined(null, unmapperProxy::unmap, null);
             int modes = defaultAccessModes(bytesSize);
             if (mapMode == FileChannel.MapMode.READ_ONLY) {
                 modes &= ~WRITE;

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/MemoryAddressImpl.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/MemoryAddressImpl.java
@@ -91,4 +91,13 @@ public final class MemoryAddressImpl implements MemoryAddress {
     public String toString() {
         return "MemoryAddress{ base: " + base + " offset=0x" + Long.toHexString(offset) + " }";
     }
+
+    @Override
+    public MemorySegment asSegmentRestricted(long bytesSize, Runnable cleanupAction, Object attachment) {
+        Utils.checkRestrictedAccess("MemoryAddress.asSegmentRestricted");
+        if (bytesSize <= 0) {
+            throw new IllegalArgumentException("Invalid size : " + bytesSize);
+        }
+        return NativeMemorySegmentImpl.makeNativeSegmentUnchecked(this, bytesSize, cleanupAction, attachment);
+    }
 }

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/MemoryScope.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/MemoryScope.java
@@ -27,10 +27,12 @@
 package jdk.internal.foreign;
 
 import jdk.internal.misc.ScopedMemoryAccess;
+import jdk.internal.ref.PhantomCleanable;
 import jdk.internal.vm.annotation.ForceInline;
 
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.VarHandle;
+import java.lang.ref.Cleaner;
 import java.lang.ref.Reference;
 import java.util.Objects;
 
@@ -49,10 +51,15 @@ import java.util.Objects;
  */
 abstract class MemoryScope implements ScopedMemoryAccess.Scope {
 
-    private MemoryScope(Object ref, CleanupAction cleanupAction) {
+    static final Runnable DUMMY_CLEANUP_ACTION = () -> { };
+
+    private MemoryScope(Object ref, Runnable cleanupAction, Cleaner cleaner) {
         Objects.requireNonNull(cleanupAction);
         this.ref = ref;
         this.cleanupAction = cleanupAction;
+        this.scopeCleanable = cleaner != null ?
+                new ScopeCleanable(this, cleaner, cleanupAction) :
+                null;
     }
 
     /**
@@ -62,8 +69,8 @@ abstract class MemoryScope implements ScopedMemoryAccess.Scope {
      * @param cleanupAction a cleanup action to be executed when returned scope is closed
      * @return a confined memory scope
      */
-    static MemoryScope createConfined(Object ref, CleanupAction cleanupAction) {
-        return new ConfinedScope(Thread.currentThread(), ref, cleanupAction);
+    static MemoryScope createConfined(Object ref, Runnable cleanupAction, Cleaner cleaner) {
+        return new ConfinedScope(Thread.currentThread(), ref, cleanupAction, cleaner);
     }
 
     /**
@@ -72,12 +79,13 @@ abstract class MemoryScope implements ScopedMemoryAccess.Scope {
      * @param cleanupAction a cleanup action to be executed when returned scope is closed
      * @return a shared memory scope
      */
-    static MemoryScope createShared(Object ref, CleanupAction cleanupAction) {
-        return new SharedScope(ref, cleanupAction);
+    static MemoryScope createShared(Object ref, Runnable cleanupAction, Cleaner cleaner) {
+        return new SharedScope(ref, cleanupAction, cleaner);
     }
 
     protected final Object ref;
-    protected final CleanupAction cleanupAction;
+    protected final ScopeCleanable scopeCleanable;
+    protected final Runnable cleanupAction;
     protected boolean closed; // = false
     private static final VarHandle CLOSED;
 
@@ -97,7 +105,10 @@ abstract class MemoryScope implements ScopedMemoryAccess.Scope {
     final void close() {
         try {
             justClose();
-            cleanupAction.cleanup();
+            cleanupAction.run();
+            if (scopeCleanable != null) {
+                scopeCleanable.clear();
+            }
         } finally {
             Reference.reachabilityFence(this);
         }
@@ -115,7 +126,11 @@ abstract class MemoryScope implements ScopedMemoryAccess.Scope {
     MemoryScope confineTo(Thread newOwner) {
         try {
             justClose();
-            return new ConfinedScope(newOwner, ref, cleanupAction.dup());
+            if (scopeCleanable != null) {
+                scopeCleanable.clear();
+            }
+            return new ConfinedScope(newOwner, ref, cleanupAction, scopeCleanable != null ?
+                    scopeCleanable.cleaner : null);
         } finally {
             Reference.reachabilityFence(this);
         }
@@ -131,18 +146,25 @@ abstract class MemoryScope implements ScopedMemoryAccess.Scope {
     MemoryScope share() {
         try {
             justClose();
-            return new SharedScope(ref, cleanupAction.dup());
+            if (scopeCleanable != null) {
+                scopeCleanable.clear();
+            }
+            return new SharedScope(ref, cleanupAction, scopeCleanable != null ?
+                    scopeCleanable.cleaner : null);
         } finally {
             Reference.reachabilityFence(this);
         }
     }
 
-    final MemoryScope wrapAction(Runnable runnable) {
+    MemoryScope cleanable(Cleaner cleaner) {
+        if (scopeCleanable != null) {
+            throw new IllegalStateException("Already registered with a cleaner");
+        }
         try {
             justClose();
             return ownerThread() == null ?
-                    new SharedScope(ref, cleanupAction.wrap(runnable)) :
-                    new ConfinedScope(ownerThread(), ref, cleanupAction.wrap(runnable));
+                    new SharedScope(ref, cleanupAction, cleaner) :
+                    new ConfinedScope(ownerThread(), ref, cleanupAction, cleaner);
         } finally {
             Reference.reachabilityFence(this);
         }
@@ -196,8 +218,8 @@ abstract class MemoryScope implements ScopedMemoryAccess.Scope {
 
         final Thread owner;
 
-        public ConfinedScope(Thread owner, Object ref, CleanupAction cleanupAction) {
-            super(ref, cleanupAction);
+        public ConfinedScope(Thread owner, Object ref, Runnable cleanupAction, Cleaner cleaner) {
+            super(ref, cleanupAction, cleaner);
             this.owner = owner;
         }
 
@@ -242,13 +264,8 @@ abstract class MemoryScope implements ScopedMemoryAccess.Scope {
 
         static ScopedMemoryAccess SCOPED_MEMORY_ACCESS = ScopedMemoryAccess.getScopedMemoryAccess();
 
-        SharedScope(Object ref, CleanupAction cleanupAction) {
-            super(ref, cleanupAction);
-        }
-
-        @Override
-        MemoryScope share() {
-            throw new IllegalStateException("Already shared");
+        SharedScope(Object ref, Runnable cleanupAction, Cleaner cleaner) {
+            super(ref, cleanupAction, cleaner);
         }
 
         @Override
@@ -269,127 +286,19 @@ abstract class MemoryScope implements ScopedMemoryAccess.Scope {
         }
     }
 
-    /**
-     * A functional interface modelling the cleanup action associated with a scope.
-     */
-    interface CleanupAction extends Runnable {
-        void cleanup();
-        CleanupAction dup();
-        CleanupAction wrap(Runnable runnable);
+    static class ScopeCleanable extends PhantomCleanable<MemoryScope> {
+        final Cleaner cleaner;
+        final Runnable cleanupAction;
+
+        public ScopeCleanable(MemoryScope referent, Cleaner cleaner, Runnable cleanupAction) {
+            super(referent, cleaner);
+            this.cleaner = cleaner;
+            this.cleanupAction = cleanupAction;
+        }
 
         @Override
-        default void run() {
-            cleanup();
-        }
-
-        /** Dummy cleanup action */
-        CleanupAction DUMMY = new CleanupAction() {
-            @Override
-            public void cleanup() {
-                // do nothing
-            }
-
-            @Override
-            public CleanupAction dup() {
-                return this;
-            }
-
-            @Override
-            public CleanupAction wrap(Runnable runnable) {
-                return AtMostOnceOnly.of(runnable);
-            }
-        };
-
-        /**
-         * A stateful cleanup action; this action can only be called at most once. The implementation
-         * guarantees this invariant even when multiple threads race to call the {@link #cleanup()} method.
-         */
-        abstract class AtMostOnceOnly implements CleanupAction {
-
-            static final VarHandle CALLED;
-
-            static {
-                try {
-                    CALLED = MethodHandles.lookup().findVarHandle(AtMostOnceOnly.class, "called", boolean.class);
-                } catch (Throwable ex) {
-                    throw new ExceptionInInitializerError(ex);
-                }
-            }
-
-            private boolean called = false;
-
-            abstract void doCleanup();
-
-            public final void cleanup() {
-                if (disable()) {
-                    doCleanup();
-                }
-            };
-
-            @Override
-            public CleanupAction dup() {
-                disable();
-                return new DupAction(this);
-            }
-
-            @Override
-            public CleanupAction wrap(Runnable runnable) {
-                disable();
-                return AtMostOnceOnly.of(() -> {
-                    try {
-                        runnable.run();
-                    } catch (Throwable t) {
-                        // ignore
-                    } finally {
-                        doCleanup();
-                    }
-                });
-            }
-
-            //where
-            static class DupAction extends AtMostOnceOnly {
-                final AtMostOnceOnly root;
-
-                DupAction(AtMostOnceOnly root) {
-                    this.root = root;
-                }
-
-                @Override
-                void doCleanup() {
-                    root.doCleanup();
-                }
-
-                @Override
-                public CleanupAction dup() {
-                    disable();
-                    return new DupAction(root);
-                }
-            }
-
-            final boolean disable() {
-                // This can fail under normal circumstances. The only case where a failure can happen is when
-                // when two cleaners race to cleanup the same scope. It is never possible to have a race
-                // between explicit/implicit close because all the scope terminal operations have
-                // reachability fences which prevent a scope to be deemed unreachable before we are done
-                // marking the original cleanup action as "dead".
-                return CALLED.compareAndSet(this, false, true);
-            }
-
-            /**
-             * Returns a custom {@code BasicCleanupAction} based on given {@link Runnable} instance.
-             * @param runnable the runnable to be executed when {@link #cleanup()} is called on the returned cleanup action.
-             * @return the new cleanup action.
-             */
-            static AtMostOnceOnly of(Runnable runnable) {
-                Objects.requireNonNull(runnable);
-                return new AtMostOnceOnly() {
-                    @Override
-                    void doCleanup() {
-                        runnable.run();
-                    }
-                };
-            }
+        protected void performCleanup() {
+            cleanupAction.run();
         }
     }
-
 }

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/NativeMemorySegmentImpl.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/NativeMemorySegmentImpl.java
@@ -41,8 +41,8 @@ import java.nio.ByteBuffer;
  */
 public class NativeMemorySegmentImpl extends AbstractMemorySegmentImpl {
 
-    public static final MemorySegment EVERYTHING = makeNativeSegmentUnchecked(MemoryAddress.NULL, Long.MAX_VALUE, null)
-            .withOwnerThread(null)
+    public static final MemorySegment EVERYTHING = makeNativeSegmentUnchecked(MemoryAddress.NULL, Long.MAX_VALUE, MemoryScope.DUMMY_CLEANUP_ACTION, null)
+            .share()
             .withAccessModes(READ | WRITE);
 
     private static final Unsafe unsafe = Unsafe.getUnsafe();
@@ -98,13 +98,10 @@ public class NativeMemorySegmentImpl extends AbstractMemorySegmentImpl {
             unsafe.setMemory(buf, alignedSize, (byte)0);
         }
         long alignedBuf = Utils.alignUp(buf, alignmentBytes);
-        MemoryScope scope = MemoryScope.createConfined(null, new MemoryScope.CleanupAction.AtMostOnceOnly() {
-            @Override
-            void doCleanup() {
+        MemoryScope scope = MemoryScope.createConfined(null, () -> {
                 unsafe.freeMemory(buf);
                 nioAccess.unreserveMemory(alignedSize, bytesSize);
-            }
-        });
+            }, null);
         MemorySegment segment = new NativeMemorySegmentImpl(buf, alignedSize,
                 defaultAccessModes(alignedSize), scope);
         if (alignedSize != bytesSize) {
@@ -114,8 +111,8 @@ public class NativeMemorySegmentImpl extends AbstractMemorySegmentImpl {
         return segment;
     }
 
-    public static MemorySegment makeNativeSegmentUnchecked(MemoryAddress min, long bytesSize, Object attachment) {
+    public static MemorySegment makeNativeSegmentUnchecked(MemoryAddress min, long bytesSize, Runnable cleanupAction, Object ref) {
         return new NativeMemorySegmentImpl(min.toRawLongValue(), bytesSize, defaultAccessModes(bytesSize),
-                MemoryScope.createConfined(attachment, MemoryScope.CleanupAction.DUMMY));
+                MemoryScope.createConfined(ref, cleanupAction == null ? MemoryScope.DUMMY_CLEANUP_ACTION : cleanupAction, null));
     }
 }

--- a/test/jdk/java/foreign/TestHandshake.java
+++ b/test/jdk/java/foreign/TestHandshake.java
@@ -58,7 +58,7 @@ public class TestHandshake {
     @Test(dataProvider = "accessors")
     public void testHandshake(Function<MemorySegment, Runnable> accessorFactory) throws InterruptedException {
         for (int it = 0 ; it < ITERATIONS ; it++) {
-            MemorySegment segment = MemorySegment.allocateNative(SEGMENT_SIZE).withOwnerThread(null);
+            MemorySegment segment = MemorySegment.allocateNative(SEGMENT_SIZE).share();
             System.err.println("ITERATION " + it);
             ExecutorService accessExecutor = Executors.newCachedThreadPool();
             for (int i = 0; i < Runtime.getRuntime().availableProcessors() ; i++) {
@@ -145,7 +145,7 @@ public class TestHandshake {
 
         SegmentMismatchAccessor(MemorySegment segment) {
             this.segment = segment;
-            this.copy = MemorySegment.allocateNative(SEGMENT_SIZE).withOwnerThread(null);
+            this.copy = MemorySegment.allocateNative(SEGMENT_SIZE).share();
             copy.copyFrom(segment);
             MemoryAccess.setByteAtIndex(copy, ThreadLocalRandom.current().nextInt(SEGMENT_SIZE), (byte)42);
         }

--- a/test/jdk/java/foreign/TestNative.java
+++ b/test/jdk/java/foreign/TestNative.java
@@ -167,8 +167,7 @@ public class TestNative {
     @Test
     public void testDefaultAccessModes() {
         MemoryAddress addr = MemoryAddress.ofLong(allocate(12));
-        MemorySegment mallocSegment = addr.asSegmentRestricted(12)
-                .withCleanupAction(() -> free(addr.toRawLongValue()));
+        MemorySegment mallocSegment = addr.asSegmentRestricted(12, () -> free(addr.toRawLongValue()), null);
         try (MemorySegment segment = mallocSegment) {
             assertTrue(segment.hasAccessModes(ALL_ACCESS));
             assertEquals(segment.accessModes(), ALL_ACCESS);
@@ -185,8 +184,7 @@ public class TestNative {
     @Test
     public void testMallocSegment() {
         MemoryAddress addr = MemoryAddress.ofLong(allocate(12));
-        MemorySegment mallocSegment = addr.asSegmentRestricted(12)
-                .withCleanupAction(() -> free(addr.toRawLongValue()));
+        MemorySegment mallocSegment = addr.asSegmentRestricted(12, () -> free(addr.toRawLongValue()), null);
         assertEquals(mallocSegment.byteSize(), 12);
         mallocSegment.close(); //free here
         assertTrue(!mallocSegment.isAlive());

--- a/test/jdk/java/foreign/TestSegments.java
+++ b/test/jdk/java/foreign/TestSegments.java
@@ -325,6 +325,8 @@ public class TestSegments {
                 "address",
                 "close",
                 "share",
+                "handoff",
+                "registerCleaner",
                 "fill",
                 "copyFrom",
                 "mismatch",
@@ -334,10 +336,7 @@ public class TestSegments {
                 "toIntArray",
                 "toFloatArray",
                 "toLongArray",
-                "toDoubleArray",
-                "withOwnerThread",
-                "registerCleaner",
-                "withCleanupAction"
+                "toDoubleArray"
         );
 
         public SegmentMember(Method method, Object[] params) {
@@ -395,7 +394,7 @@ public class TestSegments {
         SHARE(MemorySegment.SHARE) {
             @Override
             void run(MemorySegment segment) {
-                segment.withOwnerThread(null);
+                segment.share();
             }
         },
         CLOSE(MemorySegment.CLOSE) {
@@ -419,7 +418,7 @@ public class TestSegments {
         HANDOFF(MemorySegment.HANDOFF) {
             @Override
             void run(MemorySegment segment) {
-                segment.withOwnerThread(new Thread());
+                segment.handoff(new Thread());
             }
         };
 

--- a/test/jdk/java/foreign/TestSharedAccess.java
+++ b/test/jdk/java/foreign/TestSharedAccess.java
@@ -39,7 +39,6 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
-import java.util.function.Consumer;
 
 import static org.testng.Assert.*;
 
@@ -58,11 +57,11 @@ public class TestSharedAccess {
         for (int i = 0 ; i < 1000 ; i++) {
             threads.add(new Thread(() -> {
                 assertEquals(getInt(confined.get()), 42);
-                confined.set(confined.get().withOwnerThread(owner));
+                confined.set(confined.get().handoff(owner));
             }));
         }
         threads.forEach(t -> {
-            confined.set(confined.get().withOwnerThread(t));
+            confined.set(confined.get().handoff(t));
             t.start();
             try {
                 t.join();
@@ -76,7 +75,7 @@ public class TestSharedAccess {
     @Test
     public void testShared() throws Throwable {
         SequenceLayout layout = MemoryLayout.ofSequence(1024, MemoryLayouts.JAVA_INT);
-        try (MemorySegment s = MemorySegment.allocateNative(layout).withOwnerThread(null)) {
+        try (MemorySegment s = MemorySegment.allocateNative(layout).share()) {
             for (int i = 0 ; i < layout.elementCount().getAsLong() ; i++) {
                 setInt(s.asSlice(i * 4), 42);
             }
@@ -124,8 +123,7 @@ public class TestSharedAccess {
             setInt(s, 42);
             assertEquals(getInt(s), 42);
             List<Thread> threads = new ArrayList<>();
-            MemorySegment sharedSegment = s.address().asSegmentRestricted(s.byteSize())
-                    .withOwnerThread(null);
+            MemorySegment sharedSegment = s.address().asSegmentRestricted(s.byteSize()).share();
             for (int i = 0 ; i < 1000 ; i++) {
                 threads.add(new Thread(() -> {
                     assertEquals(getInt(sharedSegment), 42);
@@ -142,53 +140,16 @@ public class TestSharedAccess {
         }
     }
 
-    @Test(expectedExceptions=IllegalArgumentException.class)
-    public void testBadHandoffSameThread() {
-        MemorySegment.ofArray(new int[4]).withOwnerThread(Thread.currentThread());
-    }
-
     @Test(expectedExceptions=UnsupportedOperationException.class)
     public void testBadHandoffNoAccess() {
         MemorySegment.ofArray(new int[4])
-            .withAccessModes(MemorySegment.CLOSE).withOwnerThread(new Thread());
-    }
-
-    @Test(expectedExceptions=IllegalStateException.class)
-    public void testBadShareAlreadyShared() {
-        MemorySegment.ofArray(new int[4])
-                .withOwnerThread(null)
-                .withOwnerThread(null);
+            .withAccessModes(MemorySegment.CLOSE).handoff(new Thread());
     }
 
     @Test(expectedExceptions=UnsupportedOperationException.class)
     public void testBadShareNoAccess() {
         MemorySegment.ofArray(new int[4])
-                .withAccessModes(MemorySegment.CLOSE).withOwnerThread(null);
-    }
-
-    private void withAcquired(Consumer<MemorySegment> acquiredAction) {
-        CountDownLatch holder = new CountDownLatch(1);
-        MemorySegment segment = MemorySegment.allocateNative(16).withOwnerThread(null);
-        Spliterator<MemorySegment> spliterator = MemorySegment.spliterator(segment,
-                MemoryLayout.ofSequence(16, MemoryLayouts.JAVA_BYTE));
-        CountDownLatch acquired = new CountDownLatch(1);
-        Runnable r = () -> spliterator.tryAdvance(s -> {
-            try {
-                acquired.countDown();
-                holder.await();
-            } catch (InterruptedException ex) {
-                throw new AssertionError(ex);
-            }
-        });
-        new Thread(r).start();
-        try {
-            acquired.await();
-            acquiredAction.accept(segment);
-        } catch (InterruptedException ex) {
-            throw new AssertionError(ex);
-        } finally {
-            holder.countDown();
-        }
+                .withAccessModes(MemorySegment.CLOSE).share();
     }
 
     @Test

--- a/test/jdk/java/foreign/TestSpliterator.java
+++ b/test/jdk/java/foreign/TestSpliterator.java
@@ -60,7 +60,7 @@ public class TestSpliterator {
         SequenceLayout layout = MemoryLayout.ofSequence(size, MemoryLayouts.JAVA_INT);
 
         //setup
-        MemorySegment segment = MemorySegment.allocateNative(layout).withOwnerThread(null);
+        MemorySegment segment = MemorySegment.allocateNative(layout).share();
         for (int i = 0; i < layout.elementCount().getAsLong(); i++) {
             INT_HANDLE.set(segment, (long) i, i);
         }

--- a/test/micro/org/openjdk/bench/jdk/incubator/foreign/LoopOverNew.java
+++ b/test/micro/org/openjdk/bench/jdk/incubator/foreign/LoopOverNew.java
@@ -80,7 +80,7 @@ public class LoopOverNew {
 
     @Benchmark
     public void segment_loop_shared() {
-        MemorySegment segment = MemorySegment.allocateNative(ALLOC_SIZE).withOwnerThread(null);
+        MemorySegment segment = MemorySegment.allocateNative(ALLOC_SIZE).share();
         for (int i = 0; i < ELEM_SIZE; i++) {
             VH_int.set(segment, (long) i, i);
         }

--- a/test/micro/org/openjdk/bench/jdk/incubator/foreign/LoopOverNonConstantShared.java
+++ b/test/micro/org/openjdk/bench/jdk/incubator/foreign/LoopOverNonConstantShared.java
@@ -71,8 +71,7 @@ public class LoopOverNonConstantShared {
         for (int i = 0; i < ELEM_SIZE; i++) {
             unsafe.putInt(unsafe_addr + (i * CARRIER_SIZE) , i);
         }
-        segment = MemorySegment.allocateNative(ALLOC_SIZE)
-                .withOwnerThread(null);
+        segment = MemorySegment.allocateNative(ALLOC_SIZE).share();
         for (int i = 0; i < ELEM_SIZE; i++) {
             VH_int.set(segment, (long) i, i);
         }

--- a/test/micro/org/openjdk/bench/jdk/incubator/foreign/ParallelSum.java
+++ b/test/micro/org/openjdk/bench/jdk/incubator/foreign/ParallelSum.java
@@ -85,8 +85,7 @@ public class ParallelSum {
         for (int i = 0; i < ELEM_SIZE; i++) {
             unsafe.putInt(address + (i * CARRIER_SIZE), i);
         }
-        segment = MemorySegment.allocateNative(ALLOC_SIZE)
-                .withOwnerThread(null);
+        segment = MemorySegment.allocateNative(ALLOC_SIZE).share();
         for (int i = 0; i < ELEM_SIZE; i++) {
             VH_int.set(segment, (long) i, i);
         }


### PR DESCRIPTION
This is a subset of the patch proposed here:
https://git.openjdk.java.net/panama-foreign/pull/361

I'd like to integrate the memory access bits first and then merge the changes into PR 361.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [Jorn Vernee](https://openjdk.java.net/census#jvernee) (@JornVernee - Committer)


### Download
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/363/head:pull/363`
`$ git checkout pull/363`
