### PR TITLE
Add benchmark on ResourceScope::close

### DIFF
--- a/test/micro/org/openjdk/bench/jdk/incubator/foreign/ResourceScopeClose.java
+++ b/test/micro/org/openjdk/bench/jdk/incubator/foreign/ResourceScopeClose.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/micro/org/openjdk/bench/jdk/incubator/foreign/ResourceScopeClose.java
+++ b/test/micro/org/openjdk/bench/jdk/incubator/foreign/ResourceScopeClose.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.bench.jdk.incubator.foreign;
+
+import jdk.incubator.foreign.MemorySegment;
+import jdk.incubator.foreign.ResourceScope;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Warmup;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+@BenchmarkMode(Mode.AverageTime)
+@Warmup(iterations = 5, time = 500, timeUnit = TimeUnit.MILLISECONDS)
+@Measurement(iterations = 10, time = 500, timeUnit = TimeUnit.MILLISECONDS)
+@State(org.openjdk.jmh.annotations.Scope.Thread)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@Fork(value = 3, jvmArgsAppend = { "--add-modules=jdk.incubator.foreign" })
+public class ResourceScopeClose {
+
+    static final int ALLOC_SIZE = 1024;
+
+    public enum StressMode {
+        NONE,
+        MEMORY,
+        THREADS
+    }
+
+    @Param({"NONE", "MEMORY", "THREADS"})
+    StressMode mode;
+
+    List<byte[]> arrays;
+    volatile boolean stop = false;
+    List<Thread> threads;
+
+    @Setup
+    public void setup() throws Throwable {
+        if (mode == StressMode.MEMORY) {
+            arrays = new ArrayList<>();
+            for (int i = 0; i < 100_000_000; i++) {
+                arrays.add(new byte[2]);
+            }
+        } else if (mode == StressMode.THREADS) {
+            threads = new ArrayList<>();
+            for (int i = 0 ; i < 4 ; i++) {
+                threads.add(new Thread(() -> {
+                    while (true) {
+                        if (stop) break;
+                        // busy wait
+                    }
+                }));
+            }
+            threads.forEach(Thread::start);
+        }
+
+    }
+
+    @TearDown
+    public void tearDown() throws Throwable {
+        arrays = null;
+        if (threads != null) {
+            stop = true;
+            threads.forEach(t -> {
+                try {
+                    t.join();
+                } catch (InterruptedException ex) {
+                    throw new IllegalStateException(ex);
+                }
+            });
+        }
+    }
+
+    @Benchmark
+    public MemorySegment confined_close() {
+        try (ResourceScope scope = ResourceScope.newConfinedScope()) {
+            return MemorySegment.allocateNative(ALLOC_SIZE, 4, scope);
+        }
+    }
+
+    @Benchmark
+    public MemorySegment shared_close() {
+        try (ResourceScope scope = ResourceScope.newSharedScope()) {
+            return MemorySegment.allocateNative(ALLOC_SIZE, 4, scope);
+        }
+    }
+
+    @Benchmark
+    public MemorySegment implicit_close() {
+        return MemorySegment.allocateNative(ALLOC_SIZE, 4, ResourceScope.newImplicitScope());
+    }
+
+    @Benchmark
+    public MemorySegment implicit_close_systemgc() {
+        if (gcCount++ == 0) System.gc(); // GC when we overflow
+        return MemorySegment.allocateNative(ALLOC_SIZE, 4, ResourceScope.newImplicitScope());
+    }
+
+    // keep
+    static byte gcCount = 0;
+}


### PR DESCRIPTION
This patch adds a new benchamrk for ResourceScope::close. I think it's interesting to measure the tradeoffs provided by the various configurations; we test 4 diufferent configurations:

* confined scope
* shared scope
* implicit scope
* implicit scope, with periodic calls to System::gc

For each configuration, we create a scope, allocate a segment with it (of fixed size) and then close the scope.

The benchmark supports a number of stress modes:

* NONE - e.g. no extra work, just benchmark is ran
* MEMORY - this puts additional memory pressure by creating lots of small byte arrays at the start of the benchmark; designed to disrupt implicit scopes
* THREADS - this creates extra threads which are spinning in a busy loop; designed to disrupt explicit shared scopes

Results are as follows:


