### PR TITLE
8264280: Foreign linker should be more friendly with implicit scopes

### DIFF
--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/MemoryAddress.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/MemoryAddress.java
@@ -209,7 +209,7 @@ public interface MemoryAddress extends Addressable {
     /**
      * The off-heap memory address instance modelling the {@code NULL} address.
      */
-    MemoryAddress NULL = new MemoryAddressImpl.UncheckedAddress(0L);
+    MemoryAddress NULL = new MemoryAddressImpl(null, 0L);
 
     /**
      * Obtain an off-heap memory address instance from given long address.
@@ -219,6 +219,6 @@ public interface MemoryAddress extends Addressable {
     static MemoryAddress ofLong(long value) {
         return value == 0 ?
                 NULL :
-                new MemoryAddressImpl.UncheckedAddress(value);
+                new MemoryAddressImpl(null, value);
     }
 }

--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/MemoryAddress.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/MemoryAddress.java
@@ -209,7 +209,7 @@ public interface MemoryAddress extends Addressable {
     /**
      * The off-heap memory address instance modelling the {@code NULL} address.
      */
-    MemoryAddress NULL = new MemoryAddressImpl(null,  0L);
+    MemoryAddress NULL = new MemoryAddressImpl.UncheckedAddress(0L);
 
     /**
      * Obtain an off-heap memory address instance from given long address.
@@ -219,6 +219,6 @@ public interface MemoryAddress extends Addressable {
     static MemoryAddress ofLong(long value) {
         return value == 0 ?
                 NULL :
-                new MemoryAddressImpl(null, value);
+                new MemoryAddressImpl.UncheckedAddress(value);
     }
 }

--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/MemorySegment.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/MemorySegment.java
@@ -145,9 +145,10 @@ try (ResourceScope scope = ResourceScope.ofShared()) {
 public interface MemorySegment extends Addressable {
 
     /**
-     * The base memory address associated with this memory segment. The returned address is
-     * a <em>checked</em> memory address and can therefore be used in dereference operations
-     * (see {@link MemoryAddress}).
+     * The base memory address associated with this memory segment.
+     * The returned memory address contains a strong reference to this segment; this means that if this segment
+     * is associated with a resource scope featuring <a href="ResourceScope.html#implicit-closure"><em>implicit closure</em></a>,
+     * the scope won't be closed as long as the returned address is <a href="../../../java/lang/ref/package.html#reachability">reachable</a>.
      * @return The base memory address.
      * @throws IllegalStateException if this segment is not <em>alive</em>, or if access occurs from a thread other than the
      * thread owning this segment

--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/ResourceScope.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/ResourceScope.java
@@ -56,7 +56,7 @@ import java.util.Spliterator;
  *     (see {@link CLinker#upcallStub(MethodHandle, FunctionDescriptor, ResourceScope)}</li>
  * </ul>
  *
- * <h2>Implicit closure</h2>
+ * <h2><a id = "implicit-closure">Implicit closure</a></h2>
  *
  * Resource scopes can be associated with a {@link Cleaner} instance (see {@link #ofConfined(Cleaner)}) - we call these
  * resource scopes <em>managed</em> resource scopes. A managed resource scope is closed automatically once the scope instance
@@ -253,7 +253,8 @@ public interface ResourceScope extends AutoCloseable {
     }
 
     /**
-     * Create a new <em>default scope</em>, a shared, non-closeable scope which only features implicit closure.
+     * Create a new <em>default scope</em>, a shared, non-closeable scope which only features
+     * <a href="ResourceScope.html#implicit-closure"><em>implicit closure</em></a>.
      * This resource scope is used as a valid default where no resource scope is provided by the user. For instance, this code:
      * <blockquote><pre>{@code
     MemorySegment.allocateNative(10);

--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/ResourceScope.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/ResourceScope.java
@@ -253,7 +253,7 @@ public interface ResourceScope extends AutoCloseable {
     }
 
     /**
-     * Create a new <em>default scope</em>, a shared, non-closeable scope which only features
+     * Create a new <em>default scope</em>. The default scope is a shared and non-closeable scope which only features
      * <a href="ResourceScope.html#implicit-closure"><em>implicit closure</em></a>.
      * This resource scope is used as a valid default where no resource scope is provided by the user. For instance, this code:
      * <blockquote><pre>{@code

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/AbstractMemorySegmentImpl.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/AbstractMemorySegmentImpl.java
@@ -224,7 +224,7 @@ public abstract class AbstractMemorySegmentImpl extends MemorySegmentProxy imple
     @ForceInline
     public final MemoryAddress address() {
         checkValidState();
-        return new MemoryAddressImpl.SegmentAddress(this, 0L);
+        return new MemoryAddressImpl(this, 0L);
     }
 
     @Override

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/AbstractMemorySegmentImpl.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/AbstractMemorySegmentImpl.java
@@ -224,7 +224,7 @@ public abstract class AbstractMemorySegmentImpl extends MemorySegmentProxy imple
     @ForceInline
     public final MemoryAddress address() {
         checkValidState();
-        return new MemoryAddressImpl(base(), min());
+        return new MemoryAddressImpl.SegmentAddress(this, 0L);
     }
 
     @Override

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/ProgrammableInvoker.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/ProgrammableInvoker.java
@@ -336,9 +336,7 @@ public class ProgrammableInvoker {
             // make sure arguments are reachable during the call
             // technically we only need to do all Addressable parameters here
             Reference.reachabilityFence(address);
-            for (int i = 0; i < args.length; i++) {
-                Reference.reachabilityFence(args[i]);
-            }
+            Reference.reachabilityFence(args);
 
             // return value processing
             if (o == null) {

--- a/test/jdk/java/foreign/CallGeneratorHelper.java
+++ b/test/jdk/java/foreign/CallGeneratorHelper.java
@@ -47,8 +47,6 @@ public class CallGeneratorHelper extends NativeTestHelper {
     static final int MAX_PARAMS = 3;
     static final int CHUNK_SIZE = 600;
 
-    static int functions = 0;
-
     public static void assertStructEquals(MemorySegment actual, MemorySegment expected, MemoryLayout layout) {
         assertEquals(actual.byteSize(), expected.byteSize());
         GroupLayout g = (GroupLayout) layout;
@@ -182,6 +180,7 @@ public class CallGeneratorHelper extends NativeTestHelper {
 
     @DataProvider(name = "functions")
     public static Object[][] functions() {
+        int functions = 0;
         List<Object[]> downcalls = new ArrayList<>();
         for (Ret r : Ret.values()) {
             for (int i = 0; i <= MAX_PARAMS; i++) {
@@ -193,16 +192,18 @@ public class CallGeneratorHelper extends NativeTestHelper {
                         for (int j = 1; j <= MAX_FIELDS; j++) {
                             for (List<StructFieldType> fields : StructFieldType.perms(j)) {
                                 String structCode = sigCode(fields);
+                                int count = functions;
                                 int fCode = functions++ / CHUNK_SIZE;
                                 String fName = String.format("f%d_%s_%s_%s", fCode, retCode, sigCode, structCode);
-                                downcalls.add(new Object[] { fName, r, ptypes, fields });
+                                downcalls.add(new Object[] { count, fName, r, ptypes, fields });
                             }
                         }
                     } else {
                         String structCode = sigCode(List.<StructFieldType>of());
+                        int count = functions;
                         int fCode = functions++ / CHUNK_SIZE;
                         String fName = String.format("f%d_%s_%s_%s", fCode, retCode, sigCode, structCode);
-                        downcalls.add(new Object[] { fName, r, ptypes, List.of() });
+                        downcalls.add(new Object[] { count, fName, r, ptypes, List.of() });
                     }
                 }
             }


### PR DESCRIPTION
Following the recent introduction of ResourceScope, it is now "easier" to create segments backed by an implicit scope, which will deallocate memory when the scope becomes unreachable.

Because of this, some idioms, especially in the linker API, have become unsound, consider this:

```
MethodHandle STRLEN = CLinker.downcallHandle(...);
STRLEN.invokeExact(CLinker.toCString("Hello!").address());
```

The above code contains a subtle issue: since the segment is converted into an address (and, by the linker, into a raw long), it is possible for the segment (and hence the scope associated with the segment) to become unreachable *before* the native call has returned.

When working with jextract code, this idiom is even sneakier, given that jextract makes abundant use of `Addressable` in places where an address or a segment can be provided. In those cases the conversion is not even explicit in the user code, it is instead made by jextract.

This seems like an inconsistency in the foreign API; while VarHandle keep segments and scope alive, native MethodHandle don't. Of course we can't solve _all_ possible issues - after all a native call could still hold onto an address for longer, and dereference it later on, when the original segment went unreachable. But there's not much we can do to protect against this (in fact, same issue is possible even with deterministic deallocation). But for simple (and very common!) cases we should try harder to keep the Addressable arguments passed to a native call alive for the duration of the call.

This includes, notably, the Addressable parameter passed to "virtual" method handle, which also can be collected prematurely (with pretty bad consequences).

This patch rectifies that. To do so, the linker machinery will keep alive any addressable argument coming its way (thanks Jorn for wrestling with the combinators). On the API side, I've refactored the memory address implementation into an abstract class, which contains no state (ht: Valhalla) and all the implementations we had before. Then we have two thin subclasses, one that is used for all unchecked addresses, which is just a wrapper around a long; another that is an offset into a segment.

For now, I didn't make any big claim in the direction that an address "has a scope" - the API doesn't say that. The only change API-wise is that MemorySegment::address now documents that the returned address will keep the segment alive.

I've added two tests in TestUpcall/Downcall to make sure that everything works when arguments and returns are created using the default scope; the test was also passing with the previous implementation, so I went a bit more drastic, and added explicit calls to System.gc() - which immediately revealed the problem in the old code. Since calling System.gc() on every test iteration slows down test execution too much, I added some sampling logic, where System.gc() is only called every 100 tests.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [JDK-8264280](https://bugs.openjdk.java.net/browse/JDK-8264280): Foreign linker should be more friendly with implicit scopes


### Reviewers
 * [Paul Sandoz](https://openjdk.java.net/census#psandoz) (@PaulSandoz - Committer) ⚠️ Review applies to 4f8f0db9fa4e9380c8debe20c90c89b30ca20707
 * [Jorn Vernee](https://openjdk.java.net/census#jvernee) (@JornVernee - Committer) ⚠️ Review applies to 4f8f0db9fa4e9380c8debe20c90c89b30ca20707


### Download
To checkout this PR locally:
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/478/head:pull/478`
`$ git checkout pull/478`

To update a local copy of the PR:
`$ git checkout pull/478`
`$ git pull https://git.openjdk.java.net/panama-foreign pull/478/head`
