### PR TITLE
8259226: jextract should differentiate between clang errors vs other runtime issues

### DIFF
--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/clang/AccessSpecifier.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/clang/AccessSpecifier.java
@@ -61,7 +61,7 @@ public enum AccessSpecifier {
     public final static AccessSpecifier valueOf(int value) {
         AccessSpecifier x = lookup.get(value);
         if (null == x) {
-            throw new NoSuchElementException("Invalid AccessSpecifier kind value: " + value);
+            throw new ClangException("Invalid AccessSpecifier kind value: " + value);
         }
         return x;
     }

--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/clang/CallingConvention.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/clang/CallingConvention.java
@@ -68,7 +68,7 @@ public enum CallingConvention {
     public final static CallingConvention valueOf(int value) {
         CallingConvention x = lookup.get(value);
         if (null == x) {
-            throw new NoSuchElementException();
+            throw new ClangException("Invalid calling convention: " + value);
         }
         return x;
     }

--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/clang/ClangException.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/clang/ClangException.java
@@ -23,64 +23,20 @@
  *  questions.
  *
  */
-
 package jdk.internal.clang;
 
-import java.util.HashMap;
-import java.util.Map;
-import java.util.NoSuchElementException;
-
-public class TypeLayoutError extends IllegalStateException {
-
+public class ClangException extends RuntimeException {
     private static final long serialVersionUID = 0L;
 
-    private final Kind kind;
-
-    public TypeLayoutError(long value, String message) {
-        super(Kind.valueOf(value) + ". " + message);
-        this.kind = Kind.valueOf(value);
+    public ClangException(String message) {
+        super(message);
     }
 
-    public Kind kind() {
-        return kind;
+    public ClangException(String message, Throwable cause) {
+        super(message, cause);
     }
 
-    public static boolean isError(long value) {
-        return Kind.isError(value);
-    }
-
-    public enum Kind {
-        Invalid(-1),
-        Incomplete(-2),
-        Dependent(-3),
-        NotConstantSize(-4),
-        InvalidFieldName(-5);
-
-        private final long value;
-
-        Kind(long value) {
-            this.value = value;
-        }
-
-        private final static Map<Long, Kind> lookup;
-
-        static {
-            lookup = new HashMap<>();
-            for (Kind e: Kind.values()) {
-                lookup.put(e.value, e);
-            }
-        }
-
-        public final static Kind valueOf(long value) {
-            Kind x = lookup.get(value);
-            if (null == x) {
-                throw new NoSuchElementException("TypeLayoutError = " + value);
-            }
-            return x;
-        }
-
-        public static boolean isError(long value) {
-            return lookup.containsKey(value);
-        }
+    public ClangException(Throwable cause) {
+        super(cause);
     }
 }

--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/clang/CursorKind.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/clang/CursorKind.java
@@ -293,7 +293,7 @@ public enum CursorKind {
     public final static CursorKind valueOf(int value) {
         CursorKind x = lookup.get(value);
         if (null == x) {
-            throw new NoSuchElementException("Invalid Cursor kind value: " + value);
+            throw new ClangException("Invalid Cursor kind value: " + value);
         }
         return x;
     }

--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/clang/ErrorCode.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/clang/ErrorCode.java
@@ -58,6 +58,6 @@ public enum ErrorCode {
             .collect(toMap(ErrorCode::code, Function.identity()));
 
     public static ErrorCode valueOf(int code) {
-        return lookup.computeIfAbsent(code, k -> { throw new NoSuchElementException("No ErrorCode with code: " + k); });
+        return lookup.computeIfAbsent(code, k -> { throw new ClangException("No ErrorCode with code: " + k); });
     }
 }

--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/clang/EvalResult.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/clang/EvalResult.java
@@ -71,7 +71,7 @@ public class EvalResult implements AutoCloseable {
             case Integral:
                 return getAsInt0();
             default:
-                throw new IllegalStateException("Unexpected kind: " + kind);
+                throw new ClangException("Unexpected kind: " + kind);
         }
     }
 
@@ -85,7 +85,7 @@ public class EvalResult implements AutoCloseable {
             case FloatingPoint:
                 return getAsFloat0();
             default:
-                throw new IllegalStateException("Unexpected kind: " + kind);
+                throw new ClangException("Unexpected kind: " + kind);
         }
     }
 
@@ -100,7 +100,7 @@ public class EvalResult implements AutoCloseable {
             case StrLiteral:
                 return getAsString0();
             default:
-                throw new IllegalStateException("Unexpected kind: " + kind);
+                throw new ClangException("Unexpected kind: " + kind);
         }
     }
 

--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/clang/Index.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/clang/Index.java
@@ -66,7 +66,7 @@ public class Index implements AutoCloseable {
         }
     }
 
-    public static class ParsingFailedException extends RuntimeException {
+    public static class ParsingFailedException extends ClangException {
         private static final long serialVersionUID = -1L;
         private final Path srcFile;
         private final ErrorCode code;

--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/clang/LibClang.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/clang/LibClang.java
@@ -56,7 +56,7 @@ public class LibClang {
                                 FunctionDescriptor.of(CLinker.C_INT, CLinker.C_POINTER));
                 int res = (int) PUT_ENV.invokeExact(disableCrashRecovery.address());
             } catch (Throwable ex) {
-                throw new ExceptionInInitializerError(ex);
+                throw new ClangException(ex);
             }
         }
     }

--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/clang/RefQualifierKind.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/clang/RefQualifierKind.java
@@ -60,7 +60,7 @@ public enum RefQualifierKind {
     public final static RefQualifierKind valueOf(int value) {
         RefQualifierKind x = lookup.get(value);
         if (null == x) {
-            throw new NoSuchElementException("Invalid RefQualifierKind kind value: " + value);
+            throw new ClangException("Invalid RefQualifierKind kind value: " + value);
         }
         return x;
     }

--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/clang/TemplateArgumentKind.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/clang/TemplateArgumentKind.java
@@ -68,7 +68,7 @@ public enum TemplateArgumentKind {
     public final static TemplateArgumentKind valueOf(int value) {
         TemplateArgumentKind x = lookup.get(value);
         if (null == x) {
-            throw new NoSuchElementException("Invalid TemplateArgumentKind kind value: " + value);
+            throw new ClangException("Invalid TemplateArgumentKind kind value: " + value);
         }
         return x;
     }

--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/clang/TranslationUnit.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/clang/TranslationUnit.java
@@ -100,7 +100,7 @@ public class TranslationUnit implements AutoCloseable {
                         Index_h.clang_defaultReparseOptions(tu)));
 
             if (code != ErrorCode.Success) {
-                throw new IllegalStateException("Re-parsing failed: " + code);
+                throw new ClangException("Re-parsing failed: " + code);
             }
         }
     }
@@ -209,7 +209,7 @@ public class TranslationUnit implements AutoCloseable {
         }
     }
 
