### PR TITLE
8264280: Foreign linker should be more friendly with implicit scopes

### DIFF
--- a/test/jdk/java/foreign/TestLibraryLookup.java
+++ b/test/jdk/java/foreign/TestLibraryLookup.java
@@ -100,10 +100,20 @@ public class TestLibraryLookup {
         waitUnload();
     }
 
-    @Test(expectedExceptions = IllegalArgumentException.class)
-    public void testBarVariableSymbolLookup() throws Throwable {
+    @Test
+    public void testBadVariableSymbolLookup() {
         LibraryLookup lookup = LibraryLookup.ofLibrary("LookupTest");
-        lookup.lookup("c", MemoryLayouts.JAVA_INT.withBitAlignment(1 << 16)).get();
+        try {
+            MemoryLayout layout = MemoryLayouts.JAVA_INT.withBitAlignment(1 << 16);
+            MemorySegment segment = lookup.lookup("c", layout).get();
+            // no exception, check that address is aligned
+            if ((segment.address().toRawLongValue() % layout.byteAlignment()) != 0) {
+                fail("Unaligned address");
+            }
+        } catch (IllegalArgumentException ex) {
+            // ok, means address was not aligned
+        }
+
     }
 
     @Test


### PR DESCRIPTION
The newly added test sometimes fails spuriously. This is caused by the fact that the library is loaded to an address that is a multiple of the expected layout constraints.
The fix is to make the test tolerant to this situation - and check that, if no exception is thrown, the symbol alignment must be the same as the one specified by the layout.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [JDK-8264280](https://bugs.openjdk.java.net/browse/JDK-8264280): Foreign linker should be more friendly with implicit scopes ⚠️ Issue is not open.


### Reviewers
 * [Jorn Vernee](https://openjdk.java.net/census#jvernee) (@JornVernee - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/484/head:pull/484` \
`$ git checkout pull/484`

Update a local copy of the PR: \
`$ git checkout pull/484` \
`$ git pull https://git.openjdk.java.net/panama-foreign pull/484/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 484`

View PR using the GUI difftool: \
`$ git pr show -t 484`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/panama-foreign/pull/484.diff">https://git.openjdk.java.net/panama-foreign/pull/484.diff</a>

</details>
