### PR TITLE
8268160: jextract tool provider should avoid security manager usage

### DIFF
--- a/src/jdk.incubator.jextract/share/classes/jdk/incubator/jextract/JextractTool.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/incubator/jextract/JextractTool.java
@@ -335,15 +335,6 @@ public final class JextractTool {
 
         @Override
         public int run(PrintWriter out, PrintWriter err, String... args) {
-            // defensive check to throw security exception early.
-            // Note that the successful run of jextract under security
-            // manager would require far more permissions like loading
-            // library (clang), file system access etc.
-            if (System.getSecurityManager() != null) {
-                System.getSecurityManager().
-                    checkPermission(new RuntimePermission("jextract"));
-            }
-
             JextractTool instance = new JextractTool(out, err);
             return instance.run(args);
         }


### PR DESCRIPTION
jextract is not incubated in JDK as of now. By the time it makes into JDK (if it does), security 
manager would have been removed. Removing security manager usage in jextract code.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [JDK-8268160](https://bugs.openjdk.java.net/browse/JDK-8268160): jextract tool provider should avoid security manager usage


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.java.net/census#mcimadamore) (@mcimadamore - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/546/head:pull/546` \
`$ git checkout pull/546`

Update a local copy of the PR: \
`$ git checkout pull/546` \
`$ git pull https://git.openjdk.java.net/panama-foreign pull/546/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 546`

View PR using the GUI difftool: \
`$ git pr show -t 546`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/panama-foreign/pull/546.diff">https://git.openjdk.java.net/panama-foreign/pull/546.diff</a>

</details>
