### PR TITLE
8266627: CLinker allocateMemory, freeMemory implementation should not use default lookup

### DIFF
--- a/src/java.base/share/native/libjava/VMFunctions.c
+++ b/src/java.base/share/native/libjava/VMFunctions.c
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+#include <stdlib.h>
+#include <assert.h>
+
+#include "jni.h"
+
+JNIEXPORT void JNICALL
+Java_jdk_internal_foreign_abi_VMFunctions_initVMFunctions(JNIEnv *env,
+                                        jclass cls,
+                                        jlong address)
+{
+   size_t* addresses = (size_t*)(void*)address;
+   // The order in which the function pointers are stored has to match the order of constants
+   // in the VMFunctions.FunctionName enum.
+   addresses[0] = (size_t)&malloc;
+   addresses[1] = (size_t)&free;
+}

--- a/src/java.base/share/native/libjava/VMFunctions.c
+++ b/src/java.base/share/native/libjava/VMFunctions.c
@@ -24,7 +24,6 @@
  */
 
 #include <stdlib.h>
-#include <assert.h>
 
 #include "jni.h"
 

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/VMFunctions.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/VMFunctions.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package jdk.internal.foreign.abi;
+
+import jdk.incubator.foreign.CLinker;
+import jdk.incubator.foreign.FunctionDescriptor;
+import jdk.incubator.foreign.MemoryAccess;
+import jdk.incubator.foreign.MemoryAddress;
+import jdk.incubator.foreign.MemoryLayouts;
+import jdk.incubator.foreign.MemorySegment;
+import jdk.incubator.foreign.ResourceScope;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodType;
+
+import static jdk.incubator.foreign.CLinker.C_LONG_LONG;
+import static jdk.incubator.foreign.CLinker.C_POINTER;
+
+/**
+ * This class is used to setup downcall method handles which refer to commonly used functions within the JVM.
+ * A memory segment is allocated, with enough room to contain as many pointers as the number of constants
+ * defined in {@link FunctionName}. This segment is then filled by the JVM with function pointers which target
+ * the desired functions.
+ */
+class VMFunctions {
+
+    /**
+     * The order of these constants has to match that in which the VM will fill the {@code vmFunctions} pointer array.
+     */
+    enum FunctionName {
+        MALLOC,
+        FREE;
+
+        MemoryAddress get() {
+            return MemoryAccess.getAddressAtIndex(vmFunctions, ordinal());
+        }
+    }
+
+    private static final CLinker linker = SharedUtils.getSystemLinker();
+    private static final MemorySegment vmFunctions;
+
+    static {
+        vmFunctions = MemorySegment.allocateNative(
+                MemoryLayouts.ADDRESS.byteSize() * FunctionName.values().length,
+                ResourceScope.newImplicitScope());
+        initVMFunctions(vmFunctions.address().toRawLongValue());
+    }
+
+    static final MethodHandle MH_MALLOC = linker.downcallHandle(FunctionName.MALLOC.get(),
+            MethodType.methodType(MemoryAddress.class, long.class),
+            FunctionDescriptor.of(C_POINTER, C_LONG_LONG));
+
+    static final MethodHandle MH_FREE = linker.downcallHandle(FunctionName.FREE.get(),
+            MethodType.methodType(void.class, MemoryAddress.class),
+            FunctionDescriptor.ofVoid(C_POINTER));
+
+    static native void initVMFunctions(long address);
+}


### PR DESCRIPTION
This patch removes the workaround on Windows which requires loading msvcrt.dll.

The solution is to create (Java side) a memory segment and fill it with function pointers on the VM side.
This way, Java code can look up VM functions easily. I've moved this support onto a different class, as the approach might, in the future, be required for other VM functions.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [JDK-8266627](https://bugs.openjdk.java.net/browse/JDK-8266627): CLinker allocateMemory, freeMemory implementation should not use default lookup


### Reviewers
 * [Jorn Vernee](https://openjdk.java.net/census#jvernee) (@JornVernee - Committer) ⚠️ Review applies to 20d183b669fc9afc735d68c050321880541d84cb


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/527/head:pull/527` \
`$ git checkout pull/527`

Update a local copy of the PR: \
`$ git checkout pull/527` \
`$ git pull https://git.openjdk.java.net/panama-foreign pull/527/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 527`

View PR using the GUI difftool: \
`$ git pr show -t 527`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/panama-foreign/pull/527.diff">https://git.openjdk.java.net/panama-foreign/pull/527.diff</a>

</details>
