### PR TITLE
8264763: Add support for extended map modes in mapped segments

### DIFF
--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/MappedMemorySegmentImpl.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/MappedMemorySegmentImpl.java
@@ -27,6 +27,7 @@ package jdk.internal.foreign;
 
 import jdk.incubator.foreign.MemorySegment;
 import jdk.internal.access.foreign.UnmapperProxy;
+import jdk.internal.misc.ExtendedMapMode;
 import jdk.internal.misc.ScopedMemoryAccess;
 import sun.nio.ch.FileChannelImpl;
 
@@ -139,9 +140,12 @@ public class MappedMemorySegmentImpl extends NativeMemorySegmentImpl {
     }
 
     private static OpenOption[] openOptions(FileChannel.MapMode mapMode) {
-        if (mapMode == FileChannel.MapMode.READ_ONLY) {
+        if (mapMode == FileChannel.MapMode.READ_ONLY ||
+            mapMode == ExtendedMapMode.READ_ONLY_SYNC) {
             return new OpenOption[] { StandardOpenOption.READ };
-        } else if (mapMode == FileChannel.MapMode.READ_WRITE || mapMode == FileChannel.MapMode.PRIVATE) {
+        } else if (mapMode == FileChannel.MapMode.READ_WRITE ||
+                   mapMode == FileChannel.MapMode.PRIVATE ||
+                   mapMode == ExtendedMapMode.READ_WRITE_SYNC) {
             return new OpenOption[] { StandardOpenOption.READ, StandardOpenOption.WRITE };
         } else {
             throw new UnsupportedOperationException("Unsupported map mode: " + mapMode);

--- a/test/jdk/java/foreign/TestByteBuffer.java
+++ b/test/jdk/java/foreign/TestByteBuffer.java
@@ -23,7 +23,8 @@
 
 /*
  * @test
- * @modules java.base/sun.nio.ch
+ * @modules java.base/jdk.internal.misc
+ *          java.base/sun.nio.ch
  *          jdk.incubator.foreign/jdk.internal.foreign
  * @run testng/othervm --enable-native-access=ALL-UNNAMED TestByteBuffer
  */
@@ -77,6 +78,7 @@ import java.util.stream.Stream;
 import jdk.internal.foreign.HeapMemorySegmentImpl;
 import jdk.internal.foreign.MappedMemorySegmentImpl;
 import jdk.internal.foreign.NativeMemorySegmentImpl;
+import jdk.internal.misc.ExtendedMapMode;
 import org.testng.SkipException;
 import org.testng.annotations.*;
 import sun.nio.ch.DirectBuffer;

--- a/test/jdk/java/foreign/TestByteBuffer.java
+++ b/test/jdk/java/foreign/TestByteBuffer.java
@@ -23,8 +23,7 @@
 
 /*
  * @test
- * @modules java.base/jdk.internal.misc
- *          java.base/sun.nio.ch
+ * @modules java.base/sun.nio.ch
  *          jdk.incubator.foreign/jdk.internal.foreign
  * @run testng/othervm --enable-native-access=ALL-UNNAMED TestByteBuffer
  */
@@ -78,7 +77,6 @@ import java.util.stream.Stream;
 import jdk.internal.foreign.HeapMemorySegmentImpl;
 import jdk.internal.foreign.MappedMemorySegmentImpl;
 import jdk.internal.foreign.NativeMemorySegmentImpl;
-import jdk.internal.misc.ExtendedMapMode;
 import org.testng.SkipException;
 import org.testng.annotations.*;
 import sun.nio.ch.DirectBuffer;


### PR DESCRIPTION
This simple fix add support for mapping segments using the extended map modes added by JEP 352.

I tried testing the support but, to do that properly you need specific setup (as described in JEP 352).

Anyway, I have been able to verify that now there's no exception in the memory segment code,
the failure I get is deep into the native map0 method, which throws "operation not supported", presumably because the file I'm mapping is not from NVM device.

Any extra help in testing this would be appreciated.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [JDK-8264763](https://bugs.openjdk.java.net/browse/JDK-8264763): Add support for extended map modes in mapped segments


### Reviewers
 * [Athijegannathan Sundararajan](https://openjdk.java.net/census#sundar) (@sundararajana - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/489/head:pull/489` \
`$ git checkout pull/489`

Update a local copy of the PR: \
`$ git checkout pull/489` \
`$ git pull https://git.openjdk.java.net/panama-foreign pull/489/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 489`

View PR using the GUI difftool: \
`$ git pr show -t 489`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/panama-foreign/pull/489.diff">https://git.openjdk.java.net/panama-foreign/pull/489.diff</a>

</details>
