### PR TITLE
Simplify ResourceScope::acquire for implicit scopes

### DIFF
--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/ResourceScope.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/ResourceScope.java
@@ -201,10 +201,6 @@ public interface ResourceScope extends AutoCloseable {
      * If this resource scope is explicit, this method acquires a new resource scope handle, associated with this
      * resource scope; an explicit resource scope cannot be {@link #close() closed}
      * until all the resource scope handles acquired from it have been {@link #release(Handle)} released}.
-     * <p>
-     * If this scope is an {@link #isImplicit()} implicit} scope, calling this method will always return the
-     * <em>implicit</em> resource scope handle. The implicit resource scope handle is associated with the
-     * {@link ResourceScope#globalScope() global scope}.
      * @return a resource scope handle.
      */
     Handle acquire();
@@ -213,8 +209,7 @@ public interface ResourceScope extends AutoCloseable {
      * Release the provided resource scope handle. This method is idempotent, that is, releasing the same handle
      * multiple times has no effect.
      * @param handle the resource scope handle to be released.
-     * @throws IllegalArgumentException if this resource scope is explicit and the provided handle is not associated
-     * with this scope.
+     * @throws IllegalArgumentException if the provided handle is not associated with this scope.
      */
     void release(Handle handle);
 
@@ -227,10 +222,8 @@ public interface ResourceScope extends AutoCloseable {
     interface Handle {
 
         /**
-         * Returns the resource scope associated with this handle, or the {@link ResourceScope#globalScope()}
-         * if this handle is the implicit resource scope handle.
-         * @return the resource scope associated with this handle, or the {@link ResourceScope#globalScope()}
-         * if this handle is the implicit resource scope handle.
+         * Returns the resource scope associated with this handle.
+         * @return the resource scope associated with this handle.
          */
         ResourceScope scope();
     }

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/ConfinedScope.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/ConfinedScope.java
@@ -111,7 +111,7 @@ final class ConfinedScope extends ResourceScopeImpl {
         }
 
         @Override
-        public void close() {
+        public void release() {
             checkValidState(); // thread check
             if (!released) {
                 released = true;

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/ConfinedScope.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/ConfinedScope.java
@@ -116,7 +116,6 @@ final class ConfinedScope extends ResourceScopeImpl {
             if (!released) {
                 released = true;
                 lockCount--;
-                Reference.reachabilityFence(ConfinedScope.this);
             }
         }
     }

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/ResourceScopeImpl.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/ResourceScopeImpl.java
@@ -224,10 +224,9 @@ public abstract class ResourceScopeImpl implements ResourceScope, ScopedMemoryAc
     }
 
     /**
-     * A non-closeable, shared scope. Similar to a shared scope, but its {@link #release()} method throws unconditionally.
+     * A non-closeable, shared scope. Similar to a shared scope, but its {@link #close()} method throws unconditionally.
      * In addition, non-closeable scopes feature a much simpler scheme for generating resource scope handles, where
-     * the same per-scope handle is shared across multiple calls to {@link #acquire()}. In fact, for non-closeable
-     * scopes, it is sufficient for resource scope handles to keep a strong reference to their scopes, to prevent closure.
+     * the scope itself also acts as a resource scope handle and is returned by {@link #acquire()}.
      */
     static class ImplicitScopeImpl extends SharedScope implements HandleImpl {
 

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/ResourceScopeImpl.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/ResourceScopeImpl.java
@@ -127,10 +127,10 @@ public abstract class ResourceScopeImpl implements ResourceScope, ScopedMemoryAc
     private final void release0(HandleImpl handle) {
         try {
             Objects.requireNonNull(handle);
-            if (!checkHandle(handle)) {
+            if (handle.scope() != this) {
                 throw new IllegalArgumentException("Cannot release an handle acquired from another scope");
             }
-            handle.close();
+            handle.release();
         } finally {
             Reference.reachabilityFence(this);
         }
@@ -149,10 +149,6 @@ public abstract class ResourceScopeImpl implements ResourceScope, ScopedMemoryAc
     @Override
     public abstract HandleImpl acquire();
 
-    boolean checkHandle(ResourceScope.Handle handle) {
-        return handle.scope() == this;
-    }
-
     /**
      * Internal interface used to implement resource scope handles.
      */
@@ -161,7 +157,7 @@ public abstract class ResourceScopeImpl implements ResourceScope, ScopedMemoryAc
         @Override
         ResourceScopeImpl scope();
 
-        void close();
+        void release();
     }
 
     /**
@@ -228,12 +224,12 @@ public abstract class ResourceScopeImpl implements ResourceScope, ScopedMemoryAc
     }
 
     /**
-     * A non-closeable, shared scope. Similar to a shared scope, but its {@link #close()} method throws unconditionally.
+     * A non-closeable, shared scope. Similar to a shared scope, but its {@link #release()} method throws unconditionally.
      * In addition, non-closeable scopes feature a much simpler scheme for generating resource scope handles, where
      * the same per-scope handle is shared across multiple calls to {@link #acquire()}. In fact, for non-closeable
      * scopes, it is sufficient for resource scope handles to keep a strong reference to their scopes, to prevent closure.
      */
-    static class ImplicitScopeImpl extends SharedScope {
+    static class ImplicitScopeImpl extends SharedScope implements HandleImpl {
 
         public ImplicitScopeImpl(Cleaner cleaner) {
             super(cleaner);
@@ -241,7 +237,7 @@ public abstract class ResourceScopeImpl implements ResourceScope, ScopedMemoryAc
 
         @Override
         public HandleImpl acquire() {
-            return implicitHandle;
+            return this;
         }
 
         @Override
@@ -255,21 +251,14 @@ public abstract class ResourceScopeImpl implements ResourceScope, ScopedMemoryAc
         }
 
         @Override
-        boolean checkHandle(ResourceScope.Handle handle) {
-            return handle == implicitHandle;
+        public void release() {
+            // do nothing
         }
 
-        private final static HandleImpl implicitHandle = new HandleImpl() {
-            @Override
-            public void close() {
-                // do nothing
-            }
-
-            @Override
-            public ResourceScopeImpl scope() {
-                return GLOBAL;
-            }
-        };
+        @Override
+        public ResourceScopeImpl scope() {
+            return this;
+        }
     }
 
     /**

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/SharedScope.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/SharedScope.java
@@ -167,7 +167,6 @@ class SharedScope extends ResourceScopeImpl {
                         throw new IllegalStateException("Already closed");
                     }
                 } while (!STATE.compareAndSet(jdk.internal.foreign.SharedScope.this, value, value - 1));
-                Reference.reachabilityFence(SharedScope.this);
             }
         }
     }

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/SharedScope.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/SharedScope.java
@@ -157,7 +157,7 @@ class SharedScope extends ResourceScopeImpl {
         }
 
         @Override
-        public void close() {
+        public void release() {
             if (released.compareAndSet(false, true)) {
                 int value;
                 do {

--- a/test/jdk/java/foreign/TestResourceScope.java
+++ b/test/jdk/java/foreign/TestResourceScope.java
@@ -189,8 +189,10 @@ public class TestResourceScope {
         ResourceScope scope = cleaner != null ?
                 ResourceScope.newSharedScope(cleaner) :
                 ResourceScope.newSharedScope();
+        AtomicInteger lockCount = new AtomicInteger();
         for (int i = 0 ; i < N_THREADS ; i++) {
             new Thread(() -> {
+                lockCount.incrementAndGet();
                 try {
                     ResourceScope.Handle handle = scope.acquire();
                     waitSomeTime();
@@ -199,13 +201,16 @@ public class TestResourceScope {
                     scope.release(handle); // make sure it's idempotent
                 } catch (IllegalStateException ex) {
                     // might be already closed - do nothing
+                } finally {
+                    lockCount.decrementAndGet();
                 }
             }).start();
         }
 
-        while (true) {
+        while (lockCount.get() > 0) {
             try {
                 scope.close();
+                assertEquals(lockCount.get(), 0);
                 break;
             } catch (IllegalStateException ex) {
                 waitSomeTime();
@@ -258,6 +263,7 @@ public class TestResourceScope {
 
     private void acquireRecursive(ResourceScope scope, int acquireCount) {
         ResourceScope.Handle handle = scope.acquire();
+        assertEquals(handle.scope(), scope);
         if (acquireCount > 0) {
             // recursive acquire
             acquireRecursive(scope, acquireCount - 1);


### PR DESCRIPTION
As suggested in [1], we can make the API for acquiring implicit scopes simpler if we tweak the implementation so that implicit scopes also implement the `HandleImpl` interface. If we do that, we could implement `acquire` by simply returning the implicit scope instance.

The simplification is that now, from a client perspective, acquiring a scope always gives back an handle that is associated with the original scope - we no longer *cheat* using the implicit scope handle singleton.

The acquire performance are not affected by this change (I've ran `BulkMismatchAcquire` before and after).

[1] - https://mail.openjdk.java.net/pipermail/panama-dev/2021-April/013516.html

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [Paul Sandoz](https://openjdk.java.net/census#psandoz) (@PaulSandoz - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/523/head:pull/523` \
`$ git checkout pull/523`

Update a local copy of the PR: \
`$ git checkout pull/523` \
`$ git pull https://git.openjdk.java.net/panama-foreign pull/523/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 523`

View PR using the GUI difftool: \
`$ git pr show -t 523`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/panama-foreign/pull/523.diff">https://git.openjdk.java.net/panama-foreign/pull/523.diff</a>

</details>
