### PR TITLE
8256080: AArch64: fatal error with unexpected intrinsic id _linkToNative

### DIFF
--- a/src/hotspot/cpu/aarch64/methodHandles_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/methodHandles_aarch64.cpp
@@ -177,6 +177,13 @@ address MethodHandles::generate_method_handle_interpreter_entry(MacroAssembler* 
     return NULL;
   }
 
+  // No need in interpreter entry for linkToNative for now.
+  // Interpreter calls compiled entry through i2c.
+  if (iid == vmIntrinsics::_linkToNative) {
+    __ hlt(0);
+    return NULL;
+  }
+
   // r13: sender SP (must preserve; see prepare_to_jump_from_interpreted)
   // rmethod: Method*
   // r3: argument locator (parameter slot count, added to rsp)
@@ -271,7 +278,10 @@ void MethodHandles::generate_method_handle_dispatch(MacroAssembler* _masm,
   assert_different_registers(temp1, temp2, temp3, receiver_reg);
   assert_different_registers(temp1, temp2, temp3, member_reg);
 
-  if (iid == vmIntrinsics::_invokeBasic) {
+  if (iid == vmIntrinsics::_invokeBasic || iid == vmIntrinsics::_linkToNative) {
+    if (iid == vmIntrinsics::_linkToNative) {
+      assert(for_compiler_entry, "only compiler entry is supported");
+    }
     // indirect through MH.form.vmentry.vmtarget
     jump_to_lambda_form(_masm, receiver_reg, rmethod, temp1, for_compiler_entry);
 

--- a/src/hotspot/cpu/aarch64/sharedRuntime_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/sharedRuntime_aarch64.cpp
@@ -1194,7 +1194,7 @@ static void gen_special_dispatch(MacroAssembler* masm,
     member_arg_pos = method->size_of_parameters() - 1;  // trailing MemberName argument
     member_reg = r19;  // known to be free at this point
     has_receiver = MethodHandles::ref_kind_has_receiver(ref_kind);
-  } else if (iid == vmIntrinsics::_invokeBasic) {
+  } else if (iid == vmIntrinsics::_invokeBasic || iid == vmIntrinsics::_linkToNative) {
     has_receiver = true;
   } else {
     fatal("unexpected intrinsic id %d", iid);

--- a/src/hotspot/share/opto/graphKit.cpp
+++ b/src/hotspot/share/opto/graphKit.cpp
@@ -2629,7 +2629,10 @@ Node* GraphKit::make_native_call(const TypeFunc* call_type, uint nargs, ciNative
     call_addr = SharedRuntime::make_native_invoker(call_addr,
                                                    nep->shadow_space(),
                                                    arg_regs, ret_regs);
-    if (call_addr == NULL) return NULL;
+    if (call_addr == NULL) {
+      C->record_failure("native invoker not implemented on this platform");
+      return NULL;
+    }
     C->add_native_stub(call_addr);
   }
   assert(call_addr != NULL, "sanity");

--- a/src/hotspot/share/opto/output.cpp
+++ b/src/hotspot/share/opto/output.cpp
@@ -1681,7 +1681,7 @@ void PhaseOutput::fill_buffer(CodeBuffer* cb, uint* blk_starts) {
       n->emit(*cb, C->regalloc());
       current_offset = cb->insts_size();
 
-      assert(!is_mcall || (call_returns[block->_pre_order] == (uint) current_offset), "ret_addr_offset() did not match size of emitted code");
+      assert(!is_mcall || (call_returns[block->_pre_order] <= (uint) current_offset), "ret_addr_offset() not within emitted code");
 
       // Above we only verified that there is enough space in the instruction section.
       // However, the instruction may emit stubs that cause code buffer expansion.

--- a/test/jdk/java/foreign/TestIntrinsics.java
+++ b/test/jdk/java/foreign/TestIntrinsics.java
@@ -23,6 +23,7 @@
 
 /*
  * @test
+ * @requires os.arch=="amd64"
  * @run testng/othervm
  *   -Djdk.internal.foreign.ProgrammableInvoker.USE_SPEC=true
  *   -Djdk.internal.foreign.ProgrammableInvoker.USE_INTRINSICS=true

--- a/test/jdk/java/foreign/TestIntrinsics.java
+++ b/test/jdk/java/foreign/TestIntrinsics.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @requires os.arch=="amd64"
+ * @requires os.arch=="amd64" | os.arch=="x86_64"
  * @run testng/othervm
  *   -Djdk.internal.foreign.ProgrammableInvoker.USE_SPEC=true
  *   -Djdk.internal.foreign.ProgrammableInvoker.USE_INTRINSICS=true


### PR DESCRIPTION
AArch64 doesn't implement linkToNative yet. However during VM startup
several of the MethodHandles methods are called with the _linkToNative
intrinsic ID. Add minimal handling of this (taken from x86) to avoid
fatal errors.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Linux x86 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- |
| Build | ❌ (1/5 failed) | ❌ (2/2 failed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) |    |     |  ✔️ (9/9 passed) | ✔️ (9/9 passed) |

**Failed test tasks**
- [Linux x64 (build hotspot zero)](https://github.com/nick-arm/panama-foreign/runs/1388288453)
- [Linux x86 (build debug)](https://github.com/nick-arm/panama-foreign/runs/1388288490)
- [Linux x86 (build release)](https://github.com/nick-arm/panama-foreign/runs/1388288485)

### Issue
 * [JDK-8256080](https://bugs.openjdk.java.net/browse/JDK-8256080): AArch64: fatal error with unexpected intrinsic id _linkToNative


### Reviewers
 * [Jorn Vernee](https://openjdk.java.net/census#jvernee) (@JornVernee - Committer)


### Download
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/391/head:pull/391`
`$ git checkout pull/391`