```
Benchmark                                                                 (mode)  Mode  Cnt      Score      Error   Units
ResourceScopeClose.confined_close                                           NONE  avgt   30      0.107 ?    0.002   us/op
ResourceScopeClose.confined_close:?gc.time                                  NONE  avgt   30     39.000                 ms
ResourceScopeClose.confined_close                                         MEMORY  avgt   30      0.114 ?    0.006   us/op
ResourceScopeClose.confined_close:?gc.time                                MEMORY  avgt   30     12.000                 ms
ResourceScopeClose.confined_close                                        THREADS  avgt   30      0.115 ?    0.002   us/op
ResourceScopeClose.confined_close:?gc.time                               THREADS  avgt   30     30.000                 ms
ResourceScopeClose.implicit_close                                           NONE  avgt   30      5.654 ?    9.617   us/op
ResourceScopeClose.implicit_close:?gc.time                                  NONE  avgt   30  15540.000                 ms
ResourceScopeClose.implicit_close                                         MEMORY  avgt   30      4.085 ?    4.375   us/op
ResourceScopeClose.implicit_close:?gc.time                                MEMORY  avgt   30  23126.000                 ms
ResourceScopeClose.implicit_close                                        THREADS  avgt   30      2.380 ?    2.585   us/op
ResourceScopeClose.implicit_close:?gc.time                               THREADS  avgt   30  15940.000                 ms
ResourceScopeClose.implicit_close_systemgc                                  NONE  avgt   30     31.301 ?    0.667   us/op
ResourceScopeClose.implicit_close_systemgc:?gc.time                         NONE  avgt   30  14520.000                 ms
ResourceScopeClose.implicit_close_systemgc                                MEMORY  avgt   30   1502.083 ?   28.460   us/op
ResourceScopeClose.implicit_close_systemgc:?gc.time                       MEMORY  avgt   30  23087.000                 ms
ResourceScopeClose.implicit_close_systemgc                               THREADS  avgt   30     30.733 ?    0.704   us/op
ResourceScopeClose.implicit_close_systemgc:?gc.time                      THREADS  avgt   30  14551.000                 ms
ResourceScopeClose.shared_close                                             NONE  avgt   30      8.850 ?    0.936   us/op
ResourceScopeClose.shared_close:?gc.time                                    NONE  avgt   30      6.000                 ms
ResourceScopeClose.shared_close                                           MEMORY  avgt   30      8.401 ?    0.506   us/op
ResourceScopeClose.shared_close                                          THREADS  avgt   30     10.966 ?    0.349   us/op
ResourceScopeClose.shared_close:?gc.time                                 THREADS  avgt   30      4.000                 ms
```

Of course the confined case comes out on top; very little GC activity there, very good perf, and very low variance.

Shared scopes is second best - performances are not quite as good as with confined case (the close is ~10x slower) - but low variance, low GC activity.

Then there is implicit scopes. In the version without System::gc calls, if we look at scores we might be tricked into thinking that the results are good. In reality, if you look at GC activity, you see that there is a huge amount of time (~15s !!) spent on GC. What's worse, and what cannot be appreaciated here (as I didn't find a way to let JMH spit the data), is that, by observing the benchmark process with `top` in the implcit case w/o calls to `System::gc` we see peaks of resident memory up to 10g (!!).

The version which periodically calls `System::gc` helps with keeping resident memory under control (never exceeds 1g that way) - but as you can see, if we go for explicit calls to System::gc, the cost gets higher the more heap is used (look at the MEMORY stress mode).

Overall, confined and shared segments are very good, compared to what is possible to achieve using cleaners; closing a shared scope is more expensive, yes (while we don't think we can improve these numbers much, we'll keep looking for opportunities), but there's none of the system thrashing that occurs when the benchmark relies only on the GC. Also, this benchmark is rather unrealistic since it basically does nothing with the segment created from the scope; as soon as some real code is added there, the additional cost for closing the segment will likely be washed away in many cases.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [Jorn Vernee](https://openjdk.java.net/census#jvernee) (@JornVernee - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/508/head:pull/508` \
`$ git checkout pull/508`

Update a local copy of the PR: \
`$ git checkout pull/508` \
`$ git pull https://git.openjdk.java.net/panama-foreign pull/508/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 508`

View PR using the GUI difftool: \
`$ git pr show -t 508`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/panama-foreign/pull/508.diff">https://git.openjdk.java.net/panama-foreign/pull/508.diff</a>

</details>
