### PR TITLE
Investigate alternate strategy to acquire resource scopes

### DIFF
--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/ResourceScope.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/ResourceScope.java
@@ -107,22 +107,30 @@ try (ResourceScope scope = ResourceScope.newSharedScope()) {
  * such exceptions should instead be seen as an indication that the client code is lacking appropriate synchronization between the threads
  * accessing/closing the resources associated with the shared resource scope.
  *
- * <h2>Scope handles</h2>
+ * <h2>Resource scope handles</h2>
  *
- * Resource scopes can be made <em>non-closeable</em> by acquiring one or more resource scope <em>handles</em> (see
- * {@link #acquire()}. A resource scope handle can be used to make sure that its corresponding scope cannot be closed
- * (either explicitly, or implicitly) for a certain period of time - e.g. when one or more resources associated with
- * the parent scope need to be accessed. A resource scope can be acquired multiple times; the resource scope can only be
+ * Explicit resource scopes can be made <em>non-closeable</em> by (see {@link #acquire() acquiring} one or more resource
+ * scope <em>handles</em>. A resource scope handle can be used to make sure that its corresponding scope cannot be
+ * {@link #close()} closed} for a certain period of time - e.g. when one or more resources associated with
+ * the parent scope need to be accessed. An explicit resource scope can be acquired multiple times; the resource scope can only be
  * closed <em>after</em> all the handles acquired against that scope have been closed (see {@link Handle#close()}).
  * This can be useful when clients need to perform a critical operation on a memory segment, during which they have
  * to ensure that the segment will not be released; this can be done as follows:
  *
  * <blockquote><pre>{@code
 MemorySegment segment = ...
-try (ResourceScope.Handle segmentHandle = segment.scope().acquire()) {
+ResourceScope.Handle segmentHandle = segment.scope().acquire()
+try {
    <critical operation on segment>
-} // release scope handle
+} finally {
+   segment.scope().release(segmentHandle);
+}
  * }</pre></blockquote>
+ *
+ * Acquiring implicit resource scopes is also possible, but it is often unnecessary: since resources associated with
+ * an implicit scope will only be released when the scope becomes <a href="../../../java/lang/ref/package.html#reachability">unreachable</a>,
+ * clients can use e.g. {@link java.lang.ref.Reference#reachabilityFence(Object)} to make sure that resources associated
+ * with implicit scopes are not released prematurely. That said, the above code snippet works (trivially) for implicit scopes too.
  *
  * @apiNote In the future, if the Java language permits, {@link ResourceScope}
  * may become a {@code sealed} interface, which would prohibit subclassing except by other explicitly permitted subtypes.
@@ -181,28 +189,40 @@ public interface ResourceScope extends AutoCloseable {
     void addOnClose(Runnable runnable);
 
     /**
-     * Make this resource scope non-closeable by acquiring a new resource scope handle. This scope cannot be closed unless all its
-     * acquired handles have been closed first. Additionally, a resource scope handle maintains a strong reference
-     * to its resource scope; this means that if a resource scope features
-     * <a href="ResourceScope.html#implicit-closure"><em>implicit closure</em></a>, the scope cannot be implicitly closed
-     * until all its acquired handles becomes <a href="../../../java/lang/ref/package.html#reachability">unreachable</a>.
+     * If this resource scope is explicit, this method acquires a new resource scope handle, associated with this
+     * resource scope; an explicit resource scope cannot be {@link #close() closed}
+     * until all the resource scope handles acquired from it have been {@link #release(Handle)} released}.
+     * <p>
+     * If this scope is an {@link #isImplicit()} implicit} scope, calling this method will always return the
+     * <em>implicit</em> resource scope handle. The implicit resource scope handle is associated with the
+     * {@link ResourceScope#globalScope() global scope}.
      * @return a resource scope handle.
      */
     Handle acquire();
 
     /**
-     * An abstraction modelling resource scope handle. A resource scope handle is typically acquired by clients (see
-     * {@link #acquire()} in order to prevent the resource scope from being closed while executing a certain operation.
-     * A resource scope handle features a method (see {@link #close()}) which can be used by clients to release the handle.
+     * Release the provided resource scope handle. This method is idempotent, that is, releasing the same handle
+     * multiple times has no effect.
+     * @throws IllegalArgumentException if this resource scope is explicit and the provided handle is not associated
+     * with this scope.
      */
-    interface Handle extends AutoCloseable {
+    void release(Handle handle);
+
+    /**
+     * An abstraction modelling a resource scope handle. A resource scope handle is typically {@link #acquire() acquired} by clients
+     * {@link #acquire()} in order to prevent an explicit resource scope from being closed while executing a certain operation.
+     * Once obtained, resource scope handles can be {@link #release(Handle)} released}; an explicit resource scope can
+     * be closed only <em>after</em> all the resource scope handles acquired from it have been released.
+     */
+    interface Handle {
 
         /**
-         * Release this handle on the resource scope associated with this instance. This method is idempotent,
-         * that is, closing an already closed handle has no effect.
+         * Returns the resource scope associated with this handle, or the {@link ResourceScope#globalScope()}
+         * if this handle is the implicit resource scope handle.
+         * @return the resource scope associated with this handle, or the {@link ResourceScope#globalScope()}
+         * if this handle is the implicit resource scope handle.
          */
-        @Override
-        void close();
+        ResourceScope scope();
     }
 
     /**

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/ConfinedScope.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/ConfinedScope.java
@@ -25,6 +25,7 @@
 
 package jdk.internal.foreign;
 
+import jdk.incubator.foreign.ResourceScope;
 import jdk.internal.vm.annotation.ForceInline;
 
 import java.lang.ref.Cleaner;
@@ -112,8 +113,13 @@ final class ConfinedScope extends ResourceScopeImpl {
     /**
      * A confined resource scope handle; no races are possible here.
      */
-    final class ConfinedHandle implements Handle {
+    final class ConfinedHandle implements HandleImpl {
         boolean released = false;
+
+        @Override
+        public ResourceScope scope() {
+            return ConfinedScope.this;
+        }
 
         @Override
         public void close() {

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/ResourceScopeImpl.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/ResourceScopeImpl.java
@@ -126,11 +126,15 @@ public abstract class ResourceScopeImpl implements ResourceScope, ScopedMemoryAc
 
     @Override
     public void release(Handle handle) {
-        Objects.requireNonNull(handle);
-        if (!isImplicit() && handle.scope() != this) {
-            throw new IllegalArgumentException("Cannot release an handle acquired from another scope");
+        try {
+            Objects.requireNonNull(handle);
+            if (!isImplicit() && handle.scope() != this) {
+                throw new IllegalArgumentException("Cannot release an handle acquired from another scope");
+            }
+            ((HandleImpl) handle).close();
+        } finally {
+            Reference.reachabilityFence(this);
         }
-        ((HandleImpl)handle).close();
     }
 
     /**

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/ResourceScopeImpl.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/ResourceScopeImpl.java
@@ -31,7 +31,6 @@ import jdk.incubator.foreign.ResourceScope;
 import jdk.incubator.foreign.SegmentAllocator;
 import jdk.internal.misc.ScopedMemoryAccess;
 import jdk.internal.ref.CleanerFactory;
-import jdk.internal.vm.annotation.Stable;
 
 import java.lang.ref.Cleaner;
 import java.lang.ref.Reference;
@@ -100,7 +99,7 @@ public abstract class ResourceScopeImpl implements ResourceScope, ScopedMemoryAc
     }
 
     public static ResourceScopeImpl createImplicitScope() {
-        return new NonCloseableSharedScope(CleanerFactory.cleaner());
+        return new ImplicitScopeImpl(CleanerFactory.cleaner());
     }
 
     public static ResourceScopeImpl createConfined(Thread thread, Cleaner cleaner) {
@@ -125,16 +124,20 @@ public abstract class ResourceScopeImpl implements ResourceScope, ScopedMemoryAc
     }
 
     @Override
-    public void release(Handle handle) {
+    public final void release(Handle handle) {
         try {
             Objects.requireNonNull(handle);
-            if (!isImplicit() && handle.scope() != this) {
+            if (!checkHandle(handle)) {
                 throw new IllegalArgumentException("Cannot release an handle acquired from another scope");
             }
             ((HandleImpl) handle).close();
         } finally {
             Reference.reachabilityFence(this);
         }
+    }
+
+    boolean checkHandle(Handle handle) {
+        return handle.scope() == this;
     }
 
     /**
@@ -214,9 +217,9 @@ public abstract class ResourceScopeImpl implements ResourceScope, ScopedMemoryAc
      * the same per-scope handle is shared across multiple calls to {@link #acquire()}. In fact, for non-closeable
      * scopes, it is sufficient for resource scope handles to keep a strong reference to their scopes, to prevent closure.
      */
-    static class NonCloseableSharedScope extends SharedScope {
+    static class ImplicitScopeImpl extends SharedScope {
 
-        public NonCloseableSharedScope(Cleaner cleaner) {
+        public ImplicitScopeImpl(Cleaner cleaner) {
             super(cleaner);
         }
 
@@ -235,6 +238,11 @@ public abstract class ResourceScopeImpl implements ResourceScope, ScopedMemoryAc
             throw new UnsupportedOperationException("Scope cannot be closed");
         }
 
+        @Override
+        boolean checkHandle(Handle handle) {
+            return handle == implicitHandle;
+        }
+
         private final static HandleImpl implicitHandle = new HandleImpl() {
             @Override
             public void close() {
@@ -249,11 +257,11 @@ public abstract class ResourceScopeImpl implements ResourceScope, ScopedMemoryAc
     }
 
     /**
-     * The global, always alive, non-closeable, shared scope. This is like a {@link NonCloseableSharedScope non-closeable scope},
+     * The global, always alive, non-closeable, shared scope. This is like a {@link ImplicitScopeImpl non-closeable scope},
      * except that the operation which adds new resources to the global scope does nothing: as the scope can never
      * become not-alive, there is nothing to track.
      */
-    public static ResourceScopeImpl GLOBAL = new NonCloseableSharedScope( null) {
+    public static ResourceScopeImpl GLOBAL = new ImplicitScopeImpl( null) {
         @Override
         void addInternal(ResourceList.ResourceCleanup resource) {
             // do nothing

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/SharedScope.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/SharedScope.java
@@ -25,6 +25,7 @@
 
 package jdk.internal.foreign;
 
+import jdk.incubator.foreign.ResourceScope;
 import jdk.internal.misc.ScopedMemoryAccess;
 
 import java.lang.invoke.MethodHandles;
@@ -170,8 +171,13 @@ class SharedScope extends ResourceScopeImpl {
     /**
      * A shared resource scope handle; this implementation has to handle close vs. close races.
      */
-    class SharedHandle implements Handle {
+    class SharedHandle implements HandleImpl {
         final AtomicBoolean released = new AtomicBoolean(false);
+
+        @Override
+        public ResourceScope scope() {
+            return SharedScope.this;
+        }
 
         @Override
         public void close() {

--- a/test/jdk/java/foreign/NativeTestHelper.java
+++ b/test/jdk/java/foreign/NativeTestHelper.java
@@ -72,7 +72,7 @@ public class NativeTestHelper {
 
         @Override
         public void close() {
-            scopeHandle.close();
+            resourceScope.release(scopeHandle);
             resourceScope.close();
         }
     }

--- a/test/jdk/java/foreign/TestNulls.java
+++ b/test/jdk/java/foreign/TestNulls.java
@@ -158,9 +158,10 @@ public class TestNulls {
         addDefaultMapping(CLinker.VaList.class, VaListHelper.vaList);
         addDefaultMapping(CLinker.VaList.Builder.class, VaListHelper.vaListBuilder);
         addDefaultMapping(LibraryLookup.class, LibraryLookup.ofDefault());
-        addDefaultMapping(ResourceScope.class, ResourceScope.newConfinedScope());
+        addDefaultMapping(ResourceScope.class, ResourceScope.newImplicitScope());
         addDefaultMapping(SegmentAllocator.class, (size, align) -> null);
         addDefaultMapping(Supplier.class, () -> null);
+        addDefaultMapping(ResourceScope.Handle.class, ResourceScope.globalScope().acquire());
     }
 
     static class VaListHelper {

--- a/test/jdk/java/foreign/TestResourceScope.java
+++ b/test/jdk/java/foreign/TestResourceScope.java
@@ -169,9 +169,9 @@ public class TestResourceScope {
             } catch (IllegalStateException ex) {
                 assertTrue(handles.size() > 0);
                 ResourceScope.Handle handle = handles.remove(0);
-                handle.close();
-                handle.close(); // make sure it's idempotent
-                handle.close(); // make sure it's idempotent
+                scope.release(handle);
+                scope.release(handle); // make sure it's idempotent
+                scope.release(handle); // make sure it's idempotent
             }
         }
     }
@@ -187,9 +187,9 @@ public class TestResourceScope {
                 try {
                     ResourceScope.Handle handle = scope.acquire();
                     waitSomeTime();
-                    handle.close();
-                    handle.close(); // make sure it's idempotent
-                    handle.close(); // make sure it's idempotent
+                    scope.release(handle);
+                    scope.release(handle); // make sure it's idempotent
+                    scope.release(handle); // make sure it's idempotent
                 } catch (IllegalStateException ex) {
                     // might be already closed - do nothing
                 }
@@ -218,13 +218,14 @@ public class TestResourceScope {
 
     @Test
     public void testCloseConfinedLock() {
-        ResourceScope.Handle handle = ResourceScope.newConfinedScope().acquire();
+        ResourceScope scope = ResourceScope.newConfinedScope();
+        ResourceScope.Handle handle = scope.acquire();
         AtomicReference<Throwable> failure = new AtomicReference<>();
         Thread t = new Thread(() -> {
             try {
-                handle.close();
-                handle.close(); // make sure it's idempotent
-                handle.close(); // make sure it's idempotent
+                scope.release(handle);
+                scope.release(handle); // make sure it's idempotent
+                scope.release(handle); // make sure it's idempotent
             } catch (Throwable ex) {
                 failure.set(ex);
             }
@@ -257,9 +258,9 @@ public class TestResourceScope {
         if (!scope.isImplicit()) {
             assertThrows(IllegalStateException.class, scope::close);
         }
-        handle.close();
-        handle.close(); // make sure it's idempotent
-        handle.close(); // make sure it's idempotent
+        scope.release(handle);
+        scope.release(handle); // make sure it's idempotent
+        scope.release(handle); // make sure it's idempotent
     }
 
     private void waitSomeTime() {

--- a/test/jdk/java/foreign/TestScopedOperations.java
+++ b/test/jdk/java/foreign/TestScopedOperations.java
@@ -91,7 +91,10 @@ public class TestScopedOperations {
     static {
             // scope operations
             ScopedOperation.ofScope(scope -> scope.addOnClose(() -> {}), "ResourceScope::addOnClose");
-            ScopedOperation.ofScope(scope -> scope.acquire().close(), "ResourceScope::lock");
+            ScopedOperation.ofScope(scope -> {
+                ResourceScope.Handle handle = scope.acquire();
+                scope.release(handle);
+            }, "ResourceScope::lock");
             // segment operations
             ScopedOperation.ofSegment(MemorySegment::toByteArray, "MemorySegment::toByteArray");
             ScopedOperation.ofSegment(MemorySegment::toCharArray, "MemorySegment::toCharArray");

--- a/test/micro/org/openjdk/bench/jdk/incubator/foreign/BulkMismatchAcquire.java
+++ b/test/micro/org/openjdk/bench/jdk/incubator/foreign/BulkMismatchAcquire.java
@@ -138,7 +138,7 @@ public class BulkMismatchAcquire {
         try {
             return mismatchSegmentLarge1.mismatch(mismatchSegmentLarge2);
         } finally {
-            handle.close();
+            mismatchSegmentLarge1.scope().release(handle);
         }
     }
 
@@ -161,7 +161,7 @@ public class BulkMismatchAcquire {
         try {
             return mismatchSegmentSmall1.mismatch(mismatchSegmentSmall2);
         } finally {
-            handle.close();
+            mismatchSegmentLarge1.scope().release(handle);
         }
     }
 


### PR DESCRIPTION
The code in this PR demonstrates a possible, alternate approach to resource scope acquire.

Instead of having `ResourceScope.Handle` be `AutoCloseable` (which is problematic, given that `javac` issues warning when an auto closeable is not used inside the body of the try block) this patch adds a new method on resource scopes, namely `ResourceScope::release(Handle)`.

The semantics of this method is similar to the previous `Handle::close` - one thing that is different is how implicit scopes are handled - instead of trying to keep the implicit scope alive through the handle instance, here we simply return a "dummy" handle, which does nothing.

The idea is that if you write idiomatic code like:

```java
var handle = scope.acquire();
try {
   // critical region
} finally {
   scope.release(handle); 
} 
```

This will work for both explicit scopes (since acquiring actively prevents calls to `ResourceScope::close`) - but also for implicit scopes, since the `release` call inside the finally block will effectively require the scope to be reachable at this stage (see reachability fence inside `ResourceScopeImpl::release`).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [Chris Hegarty](https://openjdk.java.net/census#chegar) (@ChrisHegarty - Committer) ⚠️ Review applies to b74bba6c5dae89d5b0be947a1df03080be06f5a2
 * [Paul Sandoz](https://openjdk.java.net/census#psandoz) (@PaulSandoz - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/511/head:pull/511` \
`$ git checkout pull/511`

Update a local copy of the PR: \
`$ git checkout pull/511` \
`$ git pull https://git.openjdk.java.net/panama-foreign pull/511/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 511`

View PR using the GUI difftool: \
`$ git pr show -t 511`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/panama-foreign/pull/511.diff">https://git.openjdk.java.net/panama-foreign/pull/511.diff</a>

</details>
