### PR TITLE
8264422: SpliteratorTest fails after ResourceScope integration

### DIFF
--- a/test/jdk/java/util/stream/test/org/openjdk/tests/java/util/stream/SpliteratorTest.java
+++ b/test/jdk/java/util/stream/test/org/openjdk/tests/java/util/stream/SpliteratorTest.java
@@ -23,6 +23,7 @@
 package org.openjdk.tests.java.util.stream;
 
 import jdk.incubator.foreign.MemorySegment;
+import jdk.incubator.foreign.ResourceScope;
 import jdk.incubator.foreign.SequenceLayout;
 import org.testng.annotations.Test;
 
@@ -64,7 +65,8 @@ public class SpliteratorTest {
 
     @Test(dataProvider = "SegmentSpliterator", dataProviderClass = SegmentTestDataProvider.class )
     public void testSegmentSpliterator(String name, SequenceLayout layout, SpliteratorTestHelper.ContentAsserter<MemorySegment> contentAsserter) {
-        try (MemorySegment segment = MemorySegment.allocateNative(layout)) {
+        try (ResourceScope scope = ResourceScope.ofConfined()) {
+            MemorySegment segment = MemorySegment.allocateNative(layout, scope);
             SegmentTestDataProvider.initSegment(segment);
             SpliteratorTestHelper.testSpliterator(() -> segment.spliterator(layout),
                     SegmentTestDataProvider::segmentCopier, contentAsserter);


### PR DESCRIPTION
This simple fix adapts SpliteratorTest to use a try-with-resources block against a ResourceScope, and not against a MemorySegment directly.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [JDK-8264422](https://bugs.openjdk.java.net/browse/JDK-8264422): SpliteratorTest fails after ResourceScope integration


### Reviewers
 * [Athijegannathan Sundararajan](https://openjdk.java.net/census#sundar) (@sundararajana - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/482/head:pull/482` \
`$ git checkout pull/482`

Update a local copy of the PR: \
`$ git checkout pull/482` \
`$ git pull https://git.openjdk.java.net/panama-foreign pull/482/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 482`

View PR using the GUI difftool: \
`$ git pr show -t 482`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/panama-foreign/pull/482.diff">https://git.openjdk.java.net/panama-foreign/pull/482.diff</a>

</details>
