### PR TITLE
8268743: Require a better way for copying data between MemorySegments and on-heap arrays

### DIFF
--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/HeapMemorySegmentImpl.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/HeapMemorySegmentImpl.java
@@ -98,7 +98,8 @@ public abstract class HeapMemorySegmentImpl<H> extends AbstractMemorySegmentImpl
         public static MemorySegment fromArray(byte[] arr) {
             Objects.requireNonNull(arr);
             long byteSize = (long)arr.length * Unsafe.ARRAY_BYTE_INDEX_SCALE;
-            return new OfByte(Unsafe.ARRAY_BYTE_BASE_OFFSET, arr, byteSize, defaultAccessModes(byteSize));
+            // a byte array is always wrapped by a "small" segment
+            return new OfByte(Unsafe.ARRAY_BYTE_BASE_OFFSET, arr, byteSize, SMALL);
         }
     }
 

--- a/test/micro/org/openjdk/bench/jdk/incubator/foreign/TestSmallCopy.java
+++ b/test/micro/org/openjdk/bench/jdk/incubator/foreign/TestSmallCopy.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package org.openjdk.bench.jdk.incubator.foreign;
+
+import jdk.incubator.foreign.MemoryAccess;
+import jdk.incubator.foreign.MemorySegment;
+import jdk.incubator.foreign.ResourceScope;
+import sun.misc.Unsafe;
+import jdk.incubator.foreign.ResourceScope;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.CompilerControl;
+import static org.openjdk.jmh.annotations.CompilerControl.Mode.*;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import sun.misc.Unsafe;
+
+import jdk.incubator.foreign.MemorySegment;
+import java.nio.ByteBuffer;
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+
+import java.nio.ByteBuffer;
+import java.util.concurrent.TimeUnit;
+
+import static jdk.incubator.foreign.MemoryLayouts.JAVA_INT;
+
+@BenchmarkMode(Mode.AverageTime)
+@Warmup(iterations = 5, time = 500, timeUnit = TimeUnit.MILLISECONDS)
+@Measurement(iterations = 10, time = 500, timeUnit = TimeUnit.MILLISECONDS)
+@State(org.openjdk.jmh.annotations.Scope.Thread)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@Fork(value = 3, jvmArgsAppend = { "--add-modules=jdk.incubator.foreign" })
+public class TestSmallCopy {
+    static final Unsafe unsafe = Utils.unsafe;
+
+    static final int ELEM_SIZE = 100;
+    static final int CARRIER_SIZE = (int)JAVA_INT.byteSize();
+    static final int ALLOC_SIZE = ELEM_SIZE * CARRIER_SIZE;
+
+    static final long unsafe_addr = unsafe.allocateMemory(ALLOC_SIZE);
+    static final MemorySegment segment = MemorySegment.allocateNative(ALLOC_SIZE, ResourceScope.newConfinedScope());
+
+    static final int[] bytes = new int[ELEM_SIZE];
+    static final MemorySegment bytesSegment = MemorySegment.ofArray(bytes);
+    static final int UNSAFE_INT_OFFSET = unsafe.arrayBaseOffset(int[].class);
+
+    int srcOffset;
+    int targetOffset;
+    int nbytes;
+
+    static final Random random = new Random();
+
+    static {
+        for (int i = 0 ; i < bytes.length ; i++) {
+            bytes[i] = i;
+        }
+    }
+
+    @Setup(Level.Iteration)
+    public void setup() {
+        srcOffset = random.nextInt(ELEM_SIZE / 4);
+        targetOffset = random.nextInt(ELEM_SIZE / 4);
+        nbytes = random.nextInt(ELEM_SIZE / 2);
+    }
+
+    @Benchmark
+    @OutputTimeUnit(TimeUnit.NANOSECONDS)
+    public void unsafe_small_copy() {
+        unsafe.copyMemory(bytes, UNSAFE_INT_OFFSET + srcOffset, null, unsafe_addr + targetOffset, nbytes);
+    }
+
+    @Benchmark
+    @OutputTimeUnit(TimeUnit.NANOSECONDS)
+    public void segment_small_copy() {
+        segment.asSlice(srcOffset, nbytes).copyFrom(bytesSegment.asSlice(targetOffset, nbytes));
+    }
+
+    @Benchmark
+    @OutputTimeUnit(TimeUnit.NANOSECONDS)
+    public void segment_small_copy_fresh() {
+        segment.asSlice(srcOffset, nbytes).copyFrom(MemorySegment.ofArray(bytes).asSlice(targetOffset, nbytes));
+    }
+}


### PR DESCRIPTION
After some investigation, it seems that escape analysis is defeated in cases where a new heap segment is created fresh just before performing a bulk copy.

This is caused by the fact that, on segment creation, we perform this test:

```
static int defaultAccessModes(long size) {
        return (enableSmallSegments && size < Integer.MAX_VALUE) ?
                SMALL : 0;
    }
```

To make sure that segments whose size fits in an `int` do not incur in penalties associated with lack of optimizations over long loop bound check optimizations.

Unfortunately, this logic is control flow logic, and control flow disables escape analysis optimizations.

For segment wrappers around byte arrays we can workaround by removing the check (all byte segments are small by definition, since there's a 1-1 mapping between logical elements and physical bytes). For other segment kinds we cannot do much.

While it would be possible, in principle, to resort to more complex bound checks for heap segments, we believe the way forward is to eliminate the need for "small" segments, which will be possible once the PR below is completed:

https://github.com/openjdk/jdk/pull/2045

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8268743](https://bugs.openjdk.java.net/browse/JDK-8268743): Require a better way for copying data between MemorySegments and on-heap arrays


### Reviewers
 * [Uwe Schindler](https://openjdk.java.net/census#uschindler) (@uschindler - no project role)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/560/head:pull/560` \
`$ git checkout pull/560`

Update a local copy of the PR: \
`$ git checkout pull/560` \
`$ git pull https://git.openjdk.java.net/panama-foreign pull/560/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 560`

View PR using the GUI difftool: \
`$ git pr show -t 560`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/panama-foreign/pull/560.diff">https://git.openjdk.java.net/panama-foreign/pull/560.diff</a>

</details>
