### PR TITLE
8261950: jextract should warn and proceed on unsupported types rather than crashing

### DIFF
--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/TypeTranslator.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/TypeTranslator.java
@@ -78,7 +78,7 @@ public class TypeTranslator implements Type.Visitor<Class<?>, Void> {
             case 64:
             case 128: return !fp ? long.class : double.class;
             default:
-                throw new UnsupportedOperationException();
+                throw new UnsupportedOperationException("size: " + (int)layout.bitSize());
         }
     }
 
@@ -103,14 +103,14 @@ public class TypeTranslator implements Type.Visitor<Class<?>, Void> {
             case ENUM:
                 return layoutToClass(false, t.tree().layout().orElseThrow(UnsupportedOperationException::new));
             default:
-                throw new UnsupportedOperationException();
+                throw new UnsupportedOperationException("declaration kind: " + t.tree().kind());
         }
     }
 
     @Override
     public Class<?> visitArray(Type.Array t, Void aVoid) {
         if (t.kind() == Type.Array.Kind.VECTOR) {
-            throw new UnsupportedOperationException();
+            throw new UnsupportedOperationException("vector");
         } else {
             return MemorySegment.class;
         }
@@ -118,7 +118,7 @@ public class TypeTranslator implements Type.Visitor<Class<?>, Void> {
 
     @Override
     public Class<?> visitType(Type t, Void aVoid) {
-        throw new UnsupportedOperationException();
+        throw new UnsupportedOperationException(t.getClass().toString());
     }
 
     Class<?> getJavaType(Type t) {

--- a/test/jdk/tools/jextract/Test8261893.java
+++ b/test/jdk/tools/jextract/Test8261893.java
@@ -32,7 +32,7 @@ import static org.testng.Assert.assertNotNull;
  * @build JextractToolRunner
  * @bug 8261893
  * @summary jextract generates class names that are restricted type names
- * @run testng/othervm -Dforeign.restricted=permit -Duser.language=en --add-modules jdk.incubator.jextract Test8240181
+ * @run testng/othervm -Dforeign.restricted=permit -Duser.language=en --add-modules jdk.incubator.jextract Test8261893
  */
 public class Test8261893 extends JextractToolRunner {
     @Test
@@ -41,11 +41,11 @@ public class Test8261893 extends JextractToolRunner {
         Path test8261893H = getInputFilePath("test8261893.h");
         run("-d", test8261893Output.toString(), test8261893H.toString()).checkSuccess();
         try(Loader loader = classLoader(test8261893Output)) {
-            assertNotNull(loader.loadClass("test8261893_h$permits_");
-            assertNotNull(loader.loadClass("test8261893_h$record_");
-            assertNotNull(loader.loadClass("test8261893_h$sealed_");
-            assertNotNull(loader.loadClass("test8261893_h$var_");
-            assertNotNull(loader.loadClass("test8261893_h$yield_");
+            assertNotNull(loader.loadClass("test8261893_h$permits_"));
+            assertNotNull(loader.loadClass("test8261893_h$record_"));
+            assertNotNull(loader.loadClass("test8261893_h$sealed_"));
+            assertNotNull(loader.loadClass("test8261893_h$var_"));
+            assertNotNull(loader.loadClass("test8261893_h$yield_"));
         } finally {
             deleteDir(test8261893Output);
         }


### PR DESCRIPTION
Defensive code to handle unsupported types. piggybacking to fix issues with the test Test8261893.java

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [JDK-8261950](https://bugs.openjdk.java.net/browse/JDK-8261950): jextract should warn and proceed on unsupported types rather than crashing


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.java.net/census#mcimadamore) (@mcimadamore - Committer)


### Download
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/455/head:pull/455`
`$ git checkout pull/455`
