### PR TITLE
8262198: Overhaul bitfield parsing logic

### DIFF
--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/ConstantBuilder.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/ConstantBuilder.java
@@ -275,7 +275,7 @@ public class ConstantBuilder extends NestedClassBuilder {
             }
             incrAlign();
             String delim = "";
-            boolean isBitfield = group.attribute("BITFIELDS").isPresent();
+            boolean isBitfield = LayoutUtils.isBitfields(group);
             for (MemoryLayout e : group.memberLayouts()) {
                 append(delim);
                 indent();

--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/JavaSourceBuilder.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/JavaSourceBuilder.java
@@ -221,6 +221,7 @@ abstract class JavaSourceBuilder {
     protected void emitImportSection() {
         append("import java.lang.invoke.MethodHandle;\n");
         append("import java.lang.invoke.VarHandle;\n");
+        append("import java.nio.ByteOrder;\n");
         append("import java.util.Objects;\n");
         append("import jdk.incubator.foreign.*;\n");
         append("import jdk.incubator.foreign.MemoryLayout.PathElement;\n");

--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/LayoutUtils.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/LayoutUtils.java
@@ -27,6 +27,7 @@
 package jdk.internal.jextract.impl;
 
 import jdk.incubator.foreign.FunctionDescriptor;
+import jdk.incubator.foreign.GroupLayout;
 import jdk.incubator.foreign.MemoryLayout;
 import jdk.incubator.jextract.Type.Primitive;
 import jdk.internal.clang.Cursor;
@@ -43,6 +44,7 @@ import static jdk.incubator.foreign.CLinker.C_POINTER;
 public final class LayoutUtils {
 
     public static final String JEXTRACT_ANONYMOUS = "jextract/anonymous";
+    public static final String JEXTRACT_BITFIELDS = "jextract/bitfields";
 
     private LayoutUtils() {}
 
@@ -215,5 +217,14 @@ public final class LayoutUtils {
             case 64 -> Primitive.Kind.LongLong;
             default -> throw new IllegalStateException("Cannot infer container layout");
         };
+    }
+
+    static boolean isBitfields(GroupLayout layout) {
+        return layout.attribute(JEXTRACT_BITFIELDS).isPresent();
+    }
+
+    @SuppressWarnings("unchecked")
+    static <Z extends MemoryLayout> Z setBitfields(Z layout) {
+        return (Z) layout.withAttribute(JEXTRACT_BITFIELDS, true);
     }
 }

--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/Parser.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/Parser.java
@@ -85,7 +85,7 @@ public class Parser {
                     } else {
                         Declaration decl = treeMaker.createTree(c);
                         if (decl != null) {
-                            decls.add(treeMaker.createTree(c));
+                            decls.add(decl);
                         }
                     }
                 } else if (isMacro(c) && src.path() != null) {

--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/RecordLayoutComputer.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/RecordLayoutComputer.java
@@ -137,13 +137,8 @@ abstract class RecordLayoutComputer {
         return c.isBitField() ? c.getBitFieldWidth() : c.type().size() * 8;
     }
 
-    ValueLayout bitfield(ValueLayout container, List<MemoryLayout> sublayouts) {
-        return Utils.addContents(container, MemoryLayout.ofStruct(sublayouts.toArray(new MemoryLayout[0])));
-    }
-
-    ValueLayout bitfield(long containerSize, List<MemoryLayout> sublayouts) {
-        return bitfield((ValueLayout)LayoutUtils.valueLayoutForSize(containerSize)
-                        .layout().orElseThrow(() -> new IllegalStateException("Unsupported size: " + containerSize)), sublayouts);
+    MemoryLayout bitfield(List<MemoryLayout> sublayouts) {
+        return MemoryLayout.ofStruct(sublayouts.toArray(new MemoryLayout[0])).withAttribute("BITFIELDS", true);
     }
 
     long offsetOf(Type parent, Cursor c) {

--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/RecordLayoutComputer.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/RecordLayoutComputer.java
@@ -26,9 +26,7 @@
 
 package jdk.internal.jextract.impl;
 
-import jdk.incubator.foreign.GroupLayout;
 import jdk.incubator.foreign.MemoryLayout;
-import jdk.incubator.foreign.ValueLayout;
 import jdk.internal.clang.Cursor;
 import jdk.internal.clang.CursorKind;
 import jdk.internal.clang.Type;
@@ -138,7 +136,7 @@ abstract class RecordLayoutComputer {
     }
 
     MemoryLayout bitfield(List<MemoryLayout> sublayouts) {
-        return MemoryLayout.ofStruct(sublayouts.toArray(new MemoryLayout[0])).withAttribute("BITFIELDS", true);
+        return LayoutUtils.setBitfields(MemoryLayout.ofStruct(sublayouts.toArray(new MemoryLayout[0])));
     }
 
     long offsetOf(Type parent, Cursor c) {

--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/StructLayoutComputer.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/StructLayoutComputer.java
@@ -131,65 +131,8 @@ final class StructLayoutComputer extends RecordLayoutComputer {
     // process bitfields if any and clear bitfield layouts
     private void handleBitfields() {
         if (bitfieldLayouts != null) {
-            fieldLayouts.addAll(convertBitfields(bitfieldLayouts));
+            fieldLayouts.add(bitfield(bitfieldLayouts));
             bitfieldLayouts = null;
         }
-    }
-
-    private List<MemoryLayout> convertBitfields(List<MemoryLayout> layouts) {
-        long offset = 0L;
-        List<MemoryLayout> newFields = new ArrayList<>();
-        List<MemoryLayout> pendingFields = new ArrayList<>();
-        for (MemoryLayout l : layouts) {
-            offset += l.bitSize();
-            if (offset > MAX_STORAGE_SIZE) {
-                throw new IllegalStateException("Crossing storage unit boundaries");
-            }
-            pendingFields.add(l);
-            long storageSize = storageSize(offset);
-            if (!pendingFields.isEmpty() && storageSize != -1) {
-                //emit new
-                newFields.add(bitfield(storageSize, pendingFields));
-                pendingFields.clear();
-                offset = 0L;
-            }
-        }
-        if (!pendingFields.isEmpty()) {
-            long storageSize = nextStorageSize(offset);
-            //emit new
-            newFields.add(bitfield(storageSize, pendingFields));
-            pendingFields.clear();
-        }
-        return newFields;
-    }
-
-    static int[] STORAGE_SIZES = { 64, 32, 16, 8 };
-    static int[] ALIGN_SIZES = { 8, 16, 32, 64 };
-    static int MAX_STORAGE_SIZE = 64;
-
-    private long storageSize(long size) {
-        // offset should be < MAX_STORAGE_SIZE
-        for (int s : STORAGE_SIZES) {
-            if (size == s) {
-                return s;
-            }
-        }
-        return -1;
-    }
-
-    private long nextStorageSize(long size) {
-        // offset should be < MAX_STORAGE_SIZE
-        for (int s : ALIGN_SIZES) {
-            long alignedSize = alignUp(size, s);
-            long storageSize = storageSize(alignedSize);
-            if (storageSize != -1) {
-                return storageSize;
-            }
-        }
-        return -1;
-    }
-
-    private static long alignUp(long n, long alignment) {
-        return (n + alignment - 1) & -alignment;
     }
 }

--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/TreeMaker.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/TreeMaker.java
@@ -34,7 +34,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -299,7 +298,7 @@ class TreeMaker {
                                                                        .collect(Collectors.toSet());
         List<Declaration> newDecls = new ArrayList<>();
         for (MemoryLayout e : ((GroupLayout)layout).memberLayouts()) {
-            if (e instanceof GroupLayout contents && contents.attribute("BITFIELDS").isPresent()) {
+            if (e instanceof GroupLayout contents && LayoutUtils.isBitfields(contents)) {
                 List<Declaration.Variable> bfDecls = new ArrayList<>();
                 outer: for (MemoryLayout bitfield : contents.memberLayouts()) {
                     if (bitfield.name().isPresent() && !nestedBitfieldNames.contains(bitfield.name().get())) {

--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/TreeMaker.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/TreeMaker.java
@@ -299,10 +299,9 @@ class TreeMaker {
                                                                        .collect(Collectors.toSet());
         List<Declaration> newDecls = new ArrayList<>();
         for (MemoryLayout e : ((GroupLayout)layout).memberLayouts()) {
-            Optional<GroupLayout> contents = Utils.getContents(e);
-            if (contents.isPresent()) {
+            if (e instanceof GroupLayout contents && contents.attribute("BITFIELDS").isPresent()) {
                 List<Declaration.Variable> bfDecls = new ArrayList<>();
-                outer: for (MemoryLayout bitfield : contents.get().memberLayouts()) {
+                outer: for (MemoryLayout bitfield : contents.memberLayouts()) {
                     if (bitfield.name().isPresent() && !nestedBitfieldNames.contains(bitfield.name().get())) {
                         Iterator<Declaration> declIt = declarations.iterator();
                         while (declIt.hasNext()) {
@@ -317,7 +316,7 @@ class TreeMaker {
                     }
                 }
                 if (!bfDecls.isEmpty()) {
-                    newDecls.add(Declaration.bitfields(bfDecls.get(0).pos(), "", contents.get(), bfDecls.toArray(new Declaration.Variable[0])));
+                    newDecls.add(Declaration.bitfields(bfDecls.get(0).pos(), "", contents, bfDecls.toArray(new Declaration.Variable[0])));
                 }
             }
         }

--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/UnionLayoutComputer.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/UnionLayoutComputer.java
@@ -91,6 +91,8 @@ final class UnionLayoutComputer extends RecordLayoutComputer {
         if (actualSize < expectedSize) {
             // emit an extra padding of expected size to make sure union layout size is computed correctly
             addFieldLayout(MemoryLayout.ofPaddingBits(expectedSize));
+        } else if (actualSize > expectedSize) {
+            throw new AssertionError("Invalid union size - expected: " + expectedSize + "; found: " + actualSize);
         }
 
         MemoryLayout[] fields = fieldLayouts.toArray(new MemoryLayout[0]);

--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/Utils.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/Utils.java
@@ -26,28 +26,22 @@
 
 package jdk.internal.jextract.impl;
 
-import jdk.incubator.foreign.GroupLayout;
-import jdk.incubator.foreign.MemoryLayout;
 import jdk.internal.clang.Cursor;
 import jdk.internal.clang.CursorKind;
 import jdk.internal.clang.SourceLocation;
 import jdk.internal.clang.Type;
-import jdk.internal.clang.TypeKind;
 
 import javax.lang.model.SourceVersion;
 import javax.tools.JavaFileObject;
 import javax.tools.SimpleJavaFileObject;
 import java.io.IOException;
-import java.lang.reflect.Method;
 import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 /**
@@ -321,14 +315,5 @@ class Utils {
      */
     private static boolean isPrintableAscii(char ch) {
         return ch >= ' ' && ch <= '~';
-    }
-
-    static Optional<GroupLayout> getContents(MemoryLayout layout) {
-        return layout.attribute("contents").map(GroupLayout.class::cast);
-    }
-
-    @SuppressWarnings("unchecked")
-    static <Z extends MemoryLayout> Z addContents(Z layout, GroupLayout contents) {
-        return (Z) layout.withAttribute("contents", contents);
     }
 }

--- a/test/jdk/tools/jextract/BadBitfieldTest.java
+++ b/test/jdk/tools/jextract/BadBitfieldTest.java
@@ -61,6 +61,6 @@ public class BadBitfieldTest extends JextractToolRunner {
     @Test
     public void testBadBitfield() {
         run("-d", getOutputFilePath("badBitfieldsGen").toString(),
-                getInputFilePath("badBitfields.h").toString());
+                getInputFilePath("badBitfields.h").toString()).checkSuccess();
     }
 }

--- a/test/jdk/tools/jextract/BadBitfieldTest.java
+++ b/test/jdk/tools/jextract/BadBitfieldTest.java
@@ -65,8 +65,6 @@ public class BadBitfieldTest extends JextractToolRunner {
     @Test
     public void testBadBitfield() {
         run("-d", getOutputFilePath("badBitfieldsGen").toString(),
-                getInputFilePath("badBitfields.h").toString())
-            .checkFailure()
-            .checkContainsOutput("Crossing storage unit boundaries");
+                getInputFilePath("badBitfields.h").toString());
     }
 }

--- a/test/jdk/tools/jextract/BadBitfieldTest.java
+++ b/test/jdk/tools/jextract/BadBitfieldTest.java
@@ -23,7 +23,6 @@
 
 /*
  * @test
- * @requires os.family != "windows"
  * @modules jdk.incubator.jextract
  * @library /test/lib
  * @build BadBitfieldTest
@@ -31,9 +30,6 @@
  */
 
 /*
- * Not running on Windows since MSVC will not cross storage unit boundaries.
- * Resulting struct on SysV is 16 bytes, but 24 on MSx64
- *
  * MSVC: (/d1reportSingleClassLayoutFoo)
  * class Foo    size(24):
  *      +---


### PR DESCRIPTION
This parsing stratgey cannot (by definition) fail - so, moving forward there will be no more exceptions coming from this side of the code. Of course, since we no longer have container classification, when bitfield support is added to the backend, things might be a bit tricker; however I realized that, since the layout is well-formed, the backend can always use the layout API to query the offset and size of a given bitfield, and decide on the best strategy to get there (e.g. get the closed 8/16/32/64-bit word and apply some bitmasking). So, perhaps things don't change much in terms of code generation support.

This patch fixes a small bug in Parser, where we where creating the same tree twice (!!). There are some small tweaks to TreeMaker, to work with the new bitfield info coming out from RecordLayoutComputer, but overall nothing too difficult here.

Note that the `BadBitfieldTest`, which was previously asserting a jextract crash, has now turned into a positive test (and I've dropped the exclusion on Windows, since the test should now pass on all platforms).

[1] - https://github.com/rust-lang/rust-bindgen/issues/743

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [JDK-8262198](https://bugs.openjdk.java.net/browse/JDK-8262198): Overhaul bitfield parsing logic


### Reviewers
 * [Athijegannathan Sundararajan](https://openjdk.java.net/census#sundar) (@sundararajana - Committer) ⚠️ Review applies to e1c2e7fefbaeb86c874028492eba1e960e295e11
 * [Jorn Vernee](https://openjdk.java.net/census#jvernee) (@JornVernee - Committer) ⚠️ Review applies to e1c2e7fefbaeb86c874028492eba1e960e295e11


### Download
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/459/head:pull/459`
`$ git checkout pull/459`
