### PR TITLE
Add libclang dependency to docs jib task

### DIFF
--- a/make/conf/jib-profiles.js
+++ b/make/conf/jib-profiles.js
@@ -718,7 +718,7 @@ var getJibProfilesProfiles = function (input, common, data) {
             target_os: input.build_os,
             target_cpu: input.build_cpu,
             dependencies: [
-                "boot_jdk", "devkit", "graphviz", "pandoc", buildJdkDep,
+                "boot_jdk", "devkit", "graphviz", "pandoc", buildJdkDep, "libclang"
             ],
             configure_args: concat(
                 "--enable-full-docs",


### PR DESCRIPTION
This simple patch adds the dependency on libclang to the javadoc jib task.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [Jorn Vernee](https://openjdk.java.net/census#jvernee) (@JornVernee - Committer)


### Download
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/420/head:pull/420`
`$ git checkout pull/420`
