### PR TITLE
Misc javadoc fixes

### DIFF
--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/CLinker.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/CLinker.java
@@ -40,7 +40,7 @@ import java.util.function.Consumer;
 import static jdk.internal.foreign.PlatformLayouts.*;
 
 /**
- * A foreign linker which implements the C Application Binary Interface (ABI) calling conventions.
+ * A C linker implements the C Application Binary Interface (ABI) calling conventions.
  * Instances of this interface can be used to link foreign functions in native libraries that
  * follow the JVM's target platform C ABI.
  * <p>

--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/NativeScope.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/NativeScope.java
@@ -38,15 +38,16 @@ import java.util.function.Function;
 import java.util.stream.Stream;
 
 /**
- * This class provides a scope of given size, within which several allocations can be performed. An native scope is backed
+ * This class provides a scope, within which several allocations can be performed. An native scope is backed
  * by off-heap memory. Native scopes can be either <em>bounded</em> or <em>unbounded</em>, depending on whether the size
- * of the native scope is known statically. If an application knows before-hand how much memory it needs to allocate the values it needs,
- * using a <em>bounded</em> native scope will typically provide better performances than independently allocating the memory
+ * of the native scope is known statically. If an application knows before-hand how much memory it needs to allocate,
+ * then using a <em>bounded</em> native scope will typically provide better performances than independently allocating the memory
  * for each value (e.g. using {@link MemorySegment#allocateNative(long)}), or using an <em>unbounded</em> native scope.
  * For this reason, using a bounded native scope is recommended in cases where programs might need to emulate native stack allocation.
  * <p>
  * Allocation scopes are thread-confined (see {@link #ownerThread()}; as such, the resulting {@link MemorySegment} instances
- * returned by the native scope will be backed by memory segments confined by the same owner thread as the native scope.
+ * returned by the native scope will be backed by memory segments confined by the same owner thread as the native scope's
+ * owner thread.
  * <p>
  * To allow for more usability, it is possible for a native scope to reclaim ownership of an existing memory segment
  * (see {@link MemorySegment#handoff(NativeScope)}). This might be useful to allow one or more segments which were independently

--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/package-info.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/package-info.java
@@ -99,7 +99,7 @@ try (MemorySegment segment = MemorySegment.allocateNative(10 * 4)) {
  * <h2>Foreign function access</h2>
  * The key abstractions introduced to support foreign function access are {@link jdk.incubator.foreign.LibraryLookup} and {@link jdk.incubator.foreign.CLinker}.
  * The former is used to load foreign libraries, as well as to lookup symbols inside said libraries; the latter
- * provides linking capabilities which allow to model foreign functions as {@link jdk.incubator.foreign.MemoryHandles} instance,
+ * provides linking capabilities which allow to model foreign functions as {@link java.lang.invoke.MethodHandle} instances,
  * so that clients can perform foreign function calls directly in Java, without the need for intermediate layers of native
  * code (as it's the case with the <a href="{@docRoot}/../specs/jni/index.html">Java Native Interface (JNI)</a>).
  * <p>
@@ -118,7 +118,7 @@ try (var cString = CLinker.toCString("Hello")) {
 }
  * }</pre>
  *
- * Here, we lookup the {@code strlen} symbol in the <em>default</em> library lookup (see {@link jdk.incubator.foreign.LibraryLookup#ofDefault()}.
+ * Here, we lookup the {@code strlen} symbol in the <em>default</em> library lookup (see {@link jdk.incubator.foreign.LibraryLookup#ofDefault()}).
  * Then, we obtain a linker instance (see {@link jdk.incubator.foreign.CLinker#getInstance()}) and we use it to
  * obtain a method handle which targets the {@code strlen} library symbol. To complete the linking successfully,
  * we must provide (i) a {@link java.lang.invoke.MethodType} instance, describing the type of the resulting method handle
@@ -174,7 +174,7 @@ int x = MemoryAccess.getIntAtOffset(MemorySegment.ofNativeRestricted(), addr.toR
  * }</pre>
  *
  * <h3>Upcalls</h3>
- * The {@link jdk.incubator.foreign.CLinker} class also allows to turn an existing method handle (which might point
+ * The {@link jdk.incubator.foreign.CLinker} interface also allows to turn an existing method handle (which might point
  * to a Java method) into a native memory segment (see {@link jdk.incubator.foreign.MemorySegment}), so that Java code
  * can effectively be passed to other foreign functions. For instance, we can write a method that compares two
  * integer values, as follows:
@@ -198,7 +198,7 @@ MethodHandle intCompareHandle = MethodHandles.lookup().findStatic(IntComparator.
                                                    MethodType.methodType(int.class, MemoryAddress.class, MemoryAddress.class));
  * }</pre>
  *
- * Now that we have a method handle instance, we can link it into a fresh native memory segment, using the {@link jdk.incubator.foreign.CLinker} class, as follows:
+ * Now that we have a method handle instance, we can link it into a fresh native memory segment, using the {@link jdk.incubator.foreign.CLinker} interface, as follows:
  *
  * <pre>{@code
 MemorySegment comparFunc = CLinker.getInstance().upcallStub(
@@ -209,7 +209,7 @@ MemorySegment comparFunc = CLinker.getInstance().upcallStub(
  *
  * As before, we need to provide a {@link jdk.incubator.foreign.FunctionDescriptor} instance describing the signature
  * of the function pointer we want to create; as before, this, coupled with the method handle type, uniquely determines the
- * sequence of steps which will allow foreign code to call the {@code intCompareHandle} according to the rules specified
+ * sequence of steps which will allow foreign code to call {@code intCompareHandle} according to the rules specified
  * by the platform C ABI.
  *
  * <h2>Restricted methods</h2>


### PR DESCRIPTION
I did another pass on the ABI-related javadoc; this resulted in a biggie surgery of the javadoc in `CLinker` as well as few minor changes/fixes in several places.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [Jorn Vernee](https://openjdk.java.net/census#jvernee) (@JornVernee - Committer) ⚠️ Review applies to cbb0517065706d5fca332bdddbe31011e540ecb1
 * [Athijegannathan Sundararajan](https://openjdk.java.net/census#sundar) (@sundararajana - Committer) ⚠️ Review applies to cbb0517065706d5fca332bdddbe31011e540ecb1


### Download
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/373/head:pull/373`
`$ git checkout pull/373`
