### PR TITLE
8258405: functional interfaces are not generated for struct fields/global variables with function pointers

### DIFF
--- a/test/jdk/tools/jextract/Test8258405.java
+++ b/test/jdk/tools/jextract/Test8258405.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.nio.file.Path;
+import org.testng.annotations.Test;
+import static org.testng.Assert.assertNotNull;
+
+/*
+ * @test
+ * @modules jdk.incubator.jextract
+ * @library /test/lib
+ * @build JextractToolRunner
+ * @bug 8258405
+ * @summary functional interfaces are not generated for struct fields/global variables with function pointers
+ * @run testng/othervm -Dforeign.restricted=permit Test8258405
+ */
+public class Test8258405 extends JextractToolRunner {
+    @Test
+    public void test() {
+        Path test8258405Output = getOutputFilePath("test8258405_gen");
+        Path test8258405H = getInputFilePath("test8258405.h");
+        run("-d", test8258405Output.toString(), test8258405H.toString()).checkSuccess();
+        try(Loader loader = classLoader(test8258405Output)) {
+            Class<?> cls = loader.loadClass("test8258405_h");
+            assertNotNull(cls);
+            // check global function pointer variable 'func'
+            cls = loader.loadClass("test8258405_h$func");
+            assertNotNull(cls);
+            assertNotNull(findMethod(cls, "apply", int.class));
+            // check function pointer member 'bar' of struct 'Foo'
+            cls = loader.loadClass("test8258405_h$Foo$bar");
+            assertNotNull(cls);
+            assertNotNull(findMethod(cls, "apply", float.class, double.class));
+        } finally {
+            deleteDir(test8258405Output);
+        }
+    }
+}

--- a/test/jdk/tools/jextract/test8258405.h
+++ b/test/jdk/tools/jextract/test8258405.h
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+#ifdef __cplusplus
+extern "C" {
+#endif // __cplusplus
+
+#ifdef _WIN64
+#define EXPORT __declspec(dllexport)
+#else
+#define EXPORT
+#endif
+
+struct Foo {
+  int (*bar)(float, double);
+};
+
+void (*func)(int);
+
+#ifdef __cplusplus
+}
+#endif // __cplusplus


### PR DESCRIPTION
generating functional interfaces for globals and function pointer struct members

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [JDK-8258405](https://bugs.openjdk.java.net/browse/JDK-8258405): functional interfaces are not generated for struct fields/global variables with function pointers


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.java.net/census#mcimadamore) (@mcimadamore - Committer)
 * [Jorn Vernee](https://openjdk.java.net/census#jvernee) (@JornVernee - Committer)


### Download
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/422/head:pull/422`
`$ git checkout pull/422`
