### PR TITLE
8257892: long double not handled by jextract

### DIFF
--- a/doc/panama_jextract.html
+++ b/doc/panama_jextract.html
@@ -814,7 +814,7 @@ code span.wa { color: #60a0b0; font-weight: bold; font-style: italic; } /* Warni
 <a class="sourceLine" id="cb38-33" title="33">            }</a>
 <a class="sourceLine" id="cb38-34" title="34"></a>
 <a class="sourceLine" id="cb38-35" title="35">            <span class="co">// print operations</span></a>
-<a class="sourceLine" id="cb38-36" title="36">            var size = scope.<span class="fu">allocate</span>(C_LONGLONG);</a>
+<a class="sourceLine" id="cb38-36" title="36">            var size = scope.<span class="fu">allocate</span>(C_LONG_LONG);</a>
 <a class="sourceLine" id="cb38-37" title="37">            var operation = NULL;</a>
 <a class="sourceLine" id="cb38-38" title="38">            <span class="kw">while</span> (!(operation = <span class="fu">TF_GraphNextOperation</span>(graph, size)).<span class="fu">equals</span>(NULL)) {</a>
 <a class="sourceLine" id="cb38-39" title="39">                <span class="bu">System</span>.<span class="fu">out.printf</span>(<span class="st">&quot;</span><span class="sc">%s</span><span class="st"> : </span><span class="sc">%s\n</span><span class="st">&quot;</span>,</a>

--- a/doc/panama_jextract.md
+++ b/doc/panama_jextract.md
@@ -866,7 +866,7 @@ public class TensorflowLoadSavedModel {
             }
 
             // print operations
-            var size = scope.allocate(C_LONGLONG);
+            var size = scope.allocate(C_LONG_LONG);
             var operation = NULL;
             while (!(operation = TF_GraphNextOperation(graph, size)).equals(NULL)) {
                 System.out.printf("%s : %s\n",

--- a/src/jdk.incubator.jextract/share/classes/jdk/incubator/jextract/Type.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/incubator/jextract/Type.java
@@ -148,7 +148,7 @@ public interface Type {
             /**
              * {@code wchar} type.
              */
-            WChar("wchar_t", UnsupportedLayouts.WCHAT_T);
+            WChar("wchar_t", UnsupportedLayouts.WCHAR_T);
 
             private final String typeName;
             private final MemoryLayout layout;

--- a/src/jdk.incubator.jextract/share/classes/jdk/incubator/jextract/Type.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/incubator/jextract/Type.java
@@ -31,6 +31,7 @@ import jdk.incubator.foreign.FunctionDescriptor;
 import jdk.incubator.foreign.MemoryLayout;
 import jdk.internal.jextract.impl.LayoutUtils;
 import jdk.internal.jextract.impl.TypeImpl;
+import jdk.internal.jextract.impl.UnsupportedLayouts;
 
 import java.util.List;
 import java.util.Optional;
@@ -103,11 +104,7 @@ public interface Type {
             /**
              * {@code char16} type.
              */
-            Char16("char16", null),
-            /**
-             * {@code char32} type.
-             */
-            Char32("char32", null),
+            Char16("char16", UnsupportedLayouts.CHAR16),
             /**
              * {@code short} type.
              */
@@ -127,7 +124,7 @@ public interface Type {
             /**
              * {@code int128} type.
              */
-            Int128("__int128", null),
+            Int128("__int128", UnsupportedLayouts.__INT128),
             /**
              * {@code float} type.
              */
@@ -137,17 +134,21 @@ public interface Type {
              */
             Double("double",CLinker.C_DOUBLE),
             /**
+              * {@code long double} type.
+              */
+            LongDouble("long double", UnsupportedLayouts.LONG_DOUBLE),
+            /**
              * {@code float128} type.
              */
-            Float128("float128", null),
+            Float128("float128", UnsupportedLayouts._FLOAT128),
             /**
              * {@code float16} type.
              */
-            HalfFloat("__fp16", null),
+            HalfFloat("__fp16", UnsupportedLayouts.__FP16),
             /**
              * {@code wchar} type.
              */
-            WChar("wchar_t", null);
+            WChar("wchar_t", UnsupportedLayouts.WCHAT_T);
 
             private final String typeName;
             private final MemoryLayout layout;

--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/LayoutUtils.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/LayoutUtils.java
@@ -85,6 +85,8 @@ public final class LayoutUtils {
                 return Primitive.Kind.Float.layout().orElseThrow(unsupported);
             case Double:
                 return Primitive.Kind.Double.layout().orElseThrow(unsupported);
+            case LongDouble:
+                return Primitive.Kind.LongDouble.layout().orElseThrow(unsupported);
             case Complex:
                 throw new UnsupportedOperationException("unsupported: " + t.kind());
             case Record:

--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/OutputFactory.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/OutputFactory.java
@@ -245,8 +245,9 @@ public class OutputFactory implements Declaration.Visitor<Void, Declaration> {
     }
 
     private static MemoryLayout isUnsupported(FunctionDescriptor desc) {
-        if (isUnsupported(desc.returnLayout().orElse(null))) {
-            return desc.returnLayout().orElse(null);
+        MemoryLayout resultLayout = desc.returnLayout().orElse(null);
+        if (resultLayout != null && isUnsupported(resultLayout)) {
+            return resultLayout;
         }
 
         for (MemoryLayout argLayout : desc.argumentLayouts()) {

--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/OutputFactory.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/OutputFactory.java
@@ -230,7 +230,18 @@ public class OutputFactory implements Declaration.Visitor<Void, Declaration> {
     }
 
     private static boolean isUnsupported(MemoryLayout layout) {
-        return UnsupportedLayouts.isUnsupported(layout);
+        if (layout instanceof ValueLayout) {
+            return UnsupportedLayouts.isUnsupported((ValueLayout)layout);
+        } else if (layout instanceof GroupLayout) {
+            GroupLayout gl = (GroupLayout)layout;
+            for (MemoryLayout ml : gl.memberLayouts()) {
+                if (isUnsupported(ml)) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
     }
 
     private boolean warnUnsupported(FunctionDescriptor desc, String name) {
@@ -398,7 +409,9 @@ public class OutputFactory implements Declaration.Visitor<Void, Declaration> {
         }
 
         if (isUnsupported(layout)) {
-            warn("skipping " + fieldName + " because of unsupported type usage: " + layout.name().get());
+            String name = parent != null? parent.name() + "." : "";
+            name += fieldName;
+            warn("skipping " + name + " because of unsupported type usage: " + layout.name().get());
         }
 
         Class<?> clazz = typeTranslator.getJavaType(type);

--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/OutputFactory.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/OutputFactory.java
@@ -244,22 +244,6 @@ public class OutputFactory implements Declaration.Visitor<Void, Declaration> {
         return false;
     }
 
-    private boolean warnUnsupported(FunctionDescriptor desc, String name) {
-        if (isUnsupported(desc.returnLayout().orElse(null))) {
-            MemoryLayout layout = desc.returnLayout().get();
-            warn("skipping " + name + " because of unsupported type usage: " + layout.name().get());
-            return true;
-        }
-
-        for (MemoryLayout argLayout : desc.argumentLayouts()) {
-            if (isUnsupported(argLayout)) {
-                warn("skipping " + name + " because of unsupported type usage: " + argLayout.name().get());
-                return true;
-            }
-        }
-        return false;
-    }
-
     @Override
     public Void visitFunction(Declaration.Function funcTree, Declaration parent) {
         if (functionSeen(funcTree)) {
@@ -272,9 +256,19 @@ public class OutputFactory implements Declaration.Visitor<Void, Declaration> {
             return null;
         }
 
-        if (warnUnsupported(descriptor, funcTree.name())) {
+        if (isUnsupported(descriptor.returnLayout().orElse(null))) {
+            MemoryLayout layout = descriptor.returnLayout().get();
+            warn("skipping " + funcTree.name() + " because of unsupported type usage: " + layout.name().get());
             return null;
         }
+
+        for (MemoryLayout argLayout : descriptor.argumentLayouts()) {
+            if (isUnsupported(argLayout)) {
+                warn("skipping " + funcTree.name() + " because of unsupported type usage: " + argLayout.name().get());
+                return null;
+            }
+        }
+
         MethodType mtype = typeTranslator.getMethodType(funcTree.type());
 
         if (isVaList(descriptor)) {

--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/SourceConstantHelper.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/SourceConstantHelper.java
@@ -449,6 +449,10 @@ class SourceConstantHelper extends JavaSourceBuilder implements ConstantHelper {
     }
 
     private static String typeToLayoutName(ValueLayout vl) {
+        if (UnsupportedLayouts.isUnsupported(vl)) {
+            return "MemoryLayout.ofPaddingBits(" + vl.bitSize() + ")";
+        }
+
         CLinker.TypeKind kind = (CLinker.TypeKind)vl.attribute(CLinker.TypeKind.ATTR_NAME).orElseThrow(
                 () -> new IllegalStateException("Unexpected value layout: could not determine ABI class"));
         return switch (kind) {

--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/TypeMaker.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/TypeMaker.java
@@ -212,10 +212,19 @@ class TypeMaker {
                 return Type.vector(t.getNumberOfElements(), __type);
             }
             case WChar: //unsupported
+                return Type.primitive(Primitive.Kind.WChar);
             case Char16: //unsupported
+                return Type.primitive(Primitive.Kind.Char16);
             case Half: //unsupported
+                return Type.primitive(Primitive.Kind.HalfFloat);
             case Int128: //unsupported
-            case UInt128: //unsupported
+                return Type.primitive(Primitive.Kind.Int128);
+            case LongDouble: //unsupported
+                return Type.primitive(Primitive.Kind.LongDouble);
+            case UInt128: { //unsupported
+                Type iType = Type.primitive(Primitive.Kind.Int128);
+                return Type.qualified(Delegated.Kind.UNSIGNED, iType);
+            }
             default:
                 return TypeImpl.ERROR;
         }

--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/TypeTranslator.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/TypeTranslator.java
@@ -49,6 +49,7 @@ public class TypeTranslator implements Type.Visitor<Class<?>, Void> {
             case Float128:
             case HalfFloat:
             case Double:
+            case LongDouble:
                 return true;
             default:
                 return false;

--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/UnsupportedLayouts.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/UnsupportedLayouts.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package jdk.internal.jextract.impl;
+
+import jdk.incubator.foreign.CLinker;
+import jdk.incubator.foreign.MemoryLayout;
+import jdk.incubator.foreign.ValueLayout;
+import java.nio.ByteOrder;
+
+public final class UnsupportedLayouts {
+    private UnsupportedLayouts() {}
+
+    public static final ValueLayout __INT128 = MemoryLayout.ofValueBits(128, ByteOrder.nativeOrder()).
+            withName("__int128").withAttribute(CLinker.TypeKind.ATTR_NAME, CLinker.TypeKind.LONG_LONG);
+
+    public static final ValueLayout LONG_DOUBLE = MemoryLayout.ofValueBits(128, ByteOrder.nativeOrder()).
+            withName("long double").withAttribute(CLinker.TypeKind.ATTR_NAME, CLinker.TypeKind.DOUBLE);
+
+    public static final ValueLayout _FLOAT128 = MemoryLayout.ofValueBits(128, ByteOrder.nativeOrder()).
+            withName("_float128").withAttribute(CLinker.TypeKind.ATTR_NAME, CLinker.TypeKind.DOUBLE);
+
+    public static final ValueLayout __FP16 = MemoryLayout.ofValueBits(16, ByteOrder.nativeOrder()).
+            withName("__fp16").withAttribute(CLinker.TypeKind.ATTR_NAME, CLinker.TypeKind.FLOAT);
+
+    public static final ValueLayout CHAR16 = MemoryLayout.ofValueBits(16, ByteOrder.nativeOrder()).
+            withName("char16").withAttribute(CLinker.TypeKind.ATTR_NAME, CLinker.TypeKind.SHORT);
+
+    public static final ValueLayout WCHAT_T = MemoryLayout.ofValueBits(16, ByteOrder.nativeOrder()).
+            withName("wchar_t").withAttribute(CLinker.TypeKind.ATTR_NAME, CLinker.TypeKind.SHORT);
+
+    public static boolean isUnsupported(MemoryLayout layout) {
+        return layout == __INT128 || layout == LONG_DOUBLE || layout == _FLOAT128  ||
+                layout == __FP16 || layout == WCHAT_T;
+    }
+}

--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/UnsupportedLayouts.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/UnsupportedLayouts.java
@@ -24,35 +24,38 @@
  */
 package jdk.internal.jextract.impl;
 
-import jdk.incubator.foreign.CLinker;
 import jdk.incubator.foreign.MemoryLayout;
 import jdk.incubator.foreign.ValueLayout;
 import java.nio.ByteOrder;
 
+/*
+ * Layouts for the primitive types not supported by ABI implementations.
+ */
 public final class UnsupportedLayouts {
     private UnsupportedLayouts() {}
 
+    private static final String ATTR_UNSUPPORTED = "jextract.abi.unsupported.types";
+    private static final String ATTR_SOURCE_FORM = "jextract.abi.unsupported.types.source.form";
+
     public static final ValueLayout __INT128 = MemoryLayout.ofValueBits(128, ByteOrder.nativeOrder()).
-            withName("__int128").withAttribute(CLinker.TypeKind.ATTR_NAME, CLinker.TypeKind.LONG_LONG);
+            withName("__int128").withAttribute(ATTR_UNSUPPORTED, true);
 
     public static final ValueLayout LONG_DOUBLE = MemoryLayout.ofValueBits(128, ByteOrder.nativeOrder()).
-            withName("long double").withAttribute(CLinker.TypeKind.ATTR_NAME, CLinker.TypeKind.DOUBLE);
+            withName("long double").withAttribute(ATTR_UNSUPPORTED, true);
 
     public static final ValueLayout _FLOAT128 = MemoryLayout.ofValueBits(128, ByteOrder.nativeOrder()).
-            withName("_float128").withAttribute(CLinker.TypeKind.ATTR_NAME, CLinker.TypeKind.DOUBLE);
+            withName("_float128").withAttribute(ATTR_UNSUPPORTED, true);
 
     public static final ValueLayout __FP16 = MemoryLayout.ofValueBits(16, ByteOrder.nativeOrder()).
-            withName("__fp16").withAttribute(CLinker.TypeKind.ATTR_NAME, CLinker.TypeKind.FLOAT);
+            withName("__fp16").withAttribute(ATTR_UNSUPPORTED, true);
 
     public static final ValueLayout CHAR16 = MemoryLayout.ofValueBits(16, ByteOrder.nativeOrder()).
-            withName("char16").withAttribute(CLinker.TypeKind.ATTR_NAME, CLinker.TypeKind.SHORT);
+            withName("char16").withAttribute(ATTR_UNSUPPORTED, true);
 
     public static final ValueLayout WCHAT_T = MemoryLayout.ofValueBits(16, ByteOrder.nativeOrder()).
-            withName("wchar_t").withAttribute(CLinker.TypeKind.ATTR_NAME, CLinker.TypeKind.SHORT);
+            withName("wchar_t").withAttribute(ATTR_UNSUPPORTED, true);
 
-    public static boolean isUnsupported(MemoryLayout layout) {
-        return layout == __INT128 || layout == LONG_DOUBLE ||
-                layout == _FLOAT128  || layout == __FP16 ||
-                layout == CHAR16 ||  layout == WCHAT_T;
+    static boolean isUnsupported(ValueLayout vl) {
+        return vl.attribute(ATTR_UNSUPPORTED).isPresent();
     }
 }

--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/UnsupportedLayouts.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/UnsupportedLayouts.java
@@ -51,7 +51,8 @@ public final class UnsupportedLayouts {
             withName("wchar_t").withAttribute(CLinker.TypeKind.ATTR_NAME, CLinker.TypeKind.SHORT);
 
     public static boolean isUnsupported(MemoryLayout layout) {
-        return layout == __INT128 || layout == LONG_DOUBLE || layout == _FLOAT128  ||
-                layout == __FP16 || layout == WCHAT_T;
+        return layout == __INT128 || layout == LONG_DOUBLE ||
+                layout == _FLOAT128  || layout == __FP16 ||
+                layout == CHAR16 ||  layout == WCHAT_T;
     }
 }

--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/UnsupportedLayouts.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/UnsupportedLayouts.java
@@ -52,7 +52,7 @@ public final class UnsupportedLayouts {
     public static final ValueLayout CHAR16 = MemoryLayout.ofValueBits(16, ByteOrder.nativeOrder()).
             withName("char16").withAttribute(ATTR_UNSUPPORTED, true);
 
-    public static final ValueLayout WCHAT_T = MemoryLayout.ofValueBits(16, ByteOrder.nativeOrder()).
+    public static final ValueLayout WCHAR_T = MemoryLayout.ofValueBits(16, ByteOrder.nativeOrder()).
             withName("wchar_t").withAttribute(ATTR_UNSUPPORTED, true);
 
     static boolean isUnsupported(ValueLayout vl) {

--- a/test/jdk/tools/jextract/test8257892/LibUnsupportedTest.java
+++ b/test/jdk/tools/jextract/test8257892/LibUnsupportedTest.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.lang.reflect.Method;
+import jdk.incubator.foreign.CLinker;
+import jdk.incubator.foreign.GroupLayout;
+import jdk.incubator.foreign.MemoryLayout;
+import jdk.incubator.foreign.MemoryLayout.PathElement;
+import org.testng.annotations.Test;
+
+import test.jextract.unsupported.unsupported_h;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
+import static test.jextract.unsupported.unsupported_h.*;
+
+/*
+ * @test id=classes
+ * @library ..
+ * @modules jdk.incubator.jextract
+ * @run driver JtregJextract -l unsupported -t test.jextract.unsupported -- unsupported.h
+ * @run testng/othervm -Dforeign.restricted=permit LibUnsupportedTest
+ */
+
+/*
+ * @test id=sources
+ * @library ..
+ * @modules jdk.incubator.jextract
+ *
+ * @run driver JtregJextractSources -l unsupported -t test.jextract.unsupported -- unsupported.h
+ * @run testng/othervm -Dforeign.restricted=permit LibUnsupportedTest
+ */
+
+public class LibUnsupportedTest {
+    @Test
+    public void testAllocateFoo() {
+        try (var seg = Foo.allocate()) {
+            Foo.i$set(seg, 32);
+            Foo.c$set(seg, (byte)'z');
+            assertEquals(Foo.i$get(seg), 32);
+            assertEquals(Foo.c$get(seg), (byte)'z');
+        }
+    }
+
+    @Test
+    public void testGetFoo() {
+        var seg = getFoo().asSegmentRestricted(Foo.sizeof());
+        Foo.i$set(seg, 42);
+        Foo.c$set(seg, (byte)'j');
+        assertEquals(Foo.i$get(seg), 42);
+        assertEquals(Foo.c$get(seg), (byte)'j');
+    }
+
+    private static void checkField(GroupLayout group, String fieldName, MemoryLayout expected) {
+        assertEquals(group.select(PathElement.groupElement(fieldName)), expected.withName(fieldName));
+    }
+
+    @Test
+    public void testFieldTypes() {
+        GroupLayout g = (GroupLayout)Foo.$LAYOUT();
+        checkField(g, "i", CLinker.C_INT);
+        checkField(g, "c", CLinker.C_CHAR);
+    }
+
+    @Test
+    public void testIgnoredMethods() {
+        assertNull(findMethod(unsupported_h.class, "func"));
+        assertNull(findMethod(unsupported_h.class, "makeFoo"));
+        assertNull(findMethod(unsupported_h.class, "copyFoo"));
+    }
+
+    private Method findMethod(Class<?> cls, String name) {
+        for (Method m : cls.getMethods()) {
+            if (m.getName().equals(name)) {
+                return m;
+            }
+        }
+        return null;
+    }
+}

--- a/test/jdk/tools/jextract/test8257892/LibUnsupportedTest.java
+++ b/test/jdk/tools/jextract/test8257892/LibUnsupportedTest.java
@@ -84,6 +84,9 @@ public class LibUnsupportedTest {
     @Test
     public void testIgnoredMethods() {
         assertNull(findMethod(unsupported_h.class, "func"));
+        assertNull(findMethod(unsupported_h.class, "func2"));
+        assertNull(findMethod(unsupported_h.class, "func3"));
+        assertNull(findMethod(unsupported_h.class, "func4"));
         assertNull(findMethod(unsupported_h.class, "makeFoo"));
         assertNull(findMethod(unsupported_h.class, "copyFoo"));
     }

--- a/test/jdk/tools/jextract/test8257892/libUnsupported.c
+++ b/test/jdk/tools/jextract/test8257892/libUnsupported.c
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+#include "unsupported.h"
+
+static Foo f = { 42, 343.55, 'j' };
+
+EXPORT Foo* getFoo() {
+    return &f;
+}

--- a/test/jdk/tools/jextract/test8257892/unsupported.h
+++ b/test/jdk/tools/jextract/test8257892/unsupported.h
@@ -38,6 +38,9 @@ typedef struct Foo {
 } Foo;
 
 EXPORT void func(long double ll);
+EXPORT void func2(void (*f)(long double l));
+EXPORT void func3(long double (*f)());
+EXPORT void func4(void (*f)(Foo f));
 EXPORT Foo* getFoo();
 EXPORT Foo makeFoo();
 EXPORT void copyFoo(Foo f1, Foo f2);

--- a/test/jdk/tools/jextract/test8257892/unsupported.h
+++ b/test/jdk/tools/jextract/test8257892/unsupported.h
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+#ifdef __cplusplus
+extern "C" {
+#endif // __cplusplus
+
+#ifdef _WIN64
+#define EXPORT __declspec(dllexport)
+#else
+#define EXPORT
+#endif
+
+typedef struct Foo {
+    int i;
+    long double ld;
+    char c;
+} Foo;
+
+EXPORT void func(long double ll);
+EXPORT Foo* getFoo();
+EXPORT Foo makeFoo();
+EXPORT void copyFoo(Foo f1, Foo f2);
+
+long double ld;
+
+#ifdef __cplusplus
+}
+#endif // __cplusplus

--- a/test/jdk/tools/jextract/testStruct/struct.h
+++ b/test/jdk/tools/jextract/testStruct/struct.h
@@ -51,6 +51,7 @@ struct AllTypes {
     unsigned long long ull;
     float f;
     double d;
+    long double ld;
 };
 
 #ifdef __cplusplus


### PR DESCRIPTION
added UnsupportedLayouts and checking/warning all unsupported types uniformly

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [JDK-8257892](https://bugs.openjdk.java.net/browse/JDK-8257892): long double not handled by jextract


### Reviewers
 * [Jorn Vernee](https://openjdk.java.net/census#jvernee) (@JornVernee - Committer) ⚠️ Review applies to 0311fc512532c2217ed3459b25a26df3df859029
 * [Maurizio Cimadamore](https://openjdk.java.net/census#mcimadamore) (@mcimadamore - Committer) ⚠️ Review applies to f2522cd5d18990982d79501932f40c86ca21ca0e


### Download
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/409/head:pull/409`
`$ git checkout pull/409`
