### PR TITLE
8262825: jextract crashes when Java type names like String are used as identifiers in C header

### DIFF
--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/JavaSourceBuilder.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/JavaSourceBuilder.java
@@ -229,9 +229,7 @@ abstract class JavaSourceBuilder {
         append("import java.lang.invoke.MethodHandle;\n");
         append("import java.lang.invoke.VarHandle;\n");
         append("import java.nio.ByteOrder;\n");
-        append("import java.util.Objects;\n");
         append("import jdk.incubator.foreign.*;\n");
-        append("import jdk.incubator.foreign.MemoryLayout.PathElement;\n");
         append("import static ");
         append(OutputFactory.C_LANG_CONSTANTS_HOLDER);
         append(".*;\n");

--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/Utils.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/Utils.java
@@ -95,7 +95,7 @@ class Utils {
             // C identifiers. But we may have a java keyword used as a C identifier.
             assert SourceVersion.isIdentifier(name);
 
-            return SourceVersion.isKeyword(name) || isRestrictedTypeName(name) ? (name + "_") : name;
+            return SourceVersion.isKeyword(name) || isRestrictedTypeName(name) || isJavaTypeName(name)? (name + "_") : name;
         }
     }
 
@@ -103,6 +103,19 @@ class Utils {
         return switch (name) {
             case "var", "yield", "record",
                 "sealed", "permits" -> true;
+            default -> false;
+        };
+    }
+
+    private static boolean isJavaTypeName(String name) {
+        // Java types that are used unqualified in the generated code
+        return switch (name) {
+            case "String", "MethodHandle",
+                "VarHandle", "ByteOrder",
+                "FunctionDescriptor", "LibraryLookup",
+                "MemoryAddress", "MemoryLayout",
+                "MemorySegment", "ValueLayout",
+                "RuntimeHelper" -> true;
             default -> false;
         };
     }

--- a/test/jdk/tools/jextract/Test8262825.java
+++ b/test/jdk/tools/jextract/Test8262825.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import org.testng.annotations.Test;
+import java.nio.file.Path;
+import static org.testng.Assert.assertNotNull;
+
+/*
+ * @test
+ * @modules jdk.incubator.jextract
+ * @library /test/lib
+ * @build JextractToolRunner
+ * @bug 8262825
+ * @summary jextract crashes when Java type names like String are used as identifiers in C heade
+ * @run testng/othervm -Dforeign.restricted=permit Test8262825
+ */
+public class Test8262825 extends JextractToolRunner {
+    @Test
+    public void test() {
+        Path output = getOutputFilePath("8262825gen");
+        Path outputH = getInputFilePath("test8262825.h");
+        run("-d", output.toString(), outputH.toString()).checkSuccess();
+        try(Loader loader = classLoader(output)) {
+            Class<?> cls = loader.loadClass("test8262825_h");
+            assertNotNull(cls);
+
+            assertNotNull(findField(cls, "MemoryLayout_"));
+            assertNotNull(findField(cls, "ValueLayout_"));
+
+            assertNotNull(loader.loadClass("test8262825_h$RuntimeHelper_"));
+            assertNotNull(loader.loadClass("test8262825_h$String_"));
+            assertNotNull(loader.loadClass("test8262825_h$MemoryAddress_"));
+            assertNotNull(loader.loadClass("test8262825_h$MemorySegment_"));
+        } finally {
+            deleteDir(output);
+        }
+    }
+}

--- a/test/jdk/tools/jextract/test8262825.h
+++ b/test/jdk/tools/jextract/test8262825.h
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+struct String {
+   int x, y;
+};
+
+struct RuntimeHelper {
+   int x;
+};
+
+union MemorySegment {
+   int x; float f;
+};
+
+union MemoryAddress {
+   long l; double d;
+};
+
+typedef long MemoryLayout;
+typedef double ValueLayout;


### PR DESCRIPTION
Unqualified Java type names used in generated code are mangled (like keywords, restricted type names)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [JDK-8262825](https://bugs.openjdk.java.net/browse/JDK-8262825): jextract crashes when Java type names like String are used as identifiers in C header


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.java.net/census#mcimadamore) (@mcimadamore - Committer)


### Download
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/463/head:pull/463`
`$ git checkout pull/463`
