### PR TITLE
8259473: jextract generated code should throw exception for unfound native symbols from calls, variable access, set immediately

### DIFF
--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/HeaderFileBuilder.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/HeaderFileBuilder.java
@@ -99,23 +99,25 @@ class HeaderFileBuilder extends JavaSourceBuilder {
         builder.append(") {\n");
         builder.incrAlign();
         builder.indent();
+        builder.append("var mh$ = RuntimeHelper.requireNonNull(");
+        builder.append(methodHandleGetCallString(javaName, nativeName, mtype, desc, varargs));
+        builder.append(", \"unresolved symbol: ");
+        builder.append(nativeName);
+        builder.append("\");\n");
+        builder.indent();
         builder.append("try {\n");
         builder.incrAlign();
         builder.indent();
         if (!mtype.returnType().equals(void.class)) {
             builder.append("return (" + mtype.returnType().getName() + ")");
         }
-        builder.append("Objects.requireNonNull(");
-        builder.append(methodHandleGetCallString(javaName, nativeName, mtype, desc, varargs));
-        builder.append(", \"no such native function: ");
-        builder.append(javaName);
-        builder.append("\").invokeExact(" + String.join(", ", pExprs) + ");\n");
+        builder.append("mh$.invokeExact(" + String.join(", ", pExprs) + ");\n");
         builder.decrAlign();
         builder.indent();
-        builder.append("} catch (Throwable ex) {\n");
+        builder.append("} catch (Throwable ex$) {\n");
         builder.incrAlign();
         builder.indent();
-        builder.append("throw new AssertionError(\"should not reach here\", ex);\n");
+        builder.append("throw new AssertionError(\"should not reach here\", ex$);\n");
         builder.decrAlign();
         builder.indent();
         builder.append("}\n");

--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/HeaderFileBuilder.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/HeaderFileBuilder.java
@@ -105,13 +105,17 @@ class HeaderFileBuilder extends JavaSourceBuilder {
         if (!mtype.returnType().equals(void.class)) {
             builder.append("return (" + mtype.returnType().getName() + ")");
         }
-        builder.append(methodHandleGetCallString(javaName, nativeName, mtype, desc, varargs) + ".invokeExact(" + String.join(", ", pExprs) + ");\n");
+        builder.append("Objects.requireNonNull(");
+        builder.append(methodHandleGetCallString(javaName, nativeName, mtype, desc, varargs));
+        builder.append(", \"no such native function: ");
+        builder.append(javaName);
+        builder.append("\").invokeExact(" + String.join(", ", pExprs) + ");\n");
         builder.decrAlign();
         builder.indent();
         builder.append("} catch (Throwable ex) {\n");
         builder.incrAlign();
         builder.indent();
-        builder.append("throw new AssertionError(ex);\n");
+        builder.append("throw new AssertionError(\"should not reach here\", ex);\n");
         builder.decrAlign();
         builder.indent();
         builder.append("}\n");

--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/JavaSourceBuilder.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/JavaSourceBuilder.java
@@ -130,12 +130,12 @@ abstract class JavaSourceBuilder {
 
     void addMethodHandleGetter(String javaName, String nativeName, MethodType mtype, FunctionDescriptor desc, boolean varargs) {
         emitForwardGetter(constantHelper.addMethodHandle(javaName, nativeName, mtype, desc, varargs), "",
-            true, "no such native function: " + nativeName);
+            true, "unresolved symbol: " + nativeName);
     }
 
     void addSegmentGetter(String javaName, String nativeName, MemoryLayout layout) {
         emitForwardGetter(constantHelper.addSegment(javaName, nativeName, layout), "",
-            true, "no such native variable: " + nativeName);
+            true, "unresolved symbol: " + nativeName);
     }
 
     void addConstantGetter(String javaName, Class<?> type, Object value, String anno) {
@@ -151,9 +151,9 @@ abstract class JavaSourceBuilder {
         String vhParam = addressGetCallString(javaName, nativeName, layout);
         builder.append("return (" + type.getName() + ") ");
         builder.append(globalVarHandleGetCallString(javaName, nativeName, layout, type));
-        builder.append(".get(Objects.requireNonNull(");
+        builder.append(".get(RuntimeHelper.requireNonNull(");
         builder.append(vhParam);
-        builder.append(", \"no such native variable: ");
+        builder.append(", \"unresolved symbol: ");
         builder.append(nativeName);
         builder.append("\"));\n");
         builder.decrAlign();
@@ -170,9 +170,9 @@ abstract class JavaSourceBuilder {
         builder.indent();
         String vhParam = addressGetCallString(javaName, nativeName, layout);
         builder.append(globalVarHandleGetCallString(javaName, nativeName, layout, type));
-        builder.append(".set(Objects.requireNonNull(");
+        builder.append(".set(RuntimeHelper.requireNonNull(");
         builder.append(vhParam);
-        builder.append(", \"no such native variable: ");
+        builder.append(", \"unresolved symbol: ");
         builder.append(nativeName);
         builder.append("\"), x);\n");
         builder.decrAlign();
@@ -216,7 +216,7 @@ abstract class JavaSourceBuilder {
         builder.indent();
         builder.append("return ");
         if (nullCheck) {
-            builder.append("Objects.requireNonNull(");
+            builder.append("RuntimeHelper.requireNonNull(");
         }
         builder.append(getCallString(desc));
         if (nullCheck) {

--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/resources/RuntimeHelper.java.template
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/resources/RuntimeHelper.java.template
@@ -26,6 +26,13 @@ final class RuntimeHelper {
     private final static ClassLoader LOADER = RuntimeHelper.class.getClassLoader();
     private final static MethodHandles.Lookup MH_LOOKUP = MethodHandles.lookup();
 
+    static <T> T requireNonNull(T obj, String msg) {
+        if (obj == null) {
+            throw new UnsatisfiedLinkError(msg);
+        }
+        return obj;
+    }
+
     static final LibraryLookup[] libraries(String... libNames) {
         if (libNames.length == 0) {
             return new LibraryLookup[] { LibraryLookup.ofDefault() };

--- a/test/jdk/tools/jextract/test8259473/LibTest8259473Test.java
+++ b/test/jdk/tools/jextract/test8259473/LibTest8259473Test.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import jdk.incubator.foreign.MemoryAddress;
+import jdk.incubator.foreign.MemorySegment;
+import jdk.incubator.foreign.NativeScope;
+import org.testng.annotations.Test;
+import test.jextract.test8259473.*;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+import static test.jextract.test8259473.test8259473_h.*;
+
+/*
+ * @test id=classes
+ * @bug 8259473
+ * @summary jextract generated code should throw exception for unfound native symbols from calls, variable access, set immediately
+ * @library ..
+ * @modules jdk.incubator.jextract
+ * @run driver JtregJextract -t test.jextract.test8259473 -- test8259473.h
+ * @run testng/othervm -Dforeign.restricted=permit LibTest8259473Test
+ */
+/*
+ * @test id=sources
+ * @bug 8259473
+ * @summary jextract generated code should throw exception for unfound native symbols from calls, variable access, set immediately
+ * @library ..
+ * @modules jdk.incubator.jextract
+ * @run driver JtregJextractSources -t test.jextract.test8259473 -- test8259473.h
+ * @run testng/othervm -Dforeign.restricted=permit LibTest8259473Test
+ */
+public class LibTest8259473Test {
+    @Test
+    public void nullChecksTest() {
+        try {
+            func();
+            throw new AssertionError("should not reach here");
+        } catch (AssertionError ae) {
+            assertTrue(ae.getCause().getMessage().contains("no such native function: func"));
+        }
+
+        try {
+            func$MH();
+            throw new AssertionError("should not reach here");
+        } catch (NullPointerException npe) {
+            assertTrue(npe.getMessage().contains("no such native function: func"));
+        }
+
+        try {
+            x$get();
+            throw new AssertionError("should not reach here");
+        } catch (NullPointerException npe) {
+            assertTrue(npe.getMessage().contains("no such native variable: x"));
+        }
+
+        try {
+            x$set(1);
+            throw new AssertionError("should not reach here");
+        } catch (NullPointerException npe) {
+            assertTrue(npe.getMessage().contains("no such native variable: x"));
+        }
+
+        try {
+            x$SEGMENT();
+            throw new AssertionError("should not reach here");
+        } catch (NullPointerException npe) {
+            assertTrue(npe.getMessage().contains("no such native variable: x"));
+        }
+
+        try {
+            y$SEGMENT();
+            throw new AssertionError("should not reach here");
+        } catch (NullPointerException npe) {
+            assertTrue(npe.getMessage().contains("no such native variable: y"));
+        }
+
+        try {
+            pt$SEGMENT();
+            throw new AssertionError("should not reach here");
+        } catch (NullPointerException npe) {
+            assertTrue(npe.getMessage().contains("no such native variable: pt"));
+        }
+    }
+}

--- a/test/jdk/tools/jextract/test8259473/LibTest8259473Test.java
+++ b/test/jdk/tools/jextract/test8259473/LibTest8259473Test.java
@@ -54,50 +54,50 @@ public class LibTest8259473Test {
         try {
             func();
             throw new AssertionError("should not reach here");
-        } catch (AssertionError ae) {
-            assertTrue(ae.getCause().getMessage().contains("no such native function: func"));
+        } catch (UnsatisfiedLinkError ule) {
+            assertTrue(ule.getMessage().contains("unresolved symbol: func"));
         }
 
         try {
             func$MH();
             throw new AssertionError("should not reach here");
-        } catch (NullPointerException npe) {
-            assertTrue(npe.getMessage().contains("no such native function: func"));
+        } catch (UnsatisfiedLinkError ule) {
+            assertTrue(ule.getMessage().contains("unresolved symbol: func"));
         }
 
         try {
             x$get();
             throw new AssertionError("should not reach here");
-        } catch (NullPointerException npe) {
-            assertTrue(npe.getMessage().contains("no such native variable: x"));
+        } catch (UnsatisfiedLinkError ule) {
+            assertTrue(ule.getMessage().contains("unresolved symbol: x"));
         }
 
         try {
             x$set(1);
             throw new AssertionError("should not reach here");
-        } catch (NullPointerException npe) {
-            assertTrue(npe.getMessage().contains("no such native variable: x"));
+        } catch (UnsatisfiedLinkError ule) {
+            assertTrue(ule.getMessage().contains("unresolved symbol: x"));
         }
 
         try {
             x$SEGMENT();
             throw new AssertionError("should not reach here");
-        } catch (NullPointerException npe) {
-            assertTrue(npe.getMessage().contains("no such native variable: x"));
+        } catch (UnsatisfiedLinkError ule) {
+            assertTrue(ule.getMessage().contains("unresolved symbol: x"));
         }
 
         try {
             y$SEGMENT();
             throw new AssertionError("should not reach here");
-        } catch (NullPointerException npe) {
-            assertTrue(npe.getMessage().contains("no such native variable: y"));
+        } catch (UnsatisfiedLinkError ule) {
+            assertTrue(ule.getMessage().contains("unresolved symbol: y"));
         }
 
         try {
             pt$SEGMENT();
             throw new AssertionError("should not reach here");
-        } catch (NullPointerException npe) {
-            assertTrue(npe.getMessage().contains("no such native variable: pt"));
+        } catch (UnsatisfiedLinkError ule) {
+            assertTrue(ule.getMessage().contains("unresolved symbol: pt"));
         }
     }
 }

--- a/test/jdk/tools/jextract/test8259473/test8259473.h
+++ b/test/jdk/tools/jextract/test8259473/test8259473.h
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+#ifdef __cplusplus
+extern "C" {
+#endif // __cplusplus
+
+#ifdef _WIN64
+#define EXPORT __declspec(dllexport)
+#else
+#define EXPORT
+#endif
+
+void func();
+extern int x;
+extern int y[10];
+
+struct Point {
+    int x;
+    int y;
+};
+
+extern struct Point pt;
+
+#ifdef __cplusplus
+}
+#endif // __cplusplus


### PR DESCRIPTION
NPE with proper error message is thrown immediately (on call, variable access/set)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [JDK-8259473](https://bugs.openjdk.java.net/browse/JDK-8259473): jextract generated code should throw exception for unfound native symbols from calls, variable access, set immediately


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.java.net/census#mcimadamore) (@mcimadamore - Committer)
 * [Jorn Vernee](https://openjdk.java.net/census#jvernee) (@JornVernee - Committer)


### Download
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/432/head:pull/432`
`$ git checkout pull/432`
