### PR TITLE
8254682: Close MemorySegments passed to upcalls after the upcall is done

### DIFF
--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/AbstractNativeScope.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/AbstractNativeScope.java
@@ -18,6 +18,10 @@ public abstract class AbstractNativeScope implements NativeScope {
         this.ownerThread = ownerThread;
     }
 
+    public static NativeScope emptyScope() {
+        return new EmptyScope();
+    }
+
     @Override
     public Thread ownerThread() {
         return ownerThread;
@@ -129,6 +133,28 @@ public abstract class AbstractNativeScope implements NativeScope {
             } catch (IndexOutOfBoundsException ex) {
                 throw new OutOfMemoryError("Not enough space left to allocate");
             }
+        }
+    }
+
+    // only for registering
+    private static class EmptyScope extends AbstractNativeScope {
+        public EmptyScope() {
+            super(Thread.currentThread());
+        }
+
+        @Override
+        public OptionalLong byteSize() {
+            return OptionalLong.of(0);
+        }
+
+        @Override
+        public long allocatedBytes() {
+            return 0;
+        }
+
+        @Override
+        public MemorySegment allocate(long bytesSize, long bytesAlignment) {
+            throw new OutOfMemoryError("Not enough space left to allocate");
         }
     }
 }

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/Binding.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/Binding.java
@@ -220,7 +220,7 @@ public abstract class Binding {
             MH_ALLOCATE_BUFFER = lookup.findStatic(Binding.Allocate.class, "allocateBuffer",
                     methodType(MemorySegment.class, long.class, long.class, SharedUtils.Allocator.class));
             MH_TO_SEGMENT = lookup.findStatic(Binding.ToSegment.class, "toSegment",
-                    methodType(MemorySegment.class, MemoryAddress.class, long.class));
+                    methodType(MemorySegment.class, MemoryAddress.class, long.class, SharedUtils.Allocator.class));
         } catch (ReflectiveOperationException e) {
             throw new RuntimeException(e);
         }
@@ -837,7 +837,7 @@ public abstract class Binding {
     }
 
     /**
-     * Box_ADDRESS()
+     * BOX_ADDRESS()
      * Pops a 'long' from the operand stack, converts it to a 'MemoryAddress',
      *     and pushes that onto the operand stack.
      */
