### PR TITLE
8267240: Bounded arena allocator doesn't work if bounded size > BLOCK_SIZE

### DIFF
--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/SegmentAllocator.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/SegmentAllocator.java
@@ -402,7 +402,7 @@ public interface SegmentAllocator {
         Objects.requireNonNull(scope);
         return scope.ownerThread() == null ?
                 new ArenaAllocator.UnboundedSharedArenaAllocator(scope) :
-                new ArenaAllocator(scope);
+                new ArenaAllocator.UnboundedArenaAllocator(scope);
     }
 
     /**

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/ArenaAllocator.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/ArenaAllocator.java
@@ -40,7 +40,6 @@ public abstract class ArenaAllocator implements SegmentAllocator {
     public static class UnboundedArenaAllocator extends ArenaAllocator {
 
         private static final long DEFAULT_BLOCK_SIZE = 4 * 1024;
-        private static final long DEFAULT_MAX_ALLOC_SIZE = DEFAULT_BLOCK_SIZE / 2;
 
         public UnboundedArenaAllocator(ResourceScope scope) {
             super(MemorySegment.allocateNative(DEFAULT_BLOCK_SIZE, 1, scope));
@@ -58,7 +57,8 @@ public abstract class ArenaAllocator implements SegmentAllocator {
             if (slice != null) {
                 return slice;
             } else {
-                if (Utils.alignUp(bytesSize, bytesAlignment) > DEFAULT_MAX_ALLOC_SIZE) {
+                long maxPossibleAllocationSize = bytesSize + bytesAlignment - 1;
+                if (maxPossibleAllocationSize > DEFAULT_BLOCK_SIZE) {
                     // too big
                     return newSegment(bytesSize, bytesAlignment);
                 } else {

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/ArenaAllocator.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/ArenaAllocator.java
@@ -4,54 +4,17 @@ import jdk.incubator.foreign.MemorySegment;
 import jdk.incubator.foreign.SegmentAllocator;
 import jdk.incubator.foreign.ResourceScope;
 
-import java.util.OptionalLong;
+public abstract class ArenaAllocator implements SegmentAllocator {
 
-public class ArenaAllocator implements SegmentAllocator {
+    protected MemorySegment segment;
 
-    private final SegmentAllocator allocator;
-    private MemorySegment segment;
+    protected long sp = 0L;
 
-    private static final long BLOCK_SIZE = 4 * 1024;
-    private static final long MAX_ALLOC_SIZE = BLOCK_SIZE / 2;
-
-    private long sp = 0L;
-
-    public ArenaAllocator(ResourceScope scope) {
-        this(BLOCK_SIZE, scope);
+    ArenaAllocator(MemorySegment segment) {
+        this.segment = segment;
     }
 
-    ArenaAllocator(long initialSize, ResourceScope scope) {
-        this.allocator = (size, align) -> MemorySegment.allocateNative(size, align, scope);
-        this.segment = allocator.allocate(initialSize, 1);
-    }
-
-    MemorySegment newSegment(long size, long align) {
-        return allocator.allocate(size, align);
-    }
-
-    @Override
-    public MemorySegment allocate(long bytesSize, long bytesAlignment) {
-        checkConfinementIfNeeded();
-        if (Utils.alignUp(bytesSize, bytesAlignment) > MAX_ALLOC_SIZE) {
-            return newSegment(bytesSize, bytesAlignment);
-        }
-        // try to slice from current segment first...
-        MemorySegment slice = trySlice(bytesSize, bytesAlignment);
-        if (slice == null) {
-            // ... if that fails, allocate a new segment and slice from there
-            sp = 0L;
-            segment = newSegment(BLOCK_SIZE, 1L);
-            slice = trySlice(bytesSize, bytesAlignment);
-            if (slice == null) {
-                // this should not be possible - allocations that do not fit in BLOCK_SIZE should get their own
-                // standalone segment (see above).
-                throw new AssertionError("Cannot get here!");
-            }
-        }
-        return slice;
-    }
-
-    private MemorySegment trySlice(long bytesSize, long bytesAlignment) {
+    MemorySegment trySlice(long bytesSize, long bytesAlignment) {
         long min = segment.address().toRawLongValue();
         long start = Utils.alignUp(min + sp, bytesAlignment) - min;
         if (segment.byteSize() - start < bytesSize) {
@@ -63,22 +26,67 @@ public class ArenaAllocator implements SegmentAllocator {
         }
     }
 
-    private void checkConfinementIfNeeded() {
-        Thread segmentThread = segment.scope().ownerThread();
-        if (segmentThread != null && segmentThread != Thread.currentThread()) {
+    void checkConfinementIfNeeded() {
+        Thread ownerThread = scope().ownerThread();
+        if (ownerThread != null && ownerThread != Thread.currentThread()) {
             throw new IllegalStateException("Attempt to allocate outside confinement thread");
+        }
+    }
+
+    ResourceScope scope() {
+        return segment.scope();
+    }
+
+    public static class UnboundedArenaAllocator extends ArenaAllocator {
+
+        private static final long DEFAULT_BLOCK_SIZE = 4 * 1024;
+        private static final long DEFAULT_MAX_ALLOC_SIZE = DEFAULT_BLOCK_SIZE / 2;
+
+        public UnboundedArenaAllocator(ResourceScope scope) {
+            super(MemorySegment.allocateNative(DEFAULT_BLOCK_SIZE, 1, scope));
+        }
+
+        private MemorySegment newSegment(long size, long align) {
+            return MemorySegment.allocateNative(size, align, segment.scope());
+        }
+
+        @Override
+        public MemorySegment allocate(long bytesSize, long bytesAlignment) {
+            checkConfinementIfNeeded();
+            // try to slice from current segment first...
+            MemorySegment slice = trySlice(bytesSize, bytesAlignment);
+            if (slice != null) {
+                return slice;
+            } else {
+                if (Utils.alignUp(bytesSize, bytesAlignment) > DEFAULT_MAX_ALLOC_SIZE) {
+                    // too big
+                    return newSegment(bytesSize, bytesAlignment);
+                } else {
+                    // allocate a new segment and slice from there
+                    sp = 0L;
+                    segment = newSegment(DEFAULT_BLOCK_SIZE, 1L);
+                    return trySlice(bytesSize, bytesAlignment);
+                }
+            }
         }
     }
 
     public static class BoundedArenaAllocator extends ArenaAllocator {
 
         public BoundedArenaAllocator(ResourceScope scope, long size) {
-            super(size, scope);
+            super(MemorySegment.allocateNative(size, 1, scope));
         }
 
         @Override
-        MemorySegment newSegment(long size, long align) {
-            throw new OutOfMemoryError("Not enough space left to allocate");
+        public MemorySegment allocate(long bytesSize, long bytesAlignment) {
+            checkConfinementIfNeeded();
+            // try to slice from current segment first...
+            MemorySegment slice = trySlice(bytesSize, bytesAlignment);
+            if (slice != null) {
+                return slice;
+            } else {
+                throw new OutOfMemoryError("Not enough space left to allocate");
+            }
         }
     }
 
@@ -100,7 +108,7 @@ public class ArenaAllocator implements SegmentAllocator {
         final ThreadLocal<ArenaAllocator> allocators = new ThreadLocal<>() {
             @Override
             protected ArenaAllocator initialValue() {
-                return new ArenaAllocator(scope);
+                return new UnboundedArenaAllocator(scope);
             }
         };
 

--- a/test/jdk/java/foreign/TestSegmentAllocators.java
+++ b/test/jdk/java/foreign/TestSegmentAllocators.java
@@ -111,6 +111,22 @@ public class TestSegmentAllocators {
         }
     }
 
+    @Test(expectedExceptions = OutOfMemoryError.class)
+    public void testTooBigForBoundedArena() {
+        try (ResourceScope scope = ResourceScope.newConfinedScope()) {
+            SegmentAllocator allocator = SegmentAllocator.arenaAllocator(10, scope);
+            allocator.allocate(12);
+        }
+    }
+
+    @Test
+    public void testBiggerThanBlockForBoundedArena() {
+        try (ResourceScope scope = ResourceScope.newConfinedScope()) {
+            SegmentAllocator allocator = SegmentAllocator.arenaAllocator(4 * 1024 * 2, scope);
+            allocator.allocate(4 * 1024 + 1); // should be ok
+        }
+    }
+
     @Test(dataProvider = "arrayScopes")
     public <Z> void testArray(AllocationFactory allocationFactory, ValueLayout layout, AllocationFunction<Object> allocationFunction, ToArrayHelper<Z> arrayHelper) {
         Z arr = arrayHelper.array();


### PR DESCRIPTION
This patch follows the discussion in [1], and splits the unbounded allocator from the bounded one, as attempts to reusing logic were causing issues when bounded arena allocators were created with bounded size > BLOCK_SIZE.

I have looked for simplifications of the `trySlice` logic (also mentioned in the emails) - but in my opinion it cannot be simplified much. When an allocator is unbounded, if we receive a request that is more than half the size of the allocator block, we cannot guarantee that we can align it correctly in a segment whose size is BLOCK_SIZE. So, I think the limit of MAX_ALLOC_SIZE = BLOCK_SIZE / 2 is correct, in the sense that anything above that limit needs a standalone allocation (or we won't be able to align it in certain edge cases).

Of course, if we didn't care about alignment, the logic could be simplified, but since this is a native allocator, I think respecting alignment of the allocation request is important.

[1] - https://mail.openjdk.java.net/pipermail/panama-dev/2021-May/013796.html

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [JDK-8267240](https://bugs.openjdk.java.net/browse/JDK-8267240): Bounded arena allocator doesn't work if bounded size > BLOCK_SIZE


### Reviewers
 * [Jorn Vernee](https://openjdk.java.net/census#jvernee) (@JornVernee - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/537/head:pull/537` \
`$ git checkout pull/537`

Update a local copy of the PR: \
`$ git checkout pull/537` \
`$ git pull https://git.openjdk.java.net/panama-foreign pull/537/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 537`

View PR using the GUI difftool: \
`$ git pr show -t 537`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/panama-foreign/pull/537.diff">https://git.openjdk.java.net/panama-foreign/pull/537.diff</a>

</details>
