### PR TITLE
8256466: MemoryLayout factories do not guard against null layouts

### DIFF
--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/AbstractLayout.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/AbstractLayout.java
@@ -61,6 +61,7 @@ abstract class AbstractLayout implements MemoryLayout {
 
     @Override
     public AbstractLayout withName(String name) {
+        Objects.requireNonNull(name);
         return withAttribute(LAYOUT_NAME, name);
     }
 
@@ -71,6 +72,7 @@ abstract class AbstractLayout implements MemoryLayout {
 
     @Override
     public Optional<Constable> attribute(String name) {
+        Objects.requireNonNull(name);
         return Optional.ofNullable(attributes.get(name));
     }
 
@@ -81,6 +83,7 @@ abstract class AbstractLayout implements MemoryLayout {
 
     @Override
     public AbstractLayout withAttribute(String name, Constable value) {
+        Objects.requireNonNull(name);
         Map<String, Constable> newAttributes = new HashMap<>(attributes);
         newAttributes.put(name, value);
         return dup(alignment, newAttributes);

--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/MappedMemorySegments.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/MappedMemorySegments.java
@@ -28,6 +28,7 @@ package jdk.incubator.foreign;
 import jdk.internal.foreign.MappedMemorySegmentImpl;
 
 import java.nio.MappedByteBuffer;
+import java.util.Objects;
 
 /**
  * This class provides capabilities to manipulate mapped memory segments, such as {@link #force(MemorySegment)},
@@ -75,6 +76,7 @@ public final class MappedMemorySegments {
      * and this method is called from a thread other than the segment's owner thread.
      * @throws UnsupportedOperationException if the given segment is not a mapped memory segment, e.g. if
      * {@code segment.isMapped() == false}.
+     * @throws NullPointerException if {@code segment == null}.
      */
     public static boolean isLoaded(MemorySegment segment) {
         return toMappedSegment(segment).isLoaded();
@@ -94,6 +96,7 @@ public final class MappedMemorySegments {
      * and this method is called from a thread other than the segment's owner thread.
      * @throws UnsupportedOperationException if the given segment is not a mapped memory segment, e.g. if
      * {@code segment.isMapped() == false}.
+     * @throws NullPointerException if {@code segment == null}.
      */
     public static void load(MemorySegment segment) {
         toMappedSegment(segment).load();
@@ -113,6 +116,7 @@ public final class MappedMemorySegments {
      * and this method is called from a thread other than the segment's owner thread.
      * @throws UnsupportedOperationException if the given segment is not a mapped memory segment, e.g. if
      * {@code segment.isMapped() == false}.
+     * @throws NullPointerException if {@code segment == null}.
      */
     public static void unload(MemorySegment segment) {
         toMappedSegment(segment).unload();
@@ -145,12 +149,14 @@ public final class MappedMemorySegments {
      * and this method is called from a thread other than the segment's owner thread.
      * @throws UnsupportedOperationException if the given segment is not a mapped memory segment, e.g. if
      * {@code segment.isMapped() == false}.
+     * @throws NullPointerException if {@code segment == null}.
      */
     public static void force(MemorySegment segment) {
         toMappedSegment(segment).force();
     }
 
     static MappedMemorySegmentImpl toMappedSegment(MemorySegment segment) {
+        Objects.requireNonNull(segment);
         if (segment instanceof MappedMemorySegmentImpl) {
             return (MappedMemorySegmentImpl)segment;
         } else {

--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/MemoryAccess.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/MemoryAccess.java
@@ -30,6 +30,7 @@ import jdk.internal.vm.annotation.ForceInline;
 
 import java.lang.invoke.VarHandle;
 import java.nio.ByteOrder;
+import java.util.Objects;
 
 /**
  * This class defines ready-made static accessors which can be used to dereference memory segments in many ways.
@@ -90,8 +91,10 @@ public final class MemoryAccess {
      * @param segment the segment to be dereferenced.
      * @param offset offset in bytes (relative to {@code segment}). The final address of this read operation can be expressed as {@code segment.address().addOffset(offset)}.
      * @return a byte value read from {@code segment}.
+     * @throws NullPointerException if {@code segment == null}.
      */
     public static byte getByteAtOffset(MemorySegment segment, long offset) {
+        Objects.requireNonNull(segment);
         return (byte)byte_handle.get(segment, offset);
     }
 
@@ -101,8 +104,10 @@ public final class MemoryAccess {
      * @param segment the segment to be dereferenced.
      * @param offset offset in bytes (relative to {@code segment}). The final address of this read operation can be expressed as {@code segment.address().addOffset(offset)}.
      * @param value the byte value to be written.
+     * @throws NullPointerException if {@code segment == null}.
      */
     public static void setByteAtOffset(MemorySegment segment, long offset, byte value) {
+        Objects.requireNonNull(segment);
         byte_handle.set(segment, offset, value);
     }
 
@@ -116,6 +121,7 @@ public final class MemoryAccess {
      * @param segment the segment to be dereferenced.
      * @param offset offset in bytes (relative to {@code segment}). The final address of this read operation can be expressed as {@code segment.address().addOffset(offset)}.
      * @return a char value read from {@code segment}.
+     * @throws NullPointerException if {@code segment == null}.
      */
     public static char getCharAtOffset(MemorySegment segment, long offset) {
         return getCharAtOffset(segment, offset, ByteOrder.nativeOrder());
@@ -131,6 +137,7 @@ public final class MemoryAccess {
      * @param segment the segment to be dereferenced.
      * @param offset offset in bytes (relative to {@code segment}). The final address of this read operation can be expressed as {@code segment.address().addOffset(offset)}.
      * @param value the char value to be written.
+     * @throws NullPointerException if {@code segment == null}.
      */
     public static void setCharAtOffset(MemorySegment segment, long offset, char value) {
         setCharAtOffset(segment, offset, ByteOrder.nativeOrder(), value);
@@ -146,6 +153,7 @@ public final class MemoryAccess {
      * @param segment the segment to be dereferenced.
      * @param offset offset in bytes (relative to {@code segment}). The final address of this read operation can be expressed as {@code segment.address().addOffset(offset)}.
      * @return a short value read from {@code segment}.
+     * @throws NullPointerException if {@code segment == null}.
      */
     public static short getShortAtOffset(MemorySegment segment, long offset) {
         return getShortAtOffset(segment, offset, ByteOrder.nativeOrder());
@@ -161,6 +169,7 @@ public final class MemoryAccess {
      * @param segment the segment to be dereferenced.
      * @param offset offset in bytes (relative to {@code segment}). The final address of this read operation can be expressed as {@code segment.address().addOffset(offset)}.
      * @param value the short value to be written.
+     * @throws NullPointerException if {@code segment == null}.
      */
     public static void setShortAtOffset(MemorySegment segment, long offset, short value) {
         setShortAtOffset(segment, offset, ByteOrder.nativeOrder(), value);
@@ -176,6 +185,7 @@ public final class MemoryAccess {
      * @param segment the segment to be dereferenced.
      * @param offset offset in bytes (relative to {@code segment}). The final address of this read operation can be expressed as {@code segment.address().addOffset(offset)}.
      * @return an int value read from {@code segment}.
+     * @throws NullPointerException if {@code segment == null}.
      */
     public static int getIntAtOffset(MemorySegment segment, long offset) {
         return getIntAtOffset(segment, offset, ByteOrder.nativeOrder());
@@ -191,6 +201,7 @@ public final class MemoryAccess {
      * @param segment the segment to be dereferenced.
      * @param offset offset in bytes (relative to {@code segment}). The final address of this read operation can be expressed as {@code segment.address().addOffset(offset)}.
      * @param value the int value to be written.
+     * @throws NullPointerException if {@code segment == null}.
      */
     public static void setIntAtOffset(MemorySegment segment, long offset, int value) {
         setIntAtOffset(segment, offset, ByteOrder.nativeOrder(), value);
@@ -206,6 +217,7 @@ public final class MemoryAccess {
      * @param segment the segment to be dereferenced.
      * @param offset offset in bytes (relative to {@code segment}). The final address of this read operation can be expressed as {@code segment.address().addOffset(offset)}.
      * @return a float value read from {@code segment}.
+     * @throws NullPointerException if {@code segment == null}.
      */
     public static float getFloatAtOffset(MemorySegment segment, long offset) {
         return getFloatAtOffset(segment, offset, ByteOrder.nativeOrder());
@@ -221,6 +233,7 @@ public final class MemoryAccess {
      * @param segment the segment to be dereferenced.
      * @param offset offset in bytes (relative to {@code segment}). The final address of this read operation can be expressed as {@code segment.address().addOffset(offset)}.
      * @param value the float value to be written.
+     * @throws NullPointerException if {@code segment == null}.
      */
     public static void setFloatAtOffset(MemorySegment segment, long offset, float value) {
         setFloatAtOffset(segment, offset, ByteOrder.nativeOrder(), value);
@@ -236,6 +249,7 @@ public final class MemoryAccess {
      * @param segment the segment to be dereferenced.
      * @param offset offset in bytes (relative to {@code segment}). The final address of this read operation can be expressed as {@code segment.address().addOffset(offset)}.
      * @return a long value read from {@code segment}.
+     * @throws NullPointerException if {@code segment == null}.
      */
     public static long getLongAtOffset(MemorySegment segment, long offset) {
         return getLongAtOffset(segment, offset, ByteOrder.nativeOrder());
@@ -251,6 +265,7 @@ public final class MemoryAccess {
      * @param segment the segment to be dereferenced.
      * @param offset offset in bytes (relative to {@code segment}). The final address of this read operation can be expressed as {@code segment.address().addOffset(offset)}.
      * @param value the long value to be written.
+     * @throws NullPointerException if {@code segment == null}.
      */
     public static void setLongAtOffset(MemorySegment segment, long offset, long value) {
         setLongAtOffset(segment, offset, ByteOrder.nativeOrder(), value);
@@ -266,6 +281,7 @@ public final class MemoryAccess {
      * @param segment the segment to be dereferenced.
      * @param offset offset in bytes (relative to {@code segment}). The final address of this read operation can be expressed as {@code segment.address().addOffset(offset)}.
      * @return a double value read from {@code segment}.
+     * @throws NullPointerException if {@code segment == null}.
      */
     public static double getDoubleAtOffset(MemorySegment segment, long offset) {
         return getDoubleAtOffset(segment, offset, ByteOrder.nativeOrder());
@@ -281,6 +297,7 @@ public final class MemoryAccess {
      * @param segment the segment to be dereferenced.
      * @param offset offset in bytes (relative to {@code segment}). The final address of this read operation can be expressed as {@code segment.address().addOffset(offset)}.
      * @param value the double value to be written.
+     * @throws NullPointerException if {@code segment == null}.
      */
     public static void setDoubleAtOffset(MemorySegment segment, long offset, double value) {
         setDoubleAtOffset(segment, offset, ByteOrder.nativeOrder(), value);
@@ -297,8 +314,10 @@ public final class MemoryAccess {
      * @param segment the segment to be dereferenced.
      * @param offset offset in bytes (relative to {@code segment}). The final address of this read operation can be expressed as {@code segment.address().addOffset(offset)}.
      * @return a memory address read from {@code segment}.
+     * @throws NullPointerException if {@code segment == null}.
      */
     public static MemoryAddress getAddressAtOffset(MemorySegment segment, long offset) {
+        Objects.requireNonNull(segment);
         return (MemoryAddress)address_handle.get(segment, offset);
     }
 
@@ -313,8 +332,11 @@ public final class MemoryAccess {
      * @param segment the segment to be dereferenced.
      * @param offset offset in bytes (relative to {@code segment}). The final address of this read operation can be expressed as {@code segment.address().addOffset(offset)}.
      * @param value the memory address to be written (expressed as an {@link Addressable} instance).
+     * @throws NullPointerException if {@code segment == null}, or if {@code value == null}.
      */
     public static void setAddressAtOffset(MemorySegment segment, long offset, Addressable value) {
+        Objects.requireNonNull(segment);
+        Objects.requireNonNull(value);
         address_handle.set(segment, offset, value.address());
     }
 
@@ -330,8 +352,11 @@ public final class MemoryAccess {
      * @param offset offset in bytes (relative to {@code segment}). The final address of this read operation can be expressed as {@code segment.address().addOffset(offset)}.
      * @param order the specified byte order.
      * @return a char value read from {@code segment}.
+     * @throws NullPointerException if {@code segment == null}, or if {@code order == null}.
      */
     public static char getCharAtOffset(MemorySegment segment, long offset, ByteOrder order) {
+        Objects.requireNonNull(segment);
+        Objects.requireNonNull(order);
         return (char)((order == ByteOrder.BIG_ENDIAN) ? char_BE_handle : char_LE_handle).get(segment, offset);
     }
 
@@ -347,8 +372,11 @@ public final class MemoryAccess {
      * @param offset offset in bytes (relative to {@code segment}). The final address of this read operation can be expressed as {@code segment.address().addOffset(offset)}.
      * @param order the specified byte order.
      * @param value the char value to be written.
+     * @throws NullPointerException if {@code segment == null}, or if {@code order == null}.
      */
     public static void setCharAtOffset(MemorySegment segment, long offset, ByteOrder order, char value) {
+        Objects.requireNonNull(segment);
+        Objects.requireNonNull(order);
         ((order == ByteOrder.BIG_ENDIAN) ? char_BE_handle : char_LE_handle).set(segment, offset, value);
     }
 
@@ -364,8 +392,11 @@ public final class MemoryAccess {
      * @param offset offset in bytes (relative to {@code segment}). The final address of this read operation can be expressed as {@code segment.address().addOffset(offset)}.
      * @param order the specified byte order.
      * @return a short value read from {@code segment}.
+     * @throws NullPointerException if {@code segment == null}, or if {@code order == null}.
      */
     public static short getShortAtOffset(MemorySegment segment, long offset, ByteOrder order) {
+        Objects.requireNonNull(segment);
+        Objects.requireNonNull(order);
         return (short)((order == ByteOrder.BIG_ENDIAN) ? short_BE_handle : short_LE_handle).get(segment, offset);
     }
 
@@ -381,8 +412,11 @@ public final class MemoryAccess {
      * @param offset offset in bytes (relative to {@code segment}). The final address of this read operation can be expressed as {@code segment.address().addOffset(offset)}.
      * @param order the specified byte order.
      * @param value the short value to be written.
+     * @throws NullPointerException if {@code segment == null}, or if {@code order == null}.
      */
     public static void setShortAtOffset(MemorySegment segment, long offset, ByteOrder order, short value) {
+        Objects.requireNonNull(segment);
+        Objects.requireNonNull(order);
         ((order == ByteOrder.BIG_ENDIAN) ? short_BE_handle : short_LE_handle).set(segment, offset, value);
     }
 
@@ -398,8 +432,11 @@ public final class MemoryAccess {
      * @param offset offset in bytes (relative to {@code segment}). The final address of this read operation can be expressed as {@code segment.address().addOffset(offset)}.
      * @param order the specified byte order.
      * @return an int value read from {@code segment}.
+     * @throws NullPointerException if {@code segment == null}, or if {@code order == null}.
      */
     public static int getIntAtOffset(MemorySegment segment, long offset, ByteOrder order) {
+        Objects.requireNonNull(segment);
+        Objects.requireNonNull(order);
         return (int)((order == ByteOrder.BIG_ENDIAN) ? int_BE_handle : int_LE_handle).get(segment, offset);
     }
 
@@ -415,8 +452,11 @@ public final class MemoryAccess {
      * @param offset offset in bytes (relative to {@code segment}). The final address of this read operation can be expressed as {@code segment.address().addOffset(offset)}.
      * @param order the specified byte order.
      * @param value the int value to be written.
+     * @throws NullPointerException if {@code segment == null}, or if {@code order == null}.
      */
     public static void setIntAtOffset(MemorySegment segment, long offset, ByteOrder order, int value) {
+        Objects.requireNonNull(segment);
+        Objects.requireNonNull(order);
         ((order == ByteOrder.BIG_ENDIAN) ? int_BE_handle : int_LE_handle).set(segment, offset, value);
     }
 
@@ -432,8 +472,11 @@ public final class MemoryAccess {
      * @param offset offset in bytes (relative to {@code segment}). The final address of this read operation can be expressed as {@code segment.address().addOffset(offset)}.
      * @param order the specified byte order.
      * @return a float value read from {@code segment}.
+     * @throws NullPointerException if {@code segment == null}, or if {@code order == null}.
      */
     public static float getFloatAtOffset(MemorySegment segment, long offset, ByteOrder order) {
+        Objects.requireNonNull(segment);
+        Objects.requireNonNull(order);
         return (float)((order == ByteOrder.BIG_ENDIAN) ? float_BE_handle : float_LE_handle).get(segment, offset);
     }
 
@@ -449,8 +492,11 @@ public final class MemoryAccess {
      * @param offset offset in bytes (relative to {@code segment}). The final address of this read operation can be expressed as {@code segment.address().addOffset(offset)}.
      * @param order the specified byte order.
      * @param value the float value to be written.
+     * @throws NullPointerException if {@code segment == null}, or if {@code order == null}.
      */
     public static void setFloatAtOffset(MemorySegment segment, long offset, ByteOrder order, float value) {
+        Objects.requireNonNull(segment);
+        Objects.requireNonNull(order);
         ((order == ByteOrder.BIG_ENDIAN) ? float_BE_handle : float_LE_handle).set(segment, offset, value);
     }
 
@@ -466,8 +512,11 @@ public final class MemoryAccess {
      * @param offset offset in bytes (relative to {@code segment}). The final address of this read operation can be expressed as {@code segment.address().addOffset(offset)}.
      * @param order the specified byte order.
      * @return a long value read from {@code segment}.
+     * @throws NullPointerException if {@code segment == null}, or if {@code order == null}.
      */
     public static long getLongAtOffset(MemorySegment segment, long offset, ByteOrder order) {
+        Objects.requireNonNull(segment);
+        Objects.requireNonNull(order);
         return (long)((order == ByteOrder.BIG_ENDIAN) ? long_BE_handle : long_LE_handle).get(segment, offset);
     }
 
@@ -483,8 +532,11 @@ public final class MemoryAccess {
      * @param offset offset in bytes (relative to {@code segment}). The final address of this read operation can be expressed as {@code segment.address().addOffset(offset)}.
      * @param order the specified byte order.
      * @param value the long value to be written.
+     * @throws NullPointerException if {@code segment == null}, or if {@code order == null}.
      */
     public static void setLongAtOffset(MemorySegment segment, long offset, ByteOrder order, long value) {
+        Objects.requireNonNull(segment);
+        Objects.requireNonNull(order);
         ((order == ByteOrder.BIG_ENDIAN) ? long_BE_handle : long_LE_handle).set(segment, offset, value);
     }
 
@@ -500,8 +552,11 @@ public final class MemoryAccess {
      * @param offset offset in bytes (relative to {@code segment}). The final address of this read operation can be expressed as {@code segment.address().addOffset(offset)}.
      * @param order the specified byte order.
      * @return a double value read from {@code segment}.
+     * @throws NullPointerException if {@code segment == null}, or if {@code order == null}.
      */
     public static double getDoubleAtOffset(MemorySegment segment, long offset, ByteOrder order) {
+        Objects.requireNonNull(segment);
+        Objects.requireNonNull(order);
         return (double)((order == ByteOrder.BIG_ENDIAN) ? double_BE_handle : double_LE_handle).get(segment, offset);
     }
 
@@ -517,8 +572,11 @@ public final class MemoryAccess {
      * @param offset offset in bytes (relative to {@code segment}). The final address of this read operation can be expressed as {@code segment.address().addOffset(offset)}.
      * @param order the specified byte order.
      * @param value the double value to be written.
+     * @throws NullPointerException if {@code segment == null}, or if {@code order == null}.
      */
     public static void setDoubleAtOffset(MemorySegment segment, long offset, ByteOrder order, double value) {
+        Objects.requireNonNull(segment);
+        Objects.requireNonNull(order);
         ((order == ByteOrder.BIG_ENDIAN) ? double_BE_handle : double_LE_handle).set(segment, offset, value);
     }
 
@@ -532,6 +590,7 @@ public final class MemoryAccess {
      *
      * @param segment the segment to be dereferenced.
      * @return a byte value read from {@code segment}.
+     * @throws NullPointerException if {@code segment == null}.
      */
     public static byte getByte(MemorySegment segment) {
         return getByteAtOffset(segment, 0L);
@@ -546,6 +605,7 @@ public final class MemoryAccess {
      * }</pre></blockquote>
      * @param segment the segment to be dereferenced.
      * @param value the byte value to be written.
+     * @throws NullPointerException if {@code segment == null}.
      */
     public static void setByte(MemorySegment segment, byte value) {
         setByteAtOffset(segment, 0L, value);
@@ -560,6 +620,7 @@ public final class MemoryAccess {
      * }</pre></blockquote>
      * @param segment the segment to be dereferenced.
      * @return a char value read from {@code segment}.
+     * @throws NullPointerException if {@code segment == null}.
      */
     public static char getChar(MemorySegment segment) {
         return getCharAtOffset(segment, 0L);
@@ -574,6 +635,7 @@ public final class MemoryAccess {
      * }</pre></blockquote>
      * @param segment the segment to be dereferenced.
      * @param value the char value to be written.
+     * @throws NullPointerException if {@code segment == null}.
      */
     public static void setChar(MemorySegment segment, char value) {
         setCharAtOffset(segment, 0L, value);
@@ -588,6 +650,7 @@ public final class MemoryAccess {
      * }</pre></blockquote>
      * @param segment the segment to be dereferenced.
      * @return a short value read from {@code segment}.
+     * @throws NullPointerException if {@code segment == null}.
      */
     public static short getShort(MemorySegment segment) {
         return getShortAtOffset(segment, 0L);
@@ -602,6 +665,7 @@ public final class MemoryAccess {
      * }</pre></blockquote>
      * @param segment the segment to be dereferenced.
      * @param value the short value to be written.
+     * @throws NullPointerException if {@code segment == null}.
      */
     public static void setShort(MemorySegment segment, short value) {
         setShortAtOffset(segment, 0L, value);
@@ -616,6 +680,7 @@ public final class MemoryAccess {
      * }</pre></blockquote>
      * @param segment the segment to be dereferenced.
      * @return an int value read from {@code segment}.
+     * @throws NullPointerException if {@code segment == null}.
      */
     public static int getInt(MemorySegment segment) {
         return getIntAtOffset(segment, 0L);
@@ -630,6 +695,7 @@ public final class MemoryAccess {
      * }</pre></blockquote>
      * @param segment the segment to be dereferenced.
      * @param value the int value to be written.
+     * @throws NullPointerException if {@code segment == null}.
      */
     public static void setInt(MemorySegment segment, int value) {
         setIntAtOffset(segment, 0L, value);
@@ -644,6 +710,7 @@ public final class MemoryAccess {
      * }</pre></blockquote>
      * @param segment the segment to be dereferenced.
      * @return a float value read from {@code segment}.
+     * @throws NullPointerException if {@code segment == null}.
      */
     public static float getFloat(MemorySegment segment) {
         return getFloatAtOffset(segment, 0L);
@@ -658,6 +725,7 @@ public final class MemoryAccess {
      * }</pre></blockquote>
      * @param segment the segment to be dereferenced.
      * @param value the float value to be written.
+     * @throws NullPointerException if {@code segment == null}.
      */
     public static void setFloat(MemorySegment segment, float value) {
         setFloatAtOffset(segment, 0L, value);
@@ -672,6 +740,7 @@ public final class MemoryAccess {
      * }</pre></blockquote>
      * @param segment the segment to be dereferenced.
      * @return a long value read from {@code segment}.
+     * @throws NullPointerException if {@code segment == null}.
      */
     public static long getLong(MemorySegment segment) {
         return getLongAtOffset(segment, 0L);
@@ -686,6 +755,7 @@ public final class MemoryAccess {
      * }</pre></blockquote>
      * @param segment the segment to be dereferenced.
      * @param value the long value to be written.
+     * @throws NullPointerException if {@code segment == null}.
      */
     public static void setLong(MemorySegment segment, long value) {
         setLongAtOffset(segment, 0L, value);
@@ -700,6 +770,7 @@ public final class MemoryAccess {
      * }</pre></blockquote>
      * @param segment the segment to be dereferenced.
      * @return a double value read from {@code segment}.
+     * @throws NullPointerException if {@code segment == null}.
      */
     public static double getDouble(MemorySegment segment) {
         return getDoubleAtOffset(segment, 0L);
@@ -714,6 +785,7 @@ public final class MemoryAccess {
      * }</pre></blockquote>
      * @param segment the segment to be dereferenced.
      * @param value the double value to be written.
+     * @throws NullPointerException if {@code segment == null}.
      */
     public static void setDouble(MemorySegment segment, double value) {
         setDoubleAtOffset(segment, 0L, value);
@@ -728,6 +800,7 @@ public final class MemoryAccess {
      * }</pre></blockquote>
      * @param segment the segment to be dereferenced.
      * @return a memory address read from {@code segment}.
+     * @throws NullPointerException if {@code segment == null}.
      */
     public static MemoryAddress getAddress(MemorySegment segment) {
         return getAddressAtOffset(segment, 0L);
@@ -742,6 +815,7 @@ public final class MemoryAccess {
      * }</pre></blockquote>
      * @param segment the segment to be dereferenced.
      * @param value the memory address to be written (expressed as an {@link Addressable} instance).
+     * @throws NullPointerException if {@code segment == null}, or if {@code value == null}.
      */
     public static void setAddress(MemorySegment segment, Addressable value) {
         setAddressAtOffset(segment, 0L, value);
@@ -757,6 +831,7 @@ public final class MemoryAccess {
      * @param segment the segment to be dereferenced.
      * @param order the specified byte order.
      * @return a char value read from {@code segment}.
+     * @throws NullPointerException if {@code segment == null}, or if {@code order == null}.
      */
     public static char getChar(MemorySegment segment, ByteOrder order) {
         return getCharAtOffset(segment, 0L, order);
@@ -772,6 +847,7 @@ public final class MemoryAccess {
      * @param segment the segment to be dereferenced.
      * @param order the specified byte order.
      * @param value the char value to be written.
+     * @throws NullPointerException if {@code segment == null}, or if {@code order == null}.
      */
     public static void setChar(MemorySegment segment, ByteOrder order, char value) {
         setCharAtOffset(segment, 0L, order, value);
@@ -787,6 +863,7 @@ public final class MemoryAccess {
      * @param segment the segment to be dereferenced.
      * @param order the specified byte order.
      * @return a short value read from {@code segment}.
+     * @throws NullPointerException if {@code segment == null}, or if {@code order == null}.
      */
     public static short getShort(MemorySegment segment, ByteOrder order) {
         return getShortAtOffset(segment, 0L, order);
@@ -802,6 +879,7 @@ public final class MemoryAccess {
      * @param segment the segment to be dereferenced.
      * @param order the specified byte order.
      * @param value the short value to be written.
+     * @throws NullPointerException if {@code segment == null}, or if {@code order == null}.
      */
     public static void setShort(MemorySegment segment, ByteOrder order, short value) {
         setShortAtOffset(segment, 0L, order, value);
@@ -817,6 +895,7 @@ public final class MemoryAccess {
      * @param segment the segment to be dereferenced.
      * @param order the specified byte order.
      * @return an int value read from {@code segment}.
+     * @throws NullPointerException if {@code segment == null}, or if {@code order == null}.
      */
     public static int getInt(MemorySegment segment, ByteOrder order) {
         return getIntAtOffset(segment, 0L, order);
@@ -832,6 +911,7 @@ public final class MemoryAccess {
      * @param segment the segment to be dereferenced.
      * @param order the specified byte order.
      * @param value the int value to be written.
+     * @throws NullPointerException if {@code segment == null}, or if {@code order == null}.
      */
     public static void setInt(MemorySegment segment, ByteOrder order, int value) {
         setIntAtOffset(segment, 0L, order, value);
@@ -847,6 +927,7 @@ public final class MemoryAccess {
      * @param segment the segment to be dereferenced.
      * @param order the specified byte order.
      * @return a float value read from {@code segment}.
+     * @throws NullPointerException if {@code segment == null}, or if {@code order == null}.
      */
     public static float getFloat(MemorySegment segment, ByteOrder order) {
         return getFloatAtOffset(segment, 0L, order);
@@ -862,6 +943,7 @@ public final class MemoryAccess {
      * @param segment the segment to be dereferenced.
      * @param order the specified byte order.
      * @param value the float value to be written.
+     * @throws NullPointerException if {@code segment == null}, or if {@code order == null}.
      */
     public static void setFloat(MemorySegment segment, ByteOrder order, float value) {
         setFloatAtOffset(segment, 0L, order, value);
@@ -877,6 +959,7 @@ public final class MemoryAccess {
      * @param segment the segment to be dereferenced.
      * @param order the specified byte order.
      * @return a long value read from {@code segment}.
+     * @throws NullPointerException if {@code segment == null}, or if {@code order == null}.
      */
     public static long getLong(MemorySegment segment, ByteOrder order) {
         return getLongAtOffset(segment, 0L, order);
@@ -892,6 +975,7 @@ public final class MemoryAccess {
      * @param segment the segment to be dereferenced.
      * @param order the specified byte order.
      * @param value the long value to be written.
+     * @throws NullPointerException if {@code segment == null}, or if {@code order == null}.
      */
     public static void setLong(MemorySegment segment, ByteOrder order, long value) {
         setLongAtOffset(segment, 0L, order, value);
@@ -907,6 +991,7 @@ public final class MemoryAccess {
      * @param segment the segment to be dereferenced.
      * @param order the specified byte order.
      * @return a double value read from {@code segment}.
+     * @throws NullPointerException if {@code segment == null}, or if {@code order == null}.
      */
     public static double getDouble(MemorySegment segment, ByteOrder order) {
         return getDoubleAtOffset(segment, 0L, order);
@@ -922,6 +1007,7 @@ public final class MemoryAccess {
      * @param segment the segment to be dereferenced.
      * @param order the specified byte order.
      * @param value the double value to be written.
+     * @throws NullPointerException if {@code segment == null}, or if {@code order == null}.
      */
     public static void setDouble(MemorySegment segment, ByteOrder order, double value) {
         setDoubleAtOffset(segment, 0L, order, value);
@@ -937,6 +1023,7 @@ public final class MemoryAccess {
      * @param segment the segment to be dereferenced.
      * @param index element index (relative to {@code segment}). The final address of this read operation can be expressed as {@code segment.address().addOffset(index * 2)}.
      * @return a char value read from {@code segment} at the element index specified by {@code index}.
+     * @throws NullPointerException if {@code segment == null}.
      */
     public static char getCharAtIndex(MemorySegment segment, long index) {
         return getCharAtOffset(segment, scale(segment, index, 2));
@@ -952,6 +1039,7 @@ public final class MemoryAccess {
      * @param segment the segment to be dereferenced.
      * @param index element index (relative to {@code segment}). The final address of this read operation can be expressed as {@code segment.address().addOffset(index * 2)}.
      * @param value the char value to be written.
+     * @throws NullPointerException if {@code segment == null}.
      */
     public static void setCharAtIndex(MemorySegment segment, long index, char value) {
         setCharAtOffset(segment, scale(segment, index, 2), value);
@@ -967,6 +1055,7 @@ public final class MemoryAccess {
      * @param segment the segment to be dereferenced.
      * @param index element index (relative to {@code segment}). The final address of this read operation can be expressed as {@code segment.address().addOffset(index * 2)}.
      * @return a short value read from {@code segment} at the element index specified by {@code index}.
+     * @throws NullPointerException if {@code segment == null}.
      */
     public static short getShortAtIndex(MemorySegment segment, long index) {
         return getShortAtOffset(segment, scale(segment, index, 2));
@@ -982,6 +1071,7 @@ public final class MemoryAccess {
      * @param segment the segment to be dereferenced.
      * @param index element index (relative to {@code segment}). The final address of this read operation can be expressed as {@code segment.address().addOffset(index * 2)}.
      * @param value the short value to be written.
+     * @throws NullPointerException if {@code segment == null}.
      */
     public static void setShortAtIndex(MemorySegment segment, long index, short value) {
         setShortAtOffset(segment, scale(segment, index, 2), value);
@@ -997,6 +1087,7 @@ public final class MemoryAccess {
      * @param segment the segment to be dereferenced.
      * @param index element index (relative to {@code segment}). The final address of this read operation can be expressed as {@code segment.address().addOffset(index * 4)}.
      * @return an int value read from {@code segment} at the element index specified by {@code index}.
+     * @throws NullPointerException if {@code segment == null}.
      */
     public static int getIntAtIndex(MemorySegment segment, long index) {
         return getIntAtOffset(segment, scale(segment, index, 4));
@@ -1012,6 +1103,7 @@ public final class MemoryAccess {
      * @param segment the segment to be dereferenced.
      * @param index element index (relative to {@code segment}). The final address of this read operation can be expressed as {@code segment.address().addOffset(index * 4)}.
      * @param value the int value to be written.
+     * @throws NullPointerException if {@code segment == null}.
      */
     public static void setIntAtIndex(MemorySegment segment, long index, int value) {
         setIntAtOffset(segment, scale(segment, index, 4), value);
@@ -1027,6 +1119,7 @@ public final class MemoryAccess {
      * @param segment the segment to be dereferenced.
      * @param index element index (relative to {@code segment}). The final address of this read operation can be expressed as {@code segment.address().addOffset(index * 4)}.
      * @return a float value read from {@code segment} at the element index specified by {@code index}.
+     * @throws NullPointerException if {@code segment == null}.
      */
     public static float getFloatAtIndex(MemorySegment segment, long index) {
         return getFloatAtOffset(segment, scale(segment, index, 4));
@@ -1042,6 +1135,7 @@ public final class MemoryAccess {
      * @param segment the segment to be dereferenced.
      * @param index element index (relative to {@code segment}). The final address of this read operation can be expressed as {@code segment.address().addOffset(index * 4)}.
      * @param value the float value to be written.
+     * @throws NullPointerException if {@code segment == null}.
      */
     public static void setFloatAtIndex(MemorySegment segment, long index, float value) {
         setFloatAtOffset(segment, scale(segment, index, 4), value);
@@ -1057,6 +1151,7 @@ public final class MemoryAccess {
      * @param segment the segment to be dereferenced.
      * @param index element index (relative to {@code segment}). The final address of this read operation can be expressed as {@code segment.address().addOffset(index * 8)}.
      * @return a long value read from {@code segment} at the element index specified by {@code index}.
+     * @throws NullPointerException if {@code segment == null}.
      */
     public static long getLongAtIndex(MemorySegment segment, long index) {
         return getLongAtOffset(segment, scale(segment, index, 8));
@@ -1072,6 +1167,7 @@ public final class MemoryAccess {
      * @param segment the segment to be dereferenced.
      * @param index element index (relative to {@code segment}). The final address of this read operation can be expressed as {@code segment.address().addOffset(index * 8)}.
      * @param value the long value to be written.
+     * @throws NullPointerException if {@code segment == null}.
      */
     public static void setLongAtIndex(MemorySegment segment, long index, long value) {
         setLongAtOffset(segment, scale(segment, index, 8), value);
@@ -1087,9 +1183,26 @@ public final class MemoryAccess {
      * @param segment the segment to be dereferenced.
      * @param index element index (relative to {@code segment}). The final address of this read operation can be expressed as {@code segment.address().addOffset(index * 8)}.
      * @return a double value read from {@code segment} at the element index specified by {@code index}.
+     * @throws NullPointerException if {@code segment == null}.
      */
     public static double getDoubleAtIndex(MemorySegment segment, long index) {
         return getDoubleAtOffset(segment, scale(segment, index, 8));
+    }
+
+    /**
+     * Writes a double at given segment and element index, with byte order set to {@link ByteOrder#nativeOrder()}.
+     * <p>
+     * This is equivalent to the following code:
+     * <blockquote><pre>{@code
+    setDoubleAtOffset(segment, 8 * index, value);
+     * }</pre></blockquote>
+     * @param segment the segment to be dereferenced.
+     * @param index element index (relative to {@code segment}). The final address of this read operation can be expressed as {@code segment.address().addOffset(index * 8)}.
+     * @param value the double value to be written.
+     * @throws NullPointerException if {@code segment == null}.
+     */
+    public static void setDoubleAtIndex(MemorySegment segment, long index, double value) {
+        setDoubleAtOffset(segment, scale(segment, index, 8), value);
     }
 
     /**
@@ -1102,6 +1215,7 @@ public final class MemoryAccess {
      * @param segment the segment to be dereferenced.
      * @param index element index (relative to {@code segment}). The final address of this read operation can be expressed as {@code segment.address().addOffset(index * 8)}.
      * @return a memory address read from {@code segment} at the element index specified by {@code index}.
+     * @throws NullPointerException if {@code segment == null}.
      */
     public static MemoryAddress getAddressAtIndex(MemorySegment segment, long index) {
         return getAddressAtOffset(segment, scale(segment, index, (int)MemoryLayouts.ADDRESS.byteSize()));
@@ -1117,24 +1231,10 @@ public final class MemoryAccess {
      * @param segment the segment to be dereferenced.
      * @param index element index (relative to {@code segment}). The final address of this read operation can be expressed as {@code segment.address().addOffset(index * 8)}.
      * @param value the memory address to be written (expressed as an {@link Addressable} instance).
+     * @throws NullPointerException if {@code segment == null}, or if {@code value == null}.
      */
     public static void setAddressAtIndex(MemorySegment segment, long index, Addressable value) {
         setAddressAtOffset(segment, scale(segment, index, (int)MemoryLayouts.ADDRESS.byteSize()), value);
-    }
-
-    /**
-     * Writes a double at given segment and element index, with byte order set to {@link ByteOrder#nativeOrder()}.
-     * <p>
-     * This is equivalent to the following code:
-     * <blockquote><pre>{@code
-    setDoubleAtOffset(segment, 8 * index, value);
-     * }</pre></blockquote>
-     * @param segment the segment to be dereferenced.
-     * @param index element index (relative to {@code segment}). The final address of this read operation can be expressed as {@code segment.address().addOffset(index * 8)}.
-     * @param value the double value to be written.
-     */
-    public static void setDoubleAtIndex(MemorySegment segment, long index, double value) {
-        setDoubleAtOffset(segment, scale(segment, index, 8), value);
     }
 
     /**
@@ -1148,6 +1248,7 @@ public final class MemoryAccess {
      * @param index element index (relative to {@code segment}). The final address of this read operation can be expressed as {@code segment.address().addOffset(index * 2)}.
      * @param order the specified byte order.
      * @return a char value read from {@code segment} at the element index specified by {@code index}.
+     * @throws NullPointerException if {@code segment == null}, or if {@code order == null}.
      */
     public static char getCharAtIndex(MemorySegment segment, long index, ByteOrder order) {
         return getCharAtOffset(segment, scale(segment, index, 2), order);
@@ -1164,6 +1265,7 @@ public final class MemoryAccess {
      * @param index element index (relative to {@code segment}). The final address of this read operation can be expressed as {@code segment.address().addOffset(index * 2)}.
      * @param order the specified byte order.
      * @param value the char value to be written.
+     * @throws NullPointerException if {@code segment == null}, or if {@code order == null}.
      */
     public static void setCharAtIndex(MemorySegment segment, long index, ByteOrder order, char value) {
         setCharAtOffset(segment, scale(segment, index, 2), order, value);
@@ -1180,6 +1282,7 @@ public final class MemoryAccess {
      * @param index element index (relative to {@code segment}). The final address of this read operation can be expressed as {@code segment.address().addOffset(index * 2)}.
      * @param order the specified byte order.
      * @return a short value read from {@code segment} at the element index specified by {@code index}.
+     * @throws NullPointerException if {@code segment == null}, or if {@code order == null}.
      */
     public static short getShortAtIndex(MemorySegment segment, long index, ByteOrder order) {
         return getShortAtOffset(segment, scale(segment, index, 2), order);
@@ -1196,6 +1299,7 @@ public final class MemoryAccess {
      * @param index element index (relative to {@code segment}). The final address of this read operation can be expressed as {@code segment.address().addOffset(index * 2)}.
      * @param order the specified byte order.
      * @param value the short value to be written.
+     * @throws NullPointerException if {@code segment == null}, or if {@code order == null}.
      */
     public static void setShortAtIndex(MemorySegment segment, long index, ByteOrder order, short value) {
         setShortAtOffset(segment, scale(segment, index, 2), order, value);
@@ -1212,6 +1316,7 @@ public final class MemoryAccess {
      * @param index element index (relative to {@code segment}). The final address of this read operation can be expressed as {@code segment.address().addOffset(index * 4)}.
      * @param order the specified byte order.
      * @return an int value read from {@code segment} at the element index specified by {@code index}.
+     * @throws NullPointerException if {@code segment == null}, or if {@code order == null}.
      */
     public static int getIntAtIndex(MemorySegment segment, long index, ByteOrder order) {
         return getIntAtOffset(segment, scale(segment, index, 4), order);
@@ -1228,6 +1333,7 @@ public final class MemoryAccess {
      * @param index element index (relative to {@code segment}). The final address of this read operation can be expressed as {@code segment.address().addOffset(index * 4)}.
      * @param order the specified byte order.
      * @param value the int value to be written.
+     * @throws NullPointerException if {@code segment == null}, or if {@code order == null}.
      */
     public static void setIntAtIndex(MemorySegment segment, long index, ByteOrder order, int value) {
         setIntAtOffset(segment, scale(segment, index, 4), order, value);
@@ -1244,6 +1350,7 @@ public final class MemoryAccess {
      * @param index element index (relative to {@code segment}). The final address of this read operation can be expressed as {@code segment.address().addOffset(index * 4)}.
      * @param order the specified byte order.
      * @return a float value read from {@code segment} at the element index specified by {@code index}.
+     * @throws NullPointerException if {@code segment == null}, or if {@code order == null}.
      */
     public static float getFloatAtIndex(MemorySegment segment, long index, ByteOrder order) {
         return getFloatAtOffset(segment, scale(segment, index, 4), order);
@@ -1260,6 +1367,7 @@ public final class MemoryAccess {
      * @param index element index (relative to {@code segment}). The final address of this read operation can be expressed as {@code segment.address().addOffset(index * 4)}.
      * @param order the specified byte order.
      * @param value the float value to be written.
+     * @throws NullPointerException if {@code segment == null}, or if {@code order == null}.
      */
     public static void setFloatAtIndex(MemorySegment segment, long index, ByteOrder order, float value) {
         setFloatAtOffset(segment, scale(segment, index, 4), order, value);
@@ -1276,6 +1384,7 @@ public final class MemoryAccess {
      * @param index element index (relative to {@code segment}). The final address of this read operation can be expressed as {@code segment.address().addOffset(index * 8)}.
      * @param order the specified byte order.
      * @return a long value read from {@code segment} at the element index specified by {@code index}.
+     * @throws NullPointerException if {@code segment == null}, or if {@code order == null}.
      */
     public static long getLongAtIndex(MemorySegment segment, long index, ByteOrder order) {
         return getLongAtOffset(segment, scale(segment, index, 8), order);
@@ -1292,6 +1401,7 @@ public final class MemoryAccess {
      * @param index element index (relative to {@code segment}). The final address of this read operation can be expressed as {@code segment.address().addOffset(index * 8)}.
      * @param order the specified byte order.
      * @param value the long value to be written.
+     * @throws NullPointerException if {@code segment == null}, or if {@code order == null}.
      */
     public static void setLongAtIndex(MemorySegment segment, long index, ByteOrder order, long value) {
         setLongAtOffset(segment, scale(segment, index, 8), order, value);
@@ -1308,6 +1418,7 @@ public final class MemoryAccess {
      * @param index element index (relative to {@code segment}). The final address of this read operation can be expressed as {@code segment.address().addOffset(index * 8)}.
      * @param order the specified byte order.
      * @return a double value read from {@code segment} at the element index specified by {@code index}.
+     * @throws NullPointerException if {@code segment == null}, or if {@code order == null}.
      */
     public static double getDoubleAtIndex(MemorySegment segment, long index, ByteOrder order) {
         return getDoubleAtOffset(segment, scale(segment, index, 8), order);
@@ -1324,6 +1435,7 @@ public final class MemoryAccess {
      * @param index element index (relative to {@code segment}). The final address of this read operation can be expressed as {@code segment.address().addOffset(index * 8)}.
      * @param order the specified byte order.
      * @param value the double value to be written.
+     * @throws NullPointerException if {@code segment == null}, or if {@code order == null}.
      */
     public static void setDoubleAtIndex(MemorySegment segment, long index, ByteOrder order, double value) {
         setDoubleAtOffset(segment, scale(segment, index, 8), order, value);

--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/MemoryAddress.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/MemoryAddress.java
@@ -84,6 +84,7 @@ public interface MemoryAddress extends Addressable {
      * @param segment the segment relative to which this address offset should be computed
      * @throws IllegalArgumentException if {@code segment} is not compatible with this address; this can happen, for instance,
      * when {@code segment} models an heap memory region, while this address models an off-heap memory address.
+     * @throws NullPointerException if {@code segment == null}.
      */
     long segmentOffset(MemorySegment segment);
 

--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/MemoryHandles.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/MemoryHandles.java
@@ -168,9 +168,9 @@ public final class MemoryHandles {
      * @param byteOrder the required byte order.
      * @return the new memory access var handle.
      * @throws IllegalArgumentException when an illegal carrier type is used
+     * @throws NullPointerException if {@code carrier == null}, or {@code byteOrder == null}.
      */
     public static VarHandle varHandle(Class<?> carrier, ByteOrder byteOrder) {
-        checkCarrier(carrier);
         return varHandle(carrier,
                 carrierSize(carrier),
                 byteOrder);
@@ -194,8 +194,11 @@ public final class MemoryHandles {
      * @param byteOrder the required byte order.
      * @return the new memory access var handle.
      * @throws IllegalArgumentException if an illegal carrier type is used, or if {@code alignmentBytes} is not a power of two.
+     * @throws NullPointerException if {@code carrier == null}, or {@code byteOrder == null}.
      */
     public static VarHandle varHandle(Class<?> carrier, long alignmentBytes, ByteOrder byteOrder) {
+        Objects.requireNonNull(carrier);
+        Objects.requireNonNull(byteOrder);
         checkCarrier(carrier);
 
         if (alignmentBytes <= 0
@@ -218,8 +221,10 @@ public final class MemoryHandles {
      * @return the adapted var handle.
      * @throws IllegalArgumentException if the carrier type of {@code varHandle} is either {@code boolean},
      * {@code float}, or {@code double}, or is not a primitive type.
+     * @throws NullPointerException if {@code target == null}.
      */
     public static VarHandle asAddressVarHandle(VarHandle target) {
+        Objects.requireNonNull(target);
         Class<?> carrier = target.varType();
         if (!carrier.isPrimitive() || carrier == boolean.class ||
                 carrier == float.class || carrier == double.class) {

--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/MemoryLayout.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/MemoryLayout.java
@@ -41,6 +41,7 @@ import java.util.OptionalLong;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.function.UnaryOperator;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 /**
@@ -250,6 +251,7 @@ public interface MemoryLayout extends Constable {
      *
      * @param name the layout name.
      * @return a new layout which is the same as this layout, except for the <em>name</em> associated to it.
+     * @throws NullPointerException if {@code name == null}.
      * @see MemoryLayout#name()
      */
     MemoryLayout withName(String name);
@@ -308,6 +310,7 @@ public interface MemoryLayout extends Constable {
      *
      * @param name the attribute name
      * @return the attribute with the given name (if it exists).
+     * @throws NullPointerException if {@code name == null}.
      */
     Optional<Constable> attribute(String name);
 
@@ -319,6 +322,7 @@ public interface MemoryLayout extends Constable {
      * @param name the attribute name.
      * @param value the attribute value.
      * @return a new memory layout which features the same attributes as this layout, plus the newly specified attribute.
+     * @throws NullPointerException if {@code name == null}.
      */
     MemoryLayout withAttribute(String name, Constable value);
 
@@ -342,6 +346,7 @@ public interface MemoryLayout extends Constable {
      * layout path contains one or more path elements that select multiple sequence element indices
      * (see {@link PathElement#sequenceElement()} and {@link PathElement#sequenceElement(long, long)}).
      * @throws UnsupportedOperationException if one of the layouts traversed by the layout path has unspecified size.
+     * @throws NullPointerException if any of the elements in {@code elements} is {@code null}.
      */
     default long bitOffset(PathElement... elements) {
         return computePathOp(LayoutPath.rootPath(this, MemoryLayout::bitSize), LayoutPath::offset, EnumSet.of(PathKind.SEQUENCE_ELEMENT, PathKind.SEQUENCE_RANGE), elements);
@@ -361,6 +366,7 @@ public interface MemoryLayout extends Constable {
      * (see {@link PathElement#sequenceElement()} and {@link PathElement#sequenceElement(long, long)}).
      * @throws UnsupportedOperationException if one of the layouts traversed by the layout path has unspecified size,
      * or if {@code bitOffset(elements)} is not a multiple of 8.
+     * @throws NullPointerException if any of the elements in {@code elements} is {@code null}.
      */
     default long byteOffset(PathElement... elements) {
         return Utils.bitsToBytesOrThrow(bitOffset(elements),
@@ -401,8 +407,10 @@ public interface MemoryLayout extends Constable {
      * @throws IllegalArgumentException if the carrier does not represent a primitive type, if the carrier is {@code void},
      * {@code boolean}, or if the layout path in {@code elements} does not select a value layout (see {@link ValueLayout}),
      * or if the selected value layout has a size that that does not match that of the specified carrier type.
+     * @throws NullPointerException if {@code carrier == null}, or if any of the elements in {@code elements} is {@code null}.
      */
     default VarHandle varHandle(Class<?> carrier, PathElement... elements) {
+        Objects.requireNonNull(carrier);
         return computePathOp(LayoutPath.rootPath(this, MemoryLayout::bitSize), path -> path.dereferenceHandle(carrier),
                 Set.of(), elements);
     }
@@ -415,6 +423,7 @@ public interface MemoryLayout extends Constable {
      * @throws IllegalArgumentException if the layout path does not select any layout nested in this layout,
      * or if the layout path contains one or more path elements that select one or more sequence element indices
      * (see {@link PathElement#sequenceElement(long)} and {@link PathElement#sequenceElement(long, long)}).
+     * @throws NullPointerException if any of the elements in {@code elements} is {@code null}.
      */
     default MemoryLayout select(PathElement... elements) {
         return computePathOp(LayoutPath.rootPath(this, l -> 0L), LayoutPath::layout,
@@ -432,8 +441,10 @@ public interface MemoryLayout extends Constable {
      * @throws IllegalArgumentException if the layout path does not select any layout nested in this layout,
      * or if the layout path contains one or more path elements that select one or more sequence element indices
      * (see {@link PathElement#sequenceElement(long)} and {@link PathElement#sequenceElement(long, long)}).
+     * @throws NullPointerException if {@code op == null}, or if any of the elements in {@code elements} is {@code null}.
      */
     default MemoryLayout map(UnaryOperator<MemoryLayout> op, PathElement... elements) {
+        Objects.requireNonNull(op);
         return computePathOp(LayoutPath.rootPath(this, l -> 0L), path -> path.map(op),
                 EnumSet.of(PathKind.SEQUENCE_ELEMENT_INDEX, PathKind.SEQUENCE_RANGE), elements);
     }
@@ -441,7 +452,7 @@ public interface MemoryLayout extends Constable {
     private static <Z> Z computePathOp(LayoutPath path, Function<LayoutPath, Z> finalizer,
                                        Set<LayoutPath.PathElementImpl.PathKind> badKinds, PathElement... elements) {
         for (PathElement e : elements) {
-            LayoutPath.PathElementImpl pathElem = (LayoutPath.PathElementImpl)e;
+            LayoutPath.PathElementImpl pathElem = (LayoutPath.PathElementImpl)Objects.requireNonNull(e);
             if (badKinds.contains(pathElem.kind())) {
                 throw new IllegalArgumentException(String.format("Invalid %s selection in layout path", pathElem.kind().description()));
             }
@@ -605,10 +616,11 @@ E * (S + I * F)
      * @param order the value layout's byte order.
      * @return a new value layout.
      * @throws IllegalArgumentException if {@code size <= 0}.
+     * @throws NullPointerException if {@code order == null}.
      */
     static ValueLayout ofValueBits(long size, ByteOrder order) {
         AbstractLayout.checkSize(size);
-        return new ValueLayout(order, size);
+        return new ValueLayout(Objects.requireNonNull(order), size);
     }
 
     /**
@@ -618,11 +630,12 @@ E * (S + I * F)
      * @param elementLayout the sequence element layout.
      * @return the new sequence layout with given element layout and size.
      * @throws IllegalArgumentException if {@code elementCount < 0}.
+     * @throws NullPointerException if {@code elementLayout == null}.
      */
     static SequenceLayout ofSequence(long elementCount, MemoryLayout elementLayout) {
         AbstractLayout.checkSize(elementCount, true);
         OptionalLong size = OptionalLong.of(elementCount);
-        return new SequenceLayout(size, elementLayout);
+        return new SequenceLayout(size, Objects.requireNonNull(elementLayout));
     }
 
     /**
@@ -630,9 +643,10 @@ E * (S + I * F)
      *
      * @param elementLayout the element layout of the sequence layout.
      * @return the new sequence layout with given element layout.
+     * @throws NullPointerException if {@code elementLayout == null}.
      */
     static SequenceLayout ofSequence(MemoryLayout elementLayout) {
-        return new SequenceLayout(OptionalLong.empty(), elementLayout);
+        return new SequenceLayout(OptionalLong.empty(), Objects.requireNonNull(elementLayout));
     }
 
     /**
@@ -640,9 +654,14 @@ E * (S + I * F)
      *
      * @param elements The member layouts of the <em>struct</em> group layout.
      * @return a new <em>struct</em> group layout with given member layouts.
+     * @throws NullPointerException if {@code elements == null}, or if any of the layouts in {@code elements} is {@code null}.
      */
     static GroupLayout ofStruct(MemoryLayout... elements) {
-        return new GroupLayout(GroupLayout.Kind.STRUCT, List.of(elements));
+        Objects.requireNonNull(elements);
+        return new GroupLayout(GroupLayout.Kind.STRUCT,
+                Stream.of(elements)
+                        .map(Objects::requireNonNull)
+                        .collect(Collectors.toList()));
     }
 
     /**
@@ -650,9 +669,14 @@ E * (S + I * F)
      *
      * @param elements The member layouts of the <em>union</em> layout.
      * @return a new <em>union</em> group layout with given member layouts.
+     * @throws NullPointerException if {@code elements == null}, or if any of the layouts in {@code elements} is {@code null}.
      */
     static GroupLayout ofUnion(MemoryLayout... elements) {
-        return new GroupLayout(GroupLayout.Kind.UNION, List.of(elements));
+        Objects.requireNonNull(elements);
+        return new GroupLayout(GroupLayout.Kind.UNION,
+                Stream.of(elements)
+                        .map(Objects::requireNonNull)
+                        .collect(Collectors.toList()));
     }
 
     /**

--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/MemoryLayout.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/MemoryLayout.java
@@ -346,7 +346,8 @@ public interface MemoryLayout extends Constable {
      * layout path contains one or more path elements that select multiple sequence element indices
      * (see {@link PathElement#sequenceElement()} and {@link PathElement#sequenceElement(long, long)}).
      * @throws UnsupportedOperationException if one of the layouts traversed by the layout path has unspecified size.
-     * @throws NullPointerException if any of the elements in {@code elements} is {@code null}.
+     * @throws NullPointerException if either {@code elements == null}, or if any of the elements
+     * in {@code elements} is {@code null}.
      */
     default long bitOffset(PathElement... elements) {
         return computePathOp(LayoutPath.rootPath(this, MemoryLayout::bitSize), LayoutPath::offset, EnumSet.of(PathKind.SEQUENCE_ELEMENT, PathKind.SEQUENCE_RANGE), elements);
@@ -366,7 +367,8 @@ public interface MemoryLayout extends Constable {
      * (see {@link PathElement#sequenceElement()} and {@link PathElement#sequenceElement(long, long)}).
      * @throws UnsupportedOperationException if one of the layouts traversed by the layout path has unspecified size,
      * or if {@code bitOffset(elements)} is not a multiple of 8.
-     * @throws NullPointerException if any of the elements in {@code elements} is {@code null}.
+     * @throws NullPointerException if either {@code elements == null}, or if any of the elements
+     * in {@code elements} is {@code null}.
      */
     default long byteOffset(PathElement... elements) {
         return Utils.bitsToBytesOrThrow(bitOffset(elements),
@@ -407,7 +409,8 @@ public interface MemoryLayout extends Constable {
      * @throws IllegalArgumentException if the carrier does not represent a primitive type, if the carrier is {@code void},
      * {@code boolean}, or if the layout path in {@code elements} does not select a value layout (see {@link ValueLayout}),
      * or if the selected value layout has a size that that does not match that of the specified carrier type.
-     * @throws NullPointerException if {@code carrier == null}, or if any of the elements in {@code elements} is {@code null}.
+     * @throws NullPointerException if either {@code carrier == null}, {@code elements == null}, or if any of the elements
+     * in {@code elements} is {@code null}.
      */
     default VarHandle varHandle(Class<?> carrier, PathElement... elements) {
         Objects.requireNonNull(carrier);
@@ -423,7 +426,8 @@ public interface MemoryLayout extends Constable {
      * @throws IllegalArgumentException if the layout path does not select any layout nested in this layout,
      * or if the layout path contains one or more path elements that select one or more sequence element indices
      * (see {@link PathElement#sequenceElement(long)} and {@link PathElement#sequenceElement(long, long)}).
-     * @throws NullPointerException if any of the elements in {@code elements} is {@code null}.
+     * @throws NullPointerException if either {@code elements == null}, or if any of the elements
+     * in {@code elements} is {@code null}.
      */
     default MemoryLayout select(PathElement... elements) {
         return computePathOp(LayoutPath.rootPath(this, l -> 0L), LayoutPath::layout,
@@ -441,7 +445,8 @@ public interface MemoryLayout extends Constable {
      * @throws IllegalArgumentException if the layout path does not select any layout nested in this layout,
      * or if the layout path contains one or more path elements that select one or more sequence element indices
      * (see {@link PathElement#sequenceElement(long)} and {@link PathElement#sequenceElement(long, long)}).
-     * @throws NullPointerException if {@code op == null}, or if any of the elements in {@code elements} is {@code null}.
+     * @throws NullPointerException if either {@code op == null}, {@code elements == null}, or if any of the elements
+     * in {@code elements} is {@code null}.
      */
     default MemoryLayout map(UnaryOperator<MemoryLayout> op, PathElement... elements) {
         Objects.requireNonNull(op);
@@ -451,6 +456,7 @@ public interface MemoryLayout extends Constable {
 
     private static <Z> Z computePathOp(LayoutPath path, Function<LayoutPath, Z> finalizer,
                                        Set<LayoutPath.PathElementImpl.PathKind> badKinds, PathElement... elements) {
+        Objects.requireNonNull(elements);
         for (PathElement e : elements) {
             LayoutPath.PathElementImpl pathElem = (LayoutPath.PathElementImpl)Objects.requireNonNull(e);
             if (badKinds.contains(pathElem.kind())) {

--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/MemorySegment.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/MemorySegment.java
@@ -251,6 +251,7 @@ public interface MemorySegment extends Addressable, AutoCloseable {
      * @return the element spliterator for this segment
      * @throws IllegalStateException if the segment is not <em>alive</em>, or if access occurs from a thread other than the
      * thread owning this segment
+     * @throws NullPointerException if {@code layout == null}.
      */
     Spliterator<MemorySegment> spliterator(SequenceLayout layout);
 
@@ -475,6 +476,7 @@ public interface MemorySegment extends Addressable, AutoCloseable {
      * @throws IllegalStateException if this segment is not <em>alive</em>, or if access occurs from a thread other than the
      * thread owning this segment, or if this segment is already associated with a cleaner.
      * @throws UnsupportedOperationException if this segment does not support the {@link #CLOSE} access mode.
+     * @throws NullPointerException if {@code cleaner == null}.
      */
     MemorySegment registerCleaner(Cleaner cleaner);
 
@@ -525,6 +527,7 @@ for (long l = 0; l < segment.byteSize(); l++) {
      * @throws UnsupportedOperationException if either the source segment or this segment do not feature required access modes;
      * more specifically, {@code src} should feature at least the {@link MemorySegment#READ} access mode,
      * while this segment should feature at least the {@link MemorySegment#WRITE} access mode.
+     * @throws NullPointerException if {@code src == null}.
      */
     void copyFrom(MemorySegment src);
 
@@ -551,6 +554,7 @@ for (long l = 0; l < segment.byteSize(); l++) {
      * thread owning either segment
      * @throws UnsupportedOperationException if either this segment or the other
      * segment does not feature at least the {@link MemorySegment#READ} access mode
+     * @throws NullPointerException if {@code src == null}.
      */
     long mismatch(MemorySegment other);
 
@@ -675,6 +679,7 @@ for (long l = 0; l < segment.byteSize(); l++) {
      *
      * @param bb the byte buffer backing the buffer memory segment.
      * @return a new confined buffer memory segment.
+     * @throws NullPointerException if {@code bb == null}.
      */
     static MemorySegment ofByteBuffer(ByteBuffer bb) {
         return AbstractMemorySegmentImpl.ofBuffer(bb);
@@ -689,6 +694,7 @@ for (long l = 0; l < segment.byteSize(); l++) {
      *
      * @param arr the primitive array backing the array memory segment.
      * @return a new confined array memory segment.
+     * @throws NullPointerException if {@code arr == null}.
      */
     static MemorySegment ofArray(byte[] arr) {
         return HeapMemorySegmentImpl.makeArraySegment(arr);
@@ -703,6 +709,7 @@ for (long l = 0; l < segment.byteSize(); l++) {
      *
      * @param arr the primitive array backing the array memory segment.
      * @return a new confined array memory segment.
+     * @throws NullPointerException if {@code arr == null}.
      */
     static MemorySegment ofArray(char[] arr) {
         return HeapMemorySegmentImpl.makeArraySegment(arr);
@@ -717,6 +724,7 @@ for (long l = 0; l < segment.byteSize(); l++) {
      *
      * @param arr the primitive array backing the array memory segment.
      * @return a new confined array memory segment.
+     * @throws NullPointerException if {@code arr == null}.
      */
     static MemorySegment ofArray(short[] arr) {
         return HeapMemorySegmentImpl.makeArraySegment(arr);
@@ -731,6 +739,7 @@ for (long l = 0; l < segment.byteSize(); l++) {
      *
      * @param arr the primitive array backing the array memory segment.
      * @return a new confined array memory segment.
+     * @throws NullPointerException if {@code arr == null}.
      */
     static MemorySegment ofArray(int[] arr) {
         return HeapMemorySegmentImpl.makeArraySegment(arr);
@@ -745,6 +754,7 @@ for (long l = 0; l < segment.byteSize(); l++) {
      *
      * @param arr the primitive array backing the array memory segment.
      * @return a new confined array memory segment.
+     * @throws NullPointerException if {@code arr == null}.
      */
     static MemorySegment ofArray(float[] arr) {
         return HeapMemorySegmentImpl.makeArraySegment(arr);
@@ -759,6 +769,7 @@ for (long l = 0; l < segment.byteSize(); l++) {
      *
      * @param arr the primitive array backing the array memory segment.
      * @return a new confined array memory segment.
+     * @throws NullPointerException if {@code arr == null}.
      */
     static MemorySegment ofArray(long[] arr) {
         return HeapMemorySegmentImpl.makeArraySegment(arr);
@@ -773,6 +784,7 @@ for (long l = 0; l < segment.byteSize(); l++) {
      *
      * @param arr the primitive array backing the array memory segment.
      * @return a new confined array memory segment.
+     * @throws NullPointerException if {@code arr == null}.
      */
     static MemorySegment ofArray(double[] arr) {
         return HeapMemorySegmentImpl.makeArraySegment(arr);
@@ -793,8 +805,10 @@ for (long l = 0; l < segment.byteSize(); l++) {
      * @param layout the layout of the off-heap memory block backing the native memory segment.
      * @return a new native memory segment.
      * @throws IllegalArgumentException if the specified layout has illegal size or alignment constraint.
+     * @throws NullPointerException if {@code layout == null}.
      */
     static MemorySegment allocateNative(MemoryLayout layout) {
+        Objects.requireNonNull(layout);
         return allocateNative(layout.byteSize(), layout.byteAlignment());
     }
 
@@ -857,6 +871,7 @@ allocateNative(bytesSize, 1);
      * In the case of the default provider, the {@link SecurityManager#checkRead(String)} method is invoked to check
      * read access if the file is opened for reading. The {@link SecurityManager#checkWrite(String)} method is invoked to check
      * write access if the file is opened for writing.
+     * @throws NullPointerException if {@code path == null} or if {@code mapMode == null}.
      */
     static MemorySegment mapFile(Path path, long bytesOffset, long bytesSize, FileChannel.MapMode mapMode) throws IOException {
         return MappedMemorySegmentImpl.makeMappedSegment(path, bytesOffset, bytesSize, mapMode);

--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/ValueLayout.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/ValueLayout.java
@@ -75,9 +75,10 @@ public final class ValueLayout extends AbstractLayout implements MemoryLayout {
      *
      * @param order the desired byte order.
      * @return a new value layout with given byte order.
+     * @throws NullPointerException if {@code order == null}.
      */
     public ValueLayout withOrder(ByteOrder order) {
-        return new ValueLayout(order, bitSize(), alignment, attributes);
+        return new ValueLayout(Objects.requireNonNull(order), bitSize(), alignment, attributes);
     }
 
     @Override

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/AbstractMemorySegmentImpl.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/AbstractMemorySegmentImpl.java
@@ -109,6 +109,7 @@ public abstract class AbstractMemorySegmentImpl implements MemorySegment, Memory
 
     @Override
     public Spliterator<MemorySegment> spliterator(SequenceLayout sequenceLayout) {
+        Objects.requireNonNull(sequenceLayout);
         checkValidState();
         if (sequenceLayout.byteSize() != byteSize()) {
             throw new IllegalArgumentException();
@@ -125,7 +126,7 @@ public abstract class AbstractMemorySegmentImpl implements MemorySegment, Memory
     }
 
     public void copyFrom(MemorySegment src) {
-        AbstractMemorySegmentImpl that = (AbstractMemorySegmentImpl)src;
+        AbstractMemorySegmentImpl that = (AbstractMemorySegmentImpl)Objects.requireNonNull(src);
         long size = that.byteSize();
         checkAccess(0, size, false);
         that.checkAccess(0, size, true);
@@ -136,7 +137,7 @@ public abstract class AbstractMemorySegmentImpl implements MemorySegment, Memory
 
     @Override
     public long mismatch(MemorySegment other) {
-        AbstractMemorySegmentImpl that = (AbstractMemorySegmentImpl)other;
+        AbstractMemorySegmentImpl that = (AbstractMemorySegmentImpl)Objects.requireNonNull(other);
         final long thisSize = this.byteSize();
         final long thatSize = that.byteSize();
         final long length = Math.min(thisSize, thatSize);
@@ -566,6 +567,7 @@ public abstract class AbstractMemorySegmentImpl implements MemorySegment, Memory
     }
 
     public static AbstractMemorySegmentImpl ofBuffer(ByteBuffer bb) {
+        Objects.requireNonNull(bb);
         long bbAddress = nioAccess.getBufferAddress(bb);
         Object base = nioAccess.getBufferBase(bb);
         UnmapperProxy unmapper = nioAccess.unmapper(bb);

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/HeapMemorySegmentImpl.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/HeapMemorySegmentImpl.java
@@ -85,36 +85,43 @@ public class HeapMemorySegmentImpl<H> extends AbstractMemorySegmentImpl {
     // factories
 
     public static MemorySegment makeArraySegment(byte[] arr) {
+        Objects.requireNonNull(arr);
         return makeHeapSegment(() -> arr, arr.length,
                 Unsafe.ARRAY_BYTE_BASE_OFFSET, Unsafe.ARRAY_BYTE_INDEX_SCALE);
     }
 
     public static MemorySegment makeArraySegment(char[] arr) {
+        Objects.requireNonNull(arr);
         return makeHeapSegment(() -> arr, arr.length,
                 Unsafe.ARRAY_CHAR_BASE_OFFSET, Unsafe.ARRAY_CHAR_INDEX_SCALE);
     }
 
     public static MemorySegment makeArraySegment(short[] arr) {
+        Objects.requireNonNull(arr);
         return makeHeapSegment(() -> arr, arr.length,
                 Unsafe.ARRAY_SHORT_BASE_OFFSET, Unsafe.ARRAY_SHORT_INDEX_SCALE);
     }
 
     public static MemorySegment makeArraySegment(int[] arr) {
+        Objects.requireNonNull(arr);
         return makeHeapSegment(() -> arr, arr.length,
                 Unsafe.ARRAY_INT_BASE_OFFSET, Unsafe.ARRAY_INT_INDEX_SCALE);
     }
 
     public static MemorySegment makeArraySegment(long[] arr) {
+        Objects.requireNonNull(arr);
         return makeHeapSegment(() -> arr, arr.length,
                 Unsafe.ARRAY_LONG_BASE_OFFSET, Unsafe.ARRAY_LONG_INDEX_SCALE);
     }
 
     public static MemorySegment makeArraySegment(float[] arr) {
+        Objects.requireNonNull(arr);
         return makeHeapSegment(() -> arr, arr.length,
                 Unsafe.ARRAY_FLOAT_BASE_OFFSET, Unsafe.ARRAY_FLOAT_INDEX_SCALE);
     }
 
     public static MemorySegment makeArraySegment(double[] arr) {
+        Objects.requireNonNull(arr);
         return makeHeapSegment(() -> arr, arr.length,
                 Unsafe.ARRAY_DOUBLE_BASE_OFFSET, Unsafe.ARRAY_DOUBLE_INDEX_SCALE);
     }

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/MappedMemorySegmentImpl.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/MappedMemorySegmentImpl.java
@@ -37,6 +37,7 @@ import java.nio.channels.FileChannel;
 import java.nio.file.OpenOption;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
+import java.util.Objects;
 import java.util.Optional;
 
 /**
@@ -109,6 +110,8 @@ public class MappedMemorySegmentImpl extends NativeMemorySegmentImpl {
     // factories
 
     public static MemorySegment makeMappedSegment(Path path, long bytesOffset, long bytesSize, FileChannel.MapMode mapMode) throws IOException {
+        Objects.requireNonNull(path);
+        Objects.requireNonNull(mapMode);
         if (bytesSize < 0) throw new IllegalArgumentException("Requested bytes size must be >= 0.");
         if (bytesOffset < 0) throw new IllegalArgumentException("Requested bytes offset must be >= 0.");
         try (FileChannelImpl channelImpl = (FileChannelImpl)FileChannel.open(path, openOptions(mapMode))) {

--- a/test/jdk/java/foreign/TestAddressHandle.java
+++ b/test/jdk/java/foreign/TestAddressHandle.java
@@ -85,6 +85,11 @@ public class TestAddressHandle {
         }
     }
 
+    @Test(expectedExceptions = NullPointerException.class)
+    public void testBadAdaptNull() {
+        MemoryHandles.asAddressVarHandle(null);
+    }
+
     @Test(expectedExceptions = IllegalArgumentException.class)
     public void testBadAdaptFloat() {
         VarHandle floatHandle = MemoryLayouts.JAVA_FLOAT.varHandle(float.class);

--- a/test/jdk/java/foreign/TestCleaner.java
+++ b/test/jdk/java/foreign/TestCleaner.java
@@ -123,6 +123,12 @@ public class TestCleaner {
         }
     }
 
+    @Test(expectedExceptions = NullPointerException.class)
+    public void testNullCleaner() {
+        MemorySegment segment = MemorySegment.ofArray(new byte[10]);
+        segment.registerCleaner(null);
+    }
+
     enum SegmentFunction implements Function<MemorySegment, MemorySegment> {
         IDENTITY(Function.identity()),
         CLOSE(s -> { s.close(); return s; }),

--- a/test/jdk/java/foreign/TestLayoutAttributes.java
+++ b/test/jdk/java/foreign/TestLayoutAttributes.java
@@ -80,4 +80,18 @@ public class TestLayoutAttributes {
         assertTrue(attribs.contains(MemoryLayout.LAYOUT_NAME));
     }
 
+    @Test(expectedExceptions = NullPointerException.class)
+    public void testWithNameNull() {
+        MemoryLayouts.BITS_8_BE.withName(null);
+    }
+
+    @Test(expectedExceptions = NullPointerException.class)
+    public void testFetchAttributeNull() {
+        MemoryLayouts.BITS_8_BE.attribute(null);
+    }
+
+    @Test(expectedExceptions = NullPointerException.class)
+    public void testPutAttributeNull() {
+        MemoryLayouts.BITS_8_BE.withAttribute(null, "Hello");
+    }
 }

--- a/test/jdk/java/foreign/TestLayouts.java
+++ b/test/jdk/java/foreign/TestLayouts.java
@@ -30,7 +30,9 @@ import jdk.incubator.foreign.*;
 
 import java.lang.invoke.VarHandle;
 import java.nio.ByteOrder;
+import java.util.function.Function;
 import java.util.function.LongFunction;
+import java.util.function.UnaryOperator;
 import java.util.stream.Stream;
 
 import org.testng.annotations.*;
@@ -219,6 +221,81 @@ public class TestLayouts {
                 assertEquals(layout.withBitAlignment(a).toString().contains("%"), a != bitAlign);
             }
         }
+    }
+
+    @Test(expectedExceptions = NullPointerException.class)
+    public void testValueLayoutNullOrder() {
+        MemoryLayout.ofValueBits(10, null);
+    }
+
+    @Test(expectedExceptions = NullPointerException.class)
+    public void testValueLayoutWithNullOrder() {
+        MemoryLayout.ofValueBits(10, ByteOrder.BIG_ENDIAN).withOrder(null);
+    }
+
+    @Test(expectedExceptions = NullPointerException.class)
+    public void testUnboundSequenceLayoutNullElement() {
+        MemoryLayout.ofSequence(null);
+    }
+
+    @Test(expectedExceptions = NullPointerException.class)
+    public void testBoundSequenceLayoutNullElement() {
+        MemoryLayout.ofSequence(10, null);
+    }
+
+    @Test(expectedExceptions = NullPointerException.class)
+    public void testStructNullElements() {
+        MemoryLayout.ofStruct(null);
+    }
+
+    @Test(expectedExceptions = NullPointerException.class)
+    public void testUnionNullElements() {
+        MemoryLayout.ofUnion(null);
+    }
+
+    @Test(expectedExceptions = NullPointerException.class)
+    public void testStructWithNullElement() {
+        MemoryLayout.ofStruct(new MemoryLayout[] { null });
+    }
+
+    @Test(expectedExceptions = NullPointerException.class)
+    public void testUnionWithNullElement() {
+        MemoryLayout.ofUnion(new MemoryLayout[] { null });
+    }
+
+    @Test(expectedExceptions = NullPointerException.class)
+    public void testMapWithNullPathElement() {
+        MemoryLayouts.BITS_8_BE.map(UnaryOperator.identity(), new MemoryLayout.PathElement[] { null });
+    }
+
+    @Test(expectedExceptions = NullPointerException.class)
+    public void testMapWithNullOp() {
+        MemoryLayouts.BITS_8_BE.map(null);
+    }
+
+    @Test(expectedExceptions = NullPointerException.class)
+    public void testBitOffsetWithNullPathElement() {
+        MemoryLayouts.BITS_8_BE.bitOffset(new MemoryLayout.PathElement[] { null });
+    }
+
+    @Test(expectedExceptions = NullPointerException.class)
+    public void testByteOffsetWithNullPathElement() {
+        MemoryLayouts.BITS_8_BE.byteOffset(new MemoryLayout.PathElement[] { null });
+    }
+
+    @Test(expectedExceptions = NullPointerException.class)
+    public void testSelectWithNullPathElement() {
+        MemoryLayouts.BITS_8_BE.select(new MemoryLayout.PathElement[] { null });
+    }
+
+    @Test(expectedExceptions = NullPointerException.class)
+    public void testHandleWithNullPathElement() {
+        MemoryLayouts.BITS_8_BE.varHandle(int.class, new MemoryLayout.PathElement[] { null });
+    }
+
+    @Test(expectedExceptions = NullPointerException.class)
+    public void testHandleWithNullCarrier() {
+        MemoryLayouts.BITS_8_BE.varHandle(null);
     }
 
     @DataProvider(name = "badLayoutSizes")

--- a/test/jdk/java/foreign/TestLayouts.java
+++ b/test/jdk/java/foreign/TestLayouts.java
@@ -269,6 +269,11 @@ public class TestLayouts {
     }
 
     @Test(expectedExceptions = NullPointerException.class)
+    public void testMapWithNullElements() {
+        MemoryLayouts.BITS_8_BE.map(UnaryOperator.identity(), null);
+    }
+
+    @Test(expectedExceptions = NullPointerException.class)
     public void testMapWithNullOp() {
         MemoryLayouts.BITS_8_BE.map(null);
     }
@@ -279,8 +284,18 @@ public class TestLayouts {
     }
 
     @Test(expectedExceptions = NullPointerException.class)
+    public void testBitOffsetWithNullElements() {
+        MemoryLayouts.BITS_8_BE.bitOffset(null);
+    }
+
+    @Test(expectedExceptions = NullPointerException.class)
     public void testByteOffsetWithNullPathElement() {
         MemoryLayouts.BITS_8_BE.byteOffset(new MemoryLayout.PathElement[] { null });
+    }
+
+    @Test(expectedExceptions = NullPointerException.class)
+    public void testByteOffsetWithNullElements() {
+        MemoryLayouts.BITS_8_BE.byteOffset(null);
     }
 
     @Test(expectedExceptions = NullPointerException.class)
@@ -289,8 +304,18 @@ public class TestLayouts {
     }
 
     @Test(expectedExceptions = NullPointerException.class)
+    public void testSelectWithNullElements() {
+        MemoryLayouts.BITS_8_BE.select(null);
+    }
+
+    @Test(expectedExceptions = NullPointerException.class)
     public void testHandleWithNullPathElement() {
         MemoryLayouts.BITS_8_BE.varHandle(int.class, new MemoryLayout.PathElement[] { null });
+    }
+
+    @Test(expectedExceptions = NullPointerException.class)
+    public void testhandleWithNullElements() {
+        MemoryLayouts.BITS_8_BE.varHandle(null);
     }
 
     @Test(expectedExceptions = NullPointerException.class)

--- a/test/jdk/java/foreign/TestMemoryAccessStatics.java
+++ b/test/jdk/java/foreign/TestMemoryAccessStatics.java
@@ -1,0 +1,405 @@
+/*
+ *  Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ *  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ *  This code is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License version 2 only, as
+ *  published by the Free Software Foundation.
+ *
+ *  This code is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ *  version 2 for more details (a copy is included in the LICENSE file that
+ *  accompanied this code).
+ *
+ *  You should have received a copy of the GNU General Public License version
+ *  2 along with this work; if not, write to the Free Software Foundation,
+ *  Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ *  Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ *  or visit www.oracle.com if you need additional information or have any
+ *  questions.
+ */
+
+/*
+ * @test
+ * @run testng TestMemoryAccessStatics
+ */
+
+import jdk.incubator.foreign.MemoryAccess;
+import jdk.incubator.foreign.MemoryAddress;
+import jdk.incubator.foreign.MemoryLayouts;
+import jdk.incubator.foreign.MemorySegment;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+
+import org.testng.annotations.*;
+import static org.testng.Assert.*;
+
+public class TestMemoryAccessStatics {
+
+    static class Accessor<X> {
+
+        interface SegmentGetter<X> {
+            X get(MemorySegment segment);
+        }
+
+        interface SegmentSetter<X> {
+            void set(MemorySegment segment, X o);
+        }
+
+        interface BufferGetter<X> {
+            X get(ByteBuffer segment);
+        }
+
+        interface BufferSetter<X> {
+            void set(ByteBuffer buffer, X o);
+        }
+
+        final X value;
+        final SegmentGetter<X> segmentGetter;
+        final SegmentSetter<X> segmentSetter;
+        final BufferGetter<X> bufferGetter;
+        final BufferSetter<X> bufferSetter;
+
+        Accessor(X value,
+                 SegmentGetter<X> segmentGetter, SegmentSetter<X> segmentSetter,
+                 BufferGetter<X> bufferGetter, BufferSetter<X> bufferSetter) {
+            this.value = value;
+            this.segmentGetter = segmentGetter;
+            this.segmentSetter = segmentSetter;
+            this.bufferGetter = bufferGetter;
+            this.bufferSetter = bufferSetter;
+        }
+
+        void test() {
+            MemorySegment segment = MemorySegment.ofArray(new byte[32]);
+            ByteBuffer buffer = segment.asByteBuffer();
+            segmentSetter.set(segment, value);
+            assertEquals(bufferGetter.get(buffer), value);
+            bufferSetter.set(buffer, value);
+            assertEquals(value, segmentGetter.get(segment));
+        }
+
+        <Z> Accessor<Z> of(Z value,
+                           SegmentGetter<Z> segmentGetter, SegmentSetter<Z> segmentSetter,
+                           BufferGetter<Z> bufferGetter, BufferSetter<Z> bufferSetter) {
+            return new Accessor<>(value, segmentGetter, segmentSetter, bufferGetter, bufferSetter);
+        }
+    }
+
+    @Test(dataProvider = "accessors")
+    public void testMemoryAccess(String testName, Accessor<?> accessor) {
+        accessor.test();
+    }
+
+    @Test
+    public void testNulls() {
+        for (Method m : MemoryAccess.class.getMethods()) {
+            if ((m.getModifiers() & Modifier.STATIC) == 0) continue;
+            Object[] args = new Object[m.getParameterCount()];
+            for (int i = 0 ; i < args.length ; i++) {
+                args[i] = defaultValue(m.getParameterTypes()[i]);
+            }
+            try {
+                m.invoke(null, args);
+                fail();
+            } catch (InvocationTargetException ex) {
+                assertEquals(ex.getCause().getClass(), NullPointerException.class);
+                assertTrue(ex.getCause().getStackTrace()[1].getClassName().contains("MemoryAccess"));
+            } catch (Throwable ex) {
+                fail();
+            }
+        }
+    }
+
+    static Object defaultValue(Class<?> carrier) {
+        if (carrier == char.class) {
+            return (char)0;
+        } else if (carrier == byte.class) {
+            return (byte)0;
+        } else if (carrier == short.class) {
+            return (short)0;
+        } else if (carrier == int.class) {
+            return 0;
+        } else if (carrier == long.class) {
+            return 0L;
+        } else if (carrier == float.class) {
+            return 0f;
+        } else if (carrier == double.class) {
+            return 0d;
+        } else {
+            // reference type!
+            return null;
+        }
+    }
+    
+    static final ByteOrder BE = ByteOrder.BIG_ENDIAN;
+    static final ByteOrder LE = ByteOrder.LITTLE_ENDIAN;
+    static final ByteOrder NE = ByteOrder.nativeOrder();
+
+    @DataProvider(name = "accessors")
+    static Object[][] accessors() {        
+        return new Object[][]{
+
+                {"byte", new Accessor<>((byte) 42,
+                        MemoryAccess::getByte, MemoryAccess::setByte,
+                        (bb) -> bb.get(0), (bb, v) -> bb.put(0, v))
+                },
+                {"char", new Accessor<>((char) 42,
+                        MemoryAccess::getChar, MemoryAccess::setChar,
+                        (bb) -> bb.order(NE).getChar(0), (bb, v) -> bb.order(NE).putChar(0, v))
+                },
+                {"char/LE", new Accessor<>((char) 42,
+                        s -> MemoryAccess.getChar(s, LE), (s, x) -> MemoryAccess.setChar(s, LE, x),
+                        (bb) -> bb.order(LE).getChar(0), (bb, v) -> bb.order(LE).putChar(0, v))
+                },
+                {"char/BE", new Accessor<>((char) 42,
+                        s -> MemoryAccess.getChar(s, BE), (s, x) -> MemoryAccess.setChar(s, BE, x),
+                        (bb) -> bb.order(BE).getChar(0), (bb, v) -> bb.order(BE).putChar(0, v))
+                },
+                {"short", new Accessor<>((short) 42,
+                        MemoryAccess::getShort, MemoryAccess::setShort,
+                        (bb) -> bb.order(NE).getShort(0), (bb, v) -> bb.order(NE).putShort(0, v))
+                },
+                {"short/LE", new Accessor<>((short) 42,
+                        s -> MemoryAccess.getShort(s, LE), (s, x) -> MemoryAccess.setShort(s, LE, x),
+                        (bb) -> bb.order(LE).getShort(0), (bb, v) -> bb.order(LE).putShort(0, v))
+                },
+                {"short/BE", new Accessor<>((short) 42,
+                        s -> MemoryAccess.getShort(s, BE), (s, x) -> MemoryAccess.setShort(s, BE, x),
+                        (bb) -> bb.order(BE).getShort(0), (bb, v) -> bb.order(BE).putShort(0, v))
+                },
+                {"int", new Accessor<>(42,
+                        MemoryAccess::getInt, MemoryAccess::setInt,
+                        (bb) -> bb.order(NE).getInt(0), (bb, v) -> bb.order(NE).putInt(0, v))
+                },
+                {"int/LE", new Accessor<>(42,
+                        s -> MemoryAccess.getInt(s, LE), (s, x) -> MemoryAccess.setInt(s, LE, x),
+                        (bb) -> bb.order(LE).getInt(0), (bb, v) -> bb.order(LE).putInt(0, v))
+                },
+                {"int/BE", new Accessor<>(42,
+                        s -> MemoryAccess.getInt(s, BE), (s, x) -> MemoryAccess.setInt(s, BE, x),
+                        (bb) -> bb.order(BE).getInt(0), (bb, v) -> bb.order(BE).putInt(0, v))
+                },
+                // float, no offset
+                {"float", new Accessor<>(42f,
+                        MemoryAccess::getFloat, MemoryAccess::setFloat,
+                        (bb) -> bb.order(NE).getFloat(0), (bb, v) -> bb.order(NE).putFloat(0, v))
+                },
+                {"float/LE", new Accessor<>(42f,
+                        s -> MemoryAccess.getFloat(s, LE), (s, x) -> MemoryAccess.setFloat(s, LE, x),
+                        (bb) -> bb.order(LE).getFloat(0), (bb, v) -> bb.order(LE).putFloat(0, v))
+                },
+                {"float/BE", new Accessor<>(42f,
+                        s -> MemoryAccess.getFloat(s, BE), (s, x) -> MemoryAccess.setFloat(s, BE, x),
+                        (bb) -> bb.order(BE).getFloat(0), (bb, v) -> bb.order(BE).putFloat(0, v))
+                },
+                // double, no offset
+                {"double", new Accessor<>(42d,
+                        MemoryAccess::getDouble, MemoryAccess::setDouble,
+                        (bb) -> bb.order(NE).getDouble(0), (bb, v) -> bb.order(NE).putDouble(0, v))
+                },
+                {"double/LE", new Accessor<>(42d,
+                        s -> MemoryAccess.getDouble(s, LE), (s, x) -> MemoryAccess.setDouble(s, LE, x),
+                        (bb) -> bb.order(LE).getDouble(0), (bb, v) -> bb.order(LE).putDouble(0, v))
+                },
+                {"double/BE", new Accessor<>(42d,
+                        s -> MemoryAccess.getDouble(s, BE), (s, x) -> MemoryAccess.setDouble(s, BE, x),
+                        (bb) -> bb.order(BE).getDouble(0), (bb, v) -> bb.order(BE).putDouble(0, v))
+                },
+
+
+                // byte, offset
+                {"byte/offset", new Accessor<>((byte) 42,
+                        s -> MemoryAccess.getByteAtOffset(s, 4), (s, x) -> MemoryAccess.setByteAtOffset(s, 4, x),
+                        (bb) -> bb.get(4), (bb, v) -> bb.put(4, v))
+                },
+                // char, offset
+                {"char/offset", new Accessor<>((char) 42,
+                        s -> MemoryAccess.getCharAtOffset(s, 4), (s, x) -> MemoryAccess.setCharAtOffset(s, 4, x),
+                        (bb) -> bb.order(NE).getChar(4), (bb, v) -> bb.order(NE).putChar(4, v))
+                },
+                {"char/offset/LE", new Accessor<>((char) 42,
+                        s -> MemoryAccess.getCharAtOffset(s, 4, LE), (s, x) -> MemoryAccess.setCharAtOffset(s, 4, LE, x),
+                        (bb) -> bb.order(LE).getChar(4), (bb, v) -> bb.order(LE).putChar(4, v))
+                },
+                {"char/offset/BE", new Accessor<>((char) 42,
+                        s -> MemoryAccess.getCharAtOffset(s, 4, BE), (s, x) -> MemoryAccess.setCharAtOffset(s, 4, BE, x),
+                        (bb) -> bb.order(BE).getChar(4), (bb, v) -> bb.order(BE).putChar(4, v))
+                },
+                // short, offset
+                {"short/offset", new Accessor<>((short) 42,
+                        s -> MemoryAccess.getShortAtOffset(s, 4), (s, x) -> MemoryAccess.setShortAtOffset(s, 4, x),
+                        (bb) -> bb.order(NE).getShort(4), (bb, v) -> bb.order(NE).putShort(4, v))
+                },
+                {"short/offset/LE", new Accessor<>((short) 42,
+                        s -> MemoryAccess.getShortAtOffset(s, 4, LE), (s, x) -> MemoryAccess.setShortAtOffset(s, 4, LE, x),
+                        (bb) -> bb.order(LE).getShort(4), (bb, v) -> bb.order(LE).putShort(4, v))
+                },
+                {"short/offset/BE", new Accessor<>((short) 42,
+                        s -> MemoryAccess.getShortAtOffset(s, 4, BE), (s, x) -> MemoryAccess.setShortAtOffset(s, 4, BE, x),
+                        (bb) -> bb.order(BE).getShort(4), (bb, v) -> bb.order(BE).putShort(4, v))
+                },
+                // int, offset
+                {"int/offset", new Accessor<>(42,
+                        s -> MemoryAccess.getIntAtOffset(s, 4), (s, x) -> MemoryAccess.setIntAtOffset(s, 4, x),
+                        (bb) -> bb.order(NE).getInt(4), (bb, v) -> bb.order(NE).putInt(4, v))
+                },
+                {"int/offset/LE", new Accessor<>(42,
+                        s -> MemoryAccess.getIntAtOffset(s, 4, LE), (s, x) -> MemoryAccess.setIntAtOffset(s, 4, LE, x),
+                        (bb) -> bb.order(LE).getInt(4), (bb, v) -> bb.order(LE).putInt(4, v))
+                },
+                {"int/offset/BE", new Accessor<>(42,
+                        s -> MemoryAccess.getIntAtOffset(s, 4, BE), (s, x) -> MemoryAccess.setIntAtOffset(s, 4, BE, x),
+                        (bb) -> bb.order(BE).getInt(4), (bb, v) -> bb.order(BE).putInt(4, v))
+                },
+                // float, offset
+                {"float/offset", new Accessor<>(42f,
+                        s -> MemoryAccess.getFloatAtOffset(s, 4), (s, x) -> MemoryAccess.setFloatAtOffset(s, 4, x),
+                        (bb) -> bb.order(NE).getFloat(4), (bb, v) -> bb.order(NE).putFloat(4, v))
+                },
+                {"float/offset/LE", new Accessor<>(42f,
+                        s -> MemoryAccess.getFloatAtOffset(s, 4, LE), (s, x) -> MemoryAccess.setFloatAtOffset(s, 4, LE, x),
+                        (bb) -> bb.order(LE).getFloat(4), (bb, v) -> bb.order(LE).putFloat(4, v))
+                },
+                {"float/offset/BE", new Accessor<>(42f,
+                        s -> MemoryAccess.getFloatAtOffset(s, 4, BE), (s, x) -> MemoryAccess.setFloatAtOffset(s, 4, BE, x),
+                        (bb) -> bb.order(BE).getFloat(4), (bb, v) -> bb.order(BE).putFloat(4, v))
+                },
+                // double, offset
+                {"double/offset", new Accessor<>(42d,
+                        s -> MemoryAccess.getDoubleAtOffset(s, 4), (s, x) -> MemoryAccess.setDoubleAtOffset(s, 4, x),
+                        (bb) -> bb.order(NE).getDouble(4), (bb, v) -> bb.order(NE).putDouble(4, v))
+                },
+                {"double/offset/LE", new Accessor<>(42d,
+                        s -> MemoryAccess.getDoubleAtOffset(s, 4, LE), (s, x) -> MemoryAccess.setDoubleAtOffset(s, 4, LE, x),
+                        (bb) -> bb.order(LE).getDouble(4), (bb, v) -> bb.order(LE).putDouble(4, v))
+                },
+                {"double/offset/BE", new Accessor<>(42d,
+                        s -> MemoryAccess.getDoubleAtOffset(s, 4, BE), (s, x) -> MemoryAccess.setDoubleAtOffset(s, 4, BE, x),
+                        (bb) -> bb.order(BE).getDouble(4), (bb, v) -> bb.order(BE).putDouble(4, v))
+                },
+
+
+                // char, index
+                {"char/index", new Accessor<>((char) 42,
+                        s -> MemoryAccess.getCharAtIndex(s, 2), (s, x) -> MemoryAccess.setCharAtIndex(s, 2, x),
+                        (bb) -> bb.order(NE).asCharBuffer().get(2), (bb, v) -> bb.order(NE).asCharBuffer().put(2, v))
+                },
+                {"char/index/LE", new Accessor<>((char) 42,
+                        s -> MemoryAccess.getCharAtIndex(s, 2, LE), (s, x) -> MemoryAccess.setCharAtIndex(s, 2, LE, x),
+                        (bb) -> bb.order(LE).asCharBuffer().get(2), (bb, v) -> bb.order(LE).asCharBuffer().put(2, v))
+                },
+                {"char/index/BE", new Accessor<>((char) 42,
+                        s -> MemoryAccess.getCharAtIndex(s, 2, BE), (s, x) -> MemoryAccess.setCharAtIndex(s, 2, BE, x),
+                        (bb) -> bb.order(BE).asCharBuffer().get(2), (bb, v) -> bb.order(BE).asCharBuffer().put(2, v))
+                },
+                // short, index
+                {"short/index", new Accessor<>((short) 42,
+                        s -> MemoryAccess.getShortAtIndex(s, 2), (s, x) -> MemoryAccess.setShortAtIndex(s, 2, x),
+                        (bb) -> bb.order(NE).asShortBuffer().get(2), (bb, v) -> bb.order(NE).asShortBuffer().put(2, v))
+                },
+                {"short/index/LE", new Accessor<>((short) 42,
+                        s -> MemoryAccess.getShortAtIndex(s, 2, LE), (s, x) -> MemoryAccess.setShortAtIndex(s, 2, LE, x),
+                        (bb) -> bb.order(LE).asShortBuffer().get(2), (bb, v) -> bb.order(LE).asShortBuffer().put(2, v))
+                },
+                {"short/index/BE", new Accessor<>((short) 42,
+                        s -> MemoryAccess.getShortAtIndex(s, 2, BE), (s, x) -> MemoryAccess.setShortAtIndex(s, 2, BE, x),
+                        (bb) -> bb.order(BE).asShortBuffer().get(2), (bb, v) -> bb.order(BE).asShortBuffer().put(2, v))
+                },
+                {"int/index", new Accessor<>(42,
+                        s -> MemoryAccess.getIntAtIndex(s, 2), (s, x) -> MemoryAccess.setIntAtIndex(s, 2, x),
+                        (bb) -> bb.order(NE).asIntBuffer().get(2), (bb, v) -> bb.order(NE).asIntBuffer().put(2, v))
+                },
+                {"int/index/LE", new Accessor<>(42,
+                        s -> MemoryAccess.getIntAtIndex(s, 2, LE), (s, x) -> MemoryAccess.setIntAtIndex(s, 2, LE, x),
+                        (bb) -> bb.order(LE).asIntBuffer().get(2), (bb, v) -> bb.order(LE).asIntBuffer().put(2, v))
+                },
+                {"int/index/BE", new Accessor<>(42,
+                        s -> MemoryAccess.getIntAtIndex(s, 2, BE), (s, x) -> MemoryAccess.setIntAtIndex(s, 2, BE, x),
+                        (bb) -> bb.order(BE).asIntBuffer().get(2), (bb, v) -> bb.order(BE).asIntBuffer().put(2, v))
+                },
+                {"float/index", new Accessor<>(42f,
+                        s -> MemoryAccess.getFloatAtIndex(s, 2), (s, x) -> MemoryAccess.setFloatAtIndex(s, 2, x),
+                        (bb) -> bb.order(NE).asFloatBuffer().get(2), (bb, v) -> bb.order(NE).asFloatBuffer().put(2, v))
+                },
+                {"float/index/LE", new Accessor<>(42f,
+                        s -> MemoryAccess.getFloatAtIndex(s, 2, LE), (s, x) -> MemoryAccess.setFloatAtIndex(s, 2, LE, x),
+                        (bb) -> bb.order(LE).asFloatBuffer().get(2), (bb, v) -> bb.order(LE).asFloatBuffer().put(2, v))
+                },
+                {"float/index/BE", new Accessor<>(42f,
+                        s -> MemoryAccess.getFloatAtIndex(s, 2, BE), (s, x) -> MemoryAccess.setFloatAtIndex(s, 2, BE, x),
+                        (bb) -> bb.order(BE).asFloatBuffer().get(2), (bb, v) -> bb.order(BE).asFloatBuffer().put(2, v))
+                },                
+                {"double/index", new Accessor<>(42d,
+                        s -> MemoryAccess.getDoubleAtIndex(s, 2), (s, x) -> MemoryAccess.setDoubleAtIndex(s, 2, x),
+                        (bb) -> bb.order(NE).asDoubleBuffer().get(2), (bb, v) -> bb.order(NE).asDoubleBuffer().put(2, v))
+                },
+                {"double/index/LE", new Accessor<>(42d,
+                        s -> MemoryAccess.getDoubleAtIndex(s, 2, LE), (s, x) -> MemoryAccess.setDoubleAtIndex(s, 2, LE, x),
+                        (bb) -> bb.order(LE).asDoubleBuffer().get(2), (bb, v) -> bb.order(LE).asDoubleBuffer().put(2, v))
+                },
+                {"double/index/BE", new Accessor<>(42d,
+                        s -> MemoryAccess.getDoubleAtIndex(s, 2, BE), (s, x) -> MemoryAccess.setDoubleAtIndex(s, 2, BE, x),
+                        (bb) -> bb.order(BE).asDoubleBuffer().get(2), (bb, v) -> bb.order(BE).asDoubleBuffer().put(2, v))
+                },
+
+                { "address", new Accessor<>(MemoryAddress.ofLong(42),
+                        MemoryAccess::getAddress, MemoryAccess::setAddress,
+                        (bb) -> {
+                            ByteBuffer nb = bb.order(NE);
+                            long addr = MemoryLayouts.ADDRESS.byteSize() == 8 ?
+                                    nb.getLong(0) : nb.getInt(0);
+                            return MemoryAddress.ofLong(addr);
+                        },
+                        (bb, v) -> {
+                            ByteBuffer nb = bb.order(NE);
+                            if (MemoryLayouts.ADDRESS.byteSize() == 8) {
+                                nb.putLong(0, v.toRawLongValue());
+                            } else {
+                                nb.putInt(0, (int)v.toRawLongValue());
+                            }
+                        })
+                },
+                { "address/offset", new Accessor<>(MemoryAddress.ofLong(42),
+                        s -> MemoryAccess.getAddressAtOffset(s, 4), (s, x) -> MemoryAccess.setAddressAtOffset(s, 4, x),
+                        (bb) -> {
+                            ByteBuffer nb = bb.order(NE);
+                            long addr = MemoryLayouts.ADDRESS.byteSize() == 8 ?
+                                    nb.getLong(4) : nb.getInt(4);
+                            return MemoryAddress.ofLong(addr);
+                        },
+                        (bb, v) -> {
+                            ByteBuffer nb = bb.order(NE);
+                            if (MemoryLayouts.ADDRESS.byteSize() == 8) {
+                                nb.putLong(4, v.toRawLongValue());
+                            } else {
+                                nb.putInt(4, (int)v.toRawLongValue());
+                            }
+                        })
+                },
+                { "address/index", new Accessor<>(MemoryAddress.ofLong(42),
+                        s -> MemoryAccess.getAddressAtIndex(s, 2), (s, x) -> MemoryAccess.setAddressAtIndex(s, 2, x),
+                        (bb) -> {
+                            ByteBuffer nb = bb.order(NE);
+                            long addr = MemoryLayouts.ADDRESS.byteSize() == 8 ?
+                                    nb.asLongBuffer().get(2) : nb.asIntBuffer().get(2);
+                            return MemoryAddress.ofLong(addr);
+                        },
+                        (bb, v) -> {
+                            ByteBuffer nb = bb.order(NE);
+                            if (MemoryLayouts.ADDRESS.byteSize() == 8) {
+                                nb.asLongBuffer().put(2, v.toRawLongValue());
+                            } else {
+                                nb.asIntBuffer().put(2, (int)v.toRawLongValue());
+                            }
+                        })
+                },
+        };
+    }
+}

--- a/test/jdk/java/foreign/TestMemoryAccessStatics.java
+++ b/test/jdk/java/foreign/TestMemoryAccessStatics.java
@@ -137,13 +137,13 @@ public class TestMemoryAccessStatics {
             return null;
         }
     }
-    
+
     static final ByteOrder BE = ByteOrder.BIG_ENDIAN;
     static final ByteOrder LE = ByteOrder.LITTLE_ENDIAN;
     static final ByteOrder NE = ByteOrder.nativeOrder();
 
     @DataProvider(name = "accessors")
-    static Object[][] accessors() {        
+    static Object[][] accessors() {
         return new Object[][]{
 
                 {"byte", new Accessor<>((byte) 42,
@@ -335,7 +335,7 @@ public class TestMemoryAccessStatics {
                 {"float/index/BE", new Accessor<>(42f,
                         s -> MemoryAccess.getFloatAtIndex(s, 2, BE), (s, x) -> MemoryAccess.setFloatAtIndex(s, 2, BE, x),
                         (bb) -> bb.order(BE).asFloatBuffer().get(2), (bb, v) -> bb.order(BE).asFloatBuffer().put(2, v))
-                },                
+                },
                 {"double/index", new Accessor<>(42d,
                         s -> MemoryAccess.getDoubleAtIndex(s, 2), (s, x) -> MemoryAccess.setDoubleAtIndex(s, 2, x),
                         (bb) -> bb.order(NE).asDoubleBuffer().get(2), (bb, v) -> bb.order(NE).asDoubleBuffer().put(2, v))

--- a/test/jdk/java/foreign/TestMemoryCopy.java
+++ b/test/jdk/java/foreign/TestMemoryCopy.java
@@ -61,6 +61,12 @@ public class TestMemoryCopy {
         }
     }
 
+    @Test(expectedExceptions = NullPointerException.class)
+    public void testNull() {
+        var segment = MemorySegment.ofArray(new byte[4]);
+        segment.copyFrom(null);
+    }
+
     static class SegmentSlice {
 
         enum Kind {

--- a/test/jdk/java/foreign/TestSpliterator.java
+++ b/test/jdk/java/foreign/TestSpliterator.java
@@ -228,6 +228,11 @@ public class TestSpliterator {
         };
     }
 
+    @Test(expectedExceptions = NullPointerException.class)
+    public void testNullSpliteratoorLayout() {
+        MemorySegment.ofArray(new byte[10]).spliterator(null);
+    }
+
     @Test(dataProvider = "accessScenarios")
     public void testAccessModes(Supplier<Spliterator<MemorySegment>> spliteratorSupplier,
                                 int expectedAccessModes) {

--- a/test/jdk/java/foreign/TestVarHandleCombinators.java
+++ b/test/jdk/java/foreign/TestVarHandleCombinators.java
@@ -121,6 +121,26 @@ public class TestVarHandleCombinators {
         }
     }
 
+    @Test(expectedExceptions = NullPointerException.class)
+    public void testVarHandleNullCarrierNoAlign() {
+        MemoryHandles.varHandle(null, ByteOrder.nativeOrder());
+    }
+
+    @Test(expectedExceptions = NullPointerException.class)
+    public void testVarHandleNullCarrierAlign() {
+        MemoryHandles.varHandle(null, 8, ByteOrder.nativeOrder());
+    }
+
+    @Test(expectedExceptions = NullPointerException.class)
+    public void testVarHandleNullOrderNoAlign() {
+        MemoryHandles.varHandle(int.class, null);
+    }
+
+    @Test(expectedExceptions = NullPointerException.class)
+    public void testVarHandleNullOrderAlign() {
+        MemoryHandles.varHandle(int.class, 8, null);
+    }
+
     @Test(dataProvider = "badCarriers", expectedExceptions = IllegalArgumentException.class)
     public void testBadCarrier(Class<?> carrier) {
         MemoryHandles.varHandle(carrier, ByteOrder.nativeOrder());


### PR DESCRIPTION
This is a trivial, but a bit bigger than expected patch which fixes mentions of NPEs in the foreign memory access API javadoc. Almost all API points are affected, from memory layouts, to memory segments, etc.   
This patch does a number of things:
* Document the various possible NPEs with corresponding `@throws` javadoc tags
* Add `Objects::requireNotNull calls` where required
* Added tests to check for nulls
* Added a brand new test for `MemoryAccess`; this is both to check normal behavior, and also to check behavior when it comes to nulls

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Linux x86 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- |
| Build | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

### Issue
 * [JDK-8256466](https://bugs.openjdk.java.net/browse/JDK-8256466): MemoryLayout factories do not guard against null layouts


### Reviewers
 * [Jorn Vernee](https://openjdk.java.net/census#jvernee) (@JornVernee - Committer)


### Download
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/395/head:pull/395`
`$ git checkout pull/395`
