### PR TITLE
8260344: jextract crashes with exception for log.h from libdebian-installer4-dev 

### DIFF
--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/TreeMaker.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/TreeMaker.java
@@ -166,7 +166,9 @@ class TreeMaker {
         for (int i = 0 ; i < c.numberOfArgs() ; i++) {
             params.add((Declaration.Variable)createTree(c.getArgument(i)));
         }
-        return Declaration.function(toPos(c), c.spelling(), (Type.Function)toType(c),
+        Type type = toType(c);
+        Type funcType = type instanceof Type.Delegated? ((Type.Delegated)type).type() : type;
+        return Declaration.function(toPos(c), c.spelling(), (Type.Function)funcType,
                 params.toArray(new Declaration.Variable[0]));
     }
 

--- a/test/jdk/tools/jextract/Test8260344.java
+++ b/test/jdk/tools/jextract/Test8260344.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.nio.file.Path;
+import org.testng.annotations.Test;
+
+/*
+ * @test
+ * @modules jdk.incubator.jextract
+ * @library /test/lib
+ * @build JextractToolRunner
+ * @bug 8260344
+ * @summary jextract crashes with exception for log.h from libdebian-installer4-dev
+ * @run testng/othervm -Dforeign.restricted=permit -Duser.language=en --add-modules jdk.incubator.jextract Test8260344
+ */
+public class Test8260344 extends JextractToolRunner {
+    @Test
+    public void test() {
+        Path test8260344Output = getOutputFilePath("test8260344gen");
+        try {
+            Path test8260344H = getInputFilePath("test8260344.h");
+            run("-d", test8260344Output.toString(), test8260344H.toString()).checkSuccess();
+        } finally {
+            deleteDir(test8260344Output);
+        }
+    }
+}

--- a/test/jdk/tools/jextract/test8260344.h
+++ b/test/jdk/tools/jextract/test8260344.h
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+#ifdef __cplusplus
+extern "C" {
+#endif // __cplusplus
+
+#ifdef _WIN64
+#define EXPORT __declspec(dllexport)
+#else
+#define EXPORT
+#endif
+
+typedef void di_log_handler (const char *message, void *user_data);
+di_log_handler di_log_handler_default;
+
+struct json_object;
+typedef void (json_object_delete_fn)(struct json_object *jso, void *userdata);
+json_object_delete_fn json_object_free_userdata;
+
+
+#ifdef __cplusplus
+}
+#endif // __cplusplus


### PR DESCRIPTION
Fixed type handling in createFunction when typedef on function pointer is used.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [JDK-8260344](https://bugs.openjdk.java.net/browse/JDK-8260344): jextract crashes with exception for log.h from libdebian-installer4-dev 


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.java.net/census#mcimadamore) (@mcimadamore - Committer)


### Download
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/439/head:pull/439`
`$ git checkout pull/439`
