### PR TITLE
8262733: jextract generates clashing names which results in compilation error with javac

### DIFF
--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/StructBuilder.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/StructBuilder.java
@@ -151,11 +151,12 @@ class StructBuilder extends ConstantBuilder {
     private void emitFieldGetter(Constant vhConstant, String javaName, Class<?> type) {
         incrAlign();
         indent();
-        append(MEMBER_MODS + " " + type.getSimpleName() + " " + javaName + "$get(MemorySegment " + safeParameterName("seg") + ") {\n");
+        String seg = safeParameterName("seg");
+        append(MEMBER_MODS + " " + type.getSimpleName() + " " + javaName + "$get(MemorySegment " + seg + ") {\n");
         incrAlign();
         indent();
         append("return (" + type.getName() + ")"
-                + vhConstant.accessExpression() + ".get(" + safeParameterName("seg") + ");\n");
+                + vhConstant.accessExpression() + ".get(" + seg + ");\n");
         decrAlign();
         indent();
         append("}\n");
@@ -165,11 +166,13 @@ class StructBuilder extends ConstantBuilder {
     private void emitFieldSetter(Constant vhConstant, String javaName, Class<?> type) {
         incrAlign();
         indent();
-        String param = MemorySegment.class.getSimpleName() + " " + safeParameterName("seg");
-        append(MEMBER_MODS + " void " + javaName + "$set( " + param + ", " + type.getSimpleName() + " " + safeParameterName("x") + ") {\n");
+        String seg = safeParameterName("seg");
+        String x = safeParameterName("x");
+        String param = MemorySegment.class.getSimpleName() + " " + seg;
+        append(MEMBER_MODS + " void " + javaName + "$set( " + param + ", " + type.getSimpleName() + " " + x + ") {\n");
         incrAlign();
         indent();
-        append(vhConstant.accessExpression() + ".set(" + safeParameterName("seg") + ", " + safeParameterName("x") + ");\n");
+        append(vhConstant.accessExpression() + ".set(" + seg + ", " + x + ");\n");
         decrAlign();
         indent();
         append("}\n");
@@ -190,11 +193,12 @@ class StructBuilder extends ConstantBuilder {
     private void emitSegmentGetter(String javaName, String nativeName, MemoryLayout layout) {
         incrAlign();
         indent();
-        append(MEMBER_MODS + " MemorySegment " + javaName + "$slice(MemorySegment " + safeParameterName("seg") + ") {\n");
+        String seg = safeParameterName("seg");
+        append(MEMBER_MODS + " MemorySegment " + javaName + "$slice(MemorySegment " + seg + ") {\n");
         incrAlign();
         indent();
         append("return RuntimeHelper.nonCloseableNonTransferableSegment(");
-        append(safeParameterName("seg"));
+        append(seg);
         append(".asSlice(");
         append(structLayout.byteOffset(elementPaths(nativeName)));
         append(", ");
@@ -297,16 +301,18 @@ class StructBuilder extends ConstantBuilder {
     private void emitIndexedFieldGetter(Constant vhConstant, String javaName, Class<?> type) {
         incrAlign();
         indent();
-        String params = MemorySegment.class.getSimpleName() + " " + safeParameterName("seg") + ", long " + safeParameterName("index");
+        String index = safeParameterName("index");
+        String seg = safeParameterName("seg");
+        String params = MemorySegment.class.getSimpleName() + " " + seg + ", long " + index;
         append(MEMBER_MODS + " " + type.getSimpleName() + " " + javaName + "$get(" + params + ") {\n");
         incrAlign();
         indent();
         append("return (" + type.getName() + ")");
         append(vhConstant.accessExpression());
         append(".get(");
-        append(safeParameterName("seg"));
+        append(seg);
         append(".asSlice(");
-        append(safeParameterName("index"));
+        append(index);
         append("*sizeof()));\n");
         decrAlign();
         indent();
@@ -317,18 +323,21 @@ class StructBuilder extends ConstantBuilder {
     private void emitIndexedFieldSetter(Constant vhConstant, String javaName, Class<?> type) {
         incrAlign();
         indent();
-        String params = MemorySegment.class.getSimpleName() + " " + safeParameterName("seg") +
-            ", long " + safeParameterName("index") + ", " + type.getSimpleName() + " " + safeParameterName("x");
+        String index = safeParameterName("index");
+        String seg = safeParameterName("seg");
+        String x = safeParameterName("x");
+        String params = MemorySegment.class.getSimpleName() + " " + seg +
+            ", long " + index + ", " + type.getSimpleName() + " " + x;
         append(MEMBER_MODS + " void " + javaName + "$set(" + params + ") {\n");
         incrAlign();
         indent();
         append(vhConstant.accessExpression());
         append(".set(");
-        append(safeParameterName("seg"));
+        append(seg);
         append(".asSlice(");
-        append(safeParameterName("index"));
+        append(index);
         append("*sizeof()), ");
-        append(safeParameterName("x"));
+        append(x);
         append(");\n");
         decrAlign();
         indent();

--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/StructBuilder.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/StructBuilder.java
@@ -48,14 +48,18 @@ class StructBuilder extends ConstantBuilder {
     private final GroupLayout structLayout;
     private final Type structType;
     private final Deque<String> prefixElementNames;
-    private final String safeParameterName;
+    private final String setterParameterName;
 
     StructBuilder(JavaSourceBuilder enclosing, String className, GroupLayout structLayout, Type structType) {
         super(enclosing, Kind.CLASS, className);
         this.structLayout = structLayout;
         this.structType = structType;
         prefixElementNames = new ArrayDeque<>();
-        safeParameterName = isEnclosedBySameName("x")? "x$" : "x";
+        setterParameterName = safeParameterName("x");
+    }
+
+    private String safeParameterName(String paramName) {
+        return isEnclosedBySameName(paramName)? paramName + "$" : paramName;
     }
 
     void pushPrefixElement(String prefixElementName) {
@@ -164,10 +168,10 @@ class StructBuilder extends ConstantBuilder {
         incrAlign();
         indent();
         String param = MemorySegment.class.getSimpleName() + " seg";
-        append(MEMBER_MODS + " void " + javaName + "$set( " + param + ", " + type.getSimpleName() + " " + safeParameterName + ") {\n");
+        append(MEMBER_MODS + " void " + javaName + "$set( " + param + ", " + type.getSimpleName() + " " + setterParameterName + ") {\n");
         incrAlign();
         indent();
-        append(vhConstant.accessExpression() + ".set(seg, " + safeParameterName + ");\n");
+        append(vhConstant.accessExpression() + ".set(seg, " + setterParameterName + ");\n");
         decrAlign();
         indent();
         append("}\n");
@@ -309,12 +313,12 @@ class StructBuilder extends ConstantBuilder {
     private void emitIndexedFieldSetter(Constant vhConstant, String javaName, Class<?> type) {
         incrAlign();
         indent();
-        String params = MemorySegment.class.getSimpleName() + " seg, long index, " + type.getSimpleName() + " " + safeParameterName;
+        String params = MemorySegment.class.getSimpleName() + " seg, long index, " + type.getSimpleName() + " " + setterParameterName;
         append(MEMBER_MODS + " void " + javaName + "$set(" + params + ") {\n");
         incrAlign();
         indent();
         append(vhConstant.accessExpression() +
-                ".set(seg.asSlice(index*sizeof()), " + safeParameterName + ");\n");
+                ".set(seg.asSlice(index*sizeof()), " + setterParameterName + ");\n");
         decrAlign();
         indent();
         append("}\n");

--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/StructBuilder.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/StructBuilder.java
@@ -48,12 +48,14 @@ class StructBuilder extends ConstantBuilder {
     private final GroupLayout structLayout;
     private final Type structType;
     private final Deque<String> prefixElementNames;
+    private final String safeParameterName;
 
     StructBuilder(JavaSourceBuilder enclosing, String className, GroupLayout structLayout, Type structType) {
         super(enclosing, Kind.CLASS, className);
         this.structLayout = structLayout;
         this.structType = structType;
         prefixElementNames = new ArrayDeque<>();
+        safeParameterName = isEnclosedBySameName("x")? "x$" : "x";
     }
 
     void pushPrefixElement(String prefixElementName) {
@@ -162,10 +164,10 @@ class StructBuilder extends ConstantBuilder {
         incrAlign();
         indent();
         String param = MemorySegment.class.getSimpleName() + " seg";
-        append(MEMBER_MODS + " void " + javaName + "$set( " + param + ", " + type.getSimpleName() + " x) {\n");
+        append(MEMBER_MODS + " void " + javaName + "$set( " + param + ", " + type.getSimpleName() + " " + safeParameterName + ") {\n");
         incrAlign();
         indent();
-        append(vhConstant.accessExpression() + ".set(seg, x);\n");
+        append(vhConstant.accessExpression() + ".set(seg, " + safeParameterName + ");\n");
         decrAlign();
         indent();
         append("}\n");
@@ -307,12 +309,12 @@ class StructBuilder extends ConstantBuilder {
     private void emitIndexedFieldSetter(Constant vhConstant, String javaName, Class<?> type) {
         incrAlign();
         indent();
-        String params = MemorySegment.class.getSimpleName() + " seg, long index, " + type.getSimpleName() + " x";
+        String params = MemorySegment.class.getSimpleName() + " seg, long index, " + type.getSimpleName() + " " + safeParameterName;
         append(MEMBER_MODS + " void " + javaName + "$set(" + params + ") {\n");
         incrAlign();
         indent();
         append(vhConstant.accessExpression() +
-                ".set(seg.asSlice(index*sizeof()), x);\n");
+                ".set(seg.asSlice(index*sizeof()), " + safeParameterName + ");\n");
         decrAlign();
         indent();
         append("}\n");

--- a/test/jdk/tools/jextract/Test8262733.java
+++ b/test/jdk/tools/jextract/Test8262733.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import org.testng.annotations.Test;
+import java.nio.file.Path;
+import static org.testng.Assert.assertNotNull;
+
+/*
+ * @test
+ * @modules jdk.incubator.jextract
+ * @library /test/lib
+ * @build JextractToolRunner
+ * @bug 8262733
+ * @summary jextract generates clashing names which results in compilation error with javac
+ * @run testng/othervm -Dforeign.restricted=permit Test8262733
+ */
+public class Test8262733 extends JextractToolRunner {
+    @Test
+    public void test() {
+        Path output = getOutputFilePath("8262733gen");
+        Path outputH = getInputFilePath("test8262733.h");
+        run("-d", output.toString(), outputH.toString()).checkSuccess();
+        try(Loader loader = classLoader(output)) {
+            Class<?> cls = loader.loadClass("test8262733_h");
+            assertNotNull(cls);
+        } finally {
+            deleteDir(output);
+        }
+    }
+}

--- a/test/jdk/tools/jextract/test8262733.h
+++ b/test/jdk/tools/jextract/test8262733.h
@@ -32,3 +32,11 @@ struct Foo {
        float f;
    } x;
 };
+
+struct seg {
+  int x;
+};
+
+struct index {
+  int x;
+};

--- a/test/jdk/tools/jextract/test8262733.h
+++ b/test/jdk/tools/jextract/test8262733.h
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+
+struct {
+   int x, y;
+} x;
+
+struct Foo {
+   union {
+       int i;
+       float f;
+   } x;
+};


### PR DESCRIPTION
name clash is avoided by checking surrounding class names

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [JDK-8262733](https://bugs.openjdk.java.net/browse/JDK-8262733): jextract generates clashing names which results in compilation error with javac


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.java.net/census#mcimadamore) (@mcimadamore - Committer)


### Download
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/462/head:pull/462`
`$ git checkout pull/462`
