### PR TITLE
8254156: Simplify ABI classification logic

### DIFF
--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/SourceConstantHelper.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/SourceConstantHelper.java
@@ -449,7 +449,9 @@ class SourceConstantHelper extends JavaSourceBuilder implements ConstantHelper {
     }
 
     private static String typeToLayoutName(ValueLayout vl) {
-        return switch (((CLinker.CValueLayout) vl).kind()) {
+        CLinker.TypeKind kind = (CLinker.TypeKind)vl.attribute(CLinker.TypeKind.ATTR_NAME).orElseThrow(
+                () -> new IllegalStateException("Unexpected value layout: could not determine ABI class"));
+        return switch (kind) {
             case CHAR -> "C_CHAR";
             case SHORT -> "C_SHORT";
             case INT -> "C_INT";


### PR DESCRIPTION
This small patch fixes SourceConstantHelper to use the more direct classification logic.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- |
| Build | ❌ (3/3 failed) | ❌ (2/2 failed) | ❌ (2/2 failed) |
| Build / test | ⏳ (1/1 running) | ⏳ (1/1 running) | ⏳ (1/1 running) |

**Failed test tasks**
- [Linux x64 (build debug)](https://github.com/mcimadamore/panama-foreign/runs/1220730946)
- [Linux x64 (build hotspot no-pch)](https://github.com/mcimadamore/panama-foreign/runs/1220730972)
- [Linux x64 (build release)](https://github.com/mcimadamore/panama-foreign/runs/1220730905)
- [Windows x64 (build debug)](https://github.com/mcimadamore/panama-foreign/runs/1220730724)
- [Windows x64 (build release)](https://github.com/mcimadamore/panama-foreign/runs/1220730712)
- [macOS x64 (build debug)](https://github.com/mcimadamore/panama-foreign/runs/1220730855)
- [macOS x64 (build release)](https://github.com/mcimadamore/panama-foreign/runs/1220730829)

### Issue
 * [JDK-8254156](https://bugs.openjdk.java.net/browse/JDK-8254156): Simplify ABI classification logic


### Reviewers
 * [Jorn Vernee](https://openjdk.java.net/census#jvernee) (@JornVernee - Committer)


### Download
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/372/head:pull/372`
`$ git checkout pull/372`
