### PR TITLE
8268319: VersionCheck test fails for jextract on Windows

### DIFF
--- a/test/jdk/tools/launcher/VersionCheck.java
+++ b/test/jdk/tools/launcher/VersionCheck.java
@@ -173,7 +173,7 @@ public class VersionCheck extends TestHelper {
             System.out.println("Testing " + f.getName());
             String x = f.getAbsolutePath();
             String testStr = getVersion(x, "-J-version");
-            if (f.getName().equals("jextract")) {
+            if (f.getName().startsWith("jextract")) {
                 // skip the WARNING: Unknown module: jdk.incubator.jextract specified to --enable-native-access line
                 testStr = testStr.substring(testStr.indexOf('\n') + 1);
             }


### PR DESCRIPTION
The test tools/launcher/VersionCheck fails for jextract on Windows, because the filtering logic to filter out warnings in the output checks that the executable file name is "jextract", while on Windows it's "jextract.exe". So, the warnings are never filtered

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [JDK-8268319](https://bugs.openjdk.java.net/browse/JDK-8268319): VersionCheck test fails for jextract on Windows


### Reviewers
 * [Athijegannathan Sundararajan](https://openjdk.java.net/census#sundar) (@sundararajana - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/552/head:pull/552` \
`$ git checkout pull/552`

Update a local copy of the PR: \
`$ git checkout pull/552` \
`$ git pull https://git.openjdk.java.net/panama-foreign pull/552/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 552`

View PR using the GUI difftool: \
`$ git pr show -t 552`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/panama-foreign/pull/552.diff">https://git.openjdk.java.net/panama-foreign/pull/552.diff</a>

</details>
