### PR TITLE
8260705: jextract crash with libbart's types.h

### DIFF
--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/TreeMaker.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/TreeMaker.java
@@ -187,6 +187,13 @@ class TreeMaker {
 
     public Declaration.Scoped createScoped(Cursor c, Declaration.Scoped.Kind scopeKind, ScopedFactoryLayout factoryLayout, ScopedFactoryNoLayout factoryNoLayout) {
         List<Declaration> decls = filterNestedDeclarations(c.children()
+                .filter(fc -> {
+                    if (fc.isBitField()) {
+                        // only non-empty and named bit fields are generated
+                        return fc.getBitFieldWidth() != 0 && !fc.spelling().isEmpty();
+                    }
+                    return true;
+                })
                 .map(this::createTree).collect(Collectors.toList()));
         if (c.isDefinition()) {
             //just a declaration AND definition, we have a layout

--- a/test/jdk/tools/jextract/Test8260705.java
+++ b/test/jdk/tools/jextract/Test8260705.java
@@ -21,11 +21,13 @@
  * questions.
  */
 
+import java.lang.reflect.Method;
 import java.nio.file.Path;
 import jdk.incubator.foreign.MemoryAddress;
 import jdk.incubator.foreign.MemorySegment;
 import org.testng.annotations.Test;
 import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
 
 /*
  * @test
@@ -60,8 +62,25 @@ public class Test8260705 extends JextractToolRunner {
             checkMethod(Foo2Class, "w$set", void.class, MemorySegment.class, long.class, int.class);
 
             assertNotNull(loader.loadClass("test8260705_h$Foo3"));
+
+            Class<?> Foo4Class = loader.loadClass("test8260705_h$Foo4");
+            assertTrue(sizeof(Foo4Class) == 8L);
+
+            Class<?> Foo5Class = loader.loadClass("test8260705_h$Foo5");
+            assertTrue(sizeof(Foo5Class) == 4L);
+
         } finally {
             deleteDir(outputPath);
         }
     }
+
+    private long sizeof(Class<?> cls) {
+        Method m = findMethod(cls, "sizeof");
+        try {
+            return (long)m.invoke(null);
+        } catch (Exception ex) {
+            throw new RuntimeException(ex);
+        }
+    }
 }
+

--- a/test/jdk/tools/jextract/Test8260705.java
+++ b/test/jdk/tools/jextract/Test8260705.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.nio.file.Path;
+import jdk.incubator.foreign.MemoryAddress;
+import jdk.incubator.foreign.MemorySegment;
+import org.testng.annotations.Test;
+import static org.testng.Assert.assertNotNull;
+
+/*
+ * @test
+ * @library /test/lib
+ * @modules jdk.incubator.jextract
+ * @build JextractToolRunner
+ * @bug 8260705
+ * @summary jextract crash with libbart's types.h
+ * @run testng/othervm -Dforeign.restricted=permit Test8260705
+ */
+public class Test8260705 extends JextractToolRunner {
+    @Test
+    public void testPointerFields() {
+        Path outputPath = getOutputFilePath("output");
+        Path headerFile = getInputFilePath("test8260705.h");
+        run("-d", outputPath.toString(), headerFile.toString()).checkSuccess();
+        try(Loader loader = classLoader(outputPath)) {
+            Class<?> FooClass = loader.loadClass("test8260705_h$Foo");
+            checkMethod(FooClass, "c$get", byte.class, MemorySegment.class);
+            checkMethod(FooClass, "c$get", byte.class, MemorySegment.class, long.class);
+            checkMethod(FooClass, "c$set", void.class, MemorySegment.class, byte.class);
+            checkMethod(FooClass, "c$set", void.class, MemorySegment.class, long.class, byte.class);
+
+            Class<?> Foo2Class = loader.loadClass("test8260705_h$Foo2");
+            checkMethod(Foo2Class, "z$get", int.class, MemorySegment.class);
+            checkMethod(Foo2Class, "z$get", int.class, MemorySegment.class, long.class);
+            checkMethod(Foo2Class, "z$set", void.class, MemorySegment.class, int.class);
+            checkMethod(Foo2Class, "z$set", void.class, MemorySegment.class, long.class, int.class);
+            checkMethod(Foo2Class, "w$get", int.class, MemorySegment.class);
+            checkMethod(Foo2Class, "w$get", int.class, MemorySegment.class, long.class);
+            checkMethod(Foo2Class, "w$set", void.class, MemorySegment.class, int.class);
+            checkMethod(Foo2Class, "w$set", void.class, MemorySegment.class, long.class, int.class);
+
+            assertNotNull(loader.loadClass("test8260705_h$Foo3"));
+        } finally {
+            deleteDir(outputPath);
+        }
+    }
+}

--- a/test/jdk/tools/jextract/test8260705.h
+++ b/test/jdk/tools/jextract/test8260705.h
@@ -37,3 +37,18 @@ struct Foo3 {
     int: 0;
     int: 32;
 };
+
+struct Foo4 {
+  int    a:3;
+  int    b:2;
+  int     :0; // Force alignment to next boundary.
+  int    c:4;
+  int    d:3;
+};
+
+struct Foo5 {
+  int    a:3;
+  int    b:2;
+  int    c:4;
+  int    d:3;
+};

--- a/test/jdk/tools/jextract/test8260705.h
+++ b/test/jdk/tools/jextract/test8260705.h
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+struct Foo {
+    int: 0;
+    char c;
+};
+
+struct Foo2 {
+    int z;
+    int: 16;
+    int y:16;
+    int w;
+};
+
+struct Foo3 {
+    int: 0;
+    int: 32;
+};


### PR DESCRIPTION
Problematic cursors are filtered in TreeMaker

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [JDK-8260705](https://bugs.openjdk.java.net/browse/JDK-8260705): jextract crash with libbart's types.h


### Reviewers
 * [Jorn Vernee](https://openjdk.java.net/census#jvernee) (@JornVernee - Committer)


### Download
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/443/head:pull/443`
`$ git checkout pull/443`
