### PR TITLE
8262117: jextract crashes with javac compilation error "class u is already defined"

### DIFF
--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/JavaSourceBuilder.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/JavaSourceBuilder.java
@@ -212,7 +212,7 @@ abstract class JavaSourceBuilder {
 
     // is the name enclosed enclosed by a class of the same name?
     boolean isEnclosedBySameName(String name) {
-        return false;
+        return className().equals(name);
     }
 
     protected void emitPackagePrefix() {

--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/JavaSourceBuilder.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/JavaSourceBuilder.java
@@ -205,7 +205,14 @@ abstract class JavaSourceBuilder {
      */
     final String uniqueNestedClassName(String name) {
         name = Utils.javaSafeIdentifier(name);
-        return nestedClassNames.add(name.toLowerCase()) ? name : (name + "$" + nestedClassNameCount++);
+        var notSeen = nestedClassNames.add(name.toLowerCase());
+        var notEnclosed = !isEnclosedBySameName(name.toLowerCase());
+        return notSeen && notEnclosed? name : (name + "$" + nestedClassNameCount++);
+    }
+
+    // is the name enclosed enclosed by a class of the same name?
+    boolean isEnclosedBySameName(String name) {
+        return false;
     }
 
     protected void emitPackagePrefix() {

--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/NestedClassBuilder.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/NestedClassBuilder.java
@@ -46,6 +46,11 @@ public class NestedClassBuilder extends JavaSourceBuilder {
     }
 
     @Override
+    boolean isEnclosedBySameName(String name) {
+        return className().equals(name) || enclosing.isEnclosedBySameName(name);
+    }
+
+    @Override
     String fullName() {
         return enclosing.className() + "." + className();
     }

--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/NestedClassBuilder.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/NestedClassBuilder.java
@@ -47,7 +47,7 @@ public class NestedClassBuilder extends JavaSourceBuilder {
 
     @Override
     boolean isEnclosedBySameName(String name) {
-        return className().equals(name) || enclosing.isEnclosedBySameName(name);
+        return super.isEnclosedBySameName(name) || enclosing.isEnclosedBySameName(name);
     }
 
     @Override

--- a/test/jdk/tools/jextract/Test8262117.java
+++ b/test/jdk/tools/jextract/Test8262117.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.lang.reflect.Method;
+import java.nio.file.Path;
+import jdk.incubator.foreign.NativeScope;
+import org.testng.annotations.Test;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+
+/*
+ * @test
+ * @modules jdk.incubator.jextract
+ * @library /test/lib
+ * @build JextractToolRunner
+ * @bug 8262117
+ * @summary jextract crashes with javac compilation error "class u is already defined"
+ * @run testng/othervm -Dforeign.restricted=permit Test8262117
+ */
+public class Test8262117 extends JextractToolRunner {
+    @Test
+    public void testNameClash() {
+        Path test8262117Output = getOutputFilePath("test8262117_gen");
+        Path test8262117H = getInputFilePath("test8262117.h");
+        run("-d", test8262117Output.toString(), test8262117H.toString()).checkSuccess();
+        try(Loader loader = classLoader(test8262117Output)) {
+            Class<?> cls = loader.loadClass("test8262117_h");
+            assertNotNull(cls);
+
+            assertNotNull(loader.loadClass("test8262117_h$u"));
+            assertNotNull(loader.loadClass("test8262117_h$u$outer$u$0"));
+            assertNotNull(loader.loadClass("test8262117_h$v"));
+            assertNotNull(loader.loadClass("test8262117_h$v$v$0"));
+        } finally {
+            deleteDir(test8262117Output);
+        }
+    }
+}

--- a/test/jdk/tools/jextract/test8262117.h
+++ b/test/jdk/tools/jextract/test8262117.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+
+union {
+   struct {
+      union {
+         struct { int x; } inner;
+      } u;
+   } outer;
+} u;
+
+
+union {
+    union {
+       int x; long y;
+    } v;
+} v;


### PR DESCRIPTION
enclosing names are checked for clash now

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [JDK-8262117](https://bugs.openjdk.java.net/browse/JDK-8262117): jextract crashes with javac compilation error "class u is already defined"


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.java.net/census#mcimadamore) (@mcimadamore - Committer) ⚠️ Review applies to bea8e2d43e5dec5fc9f127c1adc7ede3c6e377f8


### Download
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/458/head:pull/458`
`$ git checkout pull/458`
