### PR TITLE
8258238: Some jextract samples crash with: "updating map that does not need updating"

### DIFF
--- a/src/hotspot/cpu/aarch64/frame_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/frame_aarch64.cpp
@@ -355,7 +355,7 @@ frame frame::sender_for_entry_frame(RegisterMap* map) const {
   vmassert(jfa->last_Java_pc() != NULL, "not walkable");
   frame fr(jfa->last_Java_sp(), jfa->last_Java_fp(), jfa->last_Java_pc());
 
-  if (jfa->saved_fp_address()) {
+  if (map->update_map() && jfa->saved_fp_address()) {
     update_map_with_saved_link(map, jfa->saved_fp_address());
   }
 


### PR DESCRIPTION
Hi,

This PR applies the same fix we did for x86 in [1] to frame_aarch64, which sees the same issue.

Thanks,
Jorn

[1] : https://github.com/openjdk/panama-foreign/pull/417

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [JDK-8258238](https://bugs.openjdk.java.net/browse/JDK-8258238): Some jextract samples crash with: "updating map that does not need updating" ⚠️ Issue is not open.


### Reviewers
 * [Nick Gasson](https://openjdk.java.net/census#ngasson) (@nick-arm - no project role)
 * [Maurizio Cimadamore](https://openjdk.java.net/census#mcimadamore) (@mcimadamore - Committer)


### Download
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/441/head:pull/441`
`$ git checkout pull/441`
