### PR TITLE
8264887: Implicit scope objects are used with resource try

### DIFF
--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/clang/TranslationUnit.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/clang/TranslationUnit.java
@@ -207,17 +207,13 @@ public class TranslationUnit implements AutoCloseable {
         }
 
         public SourceLocation getLocation() {
-            try (ResourceScope scope = ResourceScope.newImplicitScope()) {
-                return new SourceLocation(Index_h.clang_getTokenLocation(
-                    scope, tu, token));
-            }
+            return new SourceLocation(Index_h.clang_getTokenLocation(
+                ResourceScope.newImplicitScope(), tu, token));
         }
 
         public SourceRange getExtent() {
-            try (ResourceScope scope = ResourceScope.newImplicitScope()) {
-                return new SourceRange(Index_h.clang_getTokenExtent(scope,
+            return new SourceRange(Index_h.clang_getTokenExtent(ResourceScope.newImplicitScope(),
                     tu, token));
-            }
         }
     }
 


### PR DESCRIPTION
inspected the uses of implicit, confined scopes for correctness.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [JDK-8264887](https://bugs.openjdk.java.net/browse/JDK-8264887): Implicit scope objects are used with resource try


### Reviewers
 * [Jorn Vernee](https://openjdk.java.net/census#jvernee) (@JornVernee - Committer)
 * [Maurizio Cimadamore](https://openjdk.java.net/census#mcimadamore) (@mcimadamore - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/492/head:pull/492` \
`$ git checkout pull/492`

Update a local copy of the PR: \
`$ git checkout pull/492` \
`$ git pull https://git.openjdk.java.net/panama-foreign pull/492/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 492`

View PR using the GUI difftool: \
`$ git pr show -t 492`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/panama-foreign/pull/492.diff">https://git.openjdk.java.net/panama-foreign/pull/492.diff</a>

</details>
