### PR TITLE
8258248: jextract should generate jdk 16 compatible code

### DIFF
--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/ClassConstantHelper.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/ClassConstantHelper.java
@@ -190,7 +190,7 @@ class ClassConstantHelper implements ConstantHelper {
 
     private void classBegin(String baseClassName) {
         String baseName = baseClassName != null ? toInternalName(baseClassName) : INTR_OBJECT;
-        cw.visit(V15, 0, internalClassName, null, baseName, null);
+        cw.visit(V16, 0, internalClassName, null, baseName, null);
     }
 
     private static DirectMethodHandleDesc findRuntimeHelperBootstrap(ClassDesc runtimeHelper, String name, MethodType type) {

--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/Writer.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/Writer.java
@@ -51,6 +51,7 @@ public final class Writer {
         } else {
             return InMemoryJavaCompiler.compile(sources,
                 "--add-modules", "jdk.incubator.foreign",
+                "--release", "16",
                 "-parameters", "-g:lines",
                 "-d", dest.toAbsolutePath().toString(),
                 "-cp", dest.toAbsolutePath().toString());


### PR DESCRIPTION
using --release 16 option for inmemory java compilation. Using V16 for ASM generated code.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [JDK-8258248](https://bugs.openjdk.java.net/browse/JDK-8258248): jextract should generate jdk 16 compatible code


### Reviewers
 * [Jorn Vernee](https://openjdk.java.net/census#jvernee) (@JornVernee - Committer)


### Download
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/419/head:pull/419`
`$ git checkout pull/419`
