### PR TITLE
8264515: Rename static factory methods in the foreign API

### DIFF
--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/AbstractLayout.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/AbstractLayout.java
@@ -214,22 +214,22 @@ abstract class AbstractLayout implements MemoryLayout {
 
     static final ConstantDesc LITTLE_ENDIAN = DynamicConstantDesc.ofNamed(BSM_GET_STATIC_FINAL, "LITTLE_ENDIAN", CD_BYTEORDER, CD_BYTEORDER);
 
-    static final MethodHandleDesc MH_PADDING = MethodHandleDesc.ofMethod(DirectMethodHandleDesc.Kind.INTERFACE_STATIC, CD_MEMORY_LAYOUT, "ofPaddingBits",
+    static final MethodHandleDesc MH_PADDING = MethodHandleDesc.ofMethod(DirectMethodHandleDesc.Kind.INTERFACE_STATIC, CD_MEMORY_LAYOUT, "paddingLayout",
                 MethodTypeDesc.of(CD_MEMORY_LAYOUT, CD_long));
 
-    static final MethodHandleDesc MH_VALUE = MethodHandleDesc.ofMethod(DirectMethodHandleDesc.Kind.INTERFACE_STATIC, CD_MEMORY_LAYOUT, "ofValueBits",
+    static final MethodHandleDesc MH_VALUE = MethodHandleDesc.ofMethod(DirectMethodHandleDesc.Kind.INTERFACE_STATIC, CD_MEMORY_LAYOUT, "valueLayout",
                 MethodTypeDesc.of(CD_VALUE_LAYOUT, CD_long, CD_BYTEORDER));
 
-    static final MethodHandleDesc MH_SIZED_SEQUENCE = MethodHandleDesc.ofMethod(DirectMethodHandleDesc.Kind.INTERFACE_STATIC, CD_MEMORY_LAYOUT, "ofSequence",
+    static final MethodHandleDesc MH_SIZED_SEQUENCE = MethodHandleDesc.ofMethod(DirectMethodHandleDesc.Kind.INTERFACE_STATIC, CD_MEMORY_LAYOUT, "sequenceLayout",
                 MethodTypeDesc.of(CD_SEQUENCE_LAYOUT, CD_long, CD_MEMORY_LAYOUT));
 
-    static final MethodHandleDesc MH_UNSIZED_SEQUENCE = MethodHandleDesc.ofMethod(DirectMethodHandleDesc.Kind.INTERFACE_STATIC, CD_MEMORY_LAYOUT, "ofSequence",
+    static final MethodHandleDesc MH_UNSIZED_SEQUENCE = MethodHandleDesc.ofMethod(DirectMethodHandleDesc.Kind.INTERFACE_STATIC, CD_MEMORY_LAYOUT, "sequenceLayout",
                 MethodTypeDesc.of(CD_SEQUENCE_LAYOUT, CD_MEMORY_LAYOUT));
 
-    static final MethodHandleDesc MH_STRUCT = MethodHandleDesc.ofMethod(DirectMethodHandleDesc.Kind.INTERFACE_STATIC, CD_MEMORY_LAYOUT, "ofStruct",
+    static final MethodHandleDesc MH_STRUCT = MethodHandleDesc.ofMethod(DirectMethodHandleDesc.Kind.INTERFACE_STATIC, CD_MEMORY_LAYOUT, "structLayout",
                 MethodTypeDesc.of(CD_GROUP_LAYOUT, CD_MEMORY_LAYOUT.arrayType()));
 
-    static final MethodHandleDesc MH_UNION = MethodHandleDesc.ofMethod(DirectMethodHandleDesc.Kind.INTERFACE_STATIC, CD_MEMORY_LAYOUT, "ofUnion",
+    static final MethodHandleDesc MH_UNION = MethodHandleDesc.ofMethod(DirectMethodHandleDesc.Kind.INTERFACE_STATIC, CD_MEMORY_LAYOUT, "unionLayout",
                 MethodTypeDesc.of(CD_GROUP_LAYOUT, CD_MEMORY_LAYOUT.arrayType()));
 
     static final MethodHandleDesc MH_VOID_FUNCTION = MethodHandleDesc.ofMethod(DirectMethodHandleDesc.Kind.STATIC, CD_FUNCTION_DESC, "ofVoid",

--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/CLinker.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/CLinker.java
@@ -25,7 +25,6 @@
  */
 package jdk.incubator.foreign;
 
-import jdk.internal.foreign.MemoryScope;
 import jdk.internal.foreign.NativeMemorySegmentImpl;
 import jdk.internal.foreign.PlatformLayouts;
 import jdk.internal.foreign.abi.SharedUtils;
@@ -35,7 +34,6 @@ import jdk.internal.reflect.Reflection;
 
 import java.lang.constant.Constable;
 import java.lang.invoke.MethodHandle;
-import java.lang.invoke.MethodHandles;
 import java.lang.invoke.MethodType;
 import java.nio.charset.Charset;
 import java.util.Objects;
@@ -285,7 +283,7 @@ public interface CLinker {
      * @return a new native memory segment containing the converted C string.
      */
     static MemorySegment toCString(String str, ResourceScope scope) {
-        return toCString(str, SegmentAllocator.scoped(scope));
+        return toCString(str, SegmentAllocator.ofScope(scope));
     }
 
     /**
@@ -324,7 +322,7 @@ public interface CLinker {
      * @return a new native memory segment containing the converted C string.
      */
     static MemorySegment toCString(String str, Charset charset, ResourceScope scope) {
-        return toCString(str, charset, SegmentAllocator.scoped(scope));
+        return toCString(str, charset, SegmentAllocator.ofScope(scope));
     }
 
     /**

--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/GroupLayout.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/GroupLayout.java
@@ -42,8 +42,8 @@ import java.util.stream.Collectors;
 /**
  * A group layout is used to combine together multiple <em>member layouts</em>. There are two ways in which member layouts
  * can be combined: if member layouts are laid out one after the other, the resulting group layout is said to be a <em>struct</em>
- * (see {@link MemoryLayout#ofStruct(MemoryLayout...)}); conversely, if all member layouts are laid out at the same starting offset,
- * the resulting group layout is said to be a <em>union</em> (see {@link MemoryLayout#ofUnion(MemoryLayout...)}).
+ * (see {@link MemoryLayout#structLayout(MemoryLayout...)}); conversely, if all member layouts are laid out at the same starting offset,
+ * the resulting group layout is said to be a <em>union</em> (see {@link MemoryLayout#unionLayout(MemoryLayout...)}).
  * <p>
  * This is a <a href="{@docRoot}/java.base/java/lang/doc-files/ValueBased.html">value-based</a>
  * class; programmers should treat instances that are
@@ -118,8 +118,8 @@ public final class GroupLayout extends AbstractLayout {
      * Returns the member layouts associated with this group.
      *
      * @apiNote the order in which member layouts are returned is the same order in which member layouts have
-     * been passed to one of the group layout factory methods (see {@link MemoryLayout#ofStruct(MemoryLayout...)},
-     * {@link MemoryLayout#ofUnion(MemoryLayout...)}).
+     * been passed to one of the group layout factory methods (see {@link MemoryLayout#structLayout(MemoryLayout...)},
+     * {@link MemoryLayout#unionLayout(MemoryLayout...)}).
      *
      * @return the member layouts associated with this group.
      */

--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/MemoryHandles.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/MemoryHandles.java
@@ -254,7 +254,7 @@ public final class MemoryHandles {
      * Java {@code int} to avoid dealing with negative values, which would be
      * the case if modeled as a Java {@code short}. This is illustrated in the following example:
      * <blockquote><pre>{@code
-    MemorySegment segment = MemorySegment.allocateNative(2);
+    MemorySegment segment = MemorySegment.allocateNative(2, newImplicitScope());
     VarHandle SHORT_VH = MemoryLayouts.JAVA_SHORT.varHandle(short.class);
     VarHandle INT_VH = MemoryHandles.asUnsigned(SHORT_VH, int.class);
     SHORT_VH.set(segment, (short)-1);

--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/MemoryLayout.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/MemoryLayout.java
@@ -49,7 +49,7 @@ import java.util.stream.Stream;
  * A memory layout can be used to describe the contents of a memory segment in a <em>language neutral</em> fashion.
  * There are two leaves in the layout hierarchy, <em>value layouts</em>, which are used to represent values of given size and kind (see
  * {@link ValueLayout}) and <em>padding layouts</em> which are used, as the name suggests, to represent a portion of a memory
- * segment whose contents should be ignored, and which are primarily present for alignment reasons (see {@link MemoryLayout#ofPaddingBits(long)}).
+ * segment whose contents should be ignored, and which are primarily present for alignment reasons (see {@link MemoryLayout#paddingLayout(long)}).
  * Some common value layout constants are defined in the {@link MemoryLayouts} class.
  * <p>
  * More complex layouts can be derived from simpler ones: a <em>sequence layout</em> denotes a repetition of one or more
@@ -218,7 +218,7 @@ public interface MemoryLayout extends Constable {
      * Does this layout have a specified size? A layout does not have a specified size if it is (or contains) a sequence layout whose
      * size is unspecified (see {@link SequenceLayout#elementCount()}).
      *
-     * Value layouts (see {@link ValueLayout}) and padding layouts (see {@link MemoryLayout#ofPaddingBits(long)})
+     * Value layouts (see {@link ValueLayout}) and padding layouts (see {@link MemoryLayout#paddingLayout(long)})
      * <em>always</em> have a specified size, therefore this method always returns {@code true} in these cases.
      *
      * @return {@code true}, if this layout has a specified size.
@@ -586,7 +586,7 @@ public interface MemoryLayout extends Constable {
     }
 
     /**
-     * Is this a padding layout (e.g. a layout created from {@link #ofPaddingBits(long)}) ?
+     * Is this a padding layout (e.g. a layout created from {@link #paddingLayout(long)}) ?
      * @return true, if this layout is a padding layout.
      */
     boolean isPadding();
@@ -730,7 +730,7 @@ E * (S + I * F)
      * @return the new selector layout.
      * @throws IllegalArgumentException if {@code size <= 0}.
      */
-    static MemoryLayout ofPaddingBits(long size) {
+    static MemoryLayout paddingLayout(long size) {
         AbstractLayout.checkSize(size);
         return new PaddingLayout(size);
     }
@@ -743,7 +743,7 @@ E * (S + I * F)
      * @return a new value layout.
      * @throws IllegalArgumentException if {@code size <= 0}.
      */
-    static ValueLayout ofValueBits(long size, ByteOrder order) {
+    static ValueLayout valueLayout(long size, ByteOrder order) {
         Objects.requireNonNull(order);
         AbstractLayout.checkSize(size);
         return new ValueLayout(order, size);
@@ -757,7 +757,7 @@ E * (S + I * F)
      * @return the new sequence layout with given element layout and size.
      * @throws IllegalArgumentException if {@code elementCount < 0}.
      */
-    static SequenceLayout ofSequence(long elementCount, MemoryLayout elementLayout) {
+    static SequenceLayout sequenceLayout(long elementCount, MemoryLayout elementLayout) {
         AbstractLayout.checkSize(elementCount, true);
         OptionalLong size = OptionalLong.of(elementCount);
         return new SequenceLayout(size, Objects.requireNonNull(elementLayout));
@@ -769,7 +769,7 @@ E * (S + I * F)
      * @param elementLayout the element layout of the sequence layout.
      * @return the new sequence layout with given element layout.
      */
-    static SequenceLayout ofSequence(MemoryLayout elementLayout) {
+    static SequenceLayout sequenceLayout(MemoryLayout elementLayout) {
         return new SequenceLayout(OptionalLong.empty(), Objects.requireNonNull(elementLayout));
     }
 
@@ -779,7 +779,7 @@ E * (S + I * F)
      * @param elements The member layouts of the <em>struct</em> group layout.
      * @return a new <em>struct</em> group layout with given member layouts.
      */
-    static GroupLayout ofStruct(MemoryLayout... elements) {
+    static GroupLayout structLayout(MemoryLayout... elements) {
         Objects.requireNonNull(elements);
         return new GroupLayout(GroupLayout.Kind.STRUCT,
                 Stream.of(elements)
@@ -793,7 +793,7 @@ E * (S + I * F)
      * @param elements The member layouts of the <em>union</em> layout.
      * @return a new <em>union</em> group layout with given member layouts.
      */
-    static GroupLayout ofUnion(MemoryLayout... elements) {
+    static GroupLayout unionLayout(MemoryLayout... elements) {
         Objects.requireNonNull(elements);
         return new GroupLayout(GroupLayout.Kind.UNION,
                 Stream.of(elements)

--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/MemoryLayouts.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/MemoryLayouts.java
@@ -46,87 +46,87 @@ public final class MemoryLayouts {
     /**
      * A value layout constant with size of one byte, and byte order set to {@link ByteOrder#LITTLE_ENDIAN}.
      */
-    public static final ValueLayout BITS_8_LE = MemoryLayout.ofValueBits(8, ByteOrder.LITTLE_ENDIAN);
+    public static final ValueLayout BITS_8_LE = MemoryLayout.valueLayout(8, ByteOrder.LITTLE_ENDIAN);
 
     /**
      * A value layout constant with size of two bytes, and byte order set to {@link ByteOrder#LITTLE_ENDIAN}.
      */
-    public static final ValueLayout BITS_16_LE = MemoryLayout.ofValueBits(16, ByteOrder.LITTLE_ENDIAN);
+    public static final ValueLayout BITS_16_LE = MemoryLayout.valueLayout(16, ByteOrder.LITTLE_ENDIAN);
 
     /**
      * A value layout constant with size of four bytes, and byte order set to {@link ByteOrder#LITTLE_ENDIAN}.
      */
-    public static final ValueLayout BITS_32_LE = MemoryLayout.ofValueBits(32, ByteOrder.LITTLE_ENDIAN);
+    public static final ValueLayout BITS_32_LE = MemoryLayout.valueLayout(32, ByteOrder.LITTLE_ENDIAN);
 
     /**
      * A value layout constant with size of eight bytes, and byte order set to {@link ByteOrder#LITTLE_ENDIAN}.
      */
-    public static final ValueLayout BITS_64_LE = MemoryLayout.ofValueBits(64, ByteOrder.LITTLE_ENDIAN);
+    public static final ValueLayout BITS_64_LE = MemoryLayout.valueLayout(64, ByteOrder.LITTLE_ENDIAN);
 
     /**
      * A value layout constant with size of one byte, and byte order set to {@link ByteOrder#BIG_ENDIAN}.
      */
-    public static final ValueLayout BITS_8_BE = MemoryLayout.ofValueBits(8, ByteOrder.BIG_ENDIAN);
+    public static final ValueLayout BITS_8_BE = MemoryLayout.valueLayout(8, ByteOrder.BIG_ENDIAN);
 
     /**
      * A value layout constant with size of two bytes, and byte order set to {@link ByteOrder#BIG_ENDIAN}.
      */
-    public static final ValueLayout BITS_16_BE = MemoryLayout.ofValueBits(16, ByteOrder.BIG_ENDIAN);
+    public static final ValueLayout BITS_16_BE = MemoryLayout.valueLayout(16, ByteOrder.BIG_ENDIAN);
 
     /**
      * A value layout constant with size of four bytes, and byte order set to {@link ByteOrder#BIG_ENDIAN}.
      */
-    public static final ValueLayout BITS_32_BE = MemoryLayout.ofValueBits(32, ByteOrder.BIG_ENDIAN);
+    public static final ValueLayout BITS_32_BE = MemoryLayout.valueLayout(32, ByteOrder.BIG_ENDIAN);
 
     /**
      * A value layout constant with size of eight bytes, and byte order set to {@link ByteOrder#BIG_ENDIAN}.
      */
-    public static final ValueLayout BITS_64_BE = MemoryLayout.ofValueBits(64, ByteOrder.BIG_ENDIAN);
+    public static final ValueLayout BITS_64_BE = MemoryLayout.valueLayout(64, ByteOrder.BIG_ENDIAN);
 
     /**
      * A padding layout constant with size of one byte.
      */
-    public static final MemoryLayout PAD_8 = MemoryLayout.ofPaddingBits(8);
+    public static final MemoryLayout PAD_8 = MemoryLayout.paddingLayout(8);
 
     /**
      * A padding layout constant with size of two bytes.
      */
-    public static final MemoryLayout PAD_16 = MemoryLayout.ofPaddingBits(16);
+    public static final MemoryLayout PAD_16 = MemoryLayout.paddingLayout(16);
 
     /**
      * A padding layout constant with size of four bytes.
      */
-    public static final MemoryLayout PAD_32 = MemoryLayout.ofPaddingBits(32);
+    public static final MemoryLayout PAD_32 = MemoryLayout.paddingLayout(32);
 
     /**
      * A padding layout constant with size of eight bytes.
      */
-    public static final MemoryLayout PAD_64 = MemoryLayout.ofPaddingBits(64);
+    public static final MemoryLayout PAD_64 = MemoryLayout.paddingLayout(64);
 
     /**
      * A value layout constant whose size is the same as that of a machine address (e.g. {@code size_t}), and byte order set to {@link ByteOrder#nativeOrder()}.
      */
-    public static final ValueLayout ADDRESS = MemoryLayout.ofValueBits(Unsafe.ADDRESS_SIZE * 8, ByteOrder.nativeOrder());
+    public static final ValueLayout ADDRESS = MemoryLayout.valueLayout(Unsafe.ADDRESS_SIZE * 8, ByteOrder.nativeOrder());
 
     /**
      * A value layout constant whose size is the same as that of a Java {@code byte}, and byte order set to {@link ByteOrder#nativeOrder()}.
      */
-    public static final ValueLayout JAVA_BYTE = MemoryLayout.ofValueBits(8, ByteOrder.nativeOrder());
+    public static final ValueLayout JAVA_BYTE = MemoryLayout.valueLayout(8, ByteOrder.nativeOrder());
 
     /**
      * A value layout constant whose size is the same as that of a Java {@code char}, and byte order set to {@link ByteOrder#nativeOrder()}.
      */
-    public static final ValueLayout JAVA_CHAR = MemoryLayout.ofValueBits(16, ByteOrder.nativeOrder());
+    public static final ValueLayout JAVA_CHAR = MemoryLayout.valueLayout(16, ByteOrder.nativeOrder());
 
     /**
      * A value layout constant whose size is the same as that of a Java {@code short}, and byte order set to {@link ByteOrder#nativeOrder()}.
      */
-    public static final ValueLayout JAVA_SHORT = MemoryLayout.ofValueBits(16, ByteOrder.nativeOrder());
+    public static final ValueLayout JAVA_SHORT = MemoryLayout.valueLayout(16, ByteOrder.nativeOrder());
 
     /**
      * A value layout constant whose size is the same as that of a Java {@code int}, and byte order set to {@link ByteOrder#nativeOrder()}.
      */
-    public static final ValueLayout JAVA_INT = MemoryLayout.ofValueBits(32, ByteOrder.nativeOrder());
+    public static final ValueLayout JAVA_INT = MemoryLayout.valueLayout(32, ByteOrder.nativeOrder());
 
     /**
      * A value layout constant whose size is the same as that of a Java {@code long}, and byte order set to {@link ByteOrder#nativeOrder()}.
@@ -136,13 +136,13 @@ public final class MemoryLayouts {
     MemoryLayouts.JAVA_LONG.byteAlignment() == MemoryLayouts.ADDRESS.byteSize();
      * }</pre></blockquote>
      */
-    public static final ValueLayout JAVA_LONG = MemoryLayout.ofValueBits(64, ByteOrder.nativeOrder())
+    public static final ValueLayout JAVA_LONG = MemoryLayout.valueLayout(64, ByteOrder.nativeOrder())
             .withBitAlignment(ADDRESS.bitSize());
 
     /**
      * A value layout constant whose size is the same as that of a Java {@code float}, and byte order set to {@link ByteOrder#nativeOrder()}.
      */
-    public static final ValueLayout JAVA_FLOAT = MemoryLayout.ofValueBits(32, ByteOrder.nativeOrder());
+    public static final ValueLayout JAVA_FLOAT = MemoryLayout.valueLayout(32, ByteOrder.nativeOrder());
 
     /**
      * A value layout constant whose size is the same as that of a Java {@code double}, and byte order set to {@link ByteOrder#nativeOrder()}.
@@ -152,6 +152,6 @@ public final class MemoryLayouts {
     MemoryLayouts.JAVA_DOUBLE.byteAlignment() == MemoryLayouts.ADDRESS.byteSize();
      * }</pre></blockquote>
      */
-    public static final ValueLayout JAVA_DOUBLE = MemoryLayout.ofValueBits(64, ByteOrder.nativeOrder())
+    public static final ValueLayout JAVA_DOUBLE = MemoryLayout.valueLayout(64, ByteOrder.nativeOrder())
             .withBitAlignment(ADDRESS.bitSize());
 }

--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/MemorySegment.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/MemorySegment.java
@@ -31,7 +31,7 @@ import java.nio.ByteBuffer;
 import jdk.internal.foreign.AbstractMemorySegmentImpl;
 import jdk.internal.foreign.HeapMemorySegmentImpl;
 import jdk.internal.foreign.MappedMemorySegmentImpl;
-import jdk.internal.foreign.MemoryScope;
+import jdk.internal.foreign.ResourceScopeImpl;
 import jdk.internal.foreign.NativeMemorySegmentImpl;
 import jdk.internal.vm.annotation.NativeAccess;
 import jdk.internal.reflect.CallerSensitive;
@@ -623,7 +623,7 @@ for (long l = 0; l < segment.byteSize(); l++) {
             throw new IllegalArgumentException("Invalid alignment constraint : " + alignmentBytes);
         }
 
-        return NativeMemorySegmentImpl.makeNativeSegment(bytesSize, alignmentBytes, (MemoryScope) scope);
+        return NativeMemorySegmentImpl.makeNativeSegment(bytesSize, alignmentBytes, (ResourceScopeImpl) scope);
     }
 
     /**
@@ -667,7 +667,7 @@ for (long l = 0; l < segment.byteSize(); l++) {
      */
     static MemorySegment mapFile(Path path, long bytesOffset, long bytesSize, FileChannel.MapMode mapMode, ResourceScope scope) throws IOException {
         Objects.requireNonNull(scope);
-        return MappedMemorySegmentImpl.makeMappedSegment(path, bytesOffset, bytesSize, mapMode, (MemoryScope) scope);
+        return MappedMemorySegmentImpl.makeMappedSegment(path, bytesOffset, bytesSize, mapMode, (ResourceScopeImpl) scope);
     }
 
     /**

--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/SequenceLayout.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/SequenceLayout.java
@@ -32,7 +32,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.OptionalLong;
-import java.util.stream.LongStream;
 
 /**
  * A sequence layout. A sequence layout is used to denote a repetition of a given layout, also called the sequence layout's <em>element layout</em>.
@@ -187,7 +186,7 @@ public final class SequenceLayout extends AbstractLayout {
 
         MemoryLayout res = flat.elementLayout();
         for (int i = elementCounts.length - 1 ; i >= 0 ; i--) {
-            res = MemoryLayout.ofSequence(elementCounts[i], res);
+            res = MemoryLayout.sequenceLayout(elementCounts[i], res);
         }
         return (SequenceLayout)res;
     }
@@ -221,7 +220,7 @@ public final class SequenceLayout extends AbstractLayout {
             count = count * elemSeq.elementCount().orElseThrow(this::badUnboundSequenceLayout);
             elemLayout = elemSeq.elementLayout();
         }
-        return MemoryLayout.ofSequence(count, elemLayout);
+        return MemoryLayout.sequenceLayout(count, elemLayout);
     }
 
     private UnsupportedOperationException badUnboundSequenceLayout() {

--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/package-info.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/package-info.java
@@ -45,7 +45,7 @@
  * ranging from {@code 0} to {@code 9}, we can use the following code:
  *
  * <pre>{@code
-MemorySegment segment = MemorySegment.allocateNative(10 * 4);
+MemorySegment segment = MemorySegment.allocateNative(10 * 4, newImplicitScope());
 for (int i = 0 ; i < 10 ; i++) {
    MemoryAccess.setIntAtIndex(segment, i);
 }
@@ -146,7 +146,7 @@ try (var cString = CLinker.toCString("Hello")) {
  * the original segment accordingly, as follows:
  *
  * <pre>{@code
-MemorySegment segment = MemorySegment.allocateNative(100);
+MemorySegment segment = MemorySegment.allocateNative(100, scope);
 ...
 MemoryAddress addr = ... //obtain address from native code
 int x = MemoryAccess.getIntAtOffset(segment, addr.segmentOffset(segment));

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/AbstractCLinker.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/AbstractCLinker.java
@@ -30,7 +30,6 @@ import jdk.incubator.foreign.CLinker;
 import jdk.incubator.foreign.FunctionDescriptor;
 import jdk.incubator.foreign.MemorySegment;
 import jdk.incubator.foreign.SegmentAllocator;
-import jdk.internal.foreign.MemoryScope;
 import jdk.internal.reflect.CallerSensitive;
 import jdk.internal.reflect.Reflection;
 

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/ArenaAllocator.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/ArenaAllocator.java
@@ -21,7 +21,7 @@ public class ArenaAllocator implements SegmentAllocator {
     }
 
     ArenaAllocator(long initialSize, ResourceScope scope) {
-        this.allocator = SegmentAllocator.malloc(() -> scope);
+        this.allocator = (size, align) -> MemorySegment.allocateNative(size, align, scope);
         this.segment = allocator.allocate(initialSize, 1);
     }
 

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/ConfinedScope.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/ConfinedScope.java
@@ -36,7 +36,7 @@ import java.lang.ref.Reference;
  * owner thread will result in an exception. Because of this restriction, checking the liveness bit
  * can be performed in plain mode.
  */
-final class ConfinedScope extends MemoryScope {
+final class ConfinedScope extends ResourceScopeImpl {
 
     private boolean closed; // = false
     private int lockCount = 0;

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/HeapMemorySegmentImpl.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/HeapMemorySegmentImpl.java
@@ -52,7 +52,7 @@ public abstract class HeapMemorySegmentImpl<H> extends AbstractMemorySegmentImpl
 
     @ForceInline
     HeapMemorySegmentImpl(long offset, H base, long length, int mask) {
-        super(length, mask, MemoryScope.GLOBAL);
+        super(length, mask, ResourceScopeImpl.GLOBAL);
         this.offset = offset;
         this.base = base;
     }
@@ -66,7 +66,7 @@ public abstract class HeapMemorySegmentImpl<H> extends AbstractMemorySegmentImpl
     }
 
     @Override
-    abstract HeapMemorySegmentImpl<H> dup(long offset, long size, int mask, MemoryScope scope);
+    abstract HeapMemorySegmentImpl<H> dup(long offset, long size, int mask, ResourceScopeImpl scope);
 
     @Override
     ByteBuffer makeByteBuffer() {
@@ -86,7 +86,7 @@ public abstract class HeapMemorySegmentImpl<H> extends AbstractMemorySegmentImpl
         }
 
         @Override
-        OfByte dup(long offset, long size, int mask, MemoryScope scope) {
+        OfByte dup(long offset, long size, int mask, ResourceScopeImpl scope) {
             return new OfByte(this.offset + offset, base, size, mask);
         }
 
@@ -109,7 +109,7 @@ public abstract class HeapMemorySegmentImpl<H> extends AbstractMemorySegmentImpl
         }
 
         @Override
-        OfChar dup(long offset, long size, int mask, MemoryScope scope) {
+        OfChar dup(long offset, long size, int mask, ResourceScopeImpl scope) {
             return new OfChar(this.offset + offset, base, size, mask);
         }
 
@@ -132,7 +132,7 @@ public abstract class HeapMemorySegmentImpl<H> extends AbstractMemorySegmentImpl
         }
 
         @Override
-        OfShort dup(long offset, long size, int mask, MemoryScope scope) {
+        OfShort dup(long offset, long size, int mask, ResourceScopeImpl scope) {
             return new OfShort(this.offset + offset, base, size, mask);
         }
 
@@ -155,7 +155,7 @@ public abstract class HeapMemorySegmentImpl<H> extends AbstractMemorySegmentImpl
         }
 
         @Override
-        OfInt dup(long offset, long size, int mask, MemoryScope scope) {
+        OfInt dup(long offset, long size, int mask, ResourceScopeImpl scope) {
             return new OfInt(this.offset + offset, base, size, mask);
         }
 
@@ -178,7 +178,7 @@ public abstract class HeapMemorySegmentImpl<H> extends AbstractMemorySegmentImpl
         }
 
         @Override
-        OfLong dup(long offset, long size, int mask, MemoryScope scope) {
+        OfLong dup(long offset, long size, int mask, ResourceScopeImpl scope) {
             return new OfLong(this.offset + offset, base, size, mask);
         }
 
@@ -201,7 +201,7 @@ public abstract class HeapMemorySegmentImpl<H> extends AbstractMemorySegmentImpl
         }
 
         @Override
-        OfFloat dup(long offset, long size, int mask, MemoryScope scope) {
+        OfFloat dup(long offset, long size, int mask, ResourceScopeImpl scope) {
             return new OfFloat(this.offset + offset, base, size, mask);
         }
 
@@ -224,7 +224,7 @@ public abstract class HeapMemorySegmentImpl<H> extends AbstractMemorySegmentImpl
         }
 
         @Override
-        OfDouble dup(long offset, long size, int mask, MemoryScope scope) {
+        OfDouble dup(long offset, long size, int mask, ResourceScopeImpl scope) {
             return new OfDouble(this.offset + offset, base, size, mask);
         }
 

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/LayoutPath.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/LayoutPath.java
@@ -35,7 +35,6 @@ import jdk.internal.access.foreign.MemorySegmentProxy;
 import jdk.incubator.foreign.GroupLayout;
 import jdk.incubator.foreign.SequenceLayout;
 import jdk.incubator.foreign.ValueLayout;
-import sun.invoke.util.Wrapper;
 
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
@@ -230,9 +229,9 @@ public class LayoutPath {
         } else if (enclosing.layout instanceof SequenceLayout) {
             SequenceLayout seq = (SequenceLayout)enclosing.layout;
             if (seq.elementCount().isPresent()) {
-                return enclosing.map(l -> dup(l, MemoryLayout.ofSequence(seq.elementCount().getAsLong(), newLayout)));
+                return enclosing.map(l -> dup(l, MemoryLayout.sequenceLayout(seq.elementCount().getAsLong(), newLayout)));
             } else {
-                return enclosing.map(l -> dup(l, MemoryLayout.ofSequence(newLayout)));
+                return enclosing.map(l -> dup(l, MemoryLayout.sequenceLayout(newLayout)));
             }
         } else if (enclosing.layout instanceof GroupLayout) {
             GroupLayout g = (GroupLayout)enclosing.layout;
@@ -240,9 +239,9 @@ public class LayoutPath {
             //if we selected a layout in a group we must have a valid index
             newElements.set((int)elementIndex, newLayout);
             if (g.isUnion()) {
-                return enclosing.map(l -> dup(l, MemoryLayout.ofUnion(newElements.toArray(new MemoryLayout[0]))));
+                return enclosing.map(l -> dup(l, MemoryLayout.unionLayout(newElements.toArray(new MemoryLayout[0]))));
             } else {
-                return enclosing.map(l -> dup(l, MemoryLayout.ofStruct(newElements.toArray(new MemoryLayout[0]))));
+                return enclosing.map(l -> dup(l, MemoryLayout.structLayout(newElements.toArray(new MemoryLayout[0]))));
             }
         } else {
             return newLayout;

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/LibrariesHelper.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/LibrariesHelper.java
@@ -90,9 +90,9 @@ public final class LibrariesHelper {
         ResourceScope[] holder = new ResourceScope[1];
         try {
             WeakReference<ResourceScope> scopeRef = loadedLibraries.computeIfAbsent(library, lib -> {
-                MemoryScope s = MemoryScope.createImplicitScope();
+                ResourceScopeImpl s = ResourceScopeImpl.createImplicitScope();
                 holder[0] = s; // keep the scope alive at least until the outer method returns
-                s.addOrCleanupIfFail(MemoryScope.ResourceList.ResourceCleanup.ofRunnable(() -> {
+                s.addOrCleanupIfFail(ResourceScopeImpl.ResourceList.ResourceCleanup.ofRunnable(() -> {
                     nativeLibraries.unload(library);
                     loadedLibraries.remove(library);
                 }));
@@ -144,7 +144,7 @@ public final class LibrariesHelper {
             }
         }
 
-        static LibraryLookup DEFAULT_LOOKUP = new LibraryLookupImpl(NativeLibraries.defaultLibrary, MemoryScope.GLOBAL);
+        static LibraryLookup DEFAULT_LOOKUP = new LibraryLookupImpl(NativeLibraries.defaultLibrary, ResourceScopeImpl.GLOBAL);
     }
 
     /* used for testing */

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/MappedMemorySegmentImpl.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/MappedMemorySegmentImpl.java
@@ -52,7 +52,7 @@ public class MappedMemorySegmentImpl extends NativeMemorySegmentImpl {
 
     static ScopedMemoryAccess SCOPED_MEMORY_ACCESS = ScopedMemoryAccess.getScopedMemoryAccess();
 
-    MappedMemorySegmentImpl(long min, UnmapperProxy unmapper, long length, int mask, MemoryScope scope) {
+    MappedMemorySegmentImpl(long min, UnmapperProxy unmapper, long length, int mask, ResourceScopeImpl scope) {
         super(min, length, mask, scope);
         this.unmapper = unmapper;
     }
@@ -60,11 +60,11 @@ public class MappedMemorySegmentImpl extends NativeMemorySegmentImpl {
     @Override
     ByteBuffer makeByteBuffer() {
         return nioAccess.newMappedByteBuffer(unmapper, min, (int)length, null,
-                scope == MemoryScope.GLOBAL ? null : this);
+                scope == ResourceScopeImpl.GLOBAL ? null : this);
     }
 
     @Override
-    MappedMemorySegmentImpl dup(long offset, long size, int mask, MemoryScope scope) {
+    MappedMemorySegmentImpl dup(long offset, long size, int mask, ResourceScopeImpl scope) {
         return new MappedMemorySegmentImpl(min + offset, unmapper, size, mask, scope);
     }
 
@@ -105,7 +105,7 @@ public class MappedMemorySegmentImpl extends NativeMemorySegmentImpl {
 
     // factories
 
-    public static MemorySegment makeMappedSegment(Path path, long bytesOffset, long bytesSize, FileChannel.MapMode mapMode, MemoryScope scope) throws IOException {
+    public static MemorySegment makeMappedSegment(Path path, long bytesOffset, long bytesSize, FileChannel.MapMode mapMode, ResourceScopeImpl scope) throws IOException {
         Objects.requireNonNull(path);
         Objects.requireNonNull(mapMode);
         scope.checkValidStateSlow();
@@ -125,7 +125,7 @@ public class MappedMemorySegmentImpl extends NativeMemorySegmentImpl {
             if (unmapperProxy != null) {
                 AbstractMemorySegmentImpl segment = new MappedMemorySegmentImpl(unmapperProxy.address(), unmapperProxy, bytesSize,
                         modes, scope);
-                scope.addOrCleanupIfFail(new MemoryScope.ResourceList.ResourceCleanup() {
+                scope.addOrCleanupIfFail(new ResourceScopeImpl.ResourceList.ResourceCleanup() {
                     @Override
                     public void cleanup() {
                         unmapperProxy.unmap();
@@ -150,7 +150,7 @@ public class MappedMemorySegmentImpl extends NativeMemorySegmentImpl {
 
     static class EmptyMappedMemorySegmentImpl extends MappedMemorySegmentImpl {
 
-        public EmptyMappedMemorySegmentImpl(int modes, MemoryScope scope) {
+        public EmptyMappedMemorySegmentImpl(int modes, ResourceScopeImpl scope) {
             super(0, null, 0, modes, scope);
         }
 

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/MemoryAddressImpl.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/MemoryAddressImpl.java
@@ -122,18 +122,18 @@ public final class MemoryAddressImpl implements MemoryAddress {
         }
         return NativeMemorySegmentImpl.makeNativeSegmentUnchecked(this, bytesSize,
                 cleanupAction,
-                (MemoryScope) scope);
+                (ResourceScopeImpl) scope);
     }
 
     public static MemorySegment ofLongUnchecked(long value) {
         return ofLongUnchecked(value, Long.MAX_VALUE);
     }
 
-    public static MemorySegment ofLongUnchecked(long value, long byteSize, MemoryScope memoryScope) {
-        return NativeMemorySegmentImpl.makeNativeSegmentUnchecked(MemoryAddress.ofLong(value), byteSize, null, memoryScope);
+    public static MemorySegment ofLongUnchecked(long value, long byteSize, ResourceScopeImpl resourceScope) {
+        return NativeMemorySegmentImpl.makeNativeSegmentUnchecked(MemoryAddress.ofLong(value), byteSize, null, resourceScope);
     }
 
     public static MemorySegment ofLongUnchecked(long value, long byteSize) {
-        return NativeMemorySegmentImpl.makeNativeSegmentUnchecked(MemoryAddress.ofLong(value), byteSize, null, MemoryScope.GLOBAL);
+        return NativeMemorySegmentImpl.makeNativeSegmentUnchecked(MemoryAddress.ofLong(value), byteSize, null, ResourceScopeImpl.GLOBAL);
     }
 }

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/PlatformLayouts.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/PlatformLayouts.java
@@ -32,7 +32,6 @@ import jdk.incubator.foreign.ValueLayout;
 import java.nio.ByteOrder;
 
 import static java.nio.ByteOrder.LITTLE_ENDIAN;
-import static jdk.incubator.foreign.MemoryLayouts.ADDRESS;
 
 public class PlatformLayouts {
     public static <Z extends MemoryLayout> Z pick(Z sysv, Z win64, Z aarch64) {
@@ -51,42 +50,42 @@ public class PlatformLayouts {
     }
 
     private static ValueLayout ofChar(ByteOrder order, long bitSize) {
-        return MemoryLayout.ofValueBits(bitSize, order)
+        return MemoryLayout.valueLayout(bitSize, order)
                 .withAttribute(CLinker.TypeKind.ATTR_NAME, CLinker.TypeKind.CHAR);
     }
 
     private static ValueLayout ofShort(ByteOrder order, long bitSize) {
-        return MemoryLayout.ofValueBits(bitSize, order)
+        return MemoryLayout.valueLayout(bitSize, order)
                 .withAttribute(CLinker.TypeKind.ATTR_NAME, CLinker.TypeKind.SHORT);
     }
 
     private static ValueLayout ofInt(ByteOrder order, long bitSize) {
-        return MemoryLayout.ofValueBits(bitSize, order)
+        return MemoryLayout.valueLayout(bitSize, order)
                 .withAttribute(CLinker.TypeKind.ATTR_NAME, CLinker.TypeKind.INT);
     }
 
     private static ValueLayout ofLong(ByteOrder order, long bitSize) {
-        return MemoryLayout.ofValueBits(bitSize, order)
+        return MemoryLayout.valueLayout(bitSize, order)
                 .withAttribute(CLinker.TypeKind.ATTR_NAME, CLinker.TypeKind.LONG);
     }
 
     private static ValueLayout ofLongLong(ByteOrder order, long bitSize) {
-        return MemoryLayout.ofValueBits(bitSize, order)
+        return MemoryLayout.valueLayout(bitSize, order)
                 .withAttribute(CLinker.TypeKind.ATTR_NAME, CLinker.TypeKind.LONG_LONG);
     }
 
     private static ValueLayout ofFloat(ByteOrder order, long bitSize) {
-        return MemoryLayout.ofValueBits(bitSize, order)
+        return MemoryLayout.valueLayout(bitSize, order)
                 .withAttribute(CLinker.TypeKind.ATTR_NAME, CLinker.TypeKind.FLOAT);
     }
 
     private static ValueLayout ofDouble(ByteOrder order, long bitSize) {
-        return MemoryLayout.ofValueBits(bitSize, order)
+        return MemoryLayout.valueLayout(bitSize, order)
                 .withAttribute(CLinker.TypeKind.ATTR_NAME, CLinker.TypeKind.DOUBLE);
     }
 
     private static ValueLayout ofPointer(ByteOrder order, long bitSize) {
-        return MemoryLayout.ofValueBits(bitSize, order)
+        return MemoryLayout.valueLayout(bitSize, order)
                 .withAttribute(CLinker.TypeKind.ATTR_NAME, CLinker.TypeKind.POINTER);
     }
 

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/SharedScope.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/SharedScope.java
@@ -42,7 +42,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
  * Since it is the responsibility of the closing thread to make sure that no concurrent access is possible,
  * checking the liveness bit upon access can be performed in plain mode, as in the confined case.
  */
-class SharedScope extends MemoryScope {
+class SharedScope extends ResourceScopeImpl {
 
     private static final ScopedMemoryAccess SCOPED_MEMORY_ACCESS = ScopedMemoryAccess.getScopedMemoryAccess();
 

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/Binding.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/Binding.java
@@ -31,7 +31,7 @@ import jdk.incubator.foreign.MemorySegment;
 import jdk.incubator.foreign.ResourceScope;
 import jdk.incubator.foreign.SegmentAllocator;
 import jdk.internal.foreign.MemoryAddressImpl;
-import jdk.internal.foreign.MemoryScope;
+import jdk.internal.foreign.ResourceScopeImpl;
 
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
@@ -261,8 +261,8 @@ public abstract class Binding {
          * Create a binding context from given native scope.
          */
         public static Context ofBoundedAllocator(long size) {
-            ResourceScope scope = ResourceScope.ofConfined();
-            return new Context(SegmentAllocator.arenaBounded(size, scope), scope);
+            ResourceScope scope = ResourceScope.newConfinedScope();
+            return new Context(SegmentAllocator.arenaAllocator(size, scope), scope);
         }
 
         /**
@@ -283,7 +283,7 @@ public abstract class Binding {
          * the context's allocator is accessed.
          */
         public static Context ofScope() {
-            ResourceScope scope = ResourceScope.ofConfined();
+            ResourceScope scope = ResourceScope.newConfinedScope();
             return new Context(null, scope) {
                 @Override
                 public SegmentAllocator allocator() { throw new UnsupportedOperationException(); }
@@ -989,7 +989,7 @@ public abstract class Binding {
         }
 
         private static MemorySegment toSegment(MemoryAddress operand, long size, Context context) {
-            return MemoryAddressImpl.ofLongUnchecked(operand.toRawLongValue(), size, (MemoryScope) context.scope);
+            return MemoryAddressImpl.ofLongUnchecked(operand.toRawLongValue(), size, (ResourceScopeImpl) context.scope);
         }
 
         @Override

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/ProgrammableInvoker.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/ProgrammableInvoker.java
@@ -49,11 +49,9 @@ import java.util.stream.Stream;
 
 import static java.lang.invoke.MethodHandles.collectArguments;
 import static java.lang.invoke.MethodHandles.dropArguments;
-import static java.lang.invoke.MethodHandles.empty;
 import static java.lang.invoke.MethodHandles.filterArguments;
 import static java.lang.invoke.MethodHandles.identity;
 import static java.lang.invoke.MethodHandles.insertArguments;
-import static java.lang.invoke.MethodHandles.tryFinally;
 import static java.lang.invoke.MethodType.methodType;
 import static sun.security.action.GetBooleanAction.privilegedGetProperty;
 
@@ -264,7 +262,7 @@ public class ProgrammableInvoker {
      */
     Object invokeMoves(long addr, Object[] args, Binding.VMStore[] argBindings, Binding.VMLoad[] returnBindings) {
         MemorySegment stackArgsSeg = null;
-        try (ResourceScope scope = ResourceScope.ofConfined()) {
+        try (ResourceScope scope = ResourceScope.newConfinedScope()) {
             MemorySegment argBuffer = MemorySegment.allocateNative(layout.size, 64, scope);
             if (stackArgsBytes > 0) {
                 stackArgsSeg = MemorySegment.allocateNative(stackArgsBytes, 8, scope);

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/UpcallStubs.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/UpcallStubs.java
@@ -26,12 +26,12 @@ package jdk.internal.foreign.abi;
 
 import jdk.incubator.foreign.MemoryAddress;
 import jdk.incubator.foreign.MemorySegment;
-import jdk.internal.foreign.MemoryScope;
+import jdk.internal.foreign.ResourceScopeImpl;
 import jdk.internal.foreign.NativeMemorySegmentImpl;
 
 public class UpcallStubs {
 
-    public static MemorySegment upcallAddress(UpcallHandler handler, MemoryScope scope) {
+    public static MemorySegment upcallAddress(UpcallHandler handler, ResourceScopeImpl scope) {
         long stubAddress = handler.entryPoint();
         return NativeMemorySegmentImpl.makeNativeSegmentUnchecked(MemoryAddress.ofLong(stubAddress), 0,
                 () -> freeUpcallStub(stubAddress), scope);

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/aarch64/AArch64Linker.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/aarch64/AArch64Linker.java
@@ -30,8 +30,7 @@ import jdk.incubator.foreign.MemoryAddress;
 import jdk.incubator.foreign.MemorySegment;
 import jdk.incubator.foreign.ResourceScope;
 import jdk.internal.foreign.AbstractCLinker;
-import jdk.internal.foreign.MemoryScope;
-import jdk.internal.foreign.abi.Binding;
+import jdk.internal.foreign.ResourceScopeImpl;
 import jdk.internal.foreign.abi.SharedUtils;
 import jdk.internal.foreign.abi.UpcallStubs;
 import jdk.internal.reflect.CallerSensitive;
@@ -98,7 +97,7 @@ public final class AArch64Linker extends AbstractCLinker {
         Objects.requireNonNull(target);
         Objects.requireNonNull(function);
         target = SharedUtils.boxVaLists(target, MH_boxVaList);
-        return UpcallStubs.upcallAddress(CallArranger.arrangeUpcall(target, target.type(), function), (MemoryScope) scope);
+        return UpcallStubs.upcallAddress(CallArranger.arrangeUpcall(target, target.type(), function), (ResourceScopeImpl) scope);
     }
 
     public static VaList newVaList(Consumer<VaList.Builder> actions, ResourceScope scope) {

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/x64/sysv/SysVx64Linker.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/x64/sysv/SysVx64Linker.java
@@ -30,8 +30,7 @@ import jdk.incubator.foreign.MemoryAddress;
 import jdk.incubator.foreign.MemorySegment;
 import jdk.incubator.foreign.ResourceScope;
 import jdk.internal.foreign.AbstractCLinker;
-import jdk.internal.foreign.MemoryScope;
-import jdk.internal.foreign.abi.Binding;
+import jdk.internal.foreign.ResourceScopeImpl;
 import jdk.internal.foreign.abi.SharedUtils;
 import jdk.internal.foreign.abi.UpcallStubs;
 import jdk.internal.reflect.CallerSensitive;
@@ -109,7 +108,7 @@ public final class SysVx64Linker extends AbstractCLinker {
         Objects.requireNonNull(target);
         Objects.requireNonNull(function);
         target = SharedUtils.boxVaLists(target, MH_boxVaList);
-        return UpcallStubs.upcallAddress(CallArranger.arrangeUpcall(target, target.type(), function), (MemoryScope) scope);
+        return UpcallStubs.upcallAddress(CallArranger.arrangeUpcall(target, target.type(), function), (ResourceScopeImpl) scope);
     }
 
     public static VaList newVaListOfAddress(MemoryAddress ma, ResourceScope scope) {

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/x64/windows/WinVaList.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/x64/windows/WinVaList.java
@@ -27,7 +27,7 @@ package jdk.internal.foreign.abi.x64.windows;
 
 import jdk.incubator.foreign.*;
 import jdk.incubator.foreign.CLinker.VaList;
-import jdk.internal.foreign.MemoryScope;
+import jdk.internal.foreign.ResourceScopeImpl;
 import jdk.internal.foreign.abi.SharedUtils;
 import jdk.internal.foreign.abi.SharedUtils.SimpleVaArg;
 
@@ -102,7 +102,7 @@ class WinVaList implements VaList {
 
     @Override
     public MemorySegment vargAsSegment(MemoryLayout layout, ResourceScope scope) {
-        return vargAsSegment(layout, SegmentAllocator.scoped(scope));
+        return vargAsSegment(layout, SegmentAllocator.ofScope(scope));
     }
 
     private Object read(Class<?> carrier, MemoryLayout layout) {
@@ -161,7 +161,7 @@ class WinVaList implements VaList {
 
     @Override
     public VaList copy() {
-        ((MemoryScope)scope).checkValidStateSlow();
+        ((ResourceScopeImpl)scope).checkValidStateSlow();
         return new WinVaList(segment, scope);
     }
 
@@ -176,7 +176,7 @@ class WinVaList implements VaList {
         private final List<SimpleVaArg> args = new ArrayList<>();
 
         public Builder(ResourceScope scope) {
-            ((MemoryScope)scope).checkValidStateSlow();
+            ((ResourceScopeImpl)scope).checkValidStateSlow();
             this.scope = scope;
         }
 
@@ -217,7 +217,7 @@ class WinVaList implements VaList {
             if (args.isEmpty()) {
                 return EMPTY;
             }
-            SegmentAllocator allocator = SegmentAllocator.arenaUnbounded(scope);
+            SegmentAllocator allocator = SegmentAllocator.arenaAllocator(scope);
             MemorySegment segment = allocator.allocate(VA_SLOT_SIZE_BYTES * args.size());
             List<MemorySegment> attachedSegments = new ArrayList<>();
             attachedSegments.add(segment);

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/x64/windows/Windowsx64Linker.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/x64/windows/Windowsx64Linker.java
@@ -29,8 +29,7 @@ import jdk.incubator.foreign.MemoryAddress;
 import jdk.incubator.foreign.MemorySegment;
 import jdk.incubator.foreign.ResourceScope;
 import jdk.internal.foreign.AbstractCLinker;
-import jdk.internal.foreign.MemoryScope;
-import jdk.internal.foreign.abi.Binding;
+import jdk.internal.foreign.ResourceScopeImpl;
 import jdk.internal.foreign.abi.SharedUtils;
 import jdk.internal.foreign.abi.UpcallStubs;
 import jdk.internal.reflect.CallerSensitive;
@@ -110,7 +109,7 @@ public final class Windowsx64Linker extends AbstractCLinker {
         Objects.requireNonNull(target);
         Objects.requireNonNull(function);
         target = SharedUtils.boxVaLists(target, MH_boxVaList);
-        return UpcallStubs.upcallAddress(CallArranger.arrangeUpcall(target, target.type(), function), (MemoryScope) scope);
+        return UpcallStubs.upcallAddress(CallArranger.arrangeUpcall(target, target.type(), function), (ResourceScopeImpl) scope);
     }
 
     public static VaList newVaListOfAddress(MemoryAddress ma, ResourceScope scope) {

--- a/test/jdk/java/foreign/NativeTestHelper.java
+++ b/test/jdk/java/foreign/NativeTestHelper.java
@@ -51,9 +51,9 @@ public class NativeTestHelper {
         long allocatedBytes = 0;
 
         public NativeScope() {
-            this.resourceScope = ResourceScope.ofConfined();
+            this.resourceScope = ResourceScope.newConfinedScope();
             this.scopeHandle = resourceScope.acquire();
-            this.allocator = SegmentAllocator.arenaUnbounded(resourceScope);
+            this.allocator = SegmentAllocator.arenaAllocator(resourceScope);
         }
 
         @Override

--- a/test/jdk/java/foreign/StdLibTest.java
+++ b/test/jdk/java/foreign/StdLibTest.java
@@ -207,7 +207,7 @@ public class StdLibTest {
         }
 
         String strcat(String s1, String s2) throws Throwable {
-            try (ResourceScope scope = ResourceScope.ofConfined()) {
+            try (ResourceScope scope = ResourceScope.newConfinedScope()) {
                 MemorySegment buf = MemorySegment.allocateNative(s1.length() + s2.length() + 1, scope);
                 MemorySegment other = toCString(s2, scope);
                 char[] chars = s1.toCharArray();
@@ -220,7 +220,7 @@ public class StdLibTest {
         }
 
         int strcmp(String s1, String s2) throws Throwable {
-            try (ResourceScope scope = ResourceScope.ofConfined()) {
+            try (ResourceScope scope = ResourceScope.newConfinedScope()) {
                 MemorySegment ns1 = toCString(s1, scope);
                 MemorySegment ns2 = toCString(s2, scope);
                 return (int)strcmp.invokeExact(ns1.address(), ns2.address());
@@ -228,21 +228,21 @@ public class StdLibTest {
         }
 
         int puts(String msg) throws Throwable {
-            try (ResourceScope scope = ResourceScope.ofConfined()) {
+            try (ResourceScope scope = ResourceScope.newConfinedScope()) {
                 MemorySegment s = toCString(msg, scope);
                 return (int)puts.invokeExact(s.address());
             }
         }
 
         int strlen(String msg) throws Throwable {
-            try (ResourceScope scope = ResourceScope.ofConfined()) {
+            try (ResourceScope scope = ResourceScope.newConfinedScope()) {
                 MemorySegment s = toCString(msg, scope);
                 return (int)strlen.invokeExact(s.address());
             }
         }
 
         Tm gmtime(long arg) throws Throwable {
-            try (ResourceScope scope = ResourceScope.ofConfined()) {
+            try (ResourceScope scope = ResourceScope.newConfinedScope()) {
                 MemorySegment time = MemorySegment.allocateNative(8, scope);
                 setLong(time, arg);
                 return new Tm((MemoryAddress)gmtime.invokeExact(time.address()));
@@ -292,8 +292,8 @@ public class StdLibTest {
 
         int[] qsort(int[] arr) throws Throwable {
             //init native array
-            try (ResourceScope scope = ResourceScope.ofConfined()) {
-                SegmentAllocator allocator = SegmentAllocator.scoped(scope);
+            try (ResourceScope scope = ResourceScope.newConfinedScope()) {
+                SegmentAllocator allocator = SegmentAllocator.ofScope(scope);
                 MemorySegment nativeArr = allocator.allocateArray(C_INT, arr);
 
                 //call qsort
@@ -316,7 +316,7 @@ public class StdLibTest {
         }
 
         int printf(String format, List<PrintfArg> args) throws Throwable {
-            try (ResourceScope scope = ResourceScope.ofConfined()) {
+            try (ResourceScope scope = ResourceScope.newConfinedScope()) {
                 MemorySegment formatStr = toCString(format, scope);
                 return (int)specializedPrintf(args).invokeExact(formatStr.address(),
                         args.stream().map(a -> a.nativeValue(scope)).toArray());
@@ -324,7 +324,7 @@ public class StdLibTest {
         }
 
         int vprintf(String format, List<PrintfArg> args) throws Throwable {
-            try (ResourceScope scope = ResourceScope.ofConfined()) {
+            try (ResourceScope scope = ResourceScope.newConfinedScope()) {
                 MemorySegment formatStr = toCString(format, scope);
                 VaList vaList = VaList.make(b -> args.forEach(a -> a.accept(b, scope)), scope);
                 return (int)vprintf.invokeExact(formatStr.address(), vaList);

--- a/test/jdk/java/foreign/TestAdaptVarHandles.java
+++ b/test/jdk/java/foreign/TestAdaptVarHandles.java
@@ -30,7 +30,6 @@
  * @run testng/othervm -Djava.lang.invoke.VarHandle.VAR_HANDLE_GUARDS=false -Djava.lang.invoke.VarHandle.VAR_HANDLE_IDENTITY_ADAPT=true -Xverify:all TestAdaptVarHandles
  */
 
-import jdk.incubator.foreign.MemoryAddress;
 import jdk.incubator.foreign.MemoryHandles;
 import jdk.incubator.foreign.MemoryLayout;
 import jdk.incubator.foreign.MemoryLayouts;
@@ -87,7 +86,7 @@ public class TestAdaptVarHandles {
         }
     }
 
-    static final VarHandle intHandleIndexed = MemoryLayout.ofSequence(MemoryLayouts.JAVA_INT)
+    static final VarHandle intHandleIndexed = MemoryLayout.sequenceLayout(MemoryLayouts.JAVA_INT)
             .varHandle(int.class, MemoryLayout.PathElement.sequenceElement());
 
     static final VarHandle intHandle = MemoryLayouts.JAVA_INT.varHandle(int.class);
@@ -97,7 +96,7 @@ public class TestAdaptVarHandles {
     @Test
     public void testFilterValue() throws Throwable {
         ValueLayout layout = MemoryLayouts.JAVA_INT;
-        MemorySegment segment = MemorySegment.allocateNative(layout, ResourceScope.ofImplicit());
+        MemorySegment segment = MemorySegment.allocateNative(layout, ResourceScope.newImplicitScope());
         VarHandle intHandle = layout.varHandle(int.class);
         VarHandle i2SHandle = MemoryHandles.filterValue(intHandle, S2I, I2S);
         i2SHandle.set(segment, "1");
@@ -116,7 +115,7 @@ public class TestAdaptVarHandles {
     @Test
     public void testFilterValueComposite() throws Throwable {
         ValueLayout layout = MemoryLayouts.JAVA_INT;
-        MemorySegment segment = MemorySegment.allocateNative(layout, ResourceScope.ofImplicit());
+        MemorySegment segment = MemorySegment.allocateNative(layout, ResourceScope.newImplicitScope());
         VarHandle intHandle = layout.varHandle(int.class);
         MethodHandle CTX_S2I = MethodHandles.dropArguments(S2I, 0, String.class, String.class);
         VarHandle i2SHandle = MemoryHandles.filterValue(intHandle, CTX_S2I, CTX_I2S);
@@ -137,7 +136,7 @@ public class TestAdaptVarHandles {
     @Test
     public void testFilterValueLoose() throws Throwable {
         ValueLayout layout = MemoryLayouts.JAVA_INT;
-        MemorySegment segment = MemorySegment.allocateNative(layout, ResourceScope.ofImplicit());
+        MemorySegment segment = MemorySegment.allocateNative(layout, ResourceScope.newImplicitScope());
         VarHandle intHandle = layout.varHandle(int.class);
         VarHandle i2SHandle = MemoryHandles.filterValue(intHandle, O2I, I2O);
         i2SHandle.set(segment, "1");
@@ -205,7 +204,7 @@ public class TestAdaptVarHandles {
     @Test
     public void testFilterCoordinates() throws Throwable {
         ValueLayout layout = MemoryLayouts.JAVA_INT;
-        MemorySegment segment = MemorySegment.allocateNative(layout, ResourceScope.ofImplicit());
+        MemorySegment segment = MemorySegment.allocateNative(layout, ResourceScope.newImplicitScope());
         VarHandle intHandle_longIndex = MemoryHandles.filterCoordinates(intHandleIndexed, 0, BASE_ADDR, S2L);
         intHandle_longIndex.set(segment, "0", 1);
         int oldValue = (int)intHandle_longIndex.getAndAdd(segment, "0", 42);
@@ -248,7 +247,7 @@ public class TestAdaptVarHandles {
     @Test
     public void testInsertCoordinates() throws Throwable {
         ValueLayout layout = MemoryLayouts.JAVA_INT;
-        MemorySegment segment = MemorySegment.allocateNative(layout, ResourceScope.ofImplicit());
+        MemorySegment segment = MemorySegment.allocateNative(layout, ResourceScope.newImplicitScope());
         VarHandle intHandle_longIndex = MemoryHandles.insertCoordinates(intHandleIndexed, 0, segment, 0L);
         intHandle_longIndex.set(1);
         int oldValue = (int)intHandle_longIndex.getAndAdd(42);
@@ -286,7 +285,7 @@ public class TestAdaptVarHandles {
     @Test
     public void testPermuteCoordinates() throws Throwable {
         ValueLayout layout = MemoryLayouts.JAVA_INT;
-        MemorySegment segment = MemorySegment.allocateNative(layout, ResourceScope.ofImplicit());
+        MemorySegment segment = MemorySegment.allocateNative(layout, ResourceScope.newImplicitScope());
         VarHandle intHandle_swap = MemoryHandles.permuteCoordinates(intHandleIndexed,
                 List.of(long.class, MemorySegment.class), 1, 0);
         intHandle_swap.set(0L, segment, 1);
@@ -325,7 +324,7 @@ public class TestAdaptVarHandles {
     @Test
     public void testCollectCoordinates() throws Throwable {
         ValueLayout layout = MemoryLayouts.JAVA_INT;
-        MemorySegment segment = MemorySegment.allocateNative(layout, ResourceScope.ofImplicit());
+        MemorySegment segment = MemorySegment.allocateNative(layout, ResourceScope.newImplicitScope());
         VarHandle intHandle_sum = MemoryHandles.collectCoordinates(intHandleIndexed, 1, SUM_OFFSETS);
         intHandle_sum.set(segment, -2L, 2L, 1);
         int oldValue = (int)intHandle_sum.getAndAdd(segment, -2L, 2L, 42);
@@ -368,7 +367,7 @@ public class TestAdaptVarHandles {
     @Test
     public void testDropCoordinates() throws Throwable {
         ValueLayout layout = MemoryLayouts.JAVA_INT;
-        MemorySegment segment = MemorySegment.allocateNative(layout, ResourceScope.ofImplicit());
+        MemorySegment segment = MemorySegment.allocateNative(layout, ResourceScope.newImplicitScope());
         VarHandle intHandle_dummy = MemoryHandles.dropCoordinates(intHandleIndexed, 1, float.class, String.class);
         intHandle_dummy.set(segment, 1f, "hello", 0L, 1);
         int oldValue = (int)intHandle_dummy.getAndAdd(segment, 1f, "hello", 0L, 42);

--- a/test/jdk/java/foreign/TestAddressHandle.java
+++ b/test/jdk/java/foreign/TestAddressHandle.java
@@ -62,7 +62,7 @@ public class TestAddressHandle {
     @Test(dataProvider = "addressHandles")
     public void testAddressHandle(VarHandle addrHandle, int byteSize) {
         VarHandle longHandle = MemoryLayouts.JAVA_LONG.varHandle(long.class);
-        try (ResourceScope scope = ResourceScope.ofConfined()) {
+        try (ResourceScope scope = ResourceScope.newConfinedScope()) {
             MemorySegment segment = MemorySegment.allocateNative(8, scope);
             MemorySegment target = ByteOrder.nativeOrder() == ByteOrder.BIG_ENDIAN ?
                     segment.asSlice(8 - byteSize) :
@@ -79,7 +79,7 @@ public class TestAddressHandle {
     @Test(dataProvider = "addressHandles")
     public void testNull(VarHandle addrHandle, int byteSize) {
         VarHandle longHandle = MemoryLayouts.JAVA_LONG.varHandle(long.class);
-        try (ResourceScope scope = ResourceScope.ofConfined()) {
+        try (ResourceScope scope = ResourceScope.newConfinedScope()) {
             MemorySegment segment = MemorySegment.allocateNative(8, scope);
             longHandle.set(segment, 0L);
             MemoryAddress address = (MemoryAddress)addrHandle.get(segment);

--- a/test/jdk/java/foreign/TestArrays.java
+++ b/test/jdk/java/foreign/TestArrays.java
@@ -47,31 +47,31 @@ import static org.testng.Assert.*;
 
 public class TestArrays {
 
-    static SequenceLayout bytes = MemoryLayout.ofSequence(100,
+    static SequenceLayout bytes = MemoryLayout.sequenceLayout(100,
             MemoryLayouts.JAVA_BYTE
     );
 
-    static SequenceLayout chars = MemoryLayout.ofSequence(100,
+    static SequenceLayout chars = MemoryLayout.sequenceLayout(100,
             MemoryLayouts.JAVA_CHAR
     );
 
-    static SequenceLayout shorts = MemoryLayout.ofSequence(100,
+    static SequenceLayout shorts = MemoryLayout.sequenceLayout(100,
             MemoryLayouts.JAVA_SHORT
     );
 
-    static SequenceLayout ints = MemoryLayout.ofSequence(100,
+    static SequenceLayout ints = MemoryLayout.sequenceLayout(100,
             MemoryLayouts.JAVA_INT
     );
 
-    static SequenceLayout floats = MemoryLayout.ofSequence(100,
+    static SequenceLayout floats = MemoryLayout.sequenceLayout(100,
             MemoryLayouts.JAVA_FLOAT
     );
 
-    static SequenceLayout longs = MemoryLayout.ofSequence(100,
+    static SequenceLayout longs = MemoryLayout.sequenceLayout(100,
             MemoryLayouts.JAVA_LONG
     );
 
-    static SequenceLayout doubles = MemoryLayout.ofSequence(100,
+    static SequenceLayout doubles = MemoryLayout.sequenceLayout(100,
             MemoryLayouts.JAVA_DOUBLE
     );
 
@@ -101,7 +101,7 @@ public class TestArrays {
 
     @Test(dataProvider = "arrays")
     public void testArrays(Consumer<MemorySegment> init, Consumer<MemorySegment> checker, MemoryLayout layout) {
-        MemorySegment segment = MemorySegment.allocateNative(layout, ResourceScope.ofImplicit());
+        MemorySegment segment = MemorySegment.allocateNative(layout, ResourceScope.newImplicitScope());
         init.accept(segment);
         assertFalse(segment.isReadOnly());
         checker.accept(segment);
@@ -110,7 +110,7 @@ public class TestArrays {
     @Test(dataProvider = "elemLayouts",
             expectedExceptions = IllegalStateException.class)
     public void testTooBigForArray(MemoryLayout layout, Function<MemorySegment, Object> arrayFactory) {
-        MemoryLayout seq = MemoryLayout.ofSequence((Integer.MAX_VALUE * layout.byteSize()) + 1, layout);
+        MemoryLayout seq = MemoryLayout.sequenceLayout((Integer.MAX_VALUE * layout.byteSize()) + 1, layout);
         //do not really allocate here, as it's way too much memory
         MemorySegment segment = MemoryAddress.NULL.asSegment(seq.byteSize(), ResourceScope.globalScope());
         arrayFactory.apply(segment);
@@ -120,7 +120,7 @@ public class TestArrays {
             expectedExceptions = IllegalStateException.class)
     public void testBadSize(MemoryLayout layout, Function<MemorySegment, Object> arrayFactory) {
         if (layout.byteSize() == 1) throw new IllegalStateException(); //make it fail
-        try (ResourceScope scope = ResourceScope.ofConfined()) {
+        try (ResourceScope scope = ResourceScope.newConfinedScope()) {
             MemorySegment segment = MemorySegment.allocateNative(layout.byteSize() + 1, layout.byteSize(), scope);
             arrayFactory.apply(segment);
         }
@@ -129,7 +129,7 @@ public class TestArrays {
     @Test(dataProvider = "elemLayouts",
             expectedExceptions = IllegalStateException.class)
     public void testArrayFromClosedSegment(MemoryLayout layout, Function<MemorySegment, Object> arrayFactory) {
-        MemorySegment segment = MemorySegment.allocateNative(layout, ResourceScope.ofConfined());
+        MemorySegment segment = MemorySegment.allocateNative(layout, ResourceScope.newConfinedScope());
         segment.scope().close();
         arrayFactory.apply(segment);
     }

--- a/test/jdk/java/foreign/TestCondy.java
+++ b/test/jdk/java/foreign/TestCondy.java
@@ -69,12 +69,12 @@ public class TestCondy {
 
         testValues.addAll(Arrays.asList(constants));
 
-        testValues.add(MemoryLayout.ofStruct(constants));
-        testValues.add(MemoryLayout.ofUnion(constants));
+        testValues.add(MemoryLayout.structLayout(constants));
+        testValues.add(MemoryLayout.unionLayout(constants));
 
         for (MemoryLayout ml : constants) {
-            testValues.add(MemoryLayout.ofSequence(ml));
-            testValues.add(MemoryLayout.ofSequence(10, ml));
+            testValues.add(MemoryLayout.sequenceLayout(ml));
+            testValues.add(MemoryLayout.sequenceLayout(10, ml));
         }
 
         testValues.add(FunctionDescriptor.ofVoid(constants));

--- a/test/jdk/java/foreign/TestDowncall.java
+++ b/test/jdk/java/foreign/TestDowncall.java
@@ -93,7 +93,7 @@ public class TestDowncall extends CallGeneratorHelper {
         if (count % 100 == 0) {
             System.gc();
         }
-        Object res = doCall(addr, SegmentAllocator.implicit(), mt, descriptor, args);
+        Object res = doCall(addr, IMPLICIT_ALLOCATOR, mt, descriptor, args);
         if (ret == Ret.NON_VOID) {
             checks.forEach(c -> c.accept(res));
             if (needsScope) {

--- a/test/jdk/java/foreign/TestHandshake.java
+++ b/test/jdk/java/foreign/TestHandshake.java
@@ -64,7 +64,7 @@ public class TestHandshake {
     @Test(dataProvider = "accessors")
     public void testHandshake(String testName, AccessorFactory accessorFactory) throws InterruptedException {
         for (int it = 0 ; it < ITERATIONS ; it++) {
-            ResourceScope scope = ResourceScope.ofShared();
+            ResourceScope scope = ResourceScope.newSharedScope();
             MemorySegment segment = MemorySegment.allocateNative(SEGMENT_SIZE, 1, scope);
             System.out.println("ITERATION " + it);
             ExecutorService accessExecutor = Executors.newCachedThreadPool();

--- a/test/jdk/java/foreign/TestIllegalLink.java
+++ b/test/jdk/java/foreign/TestIllegalLink.java
@@ -73,7 +73,7 @@ public class TestIllegalLink {
             },
             {
                 MethodType.methodType(void.class, int.class),
-                FunctionDescriptor.ofVoid(MemoryLayout.ofPaddingBits(32)),
+                FunctionDescriptor.ofVoid(MemoryLayout.paddingLayout(32)),
                 "Expected a ValueLayout"
             },
             {
@@ -88,7 +88,7 @@ public class TestIllegalLink {
             },
             {
                 MethodType.methodType(void.class, MemoryAddress.class),
-                FunctionDescriptor.ofVoid(MemoryLayout.ofPaddingBits(64)),
+                FunctionDescriptor.ofVoid(MemoryLayout.paddingLayout(64)),
                 "Expected a ValueLayout"
             },
             {

--- a/test/jdk/java/foreign/TestLayoutConstants.java
+++ b/test/jdk/java/foreign/TestLayoutConstants.java
@@ -67,43 +67,43 @@ public class TestLayoutConstants {
         return new Object[][] {
                 //padding
                 { MemoryLayouts.PAD_32 },
-                { MemoryLayout.ofSequence(MemoryLayouts.PAD_32) },
-                { MemoryLayout.ofSequence(5, MemoryLayouts.PAD_32) },
-                { MemoryLayout.ofStruct(MemoryLayouts.PAD_32, MemoryLayouts.PAD_32) },
-                { MemoryLayout.ofUnion(MemoryLayouts.PAD_32, MemoryLayouts.PAD_32) },
+                { MemoryLayout.sequenceLayout(MemoryLayouts.PAD_32) },
+                { MemoryLayout.sequenceLayout(5, MemoryLayouts.PAD_32) },
+                { MemoryLayout.structLayout(MemoryLayouts.PAD_32, MemoryLayouts.PAD_32) },
+                { MemoryLayout.unionLayout(MemoryLayouts.PAD_32, MemoryLayouts.PAD_32) },
                 //values, big endian
                 { MemoryLayouts.BITS_32_BE },
-                { MemoryLayout.ofStruct(
+                { MemoryLayout.structLayout(
                         MemoryLayouts.BITS_32_BE,
                         MemoryLayouts.BITS_32_BE) },
-                { MemoryLayout.ofUnion(
+                { MemoryLayout.unionLayout(
                         MemoryLayouts.BITS_32_BE,
                         MemoryLayouts.BITS_32_BE) },
                 //values, little endian
                 { MemoryLayouts.BITS_32_LE },
-                { MemoryLayout.ofStruct(
+                { MemoryLayout.structLayout(
                         MemoryLayouts.BITS_32_LE,
                         MemoryLayouts.BITS_32_LE) },
-                { MemoryLayout.ofUnion(
+                { MemoryLayout.unionLayout(
                         MemoryLayouts.BITS_32_LE,
                         MemoryLayouts.BITS_32_LE) },
                 //deeply nested
-                { MemoryLayout.ofStruct(
+                { MemoryLayout.structLayout(
                         MemoryLayouts.PAD_16,
-                        MemoryLayout.ofStruct(
+                        MemoryLayout.structLayout(
                                 MemoryLayouts.PAD_8,
                                 MemoryLayouts.BITS_32_BE)) },
-                { MemoryLayout.ofUnion(
+                { MemoryLayout.unionLayout(
                         MemoryLayouts.PAD_16,
-                        MemoryLayout.ofStruct(
+                        MemoryLayout.structLayout(
                                 MemoryLayouts.PAD_8,
                                 MemoryLayouts.BITS_32_BE)) },
-                { MemoryLayout.ofSequence(
-                        MemoryLayout.ofStruct(
+                { MemoryLayout.sequenceLayout(
+                        MemoryLayout.structLayout(
                                 MemoryLayouts.PAD_8,
                                 MemoryLayouts.BITS_32_BE)) },
-                { MemoryLayout.ofSequence(5,
-                        MemoryLayout.ofStruct(
+                { MemoryLayout.sequenceLayout(5,
+                        MemoryLayout.structLayout(
                                 MemoryLayouts.PAD_8,
                                 MemoryLayouts.BITS_32_BE)) },
                 { MemoryLayouts.BITS_32_LE.withName("myInt") },

--- a/test/jdk/java/foreign/TestLayoutEquality.java
+++ b/test/jdk/java/foreign/TestLayoutEquality.java
@@ -45,7 +45,7 @@ public class TestLayoutEquality {
 
     @Test(dataProvider = "layoutConstants")
     public void testReconstructedEquality(ValueLayout layout) {
-        ValueLayout newLayout = MemoryLayout.ofValueBits(layout.bitSize(), layout.order());
+        ValueLayout newLayout = MemoryLayout.valueLayout(layout.bitSize(), layout.order());
 
         // properties should be equal
         assertEquals(newLayout.bitSize(), layout.bitSize());

--- a/test/jdk/java/foreign/TestLayoutPaths.java
+++ b/test/jdk/java/foreign/TestLayoutPaths.java
@@ -52,61 +52,61 @@ public class TestLayoutPaths {
 
     @Test(expectedExceptions = IllegalArgumentException.class)
     public void testBadBitSelectFromSeq() {
-        SequenceLayout seq = MemoryLayout.ofSequence(JAVA_INT);
+        SequenceLayout seq = MemoryLayout.sequenceLayout(JAVA_INT);
         seq.bitOffset(groupElement("foo"));
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class)
     public void testBadByteSelectFromSeq() {
-        SequenceLayout seq = MemoryLayout.ofSequence(JAVA_INT);
+        SequenceLayout seq = MemoryLayout.sequenceLayout(JAVA_INT);
         seq.byteOffset(groupElement("foo"));
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class)
     public void testBadBitSelectFromStruct() {
-        GroupLayout g = MemoryLayout.ofStruct(JAVA_INT);
+        GroupLayout g = MemoryLayout.structLayout(JAVA_INT);
         g.bitOffset(sequenceElement());
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class)
     public void testBadByteSelectFromStruct() {
-        GroupLayout g = MemoryLayout.ofStruct(JAVA_INT);
+        GroupLayout g = MemoryLayout.structLayout(JAVA_INT);
         g.byteOffset(sequenceElement());
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class)
     public void testBadBitSelectFromValue() {
-        SequenceLayout seq = MemoryLayout.ofSequence(JAVA_INT);
+        SequenceLayout seq = MemoryLayout.sequenceLayout(JAVA_INT);
         seq.bitOffset(sequenceElement(), sequenceElement());
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class)
     public void testBadByteSelectFromValue() {
-        SequenceLayout seq = MemoryLayout.ofSequence(JAVA_INT);
+        SequenceLayout seq = MemoryLayout.sequenceLayout(JAVA_INT);
         seq.byteOffset(sequenceElement(), sequenceElement());
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class)
     public void testUnknownBitStructField() {
-        GroupLayout g = MemoryLayout.ofStruct(JAVA_INT);
+        GroupLayout g = MemoryLayout.structLayout(JAVA_INT);
         g.bitOffset(groupElement("foo"));
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class)
     public void testUnknownByteStructField() {
-        GroupLayout g = MemoryLayout.ofStruct(JAVA_INT);
+        GroupLayout g = MemoryLayout.structLayout(JAVA_INT);
         g.byteOffset(groupElement("foo"));
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class)
     public void testBitOutOfBoundsSeqIndex() {
-        SequenceLayout seq = MemoryLayout.ofSequence(5, JAVA_INT);
+        SequenceLayout seq = MemoryLayout.sequenceLayout(5, JAVA_INT);
         seq.bitOffset(sequenceElement(6));
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class)
     public void testByteOutOfBoundsSeqIndex() {
-        SequenceLayout seq = MemoryLayout.ofSequence(5, JAVA_INT);
+        SequenceLayout seq = MemoryLayout.sequenceLayout(5, JAVA_INT);
         seq.byteOffset(sequenceElement(6));
     }
 
@@ -117,19 +117,19 @@ public class TestLayoutPaths {
 
     @Test(expectedExceptions = IllegalArgumentException.class)
     public void testBitNegativeSeqIndex() {
-        SequenceLayout seq = MemoryLayout.ofSequence(5, JAVA_INT);
+        SequenceLayout seq = MemoryLayout.sequenceLayout(5, JAVA_INT);
         seq.bitOffset(sequenceElement(-2));
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class)
     public void testByteNegativeSeqIndex() {
-        SequenceLayout seq = MemoryLayout.ofSequence(5, JAVA_INT);
+        SequenceLayout seq = MemoryLayout.sequenceLayout(5, JAVA_INT);
         seq.byteOffset(sequenceElement(-2));
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class)
     public void testOutOfBoundsSeqRange() {
-        SequenceLayout seq = MemoryLayout.ofSequence(5, JAVA_INT);
+        SequenceLayout seq = MemoryLayout.sequenceLayout(5, JAVA_INT);
         seq.bitOffset(sequenceElement(6, 2));
     }
 
@@ -140,80 +140,80 @@ public class TestLayoutPaths {
 
     @Test(expectedExceptions = IllegalArgumentException.class)
     public void testBitNegativeSeqRange() {
-        SequenceLayout seq = MemoryLayout.ofSequence(5, JAVA_INT);
+        SequenceLayout seq = MemoryLayout.sequenceLayout(5, JAVA_INT);
         seq.bitOffset(sequenceElement(-2, 2));
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class)
     public void testByteNegativeSeqRange() {
-        SequenceLayout seq = MemoryLayout.ofSequence(5, JAVA_INT);
+        SequenceLayout seq = MemoryLayout.sequenceLayout(5, JAVA_INT);
         seq.byteOffset(sequenceElement(-2, 2));
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class)
     public void testIncompleteAccess() {
-        SequenceLayout seq = MemoryLayout.ofSequence(5, MemoryLayout.ofStruct(JAVA_INT));
+        SequenceLayout seq = MemoryLayout.sequenceLayout(5, MemoryLayout.structLayout(JAVA_INT));
         seq.varHandle(int.class, sequenceElement());
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class)
     public void testBitOffsetHandleBadRange() {
-        SequenceLayout seq = MemoryLayout.ofSequence(5, MemoryLayout.ofStruct(JAVA_INT));
+        SequenceLayout seq = MemoryLayout.sequenceLayout(5, MemoryLayout.structLayout(JAVA_INT));
         seq.bitOffsetHandle(sequenceElement(0, 1)); // ranges not accepted
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class)
     public void testByteOffsetHandleBadRange() {
-        SequenceLayout seq = MemoryLayout.ofSequence(5, MemoryLayout.ofStruct(JAVA_INT));
+        SequenceLayout seq = MemoryLayout.sequenceLayout(5, MemoryLayout.structLayout(JAVA_INT));
         seq.byteOffsetHandle(sequenceElement(0, 1)); // ranges not accepted
     }
 
     @Test(expectedExceptions = UnsupportedOperationException.class)
     public void testBadMultiple() {
-        GroupLayout g = MemoryLayout.ofStruct(MemoryLayout.ofPaddingBits(3), JAVA_INT.withName("foo"));
+        GroupLayout g = MemoryLayout.structLayout(MemoryLayout.paddingLayout(3), JAVA_INT.withName("foo"));
         g.byteOffset(groupElement("foo"));
     }
 
     @Test(expectedExceptions = UnsupportedOperationException.class)
     public void testBitOffsetBadUnboundedSequenceTraverse() {
-        MemoryLayout layout = MemoryLayout.ofSequence(MemoryLayout.ofSequence(JAVA_INT));
+        MemoryLayout layout = MemoryLayout.sequenceLayout(MemoryLayout.sequenceLayout(JAVA_INT));
         layout.bitOffset(sequenceElement(1), sequenceElement(0));
     }
 
     @Test(expectedExceptions = UnsupportedOperationException.class)
     public void testByteOffsetBadUnboundedSequenceTraverse() {
-        MemoryLayout layout = MemoryLayout.ofSequence(MemoryLayout.ofSequence(JAVA_INT));
+        MemoryLayout layout = MemoryLayout.sequenceLayout(MemoryLayout.sequenceLayout(JAVA_INT));
         layout.byteOffset(sequenceElement(1), sequenceElement(0));
     }
 
     @Test(expectedExceptions = UnsupportedOperationException.class)
     public void testBitOffsetHandleBadUnboundedSequenceTraverse() {
-        MemoryLayout layout = MemoryLayout.ofSequence(MemoryLayout.ofSequence(JAVA_INT));
+        MemoryLayout layout = MemoryLayout.sequenceLayout(MemoryLayout.sequenceLayout(JAVA_INT));
         layout.bitOffsetHandle(sequenceElement(1), sequenceElement(0));
     }
 
     @Test(expectedExceptions = UnsupportedOperationException.class)
     public void testByteOffsetHandleBadUnboundedSequenceTraverse() {
-        MemoryLayout layout = MemoryLayout.ofSequence(MemoryLayout.ofSequence(JAVA_INT));
+        MemoryLayout layout = MemoryLayout.sequenceLayout(MemoryLayout.sequenceLayout(JAVA_INT));
         layout.byteOffsetHandle(sequenceElement(1), sequenceElement(0));
     }
 
     @Test(expectedExceptions = UnsupportedOperationException.class)
     public void testBadByteOffsetNoMultipleOf8() {
-        MemoryLayout layout = MemoryLayout.ofStruct(MemoryLayout.ofPaddingBits(7), JAVA_INT.withName("x"));
+        MemoryLayout layout = MemoryLayout.structLayout(MemoryLayout.paddingLayout(7), JAVA_INT.withName("x"));
         layout.byteOffset(groupElement("x"));
     }
 
     @Test(expectedExceptions = UnsupportedOperationException.class)
     public void testBadByteOffsetHandleNoMultipleOf8() throws Throwable {
-        MemoryLayout layout = MemoryLayout.ofStruct(MemoryLayout.ofPaddingBits(7), JAVA_INT.withName("x"));
+        MemoryLayout layout = MemoryLayout.structLayout(MemoryLayout.paddingLayout(7), JAVA_INT.withName("x"));
         MethodHandle handle = layout.byteOffsetHandle(groupElement("x"));
         handle.invoke();
     }
 
     @Test
     public void testBadContainerAlign() {
-        GroupLayout g = MemoryLayout.ofStruct(JAVA_INT.withBitAlignment(16).withName("foo")).withBitAlignment(8);
+        GroupLayout g = MemoryLayout.structLayout(JAVA_INT.withBitAlignment(16).withName("foo")).withBitAlignment(8);
         try {
             g.bitOffset(groupElement("foo"));
             g.byteOffset(groupElement("foo"));
@@ -232,7 +232,7 @@ public class TestLayoutPaths {
 
     @Test
     public void testBadAlignOffset() {
-        GroupLayout g = MemoryLayout.ofStruct(MemoryLayouts.PAD_8, JAVA_INT.withBitAlignment(16).withName("foo"));
+        GroupLayout g = MemoryLayout.structLayout(MemoryLayouts.PAD_8, JAVA_INT.withBitAlignment(16).withName("foo"));
         try {
             g.bitOffset(groupElement("foo"));
             g.byteOffset(groupElement("foo"));
@@ -251,7 +251,7 @@ public class TestLayoutPaths {
 
     @Test
     public void testBadSequencePathInOffset() {
-        SequenceLayout seq = MemoryLayout.ofSequence(10, JAVA_INT);
+        SequenceLayout seq = MemoryLayout.sequenceLayout(10, JAVA_INT);
         // bad path elements
         for (PathElement e : List.of( sequenceElement(), sequenceElement(0, 2) )) {
             try {
@@ -271,7 +271,7 @@ public class TestLayoutPaths {
 
     @Test
     public void testBadSequencePathInSelect() {
-        SequenceLayout seq = MemoryLayout.ofSequence(10, JAVA_INT);
+        SequenceLayout seq = MemoryLayout.sequenceLayout(10, JAVA_INT);
         for (PathElement e : List.of( sequenceElement(0), sequenceElement(0, 2) )) {
             try {
                 seq.select(e);
@@ -284,7 +284,7 @@ public class TestLayoutPaths {
 
     @Test
     public void testBadSequencePathInMap() {
-        SequenceLayout seq = MemoryLayout.ofSequence(10, JAVA_INT);
+        SequenceLayout seq = MemoryLayout.sequenceLayout(10, JAVA_INT);
         for (PathElement e : List.of( sequenceElement(0), sequenceElement(0, 2) )) {
             try {
                 seq.map(l -> l, e);
@@ -298,7 +298,7 @@ public class TestLayoutPaths {
     @Test
     public void testStructPaths() {
         long[] offsets = { 0, 8, 24, 56 };
-        GroupLayout g = MemoryLayout.ofStruct(
+        GroupLayout g = MemoryLayout.structLayout(
                 MemoryLayouts.JAVA_BYTE.withName("1"),
                 MemoryLayouts.JAVA_CHAR.withName("2"),
                 MemoryLayouts.JAVA_FLOAT.withName("3"),
@@ -339,7 +339,7 @@ public class TestLayoutPaths {
     @Test
     public void testUnionPaths() {
         long[] offsets = { 0, 0, 0, 0 };
-        GroupLayout g = MemoryLayout.ofUnion(
+        GroupLayout g = MemoryLayout.unionLayout(
                 MemoryLayouts.JAVA_BYTE.withName("1"),
                 MemoryLayouts.JAVA_CHAR.withName("2"),
                 MemoryLayouts.JAVA_FLOAT.withName("3"),
@@ -380,7 +380,7 @@ public class TestLayoutPaths {
     @Test
     public void testSequencePaths() {
         long[] offsets = { 0, 8, 16, 24 };
-        SequenceLayout g = MemoryLayout.ofSequence(4, MemoryLayouts.JAVA_BYTE);
+        SequenceLayout g = MemoryLayout.sequenceLayout(4, MemoryLayouts.JAVA_BYTE);
 
         // test select
 
@@ -422,42 +422,42 @@ public class TestLayoutPaths {
         List<Object[]> testCases = new ArrayList<>();
 
         testCases.add(new Object[] {
-            MemoryLayout.ofSequence(10, JAVA_INT),
+            MemoryLayout.sequenceLayout(10, JAVA_INT),
             new PathElement[] { sequenceElement() },
             new long[] { 4 },
             JAVA_INT.bitSize() * 4
         });
         testCases.add(new Object[] {
-            MemoryLayout.ofSequence(10, MemoryLayout.ofStruct(JAVA_INT, JAVA_INT.withName("y"))),
+            MemoryLayout.sequenceLayout(10, MemoryLayout.structLayout(JAVA_INT, JAVA_INT.withName("y"))),
             new PathElement[] { sequenceElement(), groupElement("y") },
             new long[] { 4 },
             (JAVA_INT.bitSize() * 2) * 4 + JAVA_INT.bitSize()
         });
         testCases.add(new Object[] {
-            MemoryLayout.ofSequence(10, MemoryLayout.ofStruct(MemoryLayout.ofPaddingBits(5), JAVA_INT.withName("y"))),
+            MemoryLayout.sequenceLayout(10, MemoryLayout.structLayout(MemoryLayout.paddingLayout(5), JAVA_INT.withName("y"))),
             new PathElement[] { sequenceElement(), groupElement("y") },
             new long[] { 4 },
             (JAVA_INT.bitSize() + 5) * 4 + 5
         });
         testCases.add(new Object[] {
-            MemoryLayout.ofSequence(10, JAVA_INT),
+            MemoryLayout.sequenceLayout(10, JAVA_INT),
             new PathElement[] { sequenceElement() },
             new long[] { 4 },
             JAVA_INT.bitSize() * 4
         });
         testCases.add(new Object[] {
-            MemoryLayout.ofStruct(
-                MemoryLayout.ofSequence(10, JAVA_INT).withName("data")
+            MemoryLayout.structLayout(
+                MemoryLayout.sequenceLayout(10, JAVA_INT).withName("data")
             ),
             new PathElement[] { groupElement("data"), sequenceElement() },
             new long[] { 4 },
             JAVA_INT.bitSize() * 4
         });
 
-        MemoryLayout complexLayout = MemoryLayout.ofStruct(
-            MemoryLayout.ofSequence(10,
-                MemoryLayout.ofSequence(10,
-                    MemoryLayout.ofStruct(
+        MemoryLayout complexLayout = MemoryLayout.structLayout(
+            MemoryLayout.sequenceLayout(10,
+                MemoryLayout.sequenceLayout(10,
+                    MemoryLayout.structLayout(
                         JAVA_INT.withName("x"),
                         JAVA_INT.withName("y")
                     )
@@ -503,7 +503,7 @@ public class TestLayoutPaths {
         MethodHandle sliceHandle = layout.sliceHandle(pathElements);
         sliceHandle = sliceHandle.asSpreader(long[].class, indexes.length);
 
-        try (ResourceScope scope = ResourceScope.ofConfined()) {
+        try (ResourceScope scope = ResourceScope.newConfinedScope()) {
             MemorySegment segment = MemorySegment.allocateNative(layout, scope);
             MemorySegment slice = (MemorySegment) sliceHandle.invokeExact(segment, indexes);
             assertEquals(slice.address().segmentOffset(segment), expectedBitOffset / 8);
@@ -513,9 +513,9 @@ public class TestLayoutPaths {
 
     @Test(expectedExceptions = UnsupportedOperationException.class)
     public void testSliceHandleUOEInvalidSize() {
-        MemoryLayout layout = MemoryLayout.ofStruct(
-            MemoryLayout.ofValueBits(32, ByteOrder.nativeOrder()).withName("x"),
-            MemoryLayout.ofValueBits(31, ByteOrder.nativeOrder()).withName("y") // size not a multiple of 8
+        MemoryLayout layout = MemoryLayout.structLayout(
+            MemoryLayout.valueLayout(32, ByteOrder.nativeOrder()).withName("x"),
+            MemoryLayout.valueLayout(31, ByteOrder.nativeOrder()).withName("y") // size not a multiple of 8
         );
 
         layout.sliceHandle(groupElement("y")); // should throw
@@ -523,9 +523,9 @@ public class TestLayoutPaths {
 
     @Test(expectedExceptions = UnsupportedOperationException.class)
     public void testSliceHandleUOEInvalidOffsetEager() throws Throwable {
-        MemoryLayout layout = MemoryLayout.ofStruct(
-            MemoryLayout.ofPaddingBits(5),
-            MemoryLayout.ofValueBits(32, ByteOrder.nativeOrder()).withName("y") // offset not a multiple of 8
+        MemoryLayout layout = MemoryLayout.structLayout(
+            MemoryLayout.paddingLayout(5),
+            MemoryLayout.valueLayout(32, ByteOrder.nativeOrder()).withName("y") // offset not a multiple of 8
         );
 
         layout.sliceHandle(groupElement("y")); // should throw
@@ -533,10 +533,10 @@ public class TestLayoutPaths {
 
     @Test(expectedExceptions = UnsupportedOperationException.class)
     public void testSliceHandleUOEInvalidOffsetLate() throws Throwable {
-        MemoryLayout layout = MemoryLayout.ofSequence(3,
-            MemoryLayout.ofStruct(
-                MemoryLayout.ofPaddingBits(4),
-                MemoryLayout.ofValueBits(32, ByteOrder.nativeOrder()).withName("y") // offset not a multiple of 8
+        MemoryLayout layout = MemoryLayout.sequenceLayout(3,
+            MemoryLayout.structLayout(
+                MemoryLayout.paddingLayout(4),
+                MemoryLayout.valueLayout(32, ByteOrder.nativeOrder()).withName("y") // offset not a multiple of 8
             )
         );
 
@@ -548,7 +548,7 @@ public class TestLayoutPaths {
             return;
         }
 
-        try (ResourceScope scope = ResourceScope.ofConfined()) {
+        try (ResourceScope scope = ResourceScope.newConfinedScope()) {
             MemorySegment segment = MemorySegment.allocateNative(layout, scope);
 
             try {

--- a/test/jdk/java/foreign/TestLayouts.java
+++ b/test/jdk/java/foreign/TestLayouts.java
@@ -50,16 +50,16 @@ public class TestLayouts {
 
     @Test
     public void testVLAInStruct() {
-        MemoryLayout layout = MemoryLayout.ofStruct(
+        MemoryLayout layout = MemoryLayout.structLayout(
                 MemoryLayouts.JAVA_INT.withName("size"),
-                MemoryLayout.ofPaddingBits(32),
-                MemoryLayout.ofSequence(MemoryLayouts.JAVA_DOUBLE).withName("arr"));
+                MemoryLayout.paddingLayout(32),
+                MemoryLayout.sequenceLayout(MemoryLayouts.JAVA_DOUBLE).withName("arr"));
         assertFalse(layout.hasSize());
         VarHandle size_handle = layout.varHandle(int.class, MemoryLayout.PathElement.groupElement("size"));
         VarHandle array_elem_handle = layout.varHandle(double.class,
                 MemoryLayout.PathElement.groupElement("arr"),
                 MemoryLayout.PathElement.sequenceElement());
-        try (ResourceScope scope = ResourceScope.ofConfined()) {
+        try (ResourceScope scope = ResourceScope.newConfinedScope()) {
             MemorySegment segment = MemorySegment.allocateNative(
                     layout.map(l -> ((SequenceLayout)l).withElementCount(4), MemoryLayout.PathElement.groupElement("arr")), scope);
             size_handle.set(segment, 4);
@@ -76,17 +76,17 @@ public class TestLayouts {
 
     @Test
     public void testVLAInSequence() {
-        MemoryLayout layout = MemoryLayout.ofStruct(
+        MemoryLayout layout = MemoryLayout.structLayout(
                 MemoryLayouts.JAVA_INT.withName("size"),
-                MemoryLayout.ofPaddingBits(32),
-                MemoryLayout.ofSequence(1, MemoryLayout.ofSequence(MemoryLayouts.JAVA_DOUBLE)).withName("arr"));
+                MemoryLayout.paddingLayout(32),
+                MemoryLayout.sequenceLayout(1, MemoryLayout.sequenceLayout(MemoryLayouts.JAVA_DOUBLE)).withName("arr"));
         assertFalse(layout.hasSize());
         VarHandle size_handle = layout.varHandle(int.class, MemoryLayout.PathElement.groupElement("size"));
         VarHandle array_elem_handle = layout.varHandle(double.class,
                 MemoryLayout.PathElement.groupElement("arr"),
                 MemoryLayout.PathElement.sequenceElement(0),
                 MemoryLayout.PathElement.sequenceElement());
-        try (ResourceScope scope = ResourceScope.ofConfined()) {
+        try (ResourceScope scope = ResourceScope.newConfinedScope()) {
             MemorySegment segment = MemorySegment.allocateNative(
                     layout.map(l -> ((SequenceLayout)l).withElementCount(4), MemoryLayout.PathElement.groupElement("arr"), MemoryLayout.PathElement.sequenceElement()), scope);
             size_handle.set(segment, 4);
@@ -103,8 +103,8 @@ public class TestLayouts {
 
     @Test
     public void testIndexedSequencePath() {
-        MemoryLayout seq = MemoryLayout.ofSequence(10, MemoryLayouts.JAVA_INT);
-        try (ResourceScope scope = ResourceScope.ofConfined()) {
+        MemoryLayout seq = MemoryLayout.sequenceLayout(10, MemoryLayouts.JAVA_INT);
+        try (ResourceScope scope = ResourceScope.newConfinedScope()) {
             MemorySegment segment = MemorySegment.allocateNative(seq, scope);
             VarHandle indexHandle = seq.varHandle(int.class, MemoryLayout.PathElement.sequenceElement());
             // init segment
@@ -143,31 +143,31 @@ public class TestLayouts {
 
     @Test(expectedExceptions = IllegalArgumentException.class)
     public void testBadUnboundSequenceLayoutResize() {
-        SequenceLayout seq = MemoryLayout.ofSequence(MemoryLayouts.JAVA_INT);
+        SequenceLayout seq = MemoryLayout.sequenceLayout(MemoryLayouts.JAVA_INT);
         seq.withElementCount(-1);
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class)
     public void testBadBoundSequenceLayoutResize() {
-        SequenceLayout seq = MemoryLayout.ofSequence(10, MemoryLayouts.JAVA_INT);
+        SequenceLayout seq = MemoryLayout.sequenceLayout(10, MemoryLayouts.JAVA_INT);
         seq.withElementCount(-1);
     }
 
     @Test
     public void testEmptyGroup() {
-        MemoryLayout struct = MemoryLayout.ofStruct();
+        MemoryLayout struct = MemoryLayout.structLayout();
         assertEquals(struct.bitSize(), 0);
         assertEquals(struct.bitAlignment(), 1);
 
-        MemoryLayout union = MemoryLayout.ofUnion();
+        MemoryLayout union = MemoryLayout.unionLayout();
         assertEquals(union.bitSize(), 0);
         assertEquals(union.bitAlignment(), 1);
     }
 
     @Test
     public void testStructSizeAndAlign() {
-        MemoryLayout struct = MemoryLayout.ofStruct(
-                MemoryLayout.ofPaddingBits(8),
+        MemoryLayout struct = MemoryLayout.structLayout(
+                MemoryLayout.paddingLayout(8),
                 MemoryLayouts.JAVA_BYTE,
                 MemoryLayouts.JAVA_CHAR,
                 MemoryLayouts.JAVA_INT,
@@ -179,26 +179,26 @@ public class TestLayouts {
 
     @Test(dataProvider="basicLayouts")
     public void testPaddingNoAlign(MemoryLayout layout) {
-        assertEquals(MemoryLayout.ofPaddingBits(layout.bitSize()).bitAlignment(), 1);
+        assertEquals(MemoryLayout.paddingLayout(layout.bitSize()).bitAlignment(), 1);
     }
 
     @Test(dataProvider="basicLayouts")
     public void testStructPaddingAndAlign(MemoryLayout layout) {
-        MemoryLayout struct = MemoryLayout.ofStruct(
-                layout, MemoryLayout.ofPaddingBits(128 - layout.bitSize()));
+        MemoryLayout struct = MemoryLayout.structLayout(
+                layout, MemoryLayout.paddingLayout(128 - layout.bitSize()));
         assertEquals(struct.bitAlignment(), layout.bitAlignment());
     }
 
     @Test(dataProvider="basicLayouts")
     public void testUnionPaddingAndAlign(MemoryLayout layout) {
-        MemoryLayout struct = MemoryLayout.ofUnion(
-                layout, MemoryLayout.ofPaddingBits(128 - layout.bitSize()));
+        MemoryLayout struct = MemoryLayout.unionLayout(
+                layout, MemoryLayout.paddingLayout(128 - layout.bitSize()));
         assertEquals(struct.bitAlignment(), layout.bitAlignment());
     }
 
     @Test
     public void testUnionSizeAndAlign() {
-        MemoryLayout struct = MemoryLayout.ofUnion(
+        MemoryLayout struct = MemoryLayout.unionLayout(
                 MemoryLayouts.JAVA_BYTE,
                 MemoryLayouts.JAVA_CHAR,
                 MemoryLayouts.JAVA_INT,
@@ -240,15 +240,15 @@ public class TestLayouts {
     @DataProvider(name = "unboundLayouts")
     public Object[][] unboundLayouts() {
         return new Object[][] {
-                { MemoryLayout.ofSequence(MemoryLayouts.JAVA_INT), 32 },
-                { MemoryLayout.ofSequence(MemoryLayout.ofSequence(MemoryLayouts.JAVA_INT)), 32 },
-                { MemoryLayout.ofSequence(4, MemoryLayout.ofSequence(MemoryLayouts.JAVA_INT)), 32 },
-                { MemoryLayout.ofStruct(MemoryLayout.ofSequence(MemoryLayouts.JAVA_INT)), 32 },
-                { MemoryLayout.ofStruct(MemoryLayout.ofSequence(MemoryLayout.ofSequence(MemoryLayouts.JAVA_INT))), 32 },
-                { MemoryLayout.ofStruct(MemoryLayout.ofSequence(4, MemoryLayout.ofSequence(MemoryLayouts.JAVA_INT))), 32 },
-                { MemoryLayout.ofUnion(MemoryLayout.ofSequence(MemoryLayouts.JAVA_INT)), 32 },
-                { MemoryLayout.ofUnion(MemoryLayout.ofSequence(MemoryLayout.ofSequence(MemoryLayouts.JAVA_INT))), 32 },
-                { MemoryLayout.ofUnion(MemoryLayout.ofSequence(4, MemoryLayout.ofSequence(MemoryLayouts.JAVA_INT))), 32 },
+                { MemoryLayout.sequenceLayout(MemoryLayouts.JAVA_INT), 32 },
+                { MemoryLayout.sequenceLayout(MemoryLayout.sequenceLayout(MemoryLayouts.JAVA_INT)), 32 },
+                { MemoryLayout.sequenceLayout(4, MemoryLayout.sequenceLayout(MemoryLayouts.JAVA_INT)), 32 },
+                { MemoryLayout.structLayout(MemoryLayout.sequenceLayout(MemoryLayouts.JAVA_INT)), 32 },
+                { MemoryLayout.structLayout(MemoryLayout.sequenceLayout(MemoryLayout.sequenceLayout(MemoryLayouts.JAVA_INT))), 32 },
+                { MemoryLayout.structLayout(MemoryLayout.sequenceLayout(4, MemoryLayout.sequenceLayout(MemoryLayouts.JAVA_INT))), 32 },
+                { MemoryLayout.unionLayout(MemoryLayout.sequenceLayout(MemoryLayouts.JAVA_INT)), 32 },
+                { MemoryLayout.unionLayout(MemoryLayout.sequenceLayout(MemoryLayout.sequenceLayout(MemoryLayouts.JAVA_INT))), 32 },
+                { MemoryLayout.unionLayout(MemoryLayout.sequenceLayout(4, MemoryLayout.sequenceLayout(MemoryLayouts.JAVA_INT))), 32 },
         };
     }
 
@@ -271,10 +271,10 @@ public class TestLayouts {
     }
 
     enum SizedLayoutFactory {
-        VALUE_LE(size -> MemoryLayout.ofValueBits(size, ByteOrder.LITTLE_ENDIAN)),
-        VALUE_BE(size -> MemoryLayout.ofValueBits(size, ByteOrder.BIG_ENDIAN)),
-        PADDING(MemoryLayout::ofPaddingBits),
-        SEQUENCE(size -> MemoryLayout.ofSequence(size, MemoryLayouts.PAD_8));
+        VALUE_LE(size -> MemoryLayout.valueLayout(size, ByteOrder.LITTLE_ENDIAN)),
+        VALUE_BE(size -> MemoryLayout.valueLayout(size, ByteOrder.BIG_ENDIAN)),
+        PADDING(MemoryLayout::paddingLayout),
+        SEQUENCE(size -> MemoryLayout.sequenceLayout(size, MemoryLayouts.PAD_8));
 
         private final LongFunction<MemoryLayout> factory;
 
@@ -291,9 +291,9 @@ public class TestLayouts {
         VALUE_LE(MemoryLayouts.BITS_8_LE),
         VALUE_BE(MemoryLayouts.BITS_8_BE),
         PADDING(MemoryLayouts.PAD_8),
-        SEQUENCE(MemoryLayout.ofSequence(1, MemoryLayouts.PAD_8)),
-        STRUCT(MemoryLayout.ofStruct(MemoryLayouts.PAD_8, MemoryLayouts.PAD_8)),
-        UNION(MemoryLayout.ofUnion(MemoryLayouts.PAD_8, MemoryLayouts.PAD_8));
+        SEQUENCE(MemoryLayout.sequenceLayout(1, MemoryLayouts.PAD_8)),
+        STRUCT(MemoryLayout.structLayout(MemoryLayouts.PAD_8, MemoryLayouts.PAD_8)),
+        UNION(MemoryLayout.unionLayout(MemoryLayouts.PAD_8, MemoryLayouts.PAD_8));
 
         final MemoryLayout layout;
 
@@ -319,15 +319,15 @@ public class TestLayouts {
         }
         //add basic layouts wrapped in a sequence with given size
         for (MemoryLayout l : basicLayouts) {
-            layoutsAndAlignments[i++] = new Object[] { MemoryLayout.ofSequence(4, l), l.bitAlignment() };
+            layoutsAndAlignments[i++] = new Object[] { MemoryLayout.sequenceLayout(4, l), l.bitAlignment() };
         }
         //add basic layouts wrapped in a struct
         for (MemoryLayout l : basicLayouts) {
-            layoutsAndAlignments[i++] = new Object[] { MemoryLayout.ofStruct(l), l.bitAlignment() };
+            layoutsAndAlignments[i++] = new Object[] { MemoryLayout.structLayout(l), l.bitAlignment() };
         }
         //add basic layouts wrapped in a union
         for (MemoryLayout l : basicLayouts) {
-            layoutsAndAlignments[i++] = new Object[] { MemoryLayout.ofUnion(l), l.bitAlignment() };
+            layoutsAndAlignments[i++] = new Object[] { MemoryLayout.unionLayout(l), l.bitAlignment() };
         }
         return layoutsAndAlignments;
     }

--- a/test/jdk/java/foreign/TestMemoryAccess.java
+++ b/test/jdk/java/foreign/TestMemoryAccess.java
@@ -54,37 +54,37 @@ public class TestMemoryAccess {
 
     @Test(dataProvider = "elements")
     public void testPaddedAccessByName(Function<MemorySegment, MemorySegment> viewFactory, MemoryLayout elemLayout, Class<?> carrier, Checker checker) {
-        GroupLayout layout = MemoryLayout.ofStruct(MemoryLayout.ofPaddingBits(elemLayout.bitSize()), elemLayout.withName("elem"));
+        GroupLayout layout = MemoryLayout.structLayout(MemoryLayout.paddingLayout(elemLayout.bitSize()), elemLayout.withName("elem"));
         testAccessInternal(viewFactory, layout, layout.varHandle(carrier, PathElement.groupElement("elem")), checker);
     }
 
     @Test(dataProvider = "elements")
     public void testPaddedAccessByIndexSeq(Function<MemorySegment, MemorySegment> viewFactory, MemoryLayout elemLayout, Class<?> carrier, Checker checker) {
-        SequenceLayout layout = MemoryLayout.ofSequence(2, elemLayout);
+        SequenceLayout layout = MemoryLayout.sequenceLayout(2, elemLayout);
         testAccessInternal(viewFactory, layout, layout.varHandle(carrier, PathElement.sequenceElement(1)), checker);
     }
 
     @Test(dataProvider = "arrayElements")
     public void testArrayAccess(Function<MemorySegment, MemorySegment> viewFactory, MemoryLayout elemLayout, Class<?> carrier, ArrayChecker checker) {
-        SequenceLayout seq = MemoryLayout.ofSequence(10, elemLayout.withName("elem"));
+        SequenceLayout seq = MemoryLayout.sequenceLayout(10, elemLayout.withName("elem"));
         testArrayAccessInternal(viewFactory, seq, seq.varHandle(carrier, PathElement.sequenceElement()), checker);
     }
 
     @Test(dataProvider = "arrayElements")
     public void testPaddedArrayAccessByName(Function<MemorySegment, MemorySegment> viewFactory, MemoryLayout elemLayout, Class<?> carrier, ArrayChecker checker) {
-        SequenceLayout seq = MemoryLayout.ofSequence(10, MemoryLayout.ofStruct(MemoryLayout.ofPaddingBits(elemLayout.bitSize()), elemLayout.withName("elem")));
+        SequenceLayout seq = MemoryLayout.sequenceLayout(10, MemoryLayout.structLayout(MemoryLayout.paddingLayout(elemLayout.bitSize()), elemLayout.withName("elem")));
         testArrayAccessInternal(viewFactory, seq, seq.varHandle(carrier, MemoryLayout.PathElement.sequenceElement(), MemoryLayout.PathElement.groupElement("elem")), checker);
     }
 
     @Test(dataProvider = "arrayElements")
     public void testPaddedArrayAccessByIndexSeq(Function<MemorySegment, MemorySegment> viewFactory, MemoryLayout elemLayout, Class<?> carrier, ArrayChecker checker) {
-        SequenceLayout seq = MemoryLayout.ofSequence(10, MemoryLayout.ofSequence(2, elemLayout));
+        SequenceLayout seq = MemoryLayout.sequenceLayout(10, MemoryLayout.sequenceLayout(2, elemLayout));
         testArrayAccessInternal(viewFactory, seq, seq.varHandle(carrier, PathElement.sequenceElement(), MemoryLayout.PathElement.sequenceElement(1)), checker);
     }
 
     private void testAccessInternal(Function<MemorySegment, MemorySegment> viewFactory, MemoryLayout layout, VarHandle handle, Checker checker) {
         MemorySegment outer_segment;
-        try (ResourceScope scope = ResourceScope.ofConfined()) {
+        try (ResourceScope scope = ResourceScope.newConfinedScope()) {
             MemorySegment segment = viewFactory.apply(MemorySegment.allocateNative(layout, scope));
             boolean isRO = segment.isReadOnly();
             try {
@@ -116,7 +116,7 @@ public class TestMemoryAccess {
 
     private void testArrayAccessInternal(Function<MemorySegment, MemorySegment> viewFactory, SequenceLayout seq, VarHandle handle, ArrayChecker checker) {
         MemorySegment outer_segment;
-        try (ResourceScope scope = ResourceScope.ofConfined()) {
+        try (ResourceScope scope = ResourceScope.newConfinedScope()) {
             MemorySegment segment = viewFactory.apply(MemorySegment.allocateNative(seq, scope));
             boolean isRO = segment.isReadOnly();
             try {
@@ -150,16 +150,16 @@ public class TestMemoryAccess {
 
     @Test(dataProvider = "matrixElements")
     public void testMatrixAccess(Function<MemorySegment, MemorySegment> viewFactory, MemoryLayout elemLayout, Class<?> carrier, MatrixChecker checker) {
-        SequenceLayout seq = MemoryLayout.ofSequence(20,
-                MemoryLayout.ofSequence(10, elemLayout.withName("elem")));
+        SequenceLayout seq = MemoryLayout.sequenceLayout(20,
+                MemoryLayout.sequenceLayout(10, elemLayout.withName("elem")));
         testMatrixAccessInternal(viewFactory, seq, seq.varHandle(carrier,
                 PathElement.sequenceElement(), PathElement.sequenceElement()), checker);
     }
 
     @Test(dataProvider = "matrixElements")
     public void testPaddedMatrixAccessByName(Function<MemorySegment, MemorySegment> viewFactory, MemoryLayout elemLayout, Class<?> carrier, MatrixChecker checker) {
-        SequenceLayout seq = MemoryLayout.ofSequence(20,
-                MemoryLayout.ofSequence(10, MemoryLayout.ofStruct(MemoryLayout.ofPaddingBits(elemLayout.bitSize()), elemLayout.withName("elem"))));
+        SequenceLayout seq = MemoryLayout.sequenceLayout(20,
+                MemoryLayout.sequenceLayout(10, MemoryLayout.structLayout(MemoryLayout.paddingLayout(elemLayout.bitSize()), elemLayout.withName("elem"))));
         testMatrixAccessInternal(viewFactory, seq,
                 seq.varHandle(carrier,
                         PathElement.sequenceElement(), PathElement.sequenceElement(), PathElement.groupElement("elem")),
@@ -168,8 +168,8 @@ public class TestMemoryAccess {
 
     @Test(dataProvider = "matrixElements")
     public void testPaddedMatrixAccessByIndexSeq(Function<MemorySegment, MemorySegment> viewFactory, MemoryLayout elemLayout, Class<?> carrier, MatrixChecker checker) {
-        SequenceLayout seq = MemoryLayout.ofSequence(20,
-                MemoryLayout.ofSequence(10, MemoryLayout.ofSequence(2, elemLayout)));
+        SequenceLayout seq = MemoryLayout.sequenceLayout(20,
+                MemoryLayout.sequenceLayout(10, MemoryLayout.sequenceLayout(2, elemLayout)));
         testMatrixAccessInternal(viewFactory, seq,
                 seq.varHandle(carrier,
                         PathElement.sequenceElement(), PathElement.sequenceElement(), PathElement.sequenceElement(1)),
@@ -185,7 +185,7 @@ public class TestMemoryAccess {
 
     private void testMatrixAccessInternal(Function<MemorySegment, MemorySegment> viewFactory, SequenceLayout seq, VarHandle handle, MatrixChecker checker) {
         MemorySegment outer_segment;
-        try (ResourceScope scope = ResourceScope.ofConfined()) {
+        try (ResourceScope scope = ResourceScope.newConfinedScope()) {
             MemorySegment segment = viewFactory.apply(MemorySegment.allocateNative(seq, scope));
             boolean isRO = segment.isReadOnly();
             try {

--- a/test/jdk/java/foreign/TestMemoryCopy.java
+++ b/test/jdk/java/foreign/TestMemoryCopy.java
@@ -65,7 +65,7 @@ public class TestMemoryCopy {
     static class SegmentSlice {
 
         enum Kind {
-            NATIVE(i -> MemorySegment.allocateNative(i, ResourceScope.ofImplicit())),
+            NATIVE(i -> MemorySegment.allocateNative(i, ResourceScope.newImplicitScope())),
             ARRAY(i -> MemorySegment.ofArray(new byte[i]));
 
             final IntFunction<MemorySegment> segmentFactory;

--- a/test/jdk/java/foreign/TestMemoryHandleAsUnsigned.java
+++ b/test/jdk/java/foreign/TestMemoryHandleAsUnsigned.java
@@ -22,16 +22,13 @@
  *
  */
 
-import jdk.incubator.foreign.MemoryAddress;
 import jdk.incubator.foreign.MemoryHandles;
 import jdk.incubator.foreign.MemoryLayout;
 import jdk.incubator.foreign.MemoryLayout.PathElement;
 import jdk.incubator.foreign.MemoryLayouts;
 import jdk.incubator.foreign.MemorySegment;
 import java.lang.invoke.VarHandle;
-import java.nio.ByteOrder;
 import java.util.Arrays;
-import java.util.concurrent.locks.ReentrantLock;
 import java.util.stream.IntStream;
 import java.util.stream.LongStream;
 
@@ -61,7 +58,7 @@ public class TestMemoryHandleAsUnsigned {
         VarHandle byteHandle = layout.varHandle(byte.class);
         VarHandle intHandle = MemoryHandles.asUnsigned(byteHandle, int.class);
 
-        try (ResourceScope scope = ResourceScope.ofConfined()) {
+        try (ResourceScope scope = ResourceScope.newConfinedScope()) {
             MemorySegment segment = MemorySegment.allocateNative(layout, scope);
             intHandle.set(segment, intValue);
             int expectedIntValue = Byte.toUnsignedInt(byteValue);
@@ -84,7 +81,7 @@ public class TestMemoryHandleAsUnsigned {
         VarHandle byteHandle = layout.varHandle(byte.class);
         VarHandle longHandle = MemoryHandles.asUnsigned(byteHandle, long.class);
 
-        try (ResourceScope scope = ResourceScope.ofConfined()) {
+        try (ResourceScope scope = ResourceScope.newConfinedScope()) {
             MemorySegment segment = MemorySegment.allocateNative(layout, scope);
             longHandle.set(segment, longValue);
             long expectedLongValue = Byte.toUnsignedLong(byteValue);
@@ -107,7 +104,7 @@ public class TestMemoryHandleAsUnsigned {
         VarHandle shortHandle = layout.varHandle(short.class);
         VarHandle intHandle = MemoryHandles.asUnsigned(shortHandle, int.class);
 
-        try (ResourceScope scope = ResourceScope.ofConfined()) {
+        try (ResourceScope scope = ResourceScope.newConfinedScope()) {
             MemorySegment segment = MemorySegment.allocateNative(layout, scope);
             intHandle.set(segment, intValue);
             int expectedIntValue = Short.toUnsignedInt(shortValue);
@@ -130,7 +127,7 @@ public class TestMemoryHandleAsUnsigned {
         VarHandle shortHandle = layout.varHandle(short.class);
         VarHandle longHandle = MemoryHandles.asUnsigned(shortHandle, long.class);
 
-        try (ResourceScope scope = ResourceScope.ofConfined()) {
+        try (ResourceScope scope = ResourceScope.newConfinedScope()) {
             MemorySegment segment = MemorySegment.allocateNative(layout, scope);
             longHandle.set(segment, longValue);
             long expectedLongValue = Short.toUnsignedLong(shortValue);
@@ -157,7 +154,7 @@ public class TestMemoryHandleAsUnsigned {
         VarHandle intHandle = layout.varHandle(int.class);
         VarHandle longHandle = MemoryHandles.asUnsigned(intHandle, long.class);
 
-        try (ResourceScope scope = ResourceScope.ofConfined()) {
+        try (ResourceScope scope = ResourceScope.newConfinedScope()) {
             MemorySegment segment = MemorySegment.allocateNative(layout, scope);
             longHandle.set(segment, longValue);
             long expectedLongValue = Integer.toUnsignedLong(intValue);
@@ -168,11 +165,11 @@ public class TestMemoryHandleAsUnsigned {
 
     @Test
     public void testCoordinatesSequenceLayout() {
-        MemoryLayout layout = MemoryLayout.ofSequence(2, MemoryLayouts.BITS_8_BE);
+        MemoryLayout layout = MemoryLayout.sequenceLayout(2, MemoryLayouts.BITS_8_BE);
         VarHandle byteHandle = layout.varHandle(byte.class, PathElement.sequenceElement());
         VarHandle intHandle = MemoryHandles.asUnsigned(byteHandle, int.class);
 
-        try (ResourceScope scope = ResourceScope.ofConfined()) {
+        try (ResourceScope scope = ResourceScope.newConfinedScope()) {
             MemorySegment segment = MemorySegment.allocateNative(layout, scope);
             intHandle.set(segment, 0L, (int) -1);
             assertEquals((int) intHandle.get(segment, 0L), 255);
@@ -187,13 +184,13 @@ public class TestMemoryHandleAsUnsigned {
         MemorySegment segment = MemorySegment.ofArray(arr);
 
         {
-            VarHandle byteHandle = MemoryLayout.ofSequence(MemoryLayouts.JAVA_BYTE)
+            VarHandle byteHandle = MemoryLayout.sequenceLayout(MemoryLayouts.JAVA_BYTE)
                     .varHandle(byte.class, PathElement.sequenceElement());
             VarHandle intHandle = MemoryHandles.asUnsigned(byteHandle, int.class);
             assertEquals((int) intHandle.get(segment, 2L), 129);
         }
         {
-            VarHandle byteHandle = MemoryLayout.ofSequence(MemoryLayouts.JAVA_BYTE)
+            VarHandle byteHandle = MemoryLayout.sequenceLayout(MemoryLayouts.JAVA_BYTE)
                     .varHandle(byte.class, PathElement.sequenceElement());
             VarHandle intHandle = MemoryHandles.asUnsigned(byteHandle, int.class);
             assertEquals((int) intHandle.get(segment, 2L), 129);

--- a/test/jdk/java/foreign/TestMismatch.java
+++ b/test/jdk/java/foreign/TestMismatch.java
@@ -101,7 +101,7 @@ public class TestMismatch {
     public void testEmpty() {
         var s1 = MemorySegment.ofArray(new byte[0]);
         assertEquals(s1.mismatch(s1), -1);
-        try (ResourceScope scope = ResourceScope.ofConfined()) {
+        try (ResourceScope scope = ResourceScope.newConfinedScope()) {
             var nativeSegment = MemorySegment.allocateNative(4, 4, scope);
             var s2 = nativeSegment.asSlice(0, 0);
             assertEquals(s1.mismatch(s2), -1);
@@ -113,7 +113,7 @@ public class TestMismatch {
     public void testLarge() {
         // skip if not on 64 bits
         if (MemoryLayouts.ADDRESS.byteSize() > 32) {
-            try (ResourceScope scope = ResourceScope.ofConfined()) {
+            try (ResourceScope scope = ResourceScope.newConfinedScope()) {
                 var s1 = MemorySegment.allocateNative((long) Integer.MAX_VALUE + 10L, 8, scope);
                 var s2 = MemorySegment.allocateNative((long) Integer.MAX_VALUE + 10L, 8, scope);
                 assertEquals(s1.mismatch(s1), -1);
@@ -152,7 +152,7 @@ public class TestMismatch {
     @Test
     public void testClosed() {
         MemorySegment s1, s2;
-        try (ResourceScope scope = ResourceScope.ofConfined()) {
+        try (ResourceScope scope = ResourceScope.newConfinedScope()) {
             s1 = MemorySegment.allocateNative(4, 1, scope);
             s2 = MemorySegment.allocateNative(4, 1, scope);
         }
@@ -163,7 +163,7 @@ public class TestMismatch {
 
     @Test
     public void testThreadAccess() throws Exception {
-        try (ResourceScope scope = ResourceScope.ofConfined()) {
+        try (ResourceScope scope = ResourceScope.newConfinedScope()) {
             var segment = MemorySegment.allocateNative(4, 1, scope);
             {
                 AtomicReference<RuntimeException> exception = new AtomicReference<>();
@@ -205,7 +205,7 @@ public class TestMismatch {
     }
 
     enum SegmentKind {
-        NATIVE(i -> MemorySegment.allocateNative(i, ResourceScope.ofImplicit())),
+        NATIVE(i -> MemorySegment.allocateNative(i, ResourceScope.newImplicitScope())),
         ARRAY(i -> MemorySegment.ofArray(new byte[i]));
 
         final IntFunction<MemorySegment> segmentFactory;

--- a/test/jdk/java/foreign/TestNative.java
+++ b/test/jdk/java/foreign/TestNative.java
@@ -55,36 +55,36 @@ import java.util.function.BiConsumer;
 import java.util.function.BiFunction;
 import java.util.function.Consumer;
 import java.util.function.Function;
-import static jdk.incubator.foreign.MemorySegment.*;
+
 import static org.testng.Assert.*;
 
 public class TestNative {
 
-    static SequenceLayout bytes = MemoryLayout.ofSequence(100,
+    static SequenceLayout bytes = MemoryLayout.sequenceLayout(100,
             MemoryLayouts.JAVA_BYTE.withOrder(ByteOrder.nativeOrder())
     );
 
-    static SequenceLayout chars = MemoryLayout.ofSequence(100,
+    static SequenceLayout chars = MemoryLayout.sequenceLayout(100,
             MemoryLayouts.JAVA_CHAR.withOrder(ByteOrder.nativeOrder())
     );
 
-    static SequenceLayout shorts = MemoryLayout.ofSequence(100,
+    static SequenceLayout shorts = MemoryLayout.sequenceLayout(100,
             MemoryLayouts.JAVA_SHORT.withOrder(ByteOrder.nativeOrder())
     );
 
-    static SequenceLayout ints = MemoryLayout.ofSequence(100,
+    static SequenceLayout ints = MemoryLayout.sequenceLayout(100,
             MemoryLayouts.JAVA_INT.withOrder(ByteOrder.nativeOrder())
     );
 
-    static SequenceLayout floats = MemoryLayout.ofSequence(100,
+    static SequenceLayout floats = MemoryLayout.sequenceLayout(100,
             MemoryLayouts.JAVA_FLOAT.withOrder(ByteOrder.nativeOrder())
     );
 
-    static SequenceLayout longs = MemoryLayout.ofSequence(100,
+    static SequenceLayout longs = MemoryLayout.sequenceLayout(100,
             MemoryLayouts.JAVA_LONG.withOrder(ByteOrder.nativeOrder())
     );
 
-    static SequenceLayout doubles = MemoryLayout.ofSequence(100,
+    static SequenceLayout doubles = MemoryLayout.sequenceLayout(100,
             MemoryLayouts.JAVA_DOUBLE.withOrder(ByteOrder.nativeOrder())
     );
 
@@ -154,7 +154,7 @@ public class TestNative {
 
     @Test(dataProvider="nativeAccessOps")
     public void testNativeAccess(Consumer<MemorySegment> checker, Consumer<MemorySegment> initializer, SequenceLayout seq) {
-        try (ResourceScope scope = ResourceScope.ofConfined()) {
+        try (ResourceScope scope = ResourceScope.newConfinedScope()) {
             MemorySegment segment = MemorySegment.allocateNative(seq, scope);
             initializer.accept(segment);
             checker.accept(segment);
@@ -164,7 +164,7 @@ public class TestNative {
     @Test(dataProvider="buffers")
     public void testNativeCapacity(Function<ByteBuffer, Buffer> bufferFunction, int elemSize) {
         int capacity = (int)doubles.byteSize();
-        try (ResourceScope scope = ResourceScope.ofConfined()) {
+        try (ResourceScope scope = ResourceScope.newConfinedScope()) {
             MemorySegment segment = MemorySegment.allocateNative(doubles, scope);
             ByteBuffer bb = segment.asByteBuffer();
             Buffer buf = bufferFunction.apply(bb);
@@ -177,7 +177,7 @@ public class TestNative {
     @Test
     public void testDefaultAccessModes() {
         MemoryAddress addr = allocate(12);
-        try (ResourceScope scope = ResourceScope.ofConfined()) {
+        try (ResourceScope scope = ResourceScope.newConfinedScope()) {
             MemorySegment mallocSegment = addr.asSegment(12, () -> free(addr), scope);
             assertFalse(mallocSegment.isReadOnly());
         }
@@ -193,7 +193,7 @@ public class TestNative {
     public void testMallocSegment() {
         MemoryAddress addr = allocate(12);
         MemorySegment mallocSegment = null;
-        try (ResourceScope scope = ResourceScope.ofConfined()) {
+        try (ResourceScope scope = ResourceScope.newConfinedScope()) {
             mallocSegment = addr.asSegment(12, () -> free(addr), scope);
             assertEquals(mallocSegment.byteSize(), 12);
             //free here
@@ -212,7 +212,7 @@ public class TestNative {
 
     @Test(expectedExceptions = IllegalArgumentException.class)
     public void testBadResize() {
-        try (ResourceScope scope = ResourceScope.ofConfined()) {
+        try (ResourceScope scope = ResourceScope.newConfinedScope()) {
             MemorySegment segment = MemorySegment.allocateNative(4, 1, scope);
             segment.address().asSegment(0, ResourceScope.globalScope());
         }

--- a/test/jdk/java/foreign/TestNulls.java
+++ b/test/jdk/java/foreign/TestNulls.java
@@ -150,16 +150,16 @@ public class TestNulls {
         addDefaultMapping(Addressable.class, MemoryAddress.NULL);
         addDefaultMapping(MemoryLayout.class, MemoryLayouts.JAVA_INT);
         addDefaultMapping(ValueLayout.class, MemoryLayouts.JAVA_INT);
-        addDefaultMapping(GroupLayout.class, MemoryLayout.ofStruct(MemoryLayouts.JAVA_INT));
-        addDefaultMapping(SequenceLayout.class, MemoryLayout.ofSequence(MemoryLayouts.JAVA_INT));
+        addDefaultMapping(GroupLayout.class, MemoryLayout.structLayout(MemoryLayouts.JAVA_INT));
+        addDefaultMapping(SequenceLayout.class, MemoryLayout.sequenceLayout(MemoryLayouts.JAVA_INT));
         addDefaultMapping(MemorySegment.class, MemorySegment.ofArray(new byte[10]));
         addDefaultMapping(FunctionDescriptor.class, FunctionDescriptor.ofVoid());
         addDefaultMapping(CLinker.class, CLinker.getInstance());
         addDefaultMapping(CLinker.VaList.class, VaListHelper.vaList);
         addDefaultMapping(CLinker.VaList.Builder.class, VaListHelper.vaListBuilder);
         addDefaultMapping(LibraryLookup.class, LibraryLookup.ofDefault());
-        addDefaultMapping(ResourceScope.class, ResourceScope.ofConfined());
-        addDefaultMapping(SegmentAllocator.class, SegmentAllocator.implicit());
+        addDefaultMapping(ResourceScope.class, ResourceScope.newConfinedScope());
+        addDefaultMapping(SegmentAllocator.class, (size, align) -> null);
         addDefaultMapping(Supplier.class, () -> null);
     }
 
@@ -172,7 +172,7 @@ public class TestNulls {
             vaList = CLinker.VaList.make(b -> {
                 builderRef.set(b);
                 b.vargFromLong(CLinker.C_LONG_LONG, 42L);
-            }, ResourceScope.ofImplicit());
+            }, ResourceScope.newImplicitScope());
             vaListBuilder = builderRef.get();
         }
     }

--- a/test/jdk/java/foreign/TestRebase.java
+++ b/test/jdk/java/foreign/TestRebase.java
@@ -29,13 +29,11 @@
 
 import jdk.incubator.foreign.MemoryAccess;
 import jdk.incubator.foreign.MemoryAddress;
-import jdk.incubator.foreign.MemoryLayouts;
 import jdk.incubator.foreign.MemorySegment;
 import jdk.incubator.foreign.ResourceScope;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
-import java.lang.invoke.VarHandle;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.IntFunction;
@@ -82,7 +80,7 @@ public class TestRebase {
     static class SegmentSlice {
 
         enum Kind {
-            NATIVE(i -> MemorySegment.allocateNative(i, ResourceScope.ofImplicit())),
+            NATIVE(i -> MemorySegment.allocateNative(i, ResourceScope.newImplicitScope())),
             ARRAY(i -> MemorySegment.ofArray(new byte[i]));
 
             final IntFunction<MemorySegment> segmentFactory;

--- a/test/jdk/java/foreign/TestReshape.java
+++ b/test/jdk/java/foreign/TestReshape.java
@@ -43,7 +43,7 @@ public class TestReshape {
     @Test(dataProvider = "shapes")
     public void testReshape(MemoryLayout layout, long[] expectedShape) {
         long flattenedSize = LongStream.of(expectedShape).reduce(1L, Math::multiplyExact);
-        SequenceLayout seq_flattened = MemoryLayout.ofSequence(flattenedSize, layout);
+        SequenceLayout seq_flattened = MemoryLayout.sequenceLayout(flattenedSize, layout);
         assertDimensions(seq_flattened, flattenedSize);
         for (long[] shape : new Shape(expectedShape)) {
             SequenceLayout seq_shaped = seq_flattened.reshape(shape);
@@ -54,43 +54,43 @@ public class TestReshape {
 
     @Test(expectedExceptions = IllegalArgumentException.class)
     public void testInvalidReshape() {
-        SequenceLayout seq = MemoryLayout.ofSequence(4, MemoryLayouts.JAVA_INT);
+        SequenceLayout seq = MemoryLayout.sequenceLayout(4, MemoryLayouts.JAVA_INT);
         seq.reshape(3, 2);
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class)
     public void testBadReshapeInference() {
-        SequenceLayout seq = MemoryLayout.ofSequence(4, MemoryLayouts.JAVA_INT);
+        SequenceLayout seq = MemoryLayout.sequenceLayout(4, MemoryLayouts.JAVA_INT);
         seq.reshape(-1, -1);
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class)
     public void testBadReshapeParameterZero() {
-        SequenceLayout seq = MemoryLayout.ofSequence(4, MemoryLayouts.JAVA_INT);
+        SequenceLayout seq = MemoryLayout.sequenceLayout(4, MemoryLayouts.JAVA_INT);
         seq.reshape(0, 4);
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class)
     public void testBadReshapeParameterNegative() {
-        SequenceLayout seq = MemoryLayout.ofSequence(4, MemoryLayouts.JAVA_INT);
+        SequenceLayout seq = MemoryLayout.sequenceLayout(4, MemoryLayouts.JAVA_INT);
         seq.reshape(-2, 2);
     }
 
     @Test(expectedExceptions = UnsupportedOperationException.class)
     public void testReshapeOnUnboundSequence() {
-        SequenceLayout seq = MemoryLayout.ofSequence(MemoryLayouts.JAVA_INT);
+        SequenceLayout seq = MemoryLayout.sequenceLayout(MemoryLayouts.JAVA_INT);
         seq.reshape(3, 2);
     }
 
     @Test(expectedExceptions = UnsupportedOperationException.class)
     public void testFlattenOnUnboundSequence() {
-        SequenceLayout seq = MemoryLayout.ofSequence(MemoryLayouts.JAVA_INT);
+        SequenceLayout seq = MemoryLayout.sequenceLayout(MemoryLayouts.JAVA_INT);
         seq.flatten();
     }
 
     @Test(expectedExceptions = UnsupportedOperationException.class)
     public void testFlattenOnUnboundNestedSequence() {
-        SequenceLayout seq = MemoryLayout.ofSequence(4, MemoryLayout.ofSequence(MemoryLayouts.JAVA_INT));
+        SequenceLayout seq = MemoryLayout.sequenceLayout(4, MemoryLayout.sequenceLayout(MemoryLayouts.JAVA_INT));
         seq.flatten();
     }
 
@@ -124,7 +124,7 @@ public class TestReshape {
         }
     }
 
-    static MemoryLayout POINT = MemoryLayout.ofStruct(
+    static MemoryLayout POINT = MemoryLayout.structLayout(
             MemoryLayouts.JAVA_INT,
             MemoryLayouts.JAVA_INT
     );

--- a/test/jdk/java/foreign/TestResourceScope.java
+++ b/test/jdk/java/foreign/TestResourceScope.java
@@ -53,8 +53,8 @@ public class TestResourceScope {
         AtomicInteger acc = new AtomicInteger();
         Cleaner cleaner = cleanerSupplier.get();
         ResourceScope scope = cleaner != null ?
-                ResourceScope.ofConfined(cleaner) :
-                ResourceScope.ofConfined();
+                ResourceScope.newConfinedScope(cleaner) :
+                ResourceScope.newConfinedScope();
         for (int i = 0 ; i < N_THREADS ; i++) {
             int delta = i;
             scope.addOnClose(() -> acc.addAndGet(delta));
@@ -78,8 +78,8 @@ public class TestResourceScope {
         AtomicInteger acc = new AtomicInteger();
         Cleaner cleaner = cleanerSupplier.get();
         ResourceScope scope = cleaner != null ?
-                ResourceScope.ofShared(cleaner) :
-                ResourceScope.ofShared();
+                ResourceScope.newSharedScope(cleaner) :
+                ResourceScope.newSharedScope();
         for (int i = 0 ; i < N_THREADS ; i++) {
             int delta = i;
             scope.addOnClose(() -> acc.addAndGet(delta));
@@ -104,8 +104,8 @@ public class TestResourceScope {
         Cleaner cleaner = cleanerSupplier.get();
         List<Thread> threads = new ArrayList<>();
         ResourceScope scope = cleaner != null ?
-                ResourceScope.ofShared(cleaner) :
-                ResourceScope.ofShared();
+                ResourceScope.newSharedScope(cleaner) :
+                ResourceScope.newSharedScope();
         AtomicReference<ResourceScope> scopeRef = new AtomicReference<>(scope);
         for (int i = 0 ; i < N_THREADS ; i++) {
             int delta = i;
@@ -154,8 +154,8 @@ public class TestResourceScope {
     public void testLockSingleThread(Supplier<Cleaner> cleanerSupplier) {
         Cleaner cleaner = cleanerSupplier.get();
         ResourceScope scope = cleaner != null ?
-                ResourceScope.ofConfined(cleaner) :
-                ResourceScope.ofConfined();
+                ResourceScope.newConfinedScope(cleaner) :
+                ResourceScope.newConfinedScope();
         List<ResourceScope.Handle> handles = new ArrayList<>();
         for (int i = 0 ; i < N_THREADS ; i++) {
             handles.add(scope.acquire());
@@ -180,8 +180,8 @@ public class TestResourceScope {
     public void testLockSharedMultiThread(Supplier<Cleaner> cleanerSupplier) {
         Cleaner cleaner = cleanerSupplier.get();
         ResourceScope scope = cleaner != null ?
-                ResourceScope.ofShared(cleaner) :
-                ResourceScope.ofShared();
+                ResourceScope.newSharedScope(cleaner) :
+                ResourceScope.newSharedScope();
         for (int i = 0 ; i < N_THREADS ; i++) {
             new Thread(() -> {
                 try {
@@ -208,17 +208,17 @@ public class TestResourceScope {
 
     @Test
     public void testCloseEmptyConfinedScope() {
-        ResourceScope.ofConfined().close();
+        ResourceScope.newConfinedScope().close();
     }
 
     @Test
     public void testCloseEmptySharedScope() {
-        ResourceScope.ofShared().close();
+        ResourceScope.newSharedScope().close();
     }
 
     @Test
     public void testCloseConfinedLock() {
-        ResourceScope.Handle handle = ResourceScope.ofConfined().acquire();
+        ResourceScope.Handle handle = ResourceScope.newConfinedScope().acquire();
         AtomicReference<Throwable> failure = new AtomicReference<>();
         Thread t = new Thread(() -> {
             try {

--- a/test/jdk/java/foreign/TestSegmentAllocators.java
+++ b/test/jdk/java/foreign/TestSegmentAllocators.java
@@ -65,8 +65,8 @@ public class TestSegmentAllocators {
             List<MemorySegment> addressList = new ArrayList<>();
             int elems = ELEMS / ((int)alignedLayout.byteAlignment() / (int)layout.byteAlignment());
             ResourceScope[] scopes = {
-                    ResourceScope.ofConfined(),
-                    ResourceScope.ofShared()
+                    ResourceScope.newConfinedScope(),
+                    ResourceScope.newSharedScope()
             };
             for (ResourceScope scope : scopes) {
                 try (scope) {
@@ -99,8 +99,8 @@ public class TestSegmentAllocators {
 
     @Test
     public void testBigAllocationInUnboundedScope() {
-        try (ResourceScope scope = ResourceScope.ofConfined()) {
-            SegmentAllocator allocator = SegmentAllocator.arenaUnbounded(scope);
+        try (ResourceScope scope = ResourceScope.newConfinedScope()) {
+            SegmentAllocator allocator = SegmentAllocator.arenaAllocator(scope);
             for (int i = 8 ; i < SIZE_256M ; i *= 8) {
                 MemorySegment address = allocator.allocate(i, i);
                 //check size
@@ -115,8 +115,8 @@ public class TestSegmentAllocators {
     public <Z> void testArray(AllocationFactory allocationFactory, ValueLayout layout, AllocationFunction<Object> allocationFunction, ToArrayHelper<Z> arrayHelper) {
         Z arr = arrayHelper.array();
         ResourceScope[] scopes = {
-                ResourceScope.ofConfined(),
-                ResourceScope.ofShared()
+                ResourceScope.newConfinedScope(),
+                ResourceScope.newSharedScope()
         };
         for (ResourceScope scope : scopes) {
             try (scope) {
@@ -357,8 +357,8 @@ public class TestSegmentAllocators {
             return isBound;
         }
 
-        static AllocationFactory BOUNDED = new AllocationFactory(true, SegmentAllocator::arenaBounded);
-        static AllocationFactory UNBOUNDED = new AllocationFactory(false, (size, scope) -> SegmentAllocator.arenaUnbounded(scope));
+        static AllocationFactory BOUNDED = new AllocationFactory(true, SegmentAllocator::arenaAllocator);
+        static AllocationFactory UNBOUNDED = new AllocationFactory(false, (size, scope) -> SegmentAllocator.arenaAllocator(scope));
     }
 
     interface ToArrayHelper<T> {

--- a/test/jdk/java/foreign/TestSharedAccess.java
+++ b/test/jdk/java/foreign/TestSharedAccess.java
@@ -38,7 +38,6 @@ import java.util.Spliterator;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.concurrent.atomic.AtomicReference;
 
 import static org.testng.Assert.*;
 
@@ -48,8 +47,8 @@ public class TestSharedAccess {
 
     @Test
     public void testShared() throws Throwable {
-        SequenceLayout layout = MemoryLayout.ofSequence(1024, MemoryLayouts.JAVA_INT);
-        try (ResourceScope scope = ResourceScope.ofShared()) {
+        SequenceLayout layout = MemoryLayout.sequenceLayout(1024, MemoryLayouts.JAVA_INT);
+        try (ResourceScope scope = ResourceScope.newSharedScope()) {
             MemorySegment s = MemorySegment.allocateNative(layout, scope);
             for (int i = 0 ; i < layout.elementCount().getAsLong() ; i++) {
                 setInt(s.asSlice(i * 4), 42);
@@ -94,7 +93,7 @@ public class TestSharedAccess {
 
     @Test
     public void testSharedUnsafe() throws Throwable {
-        try (ResourceScope scope = ResourceScope.ofShared()) {
+        try (ResourceScope scope = ResourceScope.newSharedScope()) {
             MemorySegment s = MemorySegment.allocateNative(4, 1, scope);
             setInt(s, 42);
             assertEquals(getInt(s), 42);
@@ -121,8 +120,8 @@ public class TestSharedAccess {
         CountDownLatch a = new CountDownLatch(1);
         CountDownLatch b = new CountDownLatch(1);
         CompletableFuture<?> r;
-        try (ResourceScope scope = ResourceScope.ofConfined()) {
-            MemorySegment s1 = MemorySegment.allocateNative(MemoryLayout.ofSequence(2, MemoryLayouts.JAVA_INT), scope);
+        try (ResourceScope scope = ResourceScope.newConfinedScope()) {
+            MemorySegment s1 = MemorySegment.allocateNative(MemoryLayout.sequenceLayout(2, MemoryLayouts.JAVA_INT), scope);
             r = CompletableFuture.runAsync(() -> {
                 try {
                     ByteBuffer bb = s1.asByteBuffer();

--- a/test/jdk/java/foreign/TestSlices.java
+++ b/test/jdk/java/foreign/TestSlices.java
@@ -22,7 +22,6 @@
  *
  */
 
-import jdk.incubator.foreign.MemoryHandles;
 import jdk.incubator.foreign.MemoryLayout;
 import jdk.incubator.foreign.MemoryLayouts;
 import jdk.incubator.foreign.MemorySegment;
@@ -39,15 +38,15 @@ import static org.testng.Assert.*;
  */
 public class TestSlices {
 
-    static MemoryLayout LAYOUT = MemoryLayout.ofSequence(2,
-            MemoryLayout.ofSequence(5, MemoryLayouts.JAVA_INT));
+    static MemoryLayout LAYOUT = MemoryLayout.sequenceLayout(2,
+            MemoryLayout.sequenceLayout(5, MemoryLayouts.JAVA_INT));
 
     static VarHandle VH_ALL = LAYOUT.varHandle(int.class,
             MemoryLayout.PathElement.sequenceElement(), MemoryLayout.PathElement.sequenceElement());
 
     @Test(dataProvider = "slices")
     public void testSlices(VarHandle handle, int lo, int hi, int[] values) {
-        try (ResourceScope scope = ResourceScope.ofConfined()) {
+        try (ResourceScope scope = ResourceScope.newConfinedScope()) {
             MemorySegment segment = MemorySegment.allocateNative(LAYOUT, scope);
             //init
             for (long i = 0 ; i < 2 ; i++) {

--- a/test/jdk/java/foreign/TestSpliterator.java
+++ b/test/jdk/java/foreign/TestSpliterator.java
@@ -35,33 +35,30 @@ import jdk.incubator.foreign.SequenceLayout;
 import java.lang.invoke.VarHandle;
 import java.util.LinkedList;
 import java.util.List;
-import java.util.Map;
 import java.util.Spliterator;
 import java.util.concurrent.CountedCompleter;
 import java.util.concurrent.RecursiveTask;
 import java.util.concurrent.atomic.AtomicLong;
-import java.util.function.Consumer;
-import java.util.function.Supplier;
 import java.util.stream.LongStream;
 import java.util.stream.StreamSupport;
 
 import org.testng.annotations.*;
-import static jdk.incubator.foreign.MemorySegment.*;
+
 import static org.testng.Assert.*;
 
 public class TestSpliterator {
 
-    static final VarHandle INT_HANDLE = MemoryLayout.ofSequence(MemoryLayouts.JAVA_INT)
+    static final VarHandle INT_HANDLE = MemoryLayout.sequenceLayout(MemoryLayouts.JAVA_INT)
             .varHandle(int.class, MemoryLayout.PathElement.sequenceElement());
 
     final static int CARRIER_SIZE = 4;
 
     @Test(dataProvider = "splits")
     public void testSum(int size, int threshold) {
-        SequenceLayout layout = MemoryLayout.ofSequence(size, MemoryLayouts.JAVA_INT);
+        SequenceLayout layout = MemoryLayout.sequenceLayout(size, MemoryLayouts.JAVA_INT);
 
         //setup
-        try (ResourceScope scope = ResourceScope.ofShared()) {
+        try (ResourceScope scope = ResourceScope.newSharedScope()) {
             MemorySegment segment = MemorySegment.allocateNative(layout, scope);
             for (int i = 0; i < layout.elementCount().getAsLong(); i++) {
                 INT_HANDLE.set(segment, (long) i, i);
@@ -85,10 +82,10 @@ public class TestSpliterator {
 
     @Test
     public void testSumSameThread() {
-        SequenceLayout layout = MemoryLayout.ofSequence(1024, MemoryLayouts.JAVA_INT);
+        SequenceLayout layout = MemoryLayout.sequenceLayout(1024, MemoryLayouts.JAVA_INT);
 
         //setup
-        MemorySegment segment = MemorySegment.allocateNative(layout, ResourceScope.ofImplicit());
+        MemorySegment segment = MemorySegment.allocateNative(layout, ResourceScope.newImplicitScope());
         for (int i = 0; i < layout.elementCount().getAsLong(); i++) {
             INT_HANDLE.set(segment, (long) i, i);
         }

--- a/test/jdk/java/foreign/TestTypeAccess.java
+++ b/test/jdk/java/foreign/TestTypeAccess.java
@@ -27,7 +27,6 @@
  * @run testng TestTypeAccess
  */
 
-import jdk.incubator.foreign.MemoryAddress;
 import jdk.incubator.foreign.MemoryHandles;
 import jdk.incubator.foreign.MemorySegment;
 import jdk.incubator.foreign.MemoryLayouts;
@@ -36,7 +35,6 @@ import org.testng.annotations.*;
 
 import java.lang.invoke.VarHandle;
 import java.lang.invoke.WrongMethodTypeException;
-import java.nio.ByteOrder;
 
 public class TestTypeAccess {
 
@@ -46,7 +44,7 @@ public class TestTypeAccess {
 
     @Test(expectedExceptions=ClassCastException.class)
     public void testMemoryAddressCoordinateAsString() {
-        try (ResourceScope scope = ResourceScope.ofConfined()) {
+        try (ResourceScope scope = ResourceScope.newConfinedScope()) {
             MemorySegment s = MemorySegment.allocateNative(8, 8, scope);
             int v = (int)INT_HANDLE.get("string");
         }
@@ -54,7 +52,7 @@ public class TestTypeAccess {
 
     @Test(expectedExceptions=WrongMethodTypeException.class)
     public void testMemoryCoordinatePrimitive() {
-        try (ResourceScope scope = ResourceScope.ofConfined()) {
+        try (ResourceScope scope = ResourceScope.newConfinedScope()) {
             MemorySegment s = MemorySegment.allocateNative(8, 8, scope);
             int v = (int)INT_HANDLE.get(1);
         }
@@ -62,7 +60,7 @@ public class TestTypeAccess {
 
     @Test(expectedExceptions=ClassCastException.class)
     public void testMemoryAddressValueGetAsString() {
-        try (ResourceScope scope = ResourceScope.ofConfined()) {
+        try (ResourceScope scope = ResourceScope.newConfinedScope()) {
             MemorySegment s = MemorySegment.allocateNative(8, 8, scope);
             String address = (String)ADDR_HANDLE.get(s.address());
         }
@@ -70,7 +68,7 @@ public class TestTypeAccess {
 
     @Test(expectedExceptions=ClassCastException.class)
     public void testMemoryAddressValueSetAsString() {
-        try (ResourceScope scope = ResourceScope.ofConfined()) {
+        try (ResourceScope scope = ResourceScope.newConfinedScope()) {
             MemorySegment s = MemorySegment.allocateNative(8, 8, scope);
             ADDR_HANDLE.set(s.address(), "string");
         }
@@ -78,7 +76,7 @@ public class TestTypeAccess {
 
     @Test(expectedExceptions=WrongMethodTypeException.class)
     public void testMemoryAddressValueGetAsPrimitive() {
-        try (ResourceScope scope = ResourceScope.ofConfined()) {
+        try (ResourceScope scope = ResourceScope.newConfinedScope()) {
             MemorySegment s = MemorySegment.allocateNative(8, 8, scope);
             int address = (int)ADDR_HANDLE.get(s.address());
         }
@@ -86,7 +84,7 @@ public class TestTypeAccess {
 
     @Test(expectedExceptions=WrongMethodTypeException.class)
     public void testMemoryAddressValueSetAsPrimitive() {
-        try (ResourceScope scope = ResourceScope.ofConfined()) {
+        try (ResourceScope scope = ResourceScope.newConfinedScope()) {
             MemorySegment s = MemorySegment.allocateNative(8, 8, scope);
             ADDR_HANDLE.set(s.address(), 1);
         }

--- a/test/jdk/java/foreign/TestUpcall.java
+++ b/test/jdk/java/foreign/TestUpcall.java
@@ -81,7 +81,7 @@ public class TestUpcall extends CallGeneratorHelper {
 
     @BeforeClass
     void setup() {
-        dummyStub = abi.upcallStub(DUMMY, FunctionDescriptor.ofVoid(), ResourceScope.ofImplicit());
+        dummyStub = abi.upcallStub(DUMMY, FunctionDescriptor.ofVoid(), ResourceScope.newImplicitScope());
     }
 
     @Test(dataProvider="functions", dataProviderClass=CallGeneratorHelper.class)
@@ -108,8 +108,8 @@ public class TestUpcall extends CallGeneratorHelper {
         List<Consumer<Object[]>> argChecks = new ArrayList<>();
         MemoryAddress addr = lib.lookup(fName).get();
         MethodType mtype = methodType(ret, paramTypes, fields);
-        MethodHandle mh = abi.downcallHandle(addr, SegmentAllocator.implicit(), mtype, function(ret, paramTypes, fields));
-        Object[] args = makeArgs(ResourceScope.ofImplicit(), ret, paramTypes, fields, returnChecks, argChecks);
+        MethodHandle mh = abi.downcallHandle(addr, IMPLICIT_ALLOCATOR, mtype, function(ret, paramTypes, fields));
+        Object[] args = makeArgs(ResourceScope.newImplicitScope(), ret, paramTypes, fields, returnChecks, argChecks);
         Object[] callArgs = args;
         if (count % 100 == 0) {
             System.gc();
@@ -197,7 +197,7 @@ public class TestUpcall extends CallGeneratorHelper {
         for (int i = 0; i < o.length; i++) {
             if (o[i] instanceof MemorySegment) {
                 MemorySegment ms = (MemorySegment) o[i];
-                MemorySegment copy = MemorySegment.allocateNative(ms.byteSize(), ResourceScope.ofImplicit());
+                MemorySegment copy = MemorySegment.allocateNative(ms.byteSize(), ResourceScope.newImplicitScope());
                 copy.copyFrom(ms);
                 o[i] = copy;
             }

--- a/test/jdk/java/foreign/TestUpcallHighArity.java
+++ b/test/jdk/java/foreign/TestUpcallHighArity.java
@@ -46,7 +46,6 @@ import org.testng.annotations.Test;
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.MethodType;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -59,7 +58,7 @@ public class TestUpcallHighArity extends CallGeneratorHelper {
     static final CLinker LINKER = CLinker.getInstance();
 
     // struct S_PDI { void* p0; double p1; int p2; };
-    static final MemoryLayout S_PDI_LAYOUT = MemoryLayout.ofStruct(
+    static final MemoryLayout S_PDI_LAYOUT = MemoryLayout.structLayout(
         C_POINTER.withName("p0"),
         C_DOUBLE.withName("p1"),
         C_INT.withName("p2")
@@ -92,7 +91,7 @@ public class TestUpcallHighArity extends CallGeneratorHelper {
         for (int i = 0; i < o.length; i++) {
             if (o[i] instanceof MemorySegment) {
                 MemorySegment ms = (MemorySegment) o[i];
-                MemorySegment copy = MemorySegment.allocateNative(ms.byteSize(), ResourceScope.ofImplicit());
+                MemorySegment copy = MemorySegment.allocateNative(ms.byteSize(), ResourceScope.newImplicitScope());
                 copy.copyFrom(ms);
                 o[i] = copy;
             }
@@ -107,7 +106,7 @@ public class TestUpcallHighArity extends CallGeneratorHelper {
         MethodHandle target = MethodHandles.insertArguments(MH_passAndSave, 1, capturedArgs)
                                          .asCollector(Object[].class, upcallType.parameterCount())
                                          .asType(upcallType);
-        try (ResourceScope scope = ResourceScope.ofConfined()) {
+        try (ResourceScope scope = ResourceScope.newConfinedScope()) {
             MemorySegment upcallStub = LINKER.upcallStub(target, upcallDescriptor, scope);
             Object[] args = new Object[upcallType.parameterCount() + 1];
             args[0] = upcallStub.address();

--- a/test/jdk/java/foreign/TestUpcallStructScope.java
+++ b/test/jdk/java/foreign/TestUpcallStructScope.java
@@ -62,7 +62,7 @@ public class TestUpcallStructScope {
     static final MethodHandle MH_Consumer_accept;
 
     // struct S_PDI { void* p0; double p1; int p2; };
-    static final MemoryLayout S_PDI_LAYOUT = MemoryLayout.ofStruct(
+    static final MemoryLayout S_PDI_LAYOUT = MemoryLayout.structLayout(
         C_POINTER.withName("p0"),
         C_DOUBLE.withName("p1"),
         C_INT.withName("p2")
@@ -93,7 +93,7 @@ public class TestUpcallStructScope {
         AtomicReference<MemorySegment> capturedSegment = new AtomicReference<>();
         MethodHandle target = methodHandle(capturedSegment::set);
         FunctionDescriptor upcallDesc = FunctionDescriptor.ofVoid(S_PDI_LAYOUT);
-        try (ResourceScope scope = ResourceScope.ofConfined()) {
+        try (ResourceScope scope = ResourceScope.newConfinedScope()) {
             MemorySegment upcallStub = LINKER.upcallStub(target, upcallDesc, scope);
             MemorySegment argSegment = MemorySegment.allocateNative(S_PDI_LAYOUT, scope);
             MH_do_upcall.invokeExact(upcallStub.address(), argSegment);

--- a/test/jdk/java/foreign/TestUpcallStubs.java
+++ b/test/jdk/java/foreign/TestUpcallStubs.java
@@ -39,7 +39,6 @@ import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.MethodType;
 import java.lang.invoke.VarHandle;
-import java.lang.ref.Cleaner;
 
 import static jdk.incubator.foreign.MemoryLayouts.JAVA_INT;
 import static org.testng.Assert.assertFalse;
@@ -59,7 +58,7 @@ public class TestUpcallStubs {
     }
 
     private static MemorySegment getStub() {
-        return abi.upcallStub(MH_dummy, FunctionDescriptor.ofVoid(), ResourceScope.ofConfined());
+        return abi.upcallStub(MH_dummy, FunctionDescriptor.ofVoid(), ResourceScope.newConfinedScope());
     }
 
     @Test(expectedExceptions = IndexOutOfBoundsException.class)

--- a/test/jdk/java/foreign/TestVarArgs.java
+++ b/test/jdk/java/foreign/TestVarArgs.java
@@ -51,14 +51,14 @@ import static org.testng.Assert.assertEquals;
 
 public class TestVarArgs {
 
-    static final MemoryLayout ML_CallInfo = MemoryLayout.ofStruct(
+    static final MemoryLayout ML_CallInfo = MemoryLayout.structLayout(
             C_POINTER.withName("writeback"), // writeback
             C_POINTER.withName("argIDs")); // arg ids
 
     static final VarHandle VH_CallInfo_writeback = ML_CallInfo.varHandle(long.class, groupElement("writeback"));
     static final VarHandle VH_CallInfo_argIDs = ML_CallInfo.varHandle(long.class, groupElement("argIDs"));
 
-    static final VarHandle VH_IntArray = MemoryLayout.ofSequence(C_INT).varHandle(int.class, sequenceElement());
+    static final VarHandle VH_IntArray = MemoryLayout.sequenceLayout(C_INT).varHandle(int.class, sequenceElement());
 
     static final CLinker abi = CLinker.getInstance();
     static final MemoryAddress varargsAddr = LibraryLookup.ofLibrary("VarArgs")
@@ -68,10 +68,10 @@ public class TestVarArgs {
 
     @Test(dataProvider = "args")
     public void testVarArgs(List<VarArg> args) throws Throwable {
-        try (ResourceScope scope = ResourceScope.ofConfined()) {
+        try (ResourceScope scope = ResourceScope.newConfinedScope()) {
             MemorySegment writeBack = MemorySegment.allocateNative(args.size() * WRITEBACK_BYTES_PER_ARG, WRITEBACK_BYTES_PER_ARG, scope);
             MemorySegment callInfo = MemorySegment.allocateNative(ML_CallInfo, scope);
-            MemorySegment argIDs = MemorySegment.allocateNative(MemoryLayout.ofSequence(args.size(), C_INT), scope);
+            MemorySegment argIDs = MemorySegment.allocateNative(MemoryLayout.sequenceLayout(args.size(), C_INT), scope);
 
             MemoryAddress callInfoPtr = callInfo.address();
 

--- a/test/jdk/java/foreign/TestVarHandleCombinators.java
+++ b/test/jdk/java/foreign/TestVarHandleCombinators.java
@@ -34,7 +34,6 @@ import org.testng.annotations.Test;
 
 import jdk.incubator.foreign.MemorySegment;
 
-import java.lang.invoke.MethodHandles;
 import java.lang.invoke.VarHandle;
 import java.nio.ByteOrder;
 
@@ -75,7 +74,7 @@ public class TestVarHandleCombinators {
     public void testAlign() {
         VarHandle vh = MemoryHandles.varHandle(byte.class, 2, ByteOrder.nativeOrder());
 
-        MemorySegment segment = MemorySegment.allocateNative(1, 2, ResourceScope.ofImplicit());
+        MemorySegment segment = MemorySegment.allocateNative(1, 2, ResourceScope.newImplicitScope());
         vh.set(segment, 0L, (byte) 10); // fine, memory region is aligned
         assertEquals((byte) vh.get(segment, 0L), (byte) 10);
     }
@@ -109,7 +108,7 @@ public class TestVarHandleCombinators {
 
         VarHandle vh = MemoryHandles.varHandle(int.class, ByteOrder.nativeOrder());
         int count = 0;
-        try (ResourceScope scope = ResourceScope.ofConfined()) {
+        try (ResourceScope scope = ResourceScope.newConfinedScope()) {
             MemorySegment segment = MemorySegment.allocateNative(inner_size * outer_size * 8, 4, scope);
             for (long i = 0; i < outer_size; i++) {
                 for (long j = 0; j < inner_size; j++) {

--- a/test/jdk/java/foreign/callarranger/TestAarch64CallArranger.java
+++ b/test/jdk/java/foreign/callarranger/TestAarch64CallArranger.java
@@ -144,10 +144,10 @@ public class TestAarch64CallArranger extends CallArrangerTestBase {
 
     @DataProvider
     public static Object[][] structs() {
-        MemoryLayout struct2 = MemoryLayout.ofStruct(C_INT, C_INT, C_DOUBLE, C_INT);
+        MemoryLayout struct2 = MemoryLayout.structLayout(C_INT, C_INT, C_DOUBLE, C_INT);
         return new Object[][]{
             // struct s { int32_t a, b; double c; };
-            { MemoryLayout.ofStruct(C_INT, C_INT, C_DOUBLE), new Binding[] {
+            { MemoryLayout.structLayout(C_INT, C_INT, C_DOUBLE), new Binding[] {
                 dup(),
                     // s.a & s.b
                     bufferLoad(0, long.class), vmStore(r0, long.class),
@@ -162,7 +162,7 @@ public class TestAarch64CallArranger extends CallArrangerTestBase {
                 vmStore(r0, long.class)
             }},
             // struct s { int32_t a[2]; float b[2] };
-            { MemoryLayout.ofStruct(C_INT, C_INT, C_FLOAT, C_FLOAT), new Binding[] {
+            { MemoryLayout.structLayout(C_INT, C_INT, C_FLOAT, C_FLOAT), new Binding[] {
                 dup(),
                     // s.a[0] & s.a[1]
                     bufferLoad(0, long.class), vmStore(r0, long.class),
@@ -170,7 +170,7 @@ public class TestAarch64CallArranger extends CallArrangerTestBase {
                     bufferLoad(8, long.class), vmStore(r1, long.class),
             }},
             // struct s { float a; /* padding */ double b };
-            { MemoryLayout.ofStruct(C_FLOAT, MemoryLayout.ofPaddingBits(32), C_DOUBLE),
+            { MemoryLayout.structLayout(C_FLOAT, MemoryLayout.paddingLayout(32), C_DOUBLE),
               new Binding[] {
                 dup(),
                 // s.a
@@ -183,8 +183,8 @@ public class TestAarch64CallArranger extends CallArrangerTestBase {
 
     @Test
     public void testMultipleStructs() {
-        MemoryLayout struct1 = MemoryLayout.ofStruct(C_INT, C_INT, C_DOUBLE, C_INT);
-        MemoryLayout struct2 = MemoryLayout.ofStruct(C_LONG, C_LONG, C_LONG);
+        MemoryLayout struct1 = MemoryLayout.structLayout(C_INT, C_INT, C_DOUBLE, C_INT);
+        MemoryLayout struct2 = MemoryLayout.structLayout(C_LONG, C_LONG, C_LONG);
 
         MethodType mt = MethodType.methodType(void.class, MemorySegment.class, MemorySegment.class, int.class);
         FunctionDescriptor fd = FunctionDescriptor.ofVoid(struct1, struct2, C_INT);
@@ -216,7 +216,7 @@ public class TestAarch64CallArranger extends CallArrangerTestBase {
 
     @Test
     public void testReturnStruct1() {
-        MemoryLayout struct = MemoryLayout.ofStruct(C_LONG, C_LONG, C_FLOAT);
+        MemoryLayout struct = MemoryLayout.structLayout(C_LONG, C_LONG, C_FLOAT);
 
         MethodType mt = MethodType.methodType(MemorySegment.class);
         FunctionDescriptor fd = FunctionDescriptor.of(struct);
@@ -239,7 +239,7 @@ public class TestAarch64CallArranger extends CallArrangerTestBase {
 
     @Test
     public void testReturnStruct2() {
-        MemoryLayout struct = MemoryLayout.ofStruct(C_LONG, C_LONG);
+        MemoryLayout struct = MemoryLayout.structLayout(C_LONG, C_LONG);
 
         MethodType mt = MethodType.methodType(MemorySegment.class);
         FunctionDescriptor fd = FunctionDescriptor.of(struct);
@@ -265,7 +265,7 @@ public class TestAarch64CallArranger extends CallArrangerTestBase {
 
     @Test
     public void testStructHFA1() {
-        MemoryLayout hfa = MemoryLayout.ofStruct(C_FLOAT, C_FLOAT);
+        MemoryLayout hfa = MemoryLayout.structLayout(C_FLOAT, C_FLOAT);
 
         MethodType mt = MethodType.methodType(MemorySegment.class, float.class, int.class, MemorySegment.class);
         FunctionDescriptor fd = FunctionDescriptor.of(hfa, C_FLOAT, C_INT, hfa);
@@ -301,7 +301,7 @@ public class TestAarch64CallArranger extends CallArrangerTestBase {
 
     @Test
     public void testStructHFA3() {
-        MemoryLayout struct = MemoryLayout.ofStruct(C_FLOAT, C_FLOAT, C_FLOAT);
+        MemoryLayout struct = MemoryLayout.structLayout(C_FLOAT, C_FLOAT, C_FLOAT);
 
         MethodType mt = MethodType.methodType(void.class, MemorySegment.class, MemorySegment.class, MemorySegment.class);
         FunctionDescriptor fd = FunctionDescriptor.ofVoid(struct, struct, struct);
@@ -351,7 +351,7 @@ public class TestAarch64CallArranger extends CallArrangerTestBase {
         // stack should be passed as a pointer to a copy and occupy one
         // stack slot.
 
-        MemoryLayout struct = MemoryLayout.ofStruct(C_INT, C_INT, C_DOUBLE, C_INT);
+        MemoryLayout struct = MemoryLayout.structLayout(C_INT, C_INT, C_DOUBLE, C_INT);
 
         MethodType mt = MethodType.methodType(
             void.class, MemorySegment.class, MemorySegment.class, int.class, int.class,

--- a/test/jdk/java/foreign/callarranger/TestSysVCallArranger.java
+++ b/test/jdk/java/foreign/callarranger/TestSysVCallArranger.java
@@ -75,9 +75,9 @@ public class TestSysVCallArranger extends CallArrangerTestBase {
 
     @Test
     public void testNestedStructs() {
-        MemoryLayout POINT = MemoryLayout.ofStruct(
+        MemoryLayout POINT = MemoryLayout.structLayout(
                 C_INT,
-                MemoryLayout.ofStruct(
+                MemoryLayout.structLayout(
                         C_INT,
                         C_INT
                 )
@@ -104,11 +104,11 @@ public class TestSysVCallArranger extends CallArrangerTestBase {
 
     @Test
     public void testNestedUnion() {
-        MemoryLayout POINT = MemoryLayout.ofStruct(
+        MemoryLayout POINT = MemoryLayout.structLayout(
                 C_INT,
-                MemoryLayout.ofPaddingBits(32),
-                MemoryLayout.ofUnion(
-                        MemoryLayout.ofStruct(C_INT, C_INT),
+                MemoryLayout.paddingLayout(32),
+                MemoryLayout.unionLayout(
+                        MemoryLayout.structLayout(C_INT, C_INT),
                         C_LONG
                 )
         );
@@ -134,9 +134,9 @@ public class TestSysVCallArranger extends CallArrangerTestBase {
 
     @Test
     public void testNestedStructsUnaligned() {
-        MemoryLayout POINT = MemoryLayout.ofStruct(
+        MemoryLayout POINT = MemoryLayout.structLayout(
                 C_INT,
-                MemoryLayout.ofStruct(
+                MemoryLayout.structLayout(
                         C_LONG,
                         C_INT
                 )
@@ -163,10 +163,10 @@ public class TestSysVCallArranger extends CallArrangerTestBase {
 
     @Test
     public void testNestedUnionUnaligned() {
-        MemoryLayout POINT = MemoryLayout.ofStruct(
+        MemoryLayout POINT = MemoryLayout.structLayout(
                 C_INT,
-                MemoryLayout.ofUnion(
-                        MemoryLayout.ofStruct(C_INT, C_INT),
+                MemoryLayout.unionLayout(
+                        MemoryLayout.structLayout(C_INT, C_INT),
                         C_LONG
                 )
         );
@@ -309,7 +309,7 @@ public class TestSysVCallArranger extends CallArrangerTestBase {
      */
     @Test
     public void testAbiExample() {
-        MemoryLayout struct = MemoryLayout.ofStruct(C_INT, C_INT, C_DOUBLE);
+        MemoryLayout struct = MemoryLayout.structLayout(C_INT, C_INT, C_DOUBLE);
 
         MethodType mt = MethodType.methodType(void.class,
                 int.class, int.class, MemorySegment.class, int.class, int.class,
@@ -400,17 +400,17 @@ public class TestSysVCallArranger extends CallArrangerTestBase {
     @DataProvider
     public static Object[][] structs() {
         return new Object[][]{
-            { MemoryLayout.ofStruct(C_LONG), new Binding[]{
+            { MemoryLayout.structLayout(C_LONG), new Binding[]{
                     bufferLoad(0, long.class), vmStore(rdi, long.class)
                 }
             },
-            { MemoryLayout.ofStruct(C_LONG, C_LONG), new Binding[]{
+            { MemoryLayout.structLayout(C_LONG, C_LONG), new Binding[]{
                     dup(),
                     bufferLoad(0, long.class), vmStore(rdi, long.class),
                     bufferLoad(8, long.class), vmStore(rsi, long.class)
                 }
             },
-            { MemoryLayout.ofStruct(C_LONG, C_LONG, C_LONG), new Binding[]{
+            { MemoryLayout.structLayout(C_LONG, C_LONG, C_LONG), new Binding[]{
                     dup(),
                     bufferLoad(0, long.class), vmStore(stackStorage(0), long.class),
                     dup(),
@@ -418,7 +418,7 @@ public class TestSysVCallArranger extends CallArrangerTestBase {
                     bufferLoad(16, long.class), vmStore(stackStorage(2), long.class)
                 }
             },
-            { MemoryLayout.ofStruct(C_LONG, C_LONG, C_LONG, C_LONG), new Binding[]{
+            { MemoryLayout.structLayout(C_LONG, C_LONG, C_LONG, C_LONG), new Binding[]{
                     dup(),
                     bufferLoad(0, long.class), vmStore(stackStorage(0), long.class),
                     dup(),
@@ -433,7 +433,7 @@ public class TestSysVCallArranger extends CallArrangerTestBase {
 
     @Test
     public void testReturnRegisterStruct() {
-        MemoryLayout struct = MemoryLayout.ofStruct(C_LONG, C_LONG);
+        MemoryLayout struct = MemoryLayout.structLayout(C_LONG, C_LONG);
 
         MethodType mt = MethodType.methodType(MemorySegment.class);
         FunctionDescriptor fd = FunctionDescriptor.of(struct);
@@ -463,7 +463,7 @@ public class TestSysVCallArranger extends CallArrangerTestBase {
 
     @Test
     public void testIMR() {
-        MemoryLayout struct = MemoryLayout.ofStruct(C_LONG, C_LONG, C_LONG);
+        MemoryLayout struct = MemoryLayout.structLayout(C_LONG, C_LONG, C_LONG);
 
         MethodType mt = MethodType.methodType(MemorySegment.class);
         FunctionDescriptor fd = FunctionDescriptor.of(struct);
@@ -486,7 +486,7 @@ public class TestSysVCallArranger extends CallArrangerTestBase {
 
     @Test
     public void testFloatStructsUpcall() {
-        MemoryLayout struct = MemoryLayout.ofStruct(C_FLOAT); // should be passed in float regs
+        MemoryLayout struct = MemoryLayout.structLayout(C_FLOAT); // should be passed in float regs
 
         MethodType mt = MethodType.methodType(MemorySegment.class, MemorySegment.class);
         FunctionDescriptor fd = FunctionDescriptor.of(struct, struct);

--- a/test/jdk/java/foreign/callarranger/TestWindowsCallArranger.java
+++ b/test/jdk/java/foreign/callarranger/TestWindowsCallArranger.java
@@ -137,7 +137,7 @@ public class TestWindowsCallArranger extends CallArrangerTestBase {
 
     @Test
     public void testAbiExample() {
-        MemoryLayout structLayout = MemoryLayout.ofStruct(C_INT, C_INT, C_DOUBLE);
+        MemoryLayout structLayout = MemoryLayout.structLayout(C_INT, C_INT, C_DOUBLE);
         MethodType mt = MethodType.methodType(void.class,
                 int.class, int.class, MemorySegment.class, int.class, int.class,
                 double.class, double.class, double.class, int.class, int.class, int.class);
@@ -208,7 +208,7 @@ public class TestWindowsCallArranger extends CallArrangerTestBase {
      */
     @Test
     public void testStructRegister() {
-        MemoryLayout struct = MemoryLayout.ofStruct(C_LONG_LONG);
+        MemoryLayout struct = MemoryLayout.structLayout(C_LONG_LONG);
 
         MethodType mt = MethodType.methodType(void.class, MemorySegment.class);
         FunctionDescriptor fd = FunctionDescriptor.ofVoid(struct);
@@ -237,7 +237,7 @@ public class TestWindowsCallArranger extends CallArrangerTestBase {
      */
     @Test
     public void testStructReference() {
-        MemoryLayout struct = MemoryLayout.ofStruct(C_LONG_LONG, C_LONG_LONG);
+        MemoryLayout struct = MemoryLayout.structLayout(C_LONG_LONG, C_LONG_LONG);
 
         MethodType mt = MethodType.methodType(void.class, MemorySegment.class);
         FunctionDescriptor fd = FunctionDescriptor.ofVoid(struct);
@@ -288,7 +288,7 @@ public class TestWindowsCallArranger extends CallArrangerTestBase {
 
     @Test
     public void testReturnRegisterStruct() {
-        MemoryLayout struct = MemoryLayout.ofStruct(C_LONG_LONG);
+        MemoryLayout struct = MemoryLayout.structLayout(C_LONG_LONG);
 
         MethodType mt = MethodType.methodType(MemorySegment.class);
         FunctionDescriptor fd = FunctionDescriptor.of(struct);
@@ -310,7 +310,7 @@ public class TestWindowsCallArranger extends CallArrangerTestBase {
 
     @Test
     public void testIMR() {
-        MemoryLayout struct = MemoryLayout.ofStruct(C_LONG_LONG, C_LONG_LONG);
+        MemoryLayout struct = MemoryLayout.structLayout(C_LONG_LONG, C_LONG_LONG);
 
         MethodType mt = MethodType.methodType(MemorySegment.class);
         FunctionDescriptor fd = FunctionDescriptor.of(struct);
@@ -330,7 +330,7 @@ public class TestWindowsCallArranger extends CallArrangerTestBase {
 
     @Test
     public void testStackStruct() {
-        MemoryLayout struct = MemoryLayout.ofStruct(C_POINTER, C_DOUBLE, C_INT);
+        MemoryLayout struct = MemoryLayout.structLayout(C_POINTER, C_DOUBLE, C_INT);
 
         MethodType mt = MethodType.methodType(void.class,
             MemorySegment.class, int.class, double.class, MemoryAddress.class,

--- a/test/jdk/java/foreign/stackwalk/TestStackWalk.java
+++ b/test/jdk/java/foreign/stackwalk/TestStackWalk.java
@@ -87,7 +87,7 @@ public class TestStackWalk {
     static boolean armed;
 
     public static void main(String[] args) throws Throwable {
-        try (ResourceScope scope = ResourceScope.ofConfined()) {
+        try (ResourceScope scope = ResourceScope.newConfinedScope()) {
             MemorySegment stub = linker.upcallStub(MH_m, FunctionDescriptor.ofVoid(), scope);
             MemoryAddress stubAddress = stub.address();
             armed = false;

--- a/test/jdk/java/foreign/valist/VaListTest.java
+++ b/test/jdk/java/foreign/valist/VaListTest.java
@@ -36,7 +36,6 @@
 
 import jdk.incubator.foreign.*;
 import jdk.incubator.foreign.CLinker.VaList;
-import jdk.internal.foreign.abi.SharedUtils;
 import jdk.internal.foreign.abi.aarch64.AArch64Linker;
 import jdk.internal.foreign.abi.x64.sysv.SysVx64Linker;
 import jdk.internal.foreign.abi.x64.windows.Windowsx64Linker;
@@ -107,13 +106,13 @@ public class VaListTest extends NativeTestHelper {
     }
 
     private static final Function<Consumer<VaList.Builder>, VaList> winVaListFactory
-            = actions -> Windowsx64Linker.newVaList(actions, ResourceScope.ofConfined());
+            = actions -> Windowsx64Linker.newVaList(actions, ResourceScope.newConfinedScope());
     private static final Function<Consumer<VaList.Builder>, VaList> sysvVaListFactory
-            = actions -> SysVx64Linker.newVaList(actions, ResourceScope.ofConfined());
+            = actions -> SysVx64Linker.newVaList(actions, ResourceScope.newConfinedScope());
     private static final Function<Consumer<VaList.Builder>, VaList> aarch64VaListFactory
-            = actions -> AArch64Linker.newVaList(actions, ResourceScope.ofConfined());
+            = actions -> AArch64Linker.newVaList(actions, ResourceScope.newConfinedScope());
     private static final Function<Consumer<VaList.Builder>, VaList> platformVaListFactory
-            = (builder) -> VaList.make(builder, ResourceScope.ofConfined());
+            = (builder) -> VaList.make(builder, ResourceScope.newConfinedScope());
 
     private static final BiFunction<Consumer<VaList.Builder>, NativeScope, VaList> winVaListScopedFactory
             = (builder, scope) -> Windowsx64Linker.newVaList(builder, scope.scope());
@@ -201,7 +200,7 @@ public class VaListTest extends NativeTestHelper {
     public void testVaListMemoryAddress(Function<Consumer<VaList.Builder>, VaList> vaListFactory,
                                         Function<VaList, Integer> getFromPointer,
                                         ValueLayout pointerLayout) {
-        try (ResourceScope scope = ResourceScope.ofConfined()) {
+        try (ResourceScope scope = ResourceScope.newConfinedScope()) {
             MemorySegment msInt = MemorySegment.allocateNative(JAVA_INT, scope);
             MemoryAccess.setInt(msInt, 10);
             VaList vaList = vaListFactory.apply(b -> b.vargFromAddress(pointerLayout, msInt.address()));
@@ -221,7 +220,7 @@ public class VaListTest extends NativeTestHelper {
         TriFunction<MemoryLayout, VarHandle, VarHandle, Function<VaList, Integer>> sumStructJavaFact
                 = (pointLayout, VH_Point_x, VH_Point_y) ->
                 list -> {
-                    MemorySegment struct = list.vargAsSegment(pointLayout, ResourceScope.ofImplicit());
+                    MemorySegment struct = list.vargAsSegment(pointLayout, ResourceScope.newImplicitScope());
                     int x = (int) VH_Point_x.get(struct);
                     int y = (int) VH_Point_y.get(struct);
                     return x + y;
@@ -234,7 +233,7 @@ public class VaListTest extends NativeTestHelper {
         TriFunction<Function<Consumer<VaList.Builder>, VaList>, MemoryLayout,
                 TriFunction<MemoryLayout, VarHandle, VarHandle, Function<VaList, Integer>>, Object[]> argsFact
                 = (vaListFact, intLayout, sumStructFact) -> {
-            GroupLayout pointLayout =  MemoryLayout.ofStruct(
+            GroupLayout pointLayout =  MemoryLayout.structLayout(
                     intLayout.withName("x"),
                     intLayout.withName("y")
             );
@@ -255,7 +254,7 @@ public class VaListTest extends NativeTestHelper {
     public void testStruct(Function<Consumer<VaList.Builder>, VaList> vaListFactory,
                            Function<VaList, Integer> sumStruct,
                            GroupLayout Point_LAYOUT, VarHandle VH_Point_x, VarHandle VH_Point_y) {
-        try (ResourceScope scope = ResourceScope.ofConfined()) {
+        try (ResourceScope scope = ResourceScope.newConfinedScope()) {
             MemorySegment struct = MemorySegment.allocateNative(Point_LAYOUT, scope);
             VH_Point_x.set(struct, 5);
             VH_Point_y.set(struct, 10);
@@ -273,7 +272,7 @@ public class VaListTest extends NativeTestHelper {
         TriFunction<MemoryLayout, VarHandle, VarHandle, Function<VaList, Long>> sumStructJavaFact
                 = (BigPoint_LAYOUT, VH_BigPoint_x, VH_BigPoint_y) ->
                 list -> {
-                    MemorySegment struct = list.vargAsSegment(BigPoint_LAYOUT, ResourceScope.ofImplicit());
+                    MemorySegment struct = list.vargAsSegment(BigPoint_LAYOUT, ResourceScope.newImplicitScope());
                     long x = (long) VH_BigPoint_x.get(struct);
                     long y = (long) VH_BigPoint_y.get(struct);
                     return x + y;
@@ -286,7 +285,7 @@ public class VaListTest extends NativeTestHelper {
         TriFunction<Function<Consumer<VaList.Builder>, VaList>, MemoryLayout,
                 TriFunction<MemoryLayout, VarHandle, VarHandle, Function<VaList, Long>>, Object[]> argsFact
                 = (vaListFact, longLongLayout, sumBigStructFact) -> {
-            GroupLayout BigPoint_LAYOUT =  MemoryLayout.ofStruct(
+            GroupLayout BigPoint_LAYOUT =  MemoryLayout.structLayout(
                     longLongLayout.withName("x"),
                     longLongLayout.withName("y")
             );
@@ -307,7 +306,7 @@ public class VaListTest extends NativeTestHelper {
     public void testBigStruct(Function<Consumer<VaList.Builder>, VaList> vaListFactory,
                               Function<VaList, Long> sumBigStruct,
                               GroupLayout BigPoint_LAYOUT, VarHandle VH_BigPoint_x, VarHandle VH_BigPoint_y) {
-        try (ResourceScope scope = ResourceScope.ofConfined()) {
+        try (ResourceScope scope = ResourceScope.newConfinedScope()) {
             MemorySegment struct = MemorySegment.allocateNative(BigPoint_LAYOUT, scope);
             VH_BigPoint_x.set(struct, 5);
             VH_BigPoint_y.set(struct, 10);
@@ -325,7 +324,7 @@ public class VaListTest extends NativeTestHelper {
         TriFunction<MemoryLayout, VarHandle, VarHandle, Function<VaList, Float>> sumStructJavaFact
                 = (FloatPoint_LAYOUT, VH_FloatPoint_x, VH_FloatPoint_y) ->
                 list -> {
-                    MemorySegment struct = list.vargAsSegment(FloatPoint_LAYOUT, ResourceScope.ofImplicit());
+                    MemorySegment struct = list.vargAsSegment(FloatPoint_LAYOUT, ResourceScope.newImplicitScope());
                     float x = (float) VH_FloatPoint_x.get(struct);
                     float y = (float) VH_FloatPoint_y.get(struct);
                     return x + y;
@@ -338,7 +337,7 @@ public class VaListTest extends NativeTestHelper {
         TriFunction<Function<Consumer<VaList.Builder>, VaList>, MemoryLayout,
                 TriFunction<MemoryLayout, VarHandle, VarHandle, Function<VaList, Float>>, Object[]> argsFact
                 = (vaListFact, floatLayout, sumFloatStructFact) -> {
-            GroupLayout FloatPoint_LAYOUT = MemoryLayout.ofStruct(
+            GroupLayout FloatPoint_LAYOUT = MemoryLayout.structLayout(
                     floatLayout.withName("x"),
                     floatLayout.withName("y")
             );
@@ -360,7 +359,7 @@ public class VaListTest extends NativeTestHelper {
                                 Function<VaList, Float> sumFloatStruct,
                                 GroupLayout FloatPoint_LAYOUT,
                                 VarHandle VH_FloatPoint_x, VarHandle VH_FloatPoint_y) {
-        try (ResourceScope scope = ResourceScope.ofConfined()) {
+        try (ResourceScope scope = ResourceScope.newConfinedScope()) {
             MemorySegment struct = MemorySegment.allocateNative(FloatPoint_LAYOUT, scope);
             VH_FloatPoint_x.set(struct, 1.234f);
             VH_FloatPoint_y.set(struct, 3.142f);
@@ -382,7 +381,7 @@ public class VaListTest extends NativeTestHelper {
         QuadFunc<MemoryLayout, VarHandle, VarHandle, VarHandle, Function<VaList, Long>> sumStructJavaFact
                 = (HugePoint_LAYOUT, VH_HugePoint_x, VH_HugePoint_y, VH_HugePoint_z) ->
                 list -> {
-                    MemorySegment struct = list.vargAsSegment(HugePoint_LAYOUT, ResourceScope.ofImplicit());
+                    MemorySegment struct = list.vargAsSegment(HugePoint_LAYOUT, ResourceScope.newImplicitScope());
                     long x = (long) VH_HugePoint_x.get(struct);
                     long y = (long) VH_HugePoint_y.get(struct);
                     long z = (long) VH_HugePoint_z.get(struct);
@@ -396,7 +395,7 @@ public class VaListTest extends NativeTestHelper {
         TriFunction<Function<Consumer<VaList.Builder>, VaList>, MemoryLayout,
                 QuadFunc<MemoryLayout, VarHandle, VarHandle, VarHandle, Function<VaList, Long>>, Object[]> argsFact
                 = (vaListFact, longLongLayout, sumBigStructFact) -> {
-            GroupLayout HugePoint_LAYOUT = MemoryLayout.ofStruct(
+            GroupLayout HugePoint_LAYOUT = MemoryLayout.structLayout(
                     longLongLayout.withName("x"),
                     longLongLayout.withName("y"),
                     longLongLayout.withName("z")
@@ -423,7 +422,7 @@ public class VaListTest extends NativeTestHelper {
                                VarHandle VH_HugePoint_x, VarHandle VH_HugePoint_y, VarHandle VH_HugePoint_z) {
         // On AArch64 a struct needs to be larger than 16 bytes to be
         // passed by reference.
-        try (ResourceScope scope = ResourceScope.ofConfined()) {
+        try (ResourceScope scope = ResourceScope.newConfinedScope()) {
             MemorySegment struct = MemorySegment.allocateNative(HugePoint_LAYOUT, scope);
             VH_HugePoint_x.set(struct, 1);
             VH_HugePoint_y.set(struct, 2);
@@ -475,7 +474,7 @@ public class VaListTest extends NativeTestHelper {
                           SumStackFunc sumStack,
                           ValueLayout longLayout,
                           ValueLayout doubleLayout) {
-        try (ResourceScope scope = ResourceScope.ofConfined()) {
+        try (ResourceScope scope = ResourceScope.newConfinedScope()) {
             MemorySegment longSum = MemorySegment.allocateNative(longLayout, scope);
             MemorySegment doubleSum = MemorySegment.allocateNative(doubleLayout, scope);
             MemoryAccess.setLong(longSum, 0L);
@@ -507,7 +506,7 @@ public class VaListTest extends NativeTestHelper {
     @Test(dataProvider = "upcalls")
     public void testUpcall(MethodHandle target, MethodHandle callback) throws Throwable {
         FunctionDescriptor desc = FunctionDescriptor.ofVoid(C_VA_LIST);
-        try (ResourceScope scope = ResourceScope.ofConfined()) {
+        try (ResourceScope scope = ResourceScope.newConfinedScope()) {
             MemorySegment stub = abi.upcallStub(callback, desc, scope);
             target.invokeExact(stub.address());
         }
@@ -569,7 +568,7 @@ public class VaListTest extends NativeTestHelper {
                                 GroupLayout Point_LAYOUT, VarHandle VH_Point_x, VarHandle VH_Point_y) {
         MemorySegment pointOut;
         try (NativeScope scope = new NativeScope()) {
-            try (ResourceScope innerScope = ResourceScope.ofConfined()) {
+            try (ResourceScope innerScope = ResourceScope.newConfinedScope()) {
                 MemorySegment pointIn = MemorySegment.allocateNative(Point_LAYOUT, innerScope);
                 VH_Point_x.set(pointIn, 3);
                 VH_Point_y.set(pointIn, 6);
@@ -628,25 +627,25 @@ public class VaListTest extends NativeTestHelper {
 
     @DataProvider
     public static Object[][] upcalls() {
-        GroupLayout BigPoint_LAYOUT = MemoryLayout.ofStruct(
+        GroupLayout BigPoint_LAYOUT = MemoryLayout.structLayout(
                 C_LONG_LONG.withName("x"),
                 C_LONG_LONG.withName("y")
         );
         VarHandle VH_BigPoint_x = BigPoint_LAYOUT.varHandle(long.class, groupElement("x"));
         VarHandle VH_BigPoint_y = BigPoint_LAYOUT.varHandle(long.class, groupElement("y"));
-        GroupLayout Point_LAYOUT = MemoryLayout.ofStruct(
+        GroupLayout Point_LAYOUT = MemoryLayout.structLayout(
                 C_INT.withName("x"),
                 C_INT.withName("y")
         );
         VarHandle VH_Point_x = Point_LAYOUT.varHandle(int.class, groupElement("x"));
         VarHandle VH_Point_y = Point_LAYOUT.varHandle(int.class, groupElement("y"));
-        GroupLayout FloatPoint_LAYOUT = MemoryLayout.ofStruct(
+        GroupLayout FloatPoint_LAYOUT = MemoryLayout.structLayout(
                 C_FLOAT.withName("x"),
                 C_FLOAT.withName("y")
         );
         VarHandle VH_FloatPoint_x = FloatPoint_LAYOUT.varHandle(float.class, groupElement("x"));
         VarHandle VH_FloatPoint_y = FloatPoint_LAYOUT.varHandle(float.class, groupElement("y"));
-        GroupLayout HugePoint_LAYOUT = MemoryLayout.ofStruct(
+        GroupLayout HugePoint_LAYOUT = MemoryLayout.structLayout(
                 C_LONG_LONG.withName("x"),
                 C_LONG_LONG.withName("y"),
                 C_LONG_LONG.withName("z")
@@ -657,13 +656,13 @@ public class VaListTest extends NativeTestHelper {
 
         return new Object[][]{
                 { linkVaListCB("upcallBigStruct"), VaListConsumer.mh(vaList -> {
-                    MemorySegment struct = vaList.vargAsSegment(BigPoint_LAYOUT, ResourceScope.ofImplicit());
+                    MemorySegment struct = vaList.vargAsSegment(BigPoint_LAYOUT, ResourceScope.newImplicitScope());
                     assertEquals((long) VH_BigPoint_x.get(struct), 8);
                     assertEquals((long) VH_BigPoint_y.get(struct), 16);
                 })},
                 { linkVaListCB("upcallBigStruct"), VaListConsumer.mh(vaList -> {
                     VaList copy = vaList.copy();
-                    MemorySegment struct = vaList.vargAsSegment(BigPoint_LAYOUT, ResourceScope.ofImplicit());
+                    MemorySegment struct = vaList.vargAsSegment(BigPoint_LAYOUT, ResourceScope.newImplicitScope());
                     assertEquals((long) VH_BigPoint_x.get(struct), 8);
                     assertEquals((long) VH_BigPoint_y.get(struct), 16);
 
@@ -671,23 +670,23 @@ public class VaListTest extends NativeTestHelper {
                     VH_BigPoint_y.set(struct, 0);
 
                     // should be independent
-                    struct = copy.vargAsSegment(BigPoint_LAYOUT, ResourceScope.ofImplicit());
+                    struct = copy.vargAsSegment(BigPoint_LAYOUT, ResourceScope.newImplicitScope());
                     assertEquals((long) VH_BigPoint_x.get(struct), 8);
                     assertEquals((long) VH_BigPoint_y.get(struct), 16);
                 })},
                 { linkVaListCB("upcallStruct"), VaListConsumer.mh(vaList -> {
-                    MemorySegment struct = vaList.vargAsSegment(Point_LAYOUT, ResourceScope.ofImplicit());
+                    MemorySegment struct = vaList.vargAsSegment(Point_LAYOUT, ResourceScope.newImplicitScope());
                     assertEquals((int) VH_Point_x.get(struct), 5);
                     assertEquals((int) VH_Point_y.get(struct), 10);
                 })},
                 { linkVaListCB("upcallHugeStruct"), VaListConsumer.mh(vaList -> {
-                    MemorySegment struct = vaList.vargAsSegment(HugePoint_LAYOUT, ResourceScope.ofImplicit());
+                    MemorySegment struct = vaList.vargAsSegment(HugePoint_LAYOUT, ResourceScope.newImplicitScope());
                     assertEquals((long) VH_HugePoint_x.get(struct), 1);
                     assertEquals((long) VH_HugePoint_y.get(struct), 2);
                     assertEquals((long) VH_HugePoint_z.get(struct), 3);
                 })},
                 { linkVaListCB("upcallFloatStruct"), VaListConsumer.mh(vaList -> {
-                    MemorySegment struct = vaList.vargAsSegment(FloatPoint_LAYOUT, ResourceScope.ofImplicit());
+                    MemorySegment struct = vaList.vargAsSegment(FloatPoint_LAYOUT, ResourceScope.newImplicitScope());
                     assertEquals((float) VH_FloatPoint_x.get(struct), 1.0f);
                     assertEquals((float) VH_FloatPoint_y.get(struct), 2.0f);
                 })},
@@ -732,12 +731,12 @@ public class VaListTest extends NativeTestHelper {
                     assertEquals((float) vaList.vargAsDouble(C_DOUBLE), 13.0F);
                     assertEquals(vaList.vargAsDouble(C_DOUBLE), 14.0D);
 
-                    MemorySegment point = vaList.vargAsSegment(Point_LAYOUT, ResourceScope.ofImplicit());
+                    MemorySegment point = vaList.vargAsSegment(Point_LAYOUT, ResourceScope.newImplicitScope());
                     assertEquals((int) VH_Point_x.get(point), 5);
                     assertEquals((int) VH_Point_y.get(point), 10);
 
                     VaList copy = vaList.copy();
-                    MemorySegment bigPoint = vaList.vargAsSegment(BigPoint_LAYOUT, ResourceScope.ofImplicit());
+                    MemorySegment bigPoint = vaList.vargAsSegment(BigPoint_LAYOUT, ResourceScope.newImplicitScope());
                     assertEquals((long) VH_BigPoint_x.get(bigPoint), 15);
                     assertEquals((long) VH_BigPoint_y.get(bigPoint), 20);
 
@@ -745,7 +744,7 @@ public class VaListTest extends NativeTestHelper {
                     VH_BigPoint_y.set(bigPoint, 0);
 
                     // should be independent
-                    MemorySegment struct = copy.vargAsSegment(BigPoint_LAYOUT, ResourceScope.ofImplicit());
+                    MemorySegment struct = copy.vargAsSegment(BigPoint_LAYOUT, ResourceScope.newImplicitScope());
                     assertEquals((long) VH_BigPoint_x.get(struct), 15);
                     assertEquals((long) VH_BigPoint_y.get(struct), 20);
                 })},

--- a/test/micro/org/openjdk/bench/jdk/incubator/foreign/BulkOps.java
+++ b/test/micro/org/openjdk/bench/jdk/incubator/foreign/BulkOps.java
@@ -56,7 +56,7 @@ public class BulkOps {
     static final int ALLOC_SIZE = ELEM_SIZE * CARRIER_SIZE;
 
     static final long unsafe_addr = unsafe.allocateMemory(ALLOC_SIZE);
-    static final MemorySegment segment = MemorySegment.allocateNative(ALLOC_SIZE, ResourceScope.ofConfined());
+    static final MemorySegment segment = MemorySegment.allocateNative(ALLOC_SIZE, ResourceScope.newConfinedScope());
 
     static final int[] bytes = new int[ELEM_SIZE];
     static final MemorySegment bytesSegment = MemorySegment.ofArray(bytes);
@@ -64,14 +64,14 @@ public class BulkOps {
 
     // large(ish) segments/buffers with same content, 0, for mismatch, non-multiple-of-8 sized
     static final int SIZE_WITH_TAIL = (1024 * 1024) + 7;
-    static final MemorySegment mismatchSegmentLarge1 = MemorySegment.allocateNative(SIZE_WITH_TAIL, ResourceScope.ofConfined());
-    static final MemorySegment mismatchSegmentLarge2 = MemorySegment.allocateNative(SIZE_WITH_TAIL, ResourceScope.ofConfined());
+    static final MemorySegment mismatchSegmentLarge1 = MemorySegment.allocateNative(SIZE_WITH_TAIL, ResourceScope.newConfinedScope());
+    static final MemorySegment mismatchSegmentLarge2 = MemorySegment.allocateNative(SIZE_WITH_TAIL, ResourceScope.newConfinedScope());
     static final ByteBuffer mismatchBufferLarge1 = ByteBuffer.allocateDirect(SIZE_WITH_TAIL);
     static final ByteBuffer mismatchBufferLarge2 = ByteBuffer.allocateDirect(SIZE_WITH_TAIL);
 
     // mismatch at first byte
-    static final MemorySegment mismatchSegmentSmall1 = MemorySegment.allocateNative(7, ResourceScope.ofConfined());
-    static final MemorySegment mismatchSegmentSmall2 = MemorySegment.allocateNative(7, ResourceScope.ofConfined());
+    static final MemorySegment mismatchSegmentSmall1 = MemorySegment.allocateNative(7, ResourceScope.newConfinedScope());
+    static final MemorySegment mismatchSegmentSmall2 = MemorySegment.allocateNative(7, ResourceScope.newConfinedScope());
     static final ByteBuffer mismatchBufferSmall1 = ByteBuffer.allocateDirect(7);
     static final ByteBuffer mismatchBufferSmall2 = ByteBuffer.allocateDirect(7);
     static {

--- a/test/micro/org/openjdk/bench/jdk/incubator/foreign/CallOverheadHelper.java
+++ b/test/micro/org/openjdk/bench/jdk/incubator/foreign/CallOverheadHelper.java
@@ -29,6 +29,7 @@ import jdk.incubator.foreign.LibraryLookup;
 import jdk.incubator.foreign.MemoryAddress;
 import jdk.incubator.foreign.MemoryLayout;
 import jdk.incubator.foreign.MemorySegment;
+import jdk.incubator.foreign.ResourceScope;
 import jdk.incubator.foreign.SegmentAllocator;
 
 import java.lang.invoke.MethodHandle;
@@ -79,13 +80,13 @@ public class CallOverheadHelper {
     static final MethodHandle identity_trivial;
     static final MethodHandle identity_trivial_v;
 
-    static final MemoryLayout POINT_LAYOUT = MemoryLayout.ofStruct(
+    static final MemoryLayout POINT_LAYOUT = MemoryLayout.structLayout(
             C_LONG_LONG, C_LONG_LONG
     );
 
-    static final MemorySegment point = MemorySegment.allocateNative(POINT_LAYOUT);
+    static final MemorySegment point = MemorySegment.allocateNative(POINT_LAYOUT, ResourceScope.newImplicitScope());
 
-    static final SegmentAllocator recycling_allocator = SegmentAllocator.prefix(MemorySegment.allocateNative(POINT_LAYOUT));
+    static final SegmentAllocator recycling_allocator = SegmentAllocator.ofSegment(MemorySegment.allocateNative(POINT_LAYOUT, ResourceScope.newImplicitScope()));
 
     static {
         System.loadLibrary("CallOverheadJNI");

--- a/test/micro/org/openjdk/bench/jdk/incubator/foreign/LoopOverConstant.java
+++ b/test/micro/org/openjdk/bench/jdk/incubator/foreign/LoopOverConstant.java
@@ -23,6 +23,7 @@
 package org.openjdk.bench.jdk.incubator.foreign;
 
 import jdk.incubator.foreign.MemoryLayout;
+import jdk.incubator.foreign.ResourceScope;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.CompilerControl;
@@ -36,7 +37,6 @@ import org.openjdk.jmh.annotations.TearDown;
 import org.openjdk.jmh.annotations.Warmup;
 import sun.misc.Unsafe;
 
-import jdk.incubator.foreign.MemoryAddress;
 import jdk.incubator.foreign.MemorySegment;
 import java.lang.invoke.VarHandle;
 import java.nio.ByteBuffer;
@@ -72,8 +72,8 @@ public class LoopOverConstant {
 
     //setup native memory segment
 
-    static final MemorySegment segment = MemorySegment.allocateNative(ALLOC_SIZE);
-    static final VarHandle VH_int = MemoryLayout.ofSequence(JAVA_INT).varHandle(int.class, sequenceElement());
+    static final MemorySegment segment = MemorySegment.allocateNative(ALLOC_SIZE, ResourceScope.newImplicitScope());
+    static final VarHandle VH_int = MemoryLayout.sequenceLayout(JAVA_INT).varHandle(int.class, sequenceElement());
 
     static {
         for (int i = 0; i < ELEM_SIZE; i++) {

--- a/test/micro/org/openjdk/bench/jdk/incubator/foreign/LoopOverNonConstant.java
+++ b/test/micro/org/openjdk/bench/jdk/incubator/foreign/LoopOverNonConstant.java
@@ -60,7 +60,7 @@ public class LoopOverNonConstant {
     static final int CARRIER_SIZE = (int)JAVA_INT.byteSize();
     static final int ALLOC_SIZE = ELEM_SIZE * CARRIER_SIZE;
 
-    static final VarHandle VH_int = MemoryLayout.ofSequence(JAVA_INT).varHandle(int.class, sequenceElement());
+    static final VarHandle VH_int = MemoryLayout.sequenceLayout(JAVA_INT).varHandle(int.class, sequenceElement());
     MemorySegment segment;
     long unsafe_addr;
 
@@ -72,7 +72,7 @@ public class LoopOverNonConstant {
         for (int i = 0; i < ELEM_SIZE; i++) {
             unsafe.putInt(unsafe_addr + (i * CARRIER_SIZE) , i);
         }
-        segment = MemorySegment.allocateNative(ALLOC_SIZE, ResourceScope.ofConfined());
+        segment = MemorySegment.allocateNative(ALLOC_SIZE, ResourceScope.newConfinedScope());
         for (int i = 0; i < ELEM_SIZE; i++) {
             VH_int.set(segment, (long) i, i);
         }

--- a/test/micro/org/openjdk/bench/jdk/incubator/foreign/LoopOverNonConstantFP.java
+++ b/test/micro/org/openjdk/bench/jdk/incubator/foreign/LoopOverNonConstantFP.java
@@ -72,8 +72,8 @@ public class LoopOverNonConstantFP {
         for (int i = 0; i < ELEM_SIZE; i++) {
             unsafe.putDouble(unsafe_addrOut + (i * CARRIER_SIZE), i);
         }
-        segmentIn = MemorySegment.allocateNative(ALLOC_SIZE, ResourceScope.ofConfined());
-        segmentOut = MemorySegment.allocateNative(ALLOC_SIZE, ResourceScope.ofConfined());
+        segmentIn = MemorySegment.allocateNative(ALLOC_SIZE, ResourceScope.newConfinedScope());
+        segmentOut = MemorySegment.allocateNative(ALLOC_SIZE, ResourceScope.newConfinedScope());
         for (int i = 0; i < ELEM_SIZE; i++) {
             MemoryAccess.setDoubleAtIndex(segmentIn, i, i);
         }

--- a/test/micro/org/openjdk/bench/jdk/incubator/foreign/LoopOverNonConstantHeap.java
+++ b/test/micro/org/openjdk/bench/jdk/incubator/foreign/LoopOverNonConstantHeap.java
@@ -63,7 +63,7 @@ public class LoopOverNonConstantHeap {
     static final int ALLOC_SIZE = ELEM_SIZE * CARRIER_SIZE;
     static final int UNSAFE_BYTE_BASE = unsafe.arrayBaseOffset(byte[].class);
 
-    static final VarHandle VH_int = MemoryLayout.ofSequence(JAVA_INT).varHandle(int.class, sequenceElement());
+    static final VarHandle VH_int = MemoryLayout.sequenceLayout(JAVA_INT).varHandle(int.class, sequenceElement());
     MemorySegment segment;
     byte[] base;
 
@@ -79,7 +79,7 @@ public class LoopOverNonConstantHeap {
             MemorySegment intI = MemorySegment.ofArray(new int[ALLOC_SIZE]);
             MemorySegment intD = MemorySegment.ofArray(new double[ALLOC_SIZE]);
             MemorySegment intF = MemorySegment.ofArray(new float[ALLOC_SIZE]);
-            MemorySegment s = MemorySegment.allocateNative(ALLOC_SIZE, 1, ResourceScope.ofConfined(Cleaner.create()));
+            MemorySegment s = MemorySegment.allocateNative(ALLOC_SIZE, 1, ResourceScope.newConfinedScope(Cleaner.create()));
             for (int i = 0; i < ALLOC_SIZE; i++) {
                 MemoryAccess.setByteAtOffset(intB, i, (byte)i);
                 MemoryAccess.setIntAtIndex(intI, i, i);

--- a/test/micro/org/openjdk/bench/jdk/incubator/foreign/LoopOverNonConstantMapped.java
+++ b/test/micro/org/openjdk/bench/jdk/incubator/foreign/LoopOverNonConstantMapped.java
@@ -81,7 +81,7 @@ public class LoopOverNonConstantMapped {
         }
     }
 
-    static final VarHandle VH_int = MemoryLayout.ofSequence(JAVA_INT).varHandle(int.class, sequenceElement());
+    static final VarHandle VH_int = MemoryLayout.sequenceLayout(JAVA_INT).varHandle(int.class, sequenceElement());
     MemorySegment segment;
     long unsafe_addr;
 
@@ -96,7 +96,7 @@ public class LoopOverNonConstantMapped {
             }
             ((MappedByteBuffer)byteBuffer).force();
         }
-        segment = MemorySegment.mapFile(tempPath, 0L, ALLOC_SIZE, FileChannel.MapMode.READ_WRITE, ResourceScope.ofConfined());
+        segment = MemorySegment.mapFile(tempPath, 0L, ALLOC_SIZE, FileChannel.MapMode.READ_WRITE, ResourceScope.newConfinedScope());
         unsafe_addr = segment.address().toRawLongValue();
     }
 

--- a/test/micro/org/openjdk/bench/jdk/incubator/foreign/LoopOverNonConstantShared.java
+++ b/test/micro/org/openjdk/bench/jdk/incubator/foreign/LoopOverNonConstantShared.java
@@ -60,7 +60,7 @@ public class LoopOverNonConstantShared {
     static final int CARRIER_SIZE = (int)JAVA_INT.byteSize();
     static final int ALLOC_SIZE = ELEM_SIZE * CARRIER_SIZE;
 
-    static final VarHandle VH_int = MemoryLayout.ofSequence(JAVA_INT).varHandle(int.class, sequenceElement());
+    static final VarHandle VH_int = MemoryLayout.sequenceLayout(JAVA_INT).varHandle(int.class, sequenceElement());
     MemorySegment segment;
     long unsafe_addr;
 
@@ -72,7 +72,7 @@ public class LoopOverNonConstantShared {
         for (int i = 0; i < ELEM_SIZE; i++) {
             unsafe.putInt(unsafe_addr + (i * CARRIER_SIZE) , i);
         }
-        segment = MemorySegment.allocateNative(ALLOC_SIZE, CARRIER_SIZE, ResourceScope.ofShared());
+        segment = MemorySegment.allocateNative(ALLOC_SIZE, CARRIER_SIZE, ResourceScope.newSharedScope());
         for (int i = 0; i < ELEM_SIZE; i++) {
             VH_int.set(segment, (long) i, i);
         }

--- a/test/micro/org/openjdk/bench/jdk/incubator/foreign/LoopOverPollutedSegments.java
+++ b/test/micro/org/openjdk/bench/jdk/incubator/foreign/LoopOverPollutedSegments.java
@@ -62,7 +62,7 @@ public class LoopOverPollutedSegments {
     byte[] arr;
     long addr;
 
-    static final VarHandle intHandle = MemoryLayout.ofSequence(JAVA_INT).varHandle(int.class, MemoryLayout.PathElement.sequenceElement());
+    static final VarHandle intHandle = MemoryLayout.sequenceLayout(JAVA_INT).varHandle(int.class, MemoryLayout.PathElement.sequenceElement());
 
 
     @Setup
@@ -72,7 +72,7 @@ public class LoopOverPollutedSegments {
             unsafe.putInt(addr + (i * 4), i);
         }
         arr = new byte[ALLOC_SIZE];
-        nativeSegment = MemorySegment.allocateNative(ALLOC_SIZE, 4, ResourceScope.ofConfined());
+        nativeSegment = MemorySegment.allocateNative(ALLOC_SIZE, 4, ResourceScope.newConfinedScope());
         heapSegmentBytes = MemorySegment.ofArray(new byte[ALLOC_SIZE]);
         heapSegmentFloats = MemorySegment.ofArray(new float[ELEM_SIZE]);
 

--- a/test/micro/org/openjdk/bench/jdk/incubator/foreign/ParallelSum.java
+++ b/test/micro/org/openjdk/bench/jdk/incubator/foreign/ParallelSum.java
@@ -66,9 +66,9 @@ public class ParallelSum {
     final static int CARRIER_SIZE = 4;
     final static int ALLOC_SIZE = CARRIER_SIZE * 1024 * 1024 * 256;
     final static int ELEM_SIZE = ALLOC_SIZE / CARRIER_SIZE;
-    static final VarHandle VH_int = MemoryLayout.ofSequence(JAVA_INT).varHandle(int.class, sequenceElement());
+    static final VarHandle VH_int = MemoryLayout.sequenceLayout(JAVA_INT).varHandle(int.class, sequenceElement());
 
-    final static SequenceLayout SEQUENCE_LAYOUT = MemoryLayout.ofSequence(ELEM_SIZE, MemoryLayouts.JAVA_INT);
+    final static SequenceLayout SEQUENCE_LAYOUT = MemoryLayout.sequenceLayout(ELEM_SIZE, MemoryLayouts.JAVA_INT);
     final static int BULK_FACTOR = 512;
     final static SequenceLayout SEQUENCE_LAYOUT_BULK = SEQUENCE_LAYOUT.reshape(-1, BULK_FACTOR);
 
@@ -83,7 +83,7 @@ public class ParallelSum {
         for (int i = 0; i < ELEM_SIZE; i++) {
             unsafe.putInt(address + (i * CARRIER_SIZE), i);
         }
-        segment = MemorySegment.allocateNative(ALLOC_SIZE, CARRIER_SIZE, ResourceScope.ofShared());
+        segment = MemorySegment.allocateNative(ALLOC_SIZE, CARRIER_SIZE, ResourceScope.newSharedScope());
         for (int i = 0; i < ELEM_SIZE; i++) {
             VH_int.set(segment, (long) i, i);
         }

--- a/test/micro/org/openjdk/bench/jdk/incubator/foreign/TestAdaptVarHandles.java
+++ b/test/micro/org/openjdk/bench/jdk/incubator/foreign/TestAdaptVarHandles.java
@@ -24,7 +24,6 @@
 
 package org.openjdk.bench.jdk.incubator.foreign;
 
-import jdk.incubator.foreign.MemoryAddress;
 import jdk.incubator.foreign.MemoryHandles;
 import jdk.incubator.foreign.MemoryLayout;
 import jdk.incubator.foreign.MemoryLayouts;
@@ -86,7 +85,7 @@ public class TestAdaptVarHandles {
 
     static final VarHandle VH_box_int = MemoryHandles.filterValue(VH_int, INTBOX_TO_INT, INT_TO_INTBOX);
 
-    static final VarHandle VH_addr_int = MemoryLayout.ofSequence(MemoryLayouts.JAVA_INT)
+    static final VarHandle VH_addr_int = MemoryLayout.sequenceLayout(MemoryLayouts.JAVA_INT)
             .varHandle(int.class, MemoryLayout.PathElement.sequenceElement());
 
     static final VarHandle VH_addr_box_int = MemoryHandles.filterValue(VH_addr_int, INTBOX_TO_INT, INT_TO_INTBOX);

--- a/test/micro/org/openjdk/bench/jdk/incubator/foreign/UnrolledAccess.java
+++ b/test/micro/org/openjdk/bench/jdk/incubator/foreign/UnrolledAccess.java
@@ -32,9 +32,7 @@ import org.openjdk.jmh.runner.options.OptionsBuilder;
 import sun.misc.Unsafe;
 import java.util.concurrent.TimeUnit;
 
-import java.lang.invoke.MethodHandles;
 import java.lang.invoke.VarHandle;
-import java.lang.reflect.Field;
 
 @BenchmarkMode(Mode.AverageTime)
 @Warmup(iterations = 5, time = 500, timeUnit = TimeUnit.MILLISECONDS)
@@ -48,7 +46,7 @@ public class UnrolledAccess {
 
     final static int SIZE = 1024;
 
-    static final VarHandle LONG_HANDLE = MemoryLayout.ofSequence(SIZE, MemoryLayouts.JAVA_LONG)
+    static final VarHandle LONG_HANDLE = MemoryLayout.sequenceLayout(SIZE, MemoryLayouts.JAVA_LONG)
             .varHandle(long.class, MemoryLayout.PathElement.sequenceElement());
 
     @State(Scope.Benchmark)
@@ -67,8 +65,8 @@ public class UnrolledAccess {
             this.outputArray = new double[SIZE];
             this.inputAddress = U.allocateMemory(8 * SIZE);
             this.outputAddress = U.allocateMemory(8 * SIZE);
-            this.inputSegment = MemoryAddress.ofLong(inputAddress).asSegmentRestricted(8*SIZE);
-            this.outputSegment = MemoryAddress.ofLong(outputAddress).asSegmentRestricted(8*SIZE);
+            this.inputSegment = MemoryAddress.ofLong(inputAddress).asSegment(8*SIZE, ResourceScope.globalScope());
+            this.outputSegment = MemoryAddress.ofLong(outputAddress).asSegment(8*SIZE, ResourceScope.globalScope());
         }
     }
 

--- a/test/micro/org/openjdk/bench/jdk/incubator/foreign/Upcalls.java
+++ b/test/micro/org/openjdk/bench/jdk/incubator/foreign/Upcalls.java
@@ -26,6 +26,7 @@ import jdk.incubator.foreign.FunctionDescriptor;
 import jdk.incubator.foreign.LibraryLookup;
 import jdk.incubator.foreign.MemoryAddress;
 import jdk.incubator.foreign.CLinker;
+import jdk.incubator.foreign.ResourceScope;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Fork;
@@ -134,7 +135,7 @@ public class Upcalls {
     static MemoryAddress makeCB(String name, MethodType mt, FunctionDescriptor fd) throws ReflectiveOperationException {
         return abi.upcallStub(
             lookup().findStatic(Upcalls.class, name, mt),
-            fd
+            fd, ResourceScope.globalScope()
         ).address();
     }
 

--- a/test/micro/org/openjdk/bench/jdk/incubator/foreign/VaList.java
+++ b/test/micro/org/openjdk/bench/jdk/incubator/foreign/VaList.java
@@ -76,7 +76,7 @@ public class VaList {
 
     @Benchmark
     public void vaList() throws Throwable {
-        try (ResourceScope scope = ResourceScope.ofConfined()) {
+        try (ResourceScope scope = ResourceScope.newConfinedScope()) {
             CLinker.VaList vaList = CLinker.VaList.make(b ->
                     b.vargFromInt(C_INT, 1)
                             .vargFromDouble(C_DOUBLE, 2D)

--- a/test/micro/org/openjdk/bench/jdk/incubator/foreign/VarHandleExact.java
+++ b/test/micro/org/openjdk/bench/jdk/incubator/foreign/VarHandleExact.java
@@ -62,7 +62,7 @@ public class VarHandleExact {
 
     @Setup
     public void setup() {
-        data = MemorySegment.allocateNative(JAVA_INT, ResourceScope.ofConfined());
+        data = MemorySegment.allocateNative(JAVA_INT, ResourceScope.newConfinedScope());
     }
 
     @TearDown

--- a/test/micro/org/openjdk/bench/jdk/incubator/foreign/points/support/PanamaPoint.java
+++ b/test/micro/org/openjdk/bench/jdk/incubator/foreign/points/support/PanamaPoint.java
@@ -39,7 +39,7 @@ import static jdk.incubator.foreign.CLinker.*;
 
 public class PanamaPoint implements AutoCloseable {
 
-    public static final MemoryLayout LAYOUT = MemoryLayout.ofStruct(
+    public static final MemoryLayout LAYOUT = MemoryLayout.structLayout(
         C_INT.withName("x"),
         C_INT.withName("y")
     );
@@ -67,7 +67,7 @@ public class PanamaPoint implements AutoCloseable {
     private final MemorySegment segment;
 
     public PanamaPoint(int x, int y) {
-        this(MemorySegment.allocateNative(LAYOUT, ResourceScope.ofConfined()), x, y);
+        this(MemorySegment.allocateNative(LAYOUT, ResourceScope.newConfinedScope()), x, y);
     }
 
     public PanamaPoint(MemorySegment segment, int x, int y) {


### PR DESCRIPTION
It has been pointed out recently, that some of the static factory names are not very friendly with use of static imports. The latest case is `ResourceScope::ofImplicit`, which would lead to code like this:

```
MemorySegment.allocateNative(100, ofImplicit());
```

But there's also the old good layout API:

```
MemoryLayout layout = MemoryLayout.ofSequence(10,
                                  MemoryLayout.ofStruct(
                                             MemoryLayout.ofValueBits(4).withName("x"),
                                             MemoryLayout.ofPadding(8),
                                             MemoryLayout.ofValueBits(4).withName("y"),
                                  )); 
```

We've been examining precedents, and also looking at some of the existing comments on the topic [1], and we came up with the following principles, which we have tried to adhere to in our renaming effort:


* a static factory should have a name that stands on its own (think `MethodType.methodType`)
* in some cases, when converting between different things, or when creating something out of something else the prefix `of` is acceptable (`LocalDateTime.ofInstant`); this also means static imports cannot be used in these cases
* if returning a new instance is relevant semantic-wise, factory name should be prefixed with `new` (as in `Files.newInputStream`); otherwise `new` can be omitted

Armed with these principles, we have made the following changes to the API:

### MemoryLayouts

Factories have been renamed from `ofXYZ` to `XYZLayout` - so the above example becomes:

```
MemoryLayout layout = sequenceLayout(10,
                                  structLayout(
                                             valueLayout(4).withName("x"),
                                             paddingLayout(8),
                                             valueLayout(4).withName("y"),
                                  )); 
```

Which is much more readable.

### ResourceScope

Here we opted for the following mapping:

* ResourceScope::ofImplicit -> ResourceScope::newImplicitScope
* ResourceScope::ofConfined -> ResourceScope::newConfinedScope
* ResourceScope::ofShared -> ResourceScope::newSharedScope
* ResourceScope::globalScope ->  ResourceScope::globalScope (unchanged)

So, the above example becomes:

```
MemorySegment.allocateNative(100, newImplicitScope());
```

Again, more readable and explicit.

### SegmentAllocator

Here it's tricky, as we have a mix of allocator-sounding names (`arenaBounded`/`arenaUnbounded`/`malloc`) and some odd ones out (`scoped`, `prefix`, `implicit`).

So, in the case of `arenaBounded`/`arenaUnbounded`, we think that having a couple of `arenaAllocator` overloads would be preferrable.

As for `scoped` and `prefix`, we think it's more useful to think of these as *conversions*, so use `of`. Following the precedent on `LocalDateTime`, let's also add the type name aftre `of`, e.g. `ofScope` and `ofSegment`, respectively.

This leaves us with `malloc` and `implicit`. Now, I think while `malloc` is allocator sounding, it is also a misleading name. This is really an allocator that just ends up calling `MemorySegment::allocateNative` with fresh scopes. 

We also noted that, being `SegmentAllocator` a functional interface, the gain with using `malloc` is relatively small:

```
SegemtAllocator allocator = malloc(ResourceScope::newConfinedScope);
```

vs.

```
SegmentAllocator allocator = (size, align) -> MemorySegment.allocateNative(size, align, newConfinedScope())
```

So we opted to remove `malloc`; we also applied a similar argument for the implicit allocator (which, in fact, is really like `malloc(ResourceScope::newImplicitScope)`). So, to summarize:

* SegmentAllocator::arenaBounded -> ResourceScope::arenaAllocator
* SegmentAllocator::arenaUnbounded -> ResourceScope::arenaAllocator
* SegmentAllocator::prefix -> ResourceScope::ofSegment
* SegmentAllocator::scoped -> ResourceScope::ofScope
* SegmentAllocator::malloc -> // removed
* SegmentAllocator::implicit -> // removed

### Conclusions

While (many) other naming schemes are possible, what we did seems consistent with precedent set by other JDK API, and seems to land the API in a place which is more amenable to using static imports, which seems like an improvement (gievn the number of static methods in the API).

While most of the changes were done using the IDE, some of them have been done manually - specifically those fixing the currently broken micro benchmark (after removal of "restricted" suffix yesterday), and fixes to scope-less MemorySegment::allocateNative in various javadoc samples.

[1] - https://blog.joda.org/2011/08/common-java-method-names.html

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [JDK-8264515](https://bugs.openjdk.java.net/browse/JDK-8264515): Rename static factory methods in the foreign API


### Reviewers
 * [Jorn Vernee](https://openjdk.java.net/census#jvernee) (@JornVernee - Committer) ⚠️ Review applies to af76b2e0b5a0b9b0ce4b9be50596dd9d78c281f2
 * [Paul Sandoz](https://openjdk.java.net/census#psandoz) (@PaulSandoz - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/487/head:pull/487` \
`$ git checkout pull/487`

Update a local copy of the PR: \
`$ git checkout pull/487` \
`$ git pull https://git.openjdk.java.net/panama-foreign pull/487/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 487`

View PR using the GUI difftool: \
`$ git pr show -t 487`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/panama-foreign/pull/487.diff">https://git.openjdk.java.net/panama-foreign/pull/487.diff</a>

</details>
