### PR TITLE
Clarify IllegalArgumentException on MemorySegment::[spliterator,elements]

### DIFF
--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/MemorySegment.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/MemorySegment.java
@@ -184,7 +184,8 @@ public interface MemorySegment extends Addressable {
      *
      * @param elementLayout the layout to be used for splitting.
      * @return the element spliterator for this segment
-     * @throws IllegalArgumentException if this segment size is not a multiple of the size of {@code elementLayout}.
+     * @throws IllegalArgumentException if this segment size is not a multiple of the size of {@code elementLayout},
+     * or if this segment size is smaller than the size of {@code elementLayout}.
      */
     Spliterator<MemorySegment> spliterator(MemoryLayout elementLayout);
 
@@ -197,7 +198,8 @@ public interface MemorySegment extends Addressable {
      *
      * @param elementLayout the layout to be used for splitting.
      * @return a sequential {@code Stream} over disjoint slices in this segment.
-     * @throws IllegalArgumentException if this segment size is not a multiple of the size of {@code elementLayout}.
+     * @throws IllegalArgumentException if this segment size is not a multiple of the size of {@code elementLayout},
+     * or if this segment size is smaller than the size of {@code elementLayout}.
      */
     Stream<MemorySegment> elements(MemoryLayout elementLayout);
 

--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/MemorySegment.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/MemorySegment.java
@@ -184,8 +184,8 @@ public interface MemorySegment extends Addressable {
      *
      * @param elementLayout the layout to be used for splitting.
      * @return the element spliterator for this segment
-     * @throws IllegalArgumentException if this segment size is not a multiple of the size of {@code elementLayout},
-     * or if this segment size is smaller than the size of {@code elementLayout}.
+     * @throws IllegalArgumentException if the {@code elementLayout} size is zero, or the segment size modulo the
+     * {@code elementLayout} size is greater than zero.
      */
     Spliterator<MemorySegment> spliterator(MemoryLayout elementLayout);
 
@@ -198,8 +198,8 @@ public interface MemorySegment extends Addressable {
      *
      * @param elementLayout the layout to be used for splitting.
      * @return a sequential {@code Stream} over disjoint slices in this segment.
-     * @throws IllegalArgumentException if this segment size is not a multiple of the size of {@code elementLayout},
-     * or if this segment size is smaller than the size of {@code elementLayout}.
+     * @throws IllegalArgumentException if the {@code elementLayout} size is zero, or the segment size modulo the
+     * {@code elementLayout} size is greater than zero.
      */
     Stream<MemorySegment> elements(MemoryLayout elementLayout);
 

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/AbstractMemorySegmentImpl.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/AbstractMemorySegmentImpl.java
@@ -118,6 +118,9 @@ public abstract class AbstractMemorySegmentImpl extends MemorySegmentProxy imple
     @Override
     public Spliterator<MemorySegment> spliterator(MemoryLayout elementLayout) {
         Objects.requireNonNull(elementLayout);
+        if (elementLayout.byteSize() == 0) {
+            throw new IllegalArgumentException("Element layout size cannot be zero");
+        }
         if (byteSize() % elementLayout.byteSize() != 0) {
             throw new IllegalArgumentException("Segment size is no a multiple of layout size");
         }

--- a/test/jdk/java/foreign/TestSpliterator.java
+++ b/test/jdk/java/foreign/TestSpliterator.java
@@ -118,6 +118,16 @@ public class TestSpliterator {
         MemorySegment.ofArray(new byte[7]).elements(MemoryLayouts.JAVA_INT);
     }
 
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testBadSpliteratorElementSizeZero() {
+        MemorySegment.ofArray(new byte[7]).spliterator(MemoryLayout.sequenceLayout(0, MemoryLayouts.JAVA_INT));
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testBadStreamElementSizeZero() {
+        MemorySegment.ofArray(new byte[7]).elements(MemoryLayout.sequenceLayout(0, MemoryLayouts.JAVA_INT));
+    }
+
     static long sumSingle(long acc, MemorySegment segment) {
         return acc + (int)INT_HANDLE.get(segment, 0L);
     }

--- a/test/jdk/java/foreign/TestSpliterator.java
+++ b/test/jdk/java/foreign/TestSpliterator.java
@@ -98,6 +98,26 @@ public class TestSpliterator {
         assertEquals(spliteratorSum.get(), expected);
     }
 
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testBadSpliteratorElementSizeTooBig() {
+        MemorySegment.ofArray(new byte[2]).spliterator(MemoryLayouts.JAVA_INT);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testBadStreamElementSizeTooBig() {
+        MemorySegment.ofArray(new byte[2]).elements(MemoryLayouts.JAVA_INT);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testBadSpliteratorElementSizeNotMultiple() {
+        MemorySegment.ofArray(new byte[7]).spliterator(MemoryLayouts.JAVA_INT);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testBadStreamElementSizeNotMultiple() {
+        MemorySegment.ofArray(new byte[7]).elements(MemoryLayouts.JAVA_INT);
+    }
+
     static long sumSingle(long acc, MemorySegment segment) {
         return acc + (int)INT_HANDLE.get(segment, 0L);
     }


### PR DESCRIPTION
In an offline discussion I was made aware that `MemorySegment.spliterator` was not specifying what happened if the size of the layout passed to spliterator() did not match that of the segment.

The newly revised method has a better javadoc, which says a bit more, but stil doesn't specify what happens if the element layout is bigger than the segment.

This small patch rectifies that, and add few tests to check that the implementation issues the expected exceptions.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [Paul Sandoz](https://openjdk.java.net/census#psandoz) (@PaulSandoz - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/522/head:pull/522` \
`$ git checkout pull/522`

Update a local copy of the PR: \
`$ git checkout pull/522` \
`$ git pull https://git.openjdk.java.net/panama-foreign pull/522/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 522`

View PR using the GUI difftool: \
`$ git pr show -t 522`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/panama-foreign/pull/522.diff">https://git.openjdk.java.net/panama-foreign/pull/522.diff</a>

</details>
