### PR TITLE
8260717: jextract crashes with 'Crossing storage unit boundaries' for libcoap's block.h

### DIFF
--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/RecordLayoutComputer.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/RecordLayoutComputer.java
@@ -33,6 +33,7 @@ import jdk.internal.clang.Cursor;
 import jdk.internal.clang.CursorKind;
 import jdk.internal.clang.Type;
 import jdk.internal.clang.TypeKind;
+import jdk.internal.clang.libclang.Index_h;
 
 import java.nio.ByteOrder;
 import java.util.ArrayList;
@@ -88,6 +89,7 @@ abstract class RecordLayoutComputer {
              * (padding is computed automatically)
              */
             if (fc.isBitField() && (fc.getBitFieldWidth() == 0 || fc.spelling().isEmpty())) {
+                startBitfield();
                 continue;
             }
 
@@ -97,6 +99,7 @@ abstract class RecordLayoutComputer {
         return finishLayout();
     }
 
+    abstract void startBitfield();
     abstract void processField(Cursor c);
     abstract MemoryLayout finishLayout();
 

--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/UnionLayoutComputer.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/UnionLayoutComputer.java
@@ -59,6 +59,11 @@ final class UnionLayoutComputer extends RecordLayoutComputer {
     }
 
     @Override
+    void startBitfield() {
+        // do nothing
+    }
+
+    @Override
     MemoryLayout fieldLayout(Cursor c) {
         if (c.isBitField()) {
             MemoryLayout layout = LayoutUtils.getLayout(c.type());

--- a/test/jdk/tools/jextract/Test8260705.java
+++ b/test/jdk/tools/jextract/Test8260705.java
@@ -40,7 +40,7 @@ import static org.testng.Assert.assertTrue;
  */
 public class Test8260705 extends JextractToolRunner {
     @Test
-    public void testPointerFields() {
+    public void test() {
         Path outputPath = getOutputFilePath("output");
         Path headerFile = getInputFilePath("test8260705.h");
         run("-d", outputPath.toString(), headerFile.toString()).checkSuccess();

--- a/test/jdk/tools/jextract/Test8260717.java
+++ b/test/jdk/tools/jextract/Test8260717.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.nio.file.Path;
+import jdk.incubator.foreign.MemoryAddress;
+import jdk.incubator.foreign.MemorySegment;
+import org.testng.annotations.Test;
+
+/*
+ * @test
+ * @library /test/lib
+ * @modules jdk.incubator.jextract
+ * @build JextractToolRunner
+ * @bug 8260717
+ * @summary jextract crashes with 'Crossing storage unit boundaries' for libcoap's block.h
+ * @run testng/othervm -Dforeign.restricted=permit Test8260717
+ */
+public class Test8260717 extends JextractToolRunner {
+    @Test
+    public void test() {
+        Path outputPath = getOutputFilePath("output");
+        Path headerFile = getInputFilePath("test8260717.h");
+        run("-d", outputPath.toString(), headerFile.toString()).checkSuccess();
+        try(Loader loader = classLoader(outputPath)) {
+            Class<?> FooClass = loader.loadClass("test8260717_h$foo_t");
+            checkMethod(FooClass, "s$get", short.class, MemorySegment.class);
+            checkMethod(FooClass, "s$get", short.class, MemorySegment.class, long.class);
+            checkMethod(FooClass, "s$set", void.class, MemorySegment.class, short.class);
+            checkMethod(FooClass, "s$set", void.class, MemorySegment.class, long.class, short.class);
+
+            checkMethod(FooClass, "ptr$get", MemoryAddress.class, MemorySegment.class);
+            checkMethod(FooClass, "ptr$get", MemoryAddress.class, MemorySegment.class, long.class);
+            checkMethod(FooClass, "ptr$set", void.class, MemorySegment.class, MemoryAddress.class);
+            checkMethod(FooClass, "ptr$set", void.class, MemorySegment.class, long.class, MemoryAddress.class);
+
+        } finally {
+            deleteDir(outputPath);
+        }
+    }
+}

--- a/test/jdk/tools/jextract/Test8260929.java
+++ b/test/jdk/tools/jextract/Test8260929.java
@@ -32,7 +32,7 @@ import static org.testng.Assert.assertNotNull;
  * @modules jdk.incubator.jextract
  * @build JextractToolRunner
  * @bug 8260929
- * @summary jextract crashes with libdnet's rabdef.h 
+ * @summary jextract crashes with libdnet's rabdef.h
  * @run testng/othervm -Dforeign.restricted=permit Test8260929
  */
 public class Test8260929 extends JextractToolRunner {
@@ -50,7 +50,7 @@ public class Test8260929 extends JextractToolRunner {
             checkMethod(rab2Class, "y$get", int.class, MemorySegment.class, long.class);
             checkMethod(rab2Class, "y$set", void.class, MemorySegment.class, int.class);
             checkMethod(rab2Class, "y$set", void.class, MemorySegment.class, long.class, int.class);
-            
+
             checkMethod(rab2Class, "x$get", short.class, MemorySegment.class);
             checkMethod(rab2Class, "x$get", short.class, MemorySegment.class, long.class);
             checkMethod(rab2Class, "x$set", void.class, MemorySegment.class, short.class);

--- a/test/jdk/tools/jextract/Test8260929.java
+++ b/test/jdk/tools/jextract/Test8260929.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.nio.file.Path;
+import org.testng.annotations.Test;
+import jdk.incubator.foreign.MemorySegment;
+import static org.testng.Assert.assertNotNull;
+
+/*
+ * @test
+ * @library /test/lib
+ * @modules jdk.incubator.jextract
+ * @build JextractToolRunner
+ * @bug 8260929
+ * @summary jextract crashes with libdnet's rabdef.h 
+ * @run testng/othervm -Dforeign.restricted=permit Test8260929
+ */
+public class Test8260929 extends JextractToolRunner {
+    @Test
+    public void test() {
+        Path outputPath = getOutputFilePath("output");
+        Path headerFile = getInputFilePath("test8260929.h");
+        run("-d", outputPath.toString(), headerFile.toString()).checkSuccess();
+        try(Loader loader = classLoader(outputPath)) {
+            assertNotNull(loader.loadClass("test8260929_h$rab"));
+            Class<?> rab2Class = loader.loadClass("test8260929_h$rab2");
+            assertNotNull(rab2Class);
+
+            checkMethod(rab2Class, "y$get", int.class, MemorySegment.class);
+            checkMethod(rab2Class, "y$get", int.class, MemorySegment.class, long.class);
+            checkMethod(rab2Class, "y$set", void.class, MemorySegment.class, int.class);
+            checkMethod(rab2Class, "y$set", void.class, MemorySegment.class, long.class, int.class);
+            
+            checkMethod(rab2Class, "x$get", short.class, MemorySegment.class);
+            checkMethod(rab2Class, "x$get", short.class, MemorySegment.class, long.class);
+            checkMethod(rab2Class, "x$set", void.class, MemorySegment.class, short.class);
+            checkMethod(rab2Class, "x$set", void.class, MemorySegment.class, long.class, short.class);
+        } finally {
+            deleteDir(outputPath);
+        }
+    }
+}

--- a/test/jdk/tools/jextract/test8260717.h
+++ b/test/jdk/tools/jextract/test8260717.h
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+typedef struct {
+  short s;
+  int i1:1;
+  int i2:1;
+  void* ptr;
+} foo_t;

--- a/test/jdk/tools/jextract/test8260929.h
+++ b/test/jdk/tools/jextract/test8260929.h
@@ -30,7 +30,7 @@ struct {
 
 struct {
    int y;
-   short x; 
+   short x;
    int r1 : 23;
    int r2 : 5;
-} rab2; 
+} rab2;

--- a/test/jdk/tools/jextract/test8260929.h
+++ b/test/jdk/tools/jextract/test8260929.h
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+struct {
+     unsigned : 6;
+     unsigned r1 : 8;
+     unsigned r2 : 1;
+     unsigned r3 : 1;
+} rab;
+
+struct {
+   int y;
+   short x; 
+   int r1 : 23;
+   int r2 : 5;
+} rab2; 


### PR DESCRIPTION
8260929: jextract crashes with libdnet's rabdef.h

bitfield handling overhaul

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Change must be properly reviewed

### Error
&nbsp;⚠️ The commit message contains trailing whitespace on line 2

### Issues
 * [JDK-8260717](https://bugs.openjdk.java.net/browse/JDK-8260717): jextract crashes with 'Crossing storage unit boundaries' for libcoap's block.h
 * [JDK-8260929](https://bugs.openjdk.java.net/browse/JDK-8260929): jextract crashes with libdnet's rabdef.h 


### Download
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/444/head:pull/444`
`$ git checkout pull/444`
