### PR TITLE
8265211: Print specific error message when an option parsing error occurs

### DIFF
--- a/src/jdk.incubator.jextract/share/classes/jdk/incubator/jextract/JextractTool.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/incubator/jextract/JextractTool.java
@@ -151,6 +151,8 @@ public final class JextractTool {
 
     private void printOptionError(String message) {
         err.println("OPTION ERROR: " + message);
+        err.println("Usage: jextract <options> [--] <header file>");
+        err.println("Use --help for a list of possible options");
     }
 
     /**

--- a/src/jdk.incubator.jextract/share/classes/jdk/incubator/jextract/JextractTool.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/incubator/jextract/JextractTool.java
@@ -142,6 +142,17 @@ public final class JextractTool {
         return exitCode;
     }
 
+    private void printOptionError(Throwable throwable) {
+        printOptionError(throwable.getMessage());
+        if (DEBUG) {
+            throwable.printStackTrace(err);
+        }
+    }
+
+    private void printOptionError(String message) {
+        err.println("OPTION ERROR: " + message);
+    }
+
     /**
      * Main entry point to run the JextractTool
      *
@@ -176,7 +187,8 @@ public final class JextractTool {
         try {
             optionSet = parser.parse(args);
         } catch (OptionException oe) {
-            return printHelp(parser, OPTION_ERROR);
+            printOptionError(oe);
+            return OPTION_ERROR;
         }
 
         if (optionSet.has("h")) {
@@ -184,7 +196,8 @@ public final class JextractTool {
         }
 
         if (optionSet.nonOptionArguments().size() != 1) {
-            return printHelp(parser, OPTION_ERROR);
+            printOptionError("Expected 1 header file, not " + optionSet.nonOptionArguments().size());
+            return OPTION_ERROR;
         }
 
         Options.Builder builder = Options.builder();


### PR DESCRIPTION
Hi,

This patch makes jextract print a more specific error message when an option parsing error occurs, where currently only the help message is printed.

For instance, when using an unrecognized option `-o` it will print

```
OPTION ERROR: o is not a recognized option
```

Or when specifying multiple header files

```
OPTION ERROR: Expected 1 header file, not 3
```

Thanks,
Jorn

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [JDK-8265211](https://bugs.openjdk.java.net/browse/JDK-8265211): Print specific error message when an option parsing error occurs


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.java.net/census#mcimadamore) (@mcimadamore - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/500/head:pull/500` \
`$ git checkout pull/500`

Update a local copy of the PR: \
`$ git checkout pull/500` \
`$ git pull https://git.openjdk.java.net/panama-foreign pull/500/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 500`

View PR using the GUI difftool: \
`$ git pr show -t 500`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/panama-foreign/pull/500.diff">https://git.openjdk.java.net/panama-foreign/pull/500.diff</a>

</details>
