### PR TITLE
Add benchmark for floating point memory access var handle performance

### DIFF
--- a/test/micro/org/openjdk/bench/jdk/incubator/foreign/LoopOverNonConstantFP.java
+++ b/test/micro/org/openjdk/bench/jdk/incubator/foreign/LoopOverNonConstantFP.java
@@ -70,10 +70,10 @@ public class LoopOverNonConstantFP {
         unsafe_addrIn2 = unsafe.allocateMemory(ALLOC_SIZE);
         unsafe_addrOut = unsafe.allocateMemory(ALLOC_SIZE);
         for (int i = 0; i < ELEM_SIZE; i++) {
-            unsafe.putFloat(unsafe_addrIn1 + (i * CARRIER_SIZE) , i);
+            unsafe.putDouble(unsafe_addrIn1 + (i * CARRIER_SIZE) , i);
         }
         for (int i = 0; i < ELEM_SIZE; i++) {
-            unsafe.putFloat(unsafe_addrIn1 + (i * CARRIER_SIZE) , i);
+            unsafe.putDouble(unsafe_addrIn2 + (i * CARRIER_SIZE) , i);
         }
         segmentIn1 = MemorySegment.allocateNative(ALLOC_SIZE);
         segmentIn2 = MemorySegment.allocateNative(ALLOC_SIZE);
@@ -109,7 +109,7 @@ public class LoopOverNonConstantFP {
     }
 
     @Benchmark
-    public void unsafe_sum() {
+    public void unsafe_loop() {
         for (int i = 0; i < ELEM_SIZE; i ++) {
             unsafe.putDouble(unsafe_addrOut + (i * CARRIER_SIZE),
                     unsafe.getDouble(unsafe_addrIn1 + (i * CARRIER_SIZE)) +

--- a/test/micro/org/openjdk/bench/jdk/incubator/foreign/LoopOverNonConstantFP.java
+++ b/test/micro/org/openjdk/bench/jdk/incubator/foreign/LoopOverNonConstantFP.java
@@ -60,51 +60,45 @@ public class LoopOverNonConstantFP {
     static final int CARRIER_SIZE = (int)JAVA_DOUBLE.byteSize();
     static final int ALLOC_SIZE = ELEM_SIZE * CARRIER_SIZE;
 
-    MemorySegment segmentIn1, segmentIn2, segmentOut;
-    long unsafe_addrIn1, unsafe_addrIn2, unsafe_addrOut;
-    ByteBuffer byteBufferIn1, byteBufferIn2, byteBufferOut;
+    MemorySegment segmentIn, segmentOut;
+    long unsafe_addrIn, unsafe_addrOut;
+    ByteBuffer byteBufferIn, byteBufferOut;
 
     @Setup
     public void setup() {
-        unsafe_addrIn1 = unsafe.allocateMemory(ALLOC_SIZE);
-        unsafe_addrIn2 = unsafe.allocateMemory(ALLOC_SIZE);
+        unsafe_addrIn = unsafe.allocateMemory(ALLOC_SIZE);
         unsafe_addrOut = unsafe.allocateMemory(ALLOC_SIZE);
         for (int i = 0; i < ELEM_SIZE; i++) {
-            unsafe.putDouble(unsafe_addrIn1 + (i * CARRIER_SIZE) , i);
+            unsafe.putDouble(unsafe_addrIn + (i * CARRIER_SIZE) , i);
         }
         for (int i = 0; i < ELEM_SIZE; i++) {
-            unsafe.putDouble(unsafe_addrIn2 + (i * CARRIER_SIZE) , i);
+            unsafe.putDouble(unsafe_addrOut + (i * CARRIER_SIZE) , i);
         }
-        segmentIn1 = MemorySegment.allocateNative(ALLOC_SIZE);
-        segmentIn2 = MemorySegment.allocateNative(ALLOC_SIZE);
+        segmentIn = MemorySegment.allocateNative(ALLOC_SIZE);
         segmentOut = MemorySegment.allocateNative(ALLOC_SIZE);
         for (int i = 0; i < ELEM_SIZE; i++) {
-            MemoryAccess.setDoubleAtIndex(segmentIn1, i, i);
+            MemoryAccess.setDoubleAtIndex(segmentIn, i, i);
         }
         for (int i = 0; i < ELEM_SIZE; i++) {
-            MemoryAccess.setDoubleAtIndex(segmentIn2, i, i);
+            MemoryAccess.setDoubleAtIndex(segmentOut, i, i);
         }
-        byteBufferIn1 = ByteBuffer.allocateDirect(ALLOC_SIZE).order(ByteOrder.nativeOrder());
-        byteBufferIn2 = ByteBuffer.allocateDirect(ALLOC_SIZE).order(ByteOrder.nativeOrder());
+        byteBufferIn = ByteBuffer.allocateDirect(ALLOC_SIZE).order(ByteOrder.nativeOrder());
         byteBufferOut = ByteBuffer.allocateDirect(ALLOC_SIZE).order(ByteOrder.nativeOrder());
         for (int i = 0; i < ELEM_SIZE; i++) {
-            byteBufferIn1.putDouble(i * CARRIER_SIZE , i);
+            byteBufferIn.putDouble(i * CARRIER_SIZE , i);
         }
         for (int i = 0; i < ELEM_SIZE; i++) {
-            byteBufferIn2.putDouble(i * CARRIER_SIZE , i);
+            byteBufferOut.putDouble(i * CARRIER_SIZE , i);
         }
     }
 
     @TearDown
     public void tearDown() {
-        segmentIn1.close();
-        segmentIn2.close();
+        segmentIn.close();
         segmentOut.close();
-        unsafe.invokeCleaner(byteBufferIn1);
-        unsafe.invokeCleaner(byteBufferIn2);
+        unsafe.invokeCleaner(byteBufferIn);
         unsafe.invokeCleaner(byteBufferOut);
-        unsafe.freeMemory(unsafe_addrIn1);
-        unsafe.freeMemory(unsafe_addrIn2);
+        unsafe.freeMemory(unsafe_addrIn);
         unsafe.freeMemory(unsafe_addrOut);
     }
 
@@ -112,8 +106,8 @@ public class LoopOverNonConstantFP {
     public void unsafe_loop() {
         for (int i = 0; i < ELEM_SIZE; i ++) {
             unsafe.putDouble(unsafe_addrOut + (i * CARRIER_SIZE),
-                    unsafe.getDouble(unsafe_addrIn1 + (i * CARRIER_SIZE)) +
-                    unsafe.getDouble(unsafe_addrIn2 + (i * CARRIER_SIZE)));
+                    unsafe.getDouble(unsafe_addrIn + (i * CARRIER_SIZE)) +
+                    unsafe.getDouble(unsafe_addrOut + (i * CARRIER_SIZE)));
         }
     }
 
@@ -121,8 +115,8 @@ public class LoopOverNonConstantFP {
     public void segment_loop() {
         for (int i = 0; i < ELEM_SIZE; i ++) {
             MemoryAccess.setDoubleAtIndex(segmentOut, i,
-                    MemoryAccess.getDoubleAtIndex(segmentIn1, i) +
-                    MemoryAccess.getDoubleAtIndex(segmentIn2, i));
+                    MemoryAccess.getDoubleAtIndex(segmentIn, i) +
+                    MemoryAccess.getDoubleAtIndex(segmentOut, i));
         }
     }
 
@@ -130,8 +124,8 @@ public class LoopOverNonConstantFP {
     public void BB_loop() {
         for (int i = 0; i < ELEM_SIZE; i++) {
             byteBufferOut.putDouble(i * CARRIER_SIZE,
-                    byteBufferIn1.getDouble(i * CARRIER_SIZE) +
-                    byteBufferIn2.getDouble(i * CARRIER_SIZE));
+                    byteBufferIn.getDouble(i * CARRIER_SIZE) +
+                    byteBufferOut.getDouble(i * CARRIER_SIZE));
         }
     }
 }

--- a/test/micro/org/openjdk/bench/jdk/incubator/foreign/LoopOverNonConstantFP.java
+++ b/test/micro/org/openjdk/bench/jdk/incubator/foreign/LoopOverNonConstantFP.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.bench.jdk.incubator.foreign;
+
+import jdk.incubator.foreign.MemoryAccess;
+import jdk.incubator.foreign.MemoryAddress;
+import jdk.incubator.foreign.MemoryLayout;
+import jdk.incubator.foreign.MemorySegment;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Warmup;
+import sun.misc.Unsafe;
+
+import java.lang.invoke.VarHandle;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.util.concurrent.TimeUnit;
+
+import static jdk.incubator.foreign.MemoryLayout.PathElement.sequenceElement;
+import static jdk.incubator.foreign.MemoryLayouts.JAVA_DOUBLE;
+
+@BenchmarkMode(Mode.AverageTime)
+@Warmup(iterations = 5, time = 500, timeUnit = TimeUnit.MILLISECONDS)
+@Measurement(iterations = 10, time = 500, timeUnit = TimeUnit.MILLISECONDS)
+@State(org.openjdk.jmh.annotations.Scope.Thread)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@Fork(3)
+public class LoopOverNonConstantFP {
+
+    static final Unsafe unsafe = Utils.unsafe;
+
+    static final int ELEM_SIZE = 1_000_000;
+    static final int CARRIER_SIZE = (int)JAVA_DOUBLE.byteSize();
+    static final int ALLOC_SIZE = ELEM_SIZE * CARRIER_SIZE;
+
+    MemorySegment segmentIn1, segmentIn2, segmentOut;
+    long unsafe_addrIn1, unsafe_addrIn2, unsafe_addrOut;
+    ByteBuffer byteBufferIn1, byteBufferIn2, byteBufferOut;
+
+    @Setup
+    public void setup() {
+        unsafe_addrIn1 = unsafe.allocateMemory(ALLOC_SIZE);
+        unsafe_addrIn2 = unsafe.allocateMemory(ALLOC_SIZE);
+        unsafe_addrOut = unsafe.allocateMemory(ALLOC_SIZE);
+        for (int i = 0; i < ELEM_SIZE; i++) {
+            unsafe.putFloat(unsafe_addrIn1 + (i * CARRIER_SIZE) , i);
+        }
+        for (int i = 0; i < ELEM_SIZE; i++) {
+            unsafe.putFloat(unsafe_addrIn1 + (i * CARRIER_SIZE) , i);
+        }
+        segmentIn1 = MemorySegment.allocateNative(ALLOC_SIZE);
+        segmentIn2 = MemorySegment.allocateNative(ALLOC_SIZE);
+        segmentOut = MemorySegment.allocateNative(ALLOC_SIZE);
+        for (int i = 0; i < ELEM_SIZE; i++) {
+            MemoryAccess.setDoubleAtIndex(segmentIn1, i, i);
+        }
+        for (int i = 0; i < ELEM_SIZE; i++) {
+            MemoryAccess.setDoubleAtIndex(segmentIn2, i, i);
+        }
+        byteBufferIn1 = ByteBuffer.allocateDirect(ALLOC_SIZE).order(ByteOrder.nativeOrder());
+        byteBufferIn2 = ByteBuffer.allocateDirect(ALLOC_SIZE).order(ByteOrder.nativeOrder());
+        byteBufferOut = ByteBuffer.allocateDirect(ALLOC_SIZE).order(ByteOrder.nativeOrder());
+        for (int i = 0; i < ELEM_SIZE; i++) {
+            byteBufferIn1.putDouble(i * CARRIER_SIZE , i);
+        }
+        for (int i = 0; i < ELEM_SIZE; i++) {
+            byteBufferIn2.putDouble(i * CARRIER_SIZE , i);
+        }
+    }
+
+    @TearDown
+    public void tearDown() {
+        segmentIn1.close();
+        segmentIn2.close();
+        segmentOut.close();
+        unsafe.invokeCleaner(byteBufferIn1);
+        unsafe.invokeCleaner(byteBufferIn2);
+        unsafe.invokeCleaner(byteBufferOut);
+        unsafe.freeMemory(unsafe_addrIn1);
+        unsafe.freeMemory(unsafe_addrIn2);
+        unsafe.freeMemory(unsafe_addrOut);
+    }
+
+    @Benchmark
+    public void unsafe_sum() {
+        for (int i = 0; i < ELEM_SIZE; i ++) {
+            unsafe.putDouble(unsafe_addrOut + (i * CARRIER_SIZE),
+                    unsafe.getDouble(unsafe_addrIn1 + (i * CARRIER_SIZE)) +
+                    unsafe.getDouble(unsafe_addrIn2 + (i * CARRIER_SIZE)));
+        }
+    }
+
+    @Benchmark
+    public void segment_loop() {
+        for (int i = 0; i < ELEM_SIZE; i ++) {
+            MemoryAccess.setDoubleAtIndex(segmentOut, i,
+                    MemoryAccess.getDoubleAtIndex(segmentIn1, i) +
+                    MemoryAccess.getDoubleAtIndex(segmentIn2, i));
+        }
+    }
+
+    @Benchmark
+    public void BB_loop() {
+        for (int i = 0; i < ELEM_SIZE; i++) {
+            byteBufferOut.putDouble(i * CARRIER_SIZE,
+                    byteBufferIn1.getDouble(i * CARRIER_SIZE) +
+                    byteBufferIn2.getDouble(i * CARRIER_SIZE));
+        }
+    }
+}


### PR DESCRIPTION
This patch adds a benchmark which reproduces the issue discovered by Antoine:

https://mail.openjdk.java.net/pipermail/panama-dev/2020-September/010869.html

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Testing

|     | Linux x32 | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- |
| Build | ⏳ (1/1 running) | ⏳ (3/5 running) | ⏳ (2/2 running) | ⏳ (2/2 running) |

### Reviewers
 * [Jorn Vernee](https://openjdk.java.net/census#jvernee) (@JornVernee - Committer)
 * [Paul Sandoz](https://openjdk.java.net/census#psandoz) (@PaulSandoz - Committer)


### Download
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/386/head:pull/386`
`$ git checkout pull/386`
