### PR TITLE
8254682: Close MemorySegments passed to upcalls after the upcall is done

### DIFF
--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/clang/Cursor.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/clang/Cursor.java
@@ -338,7 +338,9 @@ public final class Cursor {
     private static class CursorChildren {
         private static final ArrayList<Cursor> children = new ArrayList<>();
         private static final MemorySegment callback = Index_h.clang_visitChildren$visitor.allocate((c, p, d) -> {
-            Cursor cursor = new Cursor(c);
+            MemorySegment copy = MemorySegment.allocateNative(c.byteSize());
+            copy.copyFrom(c);
+            Cursor cursor = new Cursor(copy);
             children.add(cursor);
             return Index_h.CXChildVisit_Continue();
         });


### PR DESCRIPTION
These are the jextract fixes needed after: https://github.com/openjdk/panama-foreign/pull/379

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [JDK-8254682](https://bugs.openjdk.java.net/browse/JDK-8254682): Close MemorySegments passed to upcalls after the upcall is done


### Reviewers
 * [Athijegannathan Sundararajan](https://openjdk.java.net/census#sundar) (@sundararajana - Committer) ⚠️ Review applies to 972daf1f898c1e85e2a2d8b43433bf90f37d7e97


### Download
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/380/head:pull/380`
`$ git checkout pull/380`
