### PR TITLE
Performance improvement to unchecked segment ofNativeRestricted 

### DIFF
--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/NativeMemorySegmentImpl.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/NativeMemorySegmentImpl.java
@@ -116,9 +116,9 @@ public class NativeMemorySegmentImpl extends AbstractMemorySegmentImpl {
     }
 
     /**
-     * Segment representing whole native memory. Because of this
-     * it doesn't perform range checks, and attached scope doesn't do temporal checks.
-     * As the consequence it can be faster than ordinal memory segment.
+     * Segment representing whole native memory.
+     * It doesn't perform range checks, and attached scope doesn't do temporal checks,
+     * as the consequence it can be faster than ordinal memory segment.
      */
     private static final class GlobalMemorySegment extends NativeMemorySegmentImpl {
         private static final Scope SCOPE = new Scope();
@@ -135,17 +135,6 @@ public class NativeMemorySegmentImpl extends AbstractMemorySegmentImpl {
         @Override
         NativeMemorySegmentImpl dup(long offset, long size, int mask, MemoryScope scope) {
             return new NativeMemorySegmentImpl(min + offset, size, mask, scope);
-        }
-
-        @Override
-        public Object unsafeGetBase() {
-            return null;
-        }
-
-        @Override
-        public MemoryScope scope() {
-            // Return JVM const pointer, better for optimizations
-            return SCOPE;
         }
 
         /**

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/NativeMemorySegmentImpl.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/NativeMemorySegmentImpl.java
@@ -120,10 +120,11 @@ public class NativeMemorySegmentImpl extends AbstractMemorySegmentImpl {
      * Special class for the whole memory, don't make checks - this optimizes a lot of routines
      */
     private static final class EverythingSegment extends NativeMemorySegmentImpl {
-        private static final Scope SCOPE = new Scope();
-
         EverythingSegment() {
-            super(0, Long.MAX_VALUE, READ | WRITE, SCOPE);
+            // O and MAX_VAL are just dummy values, in fact last address in x64 is -1
+            // however it's typically not addressable.
+            // Null scope - will skip checking scope in VarHandles @Scoped methods
+            super(0, Long.MAX_VALUE, READ | WRITE, null);
         }
 
         @Override
@@ -139,35 +140,6 @@ public class NativeMemorySegmentImpl extends AbstractMemorySegmentImpl {
         @Override
         public Object unsafeGetBase() {
             return null;
-        }
-
-        @Override
-        public MemoryScope scope() {
-            // Return JVM const pointer, better for optimizations
-            return SCOPE;
-        }
-
-        /**
-         * Special scope - can't be closed & it's always ALIVE
-         */
-        private static final class Scope extends SharedScope {
-            Scope() {
-                super(null, MemoryScope.DUMMY_CLEANUP_ACTION, null);
-            }
-
-            @Override
-            void justClose() {
-                throw new IllegalStateException("Should never be called");
-            }
-
-            @Override
-            public boolean isAlive() {
-                return true;
-            }
-
-            @Override
-            public void checkValidState() {
-            }
         }
     }
 }


### PR DESCRIPTION
This changes removes (by making no-ops) range and temporal checks for `ofNativeRestricted` segment. As this segment is global, above checks are not needed.

Generated native code is smaller, and execution outperforms Java native arrays (depending on CPU)
Changed
```
Benchmark                           Mode  Cnt          Score        Error  Units
AccessBenchmark.foreignAddress     thrpt    5  128946129.691 ± 317433.113  ops/s
AccessBenchmark.foreignAddressRaw  thrpt    5  136883439.221 ± 749390.255  ops/s
AccessBenchmark.target             thrpt    5  125325586.957 ±  32129.931  ops/s
```
Base
```
Benchmark                           Mode  Cnt          Score        Error  Units
AccessBenchmark.foreignAddress     thrpt    5  125257424.876 ± 230508.169  ops/s
AccessBenchmark.foreignAddressRaw  thrpt    5  128818591.434 ± 241806.765  ops/s
AccessBenchmark.target             thrpt    5  125083379.819 ± 184070.467  ops/s
```
---
This PR is replacement for https://github.com/openjdk/panama-foreign/pull/431 (OCA)
and was partially discussed (before changes) in https://mail.openjdk.java.net/pipermail/panama-dev/2021-January/011747.htm

---
Benchmark
```
@State(Scope.Thread)
public class AccessBenchmark {
    static final MemorySegment ms = MemorySegment.ofNativeRestricted();
    static final VarHandle intHandle = MemoryHandles.varHandle(int.class, ByteOrder.nativeOrder());

    int[] intData = new int[12];
    volatile int intDataOffset = 0;

    volatile MemoryAddress address;
    volatile long addressRaw;

    @Setup
    public void setup() {
        var ms = MemorySegment.allocateNative(256);
        address = ms.address();
        addressRaw = address.toRawLongValue();
    }

    @Benchmark
    public void target(Blackhole bh) {
        int[] local = intData;
        int localOffset = intDataOffset;
        bh.consume(local[localOffset]);
        bh.consume(local[localOffset + 1]);
    }

    @Benchmark
    public void foreignAddress(Blackhole bh) {
        var a = address;
        bh.consume((int) intHandle.get(ms, a.addOffset(0).toRawLongValue()));
        bh.consume((int) intHandle.get(ms, a.addOffset(4).toRawLongValue()));
    }

    @Benchmark
    public void foreignAddressRaw(Blackhole bh) {
        var a = addressRaw;
        bh.consume((int) intHandle.get(ms, a));
        bh.consume((int) intHandle.get(ms, a + 4));
    }
}
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Change must be properly reviewed

### Error
&nbsp;⚠️ The commit message contains trailing whitespace on line 1

### Download
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/435/head:pull/435`
`$ git checkout pull/435`
