### PR TITLE
Fix duplicate declaration in methodData.cpp

### DIFF
--- a/src/hotspot/share/oops/methodData.cpp
+++ b/src/hotspot/share/oops/methodData.cpp
@@ -1613,18 +1613,6 @@ bool MethodData::profile_memory_access(const methodHandle& m, int bci) {
   return false;
 }
 
-bool MethodData::profile_memory_access(const methodHandle& m, int bci) {
-  Bytecode_invoke inv(m , bci);
-  if (inv.is_invokestatic()) {
-    if (inv.klass() == vmSymbols::jdk_incubator_foreign_MemoryAccess()) {
-      if (inv.name()->starts_with("get") || inv.name()->starts_with("set")) {
-        return true;
-      }
-    }
-  }
-  return false;
-}
-
 int MethodData::profile_arguments_flag() {
   return TypeProfileLevel % 10;
 }


### PR DESCRIPTION
A recent automatic merge ended up creating a duplicate declaration of a function in methodData.cpp. This patch fixes that. Thanks to Ty for the fix.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [Paul Sandoz](https://openjdk.java.net/census#psandoz) (@PaulSandoz - Committer)


### Download
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/428/head:pull/428`
`$ git checkout pull/428`
