### PR TITLE
8254983: jextract fails to hande layout paths nested structs/union

### DIFF
--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/JavaSourceBuilder.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/JavaSourceBuilder.java
@@ -241,7 +241,7 @@ abstract class JavaSourceBuilder {
         return nestedClassNames.add(name.toLowerCase()) ? name : (name + "$" + nestedClassNameCount++);
     }
 
-    StructBuilder newStructBuilder(String name, String parentLayoutFieldName, MemoryLayout parentLayout, Type type) {
-        return new StructBuilder(this, name, parentLayoutFieldName, parentLayout, type);
+    StructBuilder newStructBuilder(String name, MemoryLayout parentLayout, Type type) {
+        return new StructBuilder(this, name, parentLayout, type);
     }
 }

--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/JavaSourceBuilder.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/JavaSourceBuilder.java
@@ -25,6 +25,7 @@
 package jdk.internal.jextract.impl;
 
 import jdk.incubator.foreign.FunctionDescriptor;
+import jdk.incubator.foreign.GroupLayout;
 import jdk.incubator.foreign.MemoryLayout;
 import jdk.incubator.jextract.Type;
 
@@ -241,7 +242,7 @@ abstract class JavaSourceBuilder {
         return nestedClassNames.add(name.toLowerCase()) ? name : (name + "$" + nestedClassNameCount++);
     }
 
-    StructBuilder newStructBuilder(String name, MemoryLayout parentLayout, Type type) {
+    StructBuilder newStructBuilder(String name, GroupLayout parentLayout, Type type) {
         return new StructBuilder(this, name, parentLayout, type);
     }
 }

