### PR TITLE
Fix bad call to segment factory in VarHandleExactTest

### DIFF
--- a/test/jdk/java/lang/invoke/VarHandles/VarHandleTestExact.java
+++ b/test/jdk/java/lang/invoke/VarHandles/VarHandleTestExact.java
@@ -48,6 +48,7 @@
 
 import jdk.incubator.foreign.MemoryHandles;
 import jdk.incubator.foreign.MemorySegment;
+import jdk.incubator.foreign.ResourceScope;
 import jdk.internal.access.foreign.MemorySegmentProxy;
 import org.testng.SkipException;
 import org.testng.annotations.DataProvider;
@@ -170,8 +171,8 @@ public class VarHandleTestExact {
     @Test(dataProvider = "dataSetMemorySegment")
     public void testExactSegmentSet(Class<?> carrier, Object testValue, SetSegmentX setter) {
         VarHandle vh = MemoryHandles.varHandle(carrier, ByteOrder.nativeOrder());
-        try (MemorySegment seg = MemorySegment.allocateNative(8)) {
-
+        try (ResourceScope scope = ResourceScope.newConfinedScope()) {
+            MemorySegment seg = MemorySegment.allocateNative(8, scope);
             doTest(vh,
                 tvh -> tvh.set(seg, 0L, testValue),
                 tvh -> setter.set(tvh, seg, 0L, testValue),


### PR DESCRIPTION
Running more tests I found another place which was not rewritten to use the new static factory names.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [Paul Sandoz](https://openjdk.java.net/census#psandoz) (@PaulSandoz - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/506/head:pull/506` \
`$ git checkout pull/506`

Update a local copy of the PR: \
`$ git checkout pull/506` \
`$ git pull https://git.openjdk.java.net/panama-foreign pull/506/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 506`

View PR using the GUI difftool: \
`$ git pr show -t 506`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/panama-foreign/pull/506.diff">https://git.openjdk.java.net/panama-foreign/pull/506.diff</a>

</details>
