### PR TITLE
Remove printf and vprintf tests

### DIFF
--- a/test/jdk/java/foreign/NativeTestHelper.java
+++ b/test/jdk/java/foreign/NativeTestHelper.java
@@ -30,8 +30,6 @@ import jdk.incubator.foreign.SegmentAllocator;
 
 public class NativeTestHelper {
 
-    public static final boolean IS_WINDOWS = System.getProperty("os.name").startsWith("Windows");
-
     static CLinker.TypeKind kind(MemoryLayout layout) {
         return (CLinker.TypeKind)layout.attribute(CLinker.TypeKind.ATTR_NAME).orElseThrow(
                 () -> new IllegalStateException("Unexpected value layout: could not determine ABI class"));

--- a/test/jdk/java/foreign/NativeTestHelper.java
+++ b/test/jdk/java/foreign/NativeTestHelper.java
@@ -30,6 +30,8 @@ import jdk.incubator.foreign.SegmentAllocator;
 
 public class NativeTestHelper {
 
+    public static final boolean IS_WINDOWS = System.getProperty("os.name").startsWith("Windows");
+
     static CLinker.TypeKind kind(MemoryLayout layout) {
         return (CLinker.TypeKind)layout.attribute(CLinker.TypeKind.ATTR_NAME).orElseThrow(
                 () -> new IllegalStateException("Unexpected value layout: could not determine ABI class"));

--- a/test/jdk/java/foreign/StdLibTest.java
+++ b/test/jdk/java/foreign/StdLibTest.java
@@ -50,7 +50,6 @@ import jdk.incubator.foreign.*;
 
 import static jdk.incubator.foreign.MemoryAccess.*;
 
-import org.testng.SkipException;
 import org.testng.annotations.*;
 
 import static jdk.incubator.foreign.CLinker.*;

--- a/test/jdk/java/foreign/StdLibTest.java
+++ b/test/jdk/java/foreign/StdLibTest.java
@@ -122,36 +122,6 @@ public class StdLibTest {
         fail("All values are the same! " + val);
     }
 
-    @Test(dataProvider = "printfArgs")
-    void test_printf(List<PrintfArg> args) throws Throwable {
-        String formatArgs = args.stream()
-                .map(a -> a.format)
-                .collect(Collectors.joining(","));
-
-        String formatString = "hello(" + formatArgs + ")\n";
-
-        String expected = String.format(formatString, args.stream()
-                .map(a -> a.javaValue).toArray());
-
-        int found = stdLibHelper.printf(formatString, args);
-        assertEquals(found, expected.length());
-    }
-
-    @Test(dataProvider = "printfArgs")
-    void test_vprintf(List<PrintfArg> args) throws Throwable {
-        String formatArgs = args.stream()
-                .map(a -> a.format)
-                .collect(Collectors.joining(","));
-
-        String formatString = "hello(" + formatArgs + ")\n";
-
-        String expected = String.format(formatString, args.stream()
-                .map(a -> a.javaValue).toArray());
-
-        int found = stdLibHelper.vprintf(formatString, args);
-        assertEquals(found, expected.length());
-    }
-
     static class StdLibHelper {
 
         final static MethodHandle strcat = abi.downcallHandle(CLinker.systemLookup().lookup("strcat").get(),
@@ -170,7 +140,8 @@ public class StdLibTest {
                 MethodType.methodType(int.class, MemoryAddress.class),
                 FunctionDescriptor.of(C_INT, C_POINTER));
 
-        final static MethodHandle gmtime = abi.downcallHandle(CLinker.systemLookup().lookup("gmtime").get(),
+        final static MethodHandle gmtime = abi.downcallHandle(
+                CLinker.systemLookup().lookup(NativeTestHelper.IS_WINDOWS ? "_gmtime64" : "gmtime").get(),
                 MethodType.methodType(MemoryAddress.class, MemoryAddress.class),
                 FunctionDescriptor.of(C_POINTER, C_POINTER));
 
@@ -185,14 +156,6 @@ public class StdLibTest {
         final static MethodHandle rand = abi.downcallHandle(CLinker.systemLookup().lookup("rand").get(),
                 MethodType.methodType(int.class),
                 FunctionDescriptor.of(C_INT));
-
-        final static MethodHandle vprintf = abi.downcallHandle(CLinker.systemLookup().lookup("vprintf").get(),
-                MethodType.methodType(int.class, MemoryAddress.class, VaList.class),
-                FunctionDescriptor.of(C_INT, C_POINTER, C_VA_LIST));
-
-        final static MemoryAddress printfAddr = CLinker.systemLookup().lookup("printf").get();
-
-        final static FunctionDescriptor printfBase = FunctionDescriptor.of(C_INT, C_POINTER);
 
         static {
             try {
@@ -312,34 +275,6 @@ public class StdLibTest {
         int rand() throws Throwable {
             return (int)rand.invokeExact();
         }
-
-        int printf(String format, List<PrintfArg> args) throws Throwable {
-            try (ResourceScope scope = ResourceScope.newConfinedScope()) {
-                MemorySegment formatStr = toCString(format, scope);
-                return (int)specializedPrintf(args).invokeExact(formatStr.address(),
-                        args.stream().map(a -> a.nativeValue(scope)).toArray());
-            }
-        }
-
-        int vprintf(String format, List<PrintfArg> args) throws Throwable {
-            try (ResourceScope scope = ResourceScope.newConfinedScope()) {
-                MemorySegment formatStr = toCString(format, scope);
-                VaList vaList = VaList.make(b -> args.forEach(a -> a.accept(b, scope)), scope);
-                return (int)vprintf.invokeExact(formatStr.address(), vaList);
-            }
-        }
-
-        private MethodHandle specializedPrintf(List<PrintfArg> args) {
-            //method type
-            MethodType mt = MethodType.methodType(int.class, MemoryAddress.class);
-            FunctionDescriptor fd = printfBase;
-            for (PrintfArg arg : args) {
-                mt = mt.appendParameterTypes(arg.carrier);
-                fd = fd.withAppendedArgumentLayouts(arg.layout);
-            }
-            MethodHandle mh = abi.downcallHandle(printfAddr, mt, fd);
-            return mh.asSpreader(1, Object[].class, args.size());
-        }
     }
 
     /*** data providers ***/
@@ -381,58 +316,6 @@ public class StdLibTest {
             instants[i] = new Object[] { instant };
         }
         return instants;
-    }
-
-    @DataProvider
-    public static Object[][] printfArgs() {
-        ArrayList<List<PrintfArg>> res = new ArrayList<>();
-        List<List<PrintfArg>> perms = new ArrayList<>(perms(0, PrintfArg.values()));
-        for (int i = 0 ; i < 100 ; i++) {
-            Collections.shuffle(perms);
-            res.addAll(perms);
-        }
-        return res.stream()
-                .map(l -> new Object[] { l })
-                .toArray(Object[][]::new);
-    }
-
-    enum PrintfArg implements BiConsumer<VaList.Builder, ResourceScope> {
-
-        INTEGRAL(int.class, asVarArg(C_INT), "%d", scope -> 42, 42, VaList.Builder::vargFromInt),
-        STRING(MemoryAddress.class, asVarArg(C_POINTER), "%s", scope -> toCString("str", scope).address(), "str", VaList.Builder::vargFromAddress),
-        CHAR(byte.class, asVarArg(C_CHAR), "%c", scope -> (byte) 'h', 'h', (builder, layout, value) -> builder.vargFromInt(C_INT, (int)value)),
-        DOUBLE(double.class, asVarArg(C_DOUBLE), "%.4f", scope ->1.2345d, 1.2345d, VaList.Builder::vargFromDouble);
-
-        final Class<?> carrier;
-        final ValueLayout layout;
-        final String format;
-        final Function<ResourceScope, ?> nativeValueFactory;
-        final Object javaValue;
-        @SuppressWarnings("rawtypes")
-        final VaListBuilderCall builderCall;
-
-        <Z> PrintfArg(Class<?> carrier, ValueLayout layout, String format, Function<ResourceScope, Z> nativeValueFactory, Object javaValue, VaListBuilderCall<Z> builderCall) {
-            this.carrier = carrier;
-            this.layout = layout;
-            this.format = format;
-            this.nativeValueFactory = nativeValueFactory;
-            this.javaValue = javaValue;
-            this.builderCall = builderCall;
-        }
-
-        @Override
-        @SuppressWarnings("unchecked")
-        public void accept(VaList.Builder builder, ResourceScope scope) {
-            builderCall.build(builder, layout, nativeValueFactory.apply(scope));
-        }
-
-        interface VaListBuilderCall<V> {
-            void build(VaList.Builder builder, ValueLayout layout, V value);
-        }
-
-        public Object nativeValue(ResourceScope scope) {
-            return nativeValueFactory.apply(scope);
-        }
     }
 
     static <Z> Set<List<Z>> perms(int count, Z[] arr) {

--- a/test/jdk/java/foreign/libStdLib.c
+++ b/test/jdk/java/foreign/libStdLib.c
@@ -1,0 +1,47 @@
+/*
+ *  Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ *  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ *  This code is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License version 2 only, as
+ *  published by the Free Software Foundation.
+ *
+ *  This code is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ *  version 2 for more details (a copy is included in the LICENSE file that
+ *  accompanied this code).
+ *
+ *  You should have received a copy of the GNU General Public License version
+ *  2 along with this work; if not, write to the Free Software Foundation,
+ *  Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ *  Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ *  or visit www.oracle.com if you need additional information or have any
+ *  questions.
+ *
+ */
+
+#include <stdio.h>
+#include <time.h>
+
+#ifdef _WIN64
+#define EXPORT __declspec(dllexport)
+#else
+#define EXPORT
+#endif
+
+enum Func {
+  F_PRINTF = 0,
+  F_VPRINTF = 1,
+  F_GMTIME = 2
+};
+
+EXPORT void* get_ptr(int func) {
+    switch(func) {
+        case F_PRINTF:  return &printf;
+        case F_VPRINTF: return &vprintf;
+        case F_GMTIME:  return &gmtime;
+    }
+    return NULL;
+}

--- a/test/jdk/java/foreign/libStdLib.c
+++ b/test/jdk/java/foreign/libStdLib.c
@@ -31,17 +31,9 @@
 #define EXPORT
 #endif
 
-enum Func {
-  F_PRINTF = 0,
-  F_VPRINTF = 1,
-  F_GMTIME = 2
+// Forces generation of inline code on Windows
+EXPORT void* funcs[] = {
+    &printf,
+    &vprintf,
+    &gmtime
 };
-
-EXPORT void* get_ptr(int func) {
-    switch(func) {
-        case F_PRINTF:  return &printf;
-        case F_VPRINTF: return &vprintf;
-        case F_GMTIME:  return &gmtime;
-    }
-    return NULL;
-}


### PR DESCRIPTION
This patch removes the printf and vprintf tests, since the symbols are not available on Windows in the UCRT.

gmtime is similarly an inline function that maps to something else, but in that case there is a drop-in replacement symbol name _gmtime64 we can call instead.

This fixes the missing symbol errors in StdLibTest.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [Maurizio Cimadamore](https://openjdk.java.net/census#mcimadamore) (@mcimadamore - Committer) ⚠️ Review applies to a0cf834b32f48e5024c6e9d1d9c9175d000a1e5e


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/536/head:pull/536` \
`$ git checkout pull/536`

Update a local copy of the PR: \
`$ git checkout pull/536` \
`$ git pull https://git.openjdk.java.net/panama-foreign pull/536/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 536`

View PR using the GUI difftool: \
`$ git pr show -t 536`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/panama-foreign/pull/536.diff">https://git.openjdk.java.net/panama-foreign/pull/536.diff</a>

</details>
