### PR TITLE
8266916: Simplify logic for creating libSysLookup

### DIFF
--- a/make/modules/jdk.incubator.foreign/Lib.gmk
+++ b/make/modules/jdk.incubator.foreign/Lib.gmk
@@ -29,12 +29,9 @@ ifeq ($(call isTargetOs, linux), true)
 
 $(eval $(call SetupJdkLibrary, BUILD_LIBCSTDLIB, \
     NAME := syslookup, \
-    OPTIMIZATION := HIGH, \
-    DISABLED_WARNINGS_gcc := sign-compare pointer-arith, \
-    DISABLED_WARNINGS_clang := sign-compare pointer-arith format-nonliteral, \
     CFLAGS := $(CFLAGS_JDKLIB), \
     CXXFLAGS := $(CXXFLAGS_JDKLIB), \
-    LDFLAGS := -Wl$(COMMA)--no-as-needed -lc -lm $(LDFLAGS_JDKLIB) $(call SET_SHARED_LIBRARY_ORIGIN), \
+    LDFLAGS := -Wl$(COMMA)--no-as-needed -lc -lm -ldl $(LDFLAGS_JDKLIB) $(call SET_SHARED_LIBRARY_ORIGIN), \
     LIBS := $(LIBCXX), \
 ))
 
@@ -42,9 +39,6 @@ else ifeq ($(call isTargetOs, windows), false)
 
 $(eval $(call SetupJdkLibrary, BUILD_LIBCSTDLIB, \
     NAME := syslookup, \
-    OPTIMIZATION := HIGH, \
-    DISABLED_WARNINGS_gcc := sign-compare pointer-arith, \
-    DISABLED_WARNINGS_clang := sign-compare pointer-arith format-nonliteral, \
     CFLAGS := $(CFLAGS_JDKLIB), \
     CXXFLAGS := $(CXXFLAGS_JDKLIB), \
     LDFLAGS := $(LDFLAGS_JDKLIB) $(call SET_SHARED_LIBRARY_ORIGIN), \

--- a/src/jdk.incubator.foreign/share/native/libsyslookup/syslookup.c
+++ b/src/jdk.incubator.foreign/share/native/libsyslookup/syslookup.c
@@ -23,33 +23,6 @@
  * questions.
  */
 
-#include <assert.h>
-#include <complex.h>
-#include <ctype.h>
-#include <errno.h>
-#include <fenv.h>
-#include <float.h>
-#include <inttypes.h>
-#include <iso646.h>
-#include <limits.h>
-#include <locale.h>
-#include <math.h>
-#include <setjmp.h>
-#include <signal.h>
-#include <stdalign.h>
-#include <stdarg.h>
-#include <stdatomic.h>
-#include <stdbool.h>
-#include <stddef.h>
-#include <stdint.h>
-#include <stdio.h>
+// Note: the include below is not strictly required, as dependencies will be pulled using linker flags.
+// Adding at least one #include removes unwanted warnings on some platforms.
 #include <stdlib.h>
-#include <stdnoreturn.h>
-#include <string.h>
-#include <tgmath.h>
-// #include <threads.h>
-#include <time.h>
-// #include <uchar.h>
-#include <wchar.h>
-#include <wctype.h>
-


### PR DESCRIPTION
On Linux/Mac, the makefile for generating libSysLookup contains some unnecessary flags (given that the sources contain no code).
Moreover, it is not necessary to have a list of all headers - we can just include a single header (to make the build/toolchain happy) and rely on linker to pull in dependencies.
On Linux, also add `libdl` as a dependency (the VM also depends on that, so we can depend on that).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [JDK-8266916](https://bugs.openjdk.java.net/browse/JDK-8266916): Simplify logic for creating libSysLookup


### Reviewers
 * [Athijegannathan Sundararajan](https://openjdk.java.net/census#sundar) (@sundararajana - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/533/head:pull/533` \
`$ git checkout pull/533`

Update a local copy of the PR: \
`$ git checkout pull/533` \
`$ git pull https://git.openjdk.java.net/panama-foreign pull/533/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 533`

View PR using the GUI difftool: \
`$ git pr show -t 533`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/panama-foreign/pull/533.diff">https://git.openjdk.java.net/panama-foreign/pull/533.diff</a>

</details>
