### PR TITLE
8260976: investigate ways to filter jextract output

### DIFF
--- a/test/jdk/tools/jextract/TestFilters.java
+++ b/test/jdk/tools/jextract/TestFilters.java
@@ -26,7 +26,7 @@
  * @modules jdk.incubator.jextract
  * @library /test/lib
  * @build JextractToolRunner
- * @run testng/othervm -Dforeign.restricted=permit -Duser.language=en --add-modules jdk.incubator.jextract TestFilters
+ * @run testng/othervm --enable-native-access=jdk.incubator.jextract -Duser.language=en --add-modules jdk.incubator.jextract TestFilters
  */
 
 import org.testng.annotations.Test;


### PR DESCRIPTION
This simple patch fixes a remaining use of `-Dforeign.restriced=permit` in the filter test.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [JDK-8260976](https://bugs.openjdk.java.net/browse/JDK-8260976): investigate ways to filter jextract output ⚠️ Issue is not open.


### Reviewers
 * [Athijegannathan Sundararajan](https://openjdk.java.net/census#sundar) (@sundararajana - Committer)
 * [Jorn Vernee](https://openjdk.java.net/census#jvernee) (@JornVernee - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/493/head:pull/493` \
`$ git checkout pull/493`

Update a local copy of the PR: \
`$ git checkout pull/493` \
`$ git pull https://git.openjdk.java.net/panama-foreign pull/493/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 493`

View PR using the GUI difftool: \
`$ git pr show -t 493`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/panama-foreign/pull/493.diff">https://git.openjdk.java.net/panama-foreign/pull/493.diff</a>

</details>
