### PR TITLE
Fix NativeScope

### DIFF
--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/clang/libclang/NativeScope.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/clang/libclang/NativeScope.java
@@ -65,7 +65,7 @@ public class NativeScope implements SegmentAllocator, AutoCloseable {
 
     @Override
     public void close() {
-        scopeHandle.close();
+        resourceScope.release(scopeHandle);
         resourceScope.close();
     }
 

--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/resources/NativeScope.java.template
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/resources/NativeScope.java.template
@@ -39,7 +39,7 @@ public class NativeScope implements SegmentAllocator, AutoCloseable {
 
     @Override
     public void close() {
-        scopeHandle.close();
+        resourceScope.release(scopeHandle);
         resourceScope.close();
     }
 


### PR DESCRIPTION
The recent merge has broken the generated `NativeScope` class. The fix is trivial.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [Athijegannathan Sundararajan](https://openjdk.java.net/census#sundar) (@sundararajana - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/518/head:pull/518` \
`$ git checkout pull/518`

Update a local copy of the PR: \
`$ git checkout pull/518` \
`$ git pull https://git.openjdk.java.net/panama-foreign pull/518/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 518`

View PR using the GUI difftool: \
`$ git pr show -t 518`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/panama-foreign/pull/518.diff">https://git.openjdk.java.net/panama-foreign/pull/518.diff</a>

</details>
