### PR TITLE
Improve ResourceScope javadoc

### DIFF
--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/ResourceScope.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/ResourceScope.java
@@ -43,7 +43,7 @@ import java.util.Spliterator;
  *
  * Resource scopes obtained from {@link #newConfinedScope()}, {@link #newSharedScope()} support <em>deterministic deallocation</em>;
  * We call these resource scopes <em>explicit scopes</em>. Explicit resource scopes can be closed explicitly (see {@link ResourceScope#close()}).
- * When a resource scope is closed, it is no longer <em>alive</em> (see {@link #isAlive()}, and subsequent operation on
+ * When a resource scope is closed, it is no longer <em>alive</em> (see {@link #isAlive()}, and subsequent operations on
  * resources associated with that scope (e.g. attempting to access a {@link MemorySegment} instance) will fail with {@link IllegalStateException}.
  * <p>
  * Closing a resource scope will cause all the cleanup actions associated with that scope (see {@link #addOnClose(Runnable)}) to be called.
@@ -75,7 +75,8 @@ import java.util.Spliterator;
  * <p>
  * An important implicit resource scope is the so called {@link #globalScope() global scope}; the global scope is
  * an implicit scope that is guaranteed to never become <a href="../../../java/lang/ref/package.html#reachability">unreachable</a>.
- * As a results, resources associated to the global scope are never cleaned up.
+ * As a results, the global scope will never attempt to release resources associated with it. Such resources must, where
+ * needed, be managed independently by clients.
  *
  * <h2><a id = "thread-confinement">Thread confinement</a></h2>
  *

--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/ResourceScope.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/ResourceScope.java
@@ -39,11 +39,12 @@ import java.util.Spliterator;
  * with a resource scope can only be accessed while the resource scope is <em>alive</em> (see {@link #isAlive()}),
  * and by the thread associated with the resource scope (if any).
  *
- * <h2>Explicit closure</h2>
+ * <h2>Explicit resource scopes</h2>
  *
- * Resource scopes created using one of the factories in this class can be closed explicitly (see {@link ResourceScope#close()}).
+ * Resource scopes obtained from {@link #newConfinedScope()}, {@link #newSharedScope()} support <em>deterministic deallocation</em>;
+ * We call these resource scopes <em>explicit scopes</em>. Explicit resource scopes can be closed explicitly (see {@link ResourceScope#close()}).
  * When a resource scope is closed, it is no longer <em>alive</em> (see {@link #isAlive()}, and subsequent operation on
- * resources derived from that scope (e.g. attempting to access a {@link MemorySegment} instance) will fail with {@link IllegalStateException}.
+ * resources associated with that scope (e.g. attempting to access a {@link MemorySegment} instance) will fail with {@link IllegalStateException}.
  * <p>
  * Closing a resource scope will cause all the cleanup actions associated with that scope (see {@link #addOnClose(Runnable)}) to be called.
  * Moreover, closing a resource scope might trigger the releasing of the underlying memory resources associated with said scope; for instance:
@@ -55,21 +56,26 @@ import java.util.Spliterator;
  *     <li>closing the scope associated with an upcall stub results in releasing the stub
  *     (see {@link CLinker#upcallStub(MethodHandle, FunctionDescriptor, ResourceScope)}</li>
  * </ul>
- *
- * <h2><a id = "implicit-closure">Implicit closure</a></h2>
- *
- * Resource scopes can be associated with a {@link Cleaner} instance (see {@link #newConfinedScope(Cleaner)}) - we call these
- * resource scopes <em>managed</em> resource scopes. A managed resource scope is closed automatically once the scope instance
- * becomes <a href="../../../java/lang/ref/package.html#reachability">unreachable</a>.
  * <p>
- * Managed resource scopes can still be closed explicitly (see {@link #close()}); this can be useful to allow for predictable,
- * deterministic resource deallocation, while still prevent accidental native memory leaks. In case a managed resource
- * scope is closed explicitly, no further action will be taken when the scope becomes unreachable; that is, cleanup actions
- * (see {@link #addOnClose(Runnable)}) associated with a resource scope, whether managed or not, are called <em>exactly once</em>.
+ * Sometimes, explicit scopes can be associated with a {@link Cleaner} instance (see {@link #newConfinedScope(Cleaner)} and
+ * {@link #newSharedScope(Cleaner)}). We call these resource scopes <em>managed</em> resource scopes. A managed resource scope
+ * is closed automatically once the scope instance becomes <a href="../../../java/lang/ref/package.html#reachability">unreachable</a>.
  * <p>
- * Some managed resource scopes are implicitly managed (see {@link #newImplicitScope()}, {@link #globalScope()}, and are said to be <em>implicit scopes</em>.
- * An implicit resource scope only features implicit closure, and always throws an {@link UnsupportedOperationException}
- * when the {@link #close()} method is called directly.
+ * Managed scopes can be useful to allow for predictable, deterministic resource deallocation, while still prevent accidental native memory leaks.
+ * In case a managed resource scope is closed explicitly, no further action will be taken when the scope becomes unreachable;
+ * that is, cleanup actions (see {@link #addOnClose(Runnable)}) associated with a resource scope, whether managed or not,
+ * are called <em>exactly once</em>.
+ *
+ * <h2>Implicit resource scopes</h2>
+ *
+ * Resource scopes obtained from {@link #newImplicitScope()} cannot be closed explicitly. We call these resource scopes
+ * <em>implicit scopes</em>. Calling {@link #close()} on an implicit resource scope always results in an exception.
+ * Resources associated with implicit scopes are released once the scope instance becomes
+ * <a href="../../../java/lang/ref/package.html#reachability">unreachable</a>.
+ * <p>
+ * An important implicit resource scope is the so called {@link #globalScope() global scope}; the global scope is
+ * an implicit scope that is guaranteed to never become <a href="../../../java/lang/ref/package.html#reachability">unreachable</a>.
+ * As a results, resources associated to the global scope are never cleaned up.
  *
  * <h2><a id = "thread-confinement">Thread confinement</a></h2>
  *
@@ -82,11 +88,12 @@ import java.util.Spliterator;
  * associated with this resource scope. Any attempt to perform resource access from a thread other than the
  * owner thread will result in a runtime failure.
  * <p>
- * Shared resource scopes (see {@link #newSharedScope()}), on the other hand, have no owner thread; as such resources associated
- * with this shared resource scopes can be accessed by multiple threads. This might be useful when multiple threads need
- * to access the same resource concurrently (e.g. in the case of parallel processing). For instance, a client
- * might obtain a {@link Spliterator} from a shared segment, which can then be used to slice the segment and allow multiple
- * threads to work in parallel on disjoint segment slices. The following code can be used to sum all int values in a memory segment in parallel:
+ * Shared resource scopes (see {@link #newSharedScope()} and {@link #newImplicitScope()}), on the other hand, have no owner thread;
+ * as such resources associated with this shared resource scopes can be accessed by multiple threads.
+ * This might be useful when multiple threads need to access the same resource concurrently (e.g. in the case of parallel processing).
+ * For instance, a client might obtain a {@link Spliterator} from a shared segment, which can then be used to slice the
+ * segment and allow multiple threads to work in parallel on disjoint segment slices. The following code can be used to sum
+ * all int values in a memory segment in parallel:
  *
  * <blockquote><pre>{@code
 SequenceLayout SEQUENCE_LAYOUT = MemoryLayout.sequenceLayout(1024, MemoryLayouts.JAVA_INT);
@@ -110,10 +117,10 @@ try (ResourceScope scope = ResourceScope.newSharedScope()) {
  * <h2>Scope handles</h2>
  *
  * Resource scopes can be made <em>non-closeable</em> by acquiring one or more resource scope <em>handles</em> (see
- * {@link #acquire()}. A resource scope handle can be used to make sure that its corresponding scope cannot be closed
- * (either explicitly, or implicitly) for a certain period of time - e.g. when one or more resources associated with
- * the parent scope need to be accessed. A resource scope can be acquired multiple times; the resource scope can only be
- * closed <em>after</em> all the handles acquired against that scope have been closed (see {@link Handle#close()}).
+ * {@link #acquire()}. A resource scope handle can be used to make sure that resources associated with a given resource scope
+ * (either explicit or implicit) cannot be released for a certain period of time - e.g. during a critical region of code
+ * involving one or more resources associated with the scope. For instance, an explicit resource scope can only be closed
+ * <em>after</em> all the handles acquired against that scope have been closed (see {@link Handle#close()}).
  * This can be useful when clients need to perform a critical operation on a memory segment, during which they have
  * to ensure that the segment will not be released; this can be done as follows:
  *
@@ -183,9 +190,8 @@ public interface ResourceScope extends AutoCloseable {
     /**
      * Make this resource scope non-closeable by acquiring a new resource scope handle. This scope cannot be closed unless all its
      * acquired handles have been closed first. Additionally, a resource scope handle maintains a strong reference
-     * to its resource scope; this means that if a resource scope features
-     * <a href="ResourceScope.html#implicit-closure"><em>implicit closure</em></a>, the scope cannot be implicitly closed
-     * until all its acquired handles becomes <a href="../../../java/lang/ref/package.html#reachability">unreachable</a>.
+     * to its resource scope; in other words, resources associated with an implicit resource scopes cannot be released
+     * until <em>all</em> the handles acquired from the implicit scope become <a href="../../../java/lang/ref/package.html#reachability">unreachable</a>.
      * @return a resource scope handle.
      */
     Handle acquire();
@@ -244,11 +250,9 @@ public interface ResourceScope extends AutoCloseable {
     }
 
     /**
-     * Create a new <em>implicit scope</em>. The implicit scope is a managed, shared, and non-closeable scope which only features
-     * <a href="ResourceScope.html#implicit-closure"><em>implicit closure</em></a>.
-     * Since implicit scopes can only be closed implicitly by the garbage collector, it is recommended that implicit
-     * scopes are only used in cases where deallocation performance is not a critical concern, to avoid unnecessary
-     * memory pressure.
+     * Create a new implicit, shared resource scope. Since implicit scopes can only be closed implicitly by the garbage collector,
+     * it is recommended that implicit scopes are only used in cases where deallocation performance is not a critical concern,
+     * to avoid unnecessary memory pressure.
      *
      * @return a new implicit scope.
      */


### PR DESCRIPTION
Chris and I had some discussions around the new `ResourceScope` API, and realized that the toplevel javadoc doesn't make it easy for developers to grasp all the various dimensions of resource scopes.
This is mostly caused by the fact that the concept of implicit closure is used to refer to _all_ scopes that support some form of GC-backed closure - and this brings confusion, as we have added the concept of "implicit" scopes to denote those scopes that *cannot* be closed explicitly.

I have rewritten the javadoc to talk about explicit and implicit scopes; we now say, in the section on explicit scopes, that explicit scopes can sometimes be associated with a Cleaner, but it is now clearer that that's mostly a fallback option.

When working on this, I think that we should probably make `ResourceScope::acquire` fail for implicit scope - either return null or throw. In other words, while acquiring handles makes sense to prevent deterministic deallocation, it seems like it doesn't make a lot of sense to prevent implicit deallocation (we already have reachability fences for this). What the implementation does right now permanently capture the scope instance in a handle instance, so the original implicit scope will never be closed as long as handles are reachable, even after close. In other words, having an handle that can be closed doesn't make sense for implicit scopes, since `Handle::close` doesn't do anything intersting in that case (or is not sufficient).

Any thoughts?

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [Paul Sandoz](https://openjdk.java.net/census#psandoz) (@PaulSandoz - Committer)
 * [Chris Hegarty](https://openjdk.java.net/census#chegar) (@ChrisHegarty - Committer) ⚠️ Review applies to ed498870936a85ff6dac0809a932dac63c48563f


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/510/head:pull/510` \
`$ git checkout pull/510`

Update a local copy of the PR: \
`$ git checkout pull/510` \
`$ git pull https://git.openjdk.java.net/panama-foreign pull/510/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 510`

View PR using the GUI difftool: \
`$ git pr show -t 510`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/panama-foreign/pull/510.diff">https://git.openjdk.java.net/panama-foreign/pull/510.diff</a>

</details>
