### PR TITLE
8260602: jextract generates redundant functional interafces

### DIFF
--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/OutputFactory.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/OutputFactory.java
@@ -380,7 +380,11 @@ public class OutputFactory implements Declaration.Visitor<Void, Declaration> {
 
     Type.Function getAsFunctionPointer(Type type) {
         if (type instanceof Type.Delegated) {
-            return getAsFunctionPointer(((Type.Delegated) type).type());
+            Type.Delegated delegated = (Type.Delegated)type;
+            return switch (delegated.kind()) {
+                case POINTER -> getAsFunctionPointer(delegated.type());
+                default -> null;
+            };
         } else if (type instanceof Type.Function) {
             /*
              * // pointer to function declared as function like this
@@ -436,6 +440,11 @@ public class OutputFactory implements Declaration.Visitor<Void, Declaration> {
         } else if (type instanceof Type.Primitive) {
              String anno = annotationWriter.getCAnnotation(type);
              header().emitPrimitiveTypedef((Type.Primitive)type, tree.name(), anno);
+        } else {
+            Type.Function func = getAsFunctionPointer(type);
+            if (func != null) {
+                generateFunctionalInterface(func, type, tree.name());
+            }
         }
         return null;
     }

--- a/test/jdk/tools/jextract/test8258605/LibTest8258605Test.java
+++ b/test/jdk/tools/jextract/test8258605/LibTest8258605Test.java
@@ -52,7 +52,7 @@ public class LibTest8258605Test {
     public void testFunctionCallback() {
         try (var scope = NativeScope.unboundedScope()) {
              boolean[] callbackReached = new boolean[1];
-             f(f$x.allocate(i -> {
+             f(CB.allocate(i -> {
                  assertTrue(i == 10);
                  callbackReached[0] = true;
              }, scope));
@@ -70,7 +70,7 @@ public class LibTest8258605Test {
              // make sure that foo.bar is not NULL
              assertFalse(Foo.bar$get(foo).equals(NULL));
 
-             f2(foo, f2$cb.allocate(i -> {
+             f2(foo, CB.allocate(i -> {
                  assertTrue(i == 42);
                  callbackReached[0] = true;
              }, scope));

--- a/test/jdk/tools/jextract/testClassGen/TestClassGeneration.java
+++ b/test/jdk/tools/jextract/testClassGen/TestClassGeneration.java
@@ -138,7 +138,7 @@ public class TestClassGeneration extends JextractToolRunner {
     @DataProvider
     public static Object[][] functionalInterfaces() {
         return new Object[][]{
-            { "func_cb$cb", methodType(void.class, int.class) }
+            { "CB", methodType(void.class, int.class) }
         };
     }
 


### PR DESCRIPTION
There seems to be an issue in how jextract handles function pointer typedef.

Currently, these typedefs are handled in two places:

* OutputFactory::visitVar
* OutputFactory::visitFunction

That is, if a variable (struct field or global), or a function parameter is seen to have a typedef of a function pointer, jextract will generate a functional interface _exactly at that point_ where the variable is found. This might be inside a struct.

Now, what we really want is slightly different: the functional interface for a function pointer typedef should really be generated in the toplevel interface hierarchy; any other reference to it (from struct fields, or function parameters, or globals) should _not_ result in additional functional interface declaration.

In other words, in this example [1]:

```
    typedef void (*callback_t)(void *arg);

    typedef struct first_handler {
         callback_t cb;
    } first_handler_t;

    typedef struct second_handler {
         callback_t cb;
    } second_handler_t;
```

There should be (in the user perspective) only _one_ functional interface, and its name should just be `callback_t`.

The fix is to make OutputFactory::getAsFunctionPointer non-transparent w.r.t. typedefs - that is, if a typedef is found, that method should just return null (so that the enclosing code will skip functional interface generation). To counter balance that, we need to add logic for functional interface declaration inside OutputFactory::visitTypedef.

I did not add any new test, since it turns out we already had a test for this (LibTest8258605Test) whose code was referring to the same typedef-ed function pointer using two names - this fix rectifies that behavior, and the test is now updated.

[1] - https://mail.openjdk.java.net/pipermail/panama-dev/2021-January/011948.html

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [JDK-8260602](https://bugs.openjdk.java.net/browse/JDK-8260602): jextract generates redundant functional interafces


### Reviewers
 * [Athijegannathan Sundararajan](https://openjdk.java.net/census#sundar) (@sundararajana - Committer)


### Download
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/442/head:pull/442`
`$ git checkout pull/442`
