### PR TITLE
8260583: jextract generates redundant constant files

### DIFF
--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/HeaderFileBuilder.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/HeaderFileBuilder.java
@@ -146,8 +146,6 @@ class HeaderFileBuilder extends JavaSourceBuilder {
     List<JavaFileObject> build() {
         classEnd();
         String res = builder.build();
-        List<JavaFileObject> files = constantHelper.build();
-        files.add(Utils.fileFromString(pkgName, className, res));
-        return files;
+        return List.of(Utils.fileFromString(pkgName, className, res));
     }
 }

--- a/test/jdk/tools/jextract/TestSplit.java
+++ b/test/jdk/tools/jextract/TestSplit.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.nio.file.Path;
+import org.testng.annotations.Test;
+import static org.testng.Assert.*;
+
+/*
+ * @test
+ * @modules jdk.incubator.jextract
+ * @library /test/lib
+ * @build JextractToolRunner
+ * @bug 8244512
+ * @summary jextract throws NPE for a nested struct declaration
+ * @run testng/othervm -Djextract.decls.per.header=1 -Dforeign.restricted=permit TestSplit
+ */
+public class TestSplit extends JextractToolRunner {
+    @Test
+    public void testSplit() {
+        Path splitOutput = getOutputFilePath("split");
+        Path splitH = getInputFilePath("split.h");
+        run("-d", splitOutput.toString(), splitH.toString()).checkSuccess();
+        try(Loader loader = classLoader(splitOutput)) {
+            checkPresent(loader, "split_h");
+            checkPresent(loader, "split_h_0");
+            checkPresent(loader, "split_h_1");
+            checkPresent(loader, "split_h_2");
+            checkPresent(loader, "split_h_3");
+            checkMissing(loader, "split_h_4");
+            checkPresent(loader, "split_h_constants_0");
+            checkMissing(loader, "split_h_constants_1");
+        } finally {
+            deleteDir(splitOutput);
+        }
+    }
+
+    private static void checkPresent(Loader loader, String name) {
+        assertNotNull(loader.loadClass(name));
+    }
+
+    private static void checkMissing(Loader loader, String name) {
+        assertNull(loader.loadClass(name));
+    }
+}

--- a/test/jdk/tools/jextract/split.h
+++ b/test/jdk/tools/jextract/split.h
@@ -1,0 +1,11 @@
+#ifdef _WIN64
+#define EXPORT __declspec(dllexport)
+#else
+#define EXPORT
+#endif
+
+EXPORT int a();
+EXPORT int b();
+EXPORT int c();
+EXPORT int d();
+EXPORT int e();


### PR DESCRIPTION
When testing performances of jextract generated code with big headers, I noticed that jextract was emitting empty constant files. After some debugging, I realized that the issues lies in the fact that `ConstantHelper::build` is called both by `ToplevelBuilder::build` and by `HeaderFileBuilder::build` - so, for every new header file split that is generated, we trigger a new constant file, even though that is not needed.

The solution is to remove the call from `HeaderFileBuilder` and just keep the one inside `TopLevelBuilder`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [JDK-8260583](https://bugs.openjdk.java.net/browse/JDK-8260583): jextract generates redundant constant files


### Reviewers
 * [Athijegannathan Sundararajan](https://openjdk.java.net/census#sundar) (@sundararajana - Committer)


### Download
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/440/head:pull/440`
`$ git checkout pull/440`
