### PR TITLE
Performance improvement to unchecked segment ofNativeRestricted

### DIFF
--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/NativeMemorySegmentImpl.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/NativeMemorySegmentImpl.java
@@ -120,10 +120,11 @@ public class NativeMemorySegmentImpl extends AbstractMemorySegmentImpl {
      * Special class for the whole memory, don't make checks - this optimizes a lot of routines
      */
     private static final class EverythingSegment extends NativeMemorySegmentImpl {
-        private static final Scope SCOPE = new Scope();
-
         EverythingSegment() {
-            super(0, Long.MAX_VALUE, READ | WRITE, SCOPE);
+            // O and MAX_VAL are just dummy values, in fact last address in x64 is -1
+            // however it's typically not addressable.
+            // Null scope - will skip checking scope in VarHandles @Scoped methods
+            super(0, Long.MAX_VALUE, READ | WRITE, null);
         }
 
         @Override
@@ -139,35 +140,6 @@ public class NativeMemorySegmentImpl extends AbstractMemorySegmentImpl {
         @Override
         public Object unsafeGetBase() {
             return null;
-        }
-
-        @Override
-        public MemoryScope scope() {
-            // Return JVM const pointer, better for optimizations
-            return SCOPE;
-        }
-
-        /**
-         * Special scope - can't be closed & it's always ALIVE
-         */
-        private static final class Scope extends SharedScope {
-            Scope() {
-                super(null, MemoryScope.DUMMY_CLEANUP_ACTION, null);
-            }
-
-            @Override
-            void justClose() {
-                throw new IllegalStateException("Should never be called");
-            }
-
-            @Override
-            public boolean isAlive() {
-                return true;
-            }
-
-            @Override
-            public void checkValidState() {
-            }
         }
     }
 }

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/NativeMemorySegmentImpl.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/NativeMemorySegmentImpl.java
@@ -26,7 +26,6 @@
 
 package jdk.internal.foreign;
 
-import java.lang.ref.Cleaner;
 import jdk.incubator.foreign.MemoryAddress;
 import jdk.incubator.foreign.MemorySegment;
 import jdk.internal.foreign.MemoryScope.SharedScope;
@@ -43,7 +42,7 @@ import java.nio.ByteBuffer;
  */
 public class NativeMemorySegmentImpl extends AbstractMemorySegmentImpl {
 
-    public static final MemorySegment EVERYTHING = new EverythingSegment();
+    public static final MemorySegment EVERYTHING = new GlobalMemorySegment();
 
     private static final Unsafe unsafe = Unsafe.getUnsafe();
 
@@ -117,12 +116,14 @@ public class NativeMemorySegmentImpl extends AbstractMemorySegmentImpl {
     }
 
     /**
-     * Special class for the whole memory, don't make checks - this optimizes a lot of routines
+     * Segment representing whole native memory.
+     * It doesn't perform range checks, and attached scope doesn't do temporal checks,
+     * as the consequence it can be faster than ordinal memory segment.
      */
-    private static final class EverythingSegment extends NativeMemorySegmentImpl {
+    private static final class GlobalMemorySegment extends NativeMemorySegmentImpl {
         private static final Scope SCOPE = new Scope();
 
-        EverythingSegment() {
+        GlobalMemorySegment() {
             super(0, Long.MAX_VALUE, READ | WRITE, SCOPE);
         }
 
@@ -136,17 +137,6 @@ public class NativeMemorySegmentImpl extends AbstractMemorySegmentImpl {
             return new NativeMemorySegmentImpl(min + offset, size, mask, scope);
         }
 
-        @Override
-        public Object unsafeGetBase() {
-            return null;
-        }
-
-        @Override
-        public MemoryScope scope() {
-            // Return JVM const pointer, better for optimizations
-            return SCOPE;
-        }
-
         /**
          * Special scope - can't be closed & it's always ALIVE
          */
@@ -157,6 +147,8 @@ public class NativeMemorySegmentImpl extends AbstractMemorySegmentImpl {
 
             @Override
             void justClose() {
+                // In normal circumstances this method should not be called, as segment
+                // should prevent it.
                 throw new IllegalStateException("Should never be called");
             }
 

--- a/test/micro/org/openjdk/bench/jdk/incubator/foreign/NativeMemoryAccess.java
+++ b/test/micro/org/openjdk/bench/jdk/incubator/foreign/NativeMemoryAccess.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package org.openjdk.bench.jdk.incubator.foreign;
+
+import java.lang.invoke.VarHandle;
+import java.nio.ByteOrder;
+import java.util.concurrent.TimeUnit;
+import jdk.incubator.foreign.MemoryAddress;
+import jdk.incubator.foreign.MemoryHandles;
+import jdk.incubator.foreign.MemorySegment;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+
+/**
+ * Simulates & benchmarks random access from users (i.e. to off-heap array).
+ * Baselined to plain Java arrays.
+ */
+@Fork(
+    value = 3,
+    jvmArgsAppend = { "--add-modules", "jdk.incubator.foreign", "-Dforeign.restricted=permit"}
+)
+@Warmup(iterations = 5, time = 500, timeUnit = TimeUnit.MILLISECONDS)
+@Measurement(iterations = 10, time = 500, timeUnit = TimeUnit.MILLISECONDS)
+@State(Scope.Thread)
+public class NativeMemoryAccess {
+    static final MemorySegment ms = MemorySegment.ofNativeRestricted();
+    static final VarHandle intHandle = MemoryHandles.varHandle(int.class, ByteOrder.nativeOrder());
+
+    MemorySegment allocatedSegment;
+    int[] intData = new int[12];
+    volatile int intDataOffset = 0;
+
+    volatile MemoryAddress address;
+    volatile long addressRaw;
+
+    @Setup
+    public void setup() {
+        var ms = MemorySegment.allocateNative(256);
+        address = ms.address();
+        addressRaw = address.toRawLongValue();
+        allocatedSegment = ms;
+    }
+
+    @TearDown
+    public void tearDown() {
+        allocatedSegment.close();
+        allocatedSegment = null;
+    }
+
+    @Benchmark
+    public void target(Blackhole bh) {
+        int[] local = intData;
+        int localOffset = intDataOffset;
+        bh.consume(local[localOffset]);
+        bh.consume(local[localOffset + 1]);
+    }
+
+    @Benchmark
+    public void foreignAddress(Blackhole bh) {
+        var a = address;
+        bh.consume((int) intHandle.get(ms, a.addOffset(0).toRawLongValue()));
+        bh.consume((int) intHandle.get(ms, a.addOffset(4).toRawLongValue()));
+    }
+
+    @Benchmark
+    public void foreignAddressRaw(Blackhole bh) {
+        var a = addressRaw;
+        bh.consume((int) intHandle.get(ms, a));
+        bh.consume((int) intHandle.get(ms, a + 4));
+    }
+}


### PR DESCRIPTION
This changes removes (by making no-ops) range and temporal checks for `ofNativeRestricted` segment. As this segment is global, above checks are not needed.

Generated native code is smaller, and execution outperforms Java native arrays (depending on CPU)
Changed
```
Benchmark                           Mode  Cnt          Score        Error  Units
AccessBenchmark.foreignAddress     thrpt    5  128946129.691 ± 317433.113  ops/s
AccessBenchmark.foreignAddressRaw  thrpt    5  136883439.221 ± 749390.255  ops/s
AccessBenchmark.target             thrpt    5  125325586.957 ±  32129.931  ops/s
```
Base
```
Benchmark                           Mode  Cnt          Score        Error  Units
AccessBenchmark.foreignAddress     thrpt    5  125257424.876 ± 230508.169  ops/s
AccessBenchmark.foreignAddressRaw  thrpt    5  128818591.434 ± 241806.765  ops/s
AccessBenchmark.target             thrpt    5  125083379.819 ± 184070.467  ops/s
```
---
This PR is replacement for https://github.com/openjdk/panama-foreign/pull/431 (OCA)
and was partially discussed (before changes) in https://mail.openjdk.java.net/pipermail/panama-dev/2021-January/011747.htm

---
Benchmark
```
@State(Scope.Thread)
public class AccessBenchmark {
    static final MemorySegment ms = MemorySegment.ofNativeRestricted();
    static final VarHandle intHandle = MemoryHandles.varHandle(int.class, ByteOrder.nativeOrder());

    int[] intData = new int[12];
    volatile int intDataOffset = 0;

    volatile MemoryAddress address;
    volatile long addressRaw;

    @Setup
    public void setup() {
        var ms = MemorySegment.allocateNative(256);
        address = ms.address();
        addressRaw = address.toRawLongValue();
    }

    @Benchmark
    public void target(Blackhole bh) {
        int[] local = intData;
        int localOffset = intDataOffset;
        bh.consume(local[localOffset]);
        bh.consume(local[localOffset + 1]);
    }

    @Benchmark
    public void foreignAddress(Blackhole bh) {
        var a = address;
        bh.consume((int) intHandle.get(ms, a.addOffset(0).toRawLongValue()));
        bh.consume((int) intHandle.get(ms, a.addOffset(4).toRawLongValue()));
    }

    @Benchmark
    public void foreignAddressRaw(Blackhole bh) {
        var a = addressRaw;
        bh.consume((int) intHandle.get(ms, a));
        bh.consume((int) intHandle.get(ms, a + 4));
    }
}
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [Maurizio Cimadamore](https://openjdk.java.net/census#mcimadamore) (@mcimadamore - Committer)


### Download
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/437/head:pull/437`
`$ git checkout pull/437`
