### PR TITLE
Add a benchmark for strlen using Foreign Linker API

### DIFF
--- a/test/micro/org/openjdk/bench/jdk/incubator/foreign/StrLenTest.java
+++ b/test/micro/org/openjdk/bench/jdk/incubator/foreign/StrLenTest.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package org.openjdk.bench.jdk.incubator.foreign;
+
+import jdk.incubator.foreign.CLinker;
+import jdk.incubator.foreign.FunctionDescriptor;
+import jdk.incubator.foreign.LibraryLookup;
+import jdk.incubator.foreign.MemoryAccess;
+import jdk.incubator.foreign.MemoryAddress;
+import jdk.incubator.foreign.MemorySegment;
+import jdk.incubator.foreign.NativeScope;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodType;
+import java.util.concurrent.TimeUnit;
+
+import static jdk.incubator.foreign.CLinker.*;
+
+@BenchmarkMode(Mode.AverageTime)
+@Warmup(iterations = 5, time = 500, timeUnit = TimeUnit.MILLISECONDS)
+@Measurement(iterations = 10, time = 500, timeUnit = TimeUnit.MILLISECONDS)
+@State(org.openjdk.jmh.annotations.Scope.Thread)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Fork(value = 3, jvmArgsAppend = { "--add-modules=jdk.incubator.foreign", "-Dforeign.restricted=permit" })
+public class StrLenTest {
+
+    NativeScope scope = NativeScope.unboundedScope();
+
+    @Param({"5", "20", "100"})
+    public int size;
+    public String str;
+
+    static {
+        System.loadLibrary("StrLen");
+    }
+
+    static final MethodHandle STRLEN;
+
+    static {
+        LibraryLookup lookup = LibraryLookup.ofDefault();
+        CLinker abi = CLinker.getInstance();
+        STRLEN = abi.downcallHandle(lookup.lookup("strlen").get(),
+                MethodType.methodType(int.class, MemoryAddress.class),
+                FunctionDescriptor.of(C_INT, C_POINTER));
+    }
+
+    @Setup
+    public void setup() {
+        str = makeString(size);
+    }
+
+    @TearDown
+    public void tearDown() {
+        scope.close();
+    }
+
+    @Benchmark
+    public int jni_strlen() throws Throwable {
+        return strlen(str);
+    }
+
+    @Benchmark
+    public int panama_strlen() throws Throwable {
+        try (MemorySegment segment = CLinker.toCString(str)) {
+            return (int)STRLEN.invokeExact(segment.address());
+        }
+    }
+
+    @Benchmark
+    public int panama_strlen_scope() throws Throwable {
+        return (int)STRLEN.invokeExact(CLinker.toCString(str, scope).address());
+    }
+
+    @Benchmark
+    public int panama_strlen_unsafe() throws Throwable {
+        MemoryAddress address = makeStringUnsafe(str);
+        int res = (int) STRLEN.invokeExact(address);
+        CLinker.freeMemoryRestricted(address);
+        return res;
+    }
+
+    static MemoryAddress makeStringUnsafe(String s) {
+        byte[] bytes = s.getBytes();
+        int len = bytes.length;
+        MemoryAddress address = CLinker.allocateMemoryRestricted(len + 1);
+        MemorySegment str = address.asSegmentRestricted(len + 1);
+        str.copyFrom(MemorySegment.ofArray(bytes));
+        MemoryAccess.setByteAtOffset(str, len, (byte)0);
+        return address;
+    }
+
+    static native int strlen(String str);
+
+    static String makeString(int size) {
+        String lorem = """
+                Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et
+                 dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip
+                 ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu
+                 fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt
+                 mollit anim id est laborum.
+                """;
+        return lorem.substring(0, size);
+    }
+}

--- a/test/micro/org/openjdk/bench/jdk/incubator/foreign/libStrLen.c
+++ b/test/micro/org/openjdk/bench/jdk/incubator/foreign/libStrLen.c
@@ -29,7 +29,7 @@
 
 JNIEXPORT jint JNICALL Java_org_openjdk_bench_jdk_incubator_foreign_StrLenTest_strlen(JNIEnv *const env, const jclass cls, const jstring text) {
     const char *str = (*env)->GetStringUTFChars(env, text, NULL);
-	int len = strlen(str);
-	(*env)->ReleaseStringUTFChars(env, text, str);
-	return len;
+    int len = strlen(str);
+    (*env)->ReleaseStringUTFChars(env, text, str);
+    return len;
 }

