### PR TITLE
8264187: Add a method for creating a slicing MethodHandle

### DIFF
--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/MemoryLayout.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/MemoryLayout.java
@@ -382,8 +382,9 @@ public interface MemoryLayout extends Constable {
      * }</pre></blockquote>
      *
      * where {@code x_1}, {@code x_2}, ... {@code x_n} are <em>dynamic</em> values provided as {@code long}
-     * arguments, whereas {@code c_1}, {@code c_2}, ... {@code c_m} and {@code s_0}, {@code s_1}, ... {@code s_n} are
-     * <em>static</em> stride constants which are derived from the layout path.
+     * arguments, whereas {@code c_1}, {@code c_2}, ... {@code c_m} are <em>static</em> offset constants
+     * and {@code s_0}, {@code s_1}, ... {@code s_n} are <em>static</em> stride constants which are derived from
+     * the layout path.
      *
      * @param elements the layout path elements.
      * @return a method handle that can be used to compute the bit offset of the layout element
@@ -433,8 +434,9 @@ public interface MemoryLayout extends Constable {
      * }</pre></blockquote>
      *
      * where {@code x_1}, {@code x_2}, ... {@code x_n} are <em>dynamic</em> values provided as {@code long}
-     * arguments, whereas {@code c_1}, {@code c_2}, ... {@code c_m} and {@code s_0}, {@code s_1}, ... {@code s_n} are
-     * <em>static</em> stride constants which are derived from the layout path.
+     * arguments, whereas {@code c_1}, {@code c_2}, ... {@code c_m} are <em>static</em> offset constants
+     * and {@code s_0}, {@code s_1}, ... {@code s_n} are <em>static</em> stride constants which are derived from
+     * the layout path.
      *
      * <p>The method handle will throw an {@link UnsupportedOperationException} if the computed
      * offset in bits is not a multiple of 8.
@@ -470,9 +472,10 @@ public interface MemoryLayout extends Constable {
     offset = c_1 + c_2 + ... + c_m + (x_1 * s_1) + (x_2 * s_2) + ... + (x_n * s_n)
      * }</pre></blockquote>
      *
-     * where {@code x_1}, {@code x_2}, ... {@code x_n} are <em>dynamic</em> values provided as optional {@code long}
-     * access coordinates, whereas {@code c_1}, {@code c_2}, ... {@code c_m} and {@code s_0}, {@code s_1}, ... {@code s_n} are
-     * <em>static</em> stride constants which are derived from the layout path.
+     * where {@code x_1}, {@code x_2}, ... {@code x_n} are <em>dynamic</em> values provided as {@code long}
+     * arguments, whereas {@code c_1}, {@code c_2}, ... {@code c_m} are <em>static</em> offset constants
+     * and {@code s_0}, {@code s_1}, ... {@code s_n} are <em>static</em> stride constants which are derived from
+     * the layout path.
      *
      * @apiNote the resulting var handle will feature an additional {@code long} access coordinate for every
      * unspecified sequence access component contained in this layout path. Moreover, the resulting var handle
