### PR TITLE
8258388: jextract should avoid $ in class name used with inheritance

### DIFF
--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/MultiFileConstantHelper.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/MultiFileConstantHelper.java
@@ -60,7 +60,7 @@ public class MultiFileConstantHelper implements ConstantHelper {
     }
 
     private String getConstantClassName() {
-        return headerClassName + "$constants$" + constantClassCount;
+        return headerClassName + "_constants_" + constantClassCount;
     }
 
     private void checkNewConstantsClass() {

--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/ToplevelBuilder.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/ToplevelBuilder.java
@@ -91,7 +91,7 @@ class ToplevelBuilder extends HeaderFileBuilder {
 
     HeaderFileBuilder nextHeader() {
         if (declCount > DECLS_PER_HEADER_CLASS) {
-            HeaderFileBuilder headerFileBuilder = new HeaderFileBuilder(className + "$" + headers.size(), pkgName,
+            HeaderFileBuilder headerFileBuilder = new HeaderFileBuilder(className + "_" + headers.size(), pkgName,
                     lastHeader().map(h -> h.className).orElse(null),
                     constantHelper, annotationWriter);
             headerFileBuilder.classBegin();


### PR DESCRIPTION
all tests, samples pass 'as is'

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [JDK-8258388](https://bugs.openjdk.java.net/browse/JDK-8258388): jextract should avoid $ in class name used with inheritance


### Reviewers
 * [Jorn Vernee](https://openjdk.java.net/census#jvernee) (@JornVernee - Committer)
 * [Maurizio Cimadamore](https://openjdk.java.net/census#mcimadamore) (@mcimadamore - Committer)


### Download
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/421/head:pull/421`
`$ git checkout pull/421`
