### PR TITLE
8267989: Exceptions thrown during upcalls should be handled

### DIFF
--- a/src/java.base/share/classes/java/lang/System.java
+++ b/src/java.base/share/classes/java/lang/System.java
@@ -2352,6 +2352,11 @@ public final class System {
             public long findNative(ClassLoader loader, String entry) {
                 return ClassLoader.findNative(loader, entry);
             }
+
+            @Override
+            public void exit(int statusCode) {
+                Shutdown.exit(statusCode);
+            }
         });
     }
 }

--- a/src/java.base/share/classes/java/lang/invoke/MethodHandleImpl.java
+++ b/src/java.base/share/classes/java/lang/invoke/MethodHandleImpl.java
@@ -1488,6 +1488,11 @@ abstract class MethodHandleImpl {
             public VarHandle insertCoordinates(VarHandle target, int pos, Object... values) {
                 return VarHandles.insertCoordinates(target, pos, values);
             }
+
+            @Override
+            public Class<?>[] exceptionTypes(MethodHandle handle) {
+                return VarHandles.exceptionTypes(handle);
+            }
         });
     }
 
@@ -1959,15 +1964,16 @@ abstract class MethodHandleImpl {
 
     // Indexes into constant method handles:
     static final int
-            MH_cast                  = 0,
-            MH_selectAlternative     = 1,
-            MH_countedLoopPred       = 2,
-            MH_countedLoopStep       = 3,
-            MH_initIterator          = 4,
-            MH_iteratePred           = 5,
-            MH_iterateNext           = 6,
-            MH_Array_newInstance     = 7,
-            MH_LIMIT                 = 8;
+            MH_cast                               = 0,
+            MH_selectAlternative                  = 1,
+            MH_countedLoopPred                    = 2,
+            MH_countedLoopStep                    = 3,
+            MH_initIterator                       = 4,
+            MH_iteratePred                        = 5,
+            MH_iterateNext                        = 6,
+            MH_Array_newInstance                  = 7,
+            MH_VarHandles_handleCheckedExceptions = 8,
+            MH_LIMIT                              = 9;
 
     static MethodHandle getConstantHandle(int idx) {
         MethodHandle handle = HANDLES[idx];
@@ -2017,6 +2023,9 @@ abstract class MethodHandleImpl {
                 case MH_Array_newInstance:
                     return IMPL_LOOKUP.findStatic(Array.class, "newInstance",
                             MethodType.methodType(Object.class, Class.class, int.class));
+                case MH_VarHandles_handleCheckedExceptions:
+                    return IMPL_LOOKUP.findStatic(VarHandles.class, "handleCheckedExceptions",
+                            MethodType.methodType(void.class, Throwable.class));
             }
         } catch (ReflectiveOperationException ex) {
             throw newInternalError(ex);

--- a/src/java.base/share/classes/java/lang/invoke/VarHandles.java
+++ b/src/java.base/share/classes/java/lang/invoke/VarHandles.java
@@ -646,7 +646,7 @@ final class VarHandles {
             return new Class<?>[0];
         }
 
-        assert handle instanceof BoundMethodHandle : "Unecpexted handle type: " + handle;
+        assert handle instanceof BoundMethodHandle : "Unexpected handle type: " + handle;
         // unknown
         return null;
     }

--- a/src/java.base/share/classes/java/lang/invoke/VarHandles.java
+++ b/src/java.base/share/classes/java/lang/invoke/VarHandles.java
@@ -31,12 +31,9 @@ import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
-import java.lang.reflect.Parameter;
 import java.nio.ByteOrder;
 import java.util.ArrayList;
-import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -45,8 +42,6 @@ import java.util.stream.Stream;
 import static java.lang.invoke.MethodHandleStatics.UNSAFE;
 import static java.lang.invoke.MethodHandleStatics.VAR_HANDLE_IDENTITY_ADAPT;
 import static java.lang.invoke.MethodHandleStatics.newIllegalArgumentException;
-import static java.util.stream.Collectors.joining;
-import static java.util.stream.Collectors.toList;
 
 final class VarHandles {
 
@@ -359,13 +354,13 @@ final class VarHandles {
         return target;
     }
 
-    public static VarHandle filterValue(VarHandle target, MethodHandle filterToTarget, MethodHandle filterFromTarget) {
+    public static VarHandle filterValue(VarHandle target, MethodHandle pFilterToTarget, MethodHandle pFilterFromTarget) {
         Objects.requireNonNull(target);
-        Objects.requireNonNull(filterToTarget);
-        Objects.requireNonNull(filterFromTarget);
+        Objects.requireNonNull(pFilterToTarget);
+        Objects.requireNonNull(pFilterFromTarget);
         //check that from/to filters do not throw checked exceptions
-        noCheckedExceptions(filterToTarget);
-        noCheckedExceptions(filterFromTarget);
+        MethodHandle filterToTarget = adaptForCheckedExceptions(pFilterToTarget);
+        MethodHandle filterFromTarget = adaptForCheckedExceptions(pFilterFromTarget);
 
         List<Class<?>> newCoordinates = new ArrayList<>();
         List<Class<?>> additionalCoordinates = new ArrayList<>();
@@ -473,8 +468,9 @@ final class VarHandles {
 
         List<Class<?>> newCoordinates = new ArrayList<>(targetCoordinates);
         for (int i = 0 ; i < filters.length ; i++) {
-            noCheckedExceptions(filters[i]);
-            MethodType filterType = filters[i].type();
+            MethodHandle filter = Objects.requireNonNull(filters[i]);
+            filter = adaptForCheckedExceptions(filter);
+            MethodType filterType = filter.type();
             if (filterType.parameterCount() != 1) {
                 throw newIllegalArgumentException("Invalid filter type " + filterType);
             } else if (newCoordinates.get(pos + i) != filterType.returnType()) {
@@ -564,10 +560,10 @@ final class VarHandles {
         return adjustedType;
     }
 
-    public static VarHandle collectCoordinates(VarHandle target, int pos, MethodHandle filter) {
+    public static VarHandle collectCoordinates(VarHandle target, int pos, MethodHandle pFilter) {
         Objects.requireNonNull(target);
-        Objects.requireNonNull(filter);
-        noCheckedExceptions(filter);
+        Objects.requireNonNull(pFilter);
+        MethodHandle filter = adaptForCheckedExceptions(pFilter);
 
         List<Class<?>> targetCoordinates = target.coordinateTypes();
         if (pos < 0 || pos >= targetCoordinates.size()) {
@@ -604,42 +600,55 @@ final class VarHandles {
                 (mode, modeHandle) -> MethodHandles.dropArguments(modeHandle, 1 + pos, valueTypes));
     }
 
-    private static void noCheckedExceptions(MethodHandle handle) {
+    private static MethodHandle adaptForCheckedExceptions(MethodHandle target) {
+        Class<?>[] exceptionTypes = exceptionTypes(target);
+        if (exceptionTypes != null) { // exceptions known
+            if (Stream.of(exceptionTypes).anyMatch(VarHandles::isCheckedException)) {
+                throw newIllegalArgumentException("Cannot adapt a var handle with a method handle which throws checked exceptions");
+            }
+            return target; // no adaptation needed
+        } else {
+            MethodHandle handler = MethodHandleImpl.getConstantHandle(MethodHandleImpl.MH_VarHandles_handleCheckedExceptions);
+            MethodHandle zero = MethodHandles.zero(target.type().returnType()); // dead branch
+            handler = MethodHandles.collectArguments(zero, 0, handler);
+            return MethodHandles.catchException(target, Throwable.class, handler);
+        }
+    }
+
+    static void handleCheckedExceptions(Throwable throwable) throws Throwable {
+        if (isCheckedException(throwable.getClass())) {
+            throw new IllegalStateException("Adapter handle threw checked exception", throwable);
+        }
+        throw throwable;
+    }
+
+    static Class<?>[] exceptionTypes(MethodHandle handle) {
         if (handle instanceof DirectMethodHandle directHandle) {
             byte refKind = directHandle.member.getReferenceKind();
             MethodHandleInfo info = new InfoFromMemberName(
                     MethodHandles.Lookup.IMPL_LOOKUP,
                     directHandle.member,
                     refKind);
-            final Class<?>[] exceptionTypes;
             if (MethodHandleNatives.refKindIsMethod(refKind)) {
-                exceptionTypes = info.reflectAs(Method.class, MethodHandles.Lookup.IMPL_LOOKUP)
+                return info.reflectAs(Method.class, MethodHandles.Lookup.IMPL_LOOKUP)
                         .getExceptionTypes();
             } else if (MethodHandleNatives.refKindIsField(refKind)) {
-                exceptionTypes = null;
+                return new Class<?>[0];
             } else if (MethodHandleNatives.refKindIsConstructor(refKind)) {
-                exceptionTypes = info.reflectAs(Constructor.class, MethodHandles.Lookup.IMPL_LOOKUP)
+                return info.reflectAs(Constructor.class, MethodHandles.Lookup.IMPL_LOOKUP)
                         .getExceptionTypes();
             } else {
                 throw new AssertionError("Cannot get here");
             }
-            if (exceptionTypes != null) {
-                if (Stream.of(exceptionTypes).anyMatch(VarHandles::isCheckedException)) {
-                    throw newIllegalArgumentException("Cannot adapt a var handle with a method handle which throws checked exceptions");
-                }
-            }
         } else if (handle instanceof DelegatingMethodHandle) {
-            noCheckedExceptions(((DelegatingMethodHandle)handle).getTarget());
-        } else {
-            //bound
-            BoundMethodHandle boundHandle = (BoundMethodHandle)handle;
-            for (int i = 0 ; i < boundHandle.fieldCount() ; i++) {
-                Object arg = boundHandle.arg(i);
-                if (arg instanceof MethodHandle){
-                    noCheckedExceptions((MethodHandle) arg);
-                }
-            }
+            return exceptionTypes(((DelegatingMethodHandle)handle).getTarget());
+        } else if (handle instanceof NativeMethodHandle) {
+            return new Class<?>[0];
         }
+
+        assert handle instanceof BoundMethodHandle : "Unecpexted handle type: " + handle;
+        // unknown
+        return null;
     }
 
     private static boolean isCheckedException(Class<?> clazz) {

--- a/src/java.base/share/classes/jdk/internal/access/JavaLangAccess.java
+++ b/src/java.base/share/classes/jdk/internal/access/JavaLangAccess.java
@@ -384,4 +384,10 @@ public interface JavaLangAccess {
     boolean isEnableNativeAccess(Module m);
 
     long findNative(ClassLoader loader, String entry);
+
+    /**
+     * Direct access to Shutdown.exit to avoid security manager checks
+     * @param statusCode the status code
+     */
+    void exit(int statusCode);
 }

--- a/src/java.base/share/classes/jdk/internal/access/JavaLangInvokeAccess.java
+++ b/src/java.base/share/classes/jdk/internal/access/JavaLangInvokeAccess.java
@@ -139,4 +139,11 @@ public interface JavaLangInvokeAccess {
      * @param mh the method handle
      */
     void ensureCustomized(MethodHandle mh);
+
+    /**
+     * A best-effort method that tries to find any exceptions thrown by the given method handle.
+     * @param handle the handle to check
+     * @return an array of exceptions, or {@code null}.
+     */
+    Class<?>[] exceptionTypes(MethodHandle handle);
 }

--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/CLinker.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/CLinker.java
@@ -237,7 +237,8 @@ public interface CLinker {
      * @param function the function descriptor.
      * @param scope the upcall stub scope.
      * @return the native stub segment.
-     * @throws IllegalArgumentException if the target's method type and the function descriptor mismatch.
+     * @throws IllegalArgumentException if the target's method type and the function descriptor mismatch, or
+     *         if it is determined that the target method handle can throw an exception.
      */
     MemoryAddress upcallStub(MethodHandle target, FunctionDescriptor function, ResourceScope scope);
 

--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/CLinker.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/CLinker.java
@@ -43,6 +43,7 @@ import java.util.Optional;
 import java.util.function.Consumer;
 
 import static jdk.internal.foreign.PlatformLayouts.*;
+import static sun.security.action.GetIntegerAction.privilegedGetProperty;
 
 /**
  * A C linker implements the C Application Binary Interface (ABI) calling conventions.
@@ -119,7 +120,7 @@ public interface CLinker {
      *
      * @see CLinker#upcallStub(MethodHandle, FunctionDescriptor, ResourceScope)
      */
-    int ERR_UNCAUGHT_EXCEPTION = Integer.getInteger("jdk.incubator.foreign.uncaught_exception_code", 1);
+    int ERR_UNCAUGHT_EXCEPTION = privilegedGetProperty("jdk.incubator.foreign.uncaught_exception_code", 1);
 
     /**
      * Returns the C linker for the current platform.

--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/CLinker.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/CLinker.java
@@ -115,6 +115,13 @@ import static jdk.internal.foreign.PlatformLayouts.*;
 public interface CLinker {
 
     /**
+     * The value returned by the process when the target of an upcall throws an exception.
+     *
+     * @see CLinker#upcallStub(MethodHandle, FunctionDescriptor, ResourceScope)
+     */
+    int ERR_UNCAUGHT_EXCEPTION = Integer.getInteger("jdk.incubator.foreign.uncaught_exception_code", 1);
+
+    /**
      * Returns the C linker for the current platform.
      * <p>
      * This method is <a href="package-summary.html#restricted"><em>restricted</em></a>.
@@ -224,8 +231,13 @@ public interface CLinker {
      * Allocates a native stub with given scope which can be passed to other foreign functions (as a function pointer);
      * calling such a function pointer from native code will result in the execution of the provided method handle.
      *
-     * <p>The returned memory address is associated with the provided scope. When such scope is closed,
+     * <p>
+     * The returned memory address is associated with the provided scope. When such scope is closed,
      * the corresponding native stub will be deallocated.
+     * <p>
+     * Any exceptions that occur during an upcall should be handled during the upcall. The target method handle
+     * should not throw any exceptions. If the target method handle does throw an exception, it will be handle by
+     * calling {@link System#exit System.exit(ERR_UNCAUGHT_EXCEPTION)}. (See {@link #ERR_UNCAUGHT_EXCEPTION})
      * <p>
      * This method is <a href="package-summary.html#restricted"><em>restricted</em></a>.
      * Restricted method are unsafe, and, if used incorrectly, their use might crash

--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/CLinker.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/CLinker.java
@@ -25,8 +25,6 @@
  */
 package jdk.incubator.foreign;
 
-import jdk.internal.access.JavaLangAccess;
-import jdk.internal.access.SharedSecrets;
 import jdk.internal.foreign.NativeMemorySegmentImpl;
 import jdk.internal.foreign.PlatformLayouts;
 import jdk.internal.foreign.SystemLookup;
@@ -39,11 +37,9 @@ import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodType;
 import java.nio.charset.Charset;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.function.Consumer;
 
 import static jdk.internal.foreign.PlatformLayouts.*;
-import static sun.security.action.GetIntegerAction.privilegedGetProperty;
 
 /**
  * A C linker implements the C Application Binary Interface (ABI) calling conventions.
@@ -120,7 +116,7 @@ public interface CLinker {
      *
      * @see CLinker#upcallStub(MethodHandle, FunctionDescriptor, ResourceScope)
      */
-    int ERR_UNCAUGHT_EXCEPTION = privilegedGetProperty("jdk.incubator.foreign.uncaught_exception_code", 1);
+    int ERR_UNCAUGHT_EXCEPTION = 1;
 
     /**
      * Returns the C linker for the current platform.
@@ -236,9 +232,9 @@ public interface CLinker {
      * The returned memory address is associated with the provided scope. When such scope is closed,
      * the corresponding native stub will be deallocated.
      * <p>
-     * Any exceptions that occur during an upcall should be handled during the upcall. The target method handle
-     * should not throw any exceptions. If the target method handle does throw an exception, it will be handle by
-     * calling {@link System#exit System.exit(ERR_UNCAUGHT_EXCEPTION)}. (See {@link #ERR_UNCAUGHT_EXCEPTION})
+     * The target method handle should not throw any exceptions. If the target method handle does throw an exception,
+     * it will be handle by calling {@link System#exit System.exit(ERR_UNCAUGHT_EXCEPTION)}.
+     * (See {@link #ERR_UNCAUGHT_EXCEPTION})
      * <p>
      * This method is <a href="package-summary.html#restricted"><em>restricted</em></a>.
      * Restricted method are unsafe, and, if used incorrectly, their use might crash

--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/CLinker.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/CLinker.java
@@ -112,13 +112,6 @@ import static jdk.internal.foreign.PlatformLayouts.*;
 public interface CLinker {
 
     /**
-     * The value returned by the process when the target of an upcall throws an exception.
-     *
-     * @see CLinker#upcallStub(MethodHandle, FunctionDescriptor, ResourceScope)
-     */
-    int ERR_UNCAUGHT_EXCEPTION = 1;
-
-    /**
      * Returns the C linker for the current platform.
      * <p>
      * This method is <a href="package-summary.html#restricted"><em>restricted</em></a>.
@@ -233,8 +226,7 @@ public interface CLinker {
      * the corresponding native stub will be deallocated.
      * <p>
      * The target method handle should not throw any exceptions. If the target method handle does throw an exception,
-     * it will be handle by calling {@link System#exit System.exit(ERR_UNCAUGHT_EXCEPTION)}.
-     * (See {@link #ERR_UNCAUGHT_EXCEPTION})
+     * the VM will exit with a non-zero exit code.
      * <p>
      * This method is <a href="package-summary.html#restricted"><em>restricted</em></a>.
      * Restricted method are unsafe, and, if used incorrectly, their use might crash

--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/MemoryHandles.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/MemoryHandles.java
@@ -329,6 +329,9 @@ public final class MemoryHandles {
      * the resulting var handle will have type {@code S} and will feature the additional coordinates {@code A...} (which
      * will be appended to the coordinates of the target var handle).
      * <p>
+     * If the boxing and unboxing filters throw any checked exceptions when invoked, the resulting var handle will
+     * throw an {@link IllegalStateException}.
+     * <p>
      * The resulting var handle will feature the same access modes (see {@link java.lang.invoke.VarHandle.AccessMode} and
      * atomic access guarantees as those featured by the target var handle.
      *
@@ -338,7 +341,7 @@ public final class MemoryHandles {
      * @return an adapter var handle which accepts a new type, performing the provided boxing/unboxing conversions.
      * @throws IllegalArgumentException if {@code filterFromTarget} and {@code filterToTarget} are not well-formed, that is, they have types
      * other than {@code (A... , S) -> T} and {@code (A... , T) -> S}, respectively, where {@code T} is the type of the target var handle,
-     * or if either {@code filterFromTarget} or {@code filterToTarget} throws any checked exceptions.
+     * or if it's determined that either {@code filterFromTarget} or {@code filterToTarget} throws any checked exceptions.
      */
     public static VarHandle filterValue(VarHandle target, MethodHandle filterToTarget, MethodHandle filterFromTarget) {
         return JLI.filterValue(target, filterToTarget, filterFromTarget);
@@ -356,6 +359,9 @@ public final class MemoryHandles {
      * For the coordinate filters to be well formed, their types must be of the form {@code S1 -> T1, S2 -> T1 ... Sn -> Tn},
      * where {@code T1, T2 ... Tn} are the coordinate types starting at position {@code pos} of the target var handle.
      * <p>
+     * If any of the filters throws a checked exception when invoked, the resulting var handle will
+     * throw an {@link IllegalStateException}.
+     * <p>
      * The resulting var handle will feature the same access modes (see {@link java.lang.invoke.VarHandle.AccessMode}) and
      * atomic access guarantees as those featured by the target var handle.
      *
@@ -368,7 +374,7 @@ public final class MemoryHandles {
      * other than {@code S1 -> T1, S2 -> T2, ... Sn -> Tn} where {@code T1, T2 ... Tn} are the coordinate types starting
      * at position {@code pos} of the target var handle, if {@code pos} is not between 0 and the target var handle coordinate arity, inclusive,
      * or if more filters are provided than the actual number of coordinate types available starting at {@code pos},
-     * or if any of the filters throws any checked exceptions.
+     * or if it's determined that any of the filters throws any checked exceptions.
      */
     public static VarHandle filterCoordinates(VarHandle target, int pos, MethodHandle... filters) {
         return JLI.filterCoordinates(target, pos, filters);
@@ -464,6 +470,9 @@ public final class MemoryHandles {
      * coordinate type of the target var handle at position {@code pos}, and that target var handle
      * coordinate is supplied by the return value of the filter.
      * <p>
+     * If any of the filters throws a checked exception when invoked, the resulting var handle will
+     * throw an {@link IllegalStateException}.
+     * <p>
      * The resulting var handle will feature the same access modes (see {@link java.lang.invoke.VarHandle.AccessMode}) and
      * atomic access guarantees as those featured by the target var handle.
      *
@@ -476,7 +485,7 @@ public final class MemoryHandles {
      * is void, or it is not the same as the {@code pos} coordinate of the target var handle,
      * if {@code pos} is not between 0 and the target var handle coordinate arity, inclusive,
      * if the resulting var handle's type would have <a href="MethodHandle.html#maxarity">too many coordinates</a>,
-     * or if {@code filter} throws any checked exceptions.
+     * or if it's determined that {@code filter} throws any checked exceptions.
      */
     public static VarHandle collectCoordinates(VarHandle target, int pos, MethodHandle filter) {
         return JLI.collectCoordinates(target, pos, filter);

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/CABI.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/CABI.java
@@ -25,9 +25,10 @@
  */
 package jdk.internal.foreign;
 
-import jdk.internal.foreign.abi.SharedUtils;
+import sun.security.action.GetPropertyAction;
 
 import static jdk.incubator.foreign.MemoryLayouts.ADDRESS;
+import static sun.security.action.GetPropertyAction.privilegedGetProperty;
 
 public enum CABI {
     SysV,
@@ -37,8 +38,8 @@ public enum CABI {
     private static final CABI current;
 
     static {
-        String arch = System.getProperty("os.arch");
-        String os = System.getProperty("os.name");
+        String arch = privilegedGetProperty("os.arch");
+        String os = privilegedGetProperty("os.name");
         long addressSize = ADDRESS.bitSize();
         // might be running in a 32-bit VM on a 64-bit platform.
         // addressSize will be correctly 32

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/ProgrammableUpcallHandler.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/ProgrammableUpcallHandler.java
@@ -295,6 +295,9 @@ public class ProgrammableUpcallHandler {
             } else {
                 return returnMoves;
             }
+        } catch(Throwable t) {
+            SharedUtils.handleUncaughtException(t);
+            return null;
         }
     }
 

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/SharedUtils.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/SharedUtils.java
@@ -79,6 +79,7 @@ public class SharedUtils {
     private static final MethodHandle MH_MAKE_CONTEXT_BOUNDED_ALLOCATOR;
     private static final MethodHandle MH_CLOSE_CONTEXT;
     private static final MethodHandle MH_REACHBILITY_FENCE;
+    private static final MethodHandle MH_HANDLE_UNCAUGHT_EXCEPTION;
 
     static {
         try {
@@ -97,6 +98,8 @@ public class SharedUtils {
                     methodType(void.class));
             MH_REACHBILITY_FENCE = lookup.findStatic(Reference.class, "reachabilityFence",
                     methodType(void.class, Object.class));
+            MH_HANDLE_UNCAUGHT_EXCEPTION = lookup.findStatic(SharedUtils.class, "handleUncaughtException",
+                    methodType(void.class, Throwable.class));
         } catch (ReflectiveOperationException e) {
             throw new BootstrapMethodError(e);
         }
@@ -359,6 +362,13 @@ public class SharedUtils {
         return MH_REACHBILITY_FENCE.asType(MethodType.methodType(void.class, type));
     }
 
+    static void handleUncaughtException(Throwable t) {
+        if (t != null) {
+            t.printStackTrace();
+            System.exit(1);
+        }
+    }
+
     static MethodHandle wrapWithAllocator(MethodHandle specializedHandle,
                                           int allocatorPos, long bufferCopySize,
                                           boolean upcall) {
@@ -366,7 +376,11 @@ public class SharedUtils {
         MethodHandle closer;
         int insertPos;
         if (specializedHandle.type().returnType() == void.class) {
-            closer = empty(methodType(void.class, Throwable.class)); // (Throwable) -> void
+            if (!upcall) {
+                closer = empty(methodType(void.class, Throwable.class)); // (Throwable) -> void
+            } else {
+                closer = MH_HANDLE_UNCAUGHT_EXCEPTION;
+            }
             insertPos = 1;
         } else {
             closer = identity(specializedHandle.type().returnType()); // (V) -> V

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/SharedUtils.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/SharedUtils.java
@@ -365,7 +365,7 @@ public class SharedUtils {
     static void handleUncaughtException(Throwable t) {
         if (t != null) {
             t.printStackTrace();
-            System.exit(1);
+            System.exit(ERR_UNCAUGHT_EXCEPTION);
         }
     }
 

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/SharedUtils.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/SharedUtils.java
@@ -37,6 +37,8 @@ import jdk.incubator.foreign.SegmentAllocator;
 import jdk.incubator.foreign.SequenceLayout;
 import jdk.incubator.foreign.CLinker;
 import jdk.incubator.foreign.ValueLayout;
+import jdk.internal.access.JavaLangAccess;
+import jdk.internal.access.SharedSecrets;
 import jdk.internal.foreign.CABI;
 import jdk.internal.foreign.MemoryAddressImpl;
 import jdk.internal.foreign.Utils;
@@ -71,6 +73,8 @@ import static java.lang.invoke.MethodType.methodType;
 import static jdk.incubator.foreign.CLinker.*;
 
 public class SharedUtils {
+
+    private static final JavaLangAccess JLA = SharedSecrets.getJavaLangAccess();
 
     private static final MethodHandle MH_ALLOC_BUFFER;
     private static final MethodHandle MH_BASEADDRESS;
@@ -365,7 +369,7 @@ public class SharedUtils {
     static void handleUncaughtException(Throwable t) {
         if (t != null) {
             t.printStackTrace();
-            System.exit(ERR_UNCAUGHT_EXCEPTION);
+            JLA.exit(1);
         }
     }
 

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/SharedUtils.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/SharedUtils.java
@@ -38,6 +38,7 @@ import jdk.incubator.foreign.SequenceLayout;
 import jdk.incubator.foreign.CLinker;
 import jdk.incubator.foreign.ValueLayout;
 import jdk.internal.access.JavaLangAccess;
+import jdk.internal.access.JavaLangInvokeAccess;
 import jdk.internal.access.SharedSecrets;
 import jdk.internal.foreign.CABI;
 import jdk.internal.foreign.MemoryAddressImpl;
@@ -52,6 +53,7 @@ import java.lang.invoke.MethodType;
 import java.lang.invoke.VarHandle;
 import java.lang.ref.Reference;
 import java.nio.charset.Charset;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -75,6 +77,7 @@ import static jdk.incubator.foreign.CLinker.*;
 public class SharedUtils {
 
     private static final JavaLangAccess JLA = SharedSecrets.getJavaLangAccess();
+    private static final JavaLangInvokeAccess JLIA = SharedSecrets.getJavaLangInvokeAccess();
 
     private static final MethodHandle MH_ALLOC_BUFFER;
     private static final MethodHandle MH_BASEADDRESS;
@@ -428,6 +431,13 @@ public class SharedUtils {
         specializedHandle = tryFinally(specializedHandle, closer);
         specializedHandle = collectArguments(specializedHandle, allocatorPos, contextFactory);
         return specializedHandle;
+    }
+
+    public static void checkExceptions(MethodHandle target) {
+        Class<?>[] exceptions = JLIA.exceptionTypes(target);
+        if (exceptions != null && exceptions.length != 0) {
+            throw new IllegalArgumentException("Target handle may throw exceptions: " + Arrays.toString(exceptions));
+        }
     }
 
     // lazy init MH_ALLOC and MH_FREE handles

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/aarch64/AArch64Linker.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/aarch64/AArch64Linker.java
@@ -96,6 +96,7 @@ public final class AArch64Linker extends AbstractCLinker {
         Objects.requireNonNull(scope);
         Objects.requireNonNull(target);
         Objects.requireNonNull(function);
+        SharedUtils.checkExceptions(target);
         target = SharedUtils.boxVaLists(target, MH_boxVaList);
         return UpcallStubs.upcallAddress(CallArranger.arrangeUpcall(target, target.type(), function), (ResourceScopeImpl) scope);
     }

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/x64/sysv/SysVx64Linker.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/x64/sysv/SysVx64Linker.java
@@ -107,6 +107,7 @@ public final class SysVx64Linker extends AbstractCLinker {
         Objects.requireNonNull(scope);
         Objects.requireNonNull(target);
         Objects.requireNonNull(function);
+        SharedUtils.checkExceptions(target);
         target = SharedUtils.boxVaLists(target, MH_boxVaList);
         return UpcallStubs.upcallAddress(CallArranger.arrangeUpcall(target, target.type(), function), (ResourceScopeImpl) scope);
     }

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/x64/windows/Windowsx64Linker.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/x64/windows/Windowsx64Linker.java
@@ -108,6 +108,7 @@ public final class Windowsx64Linker extends AbstractCLinker {
         Objects.requireNonNull(scope);
         Objects.requireNonNull(target);
         Objects.requireNonNull(function);
+        SharedUtils.checkExceptions(target);
         target = SharedUtils.boxVaLists(target, MH_boxVaList);
         return UpcallStubs.upcallAddress(CallArranger.arrangeUpcall(target, target.type(), function), (ResourceScopeImpl) scope);
     }

--- a/test/jdk/java/foreign/TestAdaptVarHandles.java
+++ b/test/jdk/java/foreign/TestAdaptVarHandles.java
@@ -189,16 +189,25 @@ public class TestAdaptVarHandles {
         MemoryHandles.filterValue(intHandle, S2L_EX, I2S);
     }
 
-    @Test(expectedExceptions = IllegalArgumentException.class)
+    @Test(expectedExceptions = IllegalStateException.class)
     public void testBadFilterBoxHandleException() {
         VarHandle intHandle = MemoryLayouts.JAVA_INT.varHandle(int.class);
-        MemoryHandles.filterValue(intHandle, S2I, I2S_EX);
+        VarHandle vh = MemoryHandles.filterValue(intHandle, S2I, I2S_EX);
+        try (ResourceScope scope = ResourceScope.newConfinedScope()) {
+            MemorySegment seg = MemorySegment.allocateNative(MemoryLayouts.JAVA_INT, scope);
+            vh.set(seg, "42");
+            String x = (String) vh.get(seg); // should throw
+        }
     }
 
-    @Test(expectedExceptions = IllegalArgumentException.class)
+    @Test(expectedExceptions = IllegalStateException.class)
     public void testBadFilterUnboxHandleException() {
         VarHandle intHandle = MemoryLayouts.JAVA_INT.varHandle(int.class);
-        MemoryHandles.filterValue(intHandle, S2I_EX, I2S);
+        VarHandle vh = MemoryHandles.filterValue(intHandle, S2I_EX, I2S);
+        try (ResourceScope scope = ResourceScope.newConfinedScope()) {
+            MemorySegment seg = MemorySegment.allocateNative(MemoryLayouts.JAVA_INT, scope);
+            vh.set(seg, "42"); // should throw
+        }
     }
 
     @Test

--- a/test/jdk/java/foreign/TestUpcall.java
+++ b/test/jdk/java/foreign/TestUpcall.java
@@ -28,7 +28,7 @@
  * @modules jdk.incubator.foreign/jdk.internal.foreign
  * @build NativeTestHelper CallGeneratorHelper TestUpcall
  *
- * @run testng/othervm
+ * @run testng/othervm/timeout=720
  *   --enable-native-access=ALL-UNNAMED
  *   TestUpcall
  */

--- a/test/jdk/java/foreign/TestUpcallException.java
+++ b/test/jdk/java/foreign/TestUpcallException.java
@@ -33,6 +33,9 @@
  *   TestUpcallException
  */
 
+import jdk.incubator.foreign.CLinker;
+import jdk.incubator.foreign.FunctionDescriptor;
+import jdk.incubator.foreign.ResourceScope;
 import jdk.test.lib.Utils;
 import org.testng.annotations.Test;
 
@@ -59,6 +62,14 @@ public class TestUpcallException {
     public void testExceptionSpecialized() throws IOException, InterruptedException {
         boolean useSpec = true;
         run(useSpec);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class,
+          expectedExceptionsMessageRegExp = ".*Target handle may throw exceptions.*")
+    public void testEagerExceptionBlocked() {
+        try (ResourceScope scope = ResourceScope.newConfinedScope()) {
+            CLinker.getInstance().upcallStub(ThrowingUpcall.MH_throwException, FunctionDescriptor.ofVoid(), scope);
+        }
     }
 
     private void run(boolean useSpec) throws IOException, InterruptedException {

--- a/test/jdk/java/foreign/TestUpcallException.java
+++ b/test/jdk/java/foreign/TestUpcallException.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @requires ((os.arch == "amd64" | os.arch == "x86_64") & sun.arch.data.model == "64") | os.arch == "aarch64"
+ * @library /test/lib
+ * @modules jdk.incubator.foreign/jdk.internal.foreign
+ * @build ThrowingUpcall TestUpcallException
+ *
+ * @run testng/othervm/native
+ *   --enable-native-access=ALL-UNNAMED
+ *   TestUpcallException
+ */
+
+import jdk.test.lib.Utils;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+import java.nio.file.Paths;
+
+import static org.testng.Assert.assertEquals;
+
+public class TestUpcallException {
+
+    @Test
+    public void testExceptionInterpreted() throws InterruptedException, IOException {
+        boolean useSpec = false;
+        run(useSpec);
+    }
+
+    @Test
+    public void testExceptionSpecialized() throws IOException, InterruptedException {
+        boolean useSpec = true;
+        run(useSpec);
+    }
+
+    private void run(boolean useSpec) throws IOException, InterruptedException {
+        Process process = new ProcessBuilder()
+            .command(
+                Paths.get(Utils.TEST_JDK)
+                     .resolve("bin")
+                     .resolve("java")
+                     .toAbsolutePath()
+                     .toString(),
+                "-Djdk.internal.foreign.ProgrammableUpcallHandler.USE_SPEC=" + useSpec,
+                "-cp", Utils.TEST_CLASS_PATH,
+                "ThrowingUpcall")
+            .start();
+
+        int result = process.waitFor();
+        assertEquals(result, 1);
+    }
+
+}

--- a/test/jdk/java/foreign/ThrowingUpcall.java
+++ b/test/jdk/java/foreign/ThrowingUpcall.java
@@ -49,24 +49,23 @@ public class ThrowingUpcall {
 
         try {
             MH_throwException = MethodHandles.lookup().findStatic(ThrowingUpcall.class, "throwException",
-                    MethodType.methodType(void.class, Throwable.class));
+                    MethodType.methodType(void.class));
         } catch (ReflectiveOperationException e) {
             throw new ExceptionInInitializerError(e);
         }
     }
 
-    public static void throwException(Throwable t) throws Throwable {
-        throw t;
+    public static void throwException() throws Throwable {
+        throw new Throwable("Testing upcall exceptions");
     }
 
     public static void main(String[] args) throws Throwable {
-        test(new Throwable());
+        test();
     }
 
-    public static void test(Throwable throwable) throws Throwable {
-        MethodHandle target = MethodHandles.insertArguments(MH_throwException, 0, throwable);
+    public static void test() throws Throwable {
         try (ResourceScope scope = ResourceScope.newConfinedScope()) {
-            MemoryAddress stub = CLinker.getInstance().upcallStub(target, FunctionDescriptor.ofVoid(), scope);
+            MemoryAddress stub = CLinker.getInstance().upcallStub(MH_throwException, FunctionDescriptor.ofVoid(), scope);
 
             downcall.invokeExact(stub); // should call System.exit(1);
         }

--- a/test/jdk/java/foreign/ThrowingUpcall.java
+++ b/test/jdk/java/foreign/ThrowingUpcall.java
@@ -30,6 +30,7 @@ import jdk.incubator.foreign.SymbolLookup;
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.MethodType;
+import java.security.Permission;
 
 import static jdk.incubator.foreign.CLinker.C_POINTER;
 
@@ -39,6 +40,18 @@ public class ThrowingUpcall {
     private static final MethodHandle MH_throwException;
 
     static {
+        System.setSecurityManager(new SecurityManager() {
+            @Override
+            public void checkExit(int status) {
+                throw new IllegalStateException("Can not use exitVM");
+            }
+
+            @Override
+            public void checkPermission(Permission perm) {
+                // do nothing
+            }
+        });
+
         System.loadLibrary("TestUpcall");
         SymbolLookup lookup = SymbolLookup.loaderLookup();
         downcall = CLinker.getInstance().downcallHandle(

--- a/test/jdk/java/foreign/ThrowingUpcall.java
+++ b/test/jdk/java/foreign/ThrowingUpcall.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import jdk.incubator.foreign.CLinker;
+import jdk.incubator.foreign.FunctionDescriptor;
+import jdk.incubator.foreign.MemoryAddress;
+import jdk.incubator.foreign.ResourceScope;
+import jdk.incubator.foreign.SymbolLookup;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+
+import static jdk.incubator.foreign.CLinker.C_POINTER;
+
+public class ThrowingUpcall {
+
+    private static final MethodHandle downcall;
+    private static final MethodHandle MH_throwException;
+
+    static {
+        System.loadLibrary("TestUpcall");
+        SymbolLookup lookup = SymbolLookup.loaderLookup();
+        downcall = CLinker.getInstance().downcallHandle(
+            lookup.lookup("f0_V__").orElseThrow(),
+            MethodType.methodType(void.class, MemoryAddress.class),
+            FunctionDescriptor.ofVoid(C_POINTER)
+        );
+
+        try {
+            MH_throwException = MethodHandles.lookup().findStatic(ThrowingUpcall.class, "throwException",
+                    MethodType.methodType(void.class, Throwable.class));
+        } catch (ReflectiveOperationException e) {
+            throw new ExceptionInInitializerError(e);
+        }
+    }
+
+    public static void throwException(Throwable t) throws Throwable {
+        throw t;
+    }
+
+    public static void main(String[] args) throws Throwable {
+        test(new Throwable());
+    }
+
+    public static void test(Throwable throwable) throws Throwable {
+        MethodHandle target = MethodHandles.insertArguments(MH_throwException, 0, throwable);
+        try (ResourceScope scope = ResourceScope.newConfinedScope()) {
+            MemoryAddress stub = CLinker.getInstance().upcallStub(target, FunctionDescriptor.ofVoid(), scope);
+
+            downcall.invokeExact(stub); // should call System.exit(1);
+        }
+    }
+
+}


### PR DESCRIPTION
Hi,

This patch regularizes exception handling for exceptions thrown during upcalls. Exceptions thrown during upcalls are now always handled by printing out the stack trace and then calling `System::exit` (see the JBS issue for some motivation).

I've added some documentation for the exception handling to `CLinker::upcallStub`, as well as a new public `int` constant in `CLinker` which is the error code that is passed to `System::exit`. The returned error code can also be configured by a system property, which for now is mostly useful for testing purposes to make sure we don't get a consistent false positive.

Thanks,
Jorn

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issues
 * [JDK-8267989](https://bugs.openjdk.java.net/browse/JDK-8267989): Exceptions thrown during upcalls should be handled
 * [JDK-8268031](https://bugs.openjdk.java.net/browse/JDK-8268031): VarHandle combinator check for exceptions is too strict


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.java.net/census#mcimadamore) (@mcimadamore - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/543/head:pull/543` \
`$ git checkout pull/543`

Update a local copy of the PR: \
`$ git checkout pull/543` \
`$ git pull https://git.openjdk.java.net/panama-foreign pull/543/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 543`

View PR using the GUI difftool: \
`$ git pr show -t 543`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/panama-foreign/pull/543.diff">https://git.openjdk.java.net/panama-foreign/pull/543.diff</a>

</details>
