### PR TITLE
8262263: BadBitfieldTest fails on Windows

### DIFF
--- a/test/jdk/tools/jextract/badBitfields.h
+++ b/test/jdk/tools/jextract/badBitfields.h
@@ -23,8 +23,8 @@
 
 #pragma pack(1)
 struct Foo {
-    long  a         : 45;
-    long  b         : 24;
-    long  c         : 1;
-    long  d         : 58;
+    long long a: 45;
+    long long b: 24;
+    long long c: 1;
+    long long d: 58;
 };


### PR DESCRIPTION
Hi,

BadBitfieldTest fails on Windows due to the test struct using the `long` native type, with a bit-width larger than 32 bits, which is problematic on Windows.

Switching the type to `long long` resolves the failure. (I've also reduced the whitespace a little)

Thanks,
Jorn

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [JDK-8262263](https://bugs.openjdk.java.net/browse/JDK-8262263): BadBitfieldTest fails on Windows


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.java.net/census#mcimadamore) (@mcimadamore - Committer)


### Download
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/460/head:pull/460`
`$ git checkout pull/460`