--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/NestedClassBuilder.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/NestedClassBuilder.java
@@ -27,7 +27,7 @@ package jdk.internal.jextract.impl;
 
 public abstract class NestedClassBuilder extends JavaSourceBuilder {
 
-    private final JavaSourceBuilder enclosing;
+    protected final JavaSourceBuilder enclosing;
 
     public NestedClassBuilder(JavaSourceBuilder enclosing, Kind kind, String className) {
         super(enclosing.builder, kind, enclosing.uniqueNestedClassName(className), enclosing.pkgName, enclosing.constantHelper, enclosing.annotationWriter);

--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/OutputFactory.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/OutputFactory.java
@@ -198,12 +198,10 @@ public class OutputFactory implements Declaration.Visitor<Void, Declaration> {
                     structClass = true;
                     String className = d.name().isEmpty() ? parent.name() : d.name();
                     MemoryLayout parentLayout = parentLayout(d);
-                    String parentLayoutFieldName = className + "$struct";
-                    currentBuilder = currentBuilder.newStructBuilder(className, parentLayoutFieldName,
-                            parentLayout, Type.declared(d));
+                    currentBuilder = currentBuilder.newStructBuilder(className, parentLayout, Type.declared(d));
                     addStructDefinition(d, currentBuilder.className);
                     currentBuilder.classBegin();
-                    currentBuilder.addLayoutGetter(parentLayoutFieldName, d.layout().get());
+                    currentBuilder.addLayoutGetter(((StructBuilder)currentBuilder).layoutField(), d.layout().get());
                     break;
                 }
             }

--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/OutputFactory.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/OutputFactory.java
@@ -197,7 +197,7 @@ public class OutputFactory implements Declaration.Visitor<Void, Declaration> {
                 case UNION: {
                     structClass = true;
                     String className = d.name().isEmpty() ? parent.name() : d.name();
-                    MemoryLayout parentLayout = parentLayout(d);
+                    GroupLayout parentLayout = (GroupLayout)parentLayout(d);
                     currentBuilder = currentBuilder.newStructBuilder(className, parentLayout, Type.declared(d));
                     addStructDefinition(d, currentBuilder.className);
                     currentBuilder.classBegin();

--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/StructBuilder.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/StructBuilder.java
@@ -35,13 +35,13 @@ import jdk.incubator.jextract.Type;
  */
 class StructBuilder extends NestedClassBuilder {
 
-    private final MemoryLayout parentLayout;
+    private final GroupLayout parentLayout;
     private final String structAnno;
     private final String structArrayAnno;
     private final String structPtrAnno;
     private final Type structType;
 
-    StructBuilder(JavaSourceBuilder enclosing, String className, MemoryLayout parentLayout, Type structType) {
+    StructBuilder(JavaSourceBuilder enclosing, String className, GroupLayout parentLayout, Type structType) {
         super(enclosing, Kind.CLASS, className);
         this.parentLayout = parentLayout;
         this.structAnno = annotationWriter.getCAnnotation(structType);
@@ -291,7 +291,7 @@ class StructBuilder extends NestedClassBuilder {
     }
 
     String layoutField() {
-        GroupLayout groupLayout = (GroupLayout)parentLayout;
+        GroupLayout groupLayout = parentLayout;
         String suffix = groupLayout.isUnion() ? "union" : "struct";
         return qualifiedName(this) + "$" + suffix;
     }

--- a/test/jdk/tools/jextract/test8254983/LibTest8254983Test.java
+++ b/test/jdk/tools/jextract/test8254983/LibTest8254983Test.java
@@ -21,6 +21,7 @@
  * questions.
  */
 
+import jdk.incubator.foreign.GroupLayout;
 import jdk.incubator.foreign.MemorySegment;
 import org.testng.annotations.Test;
 import static org.testng.Assert.assertEquals;
@@ -47,6 +48,7 @@ import static test.jextract.test8254983.test8254983_h.*;
 public class LibTest8254983Test {
     @Test
     public void testOuterStruct() {
+        assertEquals(((GroupLayout)Foo._struct.$LAYOUT()).memberLayouts().size(), 1);
         MemorySegment str = Foo._struct.allocate();
         Foo._struct.x$set(str, 42);
         assertEquals(Foo._struct.x$get(str), 42);
@@ -54,6 +56,7 @@ public class LibTest8254983Test {
 
     @Test
     public void testInnerStruct() {
+        assertEquals(((GroupLayout)Foo._union._struct.$LAYOUT()).memberLayouts().size(), 2);
         MemorySegment str = Foo._union._struct.allocate();
         Foo._union._struct.x$set(str, 42);
         assertEquals(Foo._union._struct.x$get(str), 42);

--- a/test/jdk/tools/jextract/test8254983/LibTest8254983Test.java
+++ b/test/jdk/tools/jextract/test8254983/LibTest8254983Test.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import jdk.incubator.foreign.MemorySegment;
+import org.testng.annotations.Test;
+import static org.testng.Assert.assertEquals;
+import static test.jextract.test8254983.test8254983_h.*;
+
+/*
+ * @test id=classes
+ * @library ..
+ * @modules jdk.incubator.jextract
+ * @bug 8254983
+ * @summary jextract fails to hande layout paths nested structs/union
+ * @run driver JtregJextract -t test.jextract.test8254983 -- test8254983.h
+ * @run testng/othervm -Dforeign.restricted=permit LibTest8254983Test
+ */
+/*
+ * @test id=sources
+ * @library ..
+ * @modules jdk.incubator.jextract
+ * @bug 8254983
+ * @summary jextract fails to hande layout paths nested structs/union
+ * @run driver JtregJextractSources -t test.jextract.test8254983 -- test8254983.h
+ * @run testng/othervm -Dforeign.restricted=permit LibTest8254983Test
+ */
+public class LibTest8254983Test {
+    @Test
+    public void testOuterStruct() {
+        MemorySegment str = Foo._struct.allocate();
+        Foo._struct.x$set(str, 42);
+        assertEquals(Foo._struct.x$get(str), 42);
+    }
+
+    @Test
+    public void testInnerStruct() {
+        MemorySegment str = Foo._union._struct.allocate();
+        Foo._union._struct.x$set(str, 42);
+        assertEquals(Foo._union._struct.x$get(str), 42);
+    }
+}

--- a/test/jdk/tools/jextract/test8254983/test8254983.h
+++ b/test/jdk/tools/jextract/test8254983/test8254983.h
@@ -1,3 +1,26 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
 struct Foo {
    struct {
        int x;
@@ -5,6 +28,7 @@ struct Foo {
 
    union {
        struct {
+           int u;
            int x;
        } _struct;
    } _union;

--- a/test/jdk/tools/jextract/test8254983/test8254983.h
+++ b/test/jdk/tools/jextract/test8254983/test8254983.h
@@ -1,0 +1,11 @@
+struct Foo {
+   struct {
+       int x;
+   } _struct;
+
+   union {
+       struct {
+           int x;
+       } _struct;
+   } _union;
+};


### PR DESCRIPTION
This patch fixes an issue with jextract code generation. More specifically, when multiple structs with same name are found in an header (this is possible if the structs are at different level of nesting e.g. `Foo.Bar` vs. `Foo.Baz.Bar`), jextract erroneously uses the struct simple name to qualifiy the various fields associated with the struct (such as the layout field). Because of this, there are cases where, when generating a var handle for a struct field, we erroneously pick up the layout corresponding to a different struct, which then causes an error at runtime.

The fix is to always disambiguate struct names when in nested context, so that `Foo.Bar` and `Foo.Baz.Bar` lead to different constant names.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- |
| Build | ❌ (5/5 failed) | ❌ (2/2 failed) | ❌ (2/2 failed) |

**Failed test tasks**
- [Linux x64 (build debug)](https://github.com/mcimadamore/panama-foreign/runs/1276419938)
- [Linux x64 (build hotspot minimal)](https://github.com/mcimadamore/panama-foreign/runs/1276420061)
- [Linux x64 (build hotspot no-pch)](https://github.com/mcimadamore/panama-foreign/runs/1276419992)
- [Linux x64 (build hotspot zero)](https://github.com/mcimadamore/panama-foreign/runs/1276420031)
- [Linux x64 (build release)](https://github.com/mcimadamore/panama-foreign/runs/1276419914)
- [Windows x64 (build debug)](https://github.com/mcimadamore/panama-foreign/runs/1276419853)
- [Windows x64 (build release)](https://github.com/mcimadamore/panama-foreign/runs/1276419800)
- [macOS x64 (build debug)](https://github.com/mcimadamore/panama-foreign/runs/1276419711)
- [macOS x64 (build release)](https://github.com/mcimadamore/panama-foreign/runs/1276419676)

### Issue
 * [JDK-8254983](https://bugs.openjdk.java.net/browse/JDK-8254983): jextract fails to hande layout paths nested structs/union


### Reviewers
 * [Jorn Vernee](https://openjdk.java.net/census#jvernee) (@JornVernee - Committer)
 * [Athijegannathan Sundararajan](https://openjdk.java.net/census#sundar) (@sundararajana - Committer)


### Download
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/384/head:pull/384`
`$ git checkout pull/384`