@@ -494,8 +497,8 @@ public interface MemoryLayout extends Constable {
     }
 
     /**
-     * Creates a method handle which can be used to create a slice of the layout selected by a given layout path,
-     * where the path is considered rooted in this layout.
+     * Creates a method handle which, given a memory segment, returns a {@link MemorySegment#asSlice(long,long)}
+     * corresponding to the layout selected by a given layout path, where the path is considered rooted in this layout.
      *
      * <p>The returned method handle has a return type of {@code MemorySegment}, features a {@code MemorySegment}
      * parameter as leading parameter representing the segment to be sliced, and features as many trailing {@code long}
@@ -512,8 +515,9 @@ public interface MemoryLayout extends Constable {
      * }</pre></blockquote>
      *
      * where {@code x_1}, {@code x_2}, ... {@code x_n} are <em>dynamic</em> values provided as {@code long}
-     * arguments, whereas {@code c_1}, {@code c_2}, ... {@code c_m} and {@code s_0}, {@code s_1}, ... {@code s_n} are
-     * <em>static</em> stride constants which are derived from the layout path.
+     * arguments, whereas {@code c_1}, {@code c_2}, ... {@code c_m} are <em>static</em> offset constants
+     * and {@code s_0}, {@code s_1}, ... {@code s_n} are <em>static</em> stride constants which are derived from
+     * the layout path.
      *
      * <p>After the offset is computed, the returned segment is create as if by calling:
      * <blockquote><pre>{@code
@@ -521,7 +525,7 @@ public interface MemoryLayout extends Constable {
      * }</pre></blockquote>
      *
      * where {@code segment} is the segment to be sliced, and where {@code layout} is the layout selected by the given
-     * layout path.
+     * layout path, as per {@link MemoryLayout#select(PathElement...)}.
      *
      * <p>The method handle will throw an {@link UnsupportedOperationException} if the computed
      * offset in bits is not a multiple of 8.

--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/MemoryLayout.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/MemoryLayout.java
@@ -497,7 +497,7 @@ public interface MemoryLayout extends Constable {
     }
 
     /**
-     * Creates a method handle which, given a memory segment, returns a {@link MemorySegment#asSlice(long,long)}
+     * Creates a method handle which, given a memory segment, returns a {@link MemorySegment#asSlice(long,long) slice}
      * corresponding to the layout selected by a given layout path, where the path is considered rooted in this layout.
      *
      * <p>The returned method handle has a return type of {@code MemorySegment}, features a {@code MemorySegment}

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/LayoutPath.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/LayoutPath.java
@@ -208,8 +208,6 @@ public class LayoutPath {
     }
 
     public MethodHandle sliceHandle() {
-        checkAlignment(this);
-
         MethodHandle offsetHandle = offsetHandle(); // bit offset
         offsetHandle = MethodHandles.filterReturnValue(offsetHandle, Utils.MH_bitsToBytesOrThrowForOffset); // byte offset
 

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/LayoutPath.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/LayoutPath.java
@@ -62,6 +62,7 @@ public class LayoutPath {
 
     private static final MethodHandle ADD_STRIDE;
     private static final MethodHandle MH_ADD_SCALED_OFFSET;
+    private static final MethodHandle MH_SLICE;
 
     private static final int UNSPECIFIED_ELEM_INDEX = -1;
 
@@ -72,6 +73,8 @@ public class LayoutPath {
                     MethodType.methodType(long.class, MemorySegment.class, long.class, long.class, long.class));
             MH_ADD_SCALED_OFFSET = lookup.findStatic(LayoutPath.class, "addScaledOffset",
                     MethodType.methodType(long.class, long.class, long.class, long.class));
+            MH_SLICE = lookup.findStatic(LayoutPath.class, "slice",
+                    MethodType.methodType(MemorySegment.class, MemorySegment.class, long.class, long.class));
         } catch (Throwable ex) {
             throw new ExceptionInInitializerError(ex);
         }
@@ -198,6 +201,23 @@ public class LayoutPath {
         }
         mh = MethodHandles.insertArguments(mh, 0, offset);
         return mh;
+    }
+
+    private static MemorySegment slice(MemorySegment base, long offset, long length) {
+        return base.asSlice(offset, length);
+    }
+
+    public MethodHandle sliceHandle() {
+        checkAlignment(this);
+
+        MethodHandle offsetHandle = offsetHandle(); // bit offset
+        offsetHandle = MethodHandles.filterReturnValue(offsetHandle, Utils.MH_bitsToBytesOrThrowForOffset); // byte offset
+
+        MethodHandle sliceHandle = MH_SLICE; // (MS, long, long) -> MS
+        sliceHandle = MethodHandles.insertArguments(sliceHandle, 2, layout.byteSize()); // (MS, long) -> MS
+        sliceHandle = MethodHandles.collectArguments(sliceHandle, 1, offsetHandle); // (MS, ...) -> MS
+
+        return sliceHandle;
     }
 
     public MemoryLayout layout() {

--- a/test/jdk/java/foreign/TestLayoutPaths.java
+++ b/test/jdk/java/foreign/TestLayoutPaths.java
@@ -31,11 +31,15 @@ import jdk.incubator.foreign.GroupLayout;
 import jdk.incubator.foreign.MemoryLayouts;
 import jdk.incubator.foreign.MemoryLayout;
 import jdk.incubator.foreign.MemoryLayout.PathElement;
+import jdk.incubator.foreign.MemorySegment;
+import jdk.incubator.foreign.ResourceScope;
 import jdk.incubator.foreign.SequenceLayout;
 
+import org.testng.SkipException;
 import org.testng.annotations.*;
 
 import java.lang.invoke.MethodHandle;
+import java.nio.ByteOrder;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -398,7 +402,7 @@ public class TestLayoutPaths {
         assertTrue(seq2.elementLayout() == MemoryLayouts.JAVA_DOUBLE);
     }
 
-    @Test(dataProvider =  "offsetHandleCases")
+    @Test(dataProvider = "testLayouts")
     public void testOffsetHandle(MemoryLayout layout, PathElement[] pathElements, long[] indexes,
                                  long expectedBitOffset) throws Throwable {
         MethodHandle bitOffsetHandle = layout.bitOffsetHandle(pathElements);
@@ -414,7 +418,7 @@ public class TestLayoutPaths {
     }
 
     @DataProvider
-    public static Object[][] offsetHandleCases() {
+    public static Object[][] testLayouts() {
         List<Object[]> testCases = new ArrayList<>();
 
         testCases.add(new Object[] {
@@ -489,5 +493,53 @@ public class TestLayoutPaths {
         return testCases.toArray(Object[][]::new);
     }
 
+    @Test(dataProvider = "testLayouts")
+    public void testSliceHandle(MemoryLayout layout, PathElement[] pathElements, long[] indexes,
+                                long expectedBitOffset) throws Throwable {
+        if (expectedBitOffset % 8 != 0)
+            throw new SkipException("Offset not a multiple of 8");
+
+        MemoryLayout selected = layout.select(pathElements);
+        MethodHandle sliceHandle = layout.sliceHandle(pathElements);
+        sliceHandle = sliceHandle.asSpreader(long[].class, indexes.length);
+
+        try (ResourceScope scope = ResourceScope.ofConfined()) {
+            MemorySegment segment = MemorySegment.allocateNative(layout, scope);
+            MemorySegment slice = (MemorySegment) sliceHandle.invokeExact(segment, indexes);
+            assertEquals(slice.address().segmentOffset(segment), expectedBitOffset / 8);
+            assertEquals(slice.byteSize(), selected.byteSize());
+        }
+    }
+
+    @Test(expectedExceptions = UnsupportedOperationException.class)
+    public void testSliceHandleUOEInvalidSize() {
+        MemoryLayout layout = MemoryLayout.ofStruct(
+            MemoryLayout.ofValueBits(32, ByteOrder.nativeOrder()).withName("x"),
+            MemoryLayout.ofValueBits(31, ByteOrder.nativeOrder()).withName("y") // not a multiple of 8
+        );
+
+        layout.sliceHandle(groupElement("y")); // should throw
+    }
+
+    @Test(expectedExceptions = UnsupportedOperationException.class)
+    public void testSliceHandleUOEInvalidOffset() throws Throwable {
+        MemoryLayout layout = MemoryLayout.ofStruct(
+            MemoryLayout.ofPaddingBits(5),
+            MemoryLayout.ofValueBits(32, ByteOrder.nativeOrder()).withName("y") // offset not a multiple of 8
+        );
+
+        MethodHandle sliceHandle;
+        try {
+            sliceHandle = layout.sliceHandle(groupElement("y")); // should work
+        } catch (UnsupportedOperationException uoe) {
+            fail("Unexpected exception", uoe);
+            return;
+        }
+
+        try (ResourceScope scope = ResourceScope.ofConfined()) {
+            MemorySegment segment = MemorySegment.allocateNative(layout, scope);
+            sliceHandle.invokeExact(segment); // should throw
+        }
+    }
 }
 


### PR DESCRIPTION
Hi,

This patch adds a `sliceHandle(PathElement...)` method to MemoryLayout, which can be used to create a method handle that, when given a segment, will return a slice of that segment for the layout element selected by the earlier given layout path.

This for instance makes it easier to iterate over an array of structs by first creating a slice for each element, and then accessing struct fields from there, without having to resolve to manual offset computation. For example:

```
SequenceLayout seq = MemoryLayout.ofSequence(5,
    MemoryLayout.ofStruct(
       MemoryLayout.ofValueBits(32, ByteOrder.nativeOrder()).withName("x"),
       MemoryLayout.ofValueBits(32, ByteOrder.nativeOrder()).withName("y")
    ));

MethodHandle sliceHandle = seq.sliceHandle(sequenceElement());

MemoryLayout structLayout = seq.select(sequenceElement());
VarHandle xHandle = structLayout.varHandle(int.class, groupElement("x"));
VarHandle yHandle = structLayout.varHandle(int.class, groupElement("y"));

try (ResourceScope scope = ResourceScope.ofConfined()) {
    MemorySegment segment = MemorySegment.allocateNative(seq, scope);
    long count = seq.elementCount().orElseThrow();
    for (int i = 0; i < count; i++) {
        // create view segment of single struct element
        MemorySegment struct = (MemorySegment) sliceHandle.invokeExact(segment, (long) i);
        xHandle.set(struct, 42);
        yHandle.set(struct, 84);
    }
}
```

Thanks,
Jorn

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [JDK-8264187](https://bugs.openjdk.java.net/browse/JDK-8264187): Add a method for creating a slicing MethodHandle


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.java.net/census#mcimadamore) (@mcimadamore - Committer) ⚠️ Review applies to 8db12b617ad411ea70f8bf0b1b8977e6128e434f


### Download
To checkout this PR locally:
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/477/head:pull/477`
`$ git checkout pull/477`

To update a local copy of the PR:
`$ git checkout pull/477`
`$ git pull https://git.openjdk.java.net/panama-foreign pull/477/head`
