### PR TITLE
8266371: Memory segment bound check fails because of small segment optimizations

### DIFF
--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/AbstractMemorySegmentImpl.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/AbstractMemorySegmentImpl.java
@@ -381,7 +381,7 @@ public abstract class AbstractMemorySegmentImpl extends MemorySegmentProxy imple
     }
 
     private void checkBounds(long offset, long length) {
-        if (isSmall()) {
+        if (isSmall() && offset < Integer.MAX_VALUE && length < Integer.MAX_VALUE) {
             checkBoundsSmall((int)offset, (int)length);
         } else {
             if (length < 0 ||

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/AbstractMemorySegmentImpl.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/AbstractMemorySegmentImpl.java
@@ -381,7 +381,9 @@ public abstract class AbstractMemorySegmentImpl extends MemorySegmentProxy imple
     }
 
     private void checkBounds(long offset, long length) {
-        if (isSmall() && offset < Integer.MAX_VALUE && length < Integer.MAX_VALUE) {
+        if (isSmall() &&
+                offset < Integer.MAX_VALUE && length < Integer.MAX_VALUE &&
+                offset > Integer.MIN_VALUE && length > Integer.MIN_VALUE) {
             checkBoundsSmall((int)offset, (int)length);
         } else {
             if (length < 0 ||

--- a/test/jdk/java/foreign/TestSegments.java
+++ b/test/jdk/java/foreign/TestSegments.java
@@ -104,8 +104,15 @@ public class TestSegments {
     }
 
     @Test(expectedExceptions = IndexOutOfBoundsException.class)
-    public void testSmallSegment() {
+    public void testSmallSegmentMax() {
         long offset = (long)Integer.MAX_VALUE + (long)Integer.MAX_VALUE + 2L + 6L; // overflows to 6 when casted to int
+        MemorySegment memorySegment = MemorySegment.allocateNative(10, ResourceScope.newImplicitScope());
+        MemoryAccess.getIntAtOffset(memorySegment, offset);
+    }
+
+    @Test(expectedExceptions = IndexOutOfBoundsException.class)
+    public void testSmallSegmentMin() {
+        long offset = ((long)Integer.MIN_VALUE * 2L) + 6L;
         MemorySegment memorySegment = MemorySegment.allocateNative(10, ResourceScope.newImplicitScope());
         MemoryAccess.getIntAtOffset(memorySegment, offset);
     }

--- a/test/jdk/java/foreign/TestSegments.java
+++ b/test/jdk/java/foreign/TestSegments.java
@@ -112,7 +112,7 @@ public class TestSegments {
 
     @Test(expectedExceptions = IndexOutOfBoundsException.class)
     public void testSmallSegmentMin() {
-        long offset = ((long)Integer.MIN_VALUE * 2L) + 6L;
+        long offset = ((long)Integer.MIN_VALUE * 2L) + 6L; // underflows to 6 when casted to int
         MemorySegment memorySegment = MemorySegment.allocateNative(10, ResourceScope.newImplicitScope());
         MemoryAccess.getIntAtOffset(memorySegment, offset);
     }

--- a/test/jdk/java/foreign/TestSegments.java
+++ b/test/jdk/java/foreign/TestSegments.java
@@ -27,6 +27,7 @@
  * @run testng/othervm -Xmx4G -XX:MaxDirectMemorySize=1M TestSegments
  */
 
+import jdk.incubator.foreign.MemoryAccess;
 import jdk.incubator.foreign.MemoryLayout;
 import jdk.incubator.foreign.MemoryLayouts;
 import jdk.incubator.foreign.MemorySegment;
@@ -100,6 +101,13 @@ public class TestSegments {
                 }
             }
         }
+    }
+
+    @Test(expectedExceptions = IndexOutOfBoundsException.class)
+    public void testSmallSegment() {
+        long offset = (long)Integer.MAX_VALUE + (long)Integer.MAX_VALUE + 2L + 6L; // overflows to 6 when casted to int
+        MemorySegment memorySegment = MemorySegment.allocateNative(10, ResourceScope.newImplicitScope());
+        MemoryAccess.getIntAtOffset(memorySegment, offset);
     }
 
     @Test(dataProvider = "segmentFactories")

--- a/test/micro/org/openjdk/bench/jdk/incubator/foreign/LoopOverNonConstantHeap.java
+++ b/test/micro/org/openjdk/bench/jdk/incubator/foreign/LoopOverNonConstantHeap.java
@@ -97,11 +97,6 @@ public class LoopOverNonConstantHeap {
         byteBuffer = ByteBuffer.wrap(base).order(ByteOrder.nativeOrder());
     }
 
-    @TearDown
-    public void tearDown() {
-        segment.scope().close();
-    }
-
     @Benchmark
     @OutputTimeUnit(TimeUnit.NANOSECONDS)
     public int unsafe_get() {


### PR DESCRIPTION
The optimization for small memory segment bound check does not take into account numeric overflow. As a result, the bounds check does not detect big long values which, when casted back to int values appear to be within the segment's bounds.

The fix is to avoid the optimized bound check routine if the offset/length at which the segment is accessed is bigger than Integer.MAX_VALUE.

Benchmarks do not seem affected by this change (I'll post results in a separate comment).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [JDK-8266371](https://bugs.openjdk.java.net/browse/JDK-8266371): Memory segment bound check fails because of small segment optimizations


### Reviewers
 * [Athijegannathan Sundararajan](https://openjdk.java.net/census#sundar) (@sundararajana - Committer) ⚠️ Review applies to 6f9d37540075fad76117c7ec7f38273feaaaaa11
 * [Chris Hegarty](https://openjdk.java.net/census#chegar) (@ChrisHegarty - Committer) ⚠️ Review applies to 2cbf6f5ef817bcfb41e79d58537272ce5bdcca45


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/524/head:pull/524` \
`$ git checkout pull/524`

Update a local copy of the PR: \
`$ git checkout pull/524` \
`$ git pull https://git.openjdk.java.net/panama-foreign pull/524/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 524`

View PR using the GUI difftool: \
`$ git pr show -t 524`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/panama-foreign/pull/524.diff">https://git.openjdk.java.net/panama-foreign/pull/524.diff</a>

</details>
