### PR TITLE
8261337: jextract error message when directory is passed as header file argument

### DIFF
--- a/src/jdk.incubator.jextract/share/classes/jdk/incubator/jextract/JextractTool.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/incubator/jextract/JextractTool.java
@@ -235,6 +235,10 @@ public final class JextractTool {
             err.println(format("cannot.read.header.file", header));
             return INPUT_ERROR;
         }
+        if (!(Files.isRegularFile(header))) {
+            err.println(format("not.a.file", header));
+            return INPUT_ERROR;
+        }
 
         List<JavaFileObject> files = null;
         try {

--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/clang/ErrorCode.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/clang/ErrorCode.java
@@ -39,7 +39,7 @@ import static jdk.internal.clang.libclang.Index_h.CXError_Success;
 
 public enum ErrorCode {
     Success(CXError_Success()),
-    Failue(CXError_Failure()),
+    Failure(CXError_Failure()),
     Crashed(CXError_Crashed()),
     InvalidArguments(CXError_InvalidArguments()),
     ASTReadError(CXError_ASTReadError());

--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/resources/Messages.properties
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/resources/Messages.properties
@@ -23,6 +23,7 @@
 
 # error message
 cannot.read.header.file=cannot read header file: {0}
+not.a.file=not a file: {0}
 l.option.value.invalid=option value for -l option should be a name or an absolute path
 
 # help messages for options

--- a/test/jdk/tools/jextract/JextractToolProviderTest.java
+++ b/test/jdk/tools/jextract/JextractToolProviderTest.java
@@ -68,6 +68,13 @@ public class JextractToolProviderTest extends JextractToolRunner {
             .checkContainsOutput("file not found");
     }
 
+    @Test
+    public void testDirectoryAsHeader() {
+        run(getInputFilePath("directory.h").toString())
+            .checkFailure(INPUT_ERROR)
+            .checkContainsOutput("not a file");
+    }
+
     // error for header with parser errors
     @Test
     public void testHeaderWithDeclarationErrors() {

--- a/test/jdk/tools/jextract/directory.h/DUMMY.TXT
+++ b/test/jdk/tools/jextract/directory.h/DUMMY.TXT
@@ -1,0 +1,1 @@
+dummy file for this directory


### PR DESCRIPTION
directory-as-header is detected upfront before parsing and proper error message is issued.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [JDK-8261337](https://bugs.openjdk.java.net/browse/JDK-8261337): jextract error message when directory is passed as header file argument


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.java.net/census#mcimadamore) (@mcimadamore - Committer)


### Download
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/448/head:pull/448`
`$ git checkout pull/448`
