### PR TITLE
Make `UNSAFE` variable static final

### DIFF
--- a/src/java.base/share/classes/jdk/internal/misc/X-ScopedMemoryAccess.java.template
+++ b/src/java.base/share/classes/jdk/internal/misc/X-ScopedMemoryAccess.java.template
@@ -71,7 +71,7 @@ import jdk.internal.vm.annotation.ForceInline;
  */
 public class ScopedMemoryAccess {
 
-    private static Unsafe UNSAFE = Unsafe.getUnsafe();
+    private static final Unsafe UNSAFE = Unsafe.getUnsafe();
 
     private static native void registerNatives();
     static {


### PR DESCRIPTION
Make `UNSAFE` static final, to avoid null checks
and traps.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [Maurizio Cimadamore](https://openjdk.java.net/census#mcimadamore) (@mcimadamore - Committer)


### Download
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/436/head:pull/436`
`$ git checkout pull/436`
