### PR TITLE
8261879: jextract javac compilation errors should not result in OUTPUT_ERROR exit code

### DIFF
--- a/src/jdk.incubator.jextract/share/classes/jdk/incubator/jextract/JextractTool.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/incubator/jextract/JextractTool.java
@@ -26,7 +26,6 @@
 package jdk.incubator.jextract;
 
 import jdk.internal.jextract.impl.ClangException;
-import jdk.internal.jextract.impl.CompilationFailedException;
 import jdk.internal.jextract.impl.Filter;
 import jdk.internal.jextract.impl.OutputFactory;
 import jdk.internal.jextract.impl.Parser;
@@ -274,18 +273,18 @@ public final class JextractTool {
         try {
             Path output = Path.of(options.outputDir);
             write(output, !options.source, files);
-        } catch (CompilationFailedException cfe) {
-            err.println(cfe.getMessage());
-            if (JextractTool.DEBUG) {
-                cfe.printStackTrace(err);
-            }
-            return RUNTIME_ERROR;
         } catch (UncheckedIOException uioe) {
             err.println(uioe.getMessage());
             if (JextractTool.DEBUG) {
                 uioe.printStackTrace(err);
             }
             return OUTPUT_ERROR;
+        } catch (RuntimeException re) {
+            err.println(re.getMessage());
+            if (JextractTool.DEBUG) {
+                re.printStackTrace(err);
+            }
+            return RUNTIME_ERROR;
         }
 
         return SUCCESS;

--- a/src/jdk.incubator.jextract/share/classes/jdk/incubator/jextract/JextractTool.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/incubator/jextract/JextractTool.java
@@ -26,6 +26,7 @@
 package jdk.incubator.jextract;
 
 import jdk.internal.jextract.impl.ClangException;
+import jdk.internal.jextract.impl.CompilationFailedException;
 import jdk.internal.jextract.impl.Filter;
 import jdk.internal.jextract.impl.OutputFactory;
 import jdk.internal.jextract.impl.Parser;
@@ -273,10 +274,16 @@ public final class JextractTool {
         try {
             Path output = Path.of(options.outputDir);
             write(output, !options.source, files);
-        } catch (RuntimeException re) {
-            err.println(re.getMessage());
+        } catch (CompilationFailedException cfe) {
+            err.println(cfe.getMessage());
             if (JextractTool.DEBUG) {
-                re.printStackTrace(err);
+                cfe.printStackTrace(err);
+            }
+            return RUNTIME_ERROR;
+        } catch (UncheckedIOException uioe) {
+            err.println(uioe.getMessage());
+            if (JextractTool.DEBUG) {
+                uioe.printStackTrace(err);
             }
             return OUTPUT_ERROR;
         }

--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/CompilationFailedException.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/CompilationFailedException.java
@@ -1,0 +1,38 @@
+/*
+ *  Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ *  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ *  This code is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License version 2 only, as
+ *  published by the Free Software Foundation.  Oracle designates this
+ *  particular file as subject to the "Classpath" exception as provided
+ *  by Oracle in the LICENSE file that accompanied this code.
+ *
+ *  This code is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ *  version 2 for more details (a copy is included in the LICENSE file that
+ *  accompanied this code).
+ *
+ *  You should have received a copy of the GNU General Public License version
+ *  2 along with this work; if not, write to the Free Software Foundation,
+ *  Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ *   Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ *  or visit www.oracle.com if you need additional information or have any
+ *  questions.
+ *
+ */
+package jdk.internal.jextract.impl;
+
+public class CompilationFailedException extends RuntimeException {
+    private static final long serialVersionUID = 1L;
+
+    public CompilationFailedException(String msg) {
+        super(msg);
+    }
+
+    public CompilationFailedException(String msg, Throwable cause) {
+        super(msg, cause);
+    }
+}

--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/InMemoryJavaCompiler.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/InMemoryJavaCompiler.java
@@ -50,7 +50,7 @@ final class InMemoryJavaCompiler {
         Writer writer = new StringWriter();
         Boolean exitCode = compiler.getTask(writer, fileManager, null, Arrays.asList(options), null, files).call();
         if (!exitCode) {
-            throw new RuntimeException("In memory compilation failed: " + writer.toString());
+            throw new CompilationFailedException("In memory compilation failed: " + writer.toString());
         }
         return fileManager.getCompiledFiles();
     }


### PR DESCRIPTION
correct exit code is used for javac compilation errors.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [JDK-8261879](https://bugs.openjdk.java.net/browse/JDK-8261879): jextract javac compilation errors should not result in OUTPUT_ERROR exit code


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.java.net/census#mcimadamore) (@mcimadamore - Committer)


### Download
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/452/head:pull/452`
`$ git checkout pull/452`
