### PR TITLE
8262118: Specialize upcalls

### DIFF
--- a/src/hotspot/cpu/aarch64/foreign_globals_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/foreign_globals_aarch64.cpp
@@ -84,3 +84,7 @@ const BufferLayout ForeignGlobals::parse_buffer_layout_impl(jobject jlayout) con
 
   return layout;
 }
+
+const CallRegs ForeignGlobals::parse_call_regs_impl(jobject jconv) const {
+  ShouldNotCallThis();
+}

--- a/src/hotspot/cpu/aarch64/foreign_globals_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/foreign_globals_aarch64.cpp
@@ -87,4 +87,5 @@ const BufferLayout ForeignGlobals::parse_buffer_layout_impl(jobject jlayout) con
 
 const CallRegs ForeignGlobals::parse_call_regs_impl(jobject jconv) const {
   ShouldNotCallThis();
+  return {};
 }

--- a/src/hotspot/cpu/aarch64/frame_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/frame_aarch64.cpp
@@ -364,10 +364,12 @@ frame frame::sender_for_entry_frame(RegisterMap* map) const {
 
 JavaFrameAnchor* EntryBlob::jfa_for_frame(const frame& frame) const {
   ShouldNotCallThis();
+  return nullptr;
 }
 
 frame frame::sender_for_panama_entry_frame(RegisterMap* map) const {
   ShouldNotCallThis();
+  return {};
 }
 
 //------------------------------------------------------------------------------

--- a/src/hotspot/cpu/aarch64/frame_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/frame_aarch64.cpp
@@ -362,6 +362,14 @@ frame frame::sender_for_entry_frame(RegisterMap* map) const {
   return fr;
 }
 
+JavaFrameAnchor* EntryBlob::jfa_for_frame(const frame& frame) const {
+  ShouldNotCallThis();
+}
+
+frame frame::sender_for_panama_entry_frame(RegisterMap* map) const {
+  ShouldNotCallThis();
+}
+
 //------------------------------------------------------------------------------
 // frame::verify_deopt_original_pc
 //

--- a/src/hotspot/cpu/aarch64/sharedRuntime_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/sharedRuntime_aarch64.cpp
@@ -857,7 +857,7 @@ int SharedRuntime::c_calling_convention(const BasicType *sig_bt,
 // 64 bits items (Aarch64 abi) even though java would only store
 // 32bits for a parameter. On 32bit it will simply be 32 bits
 // So this routine will do 32->32 on 32bit and 32->64 on 64bit
-static void move32_64(MacroAssembler* masm, VMRegPair src, VMRegPair dst) {
+void SharedRuntime::move32_64(MacroAssembler* masm, VMRegPair src, VMRegPair dst) {
   if (src.first()->is_stack()) {
     if (dst.first()->is_stack()) {
       // stack to stack
@@ -958,7 +958,7 @@ static void object_move(MacroAssembler* masm,
 }
 
 // A float arg may have to do float reg int reg conversion
-static void float_move(MacroAssembler* masm, VMRegPair src, VMRegPair dst) {
+void SharedRuntime::float_move(MacroAssembler* masm, VMRegPair src, VMRegPair dst) {
   assert(src.first()->is_stack() && dst.first()->is_stack() ||
          src.first()->is_reg() && dst.first()->is_reg(), "Unexpected error");
   if (src.first()->is_stack()) {
@@ -977,7 +977,7 @@ static void float_move(MacroAssembler* masm, VMRegPair src, VMRegPair dst) {
 }
 
 // A long move
-static void long_move(MacroAssembler* masm, VMRegPair src, VMRegPair dst) {
+void SharedRuntime::long_move(MacroAssembler* masm, VMRegPair src, VMRegPair dst) {
   if (src.first()->is_stack()) {
     if (dst.first()->is_stack()) {
       // stack to stack
@@ -1001,7 +1001,7 @@ static void long_move(MacroAssembler* masm, VMRegPair src, VMRegPair dst) {
 
 
 // A double move
-static void double_move(MacroAssembler* masm, VMRegPair src, VMRegPair dst) {
+void SharedRuntime::double_move(MacroAssembler* masm, VMRegPair src, VMRegPair dst) {
   assert(src.first()->is_stack() && dst.first()->is_stack() ||
          src.first()->is_reg() && dst.first()->is_reg(), "Unexpected error");
   if (src.first()->is_stack()) {

--- a/src/hotspot/cpu/aarch64/universalUpcallHandler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/universalUpcallHandler_aarch64.cpp
@@ -100,6 +100,11 @@ address ProgrammableUpcallHandler::generate_upcall_stub(jobject rec, jobject jab
   return blob->code_begin();
 }
 
+address ProgrammableUpcallHandler::generate_optimized_upcall_stub(jobject mh, Method* entry, jobject jabi, jobject jconv) {
+  ShouldNotCallThis();
+  return nullptr;
+}
+
 bool ProgrammableUpcallHandler::supports_optimized_upcalls() {
   return false;
 }

--- a/src/hotspot/cpu/aarch64/universalUpcallHandler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/universalUpcallHandler_aarch64.cpp
@@ -99,3 +99,7 @@ address ProgrammableUpcallHandler::generate_upcall_stub(jobject rec, jobject jab
 
   return blob->code_begin();
 }
+
+bool ProgrammableUpcallHandler::supports_optimized_upcalls() {
+  return false;
+}

--- a/src/hotspot/cpu/x86/foreign_globals_x86.cpp
+++ b/src/hotspot/cpu/x86/foreign_globals_x86.cpp
@@ -89,18 +89,29 @@ const BufferLayout ForeignGlobals::parse_buffer_layout_impl(jobject jlayout) con
 }
 
 const CallRegs ForeignGlobals::parse_call_regs_impl(jobject jconv) const {
-  // jconv is just a VMStorage[]
-  objArrayOop conv_oop = cast<objArrayOop>(JNIHandles::resolve_non_null(jconv));
+  oop conv_oop = JNIHandles::resolve_non_null(jconv);
+  objArrayOop arg_regs_oop = cast<objArrayOop>(conv_oop->obj_field(CallConvOffsets.arg_regs_offset));
+  objArrayOop ret_regs_oop = cast<objArrayOop>(conv_oop->obj_field(CallConvOffsets.ret_regs_offset));
 
   CallRegs result;
-  result._length = conv_oop->length();
-  result._regs = NEW_RESOURCE_ARRAY(VMReg, result._length);
+  result._args_length = arg_regs_oop->length();
+  result._arg_regs = NEW_RESOURCE_ARRAY(VMReg, result._args_length);
 
-  for (int i = 0; i < result._length; i++) {
-    oop storage = conv_oop->obj_at(i);
+  result._rets_length = ret_regs_oop->length();
+  result._ret_regs = NEW_RESOURCE_ARRAY(VMReg, result._rets_length);
+
+  for (int i = 0; i < result._args_length; i++) {
+    oop storage = arg_regs_oop->obj_at(i);
     jint index = storage->int_field(VMS.index_offset);
     jint type = storage->int_field(VMS.type_offset);
-    result._regs[i] = VMRegImpl::vmStorageToVMReg(type, index);
+    result._arg_regs[i] = VMRegImpl::vmStorageToVMReg(type, index);
+  }
+
+  for (int i = 0; i < result._rets_length; i++) {
+    oop storage = ret_regs_oop->obj_at(i);
+    jint index = storage->int_field(VMS.index_offset);
+    jint type = storage->int_field(VMS.type_offset);
+    result._ret_regs[i] = VMRegImpl::vmStorageToVMReg(type, index);
   }
 
   return result;

--- a/src/hotspot/cpu/x86/foreign_globals_x86.cpp
+++ b/src/hotspot/cpu/x86/foreign_globals_x86.cpp
@@ -87,3 +87,21 @@ const BufferLayout ForeignGlobals::parse_buffer_layout_impl(jobject jlayout) con
 
   return layout;
 }
+
+const CallRegs ForeignGlobals::parse_call_regs_impl(jobject jconv) const {
+  // jconv is just a VMStorage[]
+  objArrayOop conv_oop = cast<objArrayOop>(JNIHandles::resolve_non_null(jconv));
+
+  CallRegs result;
+  result._length = conv_oop->length();
+  result._regs = NEW_RESOURCE_ARRAY(VMReg, result._length);
+
+  for (int i = 0; i < result._length; i++) {
+    oop storage = conv_oop->obj_at(i);
+    jint index = storage->int_field(VMS.index_offset);
+    jint type = storage->int_field(VMS.type_offset);
+    result._regs[i] = VMRegImpl::vmStorageToVMReg(type, index);
+  }
+
+  return result;
+}

--- a/src/hotspot/cpu/x86/frame_x86.cpp
+++ b/src/hotspot/cpu/x86/frame_x86.cpp
@@ -101,7 +101,7 @@ bool frame::safe_for_sender(JavaThread *thread) {
     if (is_entry_frame()) {
       // an entry frame must have a valid fp.
       return fp_safe && is_entry_frame_valid(thread);
-    } else if (is_upcall_frame()) {
+    } else if (is_panama_entry_frame()) {
       return fp_safe; // && is_entry_frame_valid(thread);
     }
 
@@ -361,7 +361,7 @@ JavaFrameAnchor* EntryBlob::jfa_for_frame(const frame& frame) const {
   return reinterpret_cast<JavaFrameAnchor*>(reinterpret_cast<char*>(frame.unextended_sp()) + in_bytes(jfa_sp_offset()));
 }
 
-frame frame::sender_for_upcall_frame(RegisterMap* map) const {
+frame frame::sender_for_panama_entry_frame(RegisterMap* map) const {
   assert(map != NULL, "map must be set");
   EntryBlob* blob = _cb->as_entry_blob();
   // Java frame called from C; skip all C frames and return top C
@@ -515,9 +515,9 @@ frame frame::sender_raw(RegisterMap* map) const {
   // update it accordingly
   map->set_include_argument_oops(false);
 
-  if (is_entry_frame())       return sender_for_entry_frame(map);
-  if (is_upcall_frame())      return sender_for_upcall_frame(map);
-  if (is_interpreted_frame()) return sender_for_interpreter_frame(map);
+  if (is_entry_frame())        return sender_for_entry_frame(map);
+  if (is_panama_entry_frame()) return sender_for_panama_entry_frame(map);
+  if (is_interpreted_frame())  return sender_for_interpreter_frame(map);
   assert(_cb == CodeCache::find_blob(pc()),"Must be the same");
 
   if (_cb != NULL) {

--- a/src/hotspot/cpu/x86/frame_x86.cpp
+++ b/src/hotspot/cpu/x86/frame_x86.cpp
@@ -101,6 +101,8 @@ bool frame::safe_for_sender(JavaThread *thread) {
     if (is_entry_frame()) {
       // an entry frame must have a valid fp.
       return fp_safe && is_entry_frame_valid(thread);
+    } else if (is_upcall_frame()) {
+      return fp_safe; // && is_entry_frame_valid(thread);
     }
 
     intptr_t* sender_sp = NULL;
@@ -198,6 +200,8 @@ bool frame::safe_for_sender(JavaThread *thread) {
       address jcw = (address)sender.entry_frame_call_wrapper();
 
       return thread->is_in_stack_range_excl(jcw, (address)sender.fp());
+    } else if (sender_blob->is_entry_blob()) {
+      return false; // FIXME
     }
 
     CompiledMethod* nm = sender_blob->as_compiled_method_or_null();
@@ -352,6 +356,36 @@ frame frame::sender_for_entry_frame(RegisterMap* map) const {
   return fr;
 }
 
+JavaFrameAnchor* EntryBlob::jfa_for_frame(const frame& frame) const {
+  // need unextended_sp here, since normal sp is wrong for interpreter callees
+  return reinterpret_cast<JavaFrameAnchor*>(reinterpret_cast<char*>(frame.unextended_sp()) + in_bytes(jfa_sp_offset()));
+}
+
+frame frame::sender_for_upcall_frame(RegisterMap* map) const {
+  assert(map != NULL, "map must be set");
+  EntryBlob* blob = _cb->as_entry_blob();
+  // Java frame called from C; skip all C frames and return top C
+  // frame of that chunk as the sender
+  JavaFrameAnchor* jfa = blob->jfa_for_frame(*this);
+  assert(jfa->last_Java_sp() > sp(), "must be above this frame on stack");
+  // Since we are walking the stack now this nested anchor is obviously walkable
+  // even if it wasn't when it was stacked.
+  if (!jfa->walkable()) {
+    // Capture _last_Java_pc (if needed) and mark anchor walkable.
+    jfa->capture_last_Java_pc();
+  }
+  map->clear();
+  assert(map->include_argument_oops(), "should be set by clear");
+  vmassert(jfa->last_Java_pc() != NULL, "not walkable");
+  frame fr(jfa->last_Java_sp(), jfa->last_Java_fp(), jfa->last_Java_pc());
+
+  if (map->update_map() && jfa->saved_rbp_address()) {
+    update_map_with_saved_link(map, jfa->saved_rbp_address());
+  }
+
+  return fr;
+}
+
 //------------------------------------------------------------------------------
 // frame::verify_deopt_original_pc
 //
@@ -482,6 +516,7 @@ frame frame::sender_raw(RegisterMap* map) const {
   map->set_include_argument_oops(false);
 
   if (is_entry_frame())       return sender_for_entry_frame(map);
+  if (is_upcall_frame())      return sender_for_upcall_frame(map);
   if (is_interpreted_frame()) return sender_for_interpreter_frame(map);
   assert(_cb == CodeCache::find_blob(pc()),"Must be the same");
 

--- a/src/hotspot/cpu/x86/frame_x86.cpp
+++ b/src/hotspot/cpu/x86/frame_x86.cpp
@@ -102,7 +102,7 @@ bool frame::safe_for_sender(JavaThread *thread) {
       // an entry frame must have a valid fp.
       return fp_safe && is_entry_frame_valid(thread);
     } else if (is_panama_entry_frame()) {
-      return fp_safe; // && is_entry_frame_valid(thread);
+      return fp_safe;
     }
 
     intptr_t* sender_sp = NULL;
@@ -201,7 +201,7 @@ bool frame::safe_for_sender(JavaThread *thread) {
 
       return thread->is_in_stack_range_excl(jcw, (address)sender.fp());
     } else if (sender_blob->is_entry_blob()) {
-      return false; // FIXME
+      return false;
     }
 
     CompiledMethod* nm = sender_blob->as_compiled_method_or_null();

--- a/src/hotspot/cpu/x86/javaFrameAnchor_x86.hpp
+++ b/src/hotspot/cpu/x86/javaFrameAnchor_x86.hpp
@@ -78,8 +78,6 @@ public:
 
   intptr_t** saved_rbp_address(void) const       { return _saved_rbp_address; }
 
-private:
-
   static ByteSize last_Java_fp_offset()          { return byte_offset_of(JavaFrameAnchor, _last_Java_fp); }
   static ByteSize saved_rbp_address_offset()     { return byte_offset_of(JavaFrameAnchor, _saved_rbp_address); }
 

--- a/src/hotspot/cpu/x86/sharedRuntime_x86_64.cpp
+++ b/src/hotspot/cpu/x86/sharedRuntime_x86_64.cpp
@@ -1394,7 +1394,7 @@ static void restore_args(MacroAssembler *masm, int arg_count, int first_arg, VMR
 
 // Unpack an array argument into a pointer to the body and the length
 // if the array is non-null, otherwise pass 0 for both.
-void SharedRuntime::unpack_array_argument(MacroAssembler* masm, VMRegPair reg, BasicType in_elem_type, VMRegPair body_arg, VMRegPair length_arg) {
+static void unpack_array_argument(MacroAssembler* masm, VMRegPair reg, BasicType in_elem_type, VMRegPair body_arg, VMRegPair length_arg) {
   Register tmp_reg = rax;
   assert(!body_arg.first()->is_Register() || body_arg.first()->as_Register() != tmp_reg,
          "possible collision");
@@ -1419,13 +1419,13 @@ void SharedRuntime::unpack_array_argument(MacroAssembler* masm, VMRegPair reg, B
   // load the length relative to the body.
   __ movl(tmp_reg, Address(tmp_reg, arrayOopDesc::length_offset_in_bytes() -
                            arrayOopDesc::base_offset_in_bytes(in_elem_type)));
-  move32_64(masm, tmp, length_arg);
+  SharedRuntime::move32_64(masm, tmp, length_arg);
   __ jmpb(done);
   __ bind(is_null);
   // Pass zeros
   __ xorptr(tmp_reg, tmp_reg);
   move_ptr(masm, tmp, body_arg);
-  move32_64(masm, tmp, length_arg);
+  SharedRuntime::move32_64(masm, tmp, length_arg);
   __ bind(done);
 
   __ block_comment("} unpack_array_argument");

--- a/src/hotspot/cpu/x86/universalUpcallHandler_x86_64.cpp
+++ b/src/hotspot/cpu/x86/universalUpcallHandler_x86_64.cpp
@@ -31,6 +31,8 @@
 #include "memory/resourceArea.hpp"
 #include "prims/universalUpcallHandler.hpp"
 #include "runtime/sharedRuntime.hpp"
+#include "runtime/signature.hpp"
+#include "utilities/formatBuffer.hpp"
 #include "utilities/globalDefinitions.hpp"
 
 #define __ _masm->

--- a/src/hotspot/cpu/x86/universalUpcallHandler_x86_64.cpp
+++ b/src/hotspot/cpu/x86/universalUpcallHandler_x86_64.cpp
@@ -640,11 +640,14 @@ address ProgrammableUpcallHandler::generate_optimized_upcall_stub(jobject receiv
   // FIXME: mxcsr (see stubGenerator_x86_64.cpp 'generate_call_stub')
 
   __ block_comment("{ get_thread");
+  // FIXME: this crashes the VM on a detached thread
   __ get_thread(r15_thread);
   __ movptr(Address(rsp, thread_offset), r15_thread);
   __ block_comment("} get_thread");
 
   // FIXME: is it needed?
+  // There might be an active handle block if we do a call from JNI -> Panama
+  // apparently the entry frame allocates a new block in case we need to do another native call
 //  JNIHandleBlock* new_handles = JNIHandleBlock::allocate_block(thread);
 //  _handles      = _thread->active_handles();    // save previous handle block & Java frame linkage
 //  _thread->set_active_handles(new_handles);     // install new handle block and reset Java frame linkage
@@ -785,7 +788,9 @@ address ProgrammableUpcallHandler::generate_optimized_upcall_stub(jobject receiv
   __ movptr(Address(r15_thread, Thread::exception_file_offset()), rscratch1);
   __ movl(Address(r15_thread, Thread::exception_line_offset()), (int)  __LINE__);
 
-  // TODO: return value?
+  // FIXME: native code has no idea how to handle these
+  // should just crash here.
+  // later we can add a 'global exception handler' API.
 
   __ jmp(call_return);
   __ block_comment("} exception handler");

--- a/src/hotspot/cpu/x86/universalUpcallHandler_x86_64.cpp
+++ b/src/hotspot/cpu/x86/universalUpcallHandler_x86_64.cpp
@@ -24,8 +24,13 @@
 #include "precompiled.hpp"
 #include "asm/macroAssembler.hpp"
 #include "code/codeBlob.hpp"
+#include "code/vmreg.inline.hpp"
 #include "memory/resourceArea.hpp"
 #include "prims/universalUpcallHandler.hpp"
+#include "runtime/sharedRuntime.hpp"
+#include "code/codeBlob.hpp"
+#include "compiler/disassembler.hpp"
+#include "utilities/globalDefinitions.hpp"
 
 #define __ _masm->
 
@@ -140,4 +145,601 @@ address ProgrammableUpcallHandler::generate_upcall_stub(jobject rec, jobject jab
   BufferBlob* blob = BufferBlob::create("upcall_stub", &buffer);
 
   return blob->code_begin();
+}
+
+struct ArgMove {
+  BasicType bt;
+  VMRegPair from;
+  VMRegPair to;
+};
+
+static GrowableArray<ArgMove>* compute_argument_shuffle(Method* entry, int& frame_size, const CallRegs& conv) {
+  assert(entry->is_static(), "");
+
+  // Fill in the signature array, for the calling-convention call.
+  const int total_out_args = entry->size_of_parameters();
+  assert(total_out_args > 0, "receiver arg ");
+
+  BasicType* out_sig_bt = NEW_RESOURCE_ARRAY(BasicType, total_out_args);
+  VMRegPair* out_regs = NEW_RESOURCE_ARRAY(VMRegPair, total_out_args);
+
+  {
+    int i = 0; // skip receiver
+    SignatureStream ss(entry->signature());
+    for (; !ss.at_return_type(); ss.next()) {
+      out_sig_bt[i++] = ss.type();  // Collect remaining bits of signature
+      if (ss.type() == T_LONG || ss.type() == T_DOUBLE)
+        out_sig_bt[i++] = T_VOID;   // Longs & doubles take 2 Java slots
+    }
+    assert(i == total_out_args, "");
+    BasicType ret_type = ss.type();
+  }
+
+  int out_arg_slots = SharedRuntime::java_calling_convention(out_sig_bt, out_regs, total_out_args);
+
+  const int total_in_args = total_out_args - 1; // skip receiver
+  BasicType* in_sig_bt  = NEW_RESOURCE_ARRAY(BasicType, total_in_args);
+  VMRegPair* in_regs    = NEW_RESOURCE_ARRAY(VMRegPair, total_in_args);
+
+  for (int i = 0; i < total_in_args ; i++ ) {
+    in_sig_bt[i] = out_sig_bt[i+1];
+  }
+
+  // Now figure out where the args must be stored and how much stack space they require.
+  conv.calling_convention(in_sig_bt, in_regs, total_in_args);
+
+  GrowableArray<int> arg_order(2 * total_in_args);
+
+  VMRegPair tmp_vmreg;
+  tmp_vmreg.set2(rbx->as_VMReg());
+
+  // Compute a valid move order, using tmp_vmreg to break any cycles
+  SharedRuntime::compute_move_order(in_sig_bt,
+                                    total_in_args, in_regs,
+                                    total_out_args, out_regs,
+                                    arg_order,
+                                    tmp_vmreg);
+
+  GrowableArray<ArgMove>* arg_order_vmreg = new GrowableArray<ArgMove>(total_in_args); // conservative
+
+#ifdef ASSERT
+  bool reg_destroyed[RegisterImpl::number_of_registers];
+  bool freg_destroyed[XMMRegisterImpl::number_of_registers];
+  for ( int r = 0 ; r < RegisterImpl::number_of_registers ; r++ ) {
+    reg_destroyed[r] = false;
+  }
+  for ( int f = 0 ; f < XMMRegisterImpl::number_of_registers ; f++ ) {
+    freg_destroyed[f] = false;
+  }
+#endif // ASSERT
+
+  for (int i = 0; i < arg_order.length(); i += 2) {
+    int in_arg  = arg_order.at(i);
+    int out_arg = arg_order.at(i + 1);
+
+    assert(in_arg != -1 || out_arg != -1, "");
+    BasicType arg_bt = (in_arg != -1 ? in_sig_bt[in_arg] : out_sig_bt[out_arg]);
+    switch (arg_bt) {
+      case T_BOOLEAN:
+      case T_BYTE:
+      case T_SHORT:
+      case T_CHAR:
+      case T_INT:
+      case T_FLOAT:
+        break; // process
+
+      case T_LONG:
+      case T_DOUBLE:
+        assert(in_arg  == -1 || (in_arg  + 1 < total_in_args  &&  in_sig_bt[in_arg  + 1] == T_VOID), "bad arg list: %d", in_arg);
+        assert(out_arg == -1 || (out_arg + 1 < total_out_args && out_sig_bt[out_arg + 1] == T_VOID), "bad arg list: %d", out_arg);
+        break; // process
+
+      case T_VOID:
+        continue; // skip
+
+      default:
+        fatal("found in upcall args: %s", type2name(arg_bt));
+    }
+
+    ArgMove move;
+    move.bt   = arg_bt;
+    move.from = (in_arg != -1 ? in_regs[in_arg] : tmp_vmreg);
+    move.to   = (out_arg != -1 ? out_regs[out_arg] : tmp_vmreg);
+
+#ifdef ASSERT
+    if (in_regs[in_arg].first()->is_Register()) {
+      assert(!reg_destroyed[in_regs[in_arg].first()->as_Register()->encoding()], "destroyed reg!");
+    } else if (in_regs[in_arg].first()->is_XMMRegister()) {
+      assert(!freg_destroyed[in_regs[in_arg].first()->as_XMMRegister()->encoding()], "destroyed reg!");
+    }
+    if (out_arg != -1) {
+      if (out_regs[out_arg].first()->is_Register()) {
+        reg_destroyed[out_regs[out_arg].first()->as_Register()->encoding()] = true;
+      } else if (out_regs[out_arg].first()->is_XMMRegister()) {
+        freg_destroyed[out_regs[out_arg].first()->as_XMMRegister()->encoding()] = true;
+      }
+    }
+#endif /* ASSERT */
+
+    arg_order_vmreg->push(move);
+  }
+
+  // Calculate the total number of stack slots we will need.
+
+  // First count the abi requirement plus all of the outgoing args
+  int stack_slots = SharedRuntime::out_preserve_stack_slots() + out_arg_slots;
+
+  // Now a place (+2) to save return values or temp during shuffling
+  // + 4 for return address (which we own) and saved rbp
+//  stack_slots += 6;
+
+  // Ok The space we have allocated will look like:
+  //
+  //
+  // FP-> |                     |
+  //      |---------------------|
+  //      | 2 slots for moves   |
+  //      |---------------------|
+  //      | outbound memory     |
+  //      | based arguments     |
+  //      |                     |
+  //      |---------------------|
+  //      |                     |
+  // SP-> | out_preserved_slots |
+  //
+  //
+
+  // Now compute actual number of stack words we need rounding to make
+  // stack properly aligned.
+
+  frame_size = align_up(stack_slots * VMRegImpl::stack_slot_size, StackAlignmentInBytes);
+
+  return arg_order_vmreg;
+}
+
+void save_java_frame_anchor(MacroAssembler* _masm, ByteSize store_offset, Register thread) {
+  __ block_comment("{ save_java_frame_anchor ");
+  // upcall->jfa._last_Java_fp = _thread->_anchor._last_Java_fp;
+  __ movptr(rscratch1, Address(thread, JavaThread::last_Java_fp_offset()));
+  __ movptr(Address(rsp, store_offset + JavaFrameAnchor::last_Java_fp_offset()), rscratch1);
+
+  // upcall->jfa._last_Java_pc = _thread->_anchor._last_Java_pc;
+  __ movptr(rscratch1, Address(thread, JavaThread::last_Java_pc_offset()));
+  __ movptr(Address(rsp, store_offset + JavaFrameAnchor::last_Java_pc_offset()), rscratch1);
+
+  __ movptr(rscratch1, Address(thread, JavaThread::saved_rbp_address_offset()));
+  __ movptr(Address(rsp, store_offset + JavaFrameAnchor::saved_rbp_address_offset()), rscratch1);
+
+  // upcall->jfa._last_Java_sp = _thread->_anchor._last_Java_sp;
+  __ movptr(rscratch1, Address(thread, JavaThread::last_Java_sp_offset()));
+  __ movptr(Address(rsp, store_offset + JavaFrameAnchor::last_Java_sp_offset()), rscratch1);
+  __ block_comment("} save_java_frame_anchor ");
+}
+
+void restore_java_frame_anchor(MacroAssembler* _masm, ByteSize load_offset, Register thread) {
+  __ block_comment("{ restore_java_frame_anchor ");
+  // thread->_last_Java_sp = NULL
+  __ movptr(Address(thread, JavaThread::last_Java_sp_offset()), NULL_WORD);
+
+  // ThreadStateTransition::transition_from_java(_thread, _thread_in_vm);
+  // __ movl(Address(r15_thread, JavaThread::thread_state_offset()), _thread_in_native_trans);
+  __ movl(Address(r15_thread, JavaThread::thread_state_offset()), _thread_in_native);
+
+  //_thread->frame_anchor()->copy(&_anchor);
+//  _thread->_last_Java_fp = upcall->_last_Java_fp;
+//  _thread->_last_Java_pc = upcall->_last_Java_pc;
+//  _thread->_last_Java_sp = upcall->_last_Java_sp;
+
+  __ movptr(rscratch1, Address(rsp, load_offset + JavaFrameAnchor::last_Java_fp_offset()));
+  __ movptr(Address(thread, JavaThread::last_Java_fp_offset()), rscratch1);
+
+  __ movptr(rscratch1, Address(rsp, load_offset + JavaFrameAnchor::last_Java_pc_offset()));
+  __ movptr(Address(thread, JavaThread::last_Java_pc_offset()), rscratch1);
+
+  __ movptr(rscratch1, Address(rsp, load_offset + JavaFrameAnchor::saved_rbp_address_offset()));
+  __ movptr(Address(thread, JavaThread::saved_rbp_address_offset()), rscratch1);
+
+  __ movptr(rscratch1, Address(rsp, load_offset + JavaFrameAnchor::last_Java_sp_offset()));
+  __ movptr(Address(thread, JavaThread::last_Java_sp_offset()), rscratch1);
+  __ block_comment("} restore_java_frame_anchor ");
+}
+
+static void save_native_arguments(MacroAssembler* _masm, const ABIDescriptor& abi) {
+  __ block_comment("{ save_native_args ");
+  for (int i = 0; i < abi._integer_argument_registers.length(); i++) {
+    Register reg = abi._integer_argument_registers.at(i);
+    __ push(reg);
+  }
+  for (int i = 0; i < abi._vector_argument_registers.length(); i++) {
+    XMMRegister reg = abi._vector_argument_registers.at(i);
+    if (UseAVX >= 3) {
+      __ subptr(rsp, 64); // bytes
+      __ evmovdqul(Address(rsp, 0), reg, Assembler::AVX_512bit);
+    } else if (UseAVX >= 1) {
+      __ subptr(rsp, 32);
+      __ vmovdqu(Address(rsp, 0), reg);
+    } else {
+      __ subptr(rsp, 16);
+      __ movdqu(Address(rsp, 0), reg);
+    }
+  }
+  __ block_comment("} save_native_args ");
+}
+
+static void restore_native_arguments(MacroAssembler* _masm, const ABIDescriptor& abi) {
+  __ block_comment("{ restore_native_args ");
+  for (int i = abi._vector_argument_registers.length() - 1; i >= 0; i--) {
+    XMMRegister reg = abi._vector_argument_registers.at(i);
+    if (UseAVX >= 3) {
+      __ evmovdqul(reg, Address(rsp, 0), Assembler::AVX_512bit);
+      __ addptr(rsp, 64); // bytes
+    } else if (UseAVX >= 1) {
+      __ vmovdqu(reg, Address(rsp, 0));
+      __ addptr(rsp, 32);
+    } else {
+      __ movdqu(reg, Address(rsp, 0));
+      __ addptr(rsp, 16);
+    }
+  }
+  for (int i = abi._integer_argument_registers.length() - 1; i >= 0; i--) {
+    Register reg = abi._integer_argument_registers.at(i);
+    __ pop(reg);
+  }
+  __ block_comment("} restore_native_args ");
+}
+
+static bool is_valid_XMM(XMMRegister reg) {
+  return reg->is_valid() && (UseAVX >= 3 || (reg->encoding() < 16)); // why is this not covered by is_valid()?
+}
+
+static int compute_reg_save_area_size(const ABIDescriptor& abi) {
+  int size = 0;
+  for (Register reg = as_Register(0); reg->is_valid(); reg = reg->successor()) {
+    if (reg == rbp || reg == rsp) continue; // saved/restored by prologue/epilogue
+    if (!abi.is_volatile_reg(reg)) {
+      size += 8; // bytes
+    }
+  }
+
+  for (XMMRegister reg = as_XMMRegister(0); is_valid_XMM(reg); reg = reg->successor()) {
+    if (!abi.is_volatile_reg(reg)) {
+      if (UseAVX >= 3) {
+        size += 64; // bytes
+      } else if (UseAVX >= 1) {
+        size += 32;
+      } else {
+        size += 16;
+      }
+    }
+  }
+
+  return size;
+}
+
+static void preserve_callee_saved_registers(MacroAssembler* _masm, const ABIDescriptor& abi, int reg_save_area_offset) {
+  // 1. iterate all registers in the architecture
+  //     - check if they are volatile or not for the given abi
+  //     - if NOT, we need to save it here
+  // 2. save mxcsr (?)
+
+  int offset = reg_save_area_offset;
+
+  __ block_comment("{ preserve_callee_saved_regs ");
+  for (Register reg = as_Register(0); reg->is_valid(); reg = reg->successor()) {
+    if (reg == rbp || reg == rsp) continue; // saved/restored by prologue/epilogue
+    if (!abi.is_volatile_reg(reg)) {
+      __ movptr(Address(rsp, offset), reg);
+      offset += 8;
+    }
+  }
+
+  for (XMMRegister reg = as_XMMRegister(0); is_valid_XMM(reg); reg = reg->successor()) {
+    if (!abi.is_volatile_reg(reg)) {
+      if (UseAVX >= 3) {
+        __ evmovdqul(Address(rsp, offset), reg, Assembler::AVX_512bit);
+        offset += 64;
+      } else if (UseAVX >= 1) {
+        __ vmovdqu(Address(rsp, offset), reg);
+        offset += 32;
+      } else {
+        __ movdqu(Address(rsp, offset), reg);
+        offset += 16;
+      }
+    }
+  }
+  __ block_comment("} preserve_callee_saved_regs ");
+
+  // TODO mxcsr
+}
+
+static void restore_callee_saved_registers(MacroAssembler* _masm, const ABIDescriptor& abi, int reg_save_area_offset) {
+  // 1. iterate all registers in the architecture
+  //     - check if they are volatile or not for the given abi
+  //     - if NOT, we need to restore it here
+  // 2. restore mxcsr (?)
+
+  int offset = reg_save_area_offset;
+
+  __ block_comment("{ restore_callee_saved_regs ");
+  for (Register reg = as_Register(0); reg->is_valid(); reg = reg->successor()) {
+    if (reg == rbp || reg == rsp) continue; // saved/restored by prologue/epilogue
+    if (!abi.is_volatile_reg(reg)) {
+      __ movptr(reg, Address(rsp, offset));
+      offset += 8;
+    }
+  }
+
+  for (XMMRegister reg = as_XMMRegister(0); is_valid_XMM(reg); reg = reg->successor()) {
+    if (!abi.is_volatile_reg(reg)) {
+      if (UseAVX >= 3) {
+        __ evmovdqul(reg, Address(rsp, offset), Assembler::AVX_512bit);
+        offset += 64;
+      } else if (UseAVX >= 1) {
+        __ vmovdqu(reg, Address(rsp, offset));
+        offset += 32;
+      } else {
+        __ movdqu(reg, Address(rsp, offset));
+        offset += 16;
+      }
+    }
+  }
+
+  __ block_comment("} restore_callee_saved_regs ");
+
+  // TODO mxcsr
+}
+
+static const char* null_safe_string(const char* str) {
+  return str == nullptr ? "NULL" : str;
+}
+
+static void shuffle_arguments(MacroAssembler* _masm, GrowableArray<ArgMove>* arg_moves) {
+  for (int i = 0; i < arg_moves->length(); i++) {
+    ArgMove arg_mv = arg_moves->at(i);
+    BasicType arg_bt     = arg_mv.bt;
+    VMRegPair from_vmreg = arg_mv.from;
+    VMRegPair   to_vmreg = arg_mv.to;
+
+    __ block_comment(err_msg("bt=%s", null_safe_string(type2name(arg_bt))));
+    switch (arg_bt) {
+      case T_BOOLEAN:
+      case T_BYTE:
+      case T_SHORT:
+      case T_CHAR:
+      case T_INT:
+       SharedRuntime::move32_64(_masm, from_vmreg, to_vmreg);
+       break;
+
+      case T_FLOAT:
+        SharedRuntime::float_move(_masm, from_vmreg, to_vmreg);
+        break;
+
+      case T_DOUBLE:
+        SharedRuntime::double_move(_masm, from_vmreg, to_vmreg);
+        break;
+
+      case T_LONG :
+        SharedRuntime::long_move(_masm, from_vmreg, to_vmreg);
+        break;
+
+      default:
+        fatal("found in upcall args: %s", type2name(arg_bt));
+    }
+  }
+}
+
+struct AuxiliarySaves {
+  JavaFrameAnchor jfa;
+  uintptr_t thread;
+};
+
+address ProgrammableUpcallHandler::generate_optimized_upcall_stub(jobject receiver, Method* entry, jobject jabi, jobject jconv) {
+  ResourceMark rm;
+  const ABIDescriptor abi = ForeignGlobals::parse_abi_descriptor(jabi);
+  const CallRegs conv = ForeignGlobals::parse_call_regs(jconv);
+  CodeBuffer buffer("upcall_stub_linkToNative", 1024, 1024);
+
+  int stack_alignment_C = 16; // bytes. FIXME assuming C
+  int register_size = sizeof(uintptr_t);
+  int buffer_alignment = xmm_reg_size;
+
+  int shuffle_area_size = -1;
+  GrowableArray<ArgMove>* arg_moves = compute_argument_shuffle(entry, shuffle_area_size, conv);
+  assert(shuffle_area_size != -1, "Should have been set");
+
+  // FIXME:
+  // For some reason, if we don't do this the callee's locals
+  // will overlap with our register save area during a deopt
+  // and the first saved registers ends up being clobbered (rbx on SysV)
+  // I'm guessing this space corresponds to the receiver, and compute_argument_shuffle
+  // does not account for it
+  shuffle_area_size += BytesPerWord;
+
+  int reg_save_area_size = compute_reg_save_area_size(abi);
+  int frame_size = shuffle_area_size + reg_save_area_size + sizeof(AuxiliarySaves);
+
+  int auxiliary_saves_offset = shuffle_area_size + reg_save_area_size;
+  int reg_save_are_offset = shuffle_area_size;
+  int shuffle_area_offset = 0;
+  ByteSize jfa_offset = in_ByteSize(auxiliary_saves_offset) + byte_offset_of(AuxiliarySaves, jfa);
+  ByteSize thread_offset = in_ByteSize(auxiliary_saves_offset) + byte_offset_of(AuxiliarySaves, thread);
+
+  frame_size = align_up(frame_size, stack_alignment_C);
+
+  // Ok The space we have allocated will look like:
+  //
+  //
+  // FP-> |                     |
+  //      |---------------------|
+  //      |                     |
+  //      | AuxiliarySaves      |
+  //      |---------------------| = auxiliary_saves_offset = shuffle_area_size + reg_save_area_size
+  //      |                     |
+  //      | reg_save_area       |
+  //      |---------------------| = reg_save_are_offset = shuffle_area_size
+  //      |                     |
+  // SP-> | shuffle_area        |   needs to be at end for shadow space
+  //
+  //
+
+  //////////////////////////////////////////////////////////////////////////////
+
+  MacroAssembler* _masm = new MacroAssembler(&buffer);
+  Label call_return;
+  address start = __ pc();
+  __ enter(); // set up frame
+  __ subptr(rsp, frame_size);
+
+  preserve_callee_saved_registers(_masm, abi, reg_save_are_offset);
+
+  // FIXME: mxcsr (see stubGenerator_x86_64.cpp 'generate_call_stub')
+
+  __ block_comment("{ get_thread");
+  __ get_thread(r15_thread);
+  __ movptr(Address(rsp, thread_offset), r15_thread);
+  __ block_comment("} get_thread");
+
+  // FIXME: is it needed?
+//  JNIHandleBlock* new_handles = JNIHandleBlock::allocate_block(thread);
+//  _handles      = _thread->active_handles();    // save previous handle block & Java frame linkage
+//  _thread->set_active_handles(new_handles);     // install new handle block and reset Java frame linkage
+
+  // FIXME: pending exceptions?
+  __ block_comment("{ safepoint poll");
+  __ movl(Address(r15_thread, JavaThread::thread_state_offset()), _thread_in_native_trans);
+
+  if (os::is_MP()) {
+    __ membar(Assembler::Membar_mask_bits(
+                Assembler::LoadLoad  | Assembler::StoreLoad |
+                Assembler::LoadStore | Assembler::StoreStore));
+   }
+
+  // check for safepoint operation in progress and/or pending suspend requests
+  Label L_after_safepoint_poll;
+  Label L_safepoint_poll_slow_path;
+
+  __ safepoint_poll(L_safepoint_poll_slow_path, r15_thread, false /* at_return */, false /* in_nmethod */);
+
+  __ cmpl(Address(r15_thread, JavaThread::suspend_flags_offset()), 0);
+  __ jcc(Assembler::notEqual, L_safepoint_poll_slow_path);
+
+  __ bind(L_after_safepoint_poll);
+  __ block_comment("} safepoint poll");
+  // change thread state
+  __ movl(Address(r15_thread, JavaThread::thread_state_offset()), _thread_in_Java);
+
+  __ block_comment("{ reguard stack check");
+  Label L_reguard;
+  Label L_after_reguard;
+  __ cmpl(Address(r15_thread, JavaThread::stack_guard_state_offset()), StackOverflow::stack_guard_yellow_reserved_disabled);
+  __ jcc(Assembler::equal, L_reguard);
+  __ bind(L_after_reguard);
+  __ block_comment("} reguard stack check");
+
+  __ block_comment("{ argument shuffle");
+  shuffle_arguments(_masm, arg_moves);
+  __ block_comment("} argument shuffle");
+
+  __ block_comment("{ receiver ");
+  __ movptr(rscratch1, (intptr_t)receiver);
+  //__ movptr(rscratch1, ExternalAddress((address)receiver));
+  __ resolve_jobject(rscratch1, r15_thread, rscratch2);
+  __ movptr(j_rarg0, rscratch1);
+  __ block_comment("} receiver ");
+
+  __ mov_metadata(rbx, entry);
+  __ movptr(Address(r15_thread, JavaThread::callee_target_offset()), rbx); // just in case callee is deoptimized
+  __ reinit_heapbase();
+
+  save_java_frame_anchor(_masm, jfa_offset, r15_thread);
+  __ reset_last_Java_frame(r15_thread, true);
+
+  __ call(Address(rbx, Method::from_compiled_offset()));
+
+  // FIXME: return value post-processing? -> Yes, native result regs might not be the same as Java's
+
+  __ bind(call_return);
+
+  // also sets last Java frame
+  __ movptr(r15_thread, Address(rsp, thread_offset));
+  restore_java_frame_anchor(_masm, jfa_offset, r15_thread);
+  restore_callee_saved_registers(_masm, abi, reg_save_are_offset);
+
+//  __ vzeroupper()
+   __ leave();
+   __ ret(0);
+
+  //////////////////////////////////////////////////////////////////////////////
+
+  __ block_comment("{ L_safepoint_poll_slow_path");
+  __ bind(L_safepoint_poll_slow_path);
+  __ vzeroupper();
+  save_native_arguments(_masm, abi);
+  __ mov(c_rarg0, r15_thread);
+  __ mov(r12, rsp); // remember sp
+  __ subptr(rsp, frame::arg_reg_save_area_bytes); // windows
+  __ andptr(rsp, -16); // align stack as required by ABI
+  __ call(RuntimeAddress(CAST_FROM_FN_PTR(address, JavaThread::check_special_condition_for_native_trans)));
+  __ mov(rsp, r12); // restore sp
+  __ reinit_heapbase();
+  restore_native_arguments(_masm, abi);
+  __ jmp(L_after_safepoint_poll);
+
+  __ block_comment("} L_safepoint_poll_slow_path");
+
+  //////////////////////////////////////////////////////////////////////////////
+
+  __ block_comment("{ L_reguard");
+  __ bind(L_reguard);
+  __ vzeroupper();
+  save_native_arguments(_masm, abi);
+  __ mov(r12, rsp); // remember sp
+  __ subptr(rsp, frame::arg_reg_save_area_bytes); // windows
+  __ andptr(rsp, -16); // align stack as required by ABI
+  __ call(RuntimeAddress(CAST_FROM_FN_PTR(address, SharedRuntime::reguard_yellow_pages)));
+  __ mov(rsp, r12); // restore sp
+  __ reinit_heapbase();
+  restore_native_arguments(_masm, abi);
+  __ jmp(L_after_reguard);
+
+  __ block_comment("} L_reguard");
+
+  //////////////////////////////////////////////////////////////////////////////
+
+  __ block_comment("{ exception handler");
+
+  intptr_t exception_handler_offset = __ pc() - start;
+
+  // set pending exception
+  __ verify_oop(rax);
+
+  __ movptr(Address(r15_thread, Thread::pending_exception_offset()), rax);
+  __ lea(rscratch1, ExternalAddress((address)__FILE__));
+  __ movptr(Address(r15_thread, Thread::exception_file_offset()), rscratch1);
+  __ movl(Address(r15_thread, Thread::exception_line_offset()), (int)  __LINE__);
+
+  // TODO: return value?
+
+  __ jmp(call_return);
+  __ block_comment("} exception handler");
+
+   _masm->flush();
+
+
+#ifndef PRODUCT
+  stringStream ss;
+  ss.print("upcall_stub_linkToNative_J%s", entry->signature()->as_C_string());
+  const char* name = _masm->code_string(ss.as_string());
+#else // PRODUCT
+  const char* name = "upcall_stub_linkToNative";
+#endif // PRODUCT
+
+  EntryBlob* blob = EntryBlob::create(name, &buffer, exception_handler_offset, receiver, jfa_offset);
+
+  if (UseNewCode) {
+    blob->print_on(tty);
+    Disassembler::decode(blob, tty);
+  }
+
+   return blob->code_begin();
 }

--- a/src/hotspot/cpu/x86/universalUpcallHandler_x86_64.cpp
+++ b/src/hotspot/cpu/x86/universalUpcallHandler_x86_64.cpp
@@ -158,7 +158,7 @@ struct ArgMove {
   }
 };
 
-static GrowableArray<ArgMove> compute_argument_shuffle(Method* entry, int& frame_size, const CallRegs& conv, BasicType& ret_type) {
+static GrowableArray<ArgMove> compute_argument_shuffle(Method* entry, int& out_arg_size_bytes, const CallRegs& conv, BasicType& ret_type) {
   assert(entry->is_static(), "");
 
   // Fill in the signature array, for the calling-convention call.
@@ -303,7 +303,7 @@ static GrowableArray<ArgMove> compute_argument_shuffle(Method* entry, int& frame
   // Now compute actual number of stack words we need rounding to make
   // stack properly aligned.
 
-  frame_size = align_up(stack_slots * VMRegImpl::stack_slot_size, StackAlignmentInBytes);
+  out_arg_size_bytes = align_up(stack_slots * VMRegImpl::stack_slot_size, StackAlignmentInBytes);
 
   return arg_order_vmreg;
 }
@@ -313,7 +313,7 @@ static const char* null_safe_string(const char* str) {
 }
 
 #ifdef ASSERT
-static void print_arg_moves(const GrowableArray<ArgMove>& arg_moves, int shuffle_area_size, Method* entry) {
+static void print_arg_moves(const GrowableArray<ArgMove>& arg_moves, Method* entry) {
   LogTarget(Trace, panama) lt;
   if (lt.is_enabled()) {
     ResourceMark rm;
@@ -387,46 +387,38 @@ void restore_java_frame_anchor(MacroAssembler* _masm, ByteSize load_offset, Regi
   __ block_comment("} restore_java_frame_anchor ");
 }
 
-static void save_native_arguments(MacroAssembler* _masm, const ABIDescriptor& abi) {
+static void save_native_arguments(MacroAssembler* _masm, const CallRegs& conv, int arg_save_area_offset) {
   __ block_comment("{ save_native_args ");
-  for (int i = 0; i < abi._integer_argument_registers.length(); i++) {
-    Register reg = abi._integer_argument_registers.at(i);
-    __ push(reg);
-  }
-  for (int i = 0; i < abi._vector_argument_registers.length(); i++) {
-    XMMRegister reg = abi._vector_argument_registers.at(i);
-    if (UseAVX >= 3) {
-      __ subptr(rsp, 64); // bytes
-      __ evmovdqul(Address(rsp, 0), reg, Assembler::AVX_512bit);
-    } else if (UseAVX >= 1) {
-      __ subptr(rsp, 32);
-      __ vmovdqu(Address(rsp, 0), reg);
-    } else {
-      __ subptr(rsp, 16);
-      __ movdqu(Address(rsp, 0), reg);
+  int store_offset = arg_save_area_offset;
+  for (int i = 0; i < conv._args_length; i++) {
+    VMReg reg = conv._arg_regs[i];
+    if (reg->is_Register()) {
+      __ movptr(Address(rsp, store_offset), reg->as_Register());
+      store_offset += 8;
+    } else if (reg->is_XMMRegister()) {
+      // Java API doesn't support vector args
+      __ movdqu(Address(rsp, store_offset), reg->as_XMMRegister());
+      store_offset += 16;
     }
+    // do nothing for stack
   }
   __ block_comment("} save_native_args ");
 }
 
-static void restore_native_arguments(MacroAssembler* _masm, const ABIDescriptor& abi) {
+static void restore_native_arguments(MacroAssembler* _masm, const CallRegs& conv, int arg_save_area_offset) {
   __ block_comment("{ restore_native_args ");
-  for (int i = abi._vector_argument_registers.length() - 1; i >= 0; i--) {
-    XMMRegister reg = abi._vector_argument_registers.at(i);
-    if (UseAVX >= 3) {
-      __ evmovdqul(reg, Address(rsp, 0), Assembler::AVX_512bit);
-      __ addptr(rsp, 64); // bytes
-    } else if (UseAVX >= 1) {
-      __ vmovdqu(reg, Address(rsp, 0));
-      __ addptr(rsp, 32);
-    } else {
-      __ movdqu(reg, Address(rsp, 0));
-      __ addptr(rsp, 16);
+  int load_offset = arg_save_area_offset;
+  for (int i = 0; i < conv._args_length; i++) {
+    VMReg reg = conv._arg_regs[i];
+    if (reg->is_Register()) {
+      __ movptr(reg->as_Register(), Address(rsp, load_offset));
+      load_offset += 8;
+    } else if (reg->is_XMMRegister()) {
+      // Java API doesn't support vector args
+      __ movdqu(reg->as_XMMRegister(), Address(rsp, load_offset));
+      load_offset += 16;
     }
-  }
-  for (int i = abi._integer_argument_registers.length() - 1; i >= 0; i--) {
-    Register reg = abi._integer_argument_registers.at(i);
-    __ pop(reg);
+    // do nothing for stack
   }
   __ block_comment("} restore_native_args ");
 }
@@ -435,6 +427,7 @@ static bool is_valid_XMM(XMMRegister reg) {
   return reg->is_valid() && (UseAVX >= 3 || (reg->encoding() < 16)); // why is this not covered by is_valid()?
 }
 
+// for callee saved regs, according to the caller's ABI
 static int compute_reg_save_area_size(const ABIDescriptor& abi) {
   int size = 0;
   for (Register reg = as_Register(0); reg->is_valid(); reg = reg->successor()) {
@@ -457,6 +450,21 @@ static int compute_reg_save_area_size(const ABIDescriptor& abi) {
   }
 
   return size;
+}
+
+static int compute_arg_save_area_size(const CallRegs& conv) {
+  int result_size = 0;
+  for (int i = 0; i < conv._args_length; i++) {
+    VMReg reg = conv._arg_regs[i];
+    if (reg->is_Register()) {
+      result_size += 8;
+    } else if (reg->is_XMMRegister()) {
+      // Java API doesn't support vector args
+      result_size += 16;
+    }
+    // do nothing for stack
+  }
+  return result_size;
 }
 
 static void preserve_callee_saved_registers(MacroAssembler* _masm, const ABIDescriptor& abi, int reg_save_area_offset) {
@@ -575,6 +583,7 @@ static void shuffle_arguments(MacroAssembler* _masm, const GrowableArray<ArgMove
 struct AuxiliarySaves {
   JavaFrameAnchor jfa;
   uintptr_t thread;
+  bool should_detach;
 };
 
 address ProgrammableUpcallHandler::generate_optimized_upcall_stub(jobject receiver, Method* entry, jobject jabi, jobject jconv) {
@@ -582,48 +591,62 @@ address ProgrammableUpcallHandler::generate_optimized_upcall_stub(jobject receiv
   const ABIDescriptor abi = ForeignGlobals::parse_abi_descriptor(jabi);
   const CallRegs conv = ForeignGlobals::parse_call_regs(jconv);
   assert(conv._rets_length <= 1, "no multi reg returns");
-  CodeBuffer buffer("upcall_stub_linkToNative", 1024, 1024);
+  CodeBuffer buffer("upcall_stub_linkToNative", /* code_size = */ 1024, /* locs_size = */ 1024);
 
-  int stack_alignment_bytes_Java = 16;
+  int stack_alignment_bytes = 16; // for Java and C++ (runtime) calls
   int register_size = sizeof(uintptr_t);
   int buffer_alignment = xmm_reg_size;
 
-  int shuffle_area_size = -1;
+  int out_arg_area = -1;
   BasicType ret_type;
-  GrowableArray<ArgMove> arg_moves = compute_argument_shuffle(entry, shuffle_area_size, conv, ret_type);
-  assert(shuffle_area_size != -1, "Should have been set");
-  DEBUG_ONLY(print_arg_moves(arg_moves, shuffle_area_size, entry);)
+  GrowableArray<ArgMove> arg_moves = compute_argument_shuffle(entry, out_arg_area, conv, ret_type);
+  assert(out_arg_area != -1, "Should have been set");
+  DEBUG_ONLY(print_arg_moves(arg_moves, entry);)
+
+  // out_arg_area (for stack arguments) doubles as shadow space for native calls.
+  // make sure it is big enough.
+  if (out_arg_area < frame::arg_reg_save_area_bytes) {
+    out_arg_area = frame::arg_reg_save_area_bytes;
+  }
 
   int reg_save_area_size = compute_reg_save_area_size(abi);
-  // To spill locals during deopt...
-  int padding_size = 1 * BytesPerWord;
-  int frame_size = shuffle_area_size + padding_size + reg_save_area_size + sizeof(AuxiliarySaves);
+  int arg_save_area_size = compute_arg_save_area_size(conv);
+  // To spill receiver during deopt
+  int deopt_spill_size = 1 * BytesPerWord;
 
-  int auxiliary_saves_offset = shuffle_area_size + padding_size + reg_save_area_size;
-  int reg_save_are_offset = shuffle_area_size + padding_size;
-  int padding_offset = shuffle_area_size;
-  int shuffle_area_offset = 0;
-  ByteSize jfa_offset = in_ByteSize(auxiliary_saves_offset) + byte_offset_of(AuxiliarySaves, jfa);
-  ByteSize thread_offset = in_ByteSize(auxiliary_saves_offset) + byte_offset_of(AuxiliarySaves, thread);
+  int shuffle_area_offset    = 0;
+  int deopt_spill_offset     = shuffle_area_offset    + out_arg_area;
+  int arg_save_area_offset   = deopt_spill_offset     + deopt_spill_size;
+  int reg_save_area_offset   = arg_save_area_offset   + arg_save_area_size;
+  int auxiliary_saves_offset = reg_save_area_offset   + reg_save_area_size;
+  int frame_bottom_offset    = auxiliary_saves_offset + sizeof(AuxiliarySaves);
 
-  frame_size = align_up(frame_size, stack_alignment_bytes_Java);
+  ByteSize jfa_offset           = in_ByteSize(auxiliary_saves_offset) + byte_offset_of(AuxiliarySaves, jfa);
+  ByteSize thread_offset        = in_ByteSize(auxiliary_saves_offset) + byte_offset_of(AuxiliarySaves, thread);
+  ByteSize should_detach_offset = in_ByteSize(auxiliary_saves_offset) + byte_offset_of(AuxiliarySaves, should_detach);
+
+  int frame_size = frame_bottom_offset;
+  frame_size = align_up(frame_size, stack_alignment_bytes);
 
   // Ok The space we have allocated will look like:
   //
   //
   // FP-> |                     |
-  //      |---------------------|
+  //      |---------------------| = frame_bottom_offset = frame_size
   //      |                     |
   //      | AuxiliarySaves      |
-  //      |---------------------| = auxiliary_saves_offset = shuffle_area_size + padding_size + reg_save_area_size
+  //      |---------------------| = auxiliary_saves_offset
   //      |                     |
   //      | reg_save_area       |
-  //      |---------------------| = reg_save_are_offset = shuffle_area_size + padding_size
+  //      |---------------------| = reg_save_are_offset
   //      |                     |
-  //      | padding             |
-  //      |---------------------| = padding_offset = shuffle_area_size
+  //      | arg_save_area       |
+  //      |---------------------| = arg_save_are_offset
   //      |                     |
-  // SP-> | shuffle_area        |   needs to be at end for shadow space
+  //      | deopt_spill         |
+  //      |---------------------| = deopt_spill_offset
+  //      |                     |
+  // SP-> | out_arg_area        |   needs to be at end for shadow space
   //
   //
 
@@ -633,15 +656,28 @@ address ProgrammableUpcallHandler::generate_optimized_upcall_stub(jobject receiv
   Label call_return;
   address start = __ pc();
   __ enter(); // set up frame
+  if ((abi._stack_alignment_bytes % 16) != 0) {
+    // stack alignment of caller is not a multiple of 16
+    __ andptr(rsp, -stack_alignment_bytes); // align stack
+  }
+  // allocate frame (frame_size is also aligned, so stack is still aligned)
   __ subptr(rsp, frame_size);
 
-  preserve_callee_saved_registers(_masm, abi, reg_save_are_offset);
+  // we have to always spill args since we need to do a call to get the thread
+  // (and maybe attach it).
+  save_native_arguments(_masm, conv, arg_save_area_offset);
 
-  // FIXME: mxcsr (see stubGenerator_x86_64.cpp 'generate_call_stub')
+  preserve_callee_saved_registers(_masm, abi, reg_save_area_offset);
+
+  // FIXME: save/restore mxcsr? (see stubGenerator_x86_64.cpp 'generate_call_stub')
 
   __ block_comment("{ get_thread");
-  // FIXME: this crashes the VM on a detached thread
-  __ get_thread(r15_thread);
+  __ vzeroupper();
+  __ lea(c_rarg0, Address(rsp, should_detach_offset));
+  // stack already aligned
+  __ call(RuntimeAddress(CAST_FROM_FN_PTR(address, ProgrammableUpcallHandler::maybe_attach_and_get_thread)));
+  __ movptr(r15_thread, rax);
+  __ reinit_heapbase();
   __ movptr(Address(rsp, thread_offset), r15_thread);
   __ block_comment("} get_thread");
 
@@ -685,12 +721,13 @@ address ProgrammableUpcallHandler::generate_optimized_upcall_stub(jobject receiv
   __ block_comment("} reguard stack check");
 
   __ block_comment("{ argument shuffle");
+  // TODO merge these somehow
+  restore_native_arguments(_masm, conv, arg_save_area_offset);
   shuffle_arguments(_masm, arg_moves);
   __ block_comment("} argument shuffle");
 
   __ block_comment("{ receiver ");
   __ movptr(rscratch1, (intptr_t)receiver);
-  //__ movptr(rscratch1, ExternalAddress((address)receiver));
   __ resolve_jobject(rscratch1, r15_thread, rscratch2);
   __ movptr(j_rarg0, rscratch1);
   __ block_comment("} receiver ");
@@ -732,27 +769,35 @@ address ProgrammableUpcallHandler::generate_optimized_upcall_stub(jobject receiv
 
   // also sets last Java frame
   __ movptr(r15_thread, Address(rsp, thread_offset));
-  restore_java_frame_anchor(_masm, jfa_offset, r15_thread);
-  restore_callee_saved_registers(_masm, abi, reg_save_are_offset);
+  // TODO corrupted thread pointer causes havoc. Can we verify it here?
+  restore_java_frame_anchor(_masm, jfa_offset, r15_thread); // also transitions to native state
 
-//  __ vzeroupper()
-   __ leave();
-   __ ret(0);
+  __ block_comment("{ maybe_detach_thread");
+  Label L_after_detach;
+  __ cmpb(Address(rsp, should_detach_offset), 0);
+  __ jcc(Assembler::equal, L_after_detach);
+  __ vzeroupper();
+  __ mov(c_rarg0, r15_thread);
+  // stack already aligned
+  __ call(RuntimeAddress(CAST_FROM_FN_PTR(address, ProgrammableUpcallHandler::detach_thread)));
+  __ reinit_heapbase();
+  __ bind(L_after_detach);
+  __ block_comment("} maybe_detach_thread");
+
+  restore_callee_saved_registers(_masm, abi, reg_save_area_offset);
+
+  __ leave();
+  __ ret(0);
 
   //////////////////////////////////////////////////////////////////////////////
 
   __ block_comment("{ L_safepoint_poll_slow_path");
   __ bind(L_safepoint_poll_slow_path);
   __ vzeroupper();
-  save_native_arguments(_masm, abi);
   __ mov(c_rarg0, r15_thread);
-  __ mov(r12, rsp); // remember sp
-  __ subptr(rsp, frame::arg_reg_save_area_bytes); // windows
-  __ andptr(rsp, -16); // align stack as required by ABI
+  // stack already aligned
   __ call(RuntimeAddress(CAST_FROM_FN_PTR(address, JavaThread::check_special_condition_for_native_trans)));
-  __ mov(rsp, r12); // restore sp
   __ reinit_heapbase();
-  restore_native_arguments(_masm, abi);
   __ jmp(L_after_safepoint_poll);
 
   __ block_comment("} L_safepoint_poll_slow_path");
@@ -762,14 +807,9 @@ address ProgrammableUpcallHandler::generate_optimized_upcall_stub(jobject receiv
   __ block_comment("{ L_reguard");
   __ bind(L_reguard);
   __ vzeroupper();
-  save_native_arguments(_masm, abi);
-  __ mov(r12, rsp); // remember sp
-  __ subptr(rsp, frame::arg_reg_save_area_bytes); // windows
-  __ andptr(rsp, -16); // align stack as required by ABI
+  // stack already aligned
   __ call(RuntimeAddress(CAST_FROM_FN_PTR(address, SharedRuntime::reguard_yellow_pages)));
-  __ mov(rsp, r12); // restore sp
   __ reinit_heapbase();
-  restore_native_arguments(_masm, abi);
   __ jmp(L_after_reguard);
 
   __ block_comment("} L_reguard");
@@ -780,19 +820,21 @@ address ProgrammableUpcallHandler::generate_optimized_upcall_stub(jobject receiv
 
   intptr_t exception_handler_offset = __ pc() - start;
 
+  // FIXME: this is always the same, can we bypass and call handle_uncaught_exception directly?
+
   // native caller has no idea how to handle exceptions
   // we just crash here. Up to callee to catch exceptions.
   __ verify_oop(rax);
   __ vzeroupper();
   __ mov(c_rarg0, rax);
-  __ andptr(rsp, -16); // align stack as required by ABI
-  __ subptr(rsp, frame::arg_reg_save_area_bytes); // windows
+  __ andptr(rsp, -stack_alignment_bytes); // align stack as required by ABI
+  __ subptr(rsp, frame::arg_reg_save_area_bytes); // windows (not really needed)
   __ call(RuntimeAddress(CAST_FROM_FN_PTR(address, ProgrammableUpcallHandler::handle_uncaught_exception)));
   __ should_not_reach_here();
 
   __ block_comment("} exception handler");
 
-   _masm->flush();
+  _masm->flush();
 
 
 #ifndef PRODUCT
@@ -810,7 +852,7 @@ address ProgrammableUpcallHandler::generate_optimized_upcall_stub(jobject receiv
     Disassembler::decode(blob, tty);
   }
 
-   return blob->code_begin();
+  return blob->code_begin();
 }
 
 bool ProgrammableUpcallHandler::supports_optimized_upcalls() {

--- a/src/hotspot/cpu/x86/universalUpcallHandler_x86_64.cpp
+++ b/src/hotspot/cpu/x86/universalUpcallHandler_x86_64.cpp
@@ -584,7 +584,7 @@ address ProgrammableUpcallHandler::generate_optimized_upcall_stub(jobject receiv
   assert(conv._rets_length <= 1, "no multi reg returns");
   CodeBuffer buffer("upcall_stub_linkToNative", 1024, 1024);
 
-  int stack_alignment_bytes = abi._stack_alignment_bytes;
+  int stack_alignment_bytes_Java = 16;
   int register_size = sizeof(uintptr_t);
   int buffer_alignment = xmm_reg_size;
 
@@ -606,7 +606,7 @@ address ProgrammableUpcallHandler::generate_optimized_upcall_stub(jobject receiv
   ByteSize jfa_offset = in_ByteSize(auxiliary_saves_offset) + byte_offset_of(AuxiliarySaves, jfa);
   ByteSize thread_offset = in_ByteSize(auxiliary_saves_offset) + byte_offset_of(AuxiliarySaves, thread);
 
-  frame_size = align_up(frame_size, stack_alignment_bytes);
+  frame_size = align_up(frame_size, stack_alignment_bytes_Java);
 
   // Ok The space we have allocated will look like:
   //

--- a/src/hotspot/cpu/x86/universalUpcallHandler_x86_64.cpp
+++ b/src/hotspot/cpu/x86/universalUpcallHandler_x86_64.cpp
@@ -298,6 +298,10 @@ static GrowableArray<ArgMove>* compute_argument_shuffle(Method* entry, int& fram
   return arg_order_vmreg;
 }
 
+static const char* null_safe_string(const char* str) {
+  return str == nullptr ? "NULL" : str;
+}
+
 #ifdef ASSERT
 static void print_arg_moves(GrowableArray<ArgMove>* arg_moves, int shuffle_area_size, Method* entry) {
   LogTarget(Trace, panama) lt;
@@ -311,7 +315,7 @@ static void print_arg_moves(GrowableArray<ArgMove>* arg_moves, int shuffle_area_
       VMRegPair from_vmreg = arg_mv.from;
       VMRegPair to_vmreg   = arg_mv.to;
 
-      ls.print("Move a %s from (", type2name(arg_bt));
+      ls.print("Move a %s from (", null_safe_string(type2name(arg_bt)));
       from_vmreg.first()->print_on(&ls);
       ls.print(",");
       from_vmreg.second()->print_on(&ls);
@@ -516,10 +520,6 @@ static void restore_callee_saved_registers(MacroAssembler* _masm, const ABIDescr
   __ block_comment("} restore_callee_saved_regs ");
 
   // TODO mxcsr
-}
-
-static const char* null_safe_string(const char* str) {
-  return str == nullptr ? "NULL" : str;
 }
 
 static void shuffle_arguments(MacroAssembler* _masm, GrowableArray<ArgMove>* arg_moves) {

--- a/src/hotspot/cpu/x86/universalUpcallHandler_x86_64.cpp
+++ b/src/hotspot/cpu/x86/universalUpcallHandler_x86_64.cpp
@@ -795,18 +795,22 @@ address ProgrammableUpcallHandler::generate_optimized_upcall_stub(jobject receiv
 
 #ifndef PRODUCT
   stringStream ss;
-  ss.print("upcall_stub_linkToNative_J%s", entry->signature()->as_C_string());
+  ss.print("panama_upcall_stub_%s", entry->signature()->as_C_string());
   const char* name = _masm->code_string(ss.as_string());
 #else // PRODUCT
-  const char* name = "upcall_stub_linkToNative";
+  const char* name = "panama_upcall_stub";
 #endif // PRODUCT
 
   EntryBlob* blob = EntryBlob::create(name, &buffer, exception_handler_offset, receiver, jfa_offset);
 
-  if (UseNewCode) {
+  if (TracePanamaUpcallStubs) {
     blob->print_on(tty);
     Disassembler::decode(blob, tty);
   }
 
    return blob->code_begin();
+}
+
+bool ProgrammableUpcallHandler::supports_optimized_upcalls() {
+  return true;
 }

--- a/src/hotspot/share/code/codeBlob.cpp
+++ b/src/hotspot/share/code/codeBlob.cpp
@@ -724,7 +724,7 @@ EntryBlob* EntryBlob::create(const char* name, CodeBuffer* cb, intptr_t exceptio
                              jobject receiver, ByteSize jfa_sp_offset) {
   ThreadInVMfromUnknown __tiv;  // get to VM state in case we block on CodeCache_lock
 
-  EntryBlob* blob = NULL;
+  EntryBlob* blob = nullptr;
   unsigned int size = CodeBlob::allocation_size(cb, sizeof(EntryBlob));
   {
     MutexLocker mu(CodeCache_lock, Mutex::_no_safepoint_check_flag);

--- a/src/hotspot/share/code/codeBlob.cpp
+++ b/src/hotspot/share/code/codeBlob.cpp
@@ -708,3 +708,30 @@ void SingletonBlob::print_value_on(outputStream* st) const {
 void DeoptimizationBlob::print_value_on(outputStream* st) const {
   st->print_cr("Deoptimization (frame not available)");
 }
+
+// Implementation of EntryBlob
+
+EntryBlob::EntryBlob(const char* name, int size, CodeBuffer* cb, intptr_t exception_handler_offset,
+                     jobject receiver, ByteSize jfa_sp_offset) :
+  BufferBlob(name, size, cb),
+  _exception_handler_offset(exception_handler_offset),
+  _receiver(receiver),
+  _jfa_sp_offset(jfa_sp_offset) {
+  CodeCache::commit(this);
+}
+
+EntryBlob* EntryBlob::create(const char* name, CodeBuffer* cb, intptr_t exception_handler_offset,
+                             jobject receiver, ByteSize jfa_sp_offset) {
+  ThreadInVMfromUnknown __tiv;  // get to VM state in case we block on CodeCache_lock
+
+  EntryBlob* blob = NULL;
+  unsigned int size = CodeBlob::allocation_size(cb, sizeof(EntryBlob));
+  {
+    MutexLocker mu(CodeCache_lock, Mutex::_no_safepoint_check_flag);
+    blob = new (size) EntryBlob(name, size, cb, exception_handler_offset, receiver, jfa_sp_offset);
+  }
+  // Track memory usage statistic after releasing CodeCache_lock
+  MemoryService::track_code_cache_memory_usage();
+
+  return blob;
+}

--- a/src/hotspot/share/code/codeBlob.hpp
+++ b/src/hotspot/share/code/codeBlob.hpp
@@ -735,6 +735,7 @@ class SafepointBlob: public SingletonBlob {
 
 //----------------------------------------------------------------------------------------------------
 
+// For Panama upcall stubs
 class EntryBlob: public BufferBlob {
  private:
   intptr_t _exception_handler_offset;

--- a/src/hotspot/share/code/codeBlob.hpp
+++ b/src/hotspot/share/code/codeBlob.hpp
@@ -60,6 +60,7 @@ struct CodeBlobType {
 //    AdapterBlob        : Used to hold C2I/I2C adapters
 //    VtableBlob         : Used for holding vtable chunks
 //    MethodHandlesAdapterBlob : Used to hold MethodHandles adapters
+//    EntryBlob          : Used for upcalls from native code
 //   RuntimeStub         : Call to VM runtime methods
 //   SingletonBlob       : Super-class for all blobs that exist in only one instance
 //    DeoptimizationBlob : Used for deoptimization
@@ -82,6 +83,8 @@ struct CodeBlobType {
 
 
 class CodeBlobLayout;
+class EntryBlob; // for as_entry_blob()
+class JavaFrameAnchor; // for EntryBlob::jfa_for_frame
 
 class CodeBlob {
   friend class VMStructs;
@@ -144,6 +147,7 @@ public:
   virtual bool is_method_handles_adapter_blob() const { return false; }
   virtual bool is_aot() const                         { return false; }
   virtual bool is_compiled() const                    { return false; }
+  virtual bool is_entry_blob() const                  { return false; }
 
   inline bool is_compiled_by_c1() const    { return _type == compiler_c1; };
   inline bool is_compiled_by_c2() const    { return _type == compiler_c2; };
@@ -157,6 +161,7 @@ public:
   CompiledMethod* as_compiled_method_or_null() { return is_compiled() ? (CompiledMethod*) this : NULL; }
   CompiledMethod* as_compiled_method()         { assert(is_compiled(), "must be compiled"); return (CompiledMethod*) this; }
   CodeBlob* as_codeblob_or_null() const        { return (CodeBlob*) this; }
+  EntryBlob* as_entry_blob() const             { assert(is_entry_blob(), "must be entry blob"); return (EntryBlob*) this; }
 
   // Boundaries
   address header_begin() const        { return (address) this; }
@@ -388,6 +393,7 @@ class BufferBlob: public RuntimeBlob {
   friend class AdapterBlob;
   friend class VtableBlob;
   friend class MethodHandlesAdapterBlob;
+  friend class EntryBlob;
   friend class WhiteBox;
 
  private:
@@ -725,6 +731,34 @@ class SafepointBlob: public SingletonBlob {
 
   // Typing
   bool is_safepoint_stub() const                 { return true; }
+};
+
+//----------------------------------------------------------------------------------------------------
+
+class EntryBlob: public BufferBlob {
+ private:
+  intptr_t _exception_handler_offset;
+  jobject _receiver;
+  ByteSize _jfa_sp_offset;
+
+  EntryBlob(const char* name, int size, CodeBuffer* cb, intptr_t exception_handler_offset,
+            jobject receiver, ByteSize jfa_sp_offset);
+
+ public:
+  // Creation
+  static EntryBlob* create(const char* name, CodeBuffer* cb,
+                           intptr_t exception_handler_offset, jobject receiver,
+                           ByteSize jfa_sp_offset);
+
+  address exception_handler() { return code_begin() + _exception_handler_offset; }
+  jobject receiver() { return _receiver; }
+  ByteSize jfa_sp_offset() const { return _jfa_sp_offset; }
+
+  // defined in frame_ARCH.cpp
+  JavaFrameAnchor* jfa_for_frame(const frame& frame) const;
+
+  // Typing
+  virtual bool is_entry_blob() const override { return true; }
 };
 
 #endif // SHARE_CODE_CODEBLOB_HPP

--- a/src/hotspot/share/logging/logTag.hpp
+++ b/src/hotspot/share/logging/logTag.hpp
@@ -132,6 +132,7 @@
   LOG_TAG(os) \
   LOG_TAG(owner) \
   LOG_TAG(pagesize) \
+  LOG_TAG(panama) \
   LOG_TAG(parser) \
   LOG_TAG(patch) \
   LOG_TAG(path) \

--- a/src/hotspot/share/logging/logTag.hpp
+++ b/src/hotspot/share/logging/logTag.hpp
@@ -132,7 +132,7 @@
   LOG_TAG(os) \
   LOG_TAG(owner) \
   LOG_TAG(pagesize) \
-  LOG_TAG(panama) \
+  DEBUG_ONLY(LOG_TAG(panama)) \
   LOG_TAG(parser) \
   LOG_TAG(patch) \
   LOG_TAG(path) \

--- a/src/hotspot/share/prims/foreign_globals.hpp
+++ b/src/hotspot/share/prims/foreign_globals.hpp
@@ -30,6 +30,13 @@
 
 #include CPU_HEADER(foreign_globals)
 
+struct CallRegs {
+  VMReg* _regs;
+  int _length;
+
+  void calling_convention(BasicType* sig_bt, VMRegPair *parm_regs, uint argcnt) const;
+};
+
 class ForeignGlobals {
 private:
   struct {
@@ -42,6 +49,7 @@ private:
 
   struct {
     int index_offset;
+    int type_offset;
   } VMS;
 
   struct {
@@ -65,9 +73,11 @@ private:
 
   const ABIDescriptor parse_abi_descriptor_impl(jobject jabi) const;
   const BufferLayout parse_buffer_layout_impl(jobject jlayout) const;
+  const CallRegs parse_call_regs_impl(jobject jconv) const;
 public:
   static const ABIDescriptor parse_abi_descriptor(jobject jabi);
   static const BufferLayout parse_buffer_layout(jobject jlayout);
+  static const CallRegs parse_call_regs(jobject jconv);
 };
 
 #endif // SHARE_PRIMS_FOREIGN_GLOBALS

--- a/src/hotspot/share/prims/foreign_globals.hpp
+++ b/src/hotspot/share/prims/foreign_globals.hpp
@@ -31,8 +31,11 @@
 #include CPU_HEADER(foreign_globals)
 
 struct CallRegs {
-  VMReg* _regs;
-  int _length;
+  VMReg* _arg_regs;
+  int _args_length;
+
+  VMReg* _ret_regs;
+  int _rets_length;
 
   void calling_convention(BasicType* sig_bt, VMRegPair *parm_regs, uint argcnt) const;
 };
@@ -60,6 +63,11 @@ private:
     int input_type_offsets_offset;
     int output_type_offsets_offset;
   } BL;
+
+  struct {
+    int arg_regs_offset;
+    int ret_regs_offset;
+  } CallConvOffsets;
 
   ForeignGlobals();
 

--- a/src/hotspot/share/prims/foreign_globals.hpp
+++ b/src/hotspot/share/prims/foreign_globals.hpp
@@ -24,6 +24,7 @@
 #ifndef SHARE_PRIMS_FOREIGN_GLOBALS
 #define SHARE_PRIMS_FOREIGN_GLOBALS
 
+#include "code/vmreg.hpp"
 #include "oops/oopsHierarchy.hpp"
 #include "utilities/growableArray.hpp"
 #include "utilities/macros.hpp"

--- a/src/hotspot/share/prims/nativeEntryPoint.cpp
+++ b/src/hotspot/share/prims/nativeEntryPoint.cpp
@@ -37,7 +37,8 @@ static JNINativeMethod NEP_methods[] = {
   {CC "vmStorageToVMReg", CC "(II)J", FN_PTR(NEP_vmStorageToVMReg)},
 };
 
-JNI_LEAF(void, JVM_RegisterNativeEntryPointMethods(JNIEnv *env, jclass NEP_class))
+JNI_ENTRY(void, JVM_RegisterNativeEntryPointMethods(JNIEnv *env, jclass NEP_class))
+  ThreadToNativeFromVM ttnfv(thread);
   int status = env->RegisterNatives(NEP_class, NEP_methods, sizeof(NEP_methods)/sizeof(JNINativeMethod));
   guarantee(status == JNI_OK && !env->ExceptionOccurred(),
             "register jdk.internal.invoke.NativeEntryPoint natives");

--- a/src/hotspot/share/prims/universalNativeInvoker.cpp
+++ b/src/hotspot/share/prims/universalNativeInvoker.cpp
@@ -55,7 +55,8 @@ static JNINativeMethod PI_methods[] = {
   {CC "generateAdapter", CC "(" FOREIGN_ABI "/ABIDescriptor;" FOREIGN_ABI "/BufferLayout;" ")J", FN_PTR(PI_generateAdapter)}
 };
 
-JNI_LEAF(void, JVM_RegisterProgrammableInvokerMethods(JNIEnv *env, jclass PI_class))
+JNI_ENTRY(void, JVM_RegisterProgrammableInvokerMethods(JNIEnv *env, jclass PI_class))
+  ThreadToNativeFromVM ttnfv(thread);
   int status = env->RegisterNatives(PI_class, PI_methods, sizeof(PI_methods)/sizeof(JNINativeMethod));
   guarantee(status == JNI_OK && !env->ExceptionOccurred(),
             "register jdk.internal.foreign.abi.programmable.ProgrammableInvoker natives");

--- a/src/hotspot/share/prims/universalUpcallHandler.cpp
+++ b/src/hotspot/share/prims/universalUpcallHandler.cpp
@@ -112,12 +112,17 @@ JVM_ENTRY(jlong, PUH_AllocateOptimzedUpcallStub(JNIEnv *env, jclass unused, jobj
   return (jlong) ProgrammableUpcallHandler::generate_optimized_upcall_stub(mh_j, entry, abi, conv);
 JVM_END
 
+JVM_ENTRY(jboolean, PUH_SupportsOptimzedUpcalls(JNIEnv *env, jclass unused))
+  return (jboolean) ProgrammableUpcallHandler::supports_optimized_upcalls();
+JVM_END
+
 #define CC (char*)  /*cast a literal from (const char*)*/
 #define FN_PTR(f) CAST_FROM_FN_PTR(void*, &f)
 
 static JNINativeMethod PUH_methods[] = {
   {CC "allocateUpcallStub", CC "(" "L" FOREIGN_ABI "ProgrammableUpcallHandler$InterpretedHandler;" "L" FOREIGN_ABI "ABIDescriptor;" "L" FOREIGN_ABI "BufferLayout;" ")J", FN_PTR(PUH_AllocateUpcallStub)},
   {CC "allocateOptimizedUpcallStub", CC "(" "Ljava/lang/invoke/MethodHandle;" "L" FOREIGN_ABI "ABIDescriptor;" "L" FOREIGN_ABI "ProgrammableUpcallHandler$CallRegs;" ")J", FN_PTR(PUH_AllocateOptimzedUpcallStub)},
+  {CC "supportsOptimizedUpcalls", CC "()Z", FN_PTR(PUH_SupportsOptimzedUpcalls)},
 };
 
 /**

--- a/src/hotspot/share/prims/universalUpcallHandler.cpp
+++ b/src/hotspot/share/prims/universalUpcallHandler.cpp
@@ -22,6 +22,7 @@
  */
 
 #include "precompiled.hpp"
+#include "classfile/javaClasses.hpp"
 #include "classfile/symbolTable.hpp"
 #include "classfile/systemDictionary.hpp"
 #include "compiler/compilationPolicy.hpp"

--- a/src/hotspot/share/prims/universalUpcallHandler.cpp
+++ b/src/hotspot/share/prims/universalUpcallHandler.cpp
@@ -91,6 +91,13 @@ ProgrammableUpcallHandler::ProgrammableUpcallHandler() {
     upcall_method.name->as_C_string(), upcall_method.sig->as_C_string());
 }
 
+void ProgrammableUpcallHandler::handle_uncaught_exception(oop exception) {
+  // Based on CATCH macro
+  tty->print_cr("Uncaught exception:");
+  exception->print();
+  ShouldNotReachHere();
+}
+
 JVM_ENTRY(jlong, PUH_AllocateUpcallStub(JNIEnv *env, jclass unused, jobject rec, jobject abi, jobject buffer_layout))
   Handle receiver(THREAD, JNIHandles::resolve(rec));
   jobject global_rec = JNIHandles::make_global(receiver);

--- a/src/hotspot/share/prims/universalUpcallHandler.cpp
+++ b/src/hotspot/share/prims/universalUpcallHandler.cpp
@@ -77,20 +77,20 @@ const ProgrammableUpcallHandler& ProgrammableUpcallHandler::instance() {
 ProgrammableUpcallHandler::ProgrammableUpcallHandler() {
   Thread* THREAD = Thread::current();
   ResourceMark rm(THREAD);
-  Symbol* sym = SymbolTable::new_symbol(FOREIGN_ABI "ProgrammableUpcallHandler");
+  Symbol* sym = SymbolTable::new_symbol(FOREIGN_ABI "ProgrammableUpcallHandler$InterpretedHandler");
   Klass* k = SystemDictionary::resolve_or_null(sym, Handle(), Handle(), CATCH);
   k->initialize(CATCH);
 
   upcall_method.klass = k;
   upcall_method.name = SymbolTable::new_symbol("invoke");
-  upcall_method.sig = SymbolTable::new_symbol("(L" FOREIGN_ABI "ProgrammableUpcallHandler;J)V");
+  upcall_method.sig = SymbolTable::new_symbol("(L" FOREIGN_ABI "ProgrammableUpcallHandler$InterpretedHandler;J)V");
 
   assert(upcall_method.klass->lookup_method(upcall_method.name, upcall_method.sig) != nullptr,
     "Could not find upcall method: %s.%s%s", upcall_method.klass->external_name(),
     upcall_method.name->as_C_string(), upcall_method.sig->as_C_string());
 }
 
-JNI_ENTRY(jlong, PUH_AllocateUpcallStub(JNIEnv *env, jobject rec, jobject abi, jobject buffer_layout))
+JVM_ENTRY(jlong, PUH_AllocateUpcallStub(JNIEnv *env, jclass unused, jobject rec, jobject abi, jobject buffer_layout))
   Handle receiver(THREAD, JNIHandles::resolve(rec));
   jobject global_rec = JNIHandles::make_global(receiver);
   return (jlong) ProgrammableUpcallHandler::generate_upcall_stub(global_rec, abi, buffer_layout);
@@ -100,7 +100,11 @@ JNI_END
 #define FN_PTR(f) CAST_FROM_FN_PTR(void*, &f)
 
 static JNINativeMethod PUH_methods[] = {
+<<<<<<< HEAD
   {CC "allocateUpcallStub", CC "(L" FOREIGN_ABI "ABIDescriptor;L" FOREIGN_ABI "BufferLayout;" ")J", FN_PTR(PUH_AllocateUpcallStub)},
+=======
+  {CC "allocateUpcallStub", CC "(" FOREIGN_ABI "/ProgrammableUpcallHandler$InterpretedHandler;" FOREIGN_ABI "/ABIDescriptor;" FOREIGN_ABI "/BufferLayout;" ")J", FN_PTR(PUH_AllocateUpcallStub)},
+>>>>>>> b56cc46bb13... Add upcall MH spec
 };
 
 /**

--- a/src/hotspot/share/prims/universalUpcallHandler.cpp
+++ b/src/hotspot/share/prims/universalUpcallHandler.cpp
@@ -117,7 +117,7 @@ JVM_END
 
 static JNINativeMethod PUH_methods[] = {
   {CC "allocateUpcallStub", CC "(" "L" FOREIGN_ABI "ProgrammableUpcallHandler$InterpretedHandler;" "L" FOREIGN_ABI "ABIDescriptor;" "L" FOREIGN_ABI "BufferLayout;" ")J", FN_PTR(PUH_AllocateUpcallStub)},
-  {CC "allocateOptimizedUpcallStub", CC "(" "Ljava/lang/invoke/MethodHandle;" "L" FOREIGN_ABI "ABIDescriptor;" "[L" FOREIGN_ABI "VMStorage;" ")J", FN_PTR(PUH_AllocateOptimzedUpcallStub)},
+  {CC "allocateOptimizedUpcallStub", CC "(" "Ljava/lang/invoke/MethodHandle;" "L" FOREIGN_ABI "ABIDescriptor;" "L" FOREIGN_ABI "ProgrammableUpcallHandler$CallRegs;" ")J", FN_PTR(PUH_AllocateOptimzedUpcallStub)},
 };
 
 /**

--- a/src/hotspot/share/prims/universalUpcallHandler.cpp
+++ b/src/hotspot/share/prims/universalUpcallHandler.cpp
@@ -89,13 +89,13 @@ const ProgrammableUpcallHandler& ProgrammableUpcallHandler::instance() {
 ProgrammableUpcallHandler::ProgrammableUpcallHandler() {
   Thread* THREAD = Thread::current();
   ResourceMark rm(THREAD);
-  Symbol* sym = SymbolTable::new_symbol(FOREIGN_ABI "ProgrammableUpcallHandler$InterpretedHandler");
+  Symbol* sym = SymbolTable::new_symbol(FOREIGN_ABI "ProgrammableUpcallHandler");
   Klass* k = SystemDictionary::resolve_or_null(sym, Handle(), Handle(), CATCH);
   k->initialize(CATCH);
 
   upcall_method.klass = k;
   upcall_method.name = SymbolTable::new_symbol("invoke");
-  upcall_method.sig = SymbolTable::new_symbol("(L" FOREIGN_ABI "ProgrammableUpcallHandler$InterpretedHandler;J)V");
+  upcall_method.sig = SymbolTable::new_symbol("(Ljava/lang/invoke/MethodHandle;J)V");
 
   assert(upcall_method.klass->lookup_method(upcall_method.name, upcall_method.sig) != nullptr,
     "Could not find upcall method: %s.%s%s", upcall_method.klass->external_name(),
@@ -138,7 +138,7 @@ JVM_END
 #define FN_PTR(f) CAST_FROM_FN_PTR(void*, &f)
 
 static JNINativeMethod PUH_methods[] = {
-  {CC "allocateUpcallStub", CC "(" "L" FOREIGN_ABI "ProgrammableUpcallHandler$InterpretedHandler;" "L" FOREIGN_ABI "ABIDescriptor;" "L" FOREIGN_ABI "BufferLayout;" ")J", FN_PTR(PUH_AllocateUpcallStub)},
+  {CC "allocateUpcallStub", CC "(" "Ljava/lang/invoke/MethodHandle;" "L" FOREIGN_ABI "ABIDescriptor;" "L" FOREIGN_ABI "BufferLayout;" ")J", FN_PTR(PUH_AllocateUpcallStub)},
   {CC "allocateOptimizedUpcallStub", CC "(" "Ljava/lang/invoke/MethodHandle;" "L" FOREIGN_ABI "ABIDescriptor;" "L" FOREIGN_ABI "ProgrammableUpcallHandler$CallRegs;" ")J", FN_PTR(PUH_AllocateOptimzedUpcallStub)},
   {CC "supportsOptimizedUpcalls", CC "()Z", FN_PTR(PUH_SupportsOptimzedUpcalls)},
 };

--- a/src/hotspot/share/prims/universalUpcallHandler.hpp
+++ b/src/hotspot/share/prims/universalUpcallHandler.hpp
@@ -48,6 +48,7 @@ private:
 public:
   static address generate_optimized_upcall_stub(jobject mh, Method* entry, jobject jabi, jobject jconv);
   static address generate_upcall_stub(jobject rec, jobject abi, jobject buffer_layout);
+  static bool supports_optimized_upcalls();
 };
 
 #endif // SHARE_VM_PRIMS_UNIVERSALUPCALLHANDLER_HPP

--- a/src/hotspot/share/prims/universalUpcallHandler.hpp
+++ b/src/hotspot/share/prims/universalUpcallHandler.hpp
@@ -46,6 +46,7 @@ private:
   static void upcall_helper(JavaThread* thread, jobject rec, address buff);
   static void attach_thread_and_do_upcall(jobject rec, address buff);
 public:
+  static address generate_optimized_upcall_stub(jobject mh, Method* entry, jobject jabi, jobject jconv);
   static address generate_upcall_stub(jobject rec, jobject abi, jobject buffer_layout);
 };
 

--- a/src/hotspot/share/prims/universalUpcallHandler.hpp
+++ b/src/hotspot/share/prims/universalUpcallHandler.hpp
@@ -49,6 +49,7 @@ public:
   static address generate_optimized_upcall_stub(jobject mh, Method* entry, jobject jabi, jobject jconv);
   static address generate_upcall_stub(jobject rec, jobject abi, jobject buffer_layout);
   static bool supports_optimized_upcalls();
+  static void handle_uncaught_exception(oop exception);
 };
 
 #endif // SHARE_VM_PRIMS_UNIVERSALUPCALLHANDLER_HPP

--- a/src/hotspot/share/prims/universalUpcallHandler.hpp
+++ b/src/hotspot/share/prims/universalUpcallHandler.hpp
@@ -45,11 +45,14 @@ private:
 
   static void upcall_helper(JavaThread* thread, jobject rec, address buff);
   static void attach_thread_and_do_upcall(jobject rec, address buff);
+
+  static void handle_uncaught_exception(oop exception);
+  static Thread* maybe_attach_and_get_thread(bool* should_detach);
+  static void detach_thread(Thread* thread);
 public:
   static address generate_optimized_upcall_stub(jobject mh, Method* entry, jobject jabi, jobject jconv);
   static address generate_upcall_stub(jobject rec, jobject abi, jobject buffer_layout);
   static bool supports_optimized_upcalls();
-  static void handle_uncaught_exception(oop exception);
 };
 
 #endif // SHARE_VM_PRIMS_UNIVERSALUPCALLHANDLER_HPP

--- a/src/hotspot/share/prims/upcallStubs.cpp
+++ b/src/hotspot/share/prims/upcallStubs.cpp
@@ -35,8 +35,14 @@ JVM_ENTRY(static jboolean, UH_FreeUpcallStub0(JNIEnv *env, jobject _unused, jlon
     return false;
   }
   //free global JNI handle
-  jobject* rec_ptr = (jobject*)(void*)cb -> content_begin();
-  JNIHandles::destroy_global(*rec_ptr);
+  jobject handle = NULL;
+  if (cb->is_entry_blob()) {
+    handle = ((EntryBlob*)cb)->receiver();
+  } else {
+    jobject* handle_ptr = (jobject*)(void*)cb->content_begin();
+    handle = *handle_ptr;
+  }
+  JNIHandles::destroy_global(handle);
   //free code blob
   CodeCache::free(cb);
   return true;

--- a/src/hotspot/share/runtime/frame.cpp
+++ b/src/hotspot/share/runtime/frame.cpp
@@ -1069,7 +1069,7 @@ void frame::oops_do_internal(OopClosure* f, CodeBlobClosure* cf, const RegisterM
     oops_interpreted_do(f, map, use_interpreter_oop_map_cache);
   } else if (is_entry_frame()) {
     oops_entry_do(f, map);
-  } else if (is_upcall_frame()) {
+  } else if (is_panama_entry_frame()) {
    // Nothing to do
    // receiver is a global ref
    // handle block is for JNI

--- a/src/hotspot/share/runtime/frame.cpp
+++ b/src/hotspot/share/runtime/frame.cpp
@@ -1069,6 +1069,10 @@ void frame::oops_do_internal(OopClosure* f, CodeBlobClosure* cf, const RegisterM
     oops_interpreted_do(f, map, use_interpreter_oop_map_cache);
   } else if (is_entry_frame()) {
     oops_entry_do(f, map);
+  } else if (is_upcall_frame()) {
+   // Nothing to do
+   // receiver is a global ref
+   // handle block is for JNI
   } else if (CodeCache::contains(pc())) {
     oops_code_blob_do(f, cf, map, derived_mode);
   } else {

--- a/src/hotspot/share/runtime/frame.hpp
+++ b/src/hotspot/share/runtime/frame.hpp
@@ -137,7 +137,7 @@ class frame {
   bool is_compiled_frame()       const;
   bool is_safepoint_blob_frame() const;
   bool is_deoptimized_frame()    const;
-  bool is_upcall_frame()         const;
+  bool is_panama_entry_frame()         const;
 
   // testers
   bool is_first_frame() const; // oldest frame? (has no sender)
@@ -172,7 +172,7 @@ class frame {
   frame sender_for_entry_frame(RegisterMap* map) const;
   frame sender_for_interpreter_frame(RegisterMap* map) const;
   frame sender_for_native_frame(RegisterMap* map) const;
-  frame sender_for_upcall_frame(RegisterMap* map) const;
+  frame sender_for_panama_entry_frame(RegisterMap* map) const;
 
   bool is_entry_frame_valid(JavaThread* thread) const;
 

--- a/src/hotspot/share/runtime/frame.hpp
+++ b/src/hotspot/share/runtime/frame.hpp
@@ -137,6 +137,7 @@ class frame {
   bool is_compiled_frame()       const;
   bool is_safepoint_blob_frame() const;
   bool is_deoptimized_frame()    const;
+  bool is_upcall_frame()         const;
 
   // testers
   bool is_first_frame() const; // oldest frame? (has no sender)
@@ -171,6 +172,7 @@ class frame {
   frame sender_for_entry_frame(RegisterMap* map) const;
   frame sender_for_interpreter_frame(RegisterMap* map) const;
   frame sender_for_native_frame(RegisterMap* map) const;
+  frame sender_for_upcall_frame(RegisterMap* map) const;
 
   bool is_entry_frame_valid(JavaThread* thread) const;
 

--- a/src/hotspot/share/runtime/frame.inline.hpp
+++ b/src/hotspot/share/runtime/frame.inline.hpp
@@ -52,7 +52,7 @@ inline bool frame::is_first_frame() const {
   return is_entry_frame() && entry_frame_is_first();
 }
 
-inline bool frame::is_upcall_frame() const {
+inline bool frame::is_panama_entry_frame() const {
   return _cb != NULL && _cb->is_entry_blob();
 }
 

--- a/src/hotspot/share/runtime/frame.inline.hpp
+++ b/src/hotspot/share/runtime/frame.inline.hpp
@@ -52,6 +52,10 @@ inline bool frame::is_first_frame() const {
   return is_entry_frame() && entry_frame_is_first();
 }
 
+inline bool frame::is_upcall_frame() const {
+  return _cb != NULL && _cb->is_entry_blob();
+}
+
 inline oop* frame::oopmapreg_to_location(VMReg reg, const RegisterMap* reg_map) const {
   if(reg->is_reg()) {
     // If it is passed in a register, it got spilled in the stub frame.

--- a/src/hotspot/share/runtime/globals.hpp
+++ b/src/hotspot/share/runtime/globals.hpp
@@ -2080,6 +2080,9 @@ const intx ObjectAlignmentInBytes = 8;
           false AARCH64_ONLY(DEBUG_ONLY(||true)),                           \
              "Mark all threads after a safepoint, and clear on a modify "   \
              "fence. Add cleanliness checks.")                              \
+                                                                            \
+  develop(bool, TracePanamaUpcallStubs, false,                              \
+                "Trace Panama upcall stub generation")                      \
 
 // end of RUNTIME_FLAGS
 

--- a/src/hotspot/share/runtime/sharedRuntime.cpp
+++ b/src/hotspot/share/runtime/sharedRuntime.cpp
@@ -511,6 +511,9 @@ address SharedRuntime::raw_exception_handler_for_return_address(JavaThread* thre
     // JavaCallWrapper::~JavaCallWrapper
     return StubRoutines::catch_exception_entry();
   }
+  if (blob != NULL && blob->is_entry_blob()) {
+    return ((EntryBlob*)blob)->exception_handler();
+  }
   // Interpreted code
   if (Interpreter::contains(return_address)) {
     // The deferred StackWatermarkSet::after_unwind check will be performed in
@@ -1443,7 +1446,7 @@ JRT_BLOCK_ENTRY(address, SharedRuntime::handle_wrong_method_ic_miss(JavaThread* 
   frame stub_frame = thread->last_frame();
   assert(stub_frame.is_runtime_frame(), "sanity check");
   frame caller_frame = stub_frame.sender(&reg_map);
-  assert(!caller_frame.is_interpreted_frame() && !caller_frame.is_entry_frame(), "unexpected frame");
+  assert(!caller_frame.is_interpreted_frame() && !caller_frame.is_entry_frame() && !caller_frame.is_upcall_frame(), "unexpected frame");
 #endif /* ASSERT */
 
   methodHandle callee_method;
@@ -1475,7 +1478,8 @@ JRT_BLOCK_ENTRY(address, SharedRuntime::handle_wrong_method(JavaThread* thread))
   frame caller_frame = stub_frame.sender(&reg_map);
 
   if (caller_frame.is_interpreted_frame() ||
-      caller_frame.is_entry_frame()) {
+      caller_frame.is_entry_frame() ||
+      caller_frame.is_upcall_frame()) {
     Method* callee = thread->callee_target();
     guarantee(callee != NULL && callee->is_method(), "bad handshake");
     thread->set_vm_result_2(callee);

--- a/src/hotspot/share/runtime/sharedRuntime.cpp
+++ b/src/hotspot/share/runtime/sharedRuntime.cpp
@@ -1446,7 +1446,7 @@ JRT_BLOCK_ENTRY(address, SharedRuntime::handle_wrong_method_ic_miss(JavaThread* 
   frame stub_frame = thread->last_frame();
   assert(stub_frame.is_runtime_frame(), "sanity check");
   frame caller_frame = stub_frame.sender(&reg_map);
-  assert(!caller_frame.is_interpreted_frame() && !caller_frame.is_entry_frame() && !caller_frame.is_upcall_frame(), "unexpected frame");
+  assert(!caller_frame.is_interpreted_frame() && !caller_frame.is_entry_frame() && !caller_frame.is_panama_entry_frame(), "unexpected frame");
 #endif /* ASSERT */
 
   methodHandle callee_method;
@@ -1479,7 +1479,7 @@ JRT_BLOCK_ENTRY(address, SharedRuntime::handle_wrong_method(JavaThread* thread))
 
   if (caller_frame.is_interpreted_frame() ||
       caller_frame.is_entry_frame() ||
-      caller_frame.is_upcall_frame()) {
+      caller_frame.is_panama_entry_frame()) {
     Method* callee = thread->callee_target();
     guarantee(callee != NULL && callee->is_method(), "bad handshake");
     thread->set_vm_result_2(callee);

--- a/src/hotspot/share/runtime/sharedRuntime.hpp
+++ b/src/hotspot/share/runtime/sharedRuntime.hpp
@@ -473,6 +473,13 @@ class SharedRuntime: AllStatic {
   static void    save_native_result(MacroAssembler *_masm, BasicType ret_type, int frame_slots);
   static void restore_native_result(MacroAssembler *_masm, BasicType ret_type, int frame_slots);
 
+  static void unpack_array_argument(MacroAssembler* masm, VMRegPair reg, BasicType in_elem_type, VMRegPair body_arg, VMRegPair length_arg);
+
+  static void   move32_64(MacroAssembler* masm, VMRegPair src, VMRegPair dst);
+  static void   long_move(MacroAssembler* masm, VMRegPair src, VMRegPair dst);
+  static void  float_move(MacroAssembler* masm, VMRegPair src, VMRegPair dst);
+  static void double_move(MacroAssembler* masm, VMRegPair src, VMRegPair dst);
+
   // Generate a native wrapper for a given method.  The method takes arguments
   // in the Java compiled code convention, marshals them to the native
   // convention (handlizes oops, etc), transitions to native, makes the call,
@@ -521,6 +528,12 @@ class SharedRuntime: AllStatic {
                                          int shadow_space_bytes,
                                          const GrowableArray<VMReg>& input_registers,
                                          const GrowableArray<VMReg>& output_registers);
+
+  static void compute_move_order(const BasicType* in_sig_bt,
+                                 int total_in_args, const VMRegPair* in_regs,
+                                 int total_out_args, VMRegPair* out_regs,
+                                 GrowableArray<int>& arg_order,
+                                 VMRegPair tmp_vmreg);
 
 #ifndef PRODUCT
 
@@ -589,7 +602,6 @@ class SharedRuntime: AllStatic {
   static void print_call_statistics(int comp_total);
   static void print_statistics();
   static void print_ic_miss_histogram();
-
 #endif // PRODUCT
 };
 

--- a/src/hotspot/share/runtime/sharedRuntime.hpp
+++ b/src/hotspot/share/runtime/sharedRuntime.hpp
@@ -473,8 +473,6 @@ class SharedRuntime: AllStatic {
   static void    save_native_result(MacroAssembler *_masm, BasicType ret_type, int frame_slots);
   static void restore_native_result(MacroAssembler *_masm, BasicType ret_type, int frame_slots);
 
-  static void unpack_array_argument(MacroAssembler* masm, VMRegPair reg, BasicType in_elem_type, VMRegPair body_arg, VMRegPair length_arg);
-
   static void   move32_64(MacroAssembler* masm, VMRegPair src, VMRegPair dst);
   static void   long_move(MacroAssembler* masm, VMRegPair src, VMRegPair dst);
   static void  float_move(MacroAssembler* masm, VMRegPair src, VMRegPair dst);
@@ -602,6 +600,7 @@ class SharedRuntime: AllStatic {
   static void print_call_statistics(int comp_total);
   static void print_statistics();
   static void print_ic_miss_histogram();
+
 #endif // PRODUCT
 };
 

--- a/src/java.base/share/classes/java/lang/invoke/MethodHandleImpl.java
+++ b/src/java.base/share/classes/java/lang/invoke/MethodHandleImpl.java
@@ -1764,6 +1764,7 @@ abstract class MethodHandleImpl {
             public void ensureCustomized(MethodHandle mh) {
                 mh.customize();
             }
+
             @Override
             public VarHandle memoryAccessVarHandle(Class<?> carrier, boolean skipAlignmentMaskCheck, long alignmentMask,
                                                    ByteOrder order) {

--- a/src/java.base/share/classes/java/lang/invoke/MethodHandleImpl.java
+++ b/src/java.base/share/classes/java/lang/invoke/MethodHandleImpl.java
@@ -1761,6 +1761,10 @@ abstract class MethodHandleImpl {
             }
 
             @Override
+            public void ensureCustomized(MethodHandle mh) {
+                mh.customize();
+            }
+            @Override
             public VarHandle memoryAccessVarHandle(Class<?> carrier, boolean skipAlignmentMaskCheck, long alignmentMask,
                                                    ByteOrder order) {
                 return VarHandles.makeMemoryAddressViewHandle(carrier, skipAlignmentMaskCheck, alignmentMask, order);

--- a/src/java.base/share/classes/jdk/internal/access/JavaLangInvokeAccess.java
+++ b/src/java.base/share/classes/jdk/internal/access/JavaLangInvokeAccess.java
@@ -132,4 +132,11 @@ public interface JavaLangInvokeAccess {
      * @return the native method handle
      */
     MethodHandle nativeMethodHandle(NativeEntryPoint nep, MethodHandle fallback);
+
+    /**
+     * Ensure given method handle is customized
+     *
+     * @param mh the method handle
+     */
+    void ensureCustomized(MethodHandle mh);
 }

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/Binding.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/Binding.java
@@ -922,7 +922,7 @@ public abstract class Binding {
         @Override
         public MethodHandle specialize(MethodHandle specializedHandle, int insertPos, int allocatorPos) {
             MethodHandle toSegmentHandle = insertArguments(MH_TO_SEGMENT, 1, size);
-            specializedHandle = filterArguments(specializedHandle, insertPos, toSegmentHandle);
+            specializedHandle = collectArguments(specializedHandle, insertPos, toSegmentHandle);
             return SharedUtils.mergeArguments(specializedHandle, allocatorPos, insertPos + 1);
         }
 

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/Binding.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/Binding.java
@@ -541,7 +541,10 @@ public abstract class Binding {
         }
 
         public VarHandle varHandle() {
-            return MemoryHandles.insertCoordinates(MemoryHandles.varHandle(type, ByteOrder.nativeOrder()), 1, offset);
+            // alignment is set to 1 byte here to avoid exceptions for cases where we do super word
+            // copies of e.g. 2 int fields of a struct as a single long, while the struct is only
+            // 4-byte-aligned (since it only contains ints)
+            return MemoryHandles.insertCoordinates(MemoryHandles.varHandle(type, 1, ByteOrder.nativeOrder()), 1, offset);
         }
     }
 

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/BufferLayout.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/BufferLayout.java
@@ -26,6 +26,7 @@ package jdk.internal.foreign.abi;
 
 import jdk.incubator.foreign.MemoryLayouts;
 import jdk.incubator.foreign.MemorySegment;
+import jdk.internal.foreign.MemoryAddressImpl;
 
 import java.io.PrintStream;
 import java.lang.invoke.VarHandle;
@@ -115,7 +116,7 @@ class BufferLayout {
         return Long.toHexString((long) VH_LONG.get(buffer.asSlice(offset)));
     }
 
-    private static void dumpValues(jdk.internal.foreign.abi.Architecture arch, MemorySegment buff, PrintStream stream,
+    private void dumpValues(jdk.internal.foreign.abi.Architecture arch, MemorySegment buff, PrintStream stream,
                                    Map<jdk.internal.foreign.abi.VMStorage, Long> offsets) {
         for (var entry : offsets.entrySet()) {
             VMStorage storage = entry.getKey();
@@ -128,6 +129,14 @@ class BufferLayout {
             }
             stream.println("}");
         }
+        long stack_ptr = (long) VH_LONG.get(buff.asSlice(stack_args));
+        long stack_bytes = (long) VH_LONG.get(buff.asSlice(stack_args_bytes));
+        MemorySegment stackArgs = MemoryAddressImpl.ofLongUnchecked(stack_ptr, stack_bytes);
+        stream.println("Stack {");
+        for (int i = 0; i < stack_bytes / 8; i += 8) {
+            stream.printf("    @%d: %s%n", i, getLongString(stackArgs, i));
+        }
+        stream.println("}");
     }
 
     void dump(Architecture arch, MemorySegment buff, PrintStream stream) {

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/ProgrammableInvoker.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/ProgrammableInvoker.java
@@ -240,7 +240,7 @@ public class ProgrammableInvoker {
         }
 
         if (bufferCopySize > 0) {
-            specializedHandle = SharedUtils.wrapWithAllocatorForDowncall(specializedHandle, argAllocatorPos, bufferCopySize);
+            specializedHandle = SharedUtils.wrapWithAllocator(specializedHandle, argAllocatorPos, bufferCopySize, false);
         }
         return specializedHandle;
     }

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/ProgrammableInvoker.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/ProgrammableInvoker.java
@@ -240,7 +240,7 @@ public class ProgrammableInvoker {
         }
 
         if (bufferCopySize > 0) {
-            specializedHandle = SharedUtils.wrapWithAllocator(specializedHandle, argAllocatorPos, bufferCopySize);
+            specializedHandle = SharedUtils.wrapWithAllocatorForDowncall(specializedHandle, argAllocatorPos, bufferCopySize);
         }
         return specializedHandle;
     }

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/ProgrammableInvoker.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/ProgrammableInvoker.java
@@ -28,7 +28,6 @@ import jdk.incubator.foreign.Addressable;
 import jdk.incubator.foreign.MemoryAddress;
 import jdk.incubator.foreign.MemoryLayouts;
 import jdk.incubator.foreign.MemorySegment;
-import jdk.incubator.foreign.NativeScope;
 import jdk.internal.access.JavaLangInvokeAccess;
 import jdk.internal.access.SharedSecrets;
 import jdk.internal.foreign.abi.SharedUtils.Allocator;
@@ -44,19 +43,14 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.stream.Collectors;
-import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
 import static java.lang.invoke.MethodHandles.collectArguments;
 import static java.lang.invoke.MethodHandles.dropArguments;
-import static java.lang.invoke.MethodHandles.empty;
 import static java.lang.invoke.MethodHandles.filterArguments;
 import static java.lang.invoke.MethodHandles.identity;
 import static java.lang.invoke.MethodHandles.insertArguments;
-import static java.lang.invoke.MethodHandles.tryFinally;
 import static java.lang.invoke.MethodType.methodType;
-import static jdk.internal.foreign.abi.SharedUtils.Allocator.THROWING_ALLOCATOR;
 import static jdk.internal.foreign.abi.SharedUtils.DEFAULT_ALLOCATOR;
 import static sun.security.action.GetBooleanAction.privilegedGetProperty;
 
@@ -79,12 +73,7 @@ public class ProgrammableInvoker {
 
     private static final MethodHandle MH_INVOKE_MOVES;
     private static final MethodHandle MH_INVOKE_INTERP_BINDINGS;
-
     private static final MethodHandle MH_ADDR_TO_LONG;
-    private static final MethodHandle MH_MAKE_SCOPE;
-    private static final MethodHandle MH_CLOSE_SCOPE;
-    private static final MethodHandle MH_WRAP_SCOPE;
-
     private static final Map<ABIDescriptor, Long> adapterStubs = new ConcurrentHashMap<>();
 
     private static final MethodHandle EMPTY_OBJECT_ARRAY_HANDLE = MethodHandles.constant(Object[].class, new Object[0]);
@@ -96,12 +85,6 @@ public class ProgrammableInvoker {
                     methodType(Object.class, long.class, Object[].class, Binding.VMStore[].class, Binding.VMLoad[].class));
             MH_INVOKE_INTERP_BINDINGS = lookup.findVirtual(ProgrammableInvoker.class, "invokeInterpBindings",
                     methodType(Object.class, Addressable.class, Object[].class, MethodHandle.class, Map.class, Map.class));
-            MH_MAKE_SCOPE = lookup.findStatic(NativeScope.class, "boundedScope",
-                    methodType(NativeScope.class, long.class));
-            MH_CLOSE_SCOPE = lookup.findVirtual(NativeScope.class, "close",
-                    methodType(void.class));
-            MH_WRAP_SCOPE = lookup.findStatic(Allocator.class, "ofScope",
-                    methodType(Allocator.class, NativeScope.class));
             MethodHandle MH_Addressable_address = lookup.findVirtual(Addressable.class, "address",
                     methodType(MemoryAddress.class));
             MethodHandle MH_MemoryAddress_toRawLongValue = lookup.findVirtual(MemoryAddress.class, "toRawLongValue",
@@ -176,8 +159,8 @@ public class ProgrammableInvoker {
         if (USE_SPEC && isSimple) {
             handle = specialize(handle);
          } else {
-            Map<VMStorage, Integer> argIndexMap = indexMap(argMoves);
-            Map<VMStorage, Integer> retIndexMap = indexMap(retMoves);
+            Map<VMStorage, Integer> argIndexMap = SharedUtils.indexMap(argMoves);
+            Map<VMStorage, Integer> retIndexMap = SharedUtils.indexMap(retMoves);
 
             handle = insertArguments(MH_INVOKE_INTERP_BINDINGS.bindTo(this), 2, handle, argIndexMap, retIndexMap);
             MethodHandle collectorInterp = makeCollectorHandle(callingSequence.methodType());
@@ -257,31 +240,9 @@ public class ProgrammableInvoker {
         }
 
         if (bufferCopySize > 0) {
-            // insert try-finally to close the NativeScope used for Binding.Copy
-            MethodHandle closer = leafType.returnType() == void.class
-                  // (Throwable, Addressable, NativeScope) -> void
-                ? collectArguments(empty(methodType(void.class, Throwable.class, Addressable.class)), 2, MH_CLOSE_SCOPE)
-                  // (Throwable, V, Addressable, NativeScope) -> V
-                : collectArguments( // (Throwable, V, Addressable, NativeScope) -> V
-                    dropArguments( // (Throwable, V, Addressable) -> V
-                        dropArguments( // (Throwable, V) -> V
-                            identity(specializedHandle.type().returnType()), // (V) -> V
-                            0, Throwable.class),
-                        2, Addressable.class),
-                                   3, MH_CLOSE_SCOPE);
-            // Handle takes a SharedUtils.Allocator, so need to wrap our NativeScope
-            specializedHandle = filterArguments(specializedHandle, argAllocatorPos, MH_WRAP_SCOPE);
-            specializedHandle = tryFinally(specializedHandle, closer);
-            MethodHandle makeScopeHandle = insertArguments(MH_MAKE_SCOPE, 0, bufferCopySize);
-            specializedHandle = collectArguments(specializedHandle, argAllocatorPos, makeScopeHandle);
+            specializedHandle = SharedUtils.wrapWithAllocator(specializedHandle, argAllocatorPos, bufferCopySize);
         }
         return specializedHandle;
-    }
-
-    private static Map<VMStorage, Integer> indexMap(Binding.Move[] moves) {
-        return IntStream.range(0, moves.length)
-                        .boxed()
-                        .collect(Collectors.toMap(i -> moves[i].storage(), i -> i));
     }
 
     /**
@@ -350,10 +311,7 @@ public class ProgrammableInvoker {
     Object invokeInterpBindings(Addressable address, Object[] args, MethodHandle leaf,
                                 Map<VMStorage, Integer> argIndexMap,
                                 Map<VMStorage, Integer> retIndexMap) throws Throwable {
-        Allocator unboxAllocator = bufferCopySize != 0
-                ? Allocator.ofScope(NativeScope.boundedScope(bufferCopySize))
-                : THROWING_ALLOCATOR;
-        try (unboxAllocator) {
+        try (Allocator unboxAllocator = SharedUtils.makeAllocator(bufferCopySize)) {
             // do argument processing, get Object[] as result
             Object[] leafArgs = new Object[leaf.type().parameterCount()];
             leafArgs[0] = address; // addr

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/ProgrammableInvoker.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/ProgrammableInvoker.java
@@ -200,7 +200,6 @@ public class ProgrammableInvoker {
 
     private MethodHandle specialize(MethodHandle leafHandle) {
         MethodType highLevelType = callingSequence.methodType();
-        MethodType leafType = leafHandle.type();
 
         MethodHandle specializedHandle = leafHandle; // initial
 

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/ProgrammableUpcallHandler.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/ProgrammableUpcallHandler.java
@@ -122,7 +122,7 @@ public class ProgrammableUpcallHandler {
                 .anyMatch(s -> abi.arch.isStackType(s.type()));
         if (USE_INTRINSICS && isSimple && !usesStackArgs && supportsOptimizedUpcalls()) {
             checkPrimitive(doBindings.type());
-            JLI.ensureCustomized(doBindings); // FIXME: consider more flexible scheme to customize upcall entry points
+            JLI.ensureCustomized(doBindings);
             VMStorage[] args = Arrays.stream(argMoves).map(Binding.Move::storage).toArray(VMStorage[]::new);
             VMStorage[] rets = Arrays.stream(retMoves).map(Binding.Move::storage).toArray(VMStorage[]::new);
             CallRegs conv = new CallRegs(args, rets);

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/ProgrammableUpcallHandler.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/ProgrammableUpcallHandler.java
@@ -198,7 +198,7 @@ public class ProgrammableUpcallHandler {
             specializedHandle = filterReturnValue(specializedHandle, filter);
         }
 
-        specializedHandle = SharedUtils.wrapWithAllocatorForUpcall(specializedHandle, argAllocatorPos, bufferCopySize);
+        specializedHandle = SharedUtils.wrapWithAllocator(specializedHandle, argAllocatorPos, bufferCopySize, true);
 
         return specializedHandle;
     }

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/ProgrammableUpcallHandler.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/ProgrammableUpcallHandler.java
@@ -120,7 +120,7 @@ public class ProgrammableUpcallHandler {
         boolean usesStackArgs = argMoveBindingsStream(callingSequence)
                 .map(Binding.VMLoad::storage)
                 .anyMatch(s -> abi.arch.isStackType(s.type()));
-        if (USE_INTRINSICS && isSimple && !usesStackArgs) {
+        if (USE_INTRINSICS && isSimple && !usesStackArgs && supportsOptimizedUpcalls()) {
             checkPrimitive(doBindings.type());
             JLI.ensureCustomized(doBindings); // FIXME: consider more flexible scheme to customize upcall entry points
             VMStorage[] args = Arrays.stream(argMoves).map(Binding.Move::storage).toArray(VMStorage[]::new);
@@ -312,6 +312,7 @@ public class ProgrammableUpcallHandler {
 
     public static native long allocateOptimizedUpcallStub(MethodHandle mh, ABIDescriptor abi, CallRegs conv);
     public static native long allocateUpcallStub(InterpretedHandler handler, ABIDescriptor abi, BufferLayout layout);
+    public static native boolean supportsOptimizedUpcalls();
 
     private static native void registerNatives();
     static {

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/ProgrammableUpcallHandler.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/ProgrammableUpcallHandler.java
@@ -210,10 +210,6 @@ public class ProgrammableUpcallHandler {
             this.mh = mh;
         }
 
-        // Note that 'mh' is not constant -> to fix we need to clone this static invoke method,
-        // gen a wrapper class that implements some (long)void protocol, and invoke that in native code
-        // instead. The call from native is still reflective, but from there up everything should be
-        // inlined/specialized.
         public static void invoke(InterpretedHandler handler, long address) throws Throwable {
             handler.mh.invokeExact(MemoryAddress.ofLong(address));
         }

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/ProgrammableUpcallHandler.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/ProgrammableUpcallHandler.java
@@ -215,9 +215,9 @@ public class ProgrammableUpcallHandler {
         }
     }
 
-    public static void invokeMoves(MemoryAddress buffer, MethodHandle leaf,
-                                   Binding.VMLoad[] argBindings, Binding.VMStore[] returnBindings,
-                                   ABIDescriptor abi, BufferLayout layout) throws Throwable {
+    private static void invokeMoves(MemoryAddress buffer, MethodHandle leaf,
+                                    Binding.VMLoad[] argBindings, Binding.VMStore[] returnBindings,
+                                    ABIDescriptor abi, BufferLayout layout) throws Throwable {
         MemorySegment bufferBase = MemoryAddressImpl.ofLongUnchecked(buffer.toRawLongValue(), layout.size);
 
         if (DEBUG) {
@@ -261,11 +261,11 @@ public class ProgrammableUpcallHandler {
         }
     }
 
-    public static Object invokeInterpBindings(Object[] moves, MethodHandle leaf,
-                                              Map<VMStorage, Integer> argIndexMap,
-                                              Map<VMStorage, Integer> retIndexMap,
-                                              CallingSequence callingSequence,
-                                              long bufferCopySize) throws Throwable {
+    private static Object invokeInterpBindings(Object[] moves, MethodHandle leaf,
+                                               Map<VMStorage, Integer> argIndexMap,
+                                               Map<VMStorage, Integer> retIndexMap,
+                                               CallingSequence callingSequence,
+                                               long bufferCopySize) throws Throwable {
         try (Allocator allocator = SharedUtils.makeAllocator(bufferCopySize)) {
             /// Invoke interpreter, got array of high-level arguments back
             Object[] args = new Object[callingSequence.methodType().parameterCount()];

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/ProgrammableUpcallHandler.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/ProgrammableUpcallHandler.java
@@ -28,17 +28,26 @@ package jdk.internal.foreign.abi;
 import jdk.incubator.foreign.MemoryAddress;
 import jdk.incubator.foreign.MemoryLayouts;
 import jdk.incubator.foreign.MemorySegment;
-import jdk.incubator.foreign.NativeScope;
 import jdk.internal.foreign.MemoryAddressImpl;
 import jdk.internal.foreign.abi.SharedUtils.Allocator;
-import jdk.internal.vm.annotation.Stable;
+import sun.security.action.GetPropertyAction;
 
 import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
 import java.lang.invoke.MethodType;
 import java.lang.invoke.VarHandle;
 import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 
+import static java.lang.invoke.MethodHandles.dropArguments;
+import static java.lang.invoke.MethodHandles.filterReturnValue;
+import static java.lang.invoke.MethodHandles.identity;
+import static java.lang.invoke.MethodHandles.insertArguments;
+import static java.lang.invoke.MethodHandles.lookup;
+import static java.lang.invoke.MethodType.methodType;
+import static jdk.internal.foreign.abi.SharedUtils.mergeArguments;
 import static sun.security.action.GetBooleanAction.privilegedGetProperty;
 
 /**
@@ -46,65 +55,188 @@ import static sun.security.action.GetBooleanAction.privilegedGetProperty;
  * takes an array of storage pointers, which describes the state of the CPU at the time of the upcall. This can be used
  * by the Java code to fetch the upcall arguments and to store the results to the desired location, as per system ABI.
  */
-public class ProgrammableUpcallHandler implements UpcallHandler {
+public class ProgrammableUpcallHandler {
 
     private static final boolean DEBUG =
         privilegedGetProperty("jdk.internal.foreign.ProgrammableUpcallHandler.DEBUG");
+    private static final boolean USE_SPEC = Boolean.parseBoolean(
+        GetPropertyAction.privilegedGetProperty("jdk.internal.foreign.ProgrammableUpcallHandler.USE_SPEC", "true"));
 
     private static final VarHandle VH_LONG = MemoryLayouts.JAVA_LONG.varHandle(long.class);
 
-    @Stable
-    private final MethodHandle mh;
-    private final MethodType type;
-    private final CallingSequence callingSequence;
-    private final long entryPoint;
+    private static final MethodHandle MH_invokeMoves;
+    private static final MethodHandle MH_invokeInterpBindings;
 
-    private final ABIDescriptor abi;
-    private final BufferLayout layout;
-
-    private final long bufferCopySize;
-
-    public ProgrammableUpcallHandler(ABIDescriptor abi, MethodHandle target, CallingSequence callingSequence) {
-        this.abi = abi;
-        this.layout = BufferLayout.of(abi);
-        this.type = callingSequence.methodType();
-        this.callingSequence = callingSequence;
-        this.mh = target.asSpreader(Object[].class, callingSequence.methodType().parameterCount());
-        this.entryPoint = allocateUpcallStub(abi, layout);
-        this.bufferCopySize = SharedUtils.bufferCopySize(callingSequence);
+    static {
+        try {
+            MethodHandles.Lookup lookup = lookup();
+            MH_invokeMoves = lookup.findStatic(ProgrammableUpcallHandler.class, "invokeMoves",
+                    methodType(void.class, MemoryAddress.class, MethodHandle.class,
+                               Binding.VMLoad[].class, Binding.VMStore[].class, ABIDescriptor.class, BufferLayout.class));
+            MH_invokeInterpBindings = lookup.findStatic(ProgrammableUpcallHandler.class, "invokeInterpBindings",
+                    methodType(Object.class, Object[].class, MethodHandle.class, Map.class, Map.class,
+                            CallingSequence.class, long.class));
+        } catch (ReflectiveOperationException e) {
+            throw new InternalError(e);
+        }
     }
 
-    @Override
-    public long entryPoint() {
-        return entryPoint;
+    public static UpcallHandler make(ABIDescriptor abi, MethodHandle target, CallingSequence callingSequence) {
+        Binding.VMLoad[] argMoves = argMoveBindings(callingSequence);
+        Binding.VMStore[] retMoves = retMoveBindings(callingSequence);
+
+        MethodHandle doBindings;
+        long bufferCopySize = SharedUtils.bufferCopySize(callingSequence);
+        boolean isSimple = !(retMoves.length > 1);
+        if (USE_SPEC && isSimple) {
+            Class<?> llReturn = retMoves.length == 1 ? retMoves[0].type() : null;
+            doBindings = specializedBindingHandle(target, callingSequence, llReturn, bufferCopySize);
+            doBindings = doBindings.asSpreader(Object[].class, doBindings.type().parameterCount());
+        } else {
+            Map<VMStorage, Integer> argIndices = SharedUtils.indexMap(argMoves);
+            Map<VMStorage, Integer> retIndices = SharedUtils.indexMap(retMoves);
+            target = target.asSpreader(Object[].class, callingSequence.methodType().parameterCount());
+            doBindings = insertArguments(MH_invokeInterpBindings, 1, target, argIndices, retIndices, callingSequence,
+                    bufferCopySize);
+        }
+
+        BufferLayout layout = BufferLayout.of(abi);
+        MethodHandle invokeMoves = insertArguments(MH_invokeMoves, 1, doBindings, argMoves, retMoves, abi, layout);
+        InterpretedHandler handler = new InterpretedHandler(invokeMoves);
+        long entryPoint = allocateUpcallStub(handler, abi, layout);
+        return () -> entryPoint;
     }
 
-    public static void invoke(ProgrammableUpcallHandler handler, long address) {
-        handler.invoke(MemoryAddress.ofLong(address));
+    private static Binding.VMLoad[] argMoveBindings(CallingSequence callingSequence) {
+        return callingSequence.argBindings()
+                .filter(Binding.VMLoad.class::isInstance)
+                .map(Binding.VMLoad.class::cast)
+                .toArray(Binding.VMLoad[]::new);
     }
 
-    private void invoke(MemoryAddress buffer) {
-        Allocator allocator = bufferCopySize != 0
-                ? Allocator.ofScope(NativeScope.boundedScope(bufferCopySize))
-                : Allocator.empty();
-        try (allocator) {
-            MemorySegment bufferBase = MemoryAddressImpl.ofLongUnchecked(buffer.toRawLongValue(), layout.size);
+    private static Binding.VMStore[] retMoveBindings(CallingSequence callingSequence) {
+        return callingSequence.retBindings()
+                .filter(Binding.VMStore.class::isInstance)
+                .map(Binding.VMStore.class::cast)
+                .toArray(Binding.VMStore[]::new);
+    }
 
-            if (DEBUG) {
-                System.err.println("Buffer state before:");
-                layout.dump(abi.arch, bufferBase, System.err);
+    private static MethodHandle specializedBindingHandle(MethodHandle target, CallingSequence callingSequence,
+                                                         Class<?> llReturn, long bufferCopySize) {
+        MethodType highLevelType = callingSequence.methodType();
+
+        MethodHandle specializedHandle = target; // initial
+
+        int argAllocatorPos = 0;
+        int argInsertPos = 1;
+        specializedHandle = dropArguments(specializedHandle, argAllocatorPos, SharedUtils.Allocator.class);
+        for (int i = 0; i < highLevelType.parameterCount(); i++) {
+            MethodHandle filter = identity(highLevelType.parameterType(i));
+            int filterAllocatorPos = 0;
+            int filterInsertPos = 1; // +1 for allocator
+            filter = dropArguments(filter, filterAllocatorPos, SharedUtils.Allocator.class);
+
+            List<Binding> bindings = callingSequence.argumentBindings(i);
+            for (int j = bindings.size() - 1; j >= 0; j--) {
+                Binding binding = bindings.get(j);
+                filter = binding.specialize(filter, filterInsertPos, filterAllocatorPos);
             }
+            specializedHandle = MethodHandles.collectArguments(specializedHandle, argInsertPos, filter);
+            specializedHandle = mergeArguments(specializedHandle, argAllocatorPos, argInsertPos + filterAllocatorPos);
+            argInsertPos += filter.type().parameterCount() - 1; // -1 for allocator
+        }
 
-            MemorySegment stackArgsBase = MemoryAddressImpl.ofLongUnchecked((long)VH_LONG.get(bufferBase.asSlice(layout.stack_args)));
-            Object[] args = new Object[type.parameterCount()];
-            for (int i = 0 ; i < type.parameterCount() ; i++) {
+        if (llReturn != null) {
+            int retAllocatorPos = -1; // assumed not needed
+            int retInsertPos = 0;
+            MethodHandle filter = identity(llReturn);
+            List<Binding> bindings = callingSequence.returnBindings();
+            for (int j = bindings.size() - 1; j >= 0; j--) {
+                Binding binding = bindings.get(j);
+                filter = binding.specialize(filter, retInsertPos, retAllocatorPos);
+            }
+            specializedHandle = filterReturnValue(specializedHandle, filter);
+        }
+
+        specializedHandle = SharedUtils.wrapWithAllocator(specializedHandle, argAllocatorPos, bufferCopySize);
+
+        return specializedHandle;
+    }
+
+    private static class InterpretedHandler {
+        private final MethodHandle mh;
+
+        InterpretedHandler(MethodHandle mh) {
+            this.mh = mh;
+        }
+
+        // Note that 'mh' is not constant -> to fix we need to clone this static invoke method,
+        // gen a wrapper class that implements some (long)void protocol, and invoke that in native code
+        // instead. The call from native is still reflective, but from there up everything should be
+        // inlined/specialized.
+        public static void invoke(InterpretedHandler handler, long address) throws Throwable {
+            handler.mh.invokeExact(MemoryAddress.ofLong(address));
+        }
+    }
+
+    public static void invokeMoves(MemoryAddress buffer, MethodHandle leaf,
+                                   Binding.VMLoad[] argBindings, Binding.VMStore[] returnBindings,
+                                   ABIDescriptor abi, BufferLayout layout) throws Throwable {
+        MemorySegment bufferBase = MemoryAddressImpl.ofLongUnchecked(buffer.toRawLongValue(), layout.size);
+
+        if (DEBUG) {
+            System.err.println("Buffer state before:");
+            layout.dump(abi.arch, bufferBase, System.err);
+        }
+
+        MemorySegment stackArgsBase = MemoryAddressImpl.ofLongUnchecked((long)VH_LONG.get(bufferBase.asSlice(layout.stack_args)));
+        Object[] moves = new Object[argBindings.length];
+        for (int i = 0; i < moves.length; i++) {
+            Binding.VMLoad binding = argBindings[i];
+            VMStorage storage = binding.storage();
+            MemorySegment ptr = abi.arch.isStackType(storage.type())
+                ? stackArgsBase.asSlice(storage.index() * abi.arch.typeSize(abi.arch.stackType()))
+                : bufferBase.asSlice(layout.argOffset(storage));
+            moves[i] = SharedUtils.read(ptr, binding.type());
+        }
+
+        // invokeInterpBindings, and then actual target
+        Object o = leaf.invoke(moves);
+
+        if (o == null) {
+            // nop
+        } else if (o instanceof Object[]) {
+            Object[] returns = (Object[]) o;
+            for (int i = 0; i < returnBindings.length; i++) {
+                Binding.VMStore binding = returnBindings[i];
+                VMStorage storage = binding.storage();
+                MemorySegment ptr = bufferBase.asSlice(layout.retOffset(storage));
+                SharedUtils.writeOverSized(ptr, binding.type(), returns[i]);
+            }
+        } else { // single Object
+            Binding.VMStore binding = returnBindings[0];
+            VMStorage storage = binding.storage();
+            MemorySegment ptr = bufferBase.asSlice(layout.retOffset(storage));
+            SharedUtils.writeOverSized(ptr, binding.type(), o);
+        }
+
+        if (DEBUG) {
+            System.err.println("Buffer state after:");
+            layout.dump(abi.arch, bufferBase, System.err);
+        }
+    }
+
+    public static Object invokeInterpBindings(Object[] moves, MethodHandle leaf,
+                                              Map<VMStorage, Integer> argIndexMap,
+                                              Map<VMStorage, Integer> retIndexMap,
+                                              CallingSequence callingSequence,
+                                              long bufferCopySize) throws Throwable {
+        try (Allocator allocator = SharedUtils.makeAllocator(bufferCopySize)) {
+            /// Invoke interpreter, got array of high-level arguments back
+            Object[] args = new Object[callingSequence.methodType().parameterCount()];
+            for (int i = 0; i < args.length; i++) {
                 args[i] = BindingInterpreter.box(callingSequence.argumentBindings(i),
-                        (storage, type) -> {
-                            MemorySegment ptr = abi.arch.isStackType(storage.type())
-                                ? stackArgsBase.asSlice(storage.index() * abi.arch.typeSize(abi.arch.stackType()))
-                                : bufferBase.asSlice(layout.argOffset(storage));
-                            return SharedUtils.read(ptr, type);
-                        }, allocator);
+                        (storage, type) -> moves[argIndexMap.get(storage)], allocator);
             }
 
             if (DEBUG) {
@@ -112,31 +244,31 @@ public class ProgrammableUpcallHandler implements UpcallHandler {
                 System.err.println(Arrays.toString(args).indent(2));
             }
 
-            Object o = mh.invoke(args);
+            // invoke our target
+            Object o = leaf.invoke(args);
 
             if (DEBUG) {
                 System.err.println("Java return:");
                 System.err.println(Objects.toString(o).indent(2));
             }
 
-            if (mh.type().returnType() != void.class) {
+            Object[] returnMoves = new Object[retIndexMap.size()];
+            if (leaf.type().returnType() != void.class) {
                 BindingInterpreter.unbox(o, callingSequence.returnBindings(),
-                        (storage, type, value) -> {
-                            MemorySegment ptr = bufferBase.asSlice(layout.retOffset(storage));
-                            SharedUtils.writeOverSized(ptr, type, value);
-                        }, null);
+                        (storage, type, value) -> returnMoves[retIndexMap.get(storage)] = value, null);
             }
 
-            if (DEBUG) {
-                System.err.println("Buffer state after:");
-                layout.dump(abi.arch, bufferBase, System.err);
+            if (returnMoves.length == 0) {
+                return null;
+            } else if (returnMoves.length == 1) {
+                return returnMoves[0];
+            } else {
+                return returnMoves;
             }
-        } catch (Throwable t) {
-            throw new IllegalStateException(t);
         }
     }
 
-    public native long allocateUpcallStub(ABIDescriptor abi, BufferLayout layout);
+    public static native long allocateUpcallStub(InterpretedHandler handler, ABIDescriptor abi, BufferLayout layout);
 
     private static native void registerNatives();
     static {

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/ProgrammableUpcallHandler.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/ProgrammableUpcallHandler.java
@@ -64,7 +64,7 @@ public class ProgrammableUpcallHandler {
     private static final boolean USE_SPEC = Boolean.parseBoolean(
         GetPropertyAction.privilegedGetProperty("jdk.internal.foreign.ProgrammableUpcallHandler.USE_SPEC", "true"));
     private static final boolean USE_INTRINSICS = Boolean.parseBoolean(
-        GetPropertyAction.privilegedGetProperty("jdk.internal.foreign.ProgrammableUpcallHandler.USE_INTRINSICS", "false"));
+        GetPropertyAction.privilegedGetProperty("jdk.internal.foreign.ProgrammableUpcallHandler.USE_INTRINSICS", "true"));
 
     private static final JavaLangInvokeAccess JLI = SharedSecrets.getJavaLangInvokeAccess();
 

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/SharedUtils.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/SharedUtils.java
@@ -58,6 +58,7 @@ import java.util.stream.IntStream;
 
 import static java.lang.invoke.MethodHandles.collectArguments;
 import static java.lang.invoke.MethodHandles.dropArguments;
+import static java.lang.invoke.MethodHandles.dropReturn;
 import static java.lang.invoke.MethodHandles.empty;
 import static java.lang.invoke.MethodHandles.filterArguments;
 import static java.lang.invoke.MethodHandles.filterReturnValue;
@@ -199,7 +200,7 @@ public class SharedUtils {
         target = collectArguments(MH_BUFFER_COPY, 1, target); // (MemoryAddress, ...) MemoryAddress
 
         if (dropReturn) { // no handling for return value, need to drop it
-            target = filterReturnValue(target, empty(methodType(void.class, MemoryAddress.class)));
+            target = dropReturn(target);
         }
 
         return target;
@@ -238,8 +239,8 @@ public class SharedUtils {
         cDesc.returnLayout().ifPresent(rl -> checkCompatibleType(mt.returnType(), rl, addressSize));
     }
 
-    public static Class<?> primitiveCarrierForSize(long size, boolean isFloat) {
-        if (isFloat) {
+    public static Class<?> primitiveCarrierForSize(long size, boolean useFloat) {
+        if (useFloat) {
             if (size == 4) {
                 return float.class;
             } else if (size == 8) {
@@ -257,7 +258,7 @@ public class SharedUtils {
             }
         }
 
-        throw new IllegalArgumentException("No type for size: " + size + " isFloat=" + isFloat);
+        throw new IllegalArgumentException("No type for size: " + size + " isFloat=" + useFloat);
     }
 
     public static CLinker getSystemLinker() {

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/SharedUtils.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/SharedUtils.java
@@ -238,18 +238,26 @@ public class SharedUtils {
         cDesc.returnLayout().ifPresent(rl -> checkCompatibleType(mt.returnType(), rl, addressSize));
     }
 
-    public static Class<?> primitiveCarrierForSize(long size) {
-        if (size == 1) {
-            return byte.class;
-        } else if(size == 2) {
-            return short.class;
-        } else if (size <= 4) {
-            return int.class;
-        } else if (size <= 8) {
-            return long.class;
+    public static Class<?> primitiveCarrierForSize(long size, boolean isFloat) {
+        if (isFloat) {
+            if (size == 4) {
+                return float.class;
+            } else if (size == 8) {
+                return double.class;
+            }
+        } else {
+            if (size == 1) {
+                return byte.class;
+            } else if (size == 2) {
+                return short.class;
+            } else if (size <= 4) {
+                return int.class;
+            } else if (size <= 8) {
+                return long.class;
+            }
         }
 
-        throw new IllegalArgumentException("Size too large: " + size);
+        throw new IllegalArgumentException("No type for size: " + size + " isFloat=" + isFloat);
     }
 
     public static CLinker getSystemLinker() {
@@ -408,7 +416,7 @@ public class SharedUtils {
 
     public static VarHandle vhPrimitiveOrAddress(Class<?> carrier, MemoryLayout layout) {
         return carrier == MemoryAddress.class
-            ? MemoryHandles.asAddressVarHandle(layout.varHandle(primitiveCarrierForSize(layout.byteSize())))
+            ? MemoryHandles.asAddressVarHandle(layout.varHandle(primitiveCarrierForSize(layout.byteSize(), false)))
             : layout.varHandle(carrier);
     }
 
@@ -524,7 +532,7 @@ public class SharedUtils {
 
         public VarHandle varHandle() {
             return carrier == MemoryAddress.class
-                ? MemoryHandles.asAddressVarHandle(layout.varHandle(primitiveCarrierForSize(layout.byteSize())))
+                ? MemoryHandles.asAddressVarHandle(layout.varHandle(primitiveCarrierForSize(layout.byteSize(), false)))
                 : layout.varHandle(carrier);
         }
     }

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/SharedUtils.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/SharedUtils.java
@@ -24,6 +24,7 @@
  */
 package jdk.internal.foreign.abi;
 
+import jdk.incubator.foreign.Addressable;
 import jdk.incubator.foreign.FunctionDescriptor;
 import jdk.incubator.foreign.GroupLayout;
 import jdk.incubator.foreign.MemoryAccess;
@@ -50,13 +51,20 @@ import java.lang.invoke.MethodType;
 import java.lang.invoke.VarHandle;
 import java.nio.charset.Charset;
 import java.util.List;
+import java.util.Map;
 import java.util.function.Consumer;
+import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import static java.lang.invoke.MethodHandles.collectArguments;
+import static java.lang.invoke.MethodHandles.dropArguments;
+import static java.lang.invoke.MethodHandles.empty;
+import static java.lang.invoke.MethodHandles.filterArguments;
+import static java.lang.invoke.MethodHandles.filterReturnValue;
 import static java.lang.invoke.MethodHandles.identity;
 import static java.lang.invoke.MethodHandles.insertArguments;
 import static java.lang.invoke.MethodHandles.permuteArguments;
+import static java.lang.invoke.MethodHandles.tryFinally;
 import static java.lang.invoke.MethodType.methodType;
 import static jdk.incubator.foreign.CLinker.*;
 
@@ -65,6 +73,8 @@ public class SharedUtils {
     private static final MethodHandle MH_ALLOC_BUFFER;
     private static final MethodHandle MH_BASEADDRESS;
     private static final MethodHandle MH_BUFFER_COPY;
+    private static final MethodHandle MH_MAKE_ALLOCATOR;
+    private static final MethodHandle MH_CLOSE_ALLOCATOR;
 
     static final Allocator DEFAULT_ALLOCATOR = MemorySegment::allocateNative;
 
@@ -77,6 +87,10 @@ public class SharedUtils {
                     methodType(MemoryAddress.class));
             MH_BUFFER_COPY = lookup.findStatic(SharedUtils.class, "bufferCopy",
                     methodType(MemoryAddress.class, MemoryAddress.class, MemorySegment.class));
+            MH_MAKE_ALLOCATOR = lookup.findStatic(SharedUtils.class, "makeAllocator",
+                    methodType(Allocator.class, long.class));
+            MH_CLOSE_ALLOCATOR = lookup.findVirtual(Allocator.class, "close",
+                    methodType(void.class));
         } catch (ReflectiveOperationException e) {
             throw new BootstrapMethodError(e);
         }
@@ -178,11 +192,15 @@ public class SharedUtils {
      * @param target the target handle to adapt
      * @return the adapted handle
      */
-    public static MethodHandle adaptUpcallForIMR(MethodHandle target) {
+    public static MethodHandle adaptUpcallForIMR(MethodHandle target, boolean dropReturn) {
         if (target.type().returnType() != MemorySegment.class)
             throw new IllegalArgumentException("Must return MemorySegment for IMR");
 
         target = collectArguments(MH_BUFFER_COPY, 1, target); // (MemoryAddress, ...) MemoryAddress
+
+        if (dropReturn) { // no handling for return value, need to drop it
+            target = filterReturnValue(target, empty(methodType(void.class, MemoryAddress.class)));
+        }
 
         return target;
     }
@@ -282,6 +300,12 @@ public class SharedUtils {
         return size;
     }
 
+    static Map<VMStorage, Integer> indexMap(Binding.Move[] moves) {
+        return IntStream.range(0, moves.length)
+                        .boxed()
+                        .collect(Collectors.toMap(i -> moves[i].storage(), i -> i));
+    }
+
     static MethodHandle mergeArguments(MethodHandle mh, int sourceIndex, int destIndex) {
         MethodType oldType = mh.type();
         Class<?> sourceType = oldType.parameterType(sourceIndex);
@@ -301,6 +325,32 @@ public class SharedUtils {
             }
         }
         return permuteArguments(mh, newType, reorder);
+    }
+
+    static Allocator makeAllocator(long size) {
+        return  size != 0
+            ? Allocator.ofScope(NativeScope.boundedScope(size))
+            : Allocator.empty();
+    }
+
+    static MethodHandle wrapWithAllocator(MethodHandle specializedHandle,
+                                          int allocatorPos, long bufferCopySize) {
+        // insert try-finally to close the NativeScope used for Binding.Copy
+        MethodHandle closer = specializedHandle.type().returnType() == void.class
+              // (Throwable, Addressable, NativeScope) -> void
+            ? collectArguments(empty(methodType(void.class, Throwable.class, Addressable.class)), 2, MH_CLOSE_ALLOCATOR)
+              // (Throwable, V, Addressable, NativeScope) -> V
+            : collectArguments( // (Throwable, V, Addressable, NativeScope) -> V
+                dropArguments( // (Throwable, V, Addressable) -> V
+                    dropArguments( // (Throwable, V) -> V
+                        identity(specializedHandle.type().returnType()), // (V) -> V
+                        0, Throwable.class),
+                    2, Addressable.class),
+                               3, MH_CLOSE_ALLOCATOR);
+        specializedHandle = tryFinally(specializedHandle, closer);
+        MethodHandle makeScopeHandle = insertArguments(MH_MAKE_ALLOCATOR, 0, bufferCopySize);
+        specializedHandle = collectArguments(specializedHandle, allocatorPos, makeScopeHandle);
+        return specializedHandle;
     }
 
     // lazy init MH_ALLOC and MH_FREE handles
@@ -375,7 +425,7 @@ public class SharedUtils {
     public static MethodHandle unboxVaLists(MethodType type, MethodHandle handle, MethodHandle unboxer) {
         for (int i = 0; i < type.parameterCount(); i++) {
             if (type.parameterType(i) == VaList.class) {
-               handle = MethodHandles.filterArguments(handle, i + 1, unboxer); // +1 for leading address
+               handle = filterArguments(handle, i + 1, unboxer); // +1 for leading address
             }
         }
         return handle;
@@ -385,7 +435,7 @@ public class SharedUtils {
         MethodType type = handle.type();
         for (int i = 0; i < type.parameterCount(); i++) {
             if (type.parameterType(i) == VaList.class) {
-               handle = MethodHandles.filterArguments(handle, i, boxer);
+               handle = filterArguments(handle, i, boxer);
             }
         }
         return handle;
@@ -405,8 +455,6 @@ public class SharedUtils {
     }
 
     public interface Allocator extends AutoCloseable {
-        Allocator THROWING_ALLOCATOR = (size, align) -> { throw new UnsupportedOperationException("Null allocator"); };
-
         static Allocator empty() {
             return Allocator.ofScope(AbstractNativeScope.emptyScope());
         }

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/SharedUtils.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/SharedUtils.java
@@ -342,26 +342,6 @@ public class SharedUtils {
             : Allocator.empty();
     }
 
-//    static MethodHandle wrapWithAllocatorForDowncall(MethodHandle specializedHandle,
-//                                                     int allocatorPos, long bufferCopySize) {
-//        // insert try-finally to close the NativeScope used for Binding.Copy
-//        boolean isVoid = specializedHandle.type().returnType() == void.class;
-//        MethodHandle closer;
-//        if (isVoid) {
-//            closer = empty(methodType(void.class, Throwable.class, Addressable.class)); // (Throwable, Addressable) -> void
-//            closer = collectArguments(closer, 2, MH_CLOSE_ALLOCATOR); // (Throwable, Addressable, NativeScope) -> void
-//        } else {
-//            closer = identity(specializedHandle.type().returnType()); // (V) -> V
-//            closer = dropArguments(closer, 0, Throwable.class); // (Throwable, V) -> V
-//
-//            closer = collectArguments(closer, 3, MH_CLOSE_ALLOCATOR); // (Throwable, V, Addressable, NativeScope) -> V
-//        }
-//        specializedHandle = tryFinally(specializedHandle, closer);
-//        MethodHandle makeScopeHandle = insertArguments(MH_MAKE_ALLOCATOR, 0, bufferCopySize);
-//        specializedHandle = collectArguments(specializedHandle, allocatorPos, makeScopeHandle);
-//        return specializedHandle;
-//    }
-
     static MethodHandle wrapWithAllocator(MethodHandle specializedHandle,
                                           int allocatorPos, long bufferCopySize,
                                           boolean upcall) {

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/aarch64/CallArranger.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/aarch64/CallArranger.java
@@ -142,10 +142,10 @@ public class CallArranger {
         Bindings bindings = getBindings(mt, cDesc, true);
 
         if (bindings.isInMemoryReturn) {
-            target = SharedUtils.adaptUpcallForIMR(target);
+            target = SharedUtils.adaptUpcallForIMR(target, true /* drop return, since we don't have bindings for it */);
         }
 
-        return new ProgrammableUpcallHandler(C, target, bindings.callingSequence);
+        return ProgrammableUpcallHandler.make(C, target, bindings.callingSequence);
     }
 
     private static boolean isInMemoryReturn(Optional<MemoryLayout> returnLayout) {

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/aarch64/CallArranger.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/aarch64/CallArranger.java
@@ -289,7 +289,8 @@ public class CallArranger {
                         while (offset < layout.byteSize()) {
                             final long copy = Math.min(layout.byteSize() - offset, 8);
                             VMStorage storage = regs[regIndex++];
-                            Class<?> type = SharedUtils.primitiveCarrierForSize(copy, false);
+                            boolean useFloat = storage.type() == StorageClasses.VECTOR;
+                            Class<?> type = SharedUtils.primitiveCarrierForSize(copy, useFloat);
                             if (offset + copy < layout.byteSize()) {
                                 bindings.dup();
                             }
@@ -322,7 +323,8 @@ public class CallArranger {
                         for (int i = 0; i < group.memberLayouts().size(); i++) {
                             VMStorage storage = regs[i];
                             final long size = group.memberLayouts().get(i).byteSize();
-                            Class<?> type = SharedUtils.primitiveCarrierForSize(size, false);
+                            boolean useFloat = storage.type() == StorageClasses.VECTOR;
+                            Class<?> type = SharedUtils.primitiveCarrierForSize(size, useFloat);
                             if (i + 1 < group.memberLayouts().size()) {
                                 bindings.dup();
                             }
@@ -391,7 +393,8 @@ public class CallArranger {
                             final long copy = Math.min(layout.byteSize() - offset, 8);
                             VMStorage storage = regs[regIndex++];
                             bindings.dup();
-                            Class<?> type = SharedUtils.primitiveCarrierForSize(copy, false);
+                            boolean useFloat = storage.type() == StorageClasses.VECTOR;
+                            Class<?> type = SharedUtils.primitiveCarrierForSize(copy, useFloat);
                             bindings.vmLoad(storage, type)
                                     .bufferStore(offset, type);
                             offset += copy;
@@ -421,7 +424,8 @@ public class CallArranger {
                         for (int i = 0; i < group.memberLayouts().size(); i++) {
                             VMStorage storage = regs[i];
                             final long size = group.memberLayouts().get(i).byteSize();
-                            Class<?> type = SharedUtils.primitiveCarrierForSize(size, false);
+                            boolean useFloat = storage.type() == StorageClasses.VECTOR;
+                            Class<?> type = SharedUtils.primitiveCarrierForSize(size, useFloat);
                             bindings.dup()
                                     .vmLoad(storage, type)
                                     .bufferStore(offset, type);

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/aarch64/CallArranger.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/aarch64/CallArranger.java
@@ -25,13 +25,11 @@
  */
 package jdk.internal.foreign.abi.aarch64;
 
-import jdk.incubator.foreign.Addressable;
 import jdk.incubator.foreign.FunctionDescriptor;
 import jdk.incubator.foreign.GroupLayout;
 import jdk.incubator.foreign.MemoryAddress;
 import jdk.incubator.foreign.MemoryLayout;
 import jdk.incubator.foreign.MemorySegment;
-import jdk.internal.foreign.PlatformLayouts;
 import jdk.internal.foreign.Utils;
 import jdk.internal.foreign.abi.CallingSequenceBuilder;
 import jdk.internal.foreign.abi.UpcallHandler;
@@ -232,7 +230,7 @@ public class CallArranger {
                 if (offset + STACK_SLOT_SIZE < layout.byteSize()) {
                     bindings.dup();
                 }
-                Class<?> type = SharedUtils.primitiveCarrierForSize(copy);
+                Class<?> type = SharedUtils.primitiveCarrierForSize(copy, false);
                 bindings.bufferLoad(offset, type)
                         .vmStore(storage, type);
                 offset += STACK_SLOT_SIZE;
@@ -250,7 +248,7 @@ public class CallArranger {
                 long copy = Math.min(layout.byteSize() - offset, STACK_SLOT_SIZE);
                 VMStorage storage =
                     storageCalculator.stackAlloc(copy, STACK_SLOT_SIZE);
-                Class<?> type = SharedUtils.primitiveCarrierForSize(copy);
+                Class<?> type = SharedUtils.primitiveCarrierForSize(copy, false);
                 bindings.dup()
                         .vmLoad(storage, type)
                         .bufferStore(offset, type);
@@ -291,7 +289,7 @@ public class CallArranger {
                         while (offset < layout.byteSize()) {
                             final long copy = Math.min(layout.byteSize() - offset, 8);
                             VMStorage storage = regs[regIndex++];
-                            Class<?> type = SharedUtils.primitiveCarrierForSize(copy);
+                            Class<?> type = SharedUtils.primitiveCarrierForSize(copy, false);
                             if (offset + copy < layout.byteSize()) {
                                 bindings.dup();
                             }
@@ -324,7 +322,7 @@ public class CallArranger {
                         for (int i = 0; i < group.memberLayouts().size(); i++) {
                             VMStorage storage = regs[i];
                             final long size = group.memberLayouts().get(i).byteSize();
-                            Class<?> type = SharedUtils.primitiveCarrierForSize(size);
+                            Class<?> type = SharedUtils.primitiveCarrierForSize(size, false);
                             if (i + 1 < group.memberLayouts().size()) {
                                 bindings.dup();
                             }
@@ -393,7 +391,7 @@ public class CallArranger {
                             final long copy = Math.min(layout.byteSize() - offset, 8);
                             VMStorage storage = regs[regIndex++];
                             bindings.dup();
-                            Class<?> type = SharedUtils.primitiveCarrierForSize(copy);
+                            Class<?> type = SharedUtils.primitiveCarrierForSize(copy, false);
                             bindings.vmLoad(storage, type)
                                     .bufferStore(offset, type);
                             offset += copy;
@@ -423,7 +421,7 @@ public class CallArranger {
                         for (int i = 0; i < group.memberLayouts().size(); i++) {
                             VMStorage storage = regs[i];
                             final long size = group.memberLayouts().get(i).byteSize();
-                            Class<?> type = SharedUtils.primitiveCarrierForSize(size);
+                            Class<?> type = SharedUtils.primitiveCarrierForSize(size, false);
                             bindings.dup()
                                     .vmLoad(storage, type)
                                     .bufferStore(offset, type);

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/x64/sysv/CallArranger.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/x64/sysv/CallArranger.java
@@ -140,10 +140,10 @@ public class CallArranger {
         Bindings bindings = getBindings(mt, cDesc, true);
 
         if (bindings.isInMemoryReturn) {
-            target = SharedUtils.adaptUpcallForIMR(target);
+            target = SharedUtils.adaptUpcallForIMR(target, true /* drop return, since we don't have bindings for it */);
         }
 
-        return new ProgrammableUpcallHandler(CSysV, target, bindings.callingSequence);
+        return ProgrammableUpcallHandler.make(CSysV, target, bindings.callingSequence);
     }
 
     private static boolean isInMemoryReturn(Optional<MemoryLayout> returnLayout) {

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/x64/sysv/CallArranger.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/x64/sysv/CallArranger.java
@@ -25,13 +25,11 @@
  */
 package jdk.internal.foreign.abi.x64.sysv;
 
-import jdk.incubator.foreign.Addressable;
 import jdk.incubator.foreign.FunctionDescriptor;
 import jdk.incubator.foreign.GroupLayout;
 import jdk.incubator.foreign.MemoryAddress;
 import jdk.incubator.foreign.MemoryLayout;
 import jdk.incubator.foreign.MemorySegment;
-import jdk.internal.foreign.PlatformLayouts;
 import jdk.internal.foreign.abi.CallingSequenceBuilder;
 import jdk.internal.foreign.abi.UpcallHandler;
 import jdk.internal.foreign.abi.ABIDescriptor;
@@ -270,7 +268,7 @@ public class CallArranger {
                     while (offset < layout.byteSize()) {
                         final long copy = Math.min(layout.byteSize() - offset, 8);
                         VMStorage storage = regs[regIndex++];
-                        Class<?> type = SharedUtils.primitiveCarrierForSize(copy);
+                        Class<?> type = SharedUtils.primitiveCarrierForSize(copy, false);
                         if (offset + copy < layout.byteSize()) {
                             bindings.dup();
                         }
@@ -324,7 +322,8 @@ public class CallArranger {
                         final long copy = Math.min(layout.byteSize() - offset, 8);
                         VMStorage storage = regs[regIndex++];
                         bindings.dup();
-                        Class<?> type = SharedUtils.primitiveCarrierForSize(copy);
+                        boolean isFloat = storage.type() == StorageClasses.VECTOR;
+                        Class<?> type = SharedUtils.primitiveCarrierForSize(copy, isFloat);
                         bindings.vmLoad(storage, type)
                                 .bufferStore(offset, type);
                         offset += copy;

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/x64/sysv/CallArranger.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/x64/sysv/CallArranger.java
@@ -271,8 +271,8 @@ public class CallArranger {
                         if (offset + copy < layout.byteSize()) {
                             bindings.dup();
                         }
-                        boolean isFloat = storage.type() == StorageClasses.VECTOR;
-                        Class<?> type = SharedUtils.primitiveCarrierForSize(copy, isFloat);
+                        boolean useFloat = storage.type() == StorageClasses.VECTOR;
+                        Class<?> type = SharedUtils.primitiveCarrierForSize(copy, useFloat);
                         bindings.bufferLoad(offset, type)
                                 .vmStore(storage, type);
                         offset += copy;
@@ -323,8 +323,8 @@ public class CallArranger {
                         final long copy = Math.min(layout.byteSize() - offset, 8);
                         VMStorage storage = regs[regIndex++];
                         bindings.dup();
-                        boolean isFloat = storage.type() == StorageClasses.VECTOR;
-                        Class<?> type = SharedUtils.primitiveCarrierForSize(copy, isFloat);
+                        boolean useFloat = storage.type() == StorageClasses.VECTOR;
+                        Class<?> type = SharedUtils.primitiveCarrierForSize(copy, useFloat);
                         bindings.vmLoad(storage, type)
                                 .bufferStore(offset, type);
                         offset += copy;

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/x64/sysv/CallArranger.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/x64/sysv/CallArranger.java
@@ -268,10 +268,11 @@ public class CallArranger {
                     while (offset < layout.byteSize()) {
                         final long copy = Math.min(layout.byteSize() - offset, 8);
                         VMStorage storage = regs[regIndex++];
-                        Class<?> type = SharedUtils.primitiveCarrierForSize(copy, false);
                         if (offset + copy < layout.byteSize()) {
                             bindings.dup();
                         }
+                        boolean isFloat = storage.type() == StorageClasses.VECTOR;
+                        Class<?> type = SharedUtils.primitiveCarrierForSize(copy, isFloat);
                         bindings.bufferLoad(offset, type)
                                 .vmStore(storage, type);
                         offset += copy;

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/x64/windows/CallArranger.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/x64/windows/CallArranger.java
@@ -24,13 +24,11 @@
  */
 package jdk.internal.foreign.abi.x64.windows;
 
-import jdk.incubator.foreign.Addressable;
 import jdk.incubator.foreign.FunctionDescriptor;
 import jdk.incubator.foreign.GroupLayout;
 import jdk.incubator.foreign.MemoryAddress;
 import jdk.incubator.foreign.MemoryLayout;
 import jdk.incubator.foreign.MemorySegment;
-import jdk.internal.foreign.PlatformLayouts;
 import jdk.internal.foreign.Utils;
 import jdk.internal.foreign.abi.CallingSequenceBuilder;
 import jdk.internal.foreign.abi.UpcallHandler;
@@ -205,7 +203,7 @@ public class CallArranger {
                 case STRUCT_REGISTER: {
                     assert carrier == MemorySegment.class;
                     VMStorage storage = storageCalculator.nextStorage(StorageClasses.INTEGER, layout);
-                    Class<?> type = SharedUtils.primitiveCarrierForSize(layout.byteSize());
+                    Class<?> type = SharedUtils.primitiveCarrierForSize(layout.byteSize(), false);
                     bindings.bufferLoad(0, type)
                             .vmStore(storage, type);
                     break;
@@ -270,7 +268,7 @@ public class CallArranger {
                     bindings.allocate(layout)
                             .dup();
                     VMStorage storage = storageCalculator.nextStorage(StorageClasses.INTEGER, layout);
-                    Class<?> type = SharedUtils.primitiveCarrierForSize(layout.byteSize());
+                    Class<?> type = SharedUtils.primitiveCarrierForSize(layout.byteSize(), false);
                     bindings.vmLoad(storage, type)
                             .bufferStore(0, type);
                     break;

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/x64/windows/CallArranger.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/x64/windows/CallArranger.java
@@ -140,10 +140,10 @@ public class CallArranger {
         Bindings bindings = getBindings(mt, cDesc, true);
 
         if (bindings.isInMemoryReturn) {
-            target = SharedUtils.adaptUpcallForIMR(target);
+            target = SharedUtils.adaptUpcallForIMR(target, false /* need the return value as well */);
         }
 
-        return new ProgrammableUpcallHandler(CWindows, target, bindings.callingSequence);
+        return ProgrammableUpcallHandler.make(CWindows, target, bindings.callingSequence);
     }
 
     private static boolean isInMemoryReturn(Optional<MemoryLayout> returnLayout) {

--- a/test/jdk/TEST.groups
+++ b/test/jdk/TEST.groups
@@ -337,7 +337,8 @@ jdk_svc = \
     :svc_tools
 
 jdk_foreign = \
-    java/foreign
+    java/foreign \
+	-java/foreign/TestMatrix.java
 
 jdk_vector = \
     jdk/incubator/vector

--- a/test/jdk/TEST.groups
+++ b/test/jdk/TEST.groups
@@ -338,7 +338,7 @@ jdk_svc = \
 
 jdk_foreign = \
     java/foreign \
-	-java/foreign/TestMatrix.java
+    -java/foreign/TestMatrix.java
 
 jdk_vector = \
     jdk/incubator/vector

--- a/test/jdk/java/foreign/TestDowncall.java
+++ b/test/jdk/java/foreign/TestDowncall.java
@@ -30,23 +30,6 @@
  *
  * @run testng/othervm
  *   -Dforeign.restricted=permit
- *   -Djdk.internal.foreign.ProgrammableInvoker.USE_SPEC=false
- *   -Djdk.internal.foreign.ProgrammableInvoker.USE_INTRINSICS=false
- *   TestDowncall
- * @run testng/othervm
- *   -Dforeign.restricted=permit
- *   -Djdk.internal.foreign.ProgrammableInvoker.USE_SPEC=true
- *   -Djdk.internal.foreign.ProgrammableInvoker.USE_INTRINSICS=false
- *   TestDowncall
- * @run testng/othervm
- *   -Dforeign.restricted=permit
- *   -Djdk.internal.foreign.ProgrammableInvoker.USE_SPEC=false
- *   -Djdk.internal.foreign.ProgrammableInvoker.USE_INTRINSICS=true
- *   TestDowncall
- * @run testng/othervm
- *   -Dforeign.restricted=permit
- *   -Djdk.internal.foreign.ProgrammableInvoker.USE_SPEC=true
- *   -Djdk.internal.foreign.ProgrammableInvoker.USE_INTRINSICS=true
  *   TestDowncall
  */
 

--- a/test/jdk/java/foreign/TestMatrix.java
+++ b/test/jdk/java/foreign/TestMatrix.java
@@ -1,0 +1,259 @@
+/*
+ * @test
+ * @requires ((os.arch == "amd64" | os.arch == "x86_64") & sun.arch.data.model == "64") | os.arch == "aarch64"
+ * @modules jdk.incubator.foreign/jdk.internal.foreign
+ * @build NativeTestHelper CallGeneratorHelper TestUpcallHighArity TestUpcall TestDowncall
+ *
+ * @run testng/othervm/native
+ *   -Dforeign.restricted=permit
+ *   -Djdk.internal.foreign.ProgrammableInvoker.USE_SPEC=false
+ *   -Djdk.internal.foreign.ProgrammableInvoker.USE_INTRINSICS=false
+ *   -Djdk.internal.foreign.ProgrammableUpcallHandler.USE_SPEC=true
+ *   -Djdk.internal.foreign.ProgrammableUpcallHandler.USE_INTRINSICS=true
+ *   TestUpcallHighArity
+ * @run testng/othervm/native
+ *   -Dforeign.restricted=permit
+ *   -Djdk.internal.foreign.ProgrammableInvoker.USE_SPEC=true
+ *   -Djdk.internal.foreign.ProgrammableInvoker.USE_INTRINSICS=false
+ *   -Djdk.internal.foreign.ProgrammableUpcallHandler.USE_SPEC=true
+ *   -Djdk.internal.foreign.ProgrammableUpcallHandler.USE_INTRINSICS=true
+ *   TestUpcallHighArity
+ * @run testng/othervm/native
+ *   -Dforeign.restricted=permit
+ *   -Djdk.internal.foreign.ProgrammableInvoker.USE_SPEC=false
+ *   -Djdk.internal.foreign.ProgrammableInvoker.USE_INTRINSICS=true
+ *   -Djdk.internal.foreign.ProgrammableUpcallHandler.USE_SPEC=true
+ *   -Djdk.internal.foreign.ProgrammableUpcallHandler.USE_INTRINSICS=true
+ *   TestUpcallHighArity
+ * @run testng/othervm/native
+ *   -Dforeign.restricted=permit
+ *   -Djdk.internal.foreign.ProgrammableInvoker.USE_SPEC=true
+ *   -Djdk.internal.foreign.ProgrammableInvoker.USE_INTRINSICS=true
+ *   -Djdk.internal.foreign.ProgrammableUpcallHandler.USE_SPEC=true
+ *   -Djdk.internal.foreign.ProgrammableUpcallHandler.USE_INTRINSICS=true
+ *   TestUpcallHighArity
+ *
+  * @run testng/othervm/native
+ *   -Dforeign.restricted=permit
+ *   -Djdk.internal.foreign.ProgrammableInvoker.USE_SPEC=false
+ *   -Djdk.internal.foreign.ProgrammableInvoker.USE_INTRINSICS=false
+ *   -Djdk.internal.foreign.ProgrammableUpcallHandler.USE_SPEC=true
+ *   -Djdk.internal.foreign.ProgrammableUpcallHandler.USE_INTRINSICS=false
+ *   TestUpcallHighArity
+ * @run testng/othervm/native
+ *   -Dforeign.restricted=permit
+ *   -Djdk.internal.foreign.ProgrammableInvoker.USE_SPEC=true
+ *   -Djdk.internal.foreign.ProgrammableInvoker.USE_INTRINSICS=false
+ *   -Djdk.internal.foreign.ProgrammableUpcallHandler.USE_SPEC=true
+ *   -Djdk.internal.foreign.ProgrammableUpcallHandler.USE_INTRINSICS=false
+ *   TestUpcallHighArity
+ * @run testng/othervm/native
+ *   -Dforeign.restricted=permit
+ *   -Djdk.internal.foreign.ProgrammableInvoker.USE_SPEC=false
+ *   -Djdk.internal.foreign.ProgrammableInvoker.USE_INTRINSICS=true
+ *   -Djdk.internal.foreign.ProgrammableUpcallHandler.USE_SPEC=true
+ *   -Djdk.internal.foreign.ProgrammableUpcallHandler.USE_INTRINSICS=false
+ *   TestUpcallHighArity
+ * @run testng/othervm/native
+ *   -Dforeign.restricted=permit
+ *   -Djdk.internal.foreign.ProgrammableInvoker.USE_SPEC=true
+ *   -Djdk.internal.foreign.ProgrammableInvoker.USE_INTRINSICS=true
+ *   -Djdk.internal.foreign.ProgrammableUpcallHandler.USE_SPEC=true
+ *   -Djdk.internal.foreign.ProgrammableUpcallHandler.USE_INTRINSICS=false
+ *   TestUpcallHighArity
+ *
+ * @run testng/othervm/native
+ *   -Dforeign.restricted=permit
+ *   -Djdk.internal.foreign.ProgrammableInvoker.USE_SPEC=false
+ *   -Djdk.internal.foreign.ProgrammableInvoker.USE_INTRINSICS=false
+ *   -Djdk.internal.foreign.ProgrammableUpcallHandler.USE_SPEC=false
+ *   -Djdk.internal.foreign.ProgrammableUpcallHandler.USE_INTRINSICS=true
+ *   TestUpcallHighArity
+ * @run testng/othervm/native
+ *   -Dforeign.restricted=permit
+ *   -Djdk.internal.foreign.ProgrammableInvoker.USE_SPEC=true
+ *   -Djdk.internal.foreign.ProgrammableInvoker.USE_INTRINSICS=false
+ *   -Djdk.internal.foreign.ProgrammableUpcallHandler.USE_SPEC=false
+ *   -Djdk.internal.foreign.ProgrammableUpcallHandler.USE_INTRINSICS=true
+ *   TestUpcallHighArity
+ * @run testng/othervm/native
+ *   -Dforeign.restricted=permit
+ *   -Djdk.internal.foreign.ProgrammableInvoker.USE_SPEC=false
+ *   -Djdk.internal.foreign.ProgrammableInvoker.USE_INTRINSICS=true
+ *   -Djdk.internal.foreign.ProgrammableUpcallHandler.USE_SPEC=false
+ *   -Djdk.internal.foreign.ProgrammableUpcallHandler.USE_INTRINSICS=true
+ *   TestUpcallHighArity
+ * @run testng/othervm/native
+ *   -Dforeign.restricted=permit
+ *   -Djdk.internal.foreign.ProgrammableInvoker.USE_SPEC=true
+ *   -Djdk.internal.foreign.ProgrammableInvoker.USE_INTRINSICS=true
+ *   -Djdk.internal.foreign.ProgrammableUpcallHandler.USE_SPEC=false
+ *   -Djdk.internal.foreign.ProgrammableUpcallHandler.USE_INTRINSICS=true
+ *   TestUpcallHighArity
+ *
+ * @run testng/othervm/native
+ *   -Dforeign.restricted=permit
+ *   -Djdk.internal.foreign.ProgrammableInvoker.USE_SPEC=false
+ *   -Djdk.internal.foreign.ProgrammableInvoker.USE_INTRINSICS=false
+ *   -Djdk.internal.foreign.ProgrammableUpcallHandler.USE_SPEC=false
+ *   -Djdk.internal.foreign.ProgrammableUpcallHandler.USE_INTRINSICS=false
+ *   TestUpcallHighArity
+ * @run testng/othervm/native
+ *   -Dforeign.restricted=permit
+ *   -Djdk.internal.foreign.ProgrammableInvoker.USE_SPEC=true
+ *   -Djdk.internal.foreign.ProgrammableInvoker.USE_INTRINSICS=false
+ *   -Djdk.internal.foreign.ProgrammableUpcallHandler.USE_SPEC=false
+ *   -Djdk.internal.foreign.ProgrammableUpcallHandler.USE_INTRINSICS=false
+ *   TestUpcallHighArity
+ * @run testng/othervm/native
+ *   -Dforeign.restricted=permit
+ *   -Djdk.internal.foreign.ProgrammableInvoker.USE_SPEC=false
+ *   -Djdk.internal.foreign.ProgrammableInvoker.USE_INTRINSICS=true
+ *   -Djdk.internal.foreign.ProgrammableUpcallHandler.USE_SPEC=false
+ *   -Djdk.internal.foreign.ProgrammableUpcallHandler.USE_INTRINSICS=false
+ *   TestUpcallHighArity
+ * @run testng/othervm/native
+ *   -Dforeign.restricted=permit
+ *   -Djdk.internal.foreign.ProgrammableInvoker.USE_SPEC=true
+ *   -Djdk.internal.foreign.ProgrammableInvoker.USE_INTRINSICS=true
+ *   -Djdk.internal.foreign.ProgrammableUpcallHandler.USE_SPEC=false
+ *   -Djdk.internal.foreign.ProgrammableUpcallHandler.USE_INTRINSICS=false
+ *   TestUpcallHighArity
+ *
+ * @run testng/othervm
+ *   -Dforeign.restricted=permit
+ *   -Djdk.internal.foreign.ProgrammableInvoker.USE_SPEC=false
+ *   -Djdk.internal.foreign.ProgrammableInvoker.USE_INTRINSICS=false
+ *   TestDowncall
+ * @run testng/othervm
+ *   -Dforeign.restricted=permit
+ *   -Djdk.internal.foreign.ProgrammableInvoker.USE_SPEC=true
+ *   -Djdk.internal.foreign.ProgrammableInvoker.USE_INTRINSICS=false
+ *   TestDowncall
+ * @run testng/othervm
+ *   -Dforeign.restricted=permit
+ *   -Djdk.internal.foreign.ProgrammableInvoker.USE_SPEC=false
+ *   -Djdk.internal.foreign.ProgrammableInvoker.USE_INTRINSICS=true
+ *   TestDowncall
+ * @run testng/othervm
+ *   -Dforeign.restricted=permit
+ *   -Djdk.internal.foreign.ProgrammableInvoker.USE_SPEC=true
+ *   -Djdk.internal.foreign.ProgrammableInvoker.USE_INTRINSICS=true
+ *   TestDowncall
+ *
+ * @run testng/othervm
+ *   -Dforeign.restricted=permit
+ *   -Djdk.internal.foreign.ProgrammableInvoker.USE_SPEC=true
+ *   -Djdk.internal.foreign.ProgrammableInvoker.USE_INTRINSICS=false
+ *   -Djdk.internal.foreign.ProgrammableUpcallHandler.USE_SPEC=true
+ *   -Djdk.internal.foreign.ProgrammableUpcallHandler.USE_INTRINSICS=true
+ *   TestUpcall
+ * @run testng/othervm
+ *   -Dforeign.restricted=permit
+ *   -Djdk.internal.foreign.ProgrammableInvoker.USE_SPEC=true
+ *   -Djdk.internal.foreign.ProgrammableInvoker.USE_INTRINSICS=false
+ *   -Djdk.internal.foreign.ProgrammableUpcallHandler.USE_SPEC=true
+ *   -Djdk.internal.foreign.ProgrammableUpcallHandler.USE_INTRINSICS=true
+ *   TestUpcall
+ * @run testng/othervm
+ *   -Dforeign.restricted=permit
+ *   -Djdk.internal.foreign.ProgrammableInvoker.USE_SPEC=false
+ *   -Djdk.internal.foreign.ProgrammableInvoker.USE_INTRINSICS=true
+ *   -Djdk.internal.foreign.ProgrammableUpcallHandler.USE_SPEC=true
+ *   -Djdk.internal.foreign.ProgrammableUpcallHandler.USE_INTRINSICS=true
+ *   TestUpcall
+ * @run testng/othervm
+ *   -Dforeign.restricted=permit
+ *   -Djdk.internal.foreign.ProgrammableInvoker.USE_SPEC=true
+ *   -Djdk.internal.foreign.ProgrammableInvoker.USE_INTRINSICS=true
+ *   -Djdk.internal.foreign.ProgrammableUpcallHandler.USE_SPEC=true
+ *   -Djdk.internal.foreign.ProgrammableUpcallHandler.USE_INTRINSICS=true
+ *   TestUpcall
+ *
+ * @run testng/othervm
+ *   -Dforeign.restricted=permit
+ *   -Djdk.internal.foreign.ProgrammableInvoker.USE_SPEC=true
+ *   -Djdk.internal.foreign.ProgrammableInvoker.USE_INTRINSICS=false
+ *   -Djdk.internal.foreign.ProgrammableUpcallHandler.USE_SPEC=true
+ *   -Djdk.internal.foreign.ProgrammableUpcallHandler.USE_INTRINSICS=false
+ *   TestUpcall
+ * @run testng/othervm
+ *   -Dforeign.restricted=permit
+ *   -Djdk.internal.foreign.ProgrammableInvoker.USE_SPEC=true
+ *   -Djdk.internal.foreign.ProgrammableInvoker.USE_INTRINSICS=false
+ *   -Djdk.internal.foreign.ProgrammableUpcallHandler.USE_SPEC=true
+ *   -Djdk.internal.foreign.ProgrammableUpcallHandler.USE_INTRINSICS=false
+ *   TestUpcall
+ * @run testng/othervm
+ *   -Dforeign.restricted=permit
+ *   -Djdk.internal.foreign.ProgrammableInvoker.USE_SPEC=false
+ *   -Djdk.internal.foreign.ProgrammableInvoker.USE_INTRINSICS=true
+ *   -Djdk.internal.foreign.ProgrammableUpcallHandler.USE_SPEC=true
+ *   -Djdk.internal.foreign.ProgrammableUpcallHandler.USE_INTRINSICS=false
+ *   TestUpcall
+ * @run testng/othervm
+ *   -Dforeign.restricted=permit
+ *   -Djdk.internal.foreign.ProgrammableInvoker.USE_SPEC=true
+ *   -Djdk.internal.foreign.ProgrammableInvoker.USE_INTRINSICS=true
+ *   -Djdk.internal.foreign.ProgrammableUpcallHandler.USE_SPEC=true
+ *   -Djdk.internal.foreign.ProgrammableUpcallHandler.USE_INTRINSICS=false
+ *   TestUpcall
+ *
+ * @run testng/othervm
+ *   -Dforeign.restricted=permit
+ *   -Djdk.internal.foreign.ProgrammableInvoker.USE_SPEC=true
+ *   -Djdk.internal.foreign.ProgrammableInvoker.USE_INTRINSICS=false
+ *   -Djdk.internal.foreign.ProgrammableUpcallHandler.USE_SPEC=false
+ *   -Djdk.internal.foreign.ProgrammableUpcallHandler.USE_INTRINSICS=true
+ *   TestUpcall
+ * @run testng/othervm
+ *   -Dforeign.restricted=permit
+ *   -Djdk.internal.foreign.ProgrammableInvoker.USE_SPEC=true
+ *   -Djdk.internal.foreign.ProgrammableInvoker.USE_INTRINSICS=false
+ *   -Djdk.internal.foreign.ProgrammableUpcallHandler.USE_SPEC=false
+ *   -Djdk.internal.foreign.ProgrammableUpcallHandler.USE_INTRINSICS=true
+ *   TestUpcall
+ * @run testng/othervm
+ *   -Dforeign.restricted=permit
+ *   -Djdk.internal.foreign.ProgrammableInvoker.USE_SPEC=false
+ *   -Djdk.internal.foreign.ProgrammableInvoker.USE_INTRINSICS=true
+ *   -Djdk.internal.foreign.ProgrammableUpcallHandler.USE_SPEC=false
+ *   -Djdk.internal.foreign.ProgrammableUpcallHandler.USE_INTRINSICS=true
+ *   TestUpcall
+ * @run testng/othervm
+ *   -Dforeign.restricted=permit
+ *   -Djdk.internal.foreign.ProgrammableInvoker.USE_SPEC=true
+ *   -Djdk.internal.foreign.ProgrammableInvoker.USE_INTRINSICS=true
+ *   -Djdk.internal.foreign.ProgrammableUpcallHandler.USE_SPEC=false
+ *   -Djdk.internal.foreign.ProgrammableUpcallHandler.USE_INTRINSICS=true
+ *   TestUpcall
+ *
+ * @run testng/othervm
+ *   -Dforeign.restricted=permit
+ *   -Djdk.internal.foreign.ProgrammableInvoker.USE_SPEC=true
+ *   -Djdk.internal.foreign.ProgrammableInvoker.USE_INTRINSICS=false
+ *   -Djdk.internal.foreign.ProgrammableUpcallHandler.USE_SPEC=false
+ *   -Djdk.internal.foreign.ProgrammableUpcallHandler.USE_INTRINSICS=false
+ *   TestUpcall
+ * @run testng/othervm
+ *   -Dforeign.restricted=permit
+ *   -Djdk.internal.foreign.ProgrammableInvoker.USE_SPEC=true
+ *   -Djdk.internal.foreign.ProgrammableInvoker.USE_INTRINSICS=false
+ *   -Djdk.internal.foreign.ProgrammableUpcallHandler.USE_SPEC=false
+ *   -Djdk.internal.foreign.ProgrammableUpcallHandler.USE_INTRINSICS=false
+ *   TestUpcall
+ * @run testng/othervm
+ *   -Dforeign.restricted=permit
+ *   -Djdk.internal.foreign.ProgrammableInvoker.USE_SPEC=false
+ *   -Djdk.internal.foreign.ProgrammableInvoker.USE_INTRINSICS=true
+ *   -Djdk.internal.foreign.ProgrammableUpcallHandler.USE_SPEC=false
+ *   -Djdk.internal.foreign.ProgrammableUpcallHandler.USE_INTRINSICS=false
+ *   TestUpcall
+ * @run testng/othervm
+ *   -Dforeign.restricted=permit
+ *   -Djdk.internal.foreign.ProgrammableInvoker.USE_SPEC=true
+ *   -Djdk.internal.foreign.ProgrammableInvoker.USE_INTRINSICS=true
+ *   -Djdk.internal.foreign.ProgrammableUpcallHandler.USE_SPEC=false
+ *   -Djdk.internal.foreign.ProgrammableUpcallHandler.USE_INTRINSICS=false
+ *   TestUpcall
+ */

--- a/test/jdk/java/foreign/TestUpcall.java
+++ b/test/jdk/java/foreign/TestUpcall.java
@@ -30,23 +30,6 @@
  *
  * @run testng/othervm
  *   -Dforeign.restricted=permit
- *   -Djdk.internal.foreign.ProgrammableInvoker.USE_SPEC=false
- *   -Djdk.internal.foreign.ProgrammableInvoker.USE_INTRINSICS=false
- *   TestUpcall
- * @run testng/othervm
- *   -Dforeign.restricted=permit
- *   -Djdk.internal.foreign.ProgrammableInvoker.USE_SPEC=true
- *   -Djdk.internal.foreign.ProgrammableInvoker.USE_INTRINSICS=false
- *   TestUpcall
- * @run testng/othervm
- *   -Dforeign.restricted=permit
- *   -Djdk.internal.foreign.ProgrammableInvoker.USE_SPEC=false
- *   -Djdk.internal.foreign.ProgrammableInvoker.USE_INTRINSICS=true
- *   TestUpcall
- * @run testng/othervm
- *   -Dforeign.restricted=permit
- *   -Djdk.internal.foreign.ProgrammableInvoker.USE_SPEC=true
- *   -Djdk.internal.foreign.ProgrammableInvoker.USE_INTRINSICS=true
  *   TestUpcall
  */
 

--- a/test/jdk/java/foreign/TestUpcall.java
+++ b/test/jdk/java/foreign/TestUpcall.java
@@ -66,8 +66,10 @@ import java.lang.invoke.MethodHandles;
 import java.lang.invoke.MethodType;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 import static java.lang.invoke.MethodHandles.insertArguments;
@@ -76,6 +78,11 @@ import static org.testng.Assert.assertEquals;
 
 
 public class TestUpcall extends CallGeneratorHelper {
+
+    static final Set<String> FUNC_SELECT = ((Supplier<Set<String>>) () -> {
+        String prop = System.getProperty("java.foreign.test.TestUpcall.FUNC_SELECT", "");
+        return !prop.isBlank() ? Set.of(prop.split(",")) : Set.of();
+    }).get();
 
     static LibraryLookup lib = LibraryLookup.ofLibrary("TestUpcall");
     static CLinker abi = CLinker.getInstance();
@@ -107,6 +114,7 @@ public class TestUpcall extends CallGeneratorHelper {
 
     @Test(dataProvider="functions", dataProviderClass=CallGeneratorHelper.class)
     public void testUpcalls(String fName, Ret ret, List<ParamType> paramTypes, List<StructFieldType> fields) throws Throwable {
+        if (!FUNC_SELECT.isEmpty() && !FUNC_SELECT.contains(fName)) return; // skip
         List<MemorySegment> segments = new ArrayList<>();
         List<Consumer<Object>> returnChecks = new ArrayList<>();
         List<Consumer<Object[]>> argChecks = new ArrayList<>();

--- a/test/jdk/java/foreign/TestUpcall.java
+++ b/test/jdk/java/foreign/TestUpcall.java
@@ -49,10 +49,8 @@ import java.lang.invoke.MethodHandles;
 import java.lang.invoke.MethodType;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
-import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 import static java.lang.invoke.MethodHandles.insertArguments;
@@ -61,11 +59,6 @@ import static org.testng.Assert.assertEquals;
 
 
 public class TestUpcall extends CallGeneratorHelper {
-
-    static final Set<String> FUNC_SELECT = ((Supplier<Set<String>>) () -> {
-        String prop = System.getProperty("java.foreign.test.TestUpcall.FUNC_SELECT", "");
-        return !prop.isBlank() ? Set.of(prop.split(",")) : Set.of();
-    }).get();
 
     static LibraryLookup lib = LibraryLookup.ofLibrary("TestUpcall");
     static CLinker abi = CLinker.getInstance();
@@ -97,7 +90,6 @@ public class TestUpcall extends CallGeneratorHelper {
 
     @Test(dataProvider="functions", dataProviderClass=CallGeneratorHelper.class)
     public void testUpcalls(String fName, Ret ret, List<ParamType> paramTypes, List<StructFieldType> fields) throws Throwable {
-        if (!FUNC_SELECT.isEmpty() && !FUNC_SELECT.contains(fName)) return; // skip
         List<MemorySegment> segments = new ArrayList<>();
         List<Consumer<Object>> returnChecks = new ArrayList<>();
         List<Consumer<Object[]>> argChecks = new ArrayList<>();

--- a/test/jdk/java/foreign/TestUpcallHighArity.java
+++ b/test/jdk/java/foreign/TestUpcallHighArity.java
@@ -30,23 +30,6 @@
  *
  * @run testng/othervm/native
  *   -Dforeign.restricted=permit
- *   -Djdk.internal.foreign.ProgrammableInvoker.USE_SPEC=false
- *   -Djdk.internal.foreign.ProgrammableInvoker.USE_INTRINSICS=false
- *   TestUpcallHighArity
- * @run testng/othervm/native
- *   -Dforeign.restricted=permit
- *   -Djdk.internal.foreign.ProgrammableInvoker.USE_SPEC=true
- *   -Djdk.internal.foreign.ProgrammableInvoker.USE_INTRINSICS=false
- *   TestUpcallHighArity
- * @run testng/othervm/native
- *   -Dforeign.restricted=permit
- *   -Djdk.internal.foreign.ProgrammableInvoker.USE_SPEC=false
- *   -Djdk.internal.foreign.ProgrammableInvoker.USE_INTRINSICS=true
- *   TestUpcallHighArity
- * @run testng/othervm/native
- *   -Dforeign.restricted=permit
- *   -Djdk.internal.foreign.ProgrammableInvoker.USE_SPEC=true
- *   -Djdk.internal.foreign.ProgrammableInvoker.USE_INTRINSICS=true
  *   TestUpcallHighArity
  */
 

--- a/test/jdk/java/foreign/callarranger/TestAarch64CallArranger.java
+++ b/test/jdk/java/foreign/callarranger/TestAarch64CallArranger.java
@@ -281,21 +281,21 @@ public class TestAarch64CallArranger extends CallArrangerTestBase {
             { vmStore(r0, int.class) },
             {
                 dup(),
-                bufferLoad(0, int.class),
-                vmStore(v1, int.class),
-                bufferLoad(4, int.class),
-                vmStore(v2, int.class)
+                bufferLoad(0, float.class),
+                vmStore(v1, float.class),
+                bufferLoad(4, float.class),
+                vmStore(v2, float.class)
             }
         });
 
         checkReturnBindings(callingSequence, new Binding[]{
             allocate(hfa),
             dup(),
-            vmLoad(v0, int.class),
-            bufferStore(0, int.class),
+            vmLoad(v0, float.class),
+            bufferStore(0, float.class),
             dup(),
-            vmLoad(v1, int.class),
-            bufferStore(4, int.class),
+            vmLoad(v1, float.class),
+            bufferStore(4, float.class),
         });
     }
 
@@ -315,23 +315,23 @@ public class TestAarch64CallArranger extends CallArrangerTestBase {
         checkArgumentBindings(callingSequence, new Binding[][]{
             {
                 dup(),
-                bufferLoad(0, int.class),
-                vmStore(v0, int.class),
+                bufferLoad(0, float.class),
+                vmStore(v0, float.class),
                 dup(),
-                bufferLoad(4, int.class),
-                vmStore(v1, int.class),
-                bufferLoad(8, int.class),
-                vmStore(v2, int.class)
+                bufferLoad(4, float.class),
+                vmStore(v1, float.class),
+                bufferLoad(8, float.class),
+                vmStore(v2, float.class)
             },
             {
                 dup(),
-                bufferLoad(0, int.class),
-                vmStore(v3, int.class),
+                bufferLoad(0, float.class),
+                vmStore(v3, float.class),
                 dup(),
-                bufferLoad(4, int.class),
-                vmStore(v4, int.class),
-                bufferLoad(8, int.class),
-                vmStore(v5, int.class)
+                bufferLoad(4, float.class),
+                vmStore(v4, float.class),
+                bufferLoad(8, float.class),
+                vmStore(v5, float.class)
             },
             {
                 dup(),

--- a/test/jdk/java/foreign/callarranger/TestSysVCallArranger.java
+++ b/test/jdk/java/foreign/callarranger/TestSysVCallArranger.java
@@ -484,4 +484,28 @@ public class TestSysVCallArranger extends CallArrangerTestBase {
         assertEquals(bindings.nVectorArgs, 0);
     }
 
+    @Test
+    public void testFloatStructsUpcall() {
+        MemoryLayout struct = MemoryLayout.ofStruct(C_FLOAT); // should be passed in float regs
+
+        MethodType mt = MethodType.methodType(MemorySegment.class, MemorySegment.class);
+        FunctionDescriptor fd = FunctionDescriptor.of(struct, struct);
+        CallArranger.Bindings bindings = CallArranger.getBindings(mt, fd, true);
+
+        assertFalse(bindings.isInMemoryReturn);
+        CallingSequence callingSequence = bindings.callingSequence;
+        assertEquals(callingSequence.methodType(), mt);
+        assertEquals(callingSequence.functionDesc(), fd);
+
+        checkArgumentBindings(callingSequence, new Binding[][]{
+            { allocate(struct), dup(), vmLoad(xmm0, float.class), bufferStore(0, float.class) },
+        });
+
+        checkReturnBindings(callingSequence, new Binding[] {
+            bufferLoad(0, float.class), vmStore(xmm0, float.class)
+        });
+
+        assertEquals(bindings.nVectorArgs, 1);
+    }
+
 }

--- a/test/jdk/java/foreign/callarranger/TestSysVCallArranger.java
+++ b/test/jdk/java/foreign/callarranger/TestSysVCallArranger.java
@@ -329,7 +329,7 @@ public class TestSysVCallArranger extends CallArrangerTestBase {
             {
                 dup(),
                 bufferLoad(0, long.class), vmStore(rdx, long.class),
-                bufferLoad(8, long.class), vmStore(xmm0, long.class)
+                bufferLoad(8, double.class), vmStore(xmm0, double.class)
             },
             { vmStore(rcx, int.class) },
             { vmStore(r8, int.class) },

--- a/test/micro/org/openjdk/bench/jdk/incubator/foreign/Upcalls.java
+++ b/test/micro/org/openjdk/bench/jdk/incubator/foreign/Upcalls.java
@@ -66,6 +66,8 @@ public class Upcalls {
 
     static final long cb_blank_jni;
     static final long cb_identity_jni;
+    static final long cb_args5_jni;
+    static final long cb_args10_jni;
 
     static {
         System.loadLibrary("UpcallsJNI");
@@ -73,6 +75,8 @@ public class Upcalls {
         String className = "org/openjdk/bench/jdk/incubator/foreign/Upcalls";
         cb_blank_jni = makeCB(className, "blank", "()V");
         cb_identity_jni = makeCB(className, "identity", "(I)I");
+        cb_args5_jni = makeCB(className, "args5", "(JDJDJ)V");
+        cb_args10_jni = makeCB(className, "args10", "(JDJDJDJDJD)V");
 
         try {
             LibraryLookup ll = LibraryLookup.ofLibrary("Upcalls");
@@ -136,6 +140,9 @@ public class Upcalls {
 
     static native void blank(long cb);
     static native int identity(int x, long cb);
+    static native void args5(long a0, double a1, long a2, double a3, long a4, long cb);
+    static native void args10(long a0, double a1, long a2, double a3, long a4,
+                              double a5, long a6, double a7, long a8, double a9, long cb);
     static native long makeCB(String holder, String name, String signature);
 
     @Benchmark
@@ -151,6 +158,16 @@ public class Upcalls {
     @Benchmark
     public int jni_identity() throws Throwable {
         return identity(10, cb_identity_jni);
+    }
+
+    @Benchmark
+    public void jni_args5() throws Throwable {
+        args5(1L, 2D, 3L, 4D, 5L, cb_args5_jni);
+    }
+
+    @Benchmark
+    public void jni_args10() throws Throwable {
+        args10(1L, 2D, 3L, 4D, 5L, 6D, 7L, 8D, 9L, 10D, cb_args10_jni);
     }
 
     @Benchmark

--- a/test/micro/org/openjdk/bench/jdk/incubator/foreign/libUpcalls.c
+++ b/test/micro/org/openjdk/bench/jdk/incubator/foreign/libUpcalls.c
@@ -34,3 +34,15 @@ EXPORT void blank(void (*cb)(void)) {
 EXPORT int identity(int x, int (*cb)(int)) {
     return cb(x);
 }
+
+EXPORT void args5(long long a0, double a1, long long a2, double a3, long long a4,
+                  void (*cb)(long long, double, long long, double, long long)) {
+    cb(a0, a1, a2, a3, a4);
+}
+
+EXPORT void args10(long long a0, double a1, long long a2, double a3, long long a4,
+                   double a5, long long a6, double a7, long long a8, double a9,
+                   void (*cb)(long long, double, long long, double, long long,
+                              double, long long, double, long long, double)) {
+    cb(a0, a1, a2, a3, a4, a5, a6, a7, a8, a9);
+}

--- a/test/micro/org/openjdk/bench/jdk/incubator/foreign/libUpcallsJNI.c
+++ b/test/micro/org/openjdk/bench/jdk/incubator/foreign/libUpcallsJNI.c
@@ -24,14 +24,6 @@
 #include <stdlib.h>
 #include "jlong.h"
 
-//void blank(void (*cb)(void)) {
-//    cb();
-//}
-//
-//int identity(int x, int (*cb)(int)) {
-//    return cb(x);
-//}
-
 typedef struct {
     jclass holder;
     jmethodID mid;

--- a/test/micro/org/openjdk/bench/jdk/incubator/foreign/libUpcallsJNI.c
+++ b/test/micro/org/openjdk/bench/jdk/incubator/foreign/libUpcallsJNI.c
@@ -24,13 +24,13 @@
 #include <stdlib.h>
 #include "jlong.h"
 
-void blank(void (*cb)(void)) {
-    cb();
-}
-
-int identity(int x, int (*cb)(int)) {
-    return cb(x);
-}
+//void blank(void (*cb)(void)) {
+//    cb();
+//}
+//
+//int identity(int x, int (*cb)(int)) {
+//    return cb(x);
+//}
 
 typedef struct {
     jclass holder;
@@ -81,4 +81,21 @@ JNIEXPORT jint JNICALL Java_org_openjdk_bench_jdk_incubator_foreign_Upcalls_iden
   (JNIEnv *env, jclass cls, jint x, jlong cb) {
     JNICB jniCb = jlong_to_ptr(cb);
     return (*env)->CallStaticIntMethod(env, jniCb->holder, jniCb->mid, x);
+}
+
+JNIEXPORT jint JNICALL Java_org_openjdk_bench_jdk_incubator_foreign_Upcalls_args5
+  (JNIEnv *env, jclass cls,
+      jlong a0, jdouble a1, jlong a2, jdouble a3, jlong a4,
+      jlong cb) {
+    JNICB jniCb = jlong_to_ptr(cb);
+    return (*env)->CallStaticIntMethod(env, jniCb->holder, jniCb->mid, a0, a1, a2, a3, a4);
+}
+
+JNIEXPORT jint JNICALL Java_org_openjdk_bench_jdk_incubator_foreign_Upcalls_args10
+  (JNIEnv *env, jclass cls,
+      jlong a0, jdouble a1, jlong a2, jdouble a3, jlong a4,
+      jdouble a5, jlong a6, jdouble a7, jlong a8, jdouble a9,
+      jlong cb) {
+    JNICB jniCb = jlong_to_ptr(cb);
+    return (*env)->CallStaticIntMethod(env, jniCb->holder, jniCb->mid, a0, a1, a2, a3, a4, a5, a6, a7, a8, a9);
 }


### PR DESCRIPTION
Hi,

This patch adds specialization of upcalls, which includes both the specialization of the binding recipe using MethodHandle combinators, as for downcalls, as well as VM support for generating a customized wrapper for a 'low-level' method handle taking and returning only primitive types, which can be used as a base handle in the binding specialization.

The latter is based on Vladimir Ivanov's earlier linkToNative work, with a few changes to the frame layout, exception handling, and added support for attaching non-java threads, as well as re-writing it to support an arbitrary caller ABI.

The current implementation supports x86 only for now - though I've made sure all the tests still pass on AArch64. Stack argument passing is disabled, as for downcalls - there is a mismatch between the encoding for stack slots we use on the Java side, and the encoding we use in the VM, which needs some more consideration. And finally, as with downcalls, multi-register returns are disabled as well. We need to figure out what the right protocol for those should be, maybe taking inspiration from Valhalla.

In the code I've moved some things from ProgrammableInvoker to SharedUtils in order to reuse for upcalls. I also added a bit of debugging code to BufferLayout for dumping stack arguments. Note that there is quite a bit of motion in ProgrammableUpcallHandler as well. This is mostly to untangle the part of an upcall that is specialized using MethodHandle combinators (invokeInterpBindings), from the part that is replaced by the VM's wrapper stub (invokeMoves). I've for instance introduced a simple helper class, called InterpretedHandler, which acts as a wrapper around the target MethodHandle for doing the old-style interpreted calls, instead of using the whole ProgrammableUpcallHandler instance.

I've also removed some of the test configurations. We now only test the default settings of various specialization and intrinsification flags when running TestDowncall, TestUpcall, and TestUpcallHighArity. This patch 2 more of these flags, making a total of 16 combinations, which would take way too long to test, and is probably not necessary. I gave the full testing matrix a run, and found no issues. We can repeat that process periodically to check that all the combinations still work. I've also added some more benchmark cases for the upcalls benchmark.

I also gave the Windows jextract samples a try with this patch and found no issues.

Here are some of the benchmark numbers (from Linux-x64):

```
Benchmark                Mode  Cnt    Score   Error  Units
Upcalls.jni_args10       avgt   30  134.220 ? 1.553  ns/op
Upcalls.jni_args5        avgt   30   87.340 ? 1.753  ns/op
Upcalls.jni_blank        avgt   30   57.590 ? 0.877  ns/op
Upcalls.jni_identity     avgt   30  109.859 ? 0.930  ns/op
Upcalls.panama_args10    avgt   30   30.606 ? 0.088  ns/op
Upcalls.panama_args5     avgt   30   23.908 ? 0.121  ns/op
Upcalls.panama_blank     avgt   30   20.314 ? 0.137  ns/op
Upcalls.panama_identity  avgt   30   24.894 ? 0.111  ns/op
```
While these are  the numbers with the optimizations disabled (quite a bit worse):

```
Upcalls.panama_args10    avgt   30  886.885 ? 22.133  ns/op
Upcalls.panama_args5     avgt   30  566.600 ? 12.442  ns/op
Upcalls.panama_blank     avgt   30  212.962 ?  2.386  ns/op
Upcalls.panama_identity  avgt   30  361.358 ?  3.212  ns/op
```

We beat JNI across the board, and also seem to scale a lot better for larger numbers of arguments. So, this seems like a success :)

Thanks,
Jorn

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [JDK-8262118](https://bugs.openjdk.java.net/browse/JDK-8262118): Specialize upcalls


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.java.net/census#mcimadamore) (@mcimadamore - Committer) ⚠️ Review applies to 638f8a10c76436abafd7688f52d5627713ee52a6
 * [Vladimir Ivanov](https://openjdk.java.net/census#vlivanov) (@iwanowww - Committer) ⚠️ Review applies to 638f8a10c76436abafd7688f52d5627713ee52a6


### Download
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/457/head:pull/457`
`$ git checkout pull/457`
