### PR TITLE
8259226: jextract should differentiate between clang errors vs other runtime issues

### DIFF
--- a/src/jdk.incubator.jextract/share/classes/jdk/incubator/jextract/JextractTool.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/incubator/jextract/JextractTool.java
@@ -25,6 +25,7 @@
 
 package jdk.incubator.jextract;
 
+import jdk.internal.jextract.impl.ClangException;
 import jdk.internal.jextract.impl.Filter;
 import jdk.internal.jextract.impl.OutputFactory;
 import jdk.internal.jextract.impl.Parser;
@@ -71,8 +72,9 @@ public final class JextractTool {
     private static final int SUCCESS       = 0;
     private static final int OPTION_ERROR  = 1;
     private static final int INPUT_ERROR   = 2;
-    private static final int OUTPUT_ERROR  = 3;
+    private static final int CLANG_ERROR   = 3;
     private static final int RUNTIME_ERROR = 4;
+    private static final int OUTPUT_ERROR  = 5;
 
     private final PrintWriter out;
     private final PrintWriter err;
@@ -234,7 +236,7 @@ public final class JextractTool {
             return INPUT_ERROR;
         }
 
-        //parse    //generate
+        List<JavaFileObject> files = null;
         try {
             Declaration.Scoped toplevel = parse(List.of(header), options.clangArgs.toArray(new String[0]));
 
@@ -247,20 +249,34 @@ public final class JextractTool {
                 System.out.println(toplevel);
             }
 
-            Path output = Path.of(options.outputDir);
-
-            List<JavaFileObject> files = generate(
+            files = generate(
                 toplevel, header.getFileName().toString(), options.source,
                 options.targetPackage, options.libraryNames);
-
-            write(output, !options.source, files);
+        } catch (ClangException ce) {
+            err.println(ce.getMessage());
+            if (JextractTool.DEBUG) {
+                ce.printStackTrace(err);
+            }
+            return CLANG_ERROR;
         } catch (RuntimeException re) {
-            err.println(re);
+            err.println(re.getMessage());
             if (JextractTool.DEBUG) {
                 re.printStackTrace(err);
             }
             return RUNTIME_ERROR;
         }
+
+        try {
+            Path output = Path.of(options.outputDir);
+            write(output, !options.source, files);
+        } catch (RuntimeException re) {
+            err.println(re.getMessage());
+            if (JextractTool.DEBUG) {
+                re.printStackTrace(err);
+            }
+            return OUTPUT_ERROR;
+        }
+
         return SUCCESS;
     }
 

--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/ClangException.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/ClangException.java
@@ -1,0 +1,42 @@
+/*
+ *  Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ *  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ *  This code is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License version 2 only, as
+ *  published by the Free Software Foundation.  Oracle designates this
+ *  particular file as subject to the "Classpath" exception as provided
+ *  by Oracle in the LICENSE file that accompanied this code.
+ *
+ *  This code is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ *  version 2 for more details (a copy is included in the LICENSE file that
+ *  accompanied this code).
+ *
+ *  You should have received a copy of the GNU General Public License version
+ *  2 along with this work; if not, write to the Free Software Foundation,
+ *  Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ *   Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ *  or visit www.oracle.com if you need additional information or have any
+ *  questions.
+ *
+ */
+package jdk.internal.jextract.impl;
+
+public class ClangException extends RuntimeException {
+    private static final long serialVersionUID = 0L;
+
+    public ClangException(String message) {
+        super(message);
+    }
+
+    public ClangException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public ClangException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/ClangException.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/ClangException.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ *  Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
  *  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  *  This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/Parser.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/Parser.java
@@ -54,7 +54,7 @@ public class Parser {
         TranslationUnit tu = index.parse(path.toString(),
             d -> {
                 if (d.severity() > Diagnostic.CXDiagnostic_Warning) {
-                    throw new RuntimeException(d.toString());
+                    throw new ClangException(d.toString());
                 }
             },
             true, args.toArray(new String[0]));

--- a/test/jdk/tools/jextract/JextractToolProviderTest.java
+++ b/test/jdk/tools/jextract/JextractToolProviderTest.java
@@ -46,7 +46,7 @@ import static org.testng.Assert.assertTrue;
 public class JextractToolProviderTest extends JextractToolRunner {
     @Test
     public void testHelp() {
-        run().checkFailure(); // no options
+        run().checkFailure(OPTION_ERROR); // no options
         run("--help").checkSuccess();
         run("-h").checkSuccess();
         run("-?").checkSuccess();
@@ -56,8 +56,24 @@ public class JextractToolProviderTest extends JextractToolRunner {
     @Test
     public void testNonExistentHeader() {
         run(getInputFilePath("non_existent.h").toString())
-            .checkFailure()
+            .checkFailure(INPUT_ERROR)
             .checkContainsOutput("cannot read header file");
+    }
+
+    // error for header including non_existent.h file
+    @Test
+    public void testNonExistentIncluder() {
+        run(getInputFilePath("non_existent_includer.h").toString())
+            .checkFailure(CLANG_ERROR)
+            .checkContainsOutput("file not found");
+    }
+
+    // error for header with parser errors
+    @Test
+    public void testHeaderWithDeclarationErrors() {
+        run(getInputFilePath("illegal_decls.h").toString())
+            .checkFailure(CLANG_ERROR)
+            .checkContainsOutput("cannot combine with previous 'short' declaration specifier");
     }
 
     @Test

--- a/test/jdk/tools/jextract/JextractToolRunner.java
+++ b/test/jdk/tools/jextract/JextractToolRunner.java
@@ -52,6 +52,15 @@ import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
 
 public class JextractToolRunner {
+
+    // (private) exit codes from jextract tool. Copied from JextractTool.
+    static final int SUCCESS       = 0;
+    static final int OPTION_ERROR  = 1;
+    static final int INPUT_ERROR   = 2;
+    static final int CLANG_ERROR   = 3;
+    static final int RUNTIME_ERROR = 4;
+    static final int OUTPUT_ERROR  = 5;
+
     private static String safeFileName(String filename) {
         int ext = filename.lastIndexOf('.');
         return ext != -1 ? filename.substring(0, ext) : filename;
@@ -94,12 +103,17 @@ public class JextractToolRunner {
         }
 
         protected JextractResult checkSuccess() {
-            assertEquals(exitCode, 0, "Sucess expected, failed: " + exitCode);
+            assertEquals(exitCode, SUCCESS, "Sucess expected, failed: " + exitCode);
             return this;
         }
 
         protected JextractResult checkFailure() {
-            assertNotEquals(exitCode, 0, "Failure expected, succeeded!");
+            assertNotEquals(exitCode, SUCCESS, "Failure expected, succeeded!");
+            return this;
+        }
+
+        protected JextractResult checkFailure(int expectedExitCode) {
+            assertEquals(exitCode, expectedExitCode, "Expected error code " + expectedExitCode);
             return this;
         }
 

--- a/test/jdk/tools/jextract/illegal_decls.h
+++ b/test/jdk/tools/jextract/illegal_decls.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/tools/jextract/illegal_decls.h
+++ b/test/jdk/tools/jextract/illegal_decls.h
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+short long x;

--- a/test/jdk/tools/jextract/non_existent_includer.h
+++ b/test/jdk/tools/jextract/non_existent_includer.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/tools/jextract/non_existent_includer.h
+++ b/test/jdk/tools/jextract/non_existent_includer.h
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+#include "non_existent.h"


### PR DESCRIPTION
Introducing ClangException for clang diagnostic errors and returning CLANG_ERROR for diagnostic errors. Also using OUTPUT_ERROR as intended.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [JDK-8259226](https://bugs.openjdk.java.net/browse/JDK-8259226): jextract should differentiate between clang errors vs other runtime issues


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.java.net/census#mcimadamore) (@mcimadamore - Committer)


### Download
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/430/head:pull/430`
`$ git checkout pull/430`
