### PR TITLE
8264515: Rename static factory methods in the foreign API

### DIFF
--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/MemorySegment.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/MemorySegment.java
@@ -687,7 +687,7 @@ for (long l = 0; l < segment.byteSize(); l++) {
      */
     @CallerSensitive
     @NativeAccess
-    static MemorySegment ofNative() {
+    static MemorySegment globalNativeSegment() {
         Reflection.ensureNativeAccess(Reflection.getCallerClass());
         return NativeMemorySegmentImpl.EVERYTHING;
     }

--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/package-info.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/package-info.java
@@ -164,7 +164,7 @@ int x = MemoryAccess.getInt(segment);
  * }</pre>
  *
  * Alternatively, the client can fall back to use the so called <em>everything</em> segment - that is, a primordial segment
- * which covers the entire native heap. This segment can be obtained by calling the {@link jdk.incubator.foreign.MemorySegment#ofNative()}
+ * which covers the entire native heap. This segment can be obtained by calling the {@link jdk.incubator.foreign.MemorySegment#globalNativeSegment()}
  * method, so that dereference can happen without the need of creating any additional segment instances:
  *
  * <pre>{@code

--- a/test/jdk/java/foreign/TestNative.java
+++ b/test/jdk/java/foreign/TestNative.java
@@ -185,7 +185,7 @@ public class TestNative {
 
     @Test
     public void testDefaultAccessModesEverthing() {
-        MemorySegment everything = MemorySegment.ofNative();
+        MemorySegment everything = MemorySegment.globalNativeSegment();
         assertFalse(everything.isReadOnly());
     }
 
@@ -204,7 +204,7 @@ public class TestNative {
     @Test
     public void testEverythingSegment() {
         MemoryAddress addr = allocate(4);
-        MemorySegment everything = MemorySegment.ofNative();
+        MemorySegment everything = MemorySegment.globalNativeSegment();
         MemoryAccess.setIntAtOffset(everything, addr.toRawLongValue(), 42);
         assertEquals(MemoryAccess.getIntAtOffset(everything, addr.toRawLongValue()), 42);
         free(addr);

--- a/test/jdk/java/foreign/TestRestricted.java
+++ b/test/jdk/java/foreign/TestRestricted.java
@@ -38,20 +38,20 @@ import java.lang.reflect.InvocationTargetException;
 public class TestRestricted {
     @Test(expectedExceptions = InvocationTargetException.class)
     public void testReflection() throws Throwable {
-        Method method = MemorySegment.class.getDeclaredMethod("ofNative");
+        Method method = MemorySegment.class.getDeclaredMethod("globalNativeSegment");
         method.invoke(null);
     }
 
     @Test(expectedExceptions = IllegalCallerException.class)
     public void testInvoke() throws Throwable {
         var mh = MethodHandles.lookup().findStatic(MemorySegment.class,
-            "ofNative", MethodType.methodType(MemorySegment.class));
+                "globalNativeSegment", MethodType.methodType(MemorySegment.class));
         var seg = (MemorySegment)mh.invokeExact();
     }
 
     @Test(expectedExceptions = IllegalCallerException.class)
     public void testDirectAccess() throws Throwable {
-        MemorySegment.ofNative();
+        MemorySegment.globalNativeSegment();
     }
 
     @Test(expectedExceptions = InvocationTargetException.class)

--- a/test/jdk/java/foreign/valist/VaListTest.java
+++ b/test/jdk/java/foreign/valist/VaListTest.java
@@ -185,7 +185,7 @@ public class VaListTest extends NativeTestHelper {
         Function<MemoryLayout, Function<VaList, Integer>> getIntJavaFact = layout ->
                 list -> {
                     MemoryAddress ma = list.vargAsAddress(layout);
-                    return MemoryAccess.getIntAtOffset(MemorySegment.ofNative(), ma.toRawLongValue());
+                    return MemoryAccess.getIntAtOffset(MemorySegment.globalNativeSegment(), ma.toRawLongValue());
                 };
         Function<VaList, Integer> getIntNative = MethodHandleProxies.asInterfaceInstance(Function.class, MH_getInt);
         return new Object[][]{


### PR DESCRIPTION
Simple follow up patch which renames the everything segment static accessor.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [JDK-8264515](https://bugs.openjdk.java.net/browse/JDK-8264515): Rename static factory methods in the foreign API ⚠️ Issue is not open.


### Reviewers
 * [Jorn Vernee](https://openjdk.java.net/census#jvernee) (@JornVernee - Committer)
 * [Athijegannathan Sundararajan](https://openjdk.java.net/census#sundar) (@sundararajana - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/495/head:pull/495` \
`$ git checkout pull/495`

Update a local copy of the PR: \
`$ git checkout pull/495` \
`$ git pull https://git.openjdk.java.net/panama-foreign pull/495/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 495`

View PR using the GUI difftool: \
`$ git pr show -t 495`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/panama-foreign/pull/495.diff">https://git.openjdk.java.net/panama-foreign/pull/495.diff</a>

</details>