--- a/test/micro/org/openjdk/bench/jdk/incubator/foreign/libStrLen.c
+++ b/test/micro/org/openjdk/bench/jdk/incubator/foreign/libStrLen.c
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+#include <jni.h>
+#include <stdlib.h>
+#include <string.h>
+
+JNIEXPORT jint JNICALL Java_org_openjdk_bench_jdk_incubator_foreign_StrLenTest_strlen(JNIEnv *const env, const jclass cls, const jstring text) {
+    const char *str = (*env)->GetStringUTFChars(env, text, NULL);
+	int len = strlen(str);
+	(*env)->ReleaseStringUTFChars(env, text, str);
+	return len;
+}

--- a/test/micro/org/openjdk/bench/jdk/incubator/foreign/libStrLen.c
+++ b/test/micro/org/openjdk/bench/jdk/incubator/foreign/libStrLen.c
@@ -29,7 +29,7 @@
 
 JNIEXPORT jint JNICALL Java_org_openjdk_bench_jdk_incubator_foreign_StrLenTest_strlen(JNIEnv *const env, const jclass cls, const jstring text) {
     const char *str = (*env)->GetStringUTFChars(env, text, NULL);
-    int len = strlen(str);
+    int len = (int)strlen(str);
     (*env)->ReleaseStringUTFChars(env, text, str);
     return len;
 }


### PR DESCRIPTION
I've been spending some time looking into this issue:

https://bugs.openjdk.java.net/browse/JDK-8261828

And, to understand better the problem, I put together an hopefully comprehensive benchmark of the strlen function; it turns out that the strlen call itself is fast, and it's the conversion from Java to native string where the benchmark spends most of its time.

While playing with the benchmark, I came up with alternative ways to do this conversion which greatly speed up the benchmark results, even surpassing (at least on my machine) what's possible with JNI. Jorn and I think that, for future references, it would be a good idea to include this benchmark in our suite.

For the curious, there are many factors which make the default `CLinker::toCString` go slower than expected: 

* allocating a fresh segment on each iteration is expensive, because it takes two native call (malloc, memset), plus a bunch of CAS to reserve memory in the Java runtime
* freeing the segment on each iteration is equally expensive - one native call (free), plus again, some CAS to unreserve memory 
* bulk copy is fast, but again requires a native call
* all in all, we need 4 native calls per iteration (malloc, memset, copy, free) each adding cost when it comes to state transitions

In other words, the advantage of JNI here is that (i) the level of safety provided by JNI is lower (e.g. the runtime doesn't need to track e.g. allocated memory, which segments do); also (ii) when we call the JNI-ified strlen function, the malloc, free, copy happen when we're in native code already - which means less state transitions are required.

Note that we can completely eliminate (i) basically by creating restricted segments using CLinker::allocateMemoryRestricted (which does a plain malloc). We can also eliminate (ii) by creating *trivial* function descriptors for the calls to malloc/free/strlen, thereby removing cost associated with state transitions there. Both routes are tested in the benchmark (note that they both requires some willingness to embrace restricted methods). I have put together a variant which shows how NativeScope can be used to speed allocation up (which works really well for small strings, and is _not_ restricted).

What are the lessons learned for plain `CLinker::toCString` ? 

* While the logic is generally fast, all state transitions and unsafe calls are killing performance in such a tight scenario; perhaps worth considering intrinsifying Unsafe::allocateMemory/copyMemory/setMemory/freeMemory.
* The way to go, performance-wise is not to rely on the default malloc-based allocation. This is where Panama has a big edge over JNI, whose allocation logic is _fixed_. Proposals such as the one described in [1] will make passing custom allocators to `CLinker::toCString` easier, so that clients can decide which allocation strategy best fits their use case.

[1] - https://inside.java/2021/01/25/memory-access-pulling-all-the-threads/

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [Jorn Vernee](https://openjdk.java.net/census#jvernee) (@JornVernee - Committer) ⚠️ Review applies to 6c4a49816e618b62590b35b14187f806474d3052


### Download
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/454/head:pull/454`
`$ git checkout pull/454`
