### PR TITLE
8268266: Investigate way to lazily customize upcall lambda forms

### DIFF
--- a/src/java.base/share/classes/java/lang/invoke/MethodHandleImpl.java
+++ b/src/java.base/share/classes/java/lang/invoke/MethodHandleImpl.java
@@ -1468,11 +1468,6 @@ abstract class MethodHandleImpl {
             }
 
             @Override
-            public void ensureCustomized(MethodHandle mh) {
-                mh.customize();
-            }
-
-            @Override
             public VarHandle memoryAccessVarHandle(Class<?> carrier, boolean skipAlignmentMaskCheck, long alignmentMask,
                                                    ByteOrder order) {
                 return VarHandles.makeMemoryAddressViewHandle(carrier, skipAlignmentMaskCheck, alignmentMask, order);

--- a/src/java.base/share/classes/jdk/internal/access/JavaLangInvokeAccess.java
+++ b/src/java.base/share/classes/jdk/internal/access/JavaLangInvokeAccess.java
@@ -134,13 +134,6 @@ public interface JavaLangInvokeAccess {
     MethodHandle nativeMethodHandle(NativeEntryPoint nep, MethodHandle fallback);
 
     /**
-     * Ensure given method handle is customized
-     *
-     * @param mh the method handle
-     */
-    void ensureCustomized(MethodHandle mh);
-
-    /**
      * A best-effort method that tries to find any exceptions thrown by the given method handle.
      * @param handle the handle to check
      * @return an array of exceptions, or {@code null}.

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/ProgrammableUpcallHandler.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/ProgrammableUpcallHandler.java
@@ -46,6 +46,7 @@ import java.util.Objects;
 import java.util.stream.Stream;
 
 import static java.lang.invoke.MethodHandles.dropArguments;
+import static java.lang.invoke.MethodHandles.exactInvoker;
 import static java.lang.invoke.MethodHandles.filterReturnValue;
 import static java.lang.invoke.MethodHandles.identity;
 import static java.lang.invoke.MethodHandles.insertArguments;
@@ -66,8 +67,6 @@ public class ProgrammableUpcallHandler {
         GetPropertyAction.privilegedGetProperty("jdk.internal.foreign.ProgrammableUpcallHandler.USE_SPEC", "true"));
     private static final boolean USE_INTRINSICS = Boolean.parseBoolean(
         GetPropertyAction.privilegedGetProperty("jdk.internal.foreign.ProgrammableUpcallHandler.USE_INTRINSICS", "true"));
-
-    private static final JavaLangInvokeAccess JLI = SharedSecrets.getJavaLangInvokeAccess();
 
     private static final VarHandle VH_LONG = MemoryLayouts.JAVA_LONG.varHandle(long.class);
 
@@ -123,7 +122,7 @@ public class ProgrammableUpcallHandler {
                 .anyMatch(s -> abi.arch.isStackType(s.type()));
         if (USE_INTRINSICS && isSimple && !usesStackArgs && supportsOptimizedUpcalls()) {
             checkPrimitive(doBindings.type());
-            JLI.ensureCustomized(doBindings);
+            doBindings = insertArguments(exactInvoker(doBindings.type()), 0, doBindings);
             VMStorage[] args = Arrays.stream(argMoves).map(Binding.Move::storage).toArray(VMStorage[]::new);
             VMStorage[] rets = Arrays.stream(retMoves).map(Binding.Move::storage).toArray(VMStorage[]::new);
             CallRegs conv = new CallRegs(args, rets);

--- a/test/micro/org/openjdk/bench/jdk/incubator/foreign/JNICB.h
+++ b/test/micro/org/openjdk/bench/jdk/incubator/foreign/JNICB.h
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+#include <jni.h>
+
+typedef struct {
+    jclass holder;
+    jmethodID mid;
+} *JNICB;

--- a/test/micro/org/openjdk/bench/jdk/incubator/foreign/JNICB.java
+++ b/test/micro/org/openjdk/bench/jdk/incubator/foreign/JNICB.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package org.openjdk.bench.jdk.incubator.foreign;
+
+public class JNICB {
+
+    static {
+        System.loadLibrary("JNICB");
+    }
+
+    public static native long makeCB(String holder, String name, String signature);
+}

--- a/test/micro/org/openjdk/bench/jdk/incubator/foreign/QSort.java
+++ b/test/micro/org/openjdk/bench/jdk/incubator/foreign/QSort.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.bench.jdk.incubator.foreign;
+
+import jdk.incubator.foreign.FunctionDescriptor;
+import jdk.incubator.foreign.MemoryAccess;
+import jdk.incubator.foreign.MemoryAddress;
+import jdk.incubator.foreign.CLinker;
+import jdk.incubator.foreign.MemoryLayout;
+import jdk.incubator.foreign.MemorySegment;
+import jdk.incubator.foreign.ResourceScope;
+import jdk.incubator.foreign.SymbolLookup;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodType;
+import java.util.concurrent.TimeUnit;
+
+import static java.lang.invoke.MethodHandles.lookup;
+import static jdk.incubator.foreign.CLinker.C_INT;
+import static jdk.incubator.foreign.CLinker.C_LONG_LONG;
+import static jdk.incubator.foreign.CLinker.C_POINTER;
+import static jdk.incubator.foreign.MemoryLayouts.JAVA_INT;
+
+@BenchmarkMode(Mode.AverageTime)
+@Warmup(iterations = 5, time = 500, timeUnit = TimeUnit.MILLISECONDS)
+@Measurement(iterations = 10, time = 500, timeUnit = TimeUnit.MILLISECONDS)
+@State(org.openjdk.jmh.annotations.Scope.Thread)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Fork(value = 3, jvmArgsAppend = { "--add-modules=jdk.incubator.foreign", "--enable-native-access=ALL-UNNAMED" })
+public class QSort {
+
+    static final CLinker abi = CLinker.getInstance();
+    static final MethodHandle clib_qsort;
+    static final MemoryAddress native_compar;
+    static final MemoryAddress panama_upcall_compar;
+    static final long jni_upcall_compar;
+
+    static final int[] INPUT = { 5, 3, 2, 7, 8, 12, 1, 7 };
+    static final MemorySegment INPUT_SEGMENT;
+
+    static {
+        INPUT_SEGMENT = MemorySegment.allocateNative(MemoryLayout.sequenceLayout(INPUT.length, JAVA_INT), ResourceScope.globalScope());
+        INPUT_SEGMENT.copyFrom(MemorySegment.ofArray(INPUT));
+
+        System.loadLibrary("QSortJNI");
+        jni_upcall_compar = JNICB.makeCB("org/openjdk/bench/jdk/incubator/foreign/QSort", "jni_upcall_compar", "(II)I");
+
+        try {
+            SymbolLookup systemLookup = CLinker.systemLookup();
+            clib_qsort = abi.downcallHandle(
+                    systemLookup.lookup("qsort").orElseThrow(),
+                    MethodType.methodType(void.class, MemoryAddress.class, long.class, long.class, MemoryAddress.class),
+                    FunctionDescriptor.ofVoid(C_POINTER, C_LONG_LONG, C_LONG_LONG, C_POINTER)
+            );
+            System.loadLibrary("QSort");
+            native_compar = SymbolLookup.loaderLookup().lookup("compar").orElseThrow();
+            panama_upcall_compar = abi.upcallStub(
+                    lookup().findStatic(QSort.class,
+                            "panama_upcall_compar",
+                            MethodType.methodType(int.class, MemoryAddress.class, MemoryAddress.class)),
+                    FunctionDescriptor.of(C_INT, C_POINTER, C_POINTER),
+                    ResourceScope.globalScope()
+            );
+        } catch (ReflectiveOperationException e) {
+            throw new BootstrapMethodError(e);
+        }
+    }
+
+    static native void jni_qsort_optimized(int[] array, long cb);
+    static native void jni_qsort_naive(int[] array);
+
+    @FunctionalInterface
+    interface JNIComparator {
+        int cmp(int e0, int e1);
+    }
+
+    static final JNIComparator COMP = QSort::jni_upcall_compar;
+
+    @Benchmark
+    public void native_qsort() throws Throwable {
+         clib_qsort.invokeExact(INPUT_SEGMENT.address(), (long) INPUT.length, JAVA_INT.byteSize(), native_compar);
+    }
+
+    @Benchmark
+    public void jni_upcall_qsort_optimized() {
+        jni_qsort_optimized(INPUT, jni_upcall_compar);
+    }
+
+    @Benchmark
+    public void jni_upcall_qsort_naive() {
+        jni_qsort_naive(INPUT);
+    }
+
+    @Benchmark
+    public void panama_upcall_qsort() throws Throwable {
+        clib_qsort.invokeExact(INPUT_SEGMENT.address(), (long) INPUT.length, JAVA_INT.byteSize(), panama_upcall_compar);
+    }
+
+    private static int getIntAbsolute(MemoryAddress addr) {
+        return MemoryAccess.getIntAtOffset(MemorySegment.globalNativeSegment(), addr.toRawLongValue());
+    }
+
+    static int panama_upcall_compar(MemoryAddress e0, MemoryAddress e1) {
+        return Integer.compare(getIntAbsolute(e0), getIntAbsolute(e1));
+    }
+
+    static int jni_upcall_compar(int j0, int j1) {
+        return Integer.compare(j0, j1);
+    }
+}

--- a/test/micro/org/openjdk/bench/jdk/incubator/foreign/Upcalls.java
+++ b/test/micro/org/openjdk/bench/jdk/incubator/foreign/Upcalls.java
@@ -74,10 +74,10 @@ public class Upcalls {
         System.loadLibrary("UpcallsJNI");
 
         String className = "org/openjdk/bench/jdk/incubator/foreign/Upcalls";
-        cb_blank_jni = makeCB(className, "blank", "()V");
-        cb_identity_jni = makeCB(className, "identity", "(I)I");
-        cb_args5_jni = makeCB(className, "args5", "(JDJDJ)V");
-        cb_args10_jni = makeCB(className, "args10", "(JDJDJDJDJD)V");
+        cb_blank_jni = JNICB.makeCB(className, "blank", "()V");
+        cb_identity_jni = JNICB.makeCB(className, "identity", "(I)I");
+        cb_args5_jni = JNICB.makeCB(className, "args5", "(JDJDJ)V");
+        cb_args10_jni = JNICB.makeCB(className, "args10", "(JDJDJDJDJD)V");
 
         try {
             System.loadLibrary("Upcalls");
@@ -144,7 +144,6 @@ public class Upcalls {
     static native void args5(long a0, double a1, long a2, double a3, long a4, long cb);
     static native void args10(long a0, double a1, long a2, double a3, long a4,
                               double a5, long a6, double a7, long a8, double a9, long cb);
-    static native long makeCB(String holder, String name, String signature);
 
     @Benchmark
     public void jni_blank() throws Throwable {

--- a/test/micro/org/openjdk/bench/jdk/incubator/foreign/libJNICB.c
+++ b/test/micro/org/openjdk/bench/jdk/incubator/foreign/libJNICB.c
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+#include <jni.h>
+#include <stdlib.h>
+
+#include "JNICB.h"
+#include "jlong.h"
+
+#define CHECK_NULL(thing, message) \
+    if (thing == NULL) { \
+        jclass cls = (*env)->FindClass(env, "java/lang/Exception"); \
+        (*env)->ThrowNew(env, cls, message); \
+        return 0; \
+    }
+
+JNIEXPORT jlong JNICALL Java_org_openjdk_bench_jdk_incubator_foreign_JNICB_makeCB
+  (JNIEnv *env, jclass cls, jstring holderName, jstring methodName, jstring descriptor) {
+
+  const char* holderNameC = (*env)->GetStringUTFChars(env, holderName, NULL);
+  const char* methodNameC = (*env)->GetStringUTFChars(env, methodName, NULL);
+  const char* descriptorC = (*env)->GetStringUTFChars(env, descriptor, NULL);
+
+  JNICB cb = malloc(sizeof *cb);
+  CHECK_NULL(cb, "Can not allocate cb");
+
+  jclass holder = (*env)->FindClass(env, holderNameC);
+  CHECK_NULL(holder, "Can not find class");
+  holder = (jclass) (*env)->NewGlobalRef(env, holder);
+  cb->holder = holder;
+
+  jmethodID methodID = (*env)->GetStaticMethodID(env, holder, methodNameC, descriptorC);
+  CHECK_NULL(methodID, "Can not find method");
+  //methodID = (jmethodID) (*env)->NewGlobalRef(env, methodID); // DON'T DO THIS! -> Crashes GC
+  cb->mid = methodID;
+
+  (*env)->ReleaseStringUTFChars(env, holderName, holderNameC);
+  (*env)->ReleaseStringUTFChars(env, methodName, methodNameC);
+  (*env)->ReleaseStringUTFChars(env, descriptor, descriptorC);
+
+  return ptr_to_jlong(cb);
+}

--- a/test/micro/org/openjdk/bench/jdk/incubator/foreign/libQSort.c
+++ b/test/micro/org/openjdk/bench/jdk/incubator/foreign/libQSort.c
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+#ifdef _WIN64
+#define EXPORT __declspec(dllexport)
+#else
+#define EXPORT
+#endif
+
+
+EXPORT int compar(const void* e0, const void* e1) {
+    int i0 = *((int*) e0);
+    int i1 = *((int*) e1);
+    return i0 - i1;
+}

--- a/test/micro/org/openjdk/bench/jdk/incubator/foreign/libQSortJNI.c
+++ b/test/micro/org/openjdk/bench/jdk/incubator/foreign/libQSortJNI.c
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+#include <jni.h>
+
+#include <stdlib.h>
+
+#include "jlong.h"
+#include "JNICB.h"
+
+#ifdef _WIN64
+#define THREAD_LOCAL __declspec(thread)
+#else
+#define THREAD_LOCAL __thread
+#endif
+
+THREAD_LOCAL struct {
+  JNICB cb;
+  JNIEnv* env;
+} ctx_opt;
+
+static int comparator(const void* e0, const void* e1) {
+    JNICB jniCb = ctx_opt.cb;
+    JNIEnv* env = ctx_opt.env;
+    jint j0 = *((jint*) e0);
+    jint j1 = *((jint*) e1);
+    return (*env)->CallStaticIntMethod(env, jniCb->holder, jniCb->mid, j0, j1);
+}
+
+JNIEXPORT void JNICALL Java_org_openjdk_bench_jdk_incubator_foreign_QSort_jni_1qsort_1optimized
+        (JNIEnv *env, jclass cls, jintArray arr, jlong cb) {
+
+    ctx_opt.cb = jlong_to_ptr(cb);
+    ctx_opt.env = env;
+
+    jint* ints = (*env)->GetIntArrayElements(env, arr, NULL);
+    jsize length = (*env)->GetArrayLength(env, arr);
+
+    qsort(ints, length, sizeof(jint), &comparator);
+
+    (*env)->ReleaseIntArrayElements(env, arr, ints, 0);
+}
+
+JavaVM* VM = NULL;
+
+int java_cmp(const void *a, const void *b) {
+   int v1 = *((int*)a);
+   int v2 = *((int*)b);
+
+   JNIEnv* env;
+   (*VM)->GetEnv(VM, (void**) &env, JNI_VERSION_10);
+
+   jclass qsortClass = (*env)->FindClass(env, "org/openjdk/bench/jdk/incubator/foreign/QSort");
+   jmethodID methodId = (*env)->GetStaticMethodID(env, qsortClass, "jni_upcall_compar", "(II)I");
+
+   return (*env)->CallStaticIntMethod(env, qsortClass, methodId, v1, v2);
+}
+
+JNIEXPORT void JNICALL Java_org_openjdk_bench_jdk_incubator_foreign_QSort_jni_1qsort_1naive
+        (JNIEnv *env, jclass cls, jintArray arr) {
+    if (VM == NULL) {
+        (*env)->GetJavaVM(env, &VM);
+    }
+
+    jint* carr = (*env)->GetIntArrayElements(env, arr, 0);
+    jsize length = (*env)->GetArrayLength(env, arr);
+    qsort(carr, length, sizeof(jint), java_cmp);
+    (*env)->ReleaseIntArrayElements(env, arr, carr, 0);
+}

--- a/test/micro/org/openjdk/bench/jdk/incubator/foreign/libUpcallsJNI.c
+++ b/test/micro/org/openjdk/bench/jdk/incubator/foreign/libUpcallsJNI.c
@@ -22,46 +22,9 @@
  */
 #include <jni.h>
 #include <stdlib.h>
+
 #include "jlong.h"
-
-typedef struct {
-    jclass holder;
-    jmethodID mid;
-} *JNICB;
-
-#define CHECK_NULL(thing, message) \
-    if (thing == NULL) { \
-        jclass cls = (*env)->FindClass(env, "java/lang/Exception"); \
-        (*env)->ThrowNew(env, cls, message); \
-        return 0; \
-    }
-
-JNIEXPORT jlong JNICALL Java_org_openjdk_bench_jdk_incubator_foreign_Upcalls_makeCB
-  (JNIEnv *env, jclass cls, jstring holderName, jstring methodName, jstring descriptor) {
-
-  const char* holderNameC = (*env)->GetStringUTFChars(env, holderName, NULL);
-  const char* methodNameC = (*env)->GetStringUTFChars(env, methodName, NULL);
-  const char* descriptorC = (*env)->GetStringUTFChars(env, descriptor, NULL);
-
-  JNICB cb = malloc(sizeof *cb);
-  CHECK_NULL(cb, "Can not allocate cb");
-
-  jclass holder = (*env)->FindClass(env, holderNameC);
-  CHECK_NULL(holder, "Can not find class");
-  holder = (jclass) (*env)->NewGlobalRef(env, holder);
-  cb->holder = holder;
-
-  jmethodID methodID = (*env)->GetStaticMethodID(env, holder, methodNameC, descriptorC);
-  CHECK_NULL(methodID, "Can not find method");
-  //methodID = (jmethodID) (*env)->NewGlobalRef(env, methodID); // DON'T DO THIS! -> Crashes GC
-  cb->mid = methodID;
-
-  (*env)->ReleaseStringUTFChars(env, holderName, holderNameC);
-  (*env)->ReleaseStringUTFChars(env, methodName, methodNameC);
-  (*env)->ReleaseStringUTFChars(env, descriptor, descriptorC);
-
-  return ptr_to_jlong(cb);
-}
+#include "JNICB.h"
 
 JNIEXPORT void JNICALL Java_org_openjdk_bench_jdk_incubator_foreign_Upcalls_blank
   (JNIEnv *env, jclass cls, jlong cb) {


### PR DESCRIPTION
Hi,

This patch makes upcall method handle customization lazy, which helps a lot in reducing the number of lambda form classes generated during for intstance the TestUpcall test, making it complete a lot faster.

This adds a very slight overhead per call, since there's another indirection, but I think the tradeoff is acceptable.

Since the patch was otherwise really small, this also adds a qsort benchmark that is also used the measure the cost of the extra indirection. Results are as follows:

```
QSort without lazy customization:

Benchmark                         Mode  Cnt      Score     Error  Units
QSort.jni_upcall_qsort_naive      avgt   30  21096.871 � 299.669  ns/op
QSort.jni_upcall_qsort_optimized  avgt   30   3603.495 �  16.464  ns/op
QSort.native_qsort                avgt   30     96.236 �   0.713  ns/op
QSort.panama_upcall_qsort         avgt   30    937.675 �  26.160  ns/op

QSort with lazy customization:

Benchmark                         Mode  Cnt      Score     Error  Units
QSort.jni_upcall_qsort_naive      avgt   30  21454.476 � 306.135  ns/op
QSort.jni_upcall_qsort_optimized  avgt   30   3691.395 �  35.671  ns/op
QSort.native_qsort                avgt   30     97.440 �   0.894  ns/op
QSort.panama_upcall_qsort         avgt   30   1072.929 �  14.948  ns/op
```

So, while there is some regression from this change, it's not super bad (not integer factor), and I think the tradeoff is worth it to generate fewer lambda form classes, which of course has it's own overhead not visible in this benchmark.

Thanks,
Jorn

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [JDK-8268266](https://bugs.openjdk.java.net/browse/JDK-8268266): Investigate way to lazily customize upcall lambda forms


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.java.net/census#mcimadamore) (@mcimadamore - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/553/head:pull/553` \
`$ git checkout pull/553`

Update a local copy of the PR: \
`$ git checkout pull/553` \
`$ git pull https://git.openjdk.java.net/panama-foreign pull/553/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 553`

View PR using the GUI difftool: \
`$ git pr show -t 553`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/panama-foreign/pull/553.diff">https://git.openjdk.java.net/panama-foreign/pull/553.diff</a>

</details>
