### PR TITLE
8268633: CLinker::toJavaString doesn't check for NULL address 

### DIFF
--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/CLinker.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/CLinker.java
@@ -374,7 +374,8 @@ public sealed interface CLinker permits AbstractCLinker {
      *
      * @param addr the address at which the string is stored.
      * @return a Java string with the contents of the null-terminated C string at given address.
-     * @throws IllegalArgumentException if the size of the native string is greater than the largest string supported by the platform.
+     * @throws IllegalArgumentException if the size of the native string is greater than the largest string supported by the platform,
+     * or if {@code addr == MemoryAddress.NULL}.
      * @throws IllegalCallerException if access to this method occurs from a module {@code M} and the command line option
      * {@code --enable-native-access} is either absent, or does not mention the module name {@code M}, or
      * {@code ALL-UNNAMED} in case {@code M} is an unnamed module.
@@ -382,7 +383,7 @@ public sealed interface CLinker permits AbstractCLinker {
     @CallerSensitive
     static String toJavaString(MemoryAddress addr) {
         Reflection.ensureNativeAccess(Reflection.getCallerClass());
-        Objects.requireNonNull(addr);
+        SharedUtils.checkAddress(addr);
         return SharedUtils.toJavaStringInternal(NativeMemorySegmentImpl.EVERYTHING, addr.toRawLongValue(), Charset.defaultCharset());
     }
 
@@ -402,7 +403,8 @@ public sealed interface CLinker permits AbstractCLinker {
      * @param addr the address at which the string is stored.
      * @param charset The {@link java.nio.charset.Charset} to be used to compute the contents of the Java string.
      * @return a Java string with the contents of the null-terminated C string at given address.
-     * @throws IllegalArgumentException if the size of the native string is greater than the largest string supported by the platform.
+     * @throws IllegalArgumentException if the size of the native string is greater than the largest string supported by the platform,
+     * or if {@code addr == MemoryAddress.NULL}.
      * @throws IllegalCallerException if access to this method occurs from a module {@code M} and the command line option
      * {@code --enable-native-access} is either absent, or does not mention the module name {@code M}, or
      * {@code ALL-UNNAMED} in case {@code M} is an unnamed module.
@@ -410,7 +412,7 @@ public sealed interface CLinker permits AbstractCLinker {
     @CallerSensitive
     static String toJavaString(MemoryAddress addr, Charset charset) {
         Reflection.ensureNativeAccess(Reflection.getCallerClass());
-        Objects.requireNonNull(addr);
+        SharedUtils.checkAddress(addr);
         Objects.requireNonNull(charset);
         return SharedUtils.toJavaStringInternal(NativeMemorySegmentImpl.EVERYTHING, addr.toRawLongValue(), charset);
     }
@@ -501,13 +503,14 @@ public sealed interface CLinker permits AbstractCLinker {
      *
      * @param addr memory address of the native memory to be freed
      * @throws IllegalCallerException if access to this method occurs from a module {@code M} and the command line option
+     * @throws IllegalArgumentException if {@code addr == MemoryAddress.NULL}.
      * {@code --enable-native-access} is either absent, or does not mention the module name {@code M}, or
      * {@code ALL-UNNAMED} in case {@code M} is an unnamed module.
      */
     @CallerSensitive
     static void freeMemory(MemoryAddress addr) {
         Reflection.ensureNativeAccess(Reflection.getCallerClass());
-        Objects.requireNonNull(addr);
+        SharedUtils.checkAddress(addr);
         SharedUtils.freeMemoryInternal(addr);
     }
 

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/SharedUtils.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/SharedUtils.java
@@ -455,6 +455,14 @@ public class SharedUtils {
     }
 
     public static MemoryAddress checkSymbol(Addressable symbol) {
+        return checkAddressable(symbol, "Symbol is NULL");
+    }
+
+    public static MemoryAddress checkAddress(MemoryAddress address) {
+        return checkAddressable(address, "Address is NULL");
+    }
+
+    private static MemoryAddress checkAddressable(Addressable symbol, String msg) {
         Objects.requireNonNull(symbol);
         MemoryAddress symbolAddr = symbol.address();
         if (symbolAddr.equals(MemoryAddress.NULL))

--- a/test/jdk/java/foreign/TestNULLAddress.java
+++ b/test/jdk/java/foreign/TestNULLAddress.java
@@ -27,7 +27,7 @@
  * @modules jdk.incubator.foreign
  * @run testng/othervm
  *     --enable-native-access=ALL-UNNAMED
- *     TestNULLTarget
+ *     TestNULLAddress
  */
 
 import jdk.incubator.foreign.Addressable;
@@ -38,8 +38,9 @@ import org.testng.annotations.Test;
 
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodType;
+import java.nio.charset.Charset;
 
-public class TestNULLTarget {
+public class TestNULLAddress {
 
     static final CLinker LINKER = CLinker.getInstance();
 
@@ -57,5 +58,20 @@ public class TestNULLTarget {
                 MethodType.methodType(void.class),
                 FunctionDescriptor.ofVoid());
         mh.invokeExact((Addressable) MemoryAddress.NULL);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testNULLtoJavaString() {
+        CLinker.toJavaString(MemoryAddress.NULL);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testNULLtoJavaStringCharset() {
+        CLinker.toJavaString(MemoryAddress.NULL, Charset.defaultCharset());
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testNULLfreeMemory() {
+        CLinker.freeMemory(MemoryAddress.NULL);
     }
 }


### PR DESCRIPTION
As the subject says, a couple of function in CLinker do not check for NULL addresses passed as arguments.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [JDK-8268633](https://bugs.openjdk.java.net/browse/JDK-8268633): CLinker::toJavaString doesn't check for NULL address


### Reviewers
 * [Jorn Vernee](https://openjdk.java.net/census#jvernee) (@JornVernee - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/559/head:pull/559` \
`$ git checkout pull/559`

Update a local copy of the PR: \
`$ git checkout pull/559` \
`$ git pull https://git.openjdk.java.net/panama-foreign pull/559/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 559`

View PR using the GUI difftool: \
`$ git pr show -t 559`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/panama-foreign/pull/559.diff">https://git.openjdk.java.net/panama-foreign/pull/559.diff</a>

</details>
