### PR TITLE
8258223: jextract throws exception when unsupport type is used in anonymous struct

### DIFF
--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/UnsupportedLayouts.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/UnsupportedLayouts.java
@@ -34,28 +34,32 @@ import java.nio.ByteOrder;
 public final class UnsupportedLayouts {
     private UnsupportedLayouts() {}
 
-    private static final String ATTR_UNSUPPORTED = "jextract.abi.unsupported.types";
-    private static final String ATTR_SOURCE_FORM = "jextract.abi.unsupported.types.source.form";
+    private static final String ATTR_LAYOUT_KIND = "jextract.abi.unsupported.layout.kind";
 
     public static final ValueLayout __INT128 = MemoryLayout.ofValueBits(128, ByteOrder.nativeOrder()).
-            withName("__int128").withAttribute(ATTR_UNSUPPORTED, true);
+            withAttribute(ATTR_LAYOUT_KIND, "__int128");
 
     public static final ValueLayout LONG_DOUBLE = MemoryLayout.ofValueBits(128, ByteOrder.nativeOrder()).
-            withName("long double").withAttribute(ATTR_UNSUPPORTED, true);
+            withAttribute(ATTR_LAYOUT_KIND, "long double");
 
     public static final ValueLayout _FLOAT128 = MemoryLayout.ofValueBits(128, ByteOrder.nativeOrder()).
-            withName("_float128").withAttribute(ATTR_UNSUPPORTED, true);
+            withAttribute(ATTR_LAYOUT_KIND, "_float128");
 
     public static final ValueLayout __FP16 = MemoryLayout.ofValueBits(16, ByteOrder.nativeOrder()).
-            withName("__fp16").withAttribute(ATTR_UNSUPPORTED, true);
+            withAttribute(ATTR_LAYOUT_KIND, "__fp16");
 
     public static final ValueLayout CHAR16 = MemoryLayout.ofValueBits(16, ByteOrder.nativeOrder()).
-            withName("char16").withAttribute(ATTR_UNSUPPORTED, true);
+            withAttribute(ATTR_LAYOUT_KIND, "char16");
 
     public static final ValueLayout WCHAR_T = MemoryLayout.ofValueBits(16, ByteOrder.nativeOrder()).
-            withName("wchar_t").withAttribute(ATTR_UNSUPPORTED, true);
+            withAttribute(ATTR_LAYOUT_KIND, "wchar_t");
 
-    static boolean isUnsupported(ValueLayout vl) {
-        return vl.attribute(ATTR_UNSUPPORTED).isPresent();
+    static boolean isUnsupported(MemoryLayout vl) {
+        return vl.attribute(ATTR_LAYOUT_KIND).isPresent();
+    }
+
+    static String getUnsupportedTypeName(MemoryLayout vl) {
+        return (String)
+                vl.attribute(ATTR_LAYOUT_KIND).orElseThrow(IllegalArgumentException::new);
     }
 }

--- a/test/jdk/tools/jextract/Test8258223.java
+++ b/test/jdk/tools/jextract/Test8258223.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.nio.file.Path;
+import org.testng.annotations.Test;
+import static org.testng.Assert.assertNotNull;
+
+/*
+ * @test
+ * @modules jdk.incubator.jextract
+ * @library /test/lib
+ * @build JextractToolRunner
+ * @bug 8258223
+ * @summary jextract throws exception when unsupport type is used in anonymous struct
+ * @run testng/othervm -Dforeign.restricted=permit Test8258223
+ */
+public class Test8258223 extends JextractToolRunner {
+    @Test
+    public void test() {
+        Path test8258223Output = getOutputFilePath("test8258223_gen");
+        Path test8258223H = getInputFilePath("test8258223.h");
+        run("-d", test8258223Output.toString(), test8258223H.toString()).checkSuccess();
+        try(Loader loader = classLoader(test8258223Output)) {
+            Class<?> cls = loader.loadClass("test8258223_h");
+            assertNotNull(cls);
+        } finally {
+            deleteDir(test8258223Output);
+        }
+    }
+}

--- a/test/jdk/tools/jextract/test8258223.h
+++ b/test/jdk/tools/jextract/test8258223.h
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+struct Foo {
+  struct {
+   long double dl;
+  } x;
+};


### PR DESCRIPTION
actual unsupported layout is returned from isUnsupported.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [JDK-8258223](https://bugs.openjdk.java.net/browse/JDK-8258223): jextract throws exception when unsupport type is used in anonymous struct


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.java.net/census#mcimadamore) (@mcimadamore - Committer)


### Download
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/416/head:pull/416`
`$ git checkout pull/416`
