### PR TITLE
Update jib-profiles.js to point to signed libclang.dylib

### DIFF
--- a/make/conf/jib-profiles.js
+++ b/make/conf/jib-profiles.js
@@ -1046,7 +1046,7 @@ var getJibProfilesDependencies = function (input, common) {
             organization: common.organization,
             module: "libclang-" + input.build_platform,
             ext: "tar.gz",
-            revision: "9.0.0+1.0"
+            revision: "9.0.0+" + (input.build_platform == "macosx_x64" ? "2.0" : "1.0")
         },
 
         jtreg: {


### PR DESCRIPTION
Hi,

This patch updates the libclang dependency description to point to the new signed version of libclang for mac.

Thanks,
Jorn