### PR TITLE
8261893: jextract generates class names that are restricted type names

### DIFF
--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/Utils.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/Utils.java
@@ -101,8 +101,16 @@ class Utils {
             // C identifiers. But we may have a java keyword used as a C identifier.
             assert SourceVersion.isIdentifier(name);
 
-            return SourceVersion.isKeyword(name) ? (name + "_") : name;
+            return SourceVersion.isKeyword(name) || isRestrictedTypeName(name) ? (name + "_") : name;
         }
+    }
+
+    private static boolean isRestrictedTypeName(String name) {
+        return switch (name) {
+            case "var", "yield", "record",
+                "sealed", "permits" -> true;
+            default -> false;
+        };
     }
 
     static void validSimpleIdentifier(String name) {

--- a/test/jdk/tools/jextract/Test8261893.java
+++ b/test/jdk/tools/jextract/Test8261893.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.nio.file.Path;
+import org.testng.annotations.Test;
+import static org.testng.Assert.assertNotNull;
+
+/*
+ * @test
+ * @modules jdk.incubator.jextract
+ * @library /test/lib
+ * @build JextractToolRunner
+ * @bug 8261893
+ * @summary jextract generates class names that are restricted type names
+ * @run testng/othervm -Dforeign.restricted=permit -Duser.language=en --add-modules jdk.incubator.jextract Test8240181
+ */
+public class Test8261893 extends JextractToolRunner {
+    @Test
+    public void test() {
+        Path test8261893Output = getOutputFilePath("test8261893gen");
+        Path test8261893H = getInputFilePath("test8261893.h");
+        run("-d", test8261893Output.toString(), test8261893H.toString()).checkSuccess();
+        try(Loader loader = classLoader(test8261893Output)) {
+            assertNotNull(loader.loadClass("test8261893_h$permits_");
+            assertNotNull(loader.loadClass("test8261893_h$record_");
+            assertNotNull(loader.loadClass("test8261893_h$sealed_");
+            assertNotNull(loader.loadClass("test8261893_h$var_");
+            assertNotNull(loader.loadClass("test8261893_h$yield_");
+        } finally {
+            deleteDir(test8261893Output);
+        }
+    }
+}

--- a/test/jdk/tools/jextract/test8261893.h
+++ b/test/jdk/tools/jextract/test8261893.h
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+typedef struct {
+  int x, y;
+} permits;
+
+struct record {
+  int foo;
+};
+
+union sealed {
+  float i;
+  int j;
+};
+
+struct var {
+  int x;
+};
+
+typedef struct {
+  int bar;
+} yield;
+


### PR DESCRIPTION
a table of restricted type names is checked.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [JDK-8261893](https://bugs.openjdk.java.net/browse/JDK-8261893): jextract generates class names that are restricted type names


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.java.net/census#mcimadamore) (@mcimadamore - Committer)


### Download
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/453/head:pull/453`
`$ git checkout pull/453`
