### PR TITLE
8264402: drop "Restricted" suffix for methods enabled by enable-native-access and add fine grained native-access for CLinker

### DIFF
--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/CLinker.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/CLinker.java
@@ -144,13 +144,8 @@ public interface CLinker {
      * @return the downcall method handle.
      * @throws IllegalArgumentException in the case of a method type and function descriptor mismatch.
      */
-    @CallerSensitive
     @NativeAccess
-    default MethodHandle downcallHandle(Addressable symbol, MethodType type, FunctionDescriptor function) {
-        Reflection.ensureNativeAccess(Reflection.getCallerClass());
-        Objects.requireNonNull(symbol);
-        return MethodHandles.insertArguments(downcallHandle(type, function), 0, symbol);
-    }
+    MethodHandle downcallHandle(Addressable symbol, MethodType type, FunctionDescriptor function);
 
     /**
      * Obtain a foreign method handle, with the given type and featuring the given function descriptor,
@@ -168,18 +163,8 @@ public interface CLinker {
      * @return the downcall method handle.
      * @throws IllegalArgumentException in the case of a method type and function descriptor mismatch.
      */
-    @CallerSensitive
     @NativeAccess
-    default MethodHandle downcallHandle(Addressable symbol, SegmentAllocator allocator, MethodType type, FunctionDescriptor function) {
-        Reflection.ensureNativeAccess(Reflection.getCallerClass());
-        Objects.requireNonNull(symbol);
-        Objects.requireNonNull(allocator);
-        MethodHandle downcall = MethodHandles.insertArguments(downcallHandle(type, function), 0, symbol);
-        if (type.returnType().equals(MemorySegment.class)) {
-            downcall = MethodHandles.insertArguments(downcall, 0, allocator);
-        }
-        return downcall;
-    }
+    MethodHandle downcallHandle(Addressable symbol, SegmentAllocator allocator, MethodType type, FunctionDescriptor function);
 
     /**
      * Obtains a foreign method handle, with the given type and featuring the given function descriptor, which can be
@@ -231,11 +216,7 @@ public interface CLinker {
      * @throws IllegalArgumentException if the target's method type and the function descriptor mismatch.
      */
     @NativeAccess
-    @CallerSensitive
-    default MemorySegment upcallStub(MethodHandle target, FunctionDescriptor function) {
-        Reflection.ensureNativeAccess(Reflection.getCallerClass());
-        return upcallStub(target, function, MemoryScope.createDefault());
-    }
+    MemorySegment upcallStub(MethodHandle target, FunctionDescriptor function);
 
     /**
      * The layout for the {@code char} C type

--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/CLinker.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/CLinker.java
@@ -120,8 +120,6 @@ public interface CLinker {
      * the JVM or, worse, silently result in memory corruption. Thus, clients should refrain from depending on
      * restricted methods, and use safe and supported functionalities, where possible.
      * @return a linker for this system.
-     * @throws IllegalAccessError if the runtime property {@code foreign.restricted} is not set to either
-     * {@code permit}, {@code warn} or {@code debug} (the default value is set to {@code deny}).
      */
     @CallerSensitive
     @NativeAccess
@@ -146,7 +144,10 @@ public interface CLinker {
      * @return the downcall method handle.
      * @throws IllegalArgumentException in the case of a method type and function descriptor mismatch.
      */
+    @CallerSensitive
+    @NativeAccess
     default MethodHandle downcallHandle(Addressable symbol, MethodType type, FunctionDescriptor function) {
+        Reflection.ensureNativeAccess(Reflection.getCallerClass());
         Objects.requireNonNull(symbol);
         return MethodHandles.insertArguments(downcallHandle(type, function), 0, symbol);
     }
@@ -167,7 +168,10 @@ public interface CLinker {
      * @return the downcall method handle.
      * @throws IllegalArgumentException in the case of a method type and function descriptor mismatch.
      */
+    @CallerSensitive
+    @NativeAccess
     default MethodHandle downcallHandle(Addressable symbol, SegmentAllocator allocator, MethodType type, FunctionDescriptor function) {
+        Reflection.ensureNativeAccess(Reflection.getCallerClass());
         Objects.requireNonNull(symbol);
         Objects.requireNonNull(allocator);
         MethodHandle downcall = MethodHandles.insertArguments(downcallHandle(type, function), 0, symbol);
@@ -176,7 +180,6 @@ public interface CLinker {
         }
         return downcall;
     }
-
 
     /**
      * Obtains a foreign method handle, with the given type and featuring the given function descriptor, which can be
@@ -195,6 +198,7 @@ public interface CLinker {
      * @return the downcall method handle.
      * @throws IllegalArgumentException in the case of a method type and function descriptor mismatch.
      */
+    @NativeAccess
     MethodHandle downcallHandle(MethodType type, FunctionDescriptor function);
 
     /**
@@ -210,6 +214,7 @@ public interface CLinker {
      * @return the native stub segment.
      * @throws IllegalArgumentException if the target's method type and the function descriptor mismatch.
      */
+    @NativeAccess
     MemorySegment upcallStub(MethodHandle target, FunctionDescriptor function, ResourceScope scope);
 
     /**
@@ -225,7 +230,10 @@ public interface CLinker {
      * @return the native stub segment.
      * @throws IllegalArgumentException if the target's method type and the function descriptor mismatch.
      */
+    @NativeAccess
+    @CallerSensitive
     default MemorySegment upcallStub(MethodHandle target, FunctionDescriptor function) {
+        Reflection.ensureNativeAccess(Reflection.getCallerClass());
         return upcallStub(target, function, MemoryScope.createDefault());
     }
 
@@ -408,7 +416,7 @@ public interface CLinker {
      */
     @CallerSensitive
     @NativeAccess
-    static String toJavaStringRestricted(MemoryAddress addr) {
+    static String toJavaString(MemoryAddress addr) {
         Reflection.ensureNativeAccess(Reflection.getCallerClass());
         Objects.requireNonNull(addr);
         return SharedUtils.toJavaStringInternal(NativeMemorySegmentImpl.EVERYTHING, addr.toRawLongValue(), Charset.defaultCharset());
@@ -432,7 +440,7 @@ public interface CLinker {
      */
     @CallerSensitive
     @NativeAccess
-    static String toJavaStringRestricted(MemoryAddress addr, Charset charset) {
+    static String toJavaString(MemoryAddress addr, Charset charset) {
         Reflection.ensureNativeAccess(Reflection.getCallerClass());
         Objects.requireNonNull(addr);
         Objects.requireNonNull(charset);
@@ -508,7 +516,7 @@ public interface CLinker {
      */
     @CallerSensitive
     @NativeAccess
-    static MemoryAddress allocateMemoryRestricted(long size) {
+    static MemoryAddress allocateMemory(long size) {
         Reflection.ensureNativeAccess(Reflection.getCallerClass());
         MemoryAddress addr = SharedUtils.allocateMemoryInternal(size);
         if (addr.equals(MemoryAddress.NULL)) {
@@ -529,7 +537,7 @@ public interface CLinker {
      */
     @CallerSensitive
     @NativeAccess
-    static void freeMemoryRestricted(MemoryAddress addr) {
+    static void freeMemory(MemoryAddress addr) {
         Reflection.ensureNativeAccess(Reflection.getCallerClass());
         Objects.requireNonNull(addr);
         SharedUtils.freeMemoryInternal(addr);
@@ -698,7 +706,7 @@ public interface CLinker {
          */
         @CallerSensitive
         @NativeAccess
-        static VaList ofAddressRestricted(MemoryAddress address) {
+        static VaList ofAddress(MemoryAddress address) {
             Reflection.ensureNativeAccess(Reflection.getCallerClass());
             return SharedUtils.newVaListOfAddress(address, ResourceScope.globalScope());
         }
@@ -717,7 +725,7 @@ public interface CLinker {
          */
         @CallerSensitive
         @NativeAccess
-        static VaList ofAddressRestricted(MemoryAddress address, ResourceScope scope) {
+        static VaList ofAddress(MemoryAddress address, ResourceScope scope) {
             Reflection.ensureNativeAccess(Reflection.getCallerClass());
             Objects.requireNonNull(address);
             Objects.requireNonNull(scope);

--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/LibraryLookup.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/LibraryLookup.java
@@ -69,6 +69,7 @@ public interface LibraryLookup {
      * @param name the symbol name.
      * @return the memory address associated with the library symbol (if any).
      */
+    @NativeAccess
     Optional<MemoryAddress> lookup(String name);
 
     /**

--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/MappedMemorySegments.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/MappedMemorySegments.java
@@ -42,7 +42,7 @@ import java.util.Objects;
  * Clients requiring sophisticated, low-level control over mapped memory segments, should consider writing
  * custom mapped memory segment factories; using JNI, e.g. on Linux, it is possible to call {@code mmap}
  * with the desired parameters; the returned address can be easily wrapped into a memory segment, using
- * {@link MemoryAddress#ofLong(long)} and {@link MemoryAddress#asSegmentRestricted(long, Runnable, ResourceScope)}.
+ * {@link MemoryAddress#ofLong(long)} and {@link MemoryAddress#asSegment(long, Runnable, ResourceScope)}.
  *
  * <p> Unless otherwise specified, passing a {@code null} argument, or an array argument containing one or more {@code null}
  * elements to a method in this class causes a {@link NullPointerException NullPointerException} to be thrown. </p>

--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/MemoryAddress.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/MemoryAddress.java
@@ -30,8 +30,6 @@ import jdk.internal.foreign.MemoryAddressImpl;
 import jdk.internal.ref.CleanerFactory;
 import java.lang.ref.Cleaner;
 import jdk.internal.vm.annotation.NativeAccess;
-import jdk.internal.reflect.CallerSensitive;
-import jdk.internal.reflect.Reflection;
 
 /**
  * A memory address models a reference into a memory location. Memory addresses are typically obtained using the
@@ -102,7 +100,7 @@ public interface MemoryAddress extends Addressable {
      * <p>
      * This method is equivalent to the following code:
      * <pre>{@code
-    asSegmentRestricted(byteSize, null, ResourceScope.globalScope());
+    asSegment(byteSize, null, ResourceScope.globalScope());
      * }</pre>
      * This method is <em>restricted</em>. Restricted methods are unsafe, and, if used incorrectly, their use might crash
      * the JVM or, worse, silently result in memory corruption. Thus, clients should refrain from depending on
@@ -112,15 +110,9 @@ public interface MemoryAddress extends Addressable {
      * @return a new native memory segment with given base address and size.
      * @throws IllegalArgumentException if {@code bytesSize <= 0}.
      * @throws UnsupportedOperationException if this address is an heap address.
-     * @throws IllegalAccessError if the runtime property {@code foreign.restricted} is not set to either
-     * {@code permit}, {@code warn} or {@code debug} (the default value is set to {@code deny}).
      */
-    @CallerSensitive
     @NativeAccess
-    default MemorySegment asSegmentRestricted(long bytesSize) {
-        Reflection.ensureNativeAccess(Reflection.getCallerClass());
-        return asSegmentRestricted(bytesSize, null, ResourceScope.globalScope());
-    }
+    MemorySegment asSegment(long bytesSize);
 
     /**
      * Returns a native memory segment with given size and resource scope, and whose base address is this address. This method
@@ -135,7 +127,7 @@ public interface MemoryAddress extends Addressable {
      * <p>
      * This method is equivalent to the following code:
      * <pre>{@code
-    asSegmentRestricted(byteSize, null, scope);
+    asSegment(byteSize, null, scope);
      * }</pre>
      * This method is <em>restricted</em>. Restricted methods are unsafe, and, if used incorrectly, their use might crash
      * the JVM or, worse, silently result in memory corruption. Thus, clients should refrain from depending on
@@ -146,13 +138,9 @@ public interface MemoryAddress extends Addressable {
      * @return a new native memory segment with given base address, size and scope.
      * @throws IllegalArgumentException if {@code bytesSize <= 0}.
      * @throws UnsupportedOperationException if this address is an heap address.
-     * @throws IllegalAccessError if the runtime property {@code foreign.restricted} is not set to either
-     * {@code permit}, {@code warn} or {@code debug} (the default value is set to {@code deny}).
      */
     @NativeAccess
-    default MemorySegment asSegmentRestricted(long bytesSize, ResourceScope scope) {
-        return asSegmentRestricted(bytesSize, null, scope);
-    }
+    MemorySegment asSegment(long bytesSize, ResourceScope scope);
 
     /**
      * Returns a new native memory segment with given size and resource scope, and whose base address is this address. This method
@@ -177,11 +165,9 @@ public interface MemoryAddress extends Addressable {
      * @return a new native memory segment with given base address, size and scope.
      * @throws IllegalArgumentException if {@code bytesSize <= 0}.
      * @throws UnsupportedOperationException if this address is an heap address.
-     * @throws IllegalAccessError if the runtime property {@code foreign.restricted} is not set to either
-     * {@code permit}, {@code warn} or {@code debug} (the default value is set to {@code deny}).
      */
     @NativeAccess
-    MemorySegment asSegmentRestricted(long bytesSize, Runnable cleanupAction, ResourceScope scope);
+    MemorySegment asSegment(long bytesSize, Runnable cleanupAction, ResourceScope scope);
 
     /**
      * Returns the raw long value associated with this memory address.

--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/MemorySegment.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/MemorySegment.java
@@ -152,8 +152,6 @@ public interface MemorySegment extends Addressable {
      * is associated with a resource scope featuring <a href="ResourceScope.html#implicit-closure"><em>implicit closure</em></a>,
      * the scope won't be closed as long as the returned address is <a href="../../../java/lang/ref/package.html#reachability">reachable</a>.
      * @return The base memory address.
-     * @throws IllegalStateException if this segment is not <em>alive</em>, or if access occurs from a thread other than the
-     * thread owning this segment
      */
     @Override
     MemoryAddress address();
@@ -769,7 +767,7 @@ for (long l = 0; l < segment.byteSize(); l++) {
      * The returned segment is associated with the <em>global</em> resource scope (see {@link ResourceScope#globalScope()}).
      * Equivalent to (but likely more efficient than) the following code:
      * <pre>{@code
-    MemoryAddress.NULL.asSegmentRestricted(Long.MAX_VALUE)
+    MemoryAddress.NULL.asSegment(Long.MAX_VALUE)
      * }</pre>
      * <p>
      * This method is <em>restricted</em>. Restricted methods are unsafe, and, if used incorrectly, their use might crash
@@ -777,12 +775,10 @@ for (long l = 0; l < segment.byteSize(); l++) {
      * restricted methods, and use safe and supported functionalities, where possible.
      *
      * @return a memory segment whose base address is {@link MemoryAddress#NULL} and whose size is {@link Long#MAX_VALUE}.
-     * @throws IllegalAccessError if the runtime property {@code foreign.restricted} is not set to either
-     * {@code permit}, {@code warn} or {@code debug} (the default value is set to {@code deny}).
      */
     @CallerSensitive
     @NativeAccess
-    static MemorySegment ofNativeRestricted() {
+    static MemorySegment ofNative() {
         Reflection.ensureNativeAccess(Reflection.getCallerClass());
         return NativeMemorySegmentImpl.EVERYTHING;
     }

--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/package-info.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/package-info.java
@@ -153,23 +153,23 @@ int x = MemoryAccess.getIntAtOffset(segment, addr.segmentOffset(segment));
  * }</pre>
  *
  * Secondly, if the client does <em>not</em> have a segment which contains a given memory address, it can create one <em>unsafely</em>,
- * using the {@link jdk.incubator.foreign.MemoryAddress#asSegmentRestricted(long)} factory. This allows the client to
+ * using the {@link jdk.incubator.foreign.MemoryAddress#asSegment(long)} factory. This allows the client to
  * inject extra knowledge about spatial bounds which might, for instance, be available in the documentation of the foreign function
  * which produced the native address. Here is how an unsafe segment can be created from a native address:
  *
  * <pre>{@code
 MemoryAddress addr = ... //obtain address from native code
-MemorySegment segment = addr.asSegmentRestricted(4); // segment is 4 bytes long
+MemorySegment segment = addr.asSegment(4); // segment is 4 bytes long
 int x = MemoryAccess.getInt(segment);
  * }</pre>
  *
  * Alternatively, the client can fall back to use the so called <em>everything</em> segment - that is, a primordial segment
- * which covers the entire native heap. This segment can be obtained by calling the {@link jdk.incubator.foreign.MemorySegment#ofNativeRestricted()}
+ * which covers the entire native heap. This segment can be obtained by calling the {@link jdk.incubator.foreign.MemorySegment#ofNative()}
  * method, so that dereference can happen without the need of creating any additional segment instances:
  *
  * <pre>{@code
 MemoryAddress addr = ... //obtain address from native code
-int x = MemoryAccess.getIntAtOffset(MemorySegment.ofNativeRestricted(), addr.toRawLongValue());
+int x = MemoryAccess.getIntAtOffset(MemorySegment.ofNative(), addr.toRawLongValue());
  * }</pre>
  *
  * <h3>Upcalls</h3>
@@ -181,8 +181,8 @@ int x = MemoryAccess.getIntAtOffset(MemorySegment.ofNativeRestricted(), addr.toR
  * <pre>{@code
 class IntComparator {
     static int intCompare(MemoryAddress addr1, MemoryAddress addr2) {
-        return MemoryAccess.getIntAtOffset(MemorySegment.ofNativeRestricted(), addr1.toRawLongValue()) -
-               MemoryAccess.getIntAtOffset(MemorySegment.ofNativeRestricted(), addr2.toRawLongValue());
+        return MemoryAccess.getIntAtOffset(MemorySegment.ofNative(), addr1.toRawLongValue()) -
+               MemoryAccess.getIntAtOffset(MemorySegment.ofNative(), addr2.toRawLongValue());
     }
 }
  * }</pre>
@@ -214,22 +214,16 @@ MemorySegment comparFunc = CLinker.getInstance().upcallStub(
  * <h2>Restricted methods</h2>
  * Some methods in this package are considered <em>restricted</em>. Restricted methods are typically used to bind native
  * foreign data and/or functions to first-class Java API elements which can then be used directly by client. For instance
- * the restricted method {@link jdk.incubator.foreign.MemoryAddress#asSegmentRestricted(long)} can be used to create
+ * the restricted method {@link jdk.incubator.foreign.MemoryAddress#asSegment(long)} can be used to create
  * a fresh segment with given spatial bounds out of a native address.
  * <p>
  * Binding foreign data and/or functions is generally unsafe and, if done incorrectly, can result in VM crashes, or memory corruption when the bound Java API element is accessed.
- * For instance, in the case of {@link jdk.incubator.foreign.MemoryAddress#asSegmentRestricted(long)}, if the provided
+ * For instance, in the case of {@link jdk.incubator.foreign.MemoryAddress#asSegment(long)}, if the provided
  * spatial bounds are incorrect, a client of the segment returned by that method might crash the VM, or corrupt
  * memory when attempting to dereference said segment. For these reasons, it is crucial for code that calls a restricted method
  * to never pass arguments that might cause incorrect binding of foreign data and/or functions to a Java API.
  * <p>
- * Access to restricted methods is <em>disabled</em> by default; to enable restricted methods, the JDK property
- * {@code foreign.restricted} must be set to a value other than {@code deny}. The possible values for this property are:
- * <ul>
- * <li>{@code deny}: issues a runtime exception on each restricted call. This is the default value;</li>
- * <li>{@code permit}: allows restricted calls;</li>
- * <li>{@code warn}: like permit, but also prints a one-line warning on each restricted call;</li>
- * <li>{@code debug}: like permit, but also dumps the stack corresponding to any given restricted call.</li>
- * </ul>
+ * Access to restricted methods is <em>disabled</em> by default; to enable restricted methods, the JVM command line option
+ * {@code --enable-native-access} must mention the name of the caller's module.
  */
 package jdk.incubator.foreign;

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/AbstractCLinker.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/AbstractCLinker.java
@@ -1,0 +1,67 @@
+/*
+ *  Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ *  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ *  This code is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License version 2 only, as
+ *  published by the Free Software Foundation.  Oracle designates this
+ *  particular file as subject to the "Classpath" exception as provided
+ *  by Oracle in the LICENSE file that accompanied this code.
+ *
+ *  This code is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ *  version 2 for more details (a copy is included in the LICENSE file that
+ *  accompanied this code).
+ *
+ *  You should have received a copy of the GNU General Public License version
+ *  2 along with this work; if not, write to the Free Software Foundation,
+ *  Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ *   Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ *  or visit www.oracle.com if you need additional information or have any
+ *  questions.
+ *
+ */
+package jdk.internal.foreign;
+
+import jdk.incubator.foreign.Addressable;
+import jdk.incubator.foreign.CLinker;
+import jdk.incubator.foreign.FunctionDescriptor;
+import jdk.incubator.foreign.MemorySegment;
+import jdk.incubator.foreign.SegmentAllocator;
+import jdk.internal.foreign.MemoryScope;
+import jdk.internal.reflect.CallerSensitive;
+import jdk.internal.reflect.Reflection;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+import java.util.Objects;
+
+public abstract class AbstractCLinker implements CLinker {
+    @CallerSensitive
+    public final MethodHandle downcallHandle(Addressable symbol, MethodType type, FunctionDescriptor function) {
+        Reflection.ensureNativeAccess(Reflection.getCallerClass());
+        Objects.requireNonNull(symbol);
+        return MethodHandles.insertArguments(downcallHandle(type, function), 0, symbol);
+    }
+
+    @CallerSensitive
+    public final MethodHandle downcallHandle(Addressable symbol, SegmentAllocator allocator, MethodType type, FunctionDescriptor function) {
+        Reflection.ensureNativeAccess(Reflection.getCallerClass());
+        Objects.requireNonNull(symbol);
+        Objects.requireNonNull(allocator);
+        MethodHandle downcall = MethodHandles.insertArguments(downcallHandle(type, function), 0, symbol);
+        if (type.returnType().equals(MemorySegment.class)) {
+            downcall = MethodHandles.insertArguments(downcall, 0, allocator);
+        }
+        return downcall;
+    }
+
+    @CallerSensitive
+    public final MemorySegment upcallStub(MethodHandle target, FunctionDescriptor function) {
+        Reflection.ensureNativeAccess(Reflection.getCallerClass());
+        return upcallStub(target, function, MemoryScope.createDefault());
+    }
+}

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/LibrariesHelper.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/LibrariesHelper.java
@@ -105,7 +105,7 @@ public final class LibrariesHelper {
     }
 
     //Todo: in principle we could expose a scope accessor, so that users could unload libraries at will
-    static class LibraryLookupImpl implements LibraryLookup {
+    static final class LibraryLookupImpl implements LibraryLookup {
         final NativeLibrary library;
         final MemorySegment librarySegment;
 
@@ -116,7 +116,7 @@ public final class LibrariesHelper {
 
         @Override
         @CallerSensitive
-        public Optional<MemoryAddress> lookup(String name) {
+        public final Optional<MemoryAddress> lookup(String name) {
             Reflection.ensureNativeAccess(Reflection.getCallerClass());
             try {
                 Objects.requireNonNull(name);
@@ -129,7 +129,7 @@ public final class LibrariesHelper {
 
         @Override
         @CallerSensitive
-        public Optional<MemorySegment> lookup(String name, MemoryLayout layout) {
+        public final Optional<MemorySegment> lookup(String name, MemoryLayout layout) {
             Reflection.ensureNativeAccess(Reflection.getCallerClass());
             try {
                 Objects.requireNonNull(name);

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/LibrariesHelper.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/LibrariesHelper.java
@@ -111,11 +111,13 @@ public final class LibrariesHelper {
 
         LibraryLookupImpl(NativeLibrary library, ResourceScope scope) {
             this.library = library;
-            this.librarySegment = MemoryAddress.NULL.asSegmentRestricted(Long.MAX_VALUE, scope);
+            this.librarySegment = MemoryAddress.NULL.asSegment(Long.MAX_VALUE, scope);
         }
 
         @Override
+        @CallerSensitive
         public Optional<MemoryAddress> lookup(String name) {
+            Reflection.ensureNativeAccess(Reflection.getCallerClass());
             try {
                 Objects.requireNonNull(name);
                 MemoryAddress addr = MemoryAddress.ofLong(library.lookup(name));

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/MemoryAddressImpl.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/MemoryAddressImpl.java
@@ -107,21 +107,21 @@ public final class MemoryAddressImpl implements MemoryAddress {
 
     @Override
     @CallerSensitive
-    public MemorySegment asSegment(long bytesSize) {
+    public final MemorySegment asSegment(long bytesSize) {
         Reflection.ensureNativeAccess(Reflection.getCallerClass());
         return asSegment(bytesSize, null, ResourceScope.globalScope());
     }
 
     @Override
     @CallerSensitive
-    public MemorySegment asSegment(long bytesSize, ResourceScope scope) {
+    public final MemorySegment asSegment(long bytesSize, ResourceScope scope) {
         Reflection.ensureNativeAccess(Reflection.getCallerClass());
         return asSegment(bytesSize, null, scope);
     }
 
     @Override
     @CallerSensitive
-    public MemorySegment asSegment(long bytesSize, Runnable cleanupAction, ResourceScope scope) {
+    public final MemorySegment asSegment(long bytesSize, Runnable cleanupAction, ResourceScope scope) {
         Reflection.ensureNativeAccess(Reflection.getCallerClass());
         Objects.requireNonNull(scope);
         if (bytesSize <= 0) {

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/MemoryAddressImpl.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/MemoryAddressImpl.java
@@ -107,7 +107,21 @@ public final class MemoryAddressImpl implements MemoryAddress {
 
     @Override
     @CallerSensitive
-    public MemorySegment asSegmentRestricted(long bytesSize, Runnable cleanupAction, ResourceScope scope) {
+    public MemorySegment asSegment(long bytesSize) {
+        Reflection.ensureNativeAccess(Reflection.getCallerClass());
+        return asSegment(bytesSize, null, ResourceScope.globalScope());
+    }
+
+    @Override
+    @CallerSensitive
+    public MemorySegment asSegment(long bytesSize, ResourceScope scope) {
+        Reflection.ensureNativeAccess(Reflection.getCallerClass());
+        return asSegment(bytesSize, null, scope);
+    }
+
+    @Override
+    @CallerSensitive
+    public MemorySegment asSegment(long bytesSize, Runnable cleanupAction, ResourceScope scope) {
         Reflection.ensureNativeAccess(Reflection.getCallerClass());
         Objects.requireNonNull(scope);
         if (bytesSize <= 0) {

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/Utils.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/Utils.java
@@ -48,9 +48,6 @@ public final class Utils {
     private static final boolean SHOULD_ADAPT_HANDLES
         = Boolean.parseBoolean(privilegedGetProperty("jdk.internal.foreign.SHOULD_ADAPT_HANDLES", "true"));
 
-    private static final String foreignRestrictedAccess = Optional.ofNullable(VM.getSavedProperty("foreign.restricted"))
-            .orElse("deny");
-
     private static final MethodHandle SEGMENT_FILTER;
     public static final MethodHandle MH_bitsToBytesOrThrowForOffset;
 

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/aarch64/AArch64Linker.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/aarch64/AArch64Linker.java
@@ -77,7 +77,7 @@ public final class AArch64Linker extends AbstractCLinker {
 
     @Override
     @CallerSensitive
-    public MethodHandle downcallHandle(MethodType type, FunctionDescriptor function) {
+    public final MethodHandle downcallHandle(MethodType type, FunctionDescriptor function) {
         Reflection.ensureNativeAccess(Reflection.getCallerClass());
         Objects.requireNonNull(type);
         Objects.requireNonNull(function);
@@ -93,7 +93,7 @@ public final class AArch64Linker extends AbstractCLinker {
 
     @Override
     @CallerSensitive
-    public MemorySegment upcallStub(MethodHandle target, FunctionDescriptor function, ResourceScope scope) {
+    public final MemorySegment upcallStub(MethodHandle target, FunctionDescriptor function, ResourceScope scope) {
         Reflection.ensureNativeAccess(Reflection.getCallerClass());
         Objects.requireNonNull(scope);
         Objects.requireNonNull(target);

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/aarch64/AArch64Linker.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/aarch64/AArch64Linker.java
@@ -28,12 +28,15 @@ package jdk.internal.foreign.abi.aarch64;
 import jdk.incubator.foreign.FunctionDescriptor;
 import jdk.incubator.foreign.MemoryAddress;
 import jdk.incubator.foreign.MemorySegment;
-import jdk.incubator.foreign.CLinker;
 import jdk.incubator.foreign.ResourceScope;
+import jdk.internal.foreign.AbstractCLinker;
 import jdk.internal.foreign.MemoryScope;
 import jdk.internal.foreign.abi.Binding;
 import jdk.internal.foreign.abi.SharedUtils;
 import jdk.internal.foreign.abi.UpcallStubs;
+import jdk.internal.reflect.CallerSensitive;
+import jdk.internal.reflect.Reflection;
+import jdk.internal.vm.annotation.NativeAccess;
 
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
@@ -45,7 +48,7 @@ import java.util.function.Consumer;
  * ABI implementation based on ARM document "Procedure Call Standard for
  * the ARM 64-bit Architecture".
  */
-public class AArch64Linker implements CLinker {
+public class AArch64Linker extends AbstractCLinker {
     private static AArch64Linker instance;
 
     static final long ADDRESS_SIZE = 64; // bits
@@ -73,7 +76,9 @@ public class AArch64Linker implements CLinker {
     }
 
     @Override
+    @CallerSensitive
     public MethodHandle downcallHandle(MethodType type, FunctionDescriptor function) {
+        Reflection.ensureNativeAccess(Reflection.getCallerClass());
         Objects.requireNonNull(type);
         Objects.requireNonNull(function);
         MethodType llMt = SharedUtils.convertVaListCarriers(type, AArch64VaList.CARRIER);
@@ -87,7 +92,9 @@ public class AArch64Linker implements CLinker {
     }
 
     @Override
+    @CallerSensitive
     public MemorySegment upcallStub(MethodHandle target, FunctionDescriptor function, ResourceScope scope) {
+        Reflection.ensureNativeAccess(Reflection.getCallerClass());
         Objects.requireNonNull(scope);
         Objects.requireNonNull(target);
         Objects.requireNonNull(function);

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/aarch64/AArch64Linker.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/aarch64/AArch64Linker.java
@@ -48,7 +48,7 @@ import java.util.function.Consumer;
  * ABI implementation based on ARM document "Procedure Call Standard for
  * the ARM 64-bit Architecture".
  */
-public class AArch64Linker extends AbstractCLinker {
+public final class AArch64Linker extends AbstractCLinker {
     private static AArch64Linker instance;
 
     static final long ADDRESS_SIZE = 64; // bits

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/aarch64/AArch64VaList.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/aarch64/AArch64VaList.java
@@ -111,17 +111,17 @@ public class AArch64VaList implements VaList {
     }
 
     private static AArch64VaList readFromSegment(MemorySegment segment) {
-        MemorySegment gpRegsArea = grTop(segment).addOffset(-MAX_GP_OFFSET).asSegmentRestricted(
+        MemorySegment gpRegsArea = grTop(segment).addOffset(-MAX_GP_OFFSET).asSegment(
                 MAX_GP_OFFSET, segment.scope());
 
-        MemorySegment fpRegsArea = vrTop(segment).addOffset(-MAX_FP_OFFSET).asSegmentRestricted(
+        MemorySegment fpRegsArea = vrTop(segment).addOffset(-MAX_FP_OFFSET).asSegment(
                 MAX_FP_OFFSET, segment.scope());
         return new AArch64VaList(segment, gpRegsArea, fpRegsArea);
     }
 
     private static MemoryAddress emptyListAddress() {
         long ptr = U.allocateMemory(LAYOUT.byteSize());
-        MemorySegment ms = MemoryAddress.ofLong(ptr).asSegmentRestricted(
+        MemorySegment ms = MemoryAddress.ofLong(ptr).asSegment(
                 LAYOUT.byteSize(), () -> U.freeMemory(ptr), ResourceScope.ofShared());
         cleaner.register(AArch64VaList.class, () -> ms.scope().close());
         VH_stack.set(ms, MemoryAddress.NULL);
@@ -257,7 +257,7 @@ public class AArch64VaList implements VaList {
             preAlignStack(layout);
             return switch (typeClass) {
                 case STRUCT_REGISTER, STRUCT_HFA, STRUCT_REFERENCE -> {
-                    MemorySegment slice = stackPtr().asSegmentRestricted(layout.byteSize(), scope());
+                    MemorySegment slice = stackPtr().asSegment(layout.byteSize(), scope());
                     MemorySegment seg = allocator.allocate(layout);
                     seg.copyFrom(slice);
                     postAlignStack(layout);
@@ -265,7 +265,7 @@ public class AArch64VaList implements VaList {
                 }
                 case POINTER, INTEGER, FLOAT -> {
                     VarHandle reader = vhPrimitiveOrAddress(carrier, layout);
-                    MemorySegment slice = stackPtr().asSegmentRestricted(layout.byteSize(), scope());
+                    MemorySegment slice = stackPtr().asSegment(layout.byteSize(), scope());
                     Object res = reader.get(slice);
                     postAlignStack(layout);
                     yield res;
@@ -310,7 +310,7 @@ public class AArch64VaList implements VaList {
                         gpRegsArea.asSlice(currentGPOffset()));
                     consumeGPSlots(1);
 
-                    MemorySegment slice = ptr.asSegmentRestricted(layout.byteSize(), scope());
+                    MemorySegment slice = ptr.asSegment(layout.byteSize(), scope());
                     MemorySegment seg = allocator.allocate(layout);
                     seg.copyFrom(slice);
                     yield seg;
@@ -355,7 +355,7 @@ public class AArch64VaList implements VaList {
     }
 
     public static VaList ofAddress(MemoryAddress ma, ResourceScope scope) {
-        return readFromSegment(ma.asSegmentRestricted(LAYOUT.byteSize(), scope));
+        return readFromSegment(ma.asSegment(LAYOUT.byteSize(), scope));
     }
 
     @Override

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/x64/sysv/SysVVaList.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/x64/sysv/SysVVaList.java
@@ -129,7 +129,7 @@ public class SysVVaList implements VaList {
 
     private static MemoryAddress emptyListAddress() {
         long ptr = U.allocateMemory(LAYOUT.byteSize());
-        MemorySegment base = MemoryAddress.ofLong(ptr).asSegmentRestricted(
+        MemorySegment base = MemoryAddress.ofLong(ptr).asSegment(
                 LAYOUT.byteSize(), () -> U.freeMemory(ptr), ResourceScope.ofShared());
         cleaner.register(SysVVaList.class, () -> base.scope().close());
         VH_gp_offset.set(base, MAX_GP_OFFSET);
@@ -172,7 +172,7 @@ public class SysVVaList implements VaList {
     }
 
     private static MemorySegment getRegSaveArea(MemorySegment segment) {
-        return ((MemoryAddress)VH_reg_save_area.get(segment)).asSegmentRestricted(
+        return ((MemoryAddress)VH_reg_save_area.get(segment)).asSegment(
                 LAYOUT_REG_SAVE_AREA.byteSize(), segment.scope());
     }
 
@@ -235,7 +235,7 @@ public class SysVVaList implements VaList {
             preAlignStack(layout);
             return switch (typeClass.kind()) {
                 case STRUCT -> {
-                    MemorySegment slice = stackPtr().asSegmentRestricted(layout.byteSize(), scope());
+                    MemorySegment slice = stackPtr().asSegment(layout.byteSize(), scope());
                     MemorySegment seg = allocator.allocate(layout);
                     seg.copyFrom(slice);
                     postAlignStack(layout);
@@ -244,7 +244,7 @@ public class SysVVaList implements VaList {
                 case POINTER, INTEGER, FLOAT -> {
                     VarHandle reader = vhPrimitiveOrAddress(carrier, layout);
                     try (ResourceScope localScope = ResourceScope.ofConfined()) {
-                        MemorySegment slice = stackPtr().asSegmentRestricted(layout.byteSize(), localScope);
+                        MemorySegment slice = stackPtr().asSegment(layout.byteSize(), localScope);
                         Object res = reader.get(slice);
                         postAlignStack(layout);
                         yield res;
@@ -309,7 +309,7 @@ public class SysVVaList implements VaList {
     }
 
     public static VaList ofAddress(MemoryAddress ma, ResourceScope scope) {
-        return readFromSegment(ma.asSegmentRestricted(LAYOUT.byteSize(), scope));
+        return readFromSegment(ma.asSegment(LAYOUT.byteSize(), scope));
     }
 
     @Override

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/x64/sysv/SysVx64Linker.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/x64/sysv/SysVx64Linker.java
@@ -47,7 +47,7 @@ import java.util.function.Consumer;
 /**
  * ABI implementation based on System V ABI AMD64 supplement v.0.99.6
  */
-public class SysVx64Linker extends AbstractCLinker {
+public final class SysVx64Linker extends AbstractCLinker {
     public static final int MAX_INTEGER_ARGUMENT_REGISTERS = 6;
     public static final int MAX_INTEGER_RETURN_REGISTERS = 2;
     public static final int MAX_VECTOR_ARGUMENT_REGISTERS = 8;

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/x64/sysv/SysVx64Linker.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/x64/sysv/SysVx64Linker.java
@@ -24,15 +24,19 @@
  */
 package jdk.internal.foreign.abi.x64.sysv;
 
+
 import jdk.incubator.foreign.FunctionDescriptor;
 import jdk.incubator.foreign.MemoryAddress;
 import jdk.incubator.foreign.MemorySegment;
-import jdk.incubator.foreign.CLinker;
 import jdk.incubator.foreign.ResourceScope;
+import jdk.internal.foreign.AbstractCLinker;
 import jdk.internal.foreign.MemoryScope;
 import jdk.internal.foreign.abi.Binding;
 import jdk.internal.foreign.abi.SharedUtils;
 import jdk.internal.foreign.abi.UpcallStubs;
+import jdk.internal.reflect.CallerSensitive;
+import jdk.internal.reflect.Reflection;
+import jdk.internal.vm.annotation.NativeAccess;
 
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
@@ -43,7 +47,7 @@ import java.util.function.Consumer;
 /**
  * ABI implementation based on System V ABI AMD64 supplement v.0.99.6
  */
-public class SysVx64Linker implements CLinker {
+public class SysVx64Linker extends AbstractCLinker {
     public static final int MAX_INTEGER_ARGUMENT_REGISTERS = 6;
     public static final int MAX_INTEGER_RETURN_REGISTERS = 2;
     public static final int MAX_VECTOR_ARGUMENT_REGISTERS = 8;
@@ -83,7 +87,9 @@ public class SysVx64Linker implements CLinker {
     }
 
     @Override
+    @CallerSensitive
     public MethodHandle downcallHandle(MethodType type, FunctionDescriptor function) {
+        Reflection.ensureNativeAccess(Reflection.getCallerClass());
         Objects.requireNonNull(type);
         Objects.requireNonNull(function);
         MethodType llMt = SharedUtils.convertVaListCarriers(type, SysVVaList.CARRIER);
@@ -97,7 +103,9 @@ public class SysVx64Linker implements CLinker {
     }
 
     @Override
+    @CallerSensitive
     public MemorySegment upcallStub(MethodHandle target, FunctionDescriptor function, ResourceScope scope) {
+        Reflection.ensureNativeAccess(Reflection.getCallerClass());
         Objects.requireNonNull(scope);
         Objects.requireNonNull(target);
         Objects.requireNonNull(function);

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/x64/sysv/SysVx64Linker.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/x64/sysv/SysVx64Linker.java
@@ -88,7 +88,7 @@ public final class SysVx64Linker extends AbstractCLinker {
 
     @Override
     @CallerSensitive
-    public MethodHandle downcallHandle(MethodType type, FunctionDescriptor function) {
+    public final MethodHandle downcallHandle(MethodType type, FunctionDescriptor function) {
         Reflection.ensureNativeAccess(Reflection.getCallerClass());
         Objects.requireNonNull(type);
         Objects.requireNonNull(function);
@@ -104,7 +104,7 @@ public final class SysVx64Linker extends AbstractCLinker {
 
     @Override
     @CallerSensitive
-    public MemorySegment upcallStub(MethodHandle target, FunctionDescriptor function, ResourceScope scope) {
+    public final MemorySegment upcallStub(MethodHandle target, FunctionDescriptor function, ResourceScope scope) {
         Reflection.ensureNativeAccess(Reflection.getCallerClass());
         Objects.requireNonNull(scope);
         Objects.requireNonNull(target);

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/x64/windows/WinVaList.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/x64/windows/WinVaList.java
@@ -123,7 +123,7 @@ class WinVaList implements VaList {
             res = switch (typeClass) {
                 case STRUCT_REFERENCE -> {
                     MemoryAddress structAddr = (MemoryAddress) VH_address.get(segment);
-                    MemorySegment struct = structAddr.asSegmentRestricted(layout.byteSize(), scope());
+                    MemorySegment struct = structAddr.asSegment(layout.byteSize(), scope());
                     MemorySegment seg = allocator.allocate(layout);
                     seg.copyFrom(struct);
                     yield seg;
@@ -151,7 +151,7 @@ class WinVaList implements VaList {
     }
 
     static WinVaList ofAddress(MemoryAddress addr, ResourceScope scope) {
-        MemorySegment segment = addr.asSegmentRestricted(Long.MAX_VALUE, scope);
+        MemorySegment segment = addr.asSegment(Long.MAX_VALUE, scope);
         return new WinVaList(segment, scope);
     }
 

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/x64/windows/Windowsx64Linker.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/x64/windows/Windowsx64Linker.java
@@ -27,12 +27,15 @@ package jdk.internal.foreign.abi.x64.windows;
 import jdk.incubator.foreign.FunctionDescriptor;
 import jdk.incubator.foreign.MemoryAddress;
 import jdk.incubator.foreign.MemorySegment;
-import jdk.incubator.foreign.CLinker;
 import jdk.incubator.foreign.ResourceScope;
+import jdk.internal.foreign.AbstractCLinker;
 import jdk.internal.foreign.MemoryScope;
 import jdk.internal.foreign.abi.Binding;
 import jdk.internal.foreign.abi.SharedUtils;
 import jdk.internal.foreign.abi.UpcallStubs;
+import jdk.internal.reflect.CallerSensitive;
+import jdk.internal.reflect.Reflection;
+import jdk.internal.vm.annotation.NativeAccess;
 
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
@@ -43,7 +46,7 @@ import java.util.function.Consumer;
 /**
  * ABI implementation based on Windows ABI AMD64 supplement v.0.99.6
  */
-public class Windowsx64Linker implements CLinker {
+public class Windowsx64Linker extends AbstractCLinker {
 
     public static final int MAX_INTEGER_ARGUMENT_REGISTERS = 4;
     public static final int MAX_INTEGER_RETURN_REGISTERS = 1;
@@ -85,7 +88,9 @@ public class Windowsx64Linker implements CLinker {
     }
 
     @Override
+    @CallerSensitive
     public MethodHandle downcallHandle(MethodType type, FunctionDescriptor function) {
+        Reflection.ensureNativeAccess(Reflection.getCallerClass());
         Objects.requireNonNull(type);
         Objects.requireNonNull(function);
         MethodType llMt = SharedUtils.convertVaListCarriers(type, WinVaList.CARRIER);
@@ -99,7 +104,9 @@ public class Windowsx64Linker implements CLinker {
     }
 
     @Override
+    @CallerSensitive
     public MemorySegment upcallStub(MethodHandle target, FunctionDescriptor function, ResourceScope scope) {
+        Reflection.ensureNativeAccess(Reflection.getCallerClass());
         Objects.requireNonNull(scope);
         Objects.requireNonNull(target);
         Objects.requireNonNull(function);

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/x64/windows/Windowsx64Linker.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/x64/windows/Windowsx64Linker.java
@@ -46,7 +46,7 @@ import java.util.function.Consumer;
 /**
  * ABI implementation based on Windows ABI AMD64 supplement v.0.99.6
  */
-public class Windowsx64Linker extends AbstractCLinker {
+public final class Windowsx64Linker extends AbstractCLinker {
 
     public static final int MAX_INTEGER_ARGUMENT_REGISTERS = 4;
     public static final int MAX_INTEGER_RETURN_REGISTERS = 1;

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/x64/windows/Windowsx64Linker.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/x64/windows/Windowsx64Linker.java
@@ -89,7 +89,7 @@ public final class Windowsx64Linker extends AbstractCLinker {
 
     @Override
     @CallerSensitive
-    public MethodHandle downcallHandle(MethodType type, FunctionDescriptor function) {
+    public final MethodHandle downcallHandle(MethodType type, FunctionDescriptor function) {
         Reflection.ensureNativeAccess(Reflection.getCallerClass());
         Objects.requireNonNull(type);
         Objects.requireNonNull(function);
@@ -105,7 +105,7 @@ public final class Windowsx64Linker extends AbstractCLinker {
 
     @Override
     @CallerSensitive
-    public MemorySegment upcallStub(MethodHandle target, FunctionDescriptor function, ResourceScope scope) {
+    public final MemorySegment upcallStub(MethodHandle target, FunctionDescriptor function, ResourceScope scope) {
         Reflection.ensureNativeAccess(Reflection.getCallerClass());
         Objects.requireNonNull(scope);
         Objects.requireNonNull(target);

--- a/test/jdk/java/foreign/StdLibTest.java
+++ b/test/jdk/java/foreign/StdLibTest.java
@@ -215,7 +215,7 @@ public class StdLibTest {
                     setByteAtOffset(buf, i, (byte)chars[(int)i]);
                 }
                 setByteAtOffset(buf, chars.length, (byte)'\0');
-                return toJavaStringRestricted(((MemoryAddress)strcat.invokeExact(buf.address(), other.address())));
+                return toJavaString(((MemoryAddress)strcat.invokeExact(buf.address(), other.address())));
             }
         }
 
@@ -257,7 +257,7 @@ public class StdLibTest {
             static final long SIZE = 56;
 
             Tm(MemoryAddress addr) {
-                this.base = addr.asSegmentRestricted(SIZE);
+                this.base = addr.asSegment(SIZE);
             }
 
             int sec() {

--- a/test/jdk/java/foreign/TestArrays.java
+++ b/test/jdk/java/foreign/TestArrays.java
@@ -112,7 +112,7 @@ public class TestArrays {
     public void testTooBigForArray(MemoryLayout layout, Function<MemorySegment, Object> arrayFactory) {
         MemoryLayout seq = MemoryLayout.ofSequence((Integer.MAX_VALUE * layout.byteSize()) + 1, layout);
         //do not really allocate here, as it's way too much memory
-        MemorySegment segment = MemoryAddress.NULL.asSegmentRestricted(seq.byteSize());
+        MemorySegment segment = MemoryAddress.NULL.asSegment(seq.byteSize());
         arrayFactory.apply(segment);
     }
 

--- a/test/jdk/java/foreign/TestByteBuffer.java
+++ b/test/jdk/java/foreign/TestByteBuffer.java
@@ -455,7 +455,7 @@ public class TestByteBuffer {
 
     @Test(expectedExceptions = IllegalStateException.class)
     public void testTooBigForByteBuffer() {
-        MemorySegment segment = MemoryAddress.NULL.asSegmentRestricted(Integer.MAX_VALUE + 10L);
+        MemorySegment segment = MemoryAddress.NULL.asSegment(Integer.MAX_VALUE + 10L);
         segment.asByteBuffer();
     }
 

--- a/test/jdk/java/foreign/TestFree.java
+++ b/test/jdk/java/foreign/TestFree.java
@@ -37,17 +37,17 @@ import static jdk.incubator.foreign.CLinker.*;
 import static org.testng.Assert.assertEquals;
 
 public class TestFree {
-    private static MemorySegment asArrayRestricted(MemoryAddress addr, MemoryLayout layout, int numElements) {
-        return addr.asSegmentRestricted(numElements * layout.byteSize());
+    private static MemorySegment asArray(MemoryAddress addr, MemoryLayout layout, int numElements) {
+        return addr.asSegment(numElements * layout.byteSize());
     }
 
     public void test() throws Throwable {
         String str = "hello world";
-        MemoryAddress addr = allocateMemoryRestricted(str.length() + 1);
-        MemorySegment seg = asArrayRestricted(addr, C_CHAR, str.length() + 1);
+        MemoryAddress addr = allocateMemory(str.length() + 1);
+        MemorySegment seg = asArray(addr, C_CHAR, str.length() + 1);
         seg.copyFrom(MemorySegment.ofArray(str.getBytes()));
         MemoryAccess.setByteAtOffset(seg, str.length(), (byte)0);
         assertEquals(str, toJavaString(seg));
-        freeMemoryRestricted(addr);
+        freeMemory(addr);
     }
 }

--- a/test/jdk/java/foreign/TestNative.java
+++ b/test/jdk/java/foreign/TestNative.java
@@ -145,11 +145,11 @@ public class TestNative {
     public static native long getCapacity(Buffer buffer);
 
     public static MemoryAddress allocate(int size) {
-        return CLinker.allocateMemoryRestricted(size);
+        return CLinker.allocateMemory(size);
     }
 
     public static void free(MemoryAddress addr) {
-        CLinker.freeMemoryRestricted(addr);
+        CLinker.freeMemory(addr);
     }
 
     @Test(dataProvider="nativeAccessOps")
@@ -178,14 +178,14 @@ public class TestNative {
     public void testDefaultAccessModes() {
         MemoryAddress addr = allocate(12);
         try (ResourceScope scope = ResourceScope.ofConfined()) {
-            MemorySegment mallocSegment = addr.asSegmentRestricted(12, () -> free(addr), scope);
+            MemorySegment mallocSegment = addr.asSegment(12, () -> free(addr), scope);
             assertFalse(mallocSegment.isReadOnly());
         }
     }
 
     @Test
     public void testDefaultAccessModesEverthing() {
-        MemorySegment everything = MemorySegment.ofNativeRestricted();
+        MemorySegment everything = MemorySegment.ofNative();
         assertFalse(everything.isReadOnly());
     }
 
@@ -194,7 +194,7 @@ public class TestNative {
         MemoryAddress addr = allocate(12);
         MemorySegment mallocSegment = null;
         try (ResourceScope scope = ResourceScope.ofConfined()) {
-            mallocSegment = addr.asSegmentRestricted(12, () -> free(addr), scope);
+            mallocSegment = addr.asSegment(12, () -> free(addr), scope);
             assertEquals(mallocSegment.byteSize(), 12);
             //free here
         }
@@ -204,7 +204,7 @@ public class TestNative {
     @Test
     public void testEverythingSegment() {
         MemoryAddress addr = allocate(4);
-        MemorySegment everything = MemorySegment.ofNativeRestricted();
+        MemorySegment everything = MemorySegment.ofNative();
         MemoryAccess.setIntAtOffset(everything, addr.toRawLongValue(), 42);
         assertEquals(MemoryAccess.getIntAtOffset(everything, addr.toRawLongValue()), 42);
         free(addr);
@@ -214,7 +214,7 @@ public class TestNative {
     public void testBadResize() {
         try (ResourceScope scope = ResourceScope.ofConfined()) {
             MemorySegment segment = MemorySegment.allocateNative(4, 1, scope);
-            segment.address().asSegmentRestricted(0);
+            segment.address().asSegment(0);
         }
     }
 

--- a/test/jdk/java/foreign/TestNulls.java
+++ b/test/jdk/java/foreign/TestNulls.java
@@ -99,9 +99,9 @@ public class TestNulls {
 
     static final Set<String> EXCLUDE_LIST = Set.of(
             "jdk.incubator.foreign.MemoryLayout/withAttribute(java.lang.String,java.lang.constant.Constable)/1/0",
-            "jdk.incubator.foreign.MemoryAddress/asSegmentRestricted(long,java.lang.Runnable,java.lang.Object)/1/0",
-            "jdk.incubator.foreign.MemoryAddress/asSegmentRestricted(long,java.lang.Runnable,java.lang.Object)/2/0",
-            "jdk.incubator.foreign.MemoryAddress/asSegmentRestricted(long,java.lang.Runnable,jdk.incubator.foreign.ResourceScope)/1/0",
+            "jdk.incubator.foreign.MemoryAddress/asSegment(long,java.lang.Runnable,java.lang.Object)/1/0",
+            "jdk.incubator.foreign.MemoryAddress/asSegment(long,java.lang.Runnable,java.lang.Object)/2/0",
+            "jdk.incubator.foreign.MemoryAddress/asSegment(long,java.lang.Runnable,jdk.incubator.foreign.ResourceScope)/1/0",
             "jdk.incubator.foreign.SequenceLayout/withAttribute(java.lang.String,java.lang.constant.Constable)/1/0",
             "jdk.incubator.foreign.ValueLayout/withAttribute(java.lang.String,java.lang.constant.Constable)/1/0",
             "jdk.incubator.foreign.GroupLayout/withAttribute(java.lang.String,java.lang.constant.Constable)/1/0",

--- a/test/jdk/java/foreign/TestRestricted.java
+++ b/test/jdk/java/foreign/TestRestricted.java
@@ -37,37 +37,37 @@ import java.lang.reflect.InvocationTargetException;
 public class TestRestricted {
     @Test(expectedExceptions = InvocationTargetException.class)
     public void testReflection() throws Throwable {
-        Method method = MemorySegment.class.getDeclaredMethod("ofNativeRestricted");
+        Method method = MemorySegment.class.getDeclaredMethod("ofNative");
         method.invoke(null);
     }
 
     @Test(expectedExceptions = IllegalCallerException.class)
     public void testInvoke() throws Throwable {
         var mh = MethodHandles.lookup().findStatic(MemorySegment.class,
-            "ofNativeRestricted", MethodType.methodType(MemorySegment.class));
+            "ofNative", MethodType.methodType(MemorySegment.class));
         var seg = (MemorySegment)mh.invokeExact();
     }
 
     @Test(expectedExceptions = IllegalCallerException.class)
     public void testDirectAccess() throws Throwable {
-        MemorySegment.ofNativeRestricted();
+        MemorySegment.ofNative();
     }
 
     @Test(expectedExceptions = InvocationTargetException.class)
     public void testReflection2() throws Throwable {
-        Method method = MemoryAddress.class.getDeclaredMethod("asSegmentRestricted", long.class);
+        Method method = MemoryAddress.class.getDeclaredMethod("asSegment", long.class);
         method.invoke(MemoryAddress.NULL, 4000L);
     }
 
     @Test(expectedExceptions = IllegalCallerException.class)
     public void testInvoke2() throws Throwable {
-        var mh = MethodHandles.lookup().findVirtual(MemoryAddress.class, "asSegmentRestricted",
+        var mh = MethodHandles.lookup().findVirtual(MemoryAddress.class, "asSegment",
             MethodType.methodType(MemorySegment.class, long.class));
         var seg = (MemorySegment)mh.invokeExact(MemoryAddress.NULL, 4000L);
     }
 
     @Test(expectedExceptions = IllegalCallerException.class)
     public void testDirectAccess2() throws Throwable {
-        MemoryAddress.NULL.asSegmentRestricted(4000L);
+        MemoryAddress.NULL.asSegment(4000L);
     }
 }

--- a/test/jdk/java/foreign/TestScopedOperations.java
+++ b/test/jdk/java/foreign/TestScopedOperations.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @run testng/othervm -Dforeign.restricted=permit TestScopedOperations
+ * @run testng/othervm --enable-native-access=ALL-UNNAMED TestScopedOperations
  */
 
 import jdk.incubator.foreign.CLinker;
@@ -195,7 +195,7 @@ public class TestScopedOperations {
                     throw new AssertionError(ex);
                 }
             }),
-            UNSAFE(scope -> MemoryAddress.NULL.asSegmentRestricted(10, scope));
+            UNSAFE(scope -> MemoryAddress.NULL.asSegment(10, scope));
 
             static {
                 try {

--- a/test/jdk/java/foreign/TestSharedAccess.java
+++ b/test/jdk/java/foreign/TestSharedAccess.java
@@ -99,7 +99,7 @@ public class TestSharedAccess {
             setInt(s, 42);
             assertEquals(getInt(s), 42);
             List<Thread> threads = new ArrayList<>();
-            MemorySegment sharedSegment = s.address().asSegmentRestricted(s.byteSize(), scope);
+            MemorySegment sharedSegment = s.address().asSegment(s.byteSize(), scope);
             for (int i = 0 ; i < 1000 ; i++) {
                 threads.add(new Thread(() -> {
                     assertEquals(getInt(sharedSegment), 42);

--- a/test/jdk/java/foreign/valist/VaListTest.java
+++ b/test/jdk/java/foreign/valist/VaListTest.java
@@ -186,7 +186,7 @@ public class VaListTest extends NativeTestHelper {
         Function<MemoryLayout, Function<VaList, Integer>> getIntJavaFact = layout ->
                 list -> {
                     MemoryAddress ma = list.vargAsAddress(layout);
-                    return MemoryAccess.getIntAtOffset(MemorySegment.ofNativeRestricted(), ma.toRawLongValue());
+                    return MemoryAccess.getIntAtOffset(MemorySegment.ofNative(), ma.toRawLongValue());
                 };
         Function<VaList, Integer> getIntNative = MethodHandleProxies.asInterfaceInstance(Function.class, MH_getInt);
         return new Object[][]{
@@ -693,7 +693,7 @@ public class VaListTest extends NativeTestHelper {
                 })},
                 { linkVaListCB("upcallMemoryAddress"), VaListConsumer.mh(vaList -> {
                     MemoryAddress intPtr = vaList.vargAsAddress(C_POINTER);
-                    MemorySegment ms = intPtr.asSegmentRestricted(C_INT.byteSize());
+                    MemorySegment ms = intPtr.asSegment(C_INT.byteSize());
                     int x = MemoryAccess.getInt(ms);
                     assertEquals(x, 10);
                 })},


### PR DESCRIPTION
Removed Restricted suffix in method names. Fine grained native-access for CLinker. All CallerSentive methods are made static or instance-final

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [JDK-8264402](https://bugs.openjdk.java.net/browse/JDK-8264402): drop "Restricted" suffix for methods enabled by enable-native-access and add fine grained native-access for CLinker


### Reviewers
 * [Jorn Vernee](https://openjdk.java.net/census#jvernee) (@JornVernee - Committer)
 * [Maurizio Cimadamore](https://openjdk.java.net/census#mcimadamore) (@mcimadamore - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/483/head:pull/483` \
`$ git checkout pull/483`

Update a local copy of the PR: \
`$ git checkout pull/483` \
`$ git pull https://git.openjdk.java.net/panama-foreign pull/483/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 483`

View PR using the GUI difftool: \
`$ git pr show -t 483`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/panama-foreign/pull/483.diff">https://git.openjdk.java.net/panama-foreign/pull/483.diff</a>

</details>
