### PR TITLE
Add test for resource scope acquire with bulk operation

### DIFF
--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/ResourceScopeImpl.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/ResourceScopeImpl.java
@@ -204,7 +204,7 @@ public abstract class ResourceScopeImpl implements ResourceScope, ScopedMemoryAc
 
         @Override
         public Handle acquire() {
-            if (handle != null) {
+            if (handle == null) {
                 // capture 'this'
                 handle = () -> Reference.reachabilityFence(NonCloseableSharedScope.this);
             }

--- a/test/jdk/java/util/stream/test/org/openjdk/tests/java/util/stream/SpliteratorTest.java
+++ b/test/jdk/java/util/stream/test/org/openjdk/tests/java/util/stream/SpliteratorTest.java
@@ -65,7 +65,7 @@ public class SpliteratorTest {
 
     @Test(dataProvider = "SegmentSpliterator", dataProviderClass = SegmentTestDataProvider.class )
     public void testSegmentSpliterator(String name, SequenceLayout layout, SpliteratorTestHelper.ContentAsserter<MemorySegment> contentAsserter) {
-        try (ResourceScope scope = ResourceScope.ofConfined()) {
+        try (ResourceScope scope = ResourceScope.newConfinedScope()) {
             MemorySegment segment = MemorySegment.allocateNative(layout, scope);
             SegmentTestDataProvider.initSegment(segment);
             SpliteratorTestHelper.testSpliterator(() -> segment.spliterator(layout),

--- a/test/micro/org/openjdk/bench/jdk/incubator/foreign/BulkMismatchAcquire.java
+++ b/test/micro/org/openjdk/bench/jdk/incubator/foreign/BulkMismatchAcquire.java
@@ -1,0 +1,173 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package org.openjdk.bench.jdk.incubator.foreign;
+
+import jdk.incubator.foreign.ResourceScope;
+import jdk.incubator.foreign.SegmentAllocator;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Warmup;
+import sun.misc.Unsafe;
+
+import jdk.incubator.foreign.MemorySegment;
+import java.nio.ByteBuffer;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
+
+import static jdk.incubator.foreign.MemoryLayouts.JAVA_INT;
+
+@BenchmarkMode(Mode.AverageTime)
+@Warmup(iterations = 5, time = 500, timeUnit = TimeUnit.MILLISECONDS)
+@Measurement(iterations = 10, time = 500, timeUnit = TimeUnit.MILLISECONDS)
+@State(org.openjdk.jmh.annotations.Scope.Thread)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@Fork(value = 3, jvmArgsAppend = { "--add-modules=jdk.incubator.foreign" })
+public class BulkMismatchAcquire {
+
+    public enum ScopeKind {
+        CONFINED(ResourceScope::newConfinedScope),
+        SHARED(ResourceScope::newSharedScope),
+        IMPLICIT(ResourceScope::newImplicitScope);
+
+        final Supplier<ResourceScope> scopeFactory;
+
+        ScopeKind(Supplier<ResourceScope> scopeFactory) {
+            this.scopeFactory = scopeFactory;
+        }
+
+        ResourceScope makeScope() {
+            return scopeFactory.get();
+        }
+    }
+
+    @Param({"CONFINED", "SHARED", "IMPLICIT"})
+    public ScopeKind scopeKind;
+
+    // large(ish) segments/buffers with same content, 0, for mismatch, non-multiple-of-8 sized
+    static final int SIZE_WITH_TAIL = (1024 * 1024) + 7;
+
+    ResourceScope scope;
+    MemorySegment mismatchSegmentLarge1;
+    MemorySegment mismatchSegmentLarge2;
+    ByteBuffer mismatchBufferLarge1;
+    ByteBuffer mismatchBufferLarge2;
+    MemorySegment mismatchSegmentSmall1;
+    MemorySegment mismatchSegmentSmall2;
+    ByteBuffer mismatchBufferSmall1;
+    ByteBuffer mismatchBufferSmall2;
+
+    @Setup
+    public void setup() {
+        scope = scopeKind.makeScope();
+        mismatchSegmentLarge1 = MemorySegment.allocateNative(SIZE_WITH_TAIL, scope);
+        mismatchSegmentLarge2 = MemorySegment.allocateNative(SIZE_WITH_TAIL, scope);
+        mismatchBufferLarge1 = ByteBuffer.allocateDirect(SIZE_WITH_TAIL);
+        mismatchBufferLarge2 = ByteBuffer.allocateDirect(SIZE_WITH_TAIL);
+
+        // mismatch at first byte
+        mismatchSegmentSmall1 = MemorySegment.allocateNative(7, scope);
+        mismatchSegmentSmall2 = MemorySegment.allocateNative(7, scope);
+        mismatchBufferSmall1 = ByteBuffer.allocateDirect(7);
+        mismatchBufferSmall2 = ByteBuffer.allocateDirect(7);
+        {
+            mismatchSegmentSmall1.fill((byte) 0xFF);
+            mismatchBufferSmall1.put((byte) 0xFF).clear();
+            // verify expected mismatch indices
+            long si = mismatchSegmentLarge1.mismatch(mismatchSegmentLarge2);
+            if (si != -1)
+                throw new AssertionError("Unexpected mismatch index:" + si);
+            int bi = mismatchBufferLarge1.mismatch(mismatchBufferLarge2);
+            if (bi != -1)
+                throw new AssertionError("Unexpected mismatch index:" + bi);
+            si = mismatchSegmentSmall1.mismatch(mismatchSegmentSmall2);
+            if (si != 0)
+                throw new AssertionError("Unexpected mismatch index:" + si);
+            bi = mismatchBufferSmall1.mismatch(mismatchBufferSmall2);
+            if (bi != 0)
+                throw new AssertionError("Unexpected mismatch index:" + bi);
+        }
+    }
+
+    @TearDown
+    public void tearDown() {
+        if (!scope.isImplicit())
+            scope.close();
+    }
+
+    @Benchmark
+    @OutputTimeUnit(TimeUnit.NANOSECONDS)
+    public long mismatch_large_segment() {
+        return mismatchSegmentLarge1.mismatch(mismatchSegmentLarge2);
+    }
+
+    @Benchmark
+    @OutputTimeUnit(TimeUnit.NANOSECONDS)
+    public long mismatch_large_segment_acquire() {
+        var handle = mismatchSegmentLarge1.scope().acquire();
+        try {
+            return mismatchSegmentLarge1.mismatch(mismatchSegmentLarge2);
+        } finally {
+            handle.close();
+        }
+    }
+
+    @Benchmark
+    @OutputTimeUnit(TimeUnit.NANOSECONDS)
+    public int mismatch_large_bytebuffer() {
+        return mismatchBufferLarge1.mismatch(mismatchBufferLarge2);
+    }
+
+    @Benchmark
+    @OutputTimeUnit(TimeUnit.NANOSECONDS)
+    public long mismatch_small_segment() {
+        return mismatchSegmentSmall1.mismatch(mismatchSegmentSmall2);
+    }
+
+    @Benchmark
+    @OutputTimeUnit(TimeUnit.NANOSECONDS)
+    public long mismatch_small_segment_acquire() {
+        var handle = mismatchSegmentLarge1.scope().acquire();
+        try {
+            return mismatchSegmentSmall1.mismatch(mismatchSegmentSmall2);
+        } finally {
+            handle.close();
+        }
+    }
+
+    @Benchmark
+    @OutputTimeUnit(TimeUnit.NANOSECONDS)
+    public int mismatch_small_bytebuffer() {
+        return mismatchBufferSmall1.mismatch(mismatchBufferSmall2);
+    }
+}


### PR DESCRIPTION
This patch adds a test for a bulk segment mismatch inside an acquire block. This benchmark measures the relative overhead of the acquire operation, relative to the cost of the bulk mismatch. Results for large segments are as follows:

```
Benchmark                                           (scopeKind)  Mode  Cnt      Score     Error  Units
BulkMismatchAcquire.mismatch_large_segment             CONFINED  avgt   30  37662.474 ? 579.201  ns/op
BulkMismatchAcquire.mismatch_large_segment               SHARED  avgt   30  37583.186 ? 427.663  ns/op
BulkMismatchAcquire.mismatch_large_segment             IMPLICIT  avgt   30  37577.151 ? 474.734  ns/op
BulkMismatchAcquire.mismatch_large_segment_acquire     CONFINED  avgt   30  37801.227 ? 515.459  ns/op
BulkMismatchAcquire.mismatch_large_segment_acquire       SHARED  avgt   30  37159.676 ? 369.788  ns/op
BulkMismatchAcquire.mismatch_large_segment_acquire     IMPLICIT  avgt   30  37854.949 ? 464.150  ns/op
```

Here, we can see that the cost of the acquire is, in all cases, negligible, compared with the cost of the underlying bulk operation. We expect this to be the use case where resource scope handles are used the most.

For completeness, here's the same benchmark, but with a smaller segment size:

```
Benchmark                                           (scopeKind)  Mode  Cnt   Score   Error  Units
BulkMismatchAcquire.mismatch_small_segment             CONFINED  avgt   30   5.826 ? 0.091  ns/op
BulkMismatchAcquire.mismatch_small_segment               SHARED  avgt   30   5.160 ? 0.072  ns/op
BulkMismatchAcquire.mismatch_small_segment             IMPLICIT  avgt   30   5.274 ? 0.090  ns/op
BulkMismatchAcquire.mismatch_small_segment_acquire     CONFINED  avgt   30   7.386 ? 0.035  ns/op
BulkMismatchAcquire.mismatch_small_segment_acquire       SHARED  avgt   30  15.130 ? 0.649  ns/op
BulkMismatchAcquire.mismatch_small_segment_acquire     IMPLICIT  avgt   30   6.877 ? 0.083  ns/op
```

In this case, we see that for implicit and confined scope the cost is low; for shared segments we have a spike (which is related to the CAS logic in the shared handle). We believe this to be an acceptable compromise, and an unavoidable consequence of having true, deterministic shared segments.

In addition to adding the benchmark - the patch also does two other things:

* Fixes a bug in the NonCloseableScope::acquire logic (the polarity of the null check is wrong, and this was causing NPEs on the benchmark - whoops)
* Fixes the unrelated test issue with SpliteratorTest - this was also fixed by PR/494, but seeing that it's not converging, I'd like to get the tests fixed sooner rather than later

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [Chris Hegarty](https://openjdk.java.net/census#chegar) (@ChrisHegarty - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/503/head:pull/503` \
`$ git checkout pull/503`

Update a local copy of the PR: \
`$ git checkout pull/503` \
`$ git pull https://git.openjdk.java.net/panama-foreign pull/503/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 503`

View PR using the GUI difftool: \
`$ git pr show -t 503`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/panama-foreign/pull/503.diff">https://git.openjdk.java.net/panama-foreign/pull/503.diff</a>

</details>