-    public static class TranslationUnitSaveException extends IOException {
+    public static class TranslationUnitSaveException extends ClangException {
 
         static final long serialVersionUID = 1L;
 

--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/clang/Type.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/clang/Type.java
@@ -116,8 +116,8 @@ public final class Type {
 
     public long getOffsetOf(String fieldName) {
         long res = getOffsetOf0(fieldName);
-        if(TypeLayoutError.isError(res)) {
-            throw new TypeLayoutError(res, String.format("type: %s, fieldName: %s", this, fieldName));
+        if(TypeLayoutException.isError(res)) {
+            throw new TypeLayoutException(res, String.format("type: %s, fieldName: %s", this, fieldName));
         }
         return res;
     }
@@ -195,8 +195,8 @@ public final class Type {
 
     public long size() {
         long res = size0();
-        if(TypeLayoutError.isError(res)) {
-            throw new TypeLayoutError(res, String.format("type: %s", this));
+        if(TypeLayoutException.isError(res)) {
+            throw new TypeLayoutException(res, String.format("type: %s", this));
         }
         return res;
     }

--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/clang/TypeKind.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/clang/TypeKind.java
@@ -171,7 +171,7 @@ public enum TypeKind {
     public final static TypeKind valueOf(int value) {
         TypeKind x = lookup.get(value);
         if (null == x) {
-            throw new NoSuchElementException("kind = " + value);
+            throw new ClangException("Invalid type kind: " + value);
         }
         return x;
     }

--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/clang/TypeLayoutException.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/clang/TypeLayoutException.java
@@ -30,59 +30,57 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.NoSuchElementException;
 
-public enum PrintingPolicyProperty {
-    Indentation(0),
-    SuppressSpecifiers(1),
-    SuppressTagKeyword(2),
-    IncludeTagDefinition(3),
-    SuppressScope(4),
-    SuppressUnwrittenScope(5),
-    SuppressInitializers(6),
-    ConstantArraySizeAsWritten(7),
-    AnonymousTagLocations(8),
-    SuppressStrongLifetime(9),
-    SuppressLifetimeQualifiers(10),
-    SuppressTemplateArgsInCXXConstructors(11),
-    Bool(12),
-    Restrict(13),
-    Alignof(14),
-    UnderscoreAlignof(15),
-    UseVoidForZeroParams(16),
-    TerseOutput(17),
-    PolishForDeclaration(18),
-    Half(19),
-    MSWChar(20),
-    IncludeNewlines(21),
-    MSVCFormatting(22),
-    ConstantsAsWritten(23),
-    SuppressImplicitBase(24),
-    FullyQualifiedName(25),
-    LastProperty(25);
+public class TypeLayoutException extends ClangException {
 
-    private final int value;
+    private static final long serialVersionUID = 0L;
 
-    PrintingPolicyProperty(int value) {
-        this.value = value;
+    private final Kind kind;
+
+    public TypeLayoutException(long value, String message) {
+        super(Kind.valueOf(value) + ". " + message);
+        this.kind = Kind.valueOf(value);
     }
 
-    public int value() {
-        return value;
+    public Kind kind() {
+        return kind;
     }
 
-    private final static Map<Integer, PrintingPolicyProperty> lookup;
+    public static boolean isError(long value) {
+        return Kind.isError(value);
+    }
 
-    static {
-        lookup = new HashMap<>();
-        for (PrintingPolicyProperty e: PrintingPolicyProperty.values()) {
-            lookup.put(e.value(), e);
+    public enum Kind {
+        Invalid(-1),
+        Incomplete(-2),
+        Dependent(-3),
+        NotConstantSize(-4),
+        InvalidFieldName(-5);
+
+        private final long value;
+
+        Kind(long value) {
+            this.value = value;
         }
-    }
 
-    public final static PrintingPolicyProperty valueOf(int value) {
-        PrintingPolicyProperty x = lookup.get(value);
-        if (null == x) {
-            throw new ClangException("Invalid PrintingPolicyProperty value: " + value);
+        private final static Map<Long, Kind> lookup;
+
+        static {
+            lookup = new HashMap<>();
+            for (Kind e: Kind.values()) {
+                lookup.put(e.value, e);
+            }
         }
-        return x;
+
+        public final static Kind valueOf(long value) {
+            Kind x = lookup.get(value);
+            if (null == x) {
+                throw new ClangException("Invalid TypeLayout Kind: " + value);
+            }
+            return x;
+        }
+
+        public static boolean isError(long value) {
+            return lookup.containsKey(value);
+        }
     }
 }

--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/MacroParserImpl.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/MacroParserImpl.java
@@ -30,6 +30,7 @@ import jdk.incubator.jextract.Declaration;
 import jdk.incubator.jextract.Position;
 import jdk.incubator.jextract.Type;
 import jdk.incubator.jextract.JextractTool;
+import jdk.internal.clang.ClangException;
 import jdk.internal.clang.Cursor;
 import jdk.internal.clang.CursorKind;
 import jdk.internal.clang.Diagnostic;
@@ -65,8 +66,8 @@ class MacroParserImpl {
         ClangReparser reparser;
         try {
             reparser = new ClangReparser(tu, args);
-        } catch (IOException | Index.ParsingFailedException ex) {
-            throw new RuntimeException(ex);
+        } catch (IOException ex) {
+            throw new ClangException(ex);
         }
 
         return new MacroParserImpl(reparser, treeMaker);

--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/Parser.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/Parser.java
@@ -26,6 +26,7 @@
 package jdk.internal.jextract.impl;
 
 import jdk.incubator.jextract.Declaration;
+import jdk.internal.clang.ClangException;
 import jdk.internal.clang.Cursor;
 import jdk.internal.clang.CursorKind;
 import jdk.internal.clang.Diagnostic;
@@ -54,7 +55,7 @@ public class Parser {
         TranslationUnit tu = index.parse(path.toString(),
             d -> {
                 if (d.severity() > Diagnostic.CXDiagnostic_Warning) {
-                    throw new RuntimeException(d.toString());
+                    throw new ClangException(d.toString());
                 }
             },
             true, args.toArray(new String[0]));

--- a/test/jdk/tools/jextract/JextractToolProviderTest.java
+++ b/test/jdk/tools/jextract/JextractToolProviderTest.java
@@ -46,7 +46,7 @@ import static org.testng.Assert.assertTrue;
 public class JextractToolProviderTest extends JextractToolRunner {
     @Test
     public void testHelp() {
-        run().checkFailure(); // no options
+        run().checkFailure(OPTION_ERROR); // no options
         run("--help").checkSuccess();
         run("-h").checkSuccess();
         run("-?").checkSuccess();
@@ -56,8 +56,24 @@ public class JextractToolProviderTest extends JextractToolRunner {
     @Test
     public void testNonExistentHeader() {
         run(getInputFilePath("non_existent.h").toString())
-            .checkFailure()
+            .checkFailure(INPUT_ERROR)
             .checkContainsOutput("cannot read header file");
+    }
+
+    // error for header including non_existent.h file
+    @Test
+    public void testNonExistentIncluder() {
+        run(getInputFilePath("non_existent_includer.h").toString())
+            .checkFailure(CLANG_ERROR)
+            .checkContainsOutput("file not found");
+    }
+
+    // error for header with parser errors
+    @Test
+    public void testHeaderWithDeclarationErrors() {
+        run(getInputFilePath("illegal_decls.h").toString())
+            .checkFailure(CLANG_ERROR)
+            .checkContainsOutput("cannot combine with previous 'short' declaration specifier");
     }
 
     @Test

--- a/test/jdk/tools/jextract/JextractToolRunner.java
+++ b/test/jdk/tools/jextract/JextractToolRunner.java
@@ -52,6 +52,15 @@ import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
 
 public class JextractToolRunner {
+
+    // (private) exit codes from jextract tool. Copied from JextractTool.
+    static final int SUCCESS       = 0;
+    static final int OPTION_ERROR  = 1;
+    static final int INPUT_ERROR   = 2;
+    static final int CLANG_ERROR   = 3;
+    static final int RUNTIME_ERROR = 4;
+    static final int OUTPUT_ERROR  = 5;
+
     private static String safeFileName(String filename) {
         int ext = filename.lastIndexOf('.');
         return ext != -1 ? filename.substring(0, ext) : filename;
@@ -94,12 +103,17 @@ public class JextractToolRunner {
         }
 
         protected JextractResult checkSuccess() {
-            assertEquals(exitCode, 0, "Sucess expected, failed: " + exitCode);
+            assertEquals(exitCode, SUCCESS, "Sucess expected, failed: " + exitCode);
             return this;
         }
 
         protected JextractResult checkFailure() {
-            assertNotEquals(exitCode, 0, "Failure expected, succeeded!");
+            assertNotEquals(exitCode, SUCCESS, "Failure expected, succeeded!");
+            return this;
+        }
+
+        protected JextractResult checkFailure(int expectedExitCode) {
+            assertEquals(exitCode, expectedExitCode, "Expected error code " + expectedExitCode);
             return this;
         }
 

--- a/test/jdk/tools/jextract/illegal_decls.h
+++ b/test/jdk/tools/jextract/illegal_decls.h
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+short long x;

--- a/test/jdk/tools/jextract/non_existent_includer.h
+++ b/test/jdk/tools/jextract/non_existent_includer.h
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+#include "non_existent.h"


### PR DESCRIPTION
CLANG_ERROR error code added. Also OUTPUT_ERROR exit code is used as expected.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8259226](https://bugs.openjdk.java.net/browse/JDK-8259226): jextract should differentiate between clang errors vs other runtime issues


### Download
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/429/head:pull/429`
`$ git checkout pull/429`
