### PR TITLE
8256247: TestUpcallHighArity fails on AArch64

### DIFF
--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/aarch64/CallArranger.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/aarch64/CallArranger.java
@@ -308,7 +308,7 @@ public class CallArranger {
                             .baseAddress()
                             .unboxAddress();
                     VMStorage storage = storageCalculator.nextStorage(
-                        StorageClasses.INTEGER, layout);
+                        StorageClasses.INTEGER, AArch64.C_POINTER);
                     bindings.vmStore(storage, long.class);
                     break;
                 }
@@ -403,7 +403,8 @@ public class CallArranger {
                 }
                 case STRUCT_REFERENCE: {
                     assert carrier == MemorySegment.class;
-                    VMStorage storage = storageCalculator.nextStorage(StorageClasses.INTEGER, layout);
+                    VMStorage storage = storageCalculator.nextStorage(
+                        StorageClasses.INTEGER, AArch64.C_POINTER);
                     bindings.vmLoad(storage, long.class)
                             .boxAddress()
                             .toSegment(layout);


### PR DESCRIPTION
Large (> 16 byte) struct arguments should be passed by reference to a
caller-allocated copy of the struct. If this argument is passed on the
stack then the pointer should occupy a single stack slot. However the
current CallArranger allocates enough stack slots to hold the entire
struct, which is incorrect.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Linux x86 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- |
| Build | ❌ (1/5 failed) | ❌ (2/2 failed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) |    |     |  ✔️ (9/9 passed) | ✔️ (9/9 passed) |

**Failed test tasks**
- [Linux x64 (build hotspot zero)](https://github.com/nick-arm/panama-foreign/runs/1394107182)
- [Linux x86 (build debug)](https://github.com/nick-arm/panama-foreign/runs/1394107238)
- [Linux x86 (build release)](https://github.com/nick-arm/panama-foreign/runs/1394107233)

### Issue
 * [JDK-8256247](https://bugs.openjdk.java.net/browse/JDK-8256247): TestUpcallHighArity fails on AArch64


### Reviewers
 * [Jorn Vernee](https://openjdk.java.net/census#jvernee) (@JornVernee - Committer)


### Download
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/392/head:pull/392`
`$ git checkout pull/392`
