### PR TITLE
8258238: Some jextract samples crash with: "updating map that does not need updating"

### DIFF
--- a/src/hotspot/cpu/x86/frame_x86.cpp
+++ b/src/hotspot/cpu/x86/frame_x86.cpp
@@ -345,7 +345,7 @@ frame frame::sender_for_entry_frame(RegisterMap* map) const {
   vmassert(jfa->last_Java_pc() != NULL, "not walkable");
   frame fr(jfa->last_Java_sp(), jfa->last_Java_fp(), jfa->last_Java_pc());
 
-  if (jfa->saved_rbp_address()) {
+  if (map->update_map() && jfa->saved_rbp_address()) {
     update_map_with_saved_link(map, jfa->saved_rbp_address());
   }
 


### PR DESCRIPTION
This fixes the failing assert by checking if the register map needs to be updated.

This gets the jextract samples working again, but some followup is still need to add a test case that can catch this problem.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [JDK-8258238](https://bugs.openjdk.java.net/browse/JDK-8258238): Some jextract samples crash with: "updating map that does not need updating"


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.java.net/census#mcimadamore) (@mcimadamore - Committer)


### Download
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/417/head:pull/417`
`$ git checkout pull/417`
