### PR TITLE
Misc javadoc fixes

### DIFF
--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/SegmentAllocator.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/SegmentAllocator.java
@@ -59,10 +59,6 @@ try (ResourceScope scope = ResourceScope.newConfinedScope()) {
  * In addition, this interface also defines factories for commonly used allocators; for instance {@link #arenaAllocator(ResourceScope)}
  * and {@link #arenaAllocator(long, ResourceScope)} are arena-style native allocators. Finally {@link #ofSegment(MemorySegment)}
  * returns an allocator which wraps a segment (either on-heap or off-heap) and recycles its content upon each new allocation request.
- * <p>
- * Unless otherwise specified, whenever an allocator is associated with a <em>shared</em> resource scope, then allocation is
- * thread-safe and may be performed concurrently; conversely, if the allocator is associated with a <em>confined</em> resource scope
- * then allocation is confined to the owning thread of the allocator's resource scope.
  */
 @FunctionalInterface
 public interface SegmentAllocator {
@@ -356,6 +352,10 @@ public interface SegmentAllocator {
      * This can be useful when clients want to perform multiple allocation requests while avoiding the cost associated
      * with allocating a new off-heap memory region upon each allocation request.
      * <p>
+     * An allocator associated with a <em>shared</em> resource scope is thread-safe and allocation requests may be
+     * performed concurrently; conversely, if the arena allocator is associated with a <em>confined</em> resource scope,
+     * allocation requests can only occur from the thread owning the allocator's resource scope.
+     * <p>
      * The returned allocator might throw an {@link OutOfMemoryError} if an incoming allocation request exceeds
      * the allocator capacity.
      *
@@ -387,6 +387,10 @@ public interface SegmentAllocator {
      * <p>
      * This segment allocator can be useful when clients want to perform multiple allocation requests while avoiding the
      * cost associated with allocating a new off-heap memory region upon each allocation request.
+     * <p>
+     * An allocator associated with a <em>shared</em> resource scope is thread-safe and allocation requests may be
+     * performed concurrently; conversely, if the arena allocator is associated with a <em>confined</em> resource scope,
+     * allocation requests can only occur from the thread owning the allocator's resource scope.
      * <p>
      * The returned allocator might throw an {@link OutOfMemoryError} if an incoming allocation request exceeds
      * the system capacity.

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/NativeMemorySegmentImpl.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/NativeMemorySegmentImpl.java
@@ -122,7 +122,7 @@ public class NativeMemorySegmentImpl extends AbstractMemorySegmentImpl {
         scope.checkValidStateSlow();
         AbstractMemorySegmentImpl segment = new NativeMemorySegmentImpl(min.toRawLongValue(), bytesSize, defaultAccessModes(bytesSize), scope);
         if (cleanupAction != null) {
-            scope.addOnClose(cleanupAction);
+            scope.addCloseAction(cleanupAction);
         }
         return segment;
     }

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/ResourceScopeImpl.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/ResourceScopeImpl.java
@@ -54,7 +54,7 @@ public abstract class ResourceScopeImpl implements ResourceScope, ScopedMemoryAc
     final ResourceList resourceList;
 
     @Override
-    public void addOnClose(Runnable runnable) {
+    public void addCloseAction(Runnable runnable) {
         Objects.requireNonNull(runnable);
         addInternal(ResourceList.ResourceCleanup.ofRunnable(runnable));
     }

--- a/test/jdk/java/foreign/TestResourceScope.java
+++ b/test/jdk/java/foreign/TestResourceScope.java
@@ -57,7 +57,7 @@ public class TestResourceScope {
                 ResourceScope.newConfinedScope();
         for (int i = 0 ; i < N_THREADS ; i++) {
             int delta = i;
-            scope.addOnClose(() -> acc.addAndGet(delta));
+            scope.addCloseAction(() -> acc.addAndGet(delta));
         }
         assertEquals(acc.get(), 0);
 
@@ -82,7 +82,7 @@ public class TestResourceScope {
                 ResourceScope.newSharedScope();
         for (int i = 0 ; i < N_THREADS ; i++) {
             int delta = i;
-            scope.addOnClose(() -> acc.addAndGet(delta));
+            scope.addCloseAction(() -> acc.addAndGet(delta));
         }
         assertEquals(acc.get(), 0);
 
@@ -111,7 +111,7 @@ public class TestResourceScope {
             int delta = i;
             Thread thread = new Thread(() -> {
                 try {
-                    scopeRef.get().addOnClose(() -> {
+                    scopeRef.get().addCloseAction(() -> {
                         acc.addAndGet(delta);
                     });
                 } catch (IllegalStateException ex) {

--- a/test/jdk/java/foreign/TestScopedOperations.java
+++ b/test/jdk/java/foreign/TestScopedOperations.java
@@ -90,7 +90,7 @@ public class TestScopedOperations {
 
     static {
             // scope operations
-            ScopedOperation.ofScope(scope -> scope.addOnClose(() -> {}), "ResourceScope::addOnClose");
+            ScopedOperation.ofScope(scope -> scope.addCloseAction(() -> {}), "ResourceScope::addOnClose");
             ScopedOperation.ofScope(scope -> {
                 ResourceScope.Handle handle = scope.acquire();
                 scope.release(handle);


### PR DESCRIPTION
This short patch addresses some API review comments which have been raised by @jbf.

Following changes are made:

* addOnClose is renamed to addCloseAction, to remove ambiguity on when `add` happens
* some comments about allocation confinement and thread safety have been moved in the arenaAllocator factory (from the top level javadoc)
* The text in the thread-confinement section of `ResourceScope` has been massaged a little to describe how clients are expected to deal with issues when closing shared scopes in a more positive way (e.g. the new text suggests what to do "Add more synchronization" instead of saying "it's a bug"). The rewritten section also connects more nicely with what comes later (resource scope handles) which are all about avoiding close vs. access races.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [Chris Hegarty](https://openjdk.java.net/census#chegar) (@ChrisHegarty - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/515/head:pull/515` \
`$ git checkout pull/515`

Update a local copy of the PR: \
`$ git checkout pull/515` \
`$ git pull https://git.openjdk.java.net/panama-foreign pull/515/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 515`

View PR using the GUI difftool: \
`$ git pr show -t 515`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/panama-foreign/pull/515.diff">https://git.openjdk.java.net/panama-foreign/pull/515.diff</a>

</details>
