### PR TITLE
8265974: ResourceScope code does not handle close vs. add races well

### DIFF
--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/ConfinedScope.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/ConfinedScope.java
@@ -87,7 +87,7 @@ final class ConfinedScope extends ResourceScopeImpl {
     /**
      * A confined resource list; no races are possible here.
      */
-    static final class ConfinedResourceList extends ResourceList {
+    static class ConfinedResourceList extends ResourceList {
         @Override
         void add(ResourceCleanup cleanup) {
             if (fst != ResourceCleanup.CLOSED_LIST) {

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/ResourceScopeImpl.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/ResourceScopeImpl.java
@@ -83,11 +83,12 @@ public abstract class ResourceScopeImpl implements ResourceScope, ScopedMemoryAc
     }
 
     void addInternal(ResourceList.ResourceCleanup resource) {
+        ResourceScope.Handle handle = acquire();
         try {
-            checkValidStateSlow();
+            // avoid close vs. add races
             resourceList.add(resource);
-        } catch (ScopedMemoryAccess.Scope.ScopedAccessError err) {
-            throw new IllegalStateException("Already closed");
+        } finally {
+            release(handle);
         }
     }
 

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/SharedScope.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/SharedScope.java
@@ -116,9 +116,9 @@ class SharedScope extends ResourceScopeImpl {
     }
 
     /**
-     * A shared resource list; this implementation has to handle add vs. add races, as well as add vs. cleanup races.
+     * A shared resource list; this implementation has to handle add vs. add races.
      */
-    static class SharedResourceList extends ResourceList {
+    static class SharedResourceList extends ConfinedScope.ConfinedResourceList {
 
         static final VarHandle FST;
 
@@ -132,14 +132,13 @@ class SharedScope extends ResourceScopeImpl {
 
         @Override
         void add(ResourceCleanup cleanup) {
+            // We don't need to worry about add vs. close races here; adding a new cleanup action is done
+            // under acquire, which prevents scope from being closed. The only possible race here is
+            // add vs. add.
             while (true) {
                 ResourceCleanup prev = (ResourceCleanup) FST.getAcquire(this);
                 cleanup.next = prev;
-                ResourceCleanup newSegment = (ResourceCleanup) FST.compareAndExchangeRelease(this, prev, cleanup);
-                if (newSegment == ResourceCleanup.CLOSED_LIST) {
-                    // too late
-                    throw new IllegalStateException("Already closed");
-                } else if (newSegment == prev) {
+                if ((ResourceCleanup) FST.compareAndExchangeRelease(this, prev, cleanup) == prev) {
                     return; //victory
                 }
                 // keep trying
@@ -147,24 +146,12 @@ class SharedScope extends ResourceScopeImpl {
         }
 
         void cleanup() {
-            // At this point we are only interested about add vs. close races - not close vs. close
-            // (because MemoryScope::justClose ensured that this thread won the race to close the scope).
-            // So, the only "bad" thing that could happen is that some other thread adds to this list
-            // while we're closing it.
-            if (FST.getAcquire(this) != ResourceCleanup.CLOSED_LIST) {
-                //ok now we're really closing down
-                ResourceCleanup prev = null;
-                while (true) {
-                    prev = (ResourceCleanup) FST.getAcquire(this);
-                    // no need to check for DUMMY, since only one thread can get here!
-                    if (FST.weakCompareAndSetRelease(this, prev, ResourceCleanup.CLOSED_LIST)) {
-                        break;
-                    }
-                }
-                cleanup(prev);
-            } else {
-                throw new IllegalStateException("Attempt to cleanup an already closed resource list");
-            }
+            // We don't need to worry about add vs. close races here; adding a new cleanup action is done
+            // under acquire, which prevents scope from being closed. The only possible race here is
+            // add vs. add. Additionally, close vs. close races are impossible (because MemoryScope::justClose
+            // ensures that only one thread can win the race to close the scope). In other words, this is
+            // effectively single-threaded code.
+            super.cleanup();
         }
     }
 


### PR DESCRIPTION
This PR is motivated by the discussion in:

https://git.openjdk.java.net/panama-foreign/pull/519

There seems to be an issue (at least conceptually) in that the code which adds a new cleanup can, in principle, replace CLOSED_LIST with a new cleanup action, which then breaks the list invariants.

While some fixes are possible, I believe that this part of the code is too complex and there's really no reason as to why we would want to allow CLOSE and ADD to happen in parallel with as few synchronization as possible.

Since we already have a way to prevent a scope from being closed, it only seems fair that `addCloseAction` should defend against scope closure using acquire. Under this new, simplified world, in the shared case we only have to worry about add vs. add races, as add vs. close is no longer possible.

I've re-ran the benchmark `ResourceScopeClose` and noticed no performance impact of this code simplification. So I think it would be better to make the code "dumber" but more obviously correct, rather than chasing dubious micro optimizations whose correctess we're not 100% sure about.


