### PR TITLE
8261032: jextract should have an option to specify main header class name

### DIFF
--- a/src/jdk.incubator.jextract/share/classes/jdk/incubator/jextract/JextractTool.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/incubator/jextract/JextractTool.java
@@ -170,6 +170,7 @@ public final class JextractTool {
         parser.accepts("source", format("help.source"));
         parser.acceptsAll(List.of("t", "target-package"), format("help.t")).withRequiredArg();
         parser.acceptsAll(List.of("?", "h", "help"), format("help.h")).forHelp();
+        parser.accepts("header-class-name", format("help.header-class-name")).withRequiredArg();
         parser.nonOptions(format("help.non.option"));
 
         OptionSet optionSet;
@@ -261,8 +262,12 @@ public final class JextractTool {
                 System.out.println(toplevel);
             }
 
+            String headerName = optionSet.has("header-class-name") ?
+                (String) optionSet.valueOf("header-class-name") :
+                header.getFileName().toString();
+
             files = generateInternal(
-                toplevel, header.getFileName().toString(),
+                toplevel, headerName,
                 options.targetPackage, options.includeHelper, options.libraryNames);
         } catch (ClangException ce) {
             err.println(ce.getMessage());

--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/resources/Messages.properties
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/resources/Messages.properties
@@ -38,6 +38,7 @@ help.include-struct=name of struct definition to include
 help.include-union=name of union definition to include
 help.dump-includes=dump included symbols into specified file
 help.h=print help
+help.header-class-name=name of the header class
 help.l=specify a library
 help.source=generate java sources
 help.t=target package for specified header files

--- a/test/jdk/tools/jextract/JextractToolProviderTest.java
+++ b/test/jdk/tools/jextract/JextractToolProviderTest.java
@@ -124,4 +124,21 @@ public class JextractToolProviderTest extends JextractToolRunner {
     public void testTargetPackageLongOption() {
         testTargetPackage("--target-package");
     }
+
+    @Test
+    public void testHeaderClassName() {
+        Path helloOutput = getOutputFilePath("hellogen");
+        Path helloH = getInputFilePath("hello.h");
+        run("--header-class-name", "MyHello", "-t", "com.acme", "-d",
+            helloOutput.toString(), helloH.toString()).checkSuccess();
+        try(Loader loader = classLoader(helloOutput)) {
+            Class<?> cls = loader.loadClass("com.acme.MyHello");
+            // check a method for "void func(int)"
+            assertNotNull(findMethod(cls, "func", int.class));
+            // check a method for "int printf(MemoryAddress, Object[])"
+            assertNotNull(findMethod(cls, "printf", Addressable.class, Object[].class));
+        } finally {
+            deleteDir(helloOutput);
+        }
+    }
 }


### PR DESCRIPTION
adding --header-class-name option

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [JDK-8261032](https://bugs.openjdk.java.net/browse/JDK-8261032): jextract should have an option to specify main header class name


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.java.net/census#mcimadamore) (@mcimadamore - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/496/head:pull/496` \
`$ git checkout pull/496`

Update a local copy of the PR: \
`$ git checkout pull/496` \
`$ git pull https://git.openjdk.java.net/panama-foreign pull/496/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 496`

View PR using the GUI difftool: \
`$ git pr show -t 496`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/panama-foreign/pull/496.diff">https://git.openjdk.java.net/panama-foreign/pull/496.diff</a>

</details>
