### PR TITLE
8258605: regression: jextract can not handle function prototypes as function arguments

### DIFF
--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/LayoutUtils.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/LayoutUtils.java
@@ -143,7 +143,13 @@ public final class LayoutUtils {
 
         @Override
         public MemoryLayout visitFunction(jdk.incubator.jextract.Type.Function t, Void _ignored) {
-            throw new UnsupportedOperationException();
+            /*
+             * // pointer function declared as function like this
+             *
+             * typedef void CB(int);
+             * void func(CB cb);
+             */
+            return C_POINTER;
         }
 
         @Override

--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/LayoutUtils.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/LayoutUtils.java
@@ -144,7 +144,7 @@ public final class LayoutUtils {
         @Override
         public MemoryLayout visitFunction(jdk.incubator.jextract.Type.Function t, Void _ignored) {
             /*
-             * // pointer function declared as function like this
+             * // pointer to function declared as function like this
              *
              * typedef void CB(int);
              * void func(CB cb);

--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/OutputFactory.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/OutputFactory.java
@@ -361,6 +361,14 @@ public class OutputFactory implements Declaration.Visitor<Void, Declaration> {
                 default:
                     return getAsFunctionPointer(((Type.Delegated) type).type());
             }
+        } else if (type instanceof Type.Function) {
+            /*
+             * // pointer function declared as function like this
+             *
+             * typedef void CB(int);
+             * void func(CB cb);
+             */
+            return (Type.Function)type;
         } else {
             return null;
         }

--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/OutputFactory.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/OutputFactory.java
@@ -352,18 +352,10 @@ public class OutputFactory implements Declaration.Visitor<Void, Declaration> {
 
     Type.Function getAsFunctionPointer(Type type) {
         if (type instanceof Type.Delegated) {
-            switch (((Type.Delegated) type).kind()) {
-                case POINTER: {
-                    Type pointee = ((Type.Delegated) type).type();
-                    return (pointee instanceof Type.Function) ?
-                        (Type.Function)pointee : null;
-                }
-                default:
-                    return getAsFunctionPointer(((Type.Delegated) type).type());
-            }
+            return getAsFunctionPointer(((Type.Delegated) type).type());
         } else if (type instanceof Type.Function) {
             /*
-             * // pointer function declared as function like this
+             * // pointer to function declared as function like this
              *
              * typedef void CB(int);
              * void func(CB cb);

--- a/test/jdk/tools/jextract/test8258605/LibTest8258605Test.java
+++ b/test/jdk/tools/jextract/test8258605/LibTest8258605Test.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import jdk.incubator.foreign.NativeScope;
+import org.testng.annotations.Test;
+import test.jextract.test8258605.*;
+import static jdk.incubator.foreign.MemoryAddress.NULL;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+import static test.jextract.test8258605.funcParam_h.*;
+
+/*
+ * @test id=classes
+ * @bug 8258605
+ * @summary regression: jextract can not handle function prototypes as function arguments
+ * @library ..
+ * @modules jdk.incubator.jextract
+ * @run driver JtregJextract -l FuncParam -t test.jextract.test8258605 -- funcParam.h
+ * @run testng/othervm -Dforeign.restricted=permit LibTest8258605Test
+ */
+/*
+ * @test id=sources
+ * @bug 8258605
+ * @summary regression: jextract can not handle function prototypes as function arguments
+ * @library ..
+ * @modules jdk.incubator.jextract
+ * @run driver JtregJextractSources -l FuncParam -t test.jextract.test8258605 -- funcParam.h
+ * @run testng/othervm -Dforeign.restricted=permit LibTest8258605Test
+ */
+public class LibTest8258605Test {
+    @Test
+    public void testFunctionCallback() {
+        try (var scope = NativeScope.unboundedScope()) {
+             boolean[] callbackReached = new boolean[1];
+             f(f$x.allocate(i -> {
+                 assertTrue(i == 10);
+                 callbackReached[0] = true;
+             }, scope));
+             assertTrue(callbackReached[0]);
+        }
+    }
+
+    @Test
+    public void testStructFunctionPointerCallback() {
+        try (var scope = NativeScope.unboundedScope()) {
+             boolean[] callbackReached = new boolean[1];
+
+             // get struct Foo instance
+             var foo = getFoo();
+             // make sure that foo.bar is not NULL
+             assertFalse(Foo.bar$get(foo).equals(NULL));
+
+             f2(foo, f2$cb.allocate(i -> {
+                 assertTrue(i == 42);
+                 callbackReached[0] = true;
+             }, scope));
+             assertTrue(callbackReached[0]);
+        }
+    }
+}

--- a/test/jdk/tools/jextract/test8258605/funcParam.h
+++ b/test/jdk/tools/jextract/test8258605/funcParam.h
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+#ifdef _WIN64
+#define EXPORT __declspec(dllexport)
+#else
+#define EXPORT
+#endif
+
+typedef void CB(int);
+
+EXPORT void f(CB x);
+
+struct Foo {
+    void (*bar)(CB cb);
+};
+
+/* get initialised Foo struct instance */
+EXPORT struct Foo getFoo();
+
+/* first param should be initialized struct instance returned by getFoo */
+EXPORT void f2(struct Foo foo, CB cb);

--- a/test/jdk/tools/jextract/test8258605/libFuncParam.c
+++ b/test/jdk/tools/jextract/test8258605/libFuncParam.c
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+#include "funcParam.h"
+
+EXPORT void f(CB x) {
+    x(10);
+}
+
+static void barFunc(CB cb) {
+    cb(42);
+}
+
+static struct Foo theFoo;
+
+EXPORT struct Foo getFoo() {
+    theFoo.bar = barFunc;
+    return theFoo;
+}
+
+EXPORT void f2(struct Foo foo, CB cb) {
+    foo.bar(cb);
+}


### PR DESCRIPTION
Old fix is not applicable in the new code. But test brought and modified.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [JDK-8258605](https://bugs.openjdk.java.net/browse/JDK-8258605): regression: jextract can not handle function prototypes as function arguments


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.java.net/census#mcimadamore) (@mcimadamore - Committer)


### Download
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/424/head:pull/424`
`$ git checkout pull/424`
