### PR TITLE
8254156: Simplify ABI classification logic

### DIFF
--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/AbstractLayout.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/AbstractLayout.java
@@ -150,7 +150,7 @@ abstract class AbstractLayout implements MemoryLayout {
         return s;
     }
 
-    protected <T> DynamicConstantDesc<T> decorateLayoutConstant(DynamicConstantDesc<T> desc) {
+    <T> DynamicConstantDesc<T> decorateLayoutConstant(DynamicConstantDesc<T> desc) {
         if (!hasNaturalAlignment()) {
             desc = DynamicConstantDesc.ofNamed(BSM_INVOKE, "withBitAlignment", desc.constantType(), MH_WITH_BIT_ALIGNMENT,
                     desc, bitAlignment());
@@ -163,7 +163,7 @@ abstract class AbstractLayout implements MemoryLayout {
         return desc;
     }
 
-    protected boolean hasNaturalAlignment() {
+    boolean hasNaturalAlignment() {
         return size.isPresent() && size.getAsLong() == alignment;
     }
 

--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/CLinker.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/CLinker.java
@@ -31,44 +31,42 @@ import jdk.internal.foreign.Utils;
 import jdk.internal.foreign.abi.SharedUtils;
 
 import java.lang.constant.Constable;
-import java.lang.constant.DynamicConstantDesc;
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodType;
-import java.nio.ByteOrder;
 import java.nio.charset.Charset;
-import java.util.Map;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.function.Consumer;
 
-import static java.lang.constant.ConstantDescs.BSM_GET_STATIC_FINAL;
 import static jdk.internal.foreign.PlatformLayouts.*;
 
 /**
  * A foreign linker specializing for C Application Binary Interface (ABI) calling conventions.
  * Instances of this interface can be used to link foreign functions in native libraries that
  * follow the JVM's target platform C ABI.
- *
- * <p>There are two components that go into linking a foreign function: a method type, and
+ * <p>
+ * There are two components that go into linking a foreign function: a method type, and
  * a function descriptor. The method type, consists of a set of <em>carrier</em> types, which, together,
  * specify the Java signature which clients must adhere to when calling the underlying foreign function.
  * The function descriptor contains a set of memory layouts which, together, specify the foreign function
- * signature and classification information (via custom layout attributes), so that linking can take place.
- * Memory layout attributes are used in the function descriptor to attach ABI classification meta-data to
- * memory layouts, which are required for linking. Clients of this API should build function descriptors
- * using the predefined memory layout constants (based on a subset of the built-in types provided by the C language),
- * found in this interface; a failure to do so might result in linkage errors, given that linking requires additional
- * classification information to determine, for instance, how arguments should be loaded into registers during a
- * foreign function call.</p>
- *
- * <p>Implementations of this interface support the following primitive carrier types:
+ * signature and classification information (via a custom layout attributes, see {@link TypeKind}), so that linking can take place.
+ * Memory layout attributes are used in the function descriptor to attach ABI classification meta-data to memory layouts,
+ * which are required for linking.
+ * <p>
+ * Clients of this API can build function descriptors using the predefined memory layout constants
+ * (based on a subset of the built-in types provided by the C language), found in this interface; alternatively,
+ * they can also decorate existing value layouts using the required {@link TypeKind} classification attribute
+ * (this can be done using the {@link MemoryLayout#withAttribute(String, Constable)} method). A failure to do so might
+ * result in linkage errors, given that linking requires additional classification information to determine, for instance,
+ * how arguments should be loaded into registers during a foreign function call.
+ * <p>
+ * Implementations of this interface support the following primitive carrier types:
  * {@code byte}, {@code short}, {@code char}, {@code int}, {@code long}, {@code float},
  * and {@code double}, as well as {@link MemoryAddress} for passing pointers, and
  * {@link MemorySegment} for passing structs and unions. Finally, the {@link VaList}
- * carrier type can be used to match the native {@code va_list} type.</p>
- *
- * <p>The function descriptor used in linking contains a memory layout to match each carrier type.
- * There are some restrictions on the carrier type and memory layout combinations that are allowed:</p>
+ * carrier type can be used to match the native {@code va_list} type.
+ * <p>
+ * The function descriptor used in linking contains a memory layout to match each carrier type.
+ * There are some restrictions on the carrier type and memory layout combinations that are allowed:
  * <ul>
  *   <li>If a primitve type is used as a carrier type, the corresponding
  *   memory layout must be a {@code ValueLayout}, and the bit size of the layout must match that of the carrier type
@@ -94,7 +92,7 @@ import static jdk.internal.foreign.PlatformLayouts.*;
  * function descriptor when linking the function. Furthermore, as memory layouts corresponding to variadic arguments in
  * a function descriptor must contain additional classification information, it is required that
  * {@link #asVarArg(MemoryLayout)} is used to create the memory layouts for each parameter corresponding to a variadic
- * argument in a specialized function descriptor</p>
+ * argument in a specialized function descriptor
  *
  * @apiNote In the future, if the Java language permits, {@link MemoryLayout}
  * may become a {@code sealed} interface, which would prohibit subclassing except by
@@ -151,39 +149,39 @@ public interface CLinker {
     /**
      * The layout for the {@code char} C type
      */
-    CValueLayout C_CHAR = pick(SysV.C_CHAR, Win64.C_CHAR, AArch64.C_CHAR);
+    ValueLayout C_CHAR = pick(SysV.C_CHAR, Win64.C_CHAR, AArch64.C_CHAR);
     /**
      * The layout for the {@code short} C type
      */
-    CValueLayout C_SHORT = pick(SysV.C_SHORT, Win64.C_SHORT, AArch64.C_SHORT);
+    ValueLayout C_SHORT = pick(SysV.C_SHORT, Win64.C_SHORT, AArch64.C_SHORT);
     /**
      * The layout for the {@code int} C type
      */
-    CValueLayout C_INT = pick(SysV.C_INT, Win64.C_INT, AArch64.C_INT);
+    ValueLayout C_INT = pick(SysV.C_INT, Win64.C_INT, AArch64.C_INT);
     /**
      * The layout for the {@code long} C type
      */
-    CValueLayout C_LONG = pick(SysV.C_LONG, Win64.C_LONG, AArch64.C_LONG);
+    ValueLayout C_LONG = pick(SysV.C_LONG, Win64.C_LONG, AArch64.C_LONG);
     /**
      * The {@code long long} native type.
      */
-    CValueLayout C_LONGLONG = pick(SysV.C_LONGLONG, Win64.C_LONGLONG, AArch64.C_LONGLONG);
+    ValueLayout C_LONGLONG = pick(SysV.C_LONGLONG, Win64.C_LONGLONG, AArch64.C_LONGLONG);
     /**
      * The layout for the {@code float} C type
      */
-    CValueLayout C_FLOAT = pick(SysV.C_FLOAT, Win64.C_FLOAT, AArch64.C_FLOAT);
+    ValueLayout C_FLOAT = pick(SysV.C_FLOAT, Win64.C_FLOAT, AArch64.C_FLOAT);
     /**
      * The layout for the {@code double} C type
      */
-    CValueLayout C_DOUBLE = pick(SysV.C_DOUBLE, Win64.C_DOUBLE, AArch64.C_DOUBLE);
+    ValueLayout C_DOUBLE = pick(SysV.C_DOUBLE, Win64.C_DOUBLE, AArch64.C_DOUBLE);
     /**
      * The {@code long double} native type.
      */
-    CValueLayout C_LONGDOUBLE = pick(SysV.C_LONGDOUBLE, Win64.C_LONGDOUBLE, AArch64.C_LONGDOUBLE);
+    ValueLayout C_LONGDOUBLE = pick(SysV.C_LONGDOUBLE, Win64.C_LONGDOUBLE, AArch64.C_LONGDOUBLE);
     /**
      * The {@code T*} native type.
      */
-    CValueLayout C_POINTER = pick(SysV.C_POINTER, Win64.C_POINTER, AArch64.C_POINTER);
+    ValueLayout C_POINTER = pick(SysV.C_POINTER, Win64.C_POINTER, AArch64.C_POINTER);
     /**
      * The layout for the {@code va_list} C type
      */
@@ -707,196 +705,90 @@ public interface CLinker {
     }
 
     /**
-     * Subclass of {@link ValueLayout} that contains information needed when linking
-     * downcalls or upcalls.
+     * A C type kind. Each kind corresponds to a particular C language builtin type, and can be attached to
+     * {@link ValueLayout} instances using the {@link MemoryLayout#withAttribute(String, Constable)} in order
+     * to obtain a layout which can be classified accordingly by {@link CLinker#downcallHandle(Addressable, MethodType, FunctionDescriptor)}
+     * and {@link CLinker#upcallStub(MethodHandle, FunctionDescriptor)}.
      */
-    class CValueLayout extends ValueLayout {
+    enum TypeKind {
         /**
-         * The kind of {@link CValueLayout}. Each kind corresponds to a particular
-         * C language builtin type.
+         * A kind corresponding to the C {@code char} type
          */
-        public enum Kind {
-            /**
-             * A kind corresponding to the C {@code char} type
-             */
-            CHAR(findBSM("C_CHAR"), true),
-            /**
-             * A kind corresponding to the C {@code short} type
-             */
-            SHORT(findBSM("C_SHORT"), true),
-            /**
-             * A kind corresponding to the C {@code int} type
-             */
-            INT(findBSM("C_INT"), true),
-            /**
-             * A kind corresponding to the C {@code long} type
-             */
-            LONG(findBSM("C_LONG"), true),
-            /**
-             * A kind corresponding to the C {@code long long} type
-             */
-            LONGLONG(findBSM("C_LONGLONG"), true),
-            /**
-             * A kind corresponding to the C {@code float} type
-             */
-            FLOAT(findBSM("C_FLOAT"), false),
-            /**
-             * A kind corresponding to the C {@code double} type
-             */
-            DOUBLE(findBSM("C_DOUBLE"), false),
-            /**
-             * A kind corresponding to the C {@code long double} type
-             */
-            LONGDOUBLE(findBSM("C_LONGDOUBLE"), false),
-            /**
-             * A kind corresponding to the a C pointer type
-             */
-            POINTER(findBSM("C_POINTER"), false);
+        CHAR(true),
+        /**
+         * A kind corresponding to the C {@code short} type
+         */
+        SHORT(true),
+        /**
+         * A kind corresponding to the C {@code int} type
+         */
+        INT(true),
+        /**
+         * A kind corresponding to the C {@code long} type
+         */
+        LONG(true),
+        /**
+         * A kind corresponding to the C {@code long long} type
+         */
+        LONGLONG(true),
+        /**
+         * A kind corresponding to the C {@code float} type
+         */
+        FLOAT(false),
+        /**
+         * A kind corresponding to the C {@code double} type
+         */
+        DOUBLE(false),
+        /**
+         * A kind corresponding to the C {@code long double} type
+         */
+        LONGDOUBLE(false),
+        /**
+         * A kind corresponding to the a C pointer type
+         */
+        POINTER(false);
 
-            private final DynamicConstantDesc<ValueLayout> bsm;
-            private final boolean isIntegral;
+        private final boolean isIntegral;
 
-            Kind(DynamicConstantDesc<ValueLayout> bsm, boolean isIntegral) {
-                this.bsm = bsm;
-                this.isIntegral = isIntegral;
-            }
-
-            private DynamicConstantDesc<ValueLayout> bsm() {
-                return bsm;
-            }
-
-            /**
-             * Is this kind integral?
-             *
-             * @return true if this kind is integral
-             */
-            public boolean isIntergral() {
-                return isIntegral;
-            }
-
-            /**
-             * Is this kind a floating point type?
-             *
-             * @return true if this kind is a floating point type
-             */
-            public boolean isFloat() {
-                return !isIntergral() && !isPointer();
-            }
-
-            /**
-             * Is this kind a pointer kind?
-             *
-             * @return true if this kind is a pointer kind
-             */
-            public boolean isPointer() {
-                return this == POINTER;
-            }
-
-            private static DynamicConstantDesc<ValueLayout> findBSM(String fieldName) {
-                return DynamicConstantDesc.ofNamed(
-                    BSM_GET_STATIC_FINAL,
-                    fieldName,
-                    CValueLayout.class.describeConstable().orElseThrow(),
-                    CLinker.class.describeConstable().orElseThrow()
-                );
-            }
+        TypeKind(boolean isIntegral) {
+            this.isIntegral = isIntegral;
         }
 
-        private final Kind kind;
-
         /**
-         * CValueLayout constructor
+         * Is this kind integral?
          *
-         * @param kind the kind of CValueLayout
-         * @param order the byte order of the layout
-         * @param bitSize the size, in bits, of the layout
-         * @param bitAlignment the alignment, in bits, of the layout
-         * @param attributes the attribute map of this layout
+         * @return true if this kind is integral
          */
-        public CValueLayout(Kind kind, ByteOrder order, long bitSize, long bitAlignment,
-                            Map<String, Constable> attributes) {
-            super(order, bitSize, bitAlignment, attributes);
-            this.kind = kind;
+        public boolean isIntergral() {
+            return isIntegral;
         }
 
         /**
-         * Accessor for the kind of this layout
+         * Is this kind a floating point type?
          *
-         * @return the kind
+         * @return true if this kind is a floating point type
          */
-        public final Kind kind() {
-            return kind;
+        public boolean isFloat() {
+            return !isIntergral() && !isPointer();
         }
 
         /**
-         * {@inheritDoc}
+         * Is this kind a pointer kind?
+         *
+         * @return true if this kind is a pointer kind
          */
-        @Override
-        public CValueLayout withOrder(ByteOrder order) {
-            return new CValueLayout(kind, order, bitSize(), alignment, attributes);
+        public boolean isPointer() {
+            return this == POINTER;
         }
 
         /**
-         * {@inheritDoc}
+         * The layout attribute name associated with this classification kind. Clients can retrieve the type kind
+         * of a layout using the following code:
+         * <blockquote><pre>{@code
+        ValueLayout layout = ...
+        TypeKind = layout.attribute(TypeKind.ATTR_NAME).orElse(null);
+         * }</pre></blockquote>
          */
-        @Override
-        public CValueLayout withName(String name) {
-            return (CValueLayout) super.withName(name);
-        }
-
-        /**
-         * {@inheritDoc}
-         */
-        @Override
-        public CValueLayout withBitAlignment(long alignmentBits) {
-            return (CValueLayout) super.withBitAlignment(alignmentBits);
-        }
-
-        /**
-         * {@inheritDoc}
-         */
-        @Override
-        public CValueLayout withAttribute(String name, Constable value) {
-            return (CValueLayout) super.withAttribute(name, value);
-        }
-
-        @Override
-        CValueLayout dup(long alignment, Map<String, Constable> attributes) {
-            return new CValueLayout(kind, order(), bitSize(), alignment, attributes);
-        }
-
-        /**
-         * {@inheritDoc}
-         */
-        @Override
-        public Optional<DynamicConstantDesc<ValueLayout>> describeConstable() {
-            return Optional.of(decorateLayoutConstant(kind.bsm()));
-        }
-
-        /**
-         * {@inheritDoc}
-         */
-        @Override
-        public boolean equals(Object other) {
-            if (this == other) {
-                return true;
-            }
-            if (other == null || getClass() != other.getClass()) {
-                return false;
-            }
-            if (!super.equals(other)) {
-                return false;
-            }
-            CValueLayout that = (CValueLayout) other;
-            return kind == that.kind;
-        }
-
-        /**
-         * {@inheritDoc}
-         */
-        @Override
-        public int hashCode() {
-            return Objects.hash(super.hashCode(), kind);
-        }
+        public final static String ATTR_NAME = "abi/kind";
     }
 }

--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/ValueLayout.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/ValueLayout.java
@@ -48,15 +48,15 @@ import java.util.OptionalLong;
  * @implSpec
  * This class is immutable and thread-safe.
  */
-public class ValueLayout extends AbstractLayout implements MemoryLayout {
+public final class ValueLayout extends AbstractLayout implements MemoryLayout {
 
     private final ByteOrder order;
 
-    protected ValueLayout(ByteOrder order, long size) {
+    ValueLayout(ByteOrder order, long size) {
         this(order, size, size, Map.of());
     }
 
-    protected ValueLayout(ByteOrder order, long size, long alignment, Map<String, Constable> attributes) {
+    ValueLayout(ByteOrder order, long size, long alignment, Map<String, Constable> attributes) {
         super(OptionalLong.of(size), alignment, attributes);
         this.order = order;
     }
@@ -92,10 +92,10 @@ public class ValueLayout extends AbstractLayout implements MemoryLayout {
         if (this == other) {
             return true;
         }
-        if (other == null || getClass() != other.getClass()) {
+        if (!super.equals(other)) {
             return false;
         }
-        if (!super.equals(other)) {
+        if (!(other instanceof ValueLayout)) {
             return false;
         }
         ValueLayout v = (ValueLayout)other;

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/PlatformLayouts.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/PlatformLayouts.java
@@ -90,16 +90,14 @@ public class PlatformLayouts {
                 .withAttribute(CLinker.TypeKind.ATTR_NAME, CLinker.TypeKind.LONGDOUBLE);
     }
 
-    /**
-     * Creates a new ValueLayout with the {@code POINTER} kind
-     *
-     * @param order the byte order of the layout
-     * @param bitSize the size, in bits, of the layout
-     * @return the newly created ValueLayout
-     */
-    public static ValueLayout ofPointer(ByteOrder order, long bitSize) {
+    private static ValueLayout ofPointer(ByteOrder order, long bitSize) {
         return MemoryLayout.ofValueBits(bitSize, order)
                 .withAttribute(CLinker.TypeKind.ATTR_NAME, CLinker.TypeKind.POINTER);
+    }
+
+    public static CLinker.TypeKind getKind(MemoryLayout layout) {
+        return (CLinker.TypeKind)layout.attribute(CLinker.TypeKind.ATTR_NAME).orElseThrow(
+            () -> new IllegalStateException("Unexpected value layout: could not determine ABI class"));
     }
 
     /**

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/PlatformLayouts.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/PlatformLayouts.java
@@ -26,12 +26,10 @@
 package jdk.internal.foreign;
 
 import jdk.incubator.foreign.CLinker;
-import jdk.incubator.foreign.CLinker.CValueLayout;
 import jdk.incubator.foreign.MemoryLayout;
 import jdk.incubator.foreign.ValueLayout;
 
 import java.nio.ByteOrder;
-import java.util.Map;
 
 import static java.nio.ByteOrder.LITTLE_ENDIAN;
 import static jdk.incubator.foreign.MemoryLayouts.ADDRESS;
@@ -52,47 +50,56 @@ public class PlatformLayouts {
         return ml;
     }
 
-    private static CValueLayout ofChar(ByteOrder order, long bitSize) {
-        return new CValueLayout(CValueLayout.Kind.CHAR, order, bitSize, bitSize, Map.of());
+    private static ValueLayout ofChar(ByteOrder order, long bitSize) {
+        return MemoryLayout.ofValueBits(bitSize, order)
+                .withAttribute(CLinker.TypeKind.ATTR_NAME, CLinker.TypeKind.CHAR);
     }
 
-    private static CValueLayout ofShort(ByteOrder order, long bitSize) {
-        return new CValueLayout(CValueLayout.Kind.SHORT, order, bitSize, bitSize, Map.of());
+    private static ValueLayout ofShort(ByteOrder order, long bitSize) {
+        return MemoryLayout.ofValueBits(bitSize, order)
+                .withAttribute(CLinker.TypeKind.ATTR_NAME, CLinker.TypeKind.SHORT);
     }
 
-    private static CValueLayout ofInt(ByteOrder order, long bitSize) {
-        return new CValueLayout(CValueLayout.Kind.INT, order, bitSize, bitSize, Map.of());
+    private static ValueLayout ofInt(ByteOrder order, long bitSize) {
+        return MemoryLayout.ofValueBits(bitSize, order)
+                .withAttribute(CLinker.TypeKind.ATTR_NAME, CLinker.TypeKind.INT);
     }
 
-    private static CValueLayout ofLong(ByteOrder order, long bitSize) {
-        return new CValueLayout(CValueLayout.Kind.LONG, order, bitSize, bitSize, Map.of());
+    private static ValueLayout ofLong(ByteOrder order, long bitSize) {
+        return MemoryLayout.ofValueBits(bitSize, order)
+                .withAttribute(CLinker.TypeKind.ATTR_NAME, CLinker.TypeKind.LONG);
     }
 
-    private static CValueLayout ofLongLong(ByteOrder order, long bitSize) {
-        return new CValueLayout(CValueLayout.Kind.LONGLONG, order, bitSize, bitSize, Map.of());
+    private static ValueLayout ofLongLong(ByteOrder order, long bitSize) {
+        return MemoryLayout.ofValueBits(bitSize, order)
+                .withAttribute(CLinker.TypeKind.ATTR_NAME, CLinker.TypeKind.LONGLONG);
     }
 
-    private static CValueLayout ofFloat(ByteOrder order, long bitSize) {
-        return new CValueLayout(CValueLayout.Kind.FLOAT, order, bitSize, bitSize, Map.of());
+    private static ValueLayout ofFloat(ByteOrder order, long bitSize) {
+        return MemoryLayout.ofValueBits(bitSize, order)
+                .withAttribute(CLinker.TypeKind.ATTR_NAME, CLinker.TypeKind.FLOAT);
     }
 
-    private static CValueLayout ofDouble(ByteOrder order, long bitSize) {
-        return new CValueLayout(CValueLayout.Kind.DOUBLE, order, bitSize, bitSize, Map.of());
+    private static ValueLayout ofDouble(ByteOrder order, long bitSize) {
+        return MemoryLayout.ofValueBits(bitSize, order)
+                .withAttribute(CLinker.TypeKind.ATTR_NAME, CLinker.TypeKind.DOUBLE);
     }
 
-    private static CValueLayout ofLongDouble(ByteOrder order, long bitSize) {
-        return new CValueLayout(CValueLayout.Kind.LONGDOUBLE, order, bitSize, bitSize, Map.of());
+    private static ValueLayout ofLongDouble(ByteOrder order, long bitSize) {
+        return MemoryLayout.ofValueBits(bitSize, order)
+                .withAttribute(CLinker.TypeKind.ATTR_NAME, CLinker.TypeKind.LONGDOUBLE);
     }
 
     /**
-     * Creates a new CValueLayout with the {@code POINTER} kind
+     * Creates a new ValueLayout with the {@code POINTER} kind
      *
      * @param order the byte order of the layout
      * @param bitSize the size, in bits, of the layout
-     * @return the newly created CValueLayout
+     * @return the newly created ValueLayout
      */
-    public static CValueLayout ofPointer(ByteOrder order, long bitSize) {
-        return new CValueLayout(CValueLayout.Kind.POINTER, order, bitSize, bitSize, Map.of());
+    public static ValueLayout ofPointer(ByteOrder order, long bitSize) {
+        return MemoryLayout.ofValueBits(bitSize, order)
+                .withAttribute(CLinker.TypeKind.ATTR_NAME, CLinker.TypeKind.POINTER);
     }
 
     /**
@@ -106,47 +113,47 @@ public class PlatformLayouts {
         /**
          * The {@code char} native type.
          */
-        public static final CValueLayout C_CHAR = ofChar(LITTLE_ENDIAN, 8);
+        public static final ValueLayout C_CHAR = ofChar(LITTLE_ENDIAN, 8);
 
         /**
          * The {@code short} native type.
          */
-        public static final CValueLayout C_SHORT = ofShort(LITTLE_ENDIAN, 16);
+        public static final ValueLayout C_SHORT = ofShort(LITTLE_ENDIAN, 16);
 
         /**
          * The {@code int} native type.
          */
-        public static final CValueLayout C_INT = ofInt(LITTLE_ENDIAN, 32);
+        public static final ValueLayout C_INT = ofInt(LITTLE_ENDIAN, 32);
 
         /**
          * The {@code long} native type.
          */
-        public static final CValueLayout C_LONG = ofLong(LITTLE_ENDIAN, 64);
+        public static final ValueLayout C_LONG = ofLong(LITTLE_ENDIAN, 64);
 
         /**
          * The {@code long long} native type.
          */
-        public static final CValueLayout C_LONGLONG = ofLongLong(LITTLE_ENDIAN, 64);
+        public static final ValueLayout C_LONGLONG = ofLongLong(LITTLE_ENDIAN, 64);
 
         /**
          * The {@code float} native type.
          */
-        public static final CValueLayout C_FLOAT = ofFloat(LITTLE_ENDIAN, 32);
+        public static final ValueLayout C_FLOAT = ofFloat(LITTLE_ENDIAN, 32);
 
         /**
          * The {@code double} native type.
          */
-        public static final CValueLayout C_DOUBLE = ofDouble(LITTLE_ENDIAN, 64);
+        public static final ValueLayout C_DOUBLE = ofDouble(LITTLE_ENDIAN, 64);
 
         /**
          * The {@code long double} native type.
          */
-        public static final CValueLayout C_LONGDOUBLE = ofLongDouble(LITTLE_ENDIAN, 128);
+        public static final ValueLayout C_LONGDOUBLE = ofLongDouble(LITTLE_ENDIAN, 128);
 
         /**
          * The {@code T*} native type.
          */
-        public static final CValueLayout C_POINTER = ofPointer(LITTLE_ENDIAN, ADDRESS.bitSize());
+        public static final ValueLayout C_POINTER = ofPointer(LITTLE_ENDIAN, ADDRESS.bitSize());
 
         /**
          * The {@code va_list} native type, as it is passed to a function.
@@ -172,46 +179,46 @@ public class PlatformLayouts {
         /**
          * The {@code char} native type.
          */
-        public static final CValueLayout C_CHAR = ofChar(LITTLE_ENDIAN, 8);
+        public static final ValueLayout C_CHAR = ofChar(LITTLE_ENDIAN, 8);
 
         /**
          * The {@code short} native type.
          */
-        public static final CValueLayout C_SHORT = ofShort(LITTLE_ENDIAN, 16);
+        public static final ValueLayout C_SHORT = ofShort(LITTLE_ENDIAN, 16);
 
         /**
          * The {@code int} native type.
          */
-        public static final CValueLayout C_INT = ofInt(LITTLE_ENDIAN, 32);
+        public static final ValueLayout C_INT = ofInt(LITTLE_ENDIAN, 32);
         /**
          * The {@code long} native type.
          */
-        public static final CValueLayout C_LONG = ofLong(LITTLE_ENDIAN, 32);
+        public static final ValueLayout C_LONG = ofLong(LITTLE_ENDIAN, 32);
 
         /**
          * The {@code long long} native type.
          */
-        public static final CValueLayout C_LONGLONG = ofLongLong(LITTLE_ENDIAN, 64);
+        public static final ValueLayout C_LONGLONG = ofLongLong(LITTLE_ENDIAN, 64);
 
         /**
          * The {@code float} native type.
          */
-        public static final CValueLayout C_FLOAT = ofFloat(LITTLE_ENDIAN, 32);
+        public static final ValueLayout C_FLOAT = ofFloat(LITTLE_ENDIAN, 32);
 
         /**
          * The {@code double} native type.
          */
-        public static final CValueLayout C_DOUBLE = ofDouble(LITTLE_ENDIAN, 64);
+        public static final ValueLayout C_DOUBLE = ofDouble(LITTLE_ENDIAN, 64);
 
         /**
          * The {@code long double} native type.
          */
-        public static final CValueLayout C_LONGDOUBLE = ofLongDouble(LITTLE_ENDIAN, 64);
+        public static final ValueLayout C_LONGDOUBLE = ofLongDouble(LITTLE_ENDIAN, 64);
 
         /**
          * The {@code T*} native type.
          */
-        public static final CValueLayout C_POINTER = ofPointer(LITTLE_ENDIAN, ADDRESS.bitSize());
+        public static final ValueLayout C_POINTER = ofPointer(LITTLE_ENDIAN, ADDRESS.bitSize());
 
         /**
          * The {@code va_list} native type, as it is passed to a function.
@@ -241,47 +248,47 @@ public class PlatformLayouts {
         /**
          * The {@code char} native type.
          */
-        public static final CValueLayout C_CHAR = ofChar(LITTLE_ENDIAN, 8);
+        public static final ValueLayout C_CHAR = ofChar(LITTLE_ENDIAN, 8);
 
         /**
          * The {@code short} native type.
          */
-        public static final CValueLayout C_SHORT = ofShort(LITTLE_ENDIAN, 16);
+        public static final ValueLayout C_SHORT = ofShort(LITTLE_ENDIAN, 16);
 
         /**
          * The {@code int} native type.
          */
-        public static final CValueLayout C_INT = ofInt(LITTLE_ENDIAN, 32);
+        public static final ValueLayout C_INT = ofInt(LITTLE_ENDIAN, 32);
 
         /**
          * The {@code long} native type.
          */
-        public static final CValueLayout C_LONG = ofLong(LITTLE_ENDIAN, 64);
+        public static final ValueLayout C_LONG = ofLong(LITTLE_ENDIAN, 64);
 
         /**
          * The {@code long long} native type.
          */
-        public static final CValueLayout C_LONGLONG = ofLongLong(LITTLE_ENDIAN, 64);
+        public static final ValueLayout C_LONGLONG = ofLongLong(LITTLE_ENDIAN, 64);
 
         /**
          * The {@code float} native type.
          */
-        public static final CValueLayout C_FLOAT = ofFloat(LITTLE_ENDIAN, 32);
+        public static final ValueLayout C_FLOAT = ofFloat(LITTLE_ENDIAN, 32);
 
         /**
          * The {@code double} native type.
          */
-        public static final CValueLayout C_DOUBLE = ofDouble(LITTLE_ENDIAN, 64);
+        public static final ValueLayout C_DOUBLE = ofDouble(LITTLE_ENDIAN, 64);
 
         /**
          * The {@code long double} native type.
          */
-        public static final CValueLayout C_LONGDOUBLE = ofLongDouble(LITTLE_ENDIAN, 128);
+        public static final ValueLayout C_LONGDOUBLE = ofLongDouble(LITTLE_ENDIAN, 128);
 
         /**
          * The {@code T*} native type.
          */
-        public static final CValueLayout C_POINTER = ofPointer(LITTLE_ENDIAN, ADDRESS.bitSize());
+        public static final ValueLayout C_POINTER = ofPointer(LITTLE_ENDIAN, ADDRESS.bitSize());
 
         /**
          * The {@code va_list} native type, as it is passed to a function.

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/aarch64/TypeClass.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/aarch64/TypeClass.java
@@ -42,11 +42,10 @@ enum TypeClass {
     private static final int MAX_AGGREGATE_REGS_SIZE = 2;
 
     private static TypeClass classifyValueType(ValueLayout type) {
-        if (!(type instanceof CLinker.CValueLayout)) {
-            throw new IllegalStateException("Unexpected value layout: could not determine ABI class");
-        }
+        CLinker.TypeKind kind = (CLinker.TypeKind)type.attribute(CLinker.TypeKind.ATTR_NAME).orElseThrow(
+                () -> { throw new IllegalStateException("Unexpected value layout: could not determine ABI class"); });
 
-        return switch (((CLinker.CValueLayout) type).kind()) {
+        return switch (kind) {
             case CHAR, SHORT, INT, LONG, LONGLONG -> INTEGER;
             case POINTER -> POINTER;
             case FLOAT, DOUBLE, LONGDOUBLE -> FLOAT;

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/aarch64/TypeClass.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/aarch64/TypeClass.java
@@ -25,11 +25,11 @@
  */
 package jdk.internal.foreign.abi.aarch64;
 
-import jdk.incubator.foreign.CLinker;
 import jdk.incubator.foreign.GroupLayout;
 import jdk.incubator.foreign.MemoryLayout;
 import jdk.incubator.foreign.SequenceLayout;
 import jdk.incubator.foreign.ValueLayout;
+import jdk.internal.foreign.PlatformLayouts;
 
 enum TypeClass {
     STRUCT_REGISTER,
@@ -42,10 +42,7 @@ enum TypeClass {
     private static final int MAX_AGGREGATE_REGS_SIZE = 2;
 
     private static TypeClass classifyValueType(ValueLayout type) {
-        CLinker.TypeKind kind = (CLinker.TypeKind)type.attribute(CLinker.TypeKind.ATTR_NAME).orElseThrow(
-                () -> { throw new IllegalStateException("Unexpected value layout: could not determine ABI class"); });
-
-        return switch (kind) {
+        return switch (PlatformLayouts.getKind(type)) {
             case CHAR, SHORT, INT, LONG, LONGLONG -> INTEGER;
             case POINTER -> POINTER;
             case FLOAT, DOUBLE, LONGDOUBLE -> FLOAT;

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/x64/sysv/TypeClass.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/x64/sysv/TypeClass.java
@@ -24,11 +24,11 @@
  */
 package jdk.internal.foreign.abi.x64.sysv;
 
-import jdk.incubator.foreign.CLinker;
 import jdk.incubator.foreign.GroupLayout;
 import jdk.incubator.foreign.MemoryLayout;
 import jdk.incubator.foreign.SequenceLayout;
 import jdk.incubator.foreign.ValueLayout;
+import jdk.internal.foreign.PlatformLayouts;
 import jdk.internal.foreign.Utils;
 
 import java.util.ArrayList;
@@ -107,10 +107,7 @@ class TypeClass {
     }
 
     private static ArgumentClassImpl argumentClassFor(MemoryLayout layout) {
-        CLinker.TypeKind kind = (CLinker.TypeKind)layout.attribute(CLinker.TypeKind.ATTR_NAME).orElseThrow(
-                () -> { throw new IllegalStateException("Unexpected value layout: could not determine ABI class"); });
-
-        return switch (kind) {
+        return switch (PlatformLayouts.getKind(layout)) {
             case CHAR, SHORT, INT, LONG, LONGLONG -> ArgumentClassImpl.INTEGER;
             case FLOAT, DOUBLE -> ArgumentClassImpl.SSE;
             case LONGDOUBLE -> ArgumentClassImpl.X87;

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/x64/sysv/TypeClass.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/x64/sysv/TypeClass.java
@@ -107,11 +107,10 @@ class TypeClass {
     }
 
     private static ArgumentClassImpl argumentClassFor(MemoryLayout layout) {
-        if (!(layout instanceof CLinker.CValueLayout)) {
-            throw new IllegalStateException("Unexpected value layout: could not determine ABI class");
-        }
+        CLinker.TypeKind kind = (CLinker.TypeKind)layout.attribute(CLinker.TypeKind.ATTR_NAME).orElseThrow(
+                () -> { throw new IllegalStateException("Unexpected value layout: could not determine ABI class"); });
 
-        return switch (((CLinker.CValueLayout) layout).kind()) {
+        return switch (kind) {
             case CHAR, SHORT, INT, LONG, LONGLONG -> ArgumentClassImpl.INTEGER;
             case FLOAT, DOUBLE -> ArgumentClassImpl.SSE;
             case LONGDOUBLE -> ArgumentClassImpl.X87;

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/x64/windows/TypeClass.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/x64/windows/TypeClass.java
@@ -24,10 +24,10 @@
  */
 package jdk.internal.foreign.abi.x64.windows;
 
-import jdk.incubator.foreign.CLinker;
 import jdk.incubator.foreign.GroupLayout;
 import jdk.incubator.foreign.MemoryLayout;
 import jdk.incubator.foreign.ValueLayout;
+import jdk.internal.foreign.PlatformLayouts;
 
 import static jdk.internal.foreign.PlatformLayouts.Win64.VARARGS_ATTRIBUTE_NAME;
 
@@ -40,9 +40,6 @@ enum TypeClass {
     VARARG_FLOAT;
 
     private static TypeClass classifyValueType(ValueLayout type) {
-        CLinker.TypeKind kind = (CLinker.TypeKind)type.attribute(CLinker.TypeKind.ATTR_NAME).orElseThrow(
-                () -> { throw new IllegalStateException("Unexpected value layout: could not determine ABI class"); });
-
         // No 128 bit integers in the Windows C ABI. There are __m128(i|d) intrinsic types but they act just
         // like a struct when passing as an argument (passed by pointer).
         // https://docs.microsoft.com/en-us/cpp/cpp/m128?view=vs-2019
@@ -52,7 +49,7 @@ enum TypeClass {
         // but must be considered volatile across function calls."
         // https://docs.microsoft.com/en-us/cpp/build/x64-calling-convention?view=vs-2019
 
-        return switch (kind) {
+        return switch (PlatformLayouts.getKind(type)) {
             case CHAR, SHORT, INT, LONG, LONGLONG -> INTEGER;
             case POINTER -> POINTER;
             case FLOAT, DOUBLE, LONGDOUBLE -> {

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/x64/windows/TypeClass.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/x64/windows/TypeClass.java
@@ -40,9 +40,8 @@ enum TypeClass {
     VARARG_FLOAT;
 
     private static TypeClass classifyValueType(ValueLayout type) {
-        if (!(type instanceof CLinker.CValueLayout)) {
-            throw new IllegalStateException("Unexpected value layout: could not determine ABI class");
-        }
+        CLinker.TypeKind kind = (CLinker.TypeKind)type.attribute(CLinker.TypeKind.ATTR_NAME).orElseThrow(
+                () -> { throw new IllegalStateException("Unexpected value layout: could not determine ABI class"); });
 
         // No 128 bit integers in the Windows C ABI. There are __m128(i|d) intrinsic types but they act just
         // like a struct when passing as an argument (passed by pointer).
@@ -53,7 +52,7 @@ enum TypeClass {
         // but must be considered volatile across function calls."
         // https://docs.microsoft.com/en-us/cpp/build/x64-calling-convention?view=vs-2019
 
-        return switch (((CLinker.CValueLayout) type).kind()) {
+        return switch (kind) {
             case CHAR, SHORT, INT, LONG, LONGLONG -> INTEGER;
             case POINTER -> POINTER;
             case FLOAT, DOUBLE, LONGDOUBLE -> {

--- a/test/jdk/java/foreign/NativeTestHelper.java
+++ b/test/jdk/java/foreign/NativeTestHelper.java
@@ -29,7 +29,7 @@ public class NativeTestHelper {
 
     static CLinker.TypeKind kind(MemoryLayout layout) {
         return (CLinker.TypeKind)layout.attribute(CLinker.TypeKind.ATTR_NAME).orElseThrow(
-                () -> { throw new IllegalStateException("Unexpected value layout: could not determine ABI class"); });
+                () -> new IllegalStateException("Unexpected value layout: could not determine ABI class"));
     }
 
     public static boolean isIntegral(MemoryLayout layout) {

--- a/test/jdk/java/foreign/NativeTestHelper.java
+++ b/test/jdk/java/foreign/NativeTestHelper.java
@@ -27,11 +27,16 @@ import jdk.incubator.foreign.MemoryLayout;
 
 public class NativeTestHelper {
 
+    static CLinker.TypeKind kind(MemoryLayout layout) {
+        return (CLinker.TypeKind)layout.attribute(CLinker.TypeKind.ATTR_NAME).orElseThrow(
+                () -> { throw new IllegalStateException("Unexpected value layout: could not determine ABI class"); });
+    }
+
     public static boolean isIntegral(MemoryLayout layout) {
-        return ((CLinker.CValueLayout) layout).kind().isIntergral();
+        return kind(layout).isIntergral();
     }
 
     public static boolean isPointer(MemoryLayout layout) {
-        return ((CLinker.CValueLayout) layout).kind().isPointer();
+        return kind(layout).isPointer();
     }
 }

--- a/test/jdk/java/foreign/TestLayoutEquality.java
+++ b/test/jdk/java/foreign/TestLayoutEquality.java
@@ -52,9 +52,9 @@ public class TestLayoutEquality {
         assertEquals(newLayout.bitAlignment(), layout.bitAlignment());
         assertEquals(newLayout.name(), layout.name());
         assertEquals(newLayout.attributes().toArray().length, 0);
-        assertEquals(layout.attributes().toArray().length, 0);
+        assertEquals(layout.attributes().toArray().length, 1);
 
-        // but equals should return false, because one is a CValueLayout
+        // but equals should return false, because one is a ValueLayout with a CLinker kind
         assertNotEquals(newLayout, layout);
     }
 


### PR DESCRIPTION
This patch reverts recent changes to introduce a public CValueLayout class; the realization here is that, after all, CValueLayout exposes a public `Type` enum which is used by ABI classification. So, instead of using subclassing (which is messy and tedious with immutable data structures with covariant overrides), let's just double down on layout attributes, get rid of CValueLayout and simply expose the Type enum (now renamed to TypeKind).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- |
| Build | ✔️ (3/3 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) | ✔️ (9/9 passed) | ⏳ (5/9 running) | ✔️ (9/9 passed) |

### Issue
 * [JDK-8254156](https://bugs.openjdk.java.net/browse/JDK-8254156): Simplify ABI classification logic


### Reviewers
 * [Jorn Vernee](https://openjdk.java.net/census#jvernee) (@JornVernee - Committer)


### Download
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/371/head:pull/371`
`$ git checkout pull/371`
