### PR TITLE
Add stack walk test case that doesn't verify oops

### DIFF
--- a/src/hotspot/share/prims/whitebox.cpp
+++ b/src/hotspot/share/prims/whitebox.cpp
@@ -2284,23 +2284,21 @@ WB_ENTRY(void, WB_CheckThreadObjOfTerminatingThread(JNIEnv* env, jobject wb, job
   }
 WB_END
 
-WB_ENTRY(void, WB_WalkFrames(JNIEnv* env, jobject wb, jboolean log, jboolean update_reg_map_and_verify_oops))
+WB_ENTRY(void, WB_VerifyFrames(JNIEnv* env, jobject wb, jboolean log, jboolean update_map))
   intx tty_token = -1;
   if (log) {
     tty_token = ttyLocker::hold_tty();
-    tty->print_cr("[WhiteBox::WalkFrames] Walking Frames");
+    tty->print_cr("[WhiteBox::VerifyFrames] Walking Frames");
   }
-  for (StackFrameStream fst(JavaThread::current(), update_reg_map_and_verify_oops, true); !fst.is_done(); fst.next()) {
+  for (StackFrameStream fst(JavaThread::current(), update_map, true); !fst.is_done(); fst.next()) {
     frame* current_frame = fst.current();
     if (log) {
       current_frame->print_value();
     }
-    if (update_reg_map_and_verify_oops) {
-      current_frame->verify(fst.register_map());
-    }
+    current_frame->verify(fst.register_map());
   }
   if (log) {
-    tty->print_cr("[WhiteBox::WalkFrames] Done");
+    tty->print_cr("[WhiteBox::VerifyFrames] Done");
     ttyLocker::release_tty(tty_token);
   }
 WB_END
@@ -2541,7 +2539,7 @@ static JNINativeMethod methods[] = {
   {CC"handshakeWalkStack", CC"(Ljava/lang/Thread;Z)I", (void*)&WB_HandshakeWalkStack },
   {CC"asyncHandshakeWalkStack", CC"(Ljava/lang/Thread;)V", (void*)&WB_AsyncHandshakeWalkStack },
   {CC"checkThreadObjOfTerminatingThread", CC"(Ljava/lang/Thread;)V", (void*)&WB_CheckThreadObjOfTerminatingThread },
-  {CC"walkFrames",                CC"(ZZ)V",            (void*)&WB_WalkFrames },
+  {CC"verifyFrames",                CC"(ZZ)V",            (void*)&WB_VerifyFrames },
   {CC"addCompilerDirective",    CC"(Ljava/lang/String;)I",
                                                       (void*)&WB_AddCompilerDirective },
   {CC"removeCompilerDirective",   CC"(I)V",           (void*)&WB_RemoveCompilerDirective },

--- a/src/hotspot/share/prims/whitebox.cpp
+++ b/src/hotspot/share/prims/whitebox.cpp
@@ -2284,21 +2284,23 @@ WB_ENTRY(void, WB_CheckThreadObjOfTerminatingThread(JNIEnv* env, jobject wb, job
   }
 WB_END
 
-WB_ENTRY(void, WB_VerifyFrames(JNIEnv* env, jobject wb, jboolean log))
+WB_ENTRY(void, WB_WalkFrames(JNIEnv* env, jobject wb, jboolean log, jboolean verify_oops))
   intx tty_token = -1;
   if (log) {
     tty_token = ttyLocker::hold_tty();
-    tty->print_cr("[WhiteBox::VerifyFrames] Walking Frames");
+    tty->print_cr("[WhiteBox::WalkFrames] Walking Frames");
   }
-  for (StackFrameStream fst(JavaThread::current(), true, true); !fst.is_done(); fst.next()) {
+  for (StackFrameStream fst(JavaThread::current(), verify_oops, true); !fst.is_done(); fst.next()) {
     frame* current_frame = fst.current();
     if (log) {
       current_frame->print_value();
     }
-    current_frame->verify(fst.register_map());
+    if (verify_oops) {
+      current_frame->verify(fst.register_map());
+    }
   }
   if (log) {
-    tty->print_cr("[WhiteBox::VerifyFrames] Done");
+    tty->print_cr("[WhiteBox::WalkFrames] Done");
     ttyLocker::release_tty(tty_token);
   }
 WB_END
@@ -2539,7 +2541,7 @@ static JNINativeMethod methods[] = {
   {CC"handshakeWalkStack", CC"(Ljava/lang/Thread;Z)I", (void*)&WB_HandshakeWalkStack },
   {CC"asyncHandshakeWalkStack", CC"(Ljava/lang/Thread;)V", (void*)&WB_AsyncHandshakeWalkStack },
   {CC"checkThreadObjOfTerminatingThread", CC"(Ljava/lang/Thread;)V", (void*)&WB_CheckThreadObjOfTerminatingThread },
-  {CC"verifyFrames",                CC"(Z)V",            (void*)&WB_VerifyFrames },
+  {CC"walkFrames",                CC"(ZZ)V",            (void*)&WB_WalkFrames },
   {CC"addCompilerDirective",    CC"(Ljava/lang/String;)I",
                                                       (void*)&WB_AddCompilerDirective },
   {CC"removeCompilerDirective",   CC"(I)V",           (void*)&WB_RemoveCompilerDirective },

--- a/src/hotspot/share/prims/whitebox.cpp
+++ b/src/hotspot/share/prims/whitebox.cpp
@@ -2284,18 +2284,18 @@ WB_ENTRY(void, WB_CheckThreadObjOfTerminatingThread(JNIEnv* env, jobject wb, job
   }
 WB_END
 
-WB_ENTRY(void, WB_WalkFrames(JNIEnv* env, jobject wb, jboolean log, jboolean verify_oops))
+WB_ENTRY(void, WB_WalkFrames(JNIEnv* env, jobject wb, jboolean log, jboolean update_reg_map_and_verify_oops))
   intx tty_token = -1;
   if (log) {
     tty_token = ttyLocker::hold_tty();
     tty->print_cr("[WhiteBox::WalkFrames] Walking Frames");
   }
-  for (StackFrameStream fst(JavaThread::current(), verify_oops, true); !fst.is_done(); fst.next()) {
+  for (StackFrameStream fst(JavaThread::current(), update_reg_map_and_verify_oops, true); !fst.is_done(); fst.next()) {
     frame* current_frame = fst.current();
     if (log) {
       current_frame->print_value();
     }
-    if (verify_oops) {
+    if (update_reg_map_and_verify_oops) {
       current_frame->verify(fst.register_map());
     }
   }

--- a/src/hotspot/share/runtime/frame.cpp
+++ b/src/hotspot/share/runtime/frame.cpp
@@ -1105,7 +1105,7 @@ void frame::verify(const RegisterMap* map) const {
 #if COMPILER2_OR_JVMCI
   assert(DerivedPointerTable::is_empty(), "must be empty before verify");
 #endif
-  if (map->update_map()) { // does map have oops?
+  if (map->update_map()) { // The map has to be up-to-date for the current frame
     oops_do_internal(&VerifyOopClosure::verify_oop, NULL, map, false, DerivedPointerIterationMode::_ignore);
   }
 }

--- a/src/hotspot/share/runtime/frame.cpp
+++ b/src/hotspot/share/runtime/frame.cpp
@@ -1105,7 +1105,9 @@ void frame::verify(const RegisterMap* map) const {
 #if COMPILER2_OR_JVMCI
   assert(DerivedPointerTable::is_empty(), "must be empty before verify");
 #endif
-  oops_do_internal(&VerifyOopClosure::verify_oop, NULL, map, false, DerivedPointerIterationMode::_ignore);
+  if (map->update_map()) { // does map have oops?
+    oops_do_internal(&VerifyOopClosure::verify_oop, NULL, map, false, DerivedPointerIterationMode::_ignore);
+  }
 }
 
 

--- a/test/jdk/java/foreign/stackwalk/TestStackWalk.java
+++ b/test/jdk/java/foreign/stackwalk/TestStackWalk.java
@@ -105,8 +105,8 @@ public class TestStackWalk {
 
     static void m() {
         if (armed) {
-            WB.walkFrames(/*log=*/true, /*verifyOops=*/true);
-            WB.walkFrames(/*log=*/true, /*verifyOops=*/false); // triggers different code paths
+            WB.verifyFrames(/*log=*/true, /*updateRegisterMap=*/true);
+            WB.verifyFrames(/*log=*/true, /*updateRegisterMap=*/false); // triggers different code paths
         }
     }
 

--- a/test/jdk/java/foreign/stackwalk/TestStackWalk.java
+++ b/test/jdk/java/foreign/stackwalk/TestStackWalk.java
@@ -105,7 +105,8 @@ public class TestStackWalk {
 
     static void m() {
         if (armed) {
-            WB.verifyFrames(true);
+            WB.walkFrames(/*log=*/true, /*verifyOops=*/true);
+            WB.walkFrames(/*log=*/true, /*verifyOops=*/false); // triggers different code paths
         }
     }
 

--- a/test/lib/sun/hotspot/WhiteBox.java
+++ b/test/lib/sun/hotspot/WhiteBox.java
@@ -638,7 +638,7 @@ public class WhiteBox {
   public native String getLibcName();
 
   // Walk stack frames of current thread
-  public native void walkFrames(boolean log, boolean verifyOops);
+  public native void walkFrames(boolean log, boolean updateRegMapAndVerifyOops);
 
   public native boolean isJVMTIIncluded();
 

--- a/test/lib/sun/hotspot/WhiteBox.java
+++ b/test/lib/sun/hotspot/WhiteBox.java
@@ -638,7 +638,7 @@ public class WhiteBox {
   public native String getLibcName();
 
   // Walk stack frames of current thread
-  public native void verifyFrames(boolean log);
+  public native void walkFrames(boolean log, boolean verifyOops);
 
   public native boolean isJVMTIIncluded();
 

--- a/test/lib/sun/hotspot/WhiteBox.java
+++ b/test/lib/sun/hotspot/WhiteBox.java
@@ -638,7 +638,7 @@ public class WhiteBox {
   public native String getLibcName();
 
   // Walk stack frames of current thread
-  public native void walkFrames(boolean log, boolean updateRegMapAndVerifyOops);
+  public native void verifyFrames(boolean log, boolean updateRegisterMap);
 
   public native boolean isJVMTIIncluded();
 


### PR DESCRIPTION
This is a followup for the earlier quickfix of: https://github.com/openjdk/panama-foreign/pull/417

This adds another test case to TestStackWalk that catches the failing code path.

This re-uses the previously added `WhiteBox::verifyFrames`, and adds a flag to turn off the verification, which triggers the problematic code path. (I've also renamed this to just `walkFrames`, since now we don't always do verification anymore.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [Vladimir Ivanov](https://openjdk.java.net/census#vlivanov) (@iwanowww - Committer)


### Download
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/423/head:pull/423`
`$ git checkout pull/423`
