### PR TITLE
8264434: Remove ResourceScope-less overload from API

### DIFF
--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/MemoryAddress.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/MemoryAddress.java
@@ -89,32 +89,6 @@ public interface MemoryAddress extends Addressable {
     long segmentOffset(MemorySegment segment);
 
     /**
-     * Returns a shared native memory segment with given size, and whose base address is this address. This method
-     * can be useful when interacting with custom native memory sources (e.g. custom allocators), where an address to some
-     * underlying memory region is typically obtained from native code (often as a plain {@code long} value).
-     * The returned segment is associated with the {@link ResourceScope#globalScope() global} resource scope.
-     * <p>
-     * Clients should ensure that the address and bounds refers to a valid region of memory that is accessible for reading and,
-     * if appropriate, writing; an attempt to access an invalid memory location from Java code will either return an arbitrary value,
-     * have no visible effect, or cause an unspecified exception to be thrown.
-     * <p>
-     * This method is equivalent to the following code:
-     * <pre>{@code
-    asSegment(byteSize, null, ResourceScope.globalScope());
-     * }</pre>
-     * This method is <em>restricted</em>. Restricted methods are unsafe, and, if used incorrectly, their use might crash
-     * the JVM or, worse, silently result in memory corruption. Thus, clients should refrain from depending on
-     * restricted methods, and use safe and supported functionalities, where possible.
-     *
-     * @param bytesSize the desired size.
-     * @return a new native memory segment with given base address and size.
-     * @throws IllegalArgumentException if {@code bytesSize <= 0}.
-     * @throws UnsupportedOperationException if this address is an heap address.
-     */
-    @NativeAccess
-    MemorySegment asSegment(long bytesSize);
-
-    /**
      * Returns a native memory segment with given size and resource scope, and whose base address is this address. This method
      * can be useful when interacting with custom native memory sources (e.g. custom allocators), where an address to some
      * underlying memory region is typically obtained from native code (often as a plain {@code long} value).

--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/ResourceScope.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/ResourceScope.java
@@ -146,7 +146,7 @@ public interface ResourceScope extends AutoCloseable {
 
     /**
      * Is this resource scope an <em>implicit scope</em>?
-     * @return true if this scope is an an <em>implicit scope</em>.
+     * @return true if this scope is an <em>implicit scope</em>.
      * @see #ofImplicit()
      * @see #globalScope()
      */

--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/ResourceScope.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/ResourceScope.java
@@ -244,7 +244,7 @@ public interface ResourceScope extends AutoCloseable {
     }
 
     /**
-     * Create a new <em>implicit scope</em>. The implicit scope is a shared and non-closeable scope which only features
+     * Create a new <em>implicit scope</em>. The implicit scope is a managed, shared, and non-closeable scope which only features
      * <a href="ResourceScope.html#implicit-closure"><em>implicit closure</em></a>.
      * Since implicit scopes can only be closed implicitly by the garbage collector, it is recommended that implicit
      * scopes are only used in cases where deallocation performance is not a critical concern, to avoid unnecessary

--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/ResourceScope.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/ResourceScope.java
@@ -67,7 +67,7 @@ import java.util.Spliterator;
  * scope is closed explicitly, no further action will be taken when the scope becomes unreachable; that is, cleanup actions
  * (see {@link #addOnClose(Runnable)}) associated with a resource scope, whether managed or not, are called <em>exactly once</em>.
  * <p>
- * Some resource scopes (see {@link #ofImplicit()}, {@link #globalScope()} are said to be <em>implicit scopes</em>.
+ * Some managed resource scopes are implicitly managed (see {@link #ofImplicit()}, {@link #globalScope()}, and are said to be <em>implicit scopes</em>.
  * An implicit resource scope only features implicit closure, and always throws an {@link UnsupportedOperationException}
  * when the {@link #close()} method is called directly.
  *

--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/ResourceScope.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/ResourceScope.java
@@ -66,6 +66,10 @@ import java.util.Spliterator;
  * deterministic resource deallocation, while still prevent accidental native memory leaks. In case a managed resource
  * scope is closed explicitly, no further action will be taken when the scope becomes unreachable; that is, cleanup actions
  * (see {@link #addOnClose(Runnable)}) associated with a resource scope, whether managed or not, are called <em>exactly once</em>.
+ * <p>
+ * Some resource scopes (see {@link #ofImplicit()}, {@link #globalScope()} are said to be <em>implicit scopes</em>.
+ * An implicit resource scope only features implicit closure, and always throws an {@link UnsupportedOperationException}
+ * when the {@link #close()} method is called directly.
  *
  * <h2><a id = "thread-confinement">Thread confinement</a></h2>
  *
@@ -141,6 +145,14 @@ public interface ResourceScope extends AutoCloseable {
     Thread ownerThread();
 
     /**
+     * Is this resource scope an <em>implicit scope</em>?
+     * @return true if this scope is an an <em>implicit scope</em>.
+     * @see #ofImplicit()
+     * @see #globalScope()
+     */
+    boolean isImplicit();
+
+    /**
      * Closes this resource scope. As a side-effect, if this operation completes without exceptions, this scope will be marked
      * as <em>not alive</em>, and subsequent operations on resources associated with this scope will fail with {@link IllegalStateException}.
      * Additionally, upon successful closure, all native resources associated with this resource scope will be released.
@@ -157,9 +169,7 @@ public interface ResourceScope extends AutoCloseable {
      *     <li>this resource scope is shared and a resource associated with this scope is accessed while this method is called</li>
      *     <li>one or more handles (see {@link #acquire()}) associated with this resource scope have not been closed</li>
      * </ul>
-     * @throws UnsupportedOperationException if the {@code close} operation is not supported by this resource scope. This
-     * is the case for the resource scope returned by {@link #globalScope()}, or the resource scopes associated to
-     * memory segments created using certain factories (such as {@link MemorySegment#allocateNative(long)}).
+     * @throws UnsupportedOperationException if this resource scope is {@link #isImplicit() implicit}.
      */
     void close();
 
@@ -200,7 +210,7 @@ public interface ResourceScope extends AutoCloseable {
      * @return a new confined scope.
      */
     static ResourceScope ofConfined() {
-        return ofConfined(null, null);
+        return MemoryScope.createConfined( null);
     }
 
     /**
@@ -211,18 +221,7 @@ public interface ResourceScope extends AutoCloseable {
      */
     static ResourceScope ofConfined(Cleaner cleaner) {
         Objects.requireNonNull(cleaner);
-        return ofConfined(null, cleaner);
-    }
-
-    /**
-     * Create a new confined scope. The resulting scope might be managed by a {@link Cleaner} (where provided).
-     * An optional attachment can be associated with the resulting scope.
-     * @param attachment an attachment object which is kept alive by the returned resource scope (can be {@code null}).
-     * @param cleaner the cleaner to be associated with the returned scope. Can be {@code null}.
-     * @return a new confined scope, managed by {@code cleaner} (where provided).
-     */
-    static ResourceScope ofConfined(Object attachment, Cleaner cleaner) {
-        return MemoryScope.createConfined(attachment, cleaner);
+        return MemoryScope.createConfined( cleaner);
     }
 
     /**
@@ -230,7 +229,7 @@ public interface ResourceScope extends AutoCloseable {
      * @return a new shared scope.
      */
     static ResourceScope ofShared() {
-        return ofShared(null, null);
+        return MemoryScope.createShared(null);
     }
 
     /**
@@ -241,40 +240,24 @@ public interface ResourceScope extends AutoCloseable {
      */
     static ResourceScope ofShared(Cleaner cleaner) {
         Objects.requireNonNull(cleaner);
-        return ofShared(null, cleaner);
+        return MemoryScope.createShared(cleaner);
     }
 
     /**
-     * Create a new shared scope. The resulting scope might be managed by a {@link Cleaner} (where provided).
-     * An optional attachment can be associated with the resulting scope.
-     * @param attachment an attachment object which is kept alive by the returned resource scope (can be {@code null}).
-     * @param cleaner the cleaner to be associated with the returned scope. Can be {@code null}.
-     * @return a new shared scope, managed by {@code cleaner} (where provided).
-     */
-    static ResourceScope ofShared(Object attachment, Cleaner cleaner) {
-        return MemoryScope.createShared(attachment, cleaner);
-    }
-
-    /**
-     * Create a new <em>default scope</em>. The default scope is a shared and non-closeable scope which only features
+     * Create a new <em>implicit scope</em>. The implicit scope is a shared and non-closeable scope which only features
      * <a href="ResourceScope.html#implicit-closure"><em>implicit closure</em></a>.
-     * This resource scope is used as a valid default where no resource scope is provided by the user. For instance, this code:
-     * <blockquote><pre>{@code
-    MemorySegment.allocateNative(10);
-     * }</pre></blockquote>
-     * is equivalent to the following code:
-     * <blockquote><pre>{@code
-    MemorySegment.allocateNative(10, ResourceScope.ofDefault());
-     * }</pre></blockquote>
+     * Since implicit scopes can only be closed implicitly by the garbage collector, it is recommended that implicit
+     * scopes are only used in cases where deallocation performance is not a critical concern, to avoid unnecessary
+     * memory pressure.
      *
-     * @return a new default scope.
+     * @return a new implicit scope.
      */
-    static ResourceScope ofDefault() {
-        return MemoryScope.createDefault();
+    static ResourceScope ofImplicit() {
+        return MemoryScope.createImplicitScope();
     }
 
     /**
-     * A non-closeable, shared, global scope which is assumed to be always alive.
+     * Returns an implicit scope which is assumed to be always alive.
      * @return the global scope.
      */
     static ResourceScope globalScope() {

--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/SegmentAllocator.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/SegmentAllocator.java
@@ -44,7 +44,7 @@ import java.util.stream.Stream;
  * must implement the {@link #allocate(long, long)} method. This interface defines several default methods
  * which can be useful to create segments from several kinds of Java values such as primitives and arrays.
  * This interface can be seen as a thin wrapper around the basic capabilities for creating native segments
- * (e.g. {@link MemorySegment#allocateNative(long, long)}); since {@link SegmentAllocator} is a <em>functional interface</em>,
+ * (e.g. {@link MemorySegment#allocateNative(long, long, ResourceScope)}); since {@link SegmentAllocator} is a <em>functional interface</em>,
  * clients can easily obtain a native allocator by using either a lambda expression or a method reference.
  * <p>
  * This interface provides a factory, namely {@link SegmentAllocator#scoped(ResourceScope)} which can be used to obtain
@@ -53,7 +53,7 @@ import java.util.stream.Stream;
  *
  * <blockquote><pre>{@code
 try (ResourceScope scope = ResourceScope.ofConfined()) {
-   SegmentAllocator allocator = SegmentAllocator.of(scope);
+   SegmentAllocator allocator = SegmentAllocator.scoped(scope);
    ...
 }
  * }</pre></blockquote>
@@ -458,15 +458,14 @@ public interface SegmentAllocator {
     }
 
     /**
-     * Returns the default native allocator which creates segments using the default
-     * {@link MemorySegment#allocateNative(long, long) native segment factory}. This code is equivalent
+     * Returns a native allocator which creates segments associated with fresh implicit scopes. This code is equivalent
      * (but likely more efficient) to the following:
      * <blockquote><pre>{@code
-    SegmentAllocator defaultAllocator = (size, align) -> MemorySegment.allocateNative(size, align);
+    SegmentAllocator implicitAllocator = (size, align) -> MemorySegment.allocateNative(size, align, ResourceScope.ofImplicit());
      * }</pre></blockquote>
-     * @return the default native allocator.
+     * @return the implicit native allocator.
      */
-    static SegmentAllocator ofDefault() {
-        return NativeMemorySegmentImpl.DEFAULT_ALLOCATOR;
+    static SegmentAllocator implicit() {
+        return NativeMemorySegmentImpl.IMPLICIT_ALLOCATOR;
     }
 }

--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/package-info.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/package-info.java
@@ -126,7 +126,7 @@ try (var cString = CLinker.toCString("Hello")) {
  * the method handle invocation (here performed using {@link java.lang.invoke.MethodHandle#invokeExact(java.lang.Object...)})
  * into a foreign function call, according to the rules specified by the platform C ABI. The {@link jdk.incubator.foreign.CLinker}
  * class also provides many useful methods for interacting with native code, such as converting Java strings into
- * native strings and viceversa (see {@link jdk.incubator.foreign.CLinker#toCString(java.lang.String)} and
+ * native strings and viceversa (see {@link jdk.incubator.foreign.CLinker#toCString(java.lang.String, ResourceScope)} and
  * {@link jdk.incubator.foreign.CLinker#toJavaString(jdk.incubator.foreign.MemorySegment)}, respectively), as
  * demonstrated in the above example.
  *

--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/package-info.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/package-info.java
@@ -153,7 +153,7 @@ int x = MemoryAccess.getIntAtOffset(segment, addr.segmentOffset(segment));
  * }</pre>
  *
  * Secondly, if the client does <em>not</em> have a segment which contains a given memory address, it can create one <em>unsafely</em>,
- * using the {@link jdk.incubator.foreign.MemoryAddress#asSegment(long)} factory. This allows the client to
+ * using the {@link jdk.incubator.foreign.MemoryAddress#asSegment(long, ResourceScope)} factory. This allows the client to
  * inject extra knowledge about spatial bounds which might, for instance, be available in the documentation of the foreign function
  * which produced the native address. Here is how an unsafe segment can be created from a native address:
  *
@@ -214,11 +214,11 @@ MemorySegment comparFunc = CLinker.getInstance().upcallStub(
  * <h2>Restricted methods</h2>
  * Some methods in this package are considered <em>restricted</em>. Restricted methods are typically used to bind native
  * foreign data and/or functions to first-class Java API elements which can then be used directly by client. For instance
- * the restricted method {@link jdk.incubator.foreign.MemoryAddress#asSegment(long)} can be used to create
+ * the restricted method {@link jdk.incubator.foreign.MemoryAddress#asSegment(long, ResourceScope)} can be used to create
  * a fresh segment with given spatial bounds out of a native address.
  * <p>
  * Binding foreign data and/or functions is generally unsafe and, if done incorrectly, can result in VM crashes, or memory corruption when the bound Java API element is accessed.
- * For instance, in the case of {@link jdk.incubator.foreign.MemoryAddress#asSegment(long)}, if the provided
+ * For instance, in the case of {@link jdk.incubator.foreign.MemoryAddress#asSegment(long, ResourceScope)}, if the provided
  * spatial bounds are incorrect, a client of the segment returned by that method might crash the VM, or corrupt
  * memory when attempting to dereference said segment. For these reasons, it is crucial for code that calls a restricted method
  * to never pass arguments that might cause incorrect binding of foreign data and/or functions to a Java API.

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/AbstractCLinker.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/AbstractCLinker.java
@@ -58,10 +58,4 @@ public abstract class AbstractCLinker implements CLinker {
         }
         return downcall;
     }
-
-    @CallerSensitive
-    public final MemorySegment upcallStub(MethodHandle target, FunctionDescriptor function) {
-        Reflection.ensureNativeAccess(Reflection.getCallerClass());
-        return upcallStub(target, function, MemoryScope.createDefault());
-    }
 }

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/ConfinedScope.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/ConfinedScope.java
@@ -42,8 +42,8 @@ final class ConfinedScope extends MemoryScope {
     private int lockCount = 0;
     private final Thread owner;
 
-    public ConfinedScope(Thread owner, Object ref, Cleaner cleaner) {
-        super(ref, cleaner, new ConfinedResourceList());
+    public ConfinedScope(Thread owner, Cleaner cleaner) {
+        super(cleaner, new ConfinedResourceList());
         this.owner = owner;
     }
 

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/LibrariesHelper.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/LibrariesHelper.java
@@ -90,7 +90,7 @@ public final class LibrariesHelper {
         ResourceScope[] holder = new ResourceScope[1];
         try {
             WeakReference<ResourceScope> scopeRef = loadedLibraries.computeIfAbsent(library, lib -> {
-                MemoryScope s = MemoryScope.createDefault();
+                MemoryScope s = MemoryScope.createImplicitScope();
                 holder[0] = s; // keep the scope alive at least until the outer method returns
                 s.addOrCleanupIfFail(MemoryScope.ResourceList.ResourceCleanup.ofRunnable(() -> {
                     nativeLibraries.unload(library);

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/MemoryAddressImpl.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/MemoryAddressImpl.java
@@ -107,13 +107,6 @@ public final class MemoryAddressImpl implements MemoryAddress {
 
     @Override
     @CallerSensitive
-    public final MemorySegment asSegment(long bytesSize) {
-        Reflection.ensureNativeAccess(Reflection.getCallerClass());
-        return asSegment(bytesSize, null, ResourceScope.globalScope());
-    }
-
-    @Override
-    @CallerSensitive
     public final MemorySegment asSegment(long bytesSize, ResourceScope scope) {
         Reflection.ensureNativeAccess(Reflection.getCallerClass());
         return asSegment(bytesSize, null, scope);

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/NativeMemorySegmentImpl.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/NativeMemorySegmentImpl.java
@@ -28,6 +28,7 @@ package jdk.internal.foreign;
 
 import jdk.incubator.foreign.MemoryAddress;
 import jdk.incubator.foreign.MemorySegment;
+import jdk.incubator.foreign.ResourceScope;
 import jdk.incubator.foreign.SegmentAllocator;
 import jdk.internal.misc.Unsafe;
 import jdk.internal.misc.VM;
@@ -46,7 +47,7 @@ public class NativeMemorySegmentImpl extends AbstractMemorySegmentImpl {
 
     private static final Unsafe unsafe = Unsafe.getUnsafe();
 
-    public static final SegmentAllocator DEFAULT_ALLOCATOR = MemorySegment::allocateNative;
+    public static final SegmentAllocator IMPLICIT_ALLOCATOR = (size, align) -> MemorySegment.allocateNative(size, align, ResourceScope.ofImplicit());
 
     // The maximum alignment supported by malloc - typically 16 on
     // 64-bit platforms and 8 on 32-bit platforms.

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/SharedScope.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/SharedScope.java
@@ -63,8 +63,8 @@ class SharedScope extends MemoryScope {
         }
     }
 
-    SharedScope(Object ref, Cleaner cleaner) {
-        super(ref, cleaner, new SharedResourceList());
+    SharedScope(Cleaner cleaner) {
+        super(cleaner, new SharedResourceList());
     }
 
     @Override

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/Binding.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/Binding.java
@@ -291,13 +291,13 @@ public abstract class Binding {
         }
 
         /**
-         * Dummy binding context. Throws exceptions when attempting to access allocator/scope, and its
-         * {@link #close()} is idempotent.
+         * Dummy binding context. Throws exceptions when attempting to access scope, return a throwing allocator, and has
+         * an idempotent {@link #close()}.
          */
         public static Context DUMMY = new Context(null, null) {
             @Override
             public SegmentAllocator allocator() {
-                throw new UnsupportedOperationException();
+                return SharedUtils.THROWING_ALLOCATOR;
             }
 
             @Override
@@ -310,12 +310,6 @@ public abstract class Binding {
                 // do nothing
             }
         };
-
-        /**
-         * Default binding context. Does not provide a resource scope, but provides a default {@link SegmentAllocator}
-         * which uses {@link MemorySegment#allocateNative(long, long)}.
-         */
-        public static Context DEFAULT = ofAllocator(MemorySegment::allocateNative);
     }
 
     enum Tag {

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/SharedUtils.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/SharedUtils.java
@@ -102,10 +102,8 @@ public class SharedUtils {
         }
     }
 
-    // workaround for https://bugs.openjdk.java.net/browse/JDK-8239083
-    private static MemorySegment allocateNative(MemoryLayout layout) {
-        return MemorySegment.allocateNative(layout);
-    }
+    // this allocator should be used when no allocation is expected
+    public final static SegmentAllocator THROWING_ALLOCATOR = (size, align) -> { throw new IllegalStateException("Cannot get here"); };
 
     /**
      * Align the specified type from a given address
@@ -562,11 +560,6 @@ public class SharedUtils {
 
         @Override
         public MemoryAddress vargAsAddress(MemoryLayout layout) {
-            throw uoe();
-        }
-
-        @Override
-        public MemorySegment vargAsSegment(MemoryLayout layout) {
             throw uoe();
         }
 

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/aarch64/AArch64Linker.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/aarch64/AArch64Linker.java
@@ -36,7 +36,6 @@ import jdk.internal.foreign.abi.SharedUtils;
 import jdk.internal.foreign.abi.UpcallStubs;
 import jdk.internal.reflect.CallerSensitive;
 import jdk.internal.reflect.Reflection;
-import jdk.internal.vm.annotation.NativeAccess;
 
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
@@ -84,8 +83,8 @@ public final class AArch64Linker extends AbstractCLinker {
         MethodType llMt = SharedUtils.convertVaListCarriers(type, AArch64VaList.CARRIER);
         MethodHandle handle = CallArranger.arrangeDowncall(llMt, function);
         if (!type.returnType().equals(MemorySegment.class)) {
-            // not returning segment, just insert default allocator
-            handle = MethodHandles.insertArguments(handle, 1, Binding.Context.DEFAULT.allocator());
+            // not returning segment, just insert a throwing allocator
+            handle = MethodHandles.insertArguments(handle, 1, SharedUtils.THROWING_ALLOCATOR);
         }
         handle = SharedUtils.unboxVaLists(type, handle, MH_unboxVaList);
         return handle;

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/aarch64/AArch64VaList.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/aarch64/AArch64VaList.java
@@ -41,6 +41,7 @@ import static jdk.internal.foreign.PlatformLayouts.AArch64;
 import static jdk.incubator.foreign.CLinker.VaList;
 import static jdk.incubator.foreign.MemoryLayout.PathElement.groupElement;
 import static jdk.internal.foreign.abi.SharedUtils.SimpleVaArg;
+import static jdk.internal.foreign.abi.SharedUtils.THROWING_ALLOCATOR;
 import static jdk.internal.foreign.abi.SharedUtils.checkCompatibleType;
 import static jdk.internal.foreign.abi.SharedUtils.vhPrimitiveOrAddress;
 import static jdk.internal.foreign.abi.aarch64.CallArranger.MAX_REGISTER_ARGUMENTS;
@@ -229,11 +230,6 @@ public class AArch64VaList implements VaList {
     }
 
     @Override
-    public MemorySegment vargAsSegment(MemoryLayout layout) {
-        return (MemorySegment) read(MemorySegment.class, layout);
-    }
-
-    @Override
     public MemorySegment vargAsSegment(MemoryLayout layout, SegmentAllocator allocator) {
         Objects.requireNonNull(allocator);
         return (MemorySegment) read(MemorySegment.class, layout, allocator);
@@ -245,7 +241,7 @@ public class AArch64VaList implements VaList {
     }
 
     private Object read(Class<?> carrier, MemoryLayout layout) {
-        return read(carrier, layout, MemorySegment::allocateNative);
+        return read(carrier, layout, THROWING_ALLOCATOR);
     }
 
     private Object read(Class<?> carrier, MemoryLayout layout, SegmentAllocator allocator) {

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/x64/sysv/SysVVaList.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/x64/sysv/SysVVaList.java
@@ -41,6 +41,7 @@ import static jdk.internal.foreign.PlatformLayouts.SysV;
 import static jdk.incubator.foreign.CLinker.VaList;
 import static jdk.incubator.foreign.MemoryLayout.PathElement.groupElement;
 import static jdk.internal.foreign.abi.SharedUtils.SimpleVaArg;
+import static jdk.internal.foreign.abi.SharedUtils.THROWING_ALLOCATOR;
 import static jdk.internal.foreign.abi.SharedUtils.checkCompatibleType;
 import static jdk.internal.foreign.abi.SharedUtils.vhPrimitiveOrAddress;
 
@@ -207,11 +208,6 @@ public class SysVVaList implements VaList {
     }
 
     @Override
-    public MemorySegment vargAsSegment(MemoryLayout layout) {
-        return (MemorySegment) read(MemorySegment.class, layout);
-    }
-
-    @Override
     public MemorySegment vargAsSegment(MemoryLayout layout, SegmentAllocator allocator) {
         Objects.requireNonNull(allocator);
         return (MemorySegment) read(MemorySegment.class, layout, allocator);
@@ -223,7 +219,7 @@ public class SysVVaList implements VaList {
     }
 
     private Object read(Class<?> carrier, MemoryLayout layout) {
-        return read(carrier, layout, MemorySegment::allocateNative);
+        return read(carrier, layout, THROWING_ALLOCATOR);
     }
 
     private Object read(Class<?> carrier, MemoryLayout layout, SegmentAllocator allocator) {

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/x64/sysv/SysVx64Linker.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/x64/sysv/SysVx64Linker.java
@@ -36,7 +36,6 @@ import jdk.internal.foreign.abi.SharedUtils;
 import jdk.internal.foreign.abi.UpcallStubs;
 import jdk.internal.reflect.CallerSensitive;
 import jdk.internal.reflect.Reflection;
-import jdk.internal.vm.annotation.NativeAccess;
 
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
@@ -95,8 +94,8 @@ public final class SysVx64Linker extends AbstractCLinker {
         MethodType llMt = SharedUtils.convertVaListCarriers(type, SysVVaList.CARRIER);
         MethodHandle handle = CallArranger.arrangeDowncall(llMt, function);
         if (!type.returnType().equals(MemorySegment.class)) {
-            // not returning segment, just insert default allocator
-            handle = MethodHandles.insertArguments(handle, 1, Binding.Context.DEFAULT.allocator());
+            // not returning segment, just insert a throwing allocator
+            handle = MethodHandles.insertArguments(handle, 1, SharedUtils.THROWING_ALLOCATOR);
         }
         handle = SharedUtils.unboxVaLists(type, handle, MH_unboxVaList);
         return handle;

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/x64/windows/WinVaList.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/x64/windows/WinVaList.java
@@ -95,11 +95,6 @@ class WinVaList implements VaList {
     }
 
     @Override
-    public MemorySegment vargAsSegment(MemoryLayout layout) {
-        return (MemorySegment) read(MemorySegment.class, layout);
-    }
-
-    @Override
     public MemorySegment vargAsSegment(MemoryLayout layout, SegmentAllocator allocator) {
         Objects.requireNonNull(allocator);
         return (MemorySegment) read(MemorySegment.class, layout, allocator);
@@ -111,7 +106,7 @@ class WinVaList implements VaList {
     }
 
     private Object read(Class<?> carrier, MemoryLayout layout) {
-        return read(carrier, layout, MemorySegment::allocateNative);
+        return read(carrier, layout, SharedUtils.THROWING_ALLOCATOR);
     }
 
     private Object read(Class<?> carrier, MemoryLayout layout, SegmentAllocator allocator) {

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/x64/windows/Windowsx64Linker.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/x64/windows/Windowsx64Linker.java
@@ -35,7 +35,6 @@ import jdk.internal.foreign.abi.SharedUtils;
 import jdk.internal.foreign.abi.UpcallStubs;
 import jdk.internal.reflect.CallerSensitive;
 import jdk.internal.reflect.Reflection;
-import jdk.internal.vm.annotation.NativeAccess;
 
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
@@ -96,8 +95,8 @@ public final class Windowsx64Linker extends AbstractCLinker {
         MethodType llMt = SharedUtils.convertVaListCarriers(type, WinVaList.CARRIER);
         MethodHandle handle = CallArranger.arrangeDowncall(llMt, function);
         if (!type.returnType().equals(MemorySegment.class)) {
-            // not returning segment, just insert default allocator
-            handle = MethodHandles.insertArguments(handle, 1, Binding.Context.DEFAULT.allocator());
+            // not returning segment, just insert a throwing allocator
+            handle = MethodHandles.insertArguments(handle, 1, SharedUtils.THROWING_ALLOCATOR);
         }
         handle = SharedUtils.unboxVaLists(type, handle, MH_unboxVaList);
         return handle;

--- a/test/jdk/java/foreign/CallGeneratorHelper.java
+++ b/test/jdk/java/foreign/CallGeneratorHelper.java
@@ -26,6 +26,7 @@ import jdk.incubator.foreign.GroupLayout;
 import jdk.incubator.foreign.MemoryAddress;
 import jdk.incubator.foreign.MemoryLayout;
 import jdk.incubator.foreign.MemorySegment;
+import jdk.incubator.foreign.ResourceScope;
 import jdk.incubator.foreign.ValueLayout;
 
 import java.lang.invoke.VarHandle;
@@ -360,15 +361,15 @@ public class CallGeneratorHelper extends NativeTestHelper {
     @SuppressWarnings("unchecked")
     static Object makeArg(MemoryLayout layout, List<Consumer<Object>> checks, boolean check) throws ReflectiveOperationException {
         if (layout instanceof GroupLayout) {
-            MemorySegment segment = MemorySegment.allocateNative(layout);
+            MemorySegment segment = MemorySegment.allocateNative(layout, ResourceScope.ofImplicit());
             initStruct(segment, (GroupLayout)layout, checks, check);
             return segment;
         } else if (isPointer(layout)) {
-            MemorySegment segment = MemorySegment.allocateNative(1);
+            MemorySegment segment = MemorySegment.allocateNative(1, ResourceScope.ofImplicit());
             if (check) {
                 checks.add(o -> {
                     try {
-                        assertEquals((MemoryAddress)o, segment.address());
+                        assertEquals(o, segment.address());
                     } catch (Throwable ex) {
                         throw new IllegalStateException(ex);
                     }

--- a/test/jdk/java/foreign/StdLibTest.java
+++ b/test/jdk/java/foreign/StdLibTest.java
@@ -257,7 +257,7 @@ public class StdLibTest {
             static final long SIZE = 56;
 
             Tm(MemoryAddress addr) {
-                this.base = addr.asSegment(SIZE);
+                this.base = addr.asSegment(SIZE, ResourceScope.globalScope());
             }
 
             int sec() {

--- a/test/jdk/java/foreign/TestAdaptVarHandles.java
+++ b/test/jdk/java/foreign/TestAdaptVarHandles.java
@@ -35,6 +35,7 @@ import jdk.incubator.foreign.MemoryHandles;
 import jdk.incubator.foreign.MemoryLayout;
 import jdk.incubator.foreign.MemoryLayouts;
 import jdk.incubator.foreign.MemorySegment;
+import jdk.incubator.foreign.ResourceScope;
 import jdk.incubator.foreign.ValueLayout;
 import org.testng.annotations.*;
 import static org.testng.Assert.*;
@@ -96,7 +97,7 @@ public class TestAdaptVarHandles {
     @Test
     public void testFilterValue() throws Throwable {
         ValueLayout layout = MemoryLayouts.JAVA_INT;
-        MemorySegment segment = MemorySegment.allocateNative(layout);
+        MemorySegment segment = MemorySegment.allocateNative(layout, ResourceScope.ofImplicit());
         VarHandle intHandle = layout.varHandle(int.class);
         VarHandle i2SHandle = MemoryHandles.filterValue(intHandle, S2I, I2S);
         i2SHandle.set(segment, "1");
@@ -115,7 +116,7 @@ public class TestAdaptVarHandles {
     @Test
     public void testFilterValueComposite() throws Throwable {
         ValueLayout layout = MemoryLayouts.JAVA_INT;
-        MemorySegment segment = MemorySegment.allocateNative(layout);
+        MemorySegment segment = MemorySegment.allocateNative(layout, ResourceScope.ofImplicit());
         VarHandle intHandle = layout.varHandle(int.class);
         MethodHandle CTX_S2I = MethodHandles.dropArguments(S2I, 0, String.class, String.class);
         VarHandle i2SHandle = MemoryHandles.filterValue(intHandle, CTX_S2I, CTX_I2S);
@@ -136,7 +137,7 @@ public class TestAdaptVarHandles {
     @Test
     public void testFilterValueLoose() throws Throwable {
         ValueLayout layout = MemoryLayouts.JAVA_INT;
-        MemorySegment segment = MemorySegment.allocateNative(layout);
+        MemorySegment segment = MemorySegment.allocateNative(layout, ResourceScope.ofImplicit());
         VarHandle intHandle = layout.varHandle(int.class);
         VarHandle i2SHandle = MemoryHandles.filterValue(intHandle, O2I, I2O);
         i2SHandle.set(segment, "1");
@@ -204,7 +205,7 @@ public class TestAdaptVarHandles {
     @Test
     public void testFilterCoordinates() throws Throwable {
         ValueLayout layout = MemoryLayouts.JAVA_INT;
-        MemorySegment segment = MemorySegment.allocateNative(layout);
+        MemorySegment segment = MemorySegment.allocateNative(layout, ResourceScope.ofImplicit());
         VarHandle intHandle_longIndex = MemoryHandles.filterCoordinates(intHandleIndexed, 0, BASE_ADDR, S2L);
         intHandle_longIndex.set(segment, "0", 1);
         int oldValue = (int)intHandle_longIndex.getAndAdd(segment, "0", 42);
@@ -247,7 +248,7 @@ public class TestAdaptVarHandles {
     @Test
     public void testInsertCoordinates() throws Throwable {
         ValueLayout layout = MemoryLayouts.JAVA_INT;
-        MemorySegment segment = MemorySegment.allocateNative(layout);
+        MemorySegment segment = MemorySegment.allocateNative(layout, ResourceScope.ofImplicit());
         VarHandle intHandle_longIndex = MemoryHandles.insertCoordinates(intHandleIndexed, 0, segment, 0L);
         intHandle_longIndex.set(1);
         int oldValue = (int)intHandle_longIndex.getAndAdd(42);
@@ -285,7 +286,7 @@ public class TestAdaptVarHandles {
     @Test
     public void testPermuteCoordinates() throws Throwable {
         ValueLayout layout = MemoryLayouts.JAVA_INT;
-        MemorySegment segment = MemorySegment.allocateNative(layout);
+        MemorySegment segment = MemorySegment.allocateNative(layout, ResourceScope.ofImplicit());
         VarHandle intHandle_swap = MemoryHandles.permuteCoordinates(intHandleIndexed,
                 List.of(long.class, MemorySegment.class), 1, 0);
         intHandle_swap.set(0L, segment, 1);
@@ -324,7 +325,7 @@ public class TestAdaptVarHandles {
     @Test
     public void testCollectCoordinates() throws Throwable {
         ValueLayout layout = MemoryLayouts.JAVA_INT;
-        MemorySegment segment = MemorySegment.allocateNative(layout);
+        MemorySegment segment = MemorySegment.allocateNative(layout, ResourceScope.ofImplicit());
         VarHandle intHandle_sum = MemoryHandles.collectCoordinates(intHandleIndexed, 1, SUM_OFFSETS);
         intHandle_sum.set(segment, -2L, 2L, 1);
         int oldValue = (int)intHandle_sum.getAndAdd(segment, -2L, 2L, 42);
@@ -367,7 +368,7 @@ public class TestAdaptVarHandles {
     @Test
     public void testDropCoordinates() throws Throwable {
         ValueLayout layout = MemoryLayouts.JAVA_INT;
-        MemorySegment segment = MemorySegment.allocateNative(layout);
+        MemorySegment segment = MemorySegment.allocateNative(layout, ResourceScope.ofImplicit());
         VarHandle intHandle_dummy = MemoryHandles.dropCoordinates(intHandleIndexed, 1, float.class, String.class);
         intHandle_dummy.set(segment, 1f, "hello", 0L, 1);
         int oldValue = (int)intHandle_dummy.getAndAdd(segment, 1f, "hello", 0L, 42);

--- a/test/jdk/java/foreign/TestArrays.java
+++ b/test/jdk/java/foreign/TestArrays.java
@@ -101,7 +101,7 @@ public class TestArrays {
 
     @Test(dataProvider = "arrays")
     public void testArrays(Consumer<MemorySegment> init, Consumer<MemorySegment> checker, MemoryLayout layout) {
-        MemorySegment segment = MemorySegment.allocateNative(layout);
+        MemorySegment segment = MemorySegment.allocateNative(layout, ResourceScope.ofImplicit());
         init.accept(segment);
         assertFalse(segment.isReadOnly());
         checker.accept(segment);
@@ -112,7 +112,7 @@ public class TestArrays {
     public void testTooBigForArray(MemoryLayout layout, Function<MemorySegment, Object> arrayFactory) {
         MemoryLayout seq = MemoryLayout.ofSequence((Integer.MAX_VALUE * layout.byteSize()) + 1, layout);
         //do not really allocate here, as it's way too much memory
-        MemorySegment segment = MemoryAddress.NULL.asSegment(seq.byteSize());
+        MemorySegment segment = MemoryAddress.NULL.asSegment(seq.byteSize(), ResourceScope.globalScope());
         arrayFactory.apply(segment);
     }
 

--- a/test/jdk/java/foreign/TestByteBuffer.java
+++ b/test/jdk/java/foreign/TestByteBuffer.java
@@ -268,7 +268,7 @@ public class TestByteBuffer {
         f.createNewFile();
         f.deleteOnExit();
 
-        MemorySegment segment = MemorySegment.mapFile(f.toPath(), 0L, 8, FileChannel.MapMode.READ_WRITE);
+        MemorySegment segment = MemorySegment.mapFile(f.toPath(), 0L, 8, FileChannel.MapMode.READ_WRITE, ResourceScope.ofImplicit());
         assertTrue(segment.isMapped());
         segment.scope().close();
         mappedBufferOp.apply(segment);
@@ -455,7 +455,7 @@ public class TestByteBuffer {
 
     @Test(expectedExceptions = IllegalStateException.class)
     public void testTooBigForByteBuffer() {
-        MemorySegment segment = MemoryAddress.NULL.asSegment(Integer.MAX_VALUE + 10L);
+        MemorySegment segment = MemoryAddress.NULL.asSegment(Integer.MAX_VALUE + 10L, ResourceScope.globalScope());
         segment.asByteBuffer();
     }
 
@@ -464,7 +464,7 @@ public class TestByteBuffer {
         File f = new File("testNeg1.out");
         f.createNewFile();
         f.deleteOnExit();
-        MemorySegment.mapFile(f.toPath(), 0L, -1, FileChannel.MapMode.READ_WRITE);
+        MemorySegment.mapFile(f.toPath(), 0L, -1, FileChannel.MapMode.READ_WRITE, ResourceScope.ofImplicit());
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class)
@@ -472,7 +472,7 @@ public class TestByteBuffer {
         File f = new File("testNeg2.out");
         f.createNewFile();
         f.deleteOnExit();
-        MemorySegment.mapFile(f.toPath(), -1, 1, FileChannel.MapMode.READ_WRITE);
+        MemorySegment.mapFile(f.toPath(), -1, 1, FileChannel.MapMode.READ_WRITE, ResourceScope.ofImplicit());
     }
 
     @Test
@@ -531,7 +531,7 @@ public class TestByteBuffer {
     @Test(expectedExceptions = IllegalArgumentException.class)
     public void testMapCustomPath() throws IOException {
         Path path = Path.of(URI.create("jrt:/"));
-        MemorySegment.mapFile(path, 0L, 0L, FileChannel.MapMode.READ_WRITE);
+        MemorySegment.mapFile(path, 0L, 0L, FileChannel.MapMode.READ_WRITE, ResourceScope.ofImplicit());
     }
 
     @Test(dataProvider="resizeOps")
@@ -696,7 +696,7 @@ public class TestByteBuffer {
     @DataProvider(name = "segments")
     public static Object[][] segments() throws Throwable {
         return new Object[][] {
-                { (Supplier<MemorySegment>) () -> MemorySegment.allocateNative(16) },
+                { (Supplier<MemorySegment>) () -> MemorySegment.allocateNative(16, ResourceScope.ofImplicit()) },
                 { (Supplier<MemorySegment>) () -> MemorySegment.ofArray(new byte[16]) }
         };
     }

--- a/test/jdk/java/foreign/TestDowncall.java
+++ b/test/jdk/java/foreign/TestDowncall.java
@@ -93,7 +93,7 @@ public class TestDowncall extends CallGeneratorHelper {
         if (count % 100 == 0) {
             System.gc();
         }
-        Object res = doCall(addr, SegmentAllocator.ofDefault(), mt, descriptor, args);
+        Object res = doCall(addr, SegmentAllocator.implicit(), mt, descriptor, args);
         if (ret == Ret.NON_VOID) {
             checks.forEach(c -> c.accept(res));
             if (needsScope) {

--- a/test/jdk/java/foreign/TestFree.java
+++ b/test/jdk/java/foreign/TestFree.java
@@ -33,12 +33,14 @@ import jdk.incubator.foreign.MemoryAccess;
 import jdk.incubator.foreign.MemoryAddress;
 import jdk.incubator.foreign.MemoryLayout;
 import jdk.incubator.foreign.MemorySegment;
+import jdk.incubator.foreign.ResourceScope;
+
 import static jdk.incubator.foreign.CLinker.*;
 import static org.testng.Assert.assertEquals;
 
 public class TestFree {
     private static MemorySegment asArray(MemoryAddress addr, MemoryLayout layout, int numElements) {
-        return addr.asSegment(numElements * layout.byteSize());
+        return addr.asSegment(numElements * layout.byteSize(), ResourceScope.globalScope());
     }
 
     public void test() throws Throwable {

--- a/test/jdk/java/foreign/TestMemoryCopy.java
+++ b/test/jdk/java/foreign/TestMemoryCopy.java
@@ -29,6 +29,7 @@
 
 import jdk.incubator.foreign.MemoryLayouts;
 import jdk.incubator.foreign.MemorySegment;
+import jdk.incubator.foreign.ResourceScope;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
@@ -64,7 +65,7 @@ public class TestMemoryCopy {
     static class SegmentSlice {
 
         enum Kind {
-            NATIVE(MemorySegment::allocateNative),
+            NATIVE(i -> MemorySegment.allocateNative(i, ResourceScope.ofImplicit())),
             ARRAY(i -> MemorySegment.ofArray(new byte[i]));
 
             final IntFunction<MemorySegment> segmentFactory;

--- a/test/jdk/java/foreign/TestMismatch.java
+++ b/test/jdk/java/foreign/TestMismatch.java
@@ -205,7 +205,7 @@ public class TestMismatch {
     }
 
     enum SegmentKind {
-        NATIVE(MemorySegment::allocateNative),
+        NATIVE(i -> MemorySegment.allocateNative(i, ResourceScope.ofImplicit())),
         ARRAY(i -> MemorySegment.ofArray(new byte[i]));
 
         final IntFunction<MemorySegment> segmentFactory;

--- a/test/jdk/java/foreign/TestNative.java
+++ b/test/jdk/java/foreign/TestNative.java
@@ -214,7 +214,7 @@ public class TestNative {
     public void testBadResize() {
         try (ResourceScope scope = ResourceScope.ofConfined()) {
             MemorySegment segment = MemorySegment.allocateNative(4, 1, scope);
-            segment.address().asSegment(0);
+            segment.address().asSegment(0, ResourceScope.globalScope());
         }
     }
 

--- a/test/jdk/java/foreign/TestNulls.java
+++ b/test/jdk/java/foreign/TestNulls.java
@@ -106,11 +106,7 @@ public class TestNulls {
             "jdk.incubator.foreign.ValueLayout/withAttribute(java.lang.String,java.lang.constant.Constable)/1/0",
             "jdk.incubator.foreign.GroupLayout/withAttribute(java.lang.String,java.lang.constant.Constable)/1/0",
             "jdk.incubator.foreign.MemoryHandles/insertCoordinates(java.lang.invoke.VarHandle,int,java.lang.Object[])/2/1",
-            "jdk.incubator.foreign.FunctionDescriptor/withAttribute(java.lang.String,java.lang.constant.Constable)/1/0",
-            "jdk.incubator.foreign.ResourceScope/ofConfined(java.lang.Object,java.lang.ref.Cleaner)/0/0",
-            "jdk.incubator.foreign.ResourceScope/ofConfined(java.lang.Object,java.lang.ref.Cleaner)/1/0",
-            "jdk.incubator.foreign.ResourceScope/ofShared(java.lang.Object,java.lang.ref.Cleaner)/0/0",
-            "jdk.incubator.foreign.ResourceScope/ofShared(java.lang.Object,java.lang.ref.Cleaner)/1/0"
+            "jdk.incubator.foreign.FunctionDescriptor/withAttribute(java.lang.String,java.lang.constant.Constable)/1/0"
     );
 
     static final Set<String> OBJECT_METHODS = Stream.of(Object.class.getMethods())
@@ -163,7 +159,7 @@ public class TestNulls {
         addDefaultMapping(CLinker.VaList.Builder.class, VaListHelper.vaListBuilder);
         addDefaultMapping(LibraryLookup.class, LibraryLookup.ofDefault());
         addDefaultMapping(ResourceScope.class, ResourceScope.ofConfined());
-        addDefaultMapping(SegmentAllocator.class, MemorySegment::allocateNative);
+        addDefaultMapping(SegmentAllocator.class, SegmentAllocator.implicit());
         addDefaultMapping(Supplier.class, () -> null);
     }
 
@@ -176,7 +172,7 @@ public class TestNulls {
             vaList = CLinker.VaList.make(b -> {
                 builderRef.set(b);
                 b.vargFromLong(CLinker.C_LONG_LONG, 42L);
-            });
+            }, ResourceScope.ofImplicit());
             vaListBuilder = builderRef.get();
         }
     }

--- a/test/jdk/java/foreign/TestRebase.java
+++ b/test/jdk/java/foreign/TestRebase.java
@@ -31,6 +31,7 @@ import jdk.incubator.foreign.MemoryAccess;
 import jdk.incubator.foreign.MemoryAddress;
 import jdk.incubator.foreign.MemoryLayouts;
 import jdk.incubator.foreign.MemorySegment;
+import jdk.incubator.foreign.ResourceScope;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
@@ -81,7 +82,7 @@ public class TestRebase {
     static class SegmentSlice {
 
         enum Kind {
-            NATIVE(MemorySegment::allocateNative),
+            NATIVE(i -> MemorySegment.allocateNative(i, ResourceScope.ofImplicit())),
             ARRAY(i -> MemorySegment.ofArray(new byte[i]));
 
             final IntFunction<MemorySegment> segmentFactory;

--- a/test/jdk/java/foreign/TestResourceScope.java
+++ b/test/jdk/java/foreign/TestResourceScope.java
@@ -52,7 +52,9 @@ public class TestResourceScope {
     public void testConfined(Supplier<Cleaner> cleanerSupplier) {
         AtomicInteger acc = new AtomicInteger();
         Cleaner cleaner = cleanerSupplier.get();
-        ResourceScope scope = ResourceScope.ofConfined(null, cleaner);
+        ResourceScope scope = cleaner != null ?
+                ResourceScope.ofConfined(cleaner) :
+                ResourceScope.ofConfined();
         for (int i = 0 ; i < N_THREADS ; i++) {
             int delta = i;
             scope.addOnClose(() -> acc.addAndGet(delta));
@@ -75,7 +77,9 @@ public class TestResourceScope {
     public void testSharedSingleThread(Supplier<Cleaner> cleanerSupplier) {
         AtomicInteger acc = new AtomicInteger();
         Cleaner cleaner = cleanerSupplier.get();
-        ResourceScope scope = ResourceScope.ofShared(null, cleaner);
+        ResourceScope scope = cleaner != null ?
+                ResourceScope.ofShared(cleaner) :
+                ResourceScope.ofShared();
         for (int i = 0 ; i < N_THREADS ; i++) {
             int delta = i;
             scope.addOnClose(() -> acc.addAndGet(delta));
@@ -99,7 +103,9 @@ public class TestResourceScope {
         AtomicInteger acc = new AtomicInteger();
         Cleaner cleaner = cleanerSupplier.get();
         List<Thread> threads = new ArrayList<>();
-        ResourceScope scope = ResourceScope.ofShared(null, cleaner);
+        ResourceScope scope = cleaner != null ?
+                ResourceScope.ofShared(cleaner) :
+                ResourceScope.ofShared();
         AtomicReference<ResourceScope> scopeRef = new AtomicReference<>(scope);
         for (int i = 0 ; i < N_THREADS ; i++) {
             int delta = i;
@@ -147,7 +153,9 @@ public class TestResourceScope {
     @Test(dataProvider = "cleaners")
     public void testLockSingleThread(Supplier<Cleaner> cleanerSupplier) {
         Cleaner cleaner = cleanerSupplier.get();
-        ResourceScope scope = ResourceScope.ofConfined(null, cleaner);
+        ResourceScope scope = cleaner != null ?
+                ResourceScope.ofConfined(cleaner) :
+                ResourceScope.ofConfined();
         List<ResourceScope.Handle> handles = new ArrayList<>();
         for (int i = 0 ; i < N_THREADS ; i++) {
             handles.add(scope.acquire());
@@ -171,7 +179,9 @@ public class TestResourceScope {
     @Test(dataProvider = "cleaners")
     public void testLockSharedMultiThread(Supplier<Cleaner> cleanerSupplier) {
         Cleaner cleaner = cleanerSupplier.get();
-        ResourceScope scope = ResourceScope.ofShared(null, cleaner);
+        ResourceScope scope = cleaner != null ?
+                ResourceScope.ofShared(cleaner) :
+                ResourceScope.ofShared();
         for (int i = 0 ; i < N_THREADS ; i++) {
             new Thread(() -> {
                 try {

--- a/test/jdk/java/foreign/TestRestricted.java
+++ b/test/jdk/java/foreign/TestRestricted.java
@@ -23,6 +23,7 @@
 
 import jdk.incubator.foreign.MemoryAddress;
 import jdk.incubator.foreign.MemorySegment;
+import jdk.incubator.foreign.ResourceScope;
 import org.testng.annotations.Test;
 
 import java.lang.invoke.MethodHandles;
@@ -55,19 +56,19 @@ public class TestRestricted {
 
     @Test(expectedExceptions = InvocationTargetException.class)
     public void testReflection2() throws Throwable {
-        Method method = MemoryAddress.class.getDeclaredMethod("asSegment", long.class);
-        method.invoke(MemoryAddress.NULL, 4000L);
+        Method method = MemoryAddress.class.getDeclaredMethod("asSegment", long.class, ResourceScope.class);
+        method.invoke(MemoryAddress.NULL, 4000L, ResourceScope.globalScope());
     }
 
     @Test(expectedExceptions = IllegalCallerException.class)
     public void testInvoke2() throws Throwable {
         var mh = MethodHandles.lookup().findVirtual(MemoryAddress.class, "asSegment",
-            MethodType.methodType(MemorySegment.class, long.class));
-        var seg = (MemorySegment)mh.invokeExact(MemoryAddress.NULL, 4000L);
+            MethodType.methodType(MemorySegment.class, long.class, ResourceScope.class));
+        var seg = (MemorySegment)mh.invokeExact(MemoryAddress.NULL, 4000L, ResourceScope.globalScope());
     }
 
     @Test(expectedExceptions = IllegalCallerException.class)
     public void testDirectAccess2() throws Throwable {
-        MemoryAddress.NULL.asSegment(4000L);
+        MemoryAddress.NULL.asSegment(4000L, ResourceScope.globalScope());
     }
 }

--- a/test/jdk/java/foreign/TestScopedOperations.java
+++ b/test/jdk/java/foreign/TestScopedOperations.java
@@ -113,7 +113,7 @@ public class TestScopedOperations {
             ScopedOperation.ofVaList(list -> list.vargAsLong(MemoryLayouts.JAVA_LONG), "VaList::vargAsLong");
             ScopedOperation.ofVaList(list -> list.vargAsDouble(MemoryLayouts.JAVA_DOUBLE), "VaList::vargAsDouble");
             ScopedOperation.ofVaList(CLinker.VaList::skip, "VaList::skip");
-            ScopedOperation.ofVaList(list -> list.vargAsSegment(MemoryLayout.ofStruct(MemoryLayouts.JAVA_INT)), "VaList::vargAsSegment/1");
+            ScopedOperation.ofVaList(list -> list.vargAsSegment(MemoryLayout.ofStruct(MemoryLayouts.JAVA_INT), ResourceScope.ofImplicit()), "VaList::vargAsSegment/1");
             ScopedOperation.ofVaList(list -> list.vargAsSegment(MemoryLayout.ofStruct(MemoryLayouts.JAVA_INT), SegmentAllocator.malloc(list::scope)), "VaList::vargAsSegment/2");
             // allocator operations
             ScopedOperation.ofAllocator(a -> a.allocate(1), "NativeAllocator::allocate/size");

--- a/test/jdk/java/foreign/TestSegments.java
+++ b/test/jdk/java/foreign/TestSegments.java
@@ -55,23 +55,23 @@ public class TestSegments {
 
     @Test(dataProvider = "badSizeAndAlignments", expectedExceptions = IllegalArgumentException.class)
     public void testBadAllocateAlign(long size, long align) {
-        MemorySegment.allocateNative(size, align);
+        MemorySegment.allocateNative(size, align, ResourceScope.ofImplicit());
     }
 
     @Test(dataProvider = "badLayouts", expectedExceptions = UnsupportedOperationException.class)
     public void testBadAllocateLayout(MemoryLayout layout) {
-        MemorySegment.allocateNative(layout);
+        MemorySegment.allocateNative(layout, ResourceScope.ofImplicit());
     }
 
     @Test(expectedExceptions = { OutOfMemoryError.class,
                                  IllegalArgumentException.class })
     public void testAllocateTooBig() {
-        MemorySegment.allocateNative(Long.MAX_VALUE);
+        MemorySegment.allocateNative(Long.MAX_VALUE, ResourceScope.ofImplicit());
     }
 
     @Test(expectedExceptions = OutOfMemoryError.class)
     public void testNativeAllocationTooBig() {
-        MemorySegment segment = MemorySegment.allocateNative(1024 * 1024 * 8 * 2); // 2M
+        MemorySegment segment = MemorySegment.allocateNative(1024 * 1024 * 8 * 2, ResourceScope.ofImplicit()); // 2M
     }
 
     @Test
@@ -116,10 +116,8 @@ public class TestSegments {
     }
 
     static void tryClose(MemorySegment segment) {
-        try {
+        if (!segment.scope().isImplicit()) {
             segment.scope().close();
-        } catch (UnsupportedOperationException ex) {
-            // whoops - scope is not closeable
         }
     }
 
@@ -133,9 +131,9 @@ public class TestSegments {
                 () -> MemorySegment.ofArray(new int[] { 1, 2, 3, 4 }),
                 () -> MemorySegment.ofArray(new long[] { 1l, 2l, 3l, 4l } ),
                 () -> MemorySegment.ofArray(new short[] { 1, 2, 3, 4 } ),
-                () -> MemorySegment.allocateNative(4),
-                () -> MemorySegment.allocateNative(4, 8),
-                () -> MemorySegment.allocateNative(MemoryLayout.ofValueBits(32, ByteOrder.nativeOrder())),
+                () -> MemorySegment.allocateNative(4, ResourceScope.ofImplicit()),
+                () -> MemorySegment.allocateNative(4, 8, ResourceScope.ofImplicit()),
+                () -> MemorySegment.allocateNative(MemoryLayout.ofValueBits(32, ByteOrder.nativeOrder()), ResourceScope.ofImplicit()),
                 () -> MemorySegment.allocateNative(4, ResourceScope.ofConfined()),
                 () -> MemorySegment.allocateNative(4, 8, ResourceScope.ofConfined()),
                 () -> MemorySegment.allocateNative(MemoryLayout.ofValueBits(32, ByteOrder.nativeOrder()), ResourceScope.ofConfined())

--- a/test/jdk/java/foreign/TestSpliterator.java
+++ b/test/jdk/java/foreign/TestSpliterator.java
@@ -88,7 +88,7 @@ public class TestSpliterator {
         SequenceLayout layout = MemoryLayout.ofSequence(1024, MemoryLayouts.JAVA_INT);
 
         //setup
-        MemorySegment segment = MemorySegment.allocateNative(layout);
+        MemorySegment segment = MemorySegment.allocateNative(layout, ResourceScope.ofImplicit());
         for (int i = 0; i < layout.elementCount().getAsLong(); i++) {
             INT_HANDLE.set(segment, (long) i, i);
         }

--- a/test/jdk/java/foreign/TestUpcall.java
+++ b/test/jdk/java/foreign/TestUpcall.java
@@ -81,7 +81,7 @@ public class TestUpcall extends CallGeneratorHelper {
 
     @BeforeClass
     void setup() {
-        dummyStub = abi.upcallStub(DUMMY, FunctionDescriptor.ofVoid());
+        dummyStub = abi.upcallStub(DUMMY, FunctionDescriptor.ofVoid(), ResourceScope.ofImplicit());
     }
 
     @Test(dataProvider="functions", dataProviderClass=CallGeneratorHelper.class)
@@ -108,8 +108,8 @@ public class TestUpcall extends CallGeneratorHelper {
         List<Consumer<Object[]>> argChecks = new ArrayList<>();
         MemoryAddress addr = lib.lookup(fName).get();
         MethodType mtype = methodType(ret, paramTypes, fields);
-        MethodHandle mh = abi.downcallHandle(addr, SegmentAllocator.ofDefault(), mtype, function(ret, paramTypes, fields));
-        Object[] args = makeArgs(ResourceScope.ofDefault(), ret, paramTypes, fields, returnChecks, argChecks);
+        MethodHandle mh = abi.downcallHandle(addr, SegmentAllocator.implicit(), mtype, function(ret, paramTypes, fields));
+        Object[] args = makeArgs(ResourceScope.ofImplicit(), ret, paramTypes, fields, returnChecks, argChecks);
         Object[] callArgs = args;
         if (count % 100 == 0) {
             System.gc();
@@ -197,7 +197,7 @@ public class TestUpcall extends CallGeneratorHelper {
         for (int i = 0; i < o.length; i++) {
             if (o[i] instanceof MemorySegment) {
                 MemorySegment ms = (MemorySegment) o[i];
-                MemorySegment copy = MemorySegment.allocateNative(ms.byteSize());
+                MemorySegment copy = MemorySegment.allocateNative(ms.byteSize(), ResourceScope.ofImplicit());
                 copy.copyFrom(ms);
                 o[i] = copy;
             }

--- a/test/jdk/java/foreign/TestUpcallHighArity.java
+++ b/test/jdk/java/foreign/TestUpcallHighArity.java
@@ -92,7 +92,7 @@ public class TestUpcallHighArity extends CallGeneratorHelper {
         for (int i = 0; i < o.length; i++) {
             if (o[i] instanceof MemorySegment) {
                 MemorySegment ms = (MemorySegment) o[i];
-                MemorySegment copy = MemorySegment.allocateNative(ms.byteSize());
+                MemorySegment copy = MemorySegment.allocateNative(ms.byteSize(), ResourceScope.ofImplicit());
                 copy.copyFrom(ms);
                 o[i] = copy;
             }

--- a/test/jdk/java/foreign/TestVarHandleCombinators.java
+++ b/test/jdk/java/foreign/TestVarHandleCombinators.java
@@ -75,7 +75,7 @@ public class TestVarHandleCombinators {
     public void testAlign() {
         VarHandle vh = MemoryHandles.varHandle(byte.class, 2, ByteOrder.nativeOrder());
 
-        MemorySegment segment = MemorySegment.allocateNative(1, 2);
+        MemorySegment segment = MemorySegment.allocateNative(1, 2, ResourceScope.ofImplicit());
         vh.set(segment, 0L, (byte) 10); // fine, memory region is aligned
         assertEquals((byte) vh.get(segment, 0L), (byte) 10);
     }

--- a/test/jdk/java/foreign/valist/VaListTest.java
+++ b/test/jdk/java/foreign/valist/VaListTest.java
@@ -221,7 +221,7 @@ public class VaListTest extends NativeTestHelper {
         TriFunction<MemoryLayout, VarHandle, VarHandle, Function<VaList, Integer>> sumStructJavaFact
                 = (pointLayout, VH_Point_x, VH_Point_y) ->
                 list -> {
-                    MemorySegment struct = list.vargAsSegment(pointLayout);
+                    MemorySegment struct = list.vargAsSegment(pointLayout, ResourceScope.ofImplicit());
                     int x = (int) VH_Point_x.get(struct);
                     int y = (int) VH_Point_y.get(struct);
                     return x + y;
@@ -273,7 +273,7 @@ public class VaListTest extends NativeTestHelper {
         TriFunction<MemoryLayout, VarHandle, VarHandle, Function<VaList, Long>> sumStructJavaFact
                 = (BigPoint_LAYOUT, VH_BigPoint_x, VH_BigPoint_y) ->
                 list -> {
-                    MemorySegment struct = list.vargAsSegment(BigPoint_LAYOUT);
+                    MemorySegment struct = list.vargAsSegment(BigPoint_LAYOUT, ResourceScope.ofImplicit());
                     long x = (long) VH_BigPoint_x.get(struct);
                     long y = (long) VH_BigPoint_y.get(struct);
                     return x + y;
@@ -325,7 +325,7 @@ public class VaListTest extends NativeTestHelper {
         TriFunction<MemoryLayout, VarHandle, VarHandle, Function<VaList, Float>> sumStructJavaFact
                 = (FloatPoint_LAYOUT, VH_FloatPoint_x, VH_FloatPoint_y) ->
                 list -> {
-                    MemorySegment struct = list.vargAsSegment(FloatPoint_LAYOUT);
+                    MemorySegment struct = list.vargAsSegment(FloatPoint_LAYOUT, ResourceScope.ofImplicit());
                     float x = (float) VH_FloatPoint_x.get(struct);
                     float y = (float) VH_FloatPoint_y.get(struct);
                     return x + y;
@@ -382,7 +382,7 @@ public class VaListTest extends NativeTestHelper {
         QuadFunc<MemoryLayout, VarHandle, VarHandle, VarHandle, Function<VaList, Long>> sumStructJavaFact
                 = (HugePoint_LAYOUT, VH_HugePoint_x, VH_HugePoint_y, VH_HugePoint_z) ->
                 list -> {
-                    MemorySegment struct = list.vargAsSegment(HugePoint_LAYOUT);
+                    MemorySegment struct = list.vargAsSegment(HugePoint_LAYOUT, ResourceScope.ofImplicit());
                     long x = (long) VH_HugePoint_x.get(struct);
                     long y = (long) VH_HugePoint_y.get(struct);
                     long z = (long) VH_HugePoint_z.get(struct);
@@ -657,13 +657,13 @@ public class VaListTest extends NativeTestHelper {
 
         return new Object[][]{
                 { linkVaListCB("upcallBigStruct"), VaListConsumer.mh(vaList -> {
-                    MemorySegment struct = vaList.vargAsSegment(BigPoint_LAYOUT);
+                    MemorySegment struct = vaList.vargAsSegment(BigPoint_LAYOUT, ResourceScope.ofImplicit());
                     assertEquals((long) VH_BigPoint_x.get(struct), 8);
                     assertEquals((long) VH_BigPoint_y.get(struct), 16);
                 })},
                 { linkVaListCB("upcallBigStruct"), VaListConsumer.mh(vaList -> {
                     VaList copy = vaList.copy();
-                    MemorySegment struct = vaList.vargAsSegment(BigPoint_LAYOUT);
+                    MemorySegment struct = vaList.vargAsSegment(BigPoint_LAYOUT, ResourceScope.ofImplicit());
                     assertEquals((long) VH_BigPoint_x.get(struct), 8);
                     assertEquals((long) VH_BigPoint_y.get(struct), 16);
 
@@ -671,29 +671,29 @@ public class VaListTest extends NativeTestHelper {
                     VH_BigPoint_y.set(struct, 0);
 
                     // should be independent
-                    struct = copy.vargAsSegment(BigPoint_LAYOUT);
+                    struct = copy.vargAsSegment(BigPoint_LAYOUT, ResourceScope.ofImplicit());
                     assertEquals((long) VH_BigPoint_x.get(struct), 8);
                     assertEquals((long) VH_BigPoint_y.get(struct), 16);
                 })},
                 { linkVaListCB("upcallStruct"), VaListConsumer.mh(vaList -> {
-                    MemorySegment struct = vaList.vargAsSegment(Point_LAYOUT);
+                    MemorySegment struct = vaList.vargAsSegment(Point_LAYOUT, ResourceScope.ofImplicit());
                     assertEquals((int) VH_Point_x.get(struct), 5);
                     assertEquals((int) VH_Point_y.get(struct), 10);
                 })},
                 { linkVaListCB("upcallHugeStruct"), VaListConsumer.mh(vaList -> {
-                    MemorySegment struct = vaList.vargAsSegment(HugePoint_LAYOUT);
+                    MemorySegment struct = vaList.vargAsSegment(HugePoint_LAYOUT, ResourceScope.ofImplicit());
                     assertEquals((long) VH_HugePoint_x.get(struct), 1);
                     assertEquals((long) VH_HugePoint_y.get(struct), 2);
                     assertEquals((long) VH_HugePoint_z.get(struct), 3);
                 })},
                 { linkVaListCB("upcallFloatStruct"), VaListConsumer.mh(vaList -> {
-                    MemorySegment struct = vaList.vargAsSegment(FloatPoint_LAYOUT);
+                    MemorySegment struct = vaList.vargAsSegment(FloatPoint_LAYOUT, ResourceScope.ofImplicit());
                     assertEquals((float) VH_FloatPoint_x.get(struct), 1.0f);
                     assertEquals((float) VH_FloatPoint_y.get(struct), 2.0f);
                 })},
                 { linkVaListCB("upcallMemoryAddress"), VaListConsumer.mh(vaList -> {
                     MemoryAddress intPtr = vaList.vargAsAddress(C_POINTER);
-                    MemorySegment ms = intPtr.asSegment(C_INT.byteSize());
+                    MemorySegment ms = intPtr.asSegment(C_INT.byteSize(), ResourceScope.globalScope());
                     int x = MemoryAccess.getInt(ms);
                     assertEquals(x, 10);
                 })},
@@ -732,12 +732,12 @@ public class VaListTest extends NativeTestHelper {
                     assertEquals((float) vaList.vargAsDouble(C_DOUBLE), 13.0F);
                     assertEquals(vaList.vargAsDouble(C_DOUBLE), 14.0D);
 
-                    MemorySegment point = vaList.vargAsSegment(Point_LAYOUT);
+                    MemorySegment point = vaList.vargAsSegment(Point_LAYOUT, ResourceScope.ofImplicit());
                     assertEquals((int) VH_Point_x.get(point), 5);
                     assertEquals((int) VH_Point_y.get(point), 10);
 
                     VaList copy = vaList.copy();
-                    MemorySegment bigPoint = vaList.vargAsSegment(BigPoint_LAYOUT);
+                    MemorySegment bigPoint = vaList.vargAsSegment(BigPoint_LAYOUT, ResourceScope.ofImplicit());
                     assertEquals((long) VH_BigPoint_x.get(bigPoint), 15);
                     assertEquals((long) VH_BigPoint_y.get(bigPoint), 20);
 
@@ -745,7 +745,7 @@ public class VaListTest extends NativeTestHelper {
                     VH_BigPoint_y.set(bigPoint, 0);
 
                     // should be independent
-                    MemorySegment struct = copy.vargAsSegment(BigPoint_LAYOUT);
+                    MemorySegment struct = copy.vargAsSegment(BigPoint_LAYOUT, ResourceScope.ofImplicit());
                     assertEquals((long) VH_BigPoint_x.get(struct), 15);
                     assertEquals((long) VH_BigPoint_y.get(struct), 20);
                 })},


### PR DESCRIPTION
This patch does a bunch of API cleanups related to overloaded methods:

* Remove ResouceScope-less overloads (in MemorySegment, CLinker, MemoryAddress, VaList)
* Remove ResourceScope factory overloads which take Object attachment (in ResourceScope)
* Fixup javadoc

The changes are mostly mechanical - e.g. an extra ResourceScope.ofImplicit() is added wherever needed.
Similarly, for address to segment conversion, an extra ResourceScope.globalScope() is added.

The term *implicit* has been selected to denote the subset of scopes that are not only managed by a Cleaner, but that do not play into explicit deallocation.

So, ResourceScope.ofImplicit() returns a new implicit scope, whereas ResourceScope.globalScope, returns a constant implicit scope which is assumed to be alive for the entire duration of the application.

A new predicate has been added on ResourceScope, namely `isImplicit` which allows client to see whether a segment supports deterministic closure (we used to have a similar predicate, but was called `isCloseable` and that created confusion w.r.t. the semantics of close() - the new naming is more apt, in that it clearly reflects a permanent property of the resource scope).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [JDK-8264434](https://bugs.openjdk.java.net/browse/JDK-8264434): Remove ResourceScope-less overload from API


### Reviewers
 * [Paul Sandoz](https://openjdk.java.net/census#psandoz) (@PaulSandoz - Committer)
 * [Jorn Vernee](https://openjdk.java.net/census#jvernee) (@JornVernee - Committer) ⚠️ Review applies to 7d3573d64818e177e1f3914fb3cf9d70310d9f66


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/485/head:pull/485` \
`$ git checkout pull/485`

Update a local copy of the PR: \
`$ git checkout pull/485` \
`$ git pull https://git.openjdk.java.net/panama-foreign pull/485/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 485`

View PR using the GUI difftool: \
`$ git pr show -t 485`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/panama-foreign/pull/485.diff">https://git.openjdk.java.net/panama-foreign/pull/485.diff</a>

</details>
