### PR TITLE
Simplify isAlive / checkValidState methods for implicit scope

### DIFF
--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/ResourceScopeImpl.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/ResourceScopeImpl.java
@@ -258,6 +258,16 @@ public abstract class ResourceScopeImpl implements ResourceScope, ScopedMemoryAc
             return handle == implicitHandle;
         }
 
+        @Override
+        public boolean isAlive() {
+            // This scope is alive when there are references to it.
+            return true;
+        }
+
+        @Override
+        public void checkValidState() {
+        }
+
         private final static HandleImpl implicitHandle = new HandleImpl() {
             @Override
             public void close() {


### PR DESCRIPTION
This is an idea to improve performance of implicit scope which is as well a global scope.

Implicit scope is always alive, and can't be closed (by normal means),
so aliveness checks can be no-op.
In this particular case, we avoid costly volatile state check, inherited from shared scope and used in many places (especially during creation segment form address).

checkValidState is a simillar case, however here performance impact is lower.

Before
```
StrLenTest.panama_strlen_arena                               5  avgt   10   35.399 ?   1.970  ns/op
StrLenTest.panama_strlen_arena                              20  avgt   10   54.262 ?   4.368  ns/op
StrLenTest.panama_strlen_arena                             100  avgt    3  101.130 ? 153.369  ns/op
StrLenTest.panama_strlen_memsegmentpool_allocator            5  avgt   10   68.533 ?   1.137  ns/op
StrLenTest.panama_strlen_memsegmentpool_allocator           20  avgt   10   61.875 ?   0.241  ns/op
StrLenTest.panama_strlen_memsegmentpool_allocator          100  avgt   10   93.222 ?   1.712  ns/op
StrLenTest.panama_strlen_memsegmentpool_allocator_copy       5  avgt   10   62.524 ?   0.674  ns/op
StrLenTest.panama_strlen_memsegmentpool_allocator_copy      20  avgt   10   65.042 ?   0.725  ns/op
StrLenTest.panama_strlen_memsegmentpool_allocator_copy     100  avgt   10   96.331 ?   1.937  ns/op
StrLenTest.panama_strlen_prefix                              5  avgt   10   27.629 ?   0.394  ns/op
StrLenTest.panama_strlen_prefix                             20  avgt   10   33.866 ?   0.274  ns/op
StrLenTest.panama_strlen_prefix                            100  avgt   10   50.047 ?   1.007  ns/op
StrLenTest.panama_strlen_unsafe                              5  avgt   10   43.200 ?   0.683  ns/op
StrLenTest.panama_strlen_unsafe                             20  avgt   10   45.795 ?   0.604  ns/op
StrLenTest.panama_strlen_unsafe                            100  avgt   10   69.070 ?   0.198  ns/op
StrLenTest.panama_strlen_unsafe_trivial                      5  avgt   10   28.154 ?   0.263  ns/op
StrLenTest.panama_strlen_unsafe_trivial                     20  avgt   10   34.597 ?   1.554  ns/op
StrLenTest.panama_strlen_unsafe_trivial                    100  avgt   10   49.546 ?   0.501  ns/op
```
After
StrLenTest.panama_strlen_arena                               5  avgt   10  35.487 ?   1.500  ns/op
StrLenTest.panama_strlen_arena                              20  avgt   10  53.043 ?   3.375  ns/op
StrLenTest.panama_strlen_arena                             100  avgt    3  98.676 ? 134.643  ns/op
StrLenTest.panama_strlen_memsegmentpool_allocator            5  avgt   10  59.435 ?   0.787  ns/op
StrLenTest.panama_strlen_memsegmentpool_allocator           20  avgt   10  64.347 ?   1.146  ns/op
StrLenTest.panama_strlen_memsegmentpool_allocator          100  avgt   10  81.476 ?   1.002  ns/op
StrLenTest.panama_strlen_memsegmentpool_allocator_copy       5  avgt   10  58.936 ?   0.625  ns/op
StrLenTest.panama_strlen_memsegmentpool_allocator_copy      20  avgt   10  76.399 ?   0.251  ns/op
StrLenTest.panama_strlen_memsegmentpool_allocator_copy     100  avgt   10  94.255 ?   1.411  ns/op
StrLenTest.panama_strlen_prefix                              5  avgt   10  28.036 ?   0.342  ns/op
StrLenTest.panama_strlen_prefix                             20  avgt   10  33.364 ?   0.395  ns/op
StrLenTest.panama_strlen_prefix                            100  avgt   10  49.473 ?   0.515  ns/op
StrLenTest.panama_strlen_unsafe                              5  avgt   10  41.468 ?   0.919  ns/op
StrLenTest.panama_strlen_unsafe                             20  avgt   10  51.986 ?  10.217  ns/op
StrLenTest.panama_strlen_unsafe                            100  avgt   10  74.997 ?   7.457  ns/op
StrLenTest.panama_strlen_unsafe_trivial                      5  avgt   10  26.756 ?   0.619  ns/op
StrLenTest.panama_strlen_unsafe_trivial                     20  avgt   10  32.399 ?   0.317  ns/op
StrLenTest.panama_strlen_unsafe_trivial                    100  avgt   10  59.440 ?   0.864  ns/op
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Change must be properly reviewed

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/521/head:pull/521` \
`$ git checkout pull/521`

Update a local copy of the PR: \
`$ git checkout pull/521` \
`$ git pull https://git.openjdk.java.net/panama-foreign pull/521/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 521`

View PR using the GUI difftool: \
`$ git pr show -t 521`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/panama-foreign/pull/521.diff">https://git.openjdk.java.net/panama-foreign/pull/521.diff</a>

</details>
