### PR TITLE
8253937: Simplify support for shared memory segment

### DIFF
--- a/src/hotspot/share/c1/c1_Runtime1.cpp
+++ b/src/hotspot/share/c1/c1_Runtime1.cpp
@@ -636,7 +636,6 @@ address Runtime1::exception_handler_for_pc(JavaThread* thread) {
   {
     // Enter VM mode by calling the helper
     ResetNoHandleMark rnhm;
-    ExceptionHandlingMark ehm(thread);
     continuation = exception_handler_for_pc_helper(thread, exception, pc, nm);
   }
   // Back in JAVA, use no oops DON'T safepoint

--- a/src/hotspot/share/classfile/systemDictionary.hpp
+++ b/src/hotspot/share/classfile/systemDictionary.hpp
@@ -226,8 +226,6 @@ class TableStatistics;
   /* support for records */                                                                                     \
   do_klass(RecordComponent_klass,                       java_lang_reflect_RecordComponent                     ) \
                                                                                                                 \
-  /* support for Panama */                                                                                      \
-  do_klass(ScopedAccessError_klass,                     jdk_internal_misc_ScopedMemoryAccess_Scope_ScopedAccessError) \
   /*end*/
 
 class SystemDictionary : AllStatic {

--- a/src/hotspot/share/classfile/vmSymbols.hpp
+++ b/src/hotspot/share/classfile/vmSymbols.hpp
@@ -129,7 +129,6 @@
   template(sun_net_www_ParseUtil,                     "sun/net/www/ParseUtil")                    \
   template(java_util_Iterator,                        "java/util/Iterator")                       \
   template(java_lang_Record,                          "java/lang/Record")                         \
-  template(jdk_internal_misc_ScopedMemoryAccess_Scope_ScopedAccessError, "jdk/internal/misc/ScopedMemoryAccess$Scope$ScopedAccessError") \
                                                                                                   \
   template(jdk_internal_loader_NativeLibraries,       "jdk/internal/loader/NativeLibraries")      \
   template(jdk_internal_loader_BuiltinClassLoader,    "jdk/internal/loader/BuiltinClassLoader")   \

--- a/src/hotspot/share/jvmci/jvmciRuntime.cpp
+++ b/src/hotspot/share/jvmci/jvmciRuntime.cpp
@@ -376,7 +376,6 @@ address JVMCIRuntime::exception_handler_for_pc(JavaThread* thread) {
   {
     // Enter VM mode by calling the helper
     ResetNoHandleMark rnhm;
-    ExceptionHandlingMark ehm(thread);
     continuation = exception_handler_for_pc_helper(thread, exception, pc, cm);
   }
   // Back in JAVA, use no oops DON'T safepoint

--- a/src/hotspot/share/opto/runtime.cpp
+++ b/src/hotspot/share/opto/runtime.cpp
@@ -1420,7 +1420,6 @@ address OptoRuntime::handle_exception_C(JavaThread* thread) {
     // Enter the VM
 
     ResetNoHandleMark rnhm;
-    ExceptionHandlingMark ehm(thread);
     handler_address = handle_exception_C_helper(thread, nm);
   }
 

--- a/src/hotspot/share/prims/scopedMemoryAccess.cpp
+++ b/src/hotspot/share/prims/scopedMemoryAccess.cpp
@@ -102,10 +102,7 @@ public:
           if (var->type() == T_OBJECT) {
             if (var->get_obj() == JNIHandles::resolve(_deopt)) {
               assert(depth < max_critical_stack_depth, "can't have more than %d critical frames", max_critical_stack_depth);
-              if (!jt->is_exception_handling()) {
-                _found = true;
-                return;
-              }
+              _found = true;
               return;
             }
           }

--- a/src/hotspot/share/prims/unsafe.cpp
+++ b/src/hotspot/share/prims/unsafe.cpp
@@ -67,10 +67,7 @@
 
 
 #define UNSAFE_ENTRY(result_type, header) \
-   JVM_ENTRY(static result_type, header) \
-   if (JavaThread::thread_from_jni_environment(env)->has_async_exception()) { \
-     return (result_type)0; \
-   } else
+  JVM_ENTRY(static result_type, header)
 
 #define UNSAFE_LEAF(result_type, header) \
   JVM_LEAF(static result_type, header)
@@ -1050,6 +1047,7 @@ UNSAFE_ENTRY(jint, Unsafe_GetLoadAverage0(JNIEnv *env, jobject unsafe, jdoubleAr
 
   return ret;
 } UNSAFE_END
+
 
 /// JVM_RegisterUnsafeMethods
 

--- a/src/hotspot/share/runtime/deoptimization.cpp
+++ b/src/hotspot/share/runtime/deoptimization.cpp
@@ -160,10 +160,7 @@ JRT_BLOCK_ENTRY(Deoptimization::UnrollBlock*, Deoptimization::fetch_unroll_info(
   }
   thread->inc_in_deopt_handler();
 
-  UnrollBlock* result = fetch_unroll_info_helper(thread, exec_mode);
-  thread->check_and_handle_async_exceptions(true);
-
-  return result;
+  return fetch_unroll_info_helper(thread, exec_mode);
 JRT_END
 
 #if COMPILER2_OR_JVMCI

--- a/src/hotspot/share/runtime/thread.cpp
+++ b/src/hotspot/share/runtime/thread.cpp
@@ -1702,7 +1702,6 @@ void JavaThread::initialize() {
   set_exception_oop(oop());
   _exception_pc  = 0;
   _exception_handler_pc = 0;
-  _is_exception_handling = false;
   _is_method_handle_return = 0;
   _jvmti_thread_state= NULL;
   _should_post_on_exceptions_flag = JNI_FALSE;
@@ -2407,7 +2406,7 @@ void JavaThread::handle_special_runtime_exit_condition(bool check_asyncs) {
   JFR_ONLY(SUSPEND_THREAD_CONDITIONAL(this);)
 }
 
-void JavaThread::install_async_exception(oop java_throwable)  {
+void JavaThread::send_thread_stop(oop java_throwable)  {
   ResourceMark rm;
   assert(is_handshake_safe_for(Thread::current()),
          "should be self or handshakee");
@@ -2447,10 +2446,8 @@ void JavaThread::install_async_exception(oop java_throwable)  {
       Exceptions::debug_check_abort(_pending_async_exception->klass()->external_name());
     }
   }
-}
 
-void JavaThread::send_thread_stop(oop java_throwable) {
-  this->install_async_exception(java_throwable);
+
   // Interrupt thread so it will wake up from a potential wait()/sleep()/park()
   java_lang_Thread::set_interrupted(threadObj(), true);
   this->interrupt();

--- a/src/hotspot/share/runtime/thread.hpp
+++ b/src/hotspot/share/runtime/thread.hpp
@@ -1204,7 +1204,6 @@ class JavaThread: public Thread {
   volatile address _exception_pc;                // PC where exception happened
   volatile address _exception_handler_pc;        // PC for handler of exception
   volatile int     _is_method_handle_return;     // true (== 1) if the current exception PC is a MethodHandle call site.
-  bool             _is_exception_handling;
 
  private:
   // support for JNI critical regions
@@ -1470,8 +1469,6 @@ class JavaThread: public Thread {
 
   // Thread.stop support
   void send_thread_stop(oop throwable);
-  void install_async_exception(oop throwable);
-
   AsyncRequests clear_special_runtime_exit_condition() {
     AsyncRequests x = _special_runtime_exit_condition;
     _special_runtime_exit_condition = _no_async_condition;
@@ -1570,9 +1567,6 @@ class JavaThread: public Thread {
   void set_exception_pc(address a)               { _exception_pc = a; }
   void set_exception_handler_pc(address a)       { _exception_handler_pc = a; }
   void set_is_method_handle_return(bool value)   { _is_method_handle_return = value ? 1 : 0; }
-
-  bool is_exception_handling() const             { return _is_exception_handling; }
-  void set_is_exception_handling(bool val)       { _is_exception_handling = val; }
 
   void clear_exception_oop_and_pc() {
     set_exception_oop(NULL);

--- a/src/hotspot/share/utilities/exceptions.cpp
+++ b/src/hotspot/share/utilities/exceptions.cpp
@@ -73,7 +73,6 @@ void ThreadShadow::clear_pending_exception() {
 void ThreadShadow::clear_pending_nonasync_exception() {
   // Do not clear probable async exceptions.
   if (!_pending_exception->is_a(SystemDictionary::ThreadDeath_klass()) &&
-       _pending_exception->klass() != SystemDictionary::ScopedAccessError_klass() &&
       (_pending_exception->klass() != SystemDictionary::InternalError_klass() ||
        java_lang_InternalError::during_unsafe_access(_pending_exception) != JNI_TRUE)) {
     clear_pending_exception();
@@ -521,16 +520,6 @@ ExceptionMark::~ExceptionMark() {
       vm_exit_during_initialization(exception);
     }
   }
-}
-
-// Implementation of ExceptionHandlingMark
-
-ExceptionHandlingMark::ExceptionHandlingMark(JavaThread* jt) : _jt(jt) {
-  jt->set_is_exception_handling(true);
-}
-
-ExceptionHandlingMark::~ExceptionHandlingMark() {
-  _jt->set_is_exception_handling(false);
 }
 
 // ----------------------------------------------------------------------------------------

--- a/src/hotspot/share/utilities/exceptions.hpp
+++ b/src/hotspot/share/utilities/exceptions.hpp
@@ -52,7 +52,6 @@ class Thread;
 class Handle;
 class Symbol;
 class JavaCallArguments;
-class JavaThread;
 class methodHandle;
 
 // The ThreadShadow class is a helper class to access the _pending_exception
@@ -338,15 +337,6 @@ class ExceptionMark {
   ~ExceptionMark();
 };
 
-
-class ExceptionHandlingMark {
-private:
-  JavaThread* _jt;
-
-public:
-  ExceptionHandlingMark(JavaThread* jt);
-  ~ExceptionHandlingMark();
-};
 
 
 // Use an EXCEPTION_MARK for 'local' exceptions. EXCEPTION_MARK makes sure that no

--- a/src/java.base/share/classes/jdk/internal/misc/X-ScopedMemoryAccess.java.template
+++ b/src/java.base/share/classes/jdk/internal/misc/X-ScopedMemoryAccess.java.template
@@ -76,11 +76,11 @@ public class ScopedMemoryAccess {
         registerNatives();
     }
 
-    public void closeScope(Scope scope) {
-        closeScope0(scope, Scope.ScopedAccessError.INSTANCE);
+    public boolean closeScope(Scope scope) {
+        return closeScope0(scope, Scope.ScopedAccessError.INSTANCE);
     }
 
-    native void closeScope0(Scope scope, Scope.ScopedAccessError exception);
+    native boolean closeScope0(Scope scope, Scope.ScopedAccessError exception);
 
     private ScopedMemoryAccess() {}
 

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/MemoryScope.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/MemoryScope.java
@@ -86,16 +86,6 @@ abstract class MemoryScope implements ScopedMemoryAccess.Scope {
     protected final Object ref;
     protected final ScopeCleanable scopeCleanable;
     protected final Runnable cleanupAction;
-    protected boolean closed; // = false
-    private static final VarHandle CLOSED;
-
-    static {
-        try {
-            CLOSED = MethodHandles.lookup().findVarHandle(MemoryScope.class, "closed", boolean.class);
-        } catch (Throwable ex) {
-            throw new ExceptionInInitializerError(ex);
-        }
-    }
 
     /**
      * Closes this scope, executing any cleanup action (where provided).
@@ -180,9 +170,7 @@ abstract class MemoryScope implements ScopedMemoryAccess.Scope {
      * Returns true, if this scope is still alive. This method may be called in any thread.
      * @return {@code true} if this scope is not closed yet.
      */
-    final boolean isAlive() {
-        return !((boolean)CLOSED.getVolatile(this));
-    }
+    public abstract boolean isAlive();
 
     /**
      * Checks that this scope is still alive (see {@link #isAlive()}).
@@ -197,18 +185,6 @@ abstract class MemoryScope implements ScopedMemoryAccess.Scope {
     }
 
     /**
-     * Checks that this scope is still alive (see {@link #isAlive()}), by performing
-     * a quick, plain access. As such, this method should be used with care.
-     * @throws ScopedAccessError if this scope is already closed.
-     */
-    @ForceInline
-    private static void checkAliveRaw(MemoryScope scope) {
-        if (scope.closed) {
-            throw ScopedAccessError.INSTANCE;
-        }
-    }
-
-    /**
      * A confined scope, which features an owner thread. The liveness check features an additional
      * confinement check - that is, calling any operation on this scope from a thread other than the
      * owner thread will result in an exception. Because of this restriction, checking the liveness bit
@@ -216,6 +192,7 @@ abstract class MemoryScope implements ScopedMemoryAccess.Scope {
      */
     static class ConfinedScope extends MemoryScope {
 
+        private boolean closed; // = false
         final Thread owner;
 
         public ConfinedScope(Thread owner, Object ref, Runnable cleanupAction, Cleaner cleaner) {
@@ -228,7 +205,14 @@ abstract class MemoryScope implements ScopedMemoryAccess.Scope {
             if (owner != Thread.currentThread()) {
                 throw new IllegalStateException("Attempted access outside owning thread");
             }
-            checkAliveRaw(this);
+            if (closed) {
+                throw ScopedAccessError.INSTANCE;
+            }
+        }
+
+        @Override
+        public boolean isAlive() {
+            return !closed;
         }
 
         void justClose() {
@@ -264,6 +248,22 @@ abstract class MemoryScope implements ScopedMemoryAccess.Scope {
 
         static ScopedMemoryAccess SCOPED_MEMORY_ACCESS = ScopedMemoryAccess.getScopedMemoryAccess();
 
+        final static int ALIVE = 0;
+        final static int CLOSING = 1;
+        final static int CLOSED = 2;
+
+        int state = ALIVE;
+
+        private static final VarHandle STATE;
+
+        static {
+            try {
+                STATE = MethodHandles.lookup().findVarHandle(SharedScope.class, "state", int.class);
+            } catch (Throwable ex) {
+                throw new ExceptionInInitializerError(ex);
+            }
+        }
+
         SharedScope(Object ref, Runnable cleanupAction, Cleaner cleaner) {
             super(ref, cleanupAction, cleaner);
         }
@@ -275,14 +275,25 @@ abstract class MemoryScope implements ScopedMemoryAccess.Scope {
 
         @Override
         public void checkValidState() {
-            MemoryScope.checkAliveRaw(this);
+            if (state != ALIVE) {
+                throw ScopedAccessError.INSTANCE;
+            }
         }
 
         void justClose() {
-            if (!CLOSED.compareAndSet(this, false, true)) {
+            if (!STATE.compareAndSet(this, ALIVE, CLOSING)) {
                 throw new IllegalStateException("Already closed");
             }
-            SCOPED_MEMORY_ACCESS.closeScope(this);
+            boolean success = SCOPED_MEMORY_ACCESS.closeScope(this);
+            STATE.setVolatile(this, success ? CLOSED : ALIVE);
+            if (!success) {
+                throw new IllegalStateException("Cannot close while another thread is accessing the segment");
+            }
+        }
+
+        @Override
+        public boolean isAlive() {
+            return (int)STATE.getVolatile(this) != CLOSED;
         }
     }
 

--- a/test/jdk/java/foreign/TestHandshake.java
+++ b/test/jdk/java/foreign/TestHandshake.java
@@ -222,7 +222,14 @@ public class TestHandshake {
         @Override
         public void run() {
             long prev = System.currentTimeMillis();
-            segment.close();
+            while (true) {
+                try {
+                    segment.close();
+                    break;
+                } catch (IllegalStateException ex) {
+                    Thread.onSpinWait();
+                }
+            }
             long delay = System.currentTimeMillis() - prev;
             System.out.println("Segment closed - delay (ms): " + delay);
         }


### PR DESCRIPTION
This patch removs the dependency between shared memory segment support and VM async exceptions support. This dependency has proven to be problematic, since not all the code paths in the VM handle async exceptions correctly (this can also be seen by the number of places which have to be touched in the VM code - which are now reverted by this patch).

Instead, we can adopt a much simpler approach where, if when closing a segment, we detect concurrent access inside the handshake, we simply fail on close. I've added extra javadoc to clarify that, if a client sees an exception when closing a segment, that should be perceived as a bug in the code (lack of synchronization) rather than be tempted to catch the exception and rethrow.

Overall, the support requires a lot less from the VM and I think it's a fairly reasonable compromise. Note that now shared scopes have three states:

* ALIVE
* CLOSING
* CLOSED

The liveness check upon segment access fails if state != ALIVE; on the other hand, the public API `MemorySegment::isAlive` returns true, as long as the state is != CLOSED. This means that clients sees only one transition, from `isAlive() == true` to `isAlive() == false`. 

We will keep experimenting with the async exception support in a separate branch, as a future implementation improvement (note that relaxing the semantics of `close` so that it will *never* fail, is both source- and binary- compatible with the approach proposed here).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [JDK-8253937](https://bugs.openjdk.java.net/browse/JDK-8253937): Simplify support for shared memory segment


### Reviewers
 * [Paul Sandoz](https://openjdk.java.net/census#psandoz) (@PaulSandoz - Committer)


### Download
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/369/head:pull/369`
`$ git checkout pull/369`
