### PR TITLE
Removed duplicate profile_memory_access function from methodData.cpp

### DIFF
--- a/src/hotspot/share/oops/methodData.cpp
+++ b/src/hotspot/share/oops/methodData.cpp
@@ -1613,18 +1613,6 @@ bool MethodData::profile_memory_access(const methodHandle& m, int bci) {
   return false;
 }
 
-bool MethodData::profile_memory_access(const methodHandle& m, int bci) {
-  Bytecode_invoke inv(m , bci);
-  if (inv.is_invokestatic()) {
-    if (inv.klass() == vmSymbols::jdk_incubator_foreign_MemoryAccess()) {
-      if (inv.name()->starts_with("get") || inv.name()->starts_with("set")) {
-        return true;
-      }
-    }
-  }
-  return false;
-}
-
 int MethodData::profile_arguments_flag() {
   return TypeProfileLevel % 10;
 }


### PR DESCRIPTION
Removes the duplicate profile_memory_access function from methodData.cpp, which causes a build fail. This duplicate function does not exist in the foreign-jextract branch as there hasn't been a merge yet from foreign-memaccess+abi.

Note: OCA filled out and sent but needs to be processed and my Github account needs to be registered. If it takes too long due to the holidays then I'll rescind the pull request.

Note: 2 this is a resubmit to fix same-branch pull request issue the OpenJDK bot brought up.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [Maurizio Cimadamore](https://openjdk.java.net/census#mcimadamore) (@mcimadamore - Committer)


### Download
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/427/head:pull/427`
`$ git checkout pull/427`