@@ -907,8 +907,8 @@ public abstract class Binding {
     }
 
     /**
-     * BASE_ADDRESS([size])
-     *   Pops a MemoryAddress from the operand stack, and takes the converts it to a MemorySegment
+     * TO_SEGMENT([size])
+     *   Pops a MemoryAddress from the operand stack, and converts it to a MemorySegment
      *   with the given size, and pushes that onto the operand stack
      */
     public static class ToSegment extends Binding {
@@ -920,9 +920,9 @@ public abstract class Binding {
             this.size = size;
         }
 
-        // FIXME should register with scope
-        private static MemorySegment toSegment(MemoryAddress operand, long size) {
-            return MemoryAddressImpl.ofLongUnchecked(operand.toRawLongValue(), size);
+        private static MemorySegment toSegment(MemoryAddress operand, long size, SharedUtils.Allocator allocator) {
+            MemorySegment ms = MemoryAddressImpl.ofLongUnchecked(operand.toRawLongValue(), size);
+            return allocator.handoff(ms);
         }
 
         @Override
@@ -936,14 +936,15 @@ public abstract class Binding {
         public void interpret(Deque<Object> stack, BindingInterpreter.StoreFunc storeFunc,
                               BindingInterpreter.LoadFunc loadFunc, SharedUtils.Allocator allocator) {
             MemoryAddress operand = (MemoryAddress) stack.pop();
-            MemorySegment segment = toSegment(operand, size);
+            MemorySegment segment = toSegment(operand, size, allocator);
             stack.push(segment);
         }
 
         @Override
         public MethodHandle specialize(MethodHandle specializedHandle, int insertPos, int allocatorPos) {
             MethodHandle toSegmentHandle = insertArguments(MH_TO_SEGMENT, 1, size);
-            return filterArguments(specializedHandle, insertPos, toSegmentHandle);
+            specializedHandle = filterArguments(specializedHandle, insertPos, toSegmentHandle);
+            return Binding.mergeArguments(specializedHandle, allocatorPos, insertPos + 1);
         }
 
         @Override

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/ProgrammableInvoker.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/ProgrammableInvoker.java
@@ -28,7 +28,7 @@ import jdk.incubator.foreign.MemorySegment;
 import jdk.incubator.foreign.NativeScope;
 import jdk.internal.access.JavaLangInvokeAccess;
 import jdk.internal.access.SharedSecrets;
-import jdk.internal.foreign.Utils;
+import jdk.internal.foreign.abi.SharedUtils.Allocator;
 import jdk.internal.invoke.NativeEntryPoint;
 import jdk.internal.invoke.VMStorageProxy;
 import sun.security.action.GetPropertyAction;
@@ -94,8 +94,8 @@ public class ProgrammableInvoker {
                     methodType(NativeScope.class, long.class));
             MH_CLOSE_SCOPE = lookup.findVirtual(NativeScope.class, "close",
                     methodType(void.class));
-            MH_WRAP_SCOPE = lookup.findStatic(SharedUtils.Allocator.class, "ofScope",
-                    methodType(SharedUtils.Allocator.class, NativeScope.class));
+            MH_WRAP_SCOPE = lookup.findStatic(Allocator.class, "ofScope",
+                    methodType(Allocator.class, NativeScope.class));
         } catch (ReflectiveOperationException e) {
             throw new RuntimeException(e);
         }
@@ -126,24 +126,7 @@ public class ProgrammableInvoker {
                 .count()
                 * abi.arch.typeSize(abi.arch.stackType());
 
-        this.bufferCopySize = bufferCopySize(callingSequence);
-    }
-
-    private static long bufferCopySize(CallingSequence callingSequence) {
-        // FIXME: > 16 bytes alignment might need extra space since the
-        // starting address of the allocator might be un-aligned.
-        long size = 0;
-        for (int i = 0; i < callingSequence.argumentCount(); i++) {
-            List<Binding> bindings = callingSequence.argumentBindings(i);
-            for (Binding b : bindings) {
-                if (b instanceof Binding.Copy) {
-                    Binding.Copy c = (Binding.Copy) b;
-                    size = Utils.alignUp(size, c.alignment());
-                    size += c.size();
-                }
-            }
-        }
-        return size;
+        this.bufferCopySize = SharedUtils.bufferCopySize(callingSequence);
     }
 
     public MethodHandle getBoundMethodHandle() {
@@ -221,7 +204,7 @@ public class ProgrammableInvoker {
         int argAllocatorPos = -1;
         if (bufferCopySize > 0) {
             argAllocatorPos = 0;
-            specializedHandle = dropArguments(specializedHandle, argAllocatorPos, SharedUtils.Allocator.class);
+            specializedHandle = dropArguments(specializedHandle, argAllocatorPos, Allocator.class);
             argInsertPos++;
         }
         for (int i = 0; i < highLevelType.parameterCount(); i++) {
@@ -242,7 +225,7 @@ public class ProgrammableInvoker {
             MethodHandle returnFilter = identity(highLevelType.returnType());
             int retAllocatorPos = 0;
             int retInsertPos = 1;
-            returnFilter = dropArguments(returnFilter, retAllocatorPos, SharedUtils.Allocator.class);
+            returnFilter = dropArguments(returnFilter, retAllocatorPos, Allocator.class);
             List<Binding> bindings = callingSequence.returnBindings();
             for (int j = bindings.size() - 1; j >= 0; j--) {
                 Binding binding = bindings.get(j);
@@ -341,8 +324,8 @@ public class ProgrammableInvoker {
     Object invokeInterpBindings(Object[] args, MethodHandle leaf,
                                 Map<VMStorage, Integer> argIndexMap,
                                 Map<VMStorage, Integer> retIndexMap) throws Throwable {
-        SharedUtils.Allocator unboxAllocator = bufferCopySize != 0
-                ? SharedUtils.Allocator.ofScope(NativeScope.boundedScope(bufferCopySize))
+        Allocator unboxAllocator = bufferCopySize != 0
+                ? Allocator.ofScope(NativeScope.boundedScope(bufferCopySize))
                 : THROWING_ALLOCATOR;
         try (unboxAllocator) {
             // do argument processing, get Object[] as result

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/ProgrammableUpcallHandler.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/ProgrammableUpcallHandler.java
@@ -24,22 +24,19 @@
 package jdk.internal.foreign.abi;
 
 import jdk.incubator.foreign.MemoryAddress;
-import jdk.incubator.foreign.MemoryHandles;
 import jdk.incubator.foreign.MemoryLayouts;
 import jdk.incubator.foreign.MemorySegment;
+import jdk.incubator.foreign.NativeScope;
 import jdk.internal.foreign.MemoryAddressImpl;
-import jdk.internal.foreign.Utils;
+import jdk.internal.foreign.abi.SharedUtils.Allocator;
 import jdk.internal.vm.annotation.Stable;
 
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodType;
 import java.lang.invoke.VarHandle;
-import java.nio.ByteOrder;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Objects;
 
-import static jdk.internal.foreign.abi.SharedUtils.DEFAULT_ALLOCATOR;
 import static sun.security.action.GetBooleanAction.privilegedGetProperty;
 
 /**
@@ -63,6 +60,8 @@ public class ProgrammableUpcallHandler implements UpcallHandler {
     private final ABIDescriptor abi;
     private final BufferLayout layout;
 
+    private final long bufferCopySize;
+
     public ProgrammableUpcallHandler(ABIDescriptor abi, MethodHandle target, CallingSequence callingSequence) {
         this.abi = abi;
         this.layout = BufferLayout.of(abi);
@@ -70,6 +69,7 @@ public class ProgrammableUpcallHandler implements UpcallHandler {
         this.callingSequence = callingSequence;
         this.mh = target.asSpreader(Object[].class, callingSequence.methodType().parameterCount());
         this.entryPoint = allocateUpcallStub(abi, layout);
+        this.bufferCopySize = SharedUtils.bufferCopySize(callingSequence);
     }
 
     @Override
@@ -82,7 +82,10 @@ public class ProgrammableUpcallHandler implements UpcallHandler {
     }
 
     private void invoke(MemoryAddress buffer) {
-        try {
+        Allocator allocator = bufferCopySize != 0
+                ? Allocator.ofScope(NativeScope.boundedScope(bufferCopySize))
+                : Allocator.empty();
+        try (allocator) {
             MemorySegment bufferBase = MemoryAddressImpl.ofLongUnchecked(buffer.toRawLongValue(), layout.size);
 
             if (DEBUG) {
@@ -99,7 +102,7 @@ public class ProgrammableUpcallHandler implements UpcallHandler {
                                 ? stackArgsBase.asSlice(storage.index() * abi.arch.typeSize(abi.arch.stackType()))
                                 : bufferBase.asSlice(layout.argOffset(storage));
                             return SharedUtils.read(ptr, type);
-                        }, DEFAULT_ALLOCATOR);
+                        }, allocator);
             }
 
             if (DEBUG) {

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/aarch64/CallArranger.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/aarch64/CallArranger.java
@@ -407,9 +407,6 @@ public class CallArranger {
                     bindings.vmLoad(storage, long.class)
                             .boxAddress()
                             .toSegment(layout);
-                    // ASSERT SCOPE OF BOXED ADDRESS HERE
-                    // caveat. buffer should instead go out of scope after call
-                    bindings.copy(layout);
                     break;
                 }
                 case STRUCT_HFA: {

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/x64/windows/CallArranger.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/x64/windows/CallArranger.java
@@ -279,9 +279,6 @@ public class CallArranger {
                     bindings.vmLoad(storage, long.class)
                             .boxAddress()
                             .toSegment(layout);
-                    // ASSERT SCOPE OF BOXED ADDRESS HERE
-                    // caveat. buffer should instead go out of scope after call
-                    bindings.copy(layout);
                     break;
                 }
                 case POINTER: {

--- a/test/jdk/java/foreign/TestUpcall.java
+++ b/test/jdk/java/foreign/TestUpcall.java
@@ -85,7 +85,8 @@ public class TestUpcall extends CallGeneratorHelper {
     static {
         try {
             DUMMY = MethodHandles.lookup().findStatic(TestUpcall.class, "dummy", MethodType.methodType(void.class));
-            PASS_AND_SAVE = MethodHandles.lookup().findStatic(TestUpcall.class, "passAndSave", MethodType.methodType(Object.class, Object[].class, AtomicReference.class));
+            PASS_AND_SAVE = MethodHandles.lookup().findStatic(TestUpcall.class, "passAndSave",
+                    MethodType.methodType(Object.class, Object[].class, AtomicReference.class, List.class));
         } catch (Throwable ex) {
             throw new IllegalStateException(ex);
         }
@@ -155,7 +156,7 @@ public class TestUpcall extends CallGeneratorHelper {
         }
 
         AtomicReference<Object[]> box = new AtomicReference<>();
-        MethodHandle mh = insertArguments(PASS_AND_SAVE, 1, box);
+        MethodHandle mh = insertArguments(PASS_AND_SAVE, 1, box, segments);
         mh = mh.asCollector(Object[].class, params.size());
 
         for (int i = 0; i < params.size(); i++) {
@@ -193,7 +194,16 @@ public class TestUpcall extends CallGeneratorHelper {
         return stub.address();
     }
 
-    static Object passAndSave(Object[] o, AtomicReference<Object[]> ref) {
+    static Object passAndSave(Object[] o, AtomicReference<Object[]> ref, List<MemorySegment> copies) {
+        for (int i = 0; i < o.length; i++) {
+            if (o[i] instanceof MemorySegment) {
+                MemorySegment ms = (MemorySegment) o[i];
+                MemorySegment copy = MemorySegment.allocateNative(ms.byteSize());
+                copy.copyFrom(ms);
+                o[i] = copy;
+                copies.add(copy);
+            }
+        }
         ref.set(o);
         return o[0];
     }

--- a/test/jdk/java/foreign/TestUpcallHighArity.java
+++ b/test/jdk/java/foreign/TestUpcallHighArity.java
@@ -98,25 +98,34 @@ public class TestUpcallHighArity extends CallGeneratorHelper {
                     S_PDI_LAYOUT, C_INT, C_DOUBLE, C_POINTER)
             );
             MH_passAndSave = MethodHandles.lookup().findStatic(TestUpcallHighArity.class, "passAndSave",
-                    MethodType.methodType(void.class, Object[].class, AtomicReference.class));
+                    MethodType.methodType(void.class, Object[].class, AtomicReference.class, List.class));
         } catch (ReflectiveOperationException e) {
             throw new InternalError(e);
         }
     }
 
-    static void passAndSave(Object[] o, AtomicReference<Object[]> ref) {
+    static void passAndSave(Object[] o, AtomicReference<Object[]> ref, List<MemorySegment> copies) {
+        for (int i = 0; i < o.length; i++) {
+            if (o[i] instanceof MemorySegment) {
+                MemorySegment ms = (MemorySegment) o[i];
+                MemorySegment copy = MemorySegment.allocateNative(ms.byteSize());
+                copy.copyFrom(ms);
+                o[i] = copy;
+                copies.add(copy);
+            }
+        }
         ref.set(o);
     }
 
     @Test(dataProvider = "args")
     public void testUpcall(MethodHandle downcall, MethodType upcallType,
                            FunctionDescriptor upcallDescriptor) throws Throwable {
+        List<MemorySegment> segments = new ArrayList<>();
         AtomicReference<Object[]> capturedArgs = new AtomicReference<>();
-        MethodHandle target = MethodHandles.insertArguments(MH_passAndSave, 1, capturedArgs)
+        MethodHandle target = MethodHandles.insertArguments(MH_passAndSave, 1, capturedArgs, segments)
                                          .asCollector(Object[].class, upcallType.parameterCount())
                                          .asType(upcallType);
         try (MemorySegment upcallStub = LINKER.upcallStub(target, upcallDescriptor)) {
-            List<MemorySegment> segments = new ArrayList<>();
             Object[] args = new Object[upcallType.parameterCount() + 1];
             args[0] = upcallStub.address();
             List<MemoryLayout> argLayouts = upcallDescriptor.argumentLayouts();

--- a/test/jdk/java/foreign/TestUpcallStructScope.java
+++ b/test/jdk/java/foreign/TestUpcallStructScope.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ *  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ *  This code is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License version 2 only, as
+ *  published by the Free Software Foundation.
+ *
+ *  This code is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ *  version 2 for more details (a copy is included in the LICENSE file that
+ *  accompanied this code).
+ *
+ *  You should have received a copy of the GNU General Public License version
+ *  2 along with this work; if not, write to the Free Software Foundation,
+ *  Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ *  Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ *  or visit www.oracle.com if you need additional information or have any
+ *  questions.
+ *
+ */
+
+/*
+ * @test
+ * @modules jdk.incubator.foreign/jdk.internal.foreign
+ *
+ * @run testng/othervm/native
+ *   -Dforeign.restricted=permit
+ *   -Djdk.internal.foreign.ProgrammableInvoker.USE_SPEC=false
+ *   TestUpcallStructScope
+ * @run testng/othervm/native
+ *   -Dforeign.restricted=permit
+ *   -Djdk.internal.foreign.ProgrammableInvoker.USE_SPEC=true
+ *   TestUpcallStructScope
+ */
+
+import jdk.incubator.foreign.CLinker;
+import jdk.incubator.foreign.FunctionDescriptor;
+import jdk.incubator.foreign.LibraryLookup;
+import jdk.incubator.foreign.MemoryAddress;
+import jdk.incubator.foreign.MemoryLayout;
+import jdk.incubator.foreign.MemorySegment;
+import org.testng.annotations.Test;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
+
+import static jdk.incubator.foreign.CLinker.C_DOUBLE;
+import static jdk.incubator.foreign.CLinker.C_INT;
+import static jdk.incubator.foreign.CLinker.C_POINTER;
+import static org.testng.Assert.assertFalse;
+
+public class TestUpcallStructScope {
+    static final MethodHandle MH_do_upcall;
+    static final CLinker LINKER = CLinker.getInstance();
+    static final MethodHandle MH_Consumer_accept;
+
+    // struct S_PDI { void* p0; double p1; int p2; };
+    static final MemoryLayout S_PDI_LAYOUT = MemoryLayout.ofStruct(
+        C_POINTER.withName("p0"),
+        C_DOUBLE.withName("p1"),
+        C_INT.withName("p2")
+    );
+
+    static {
+        LibraryLookup lookup = LibraryLookup.ofLibrary("TestUpcallStructScope");
+        MH_do_upcall = LINKER.downcallHandle(
+            lookup.lookup("do_upcall").orElseThrow(),
+            MethodType.methodType(void.class, MemoryAddress.class, MemorySegment.class),
+            FunctionDescriptor.ofVoid(C_POINTER, S_PDI_LAYOUT)
+        );
+
+        try {
+            MH_Consumer_accept = MethodHandles.publicLookup().findVirtual(Consumer.class, "accept",
+                    MethodType.methodType(void.class, Object.class));
+        } catch (NoSuchMethodException | IllegalAccessException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static MethodHandle methodHandle (Consumer<MemorySegment> callback) {
+        return MH_Consumer_accept.bindTo(callback).asType(MethodType.methodType(void.class, MemorySegment.class));
+    }
+
+    @Test
+    public void testUpcall() throws Throwable {
+        AtomicReference<MemorySegment> capturedSegment = new AtomicReference<>();
+        MethodHandle target = methodHandle(capturedSegment::set);
+        FunctionDescriptor upcallDesc = FunctionDescriptor.ofVoid(S_PDI_LAYOUT);
+        try (MemorySegment upcallStub = LINKER.upcallStub(target, upcallDesc);
+             MemorySegment argSegment = MemorySegment.allocateNative(S_PDI_LAYOUT)) {
+
+            MH_do_upcall.invokeExact(upcallStub.address(), argSegment);
+        }
+
+        MemorySegment captured = capturedSegment.get();
+        assertFalse(captured.isAlive());
+    }
+
+}

--- a/test/jdk/java/foreign/libTestUpcallStructScope.c
+++ b/test/jdk/java/foreign/libTestUpcallStructScope.c
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+#ifdef _WIN64
+#define EXPORT __declspec(dllexport)
+#else
+#define EXPORT
+#endif
+
+struct S_PDI { void* p0; double p1; int p2; };
+
+EXPORT void do_upcall(void (*cb)(struct S_PDI), struct S_PDI a0) {
+    cb(a0);
+}


### PR DESCRIPTION
Hi,

Currently, we don't close MemorySegments that we pass to upcalls. This makes it easier to leak a MemorySegment from an upcall, but it also incurs an additional copy on Windows and Aarch64, and forces users to close these segments manually instead. (This is mostly so for historical reasons, when it was not as easy to avoid this copy due to the code structure/design at that time).

We can instead registers these segments with a NativeScope that is closed after the upcall completes, to make sure these segments do not leak inadvertently, and we don't need the additional copy on some platforms. 

In this PR I've also fixed 2 minor Javadoc issues in Binding.java that I missed last time around.

This patch will also break jexract tests, but I have a patch ready to fix (was pretty trivial). (https://github.com/openjdk/panama-foreign/pull/380)

Thanks,
Jorn

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [JDK-8254682](https://bugs.openjdk.java.net/browse/JDK-8254682): Close MemorySegments passed to upcalls after the upcall is done


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.java.net/census#mcimadamore) (@mcimadamore - Committer)


### Download
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/379/head:pull/379`
`$ git checkout pull/379`
