### PR TITLE
8269807: Implement the fix for JDK-8269240 in the panama-foreign repo

### DIFF
--- a/make/test/JtregNativeJdk.gmk
+++ b/make/test/JtregNativeJdk.gmk
@@ -54,6 +54,7 @@ BUILD_JDK_JTREG_EXECUTABLES_CFLAGS_exeJliLaunchTest := \
     -I$(TOPDIR)/src/java.base/$(OPENJDK_TARGET_OS)/native/libjli
 
 BUILD_JDK_JTREG_LIBRARIES_LDFLAGS_libAsyncStackWalk := $(LIBCXX)
+BUILD_JDK_JTREG_LIBRARIES_LDFLAGS_libAsyncInvokers := $(LIBCXX)
 
 # Platform specific setup
 ifeq ($(call isTargetOs, windows), true)
@@ -66,6 +67,7 @@ ifeq ($(call isTargetOs, windows), true)
   BUILD_JDK_JTREG_EXECUTABLES_LIBS_exeCallerAccessTest := jvm.lib
   BUILD_JDK_JTREG_EXECUTABLES_LIBS_exerevokeall := advapi32.lib
   BUILD_JDK_JTREG_LIBRARIES_CFLAGS_libAsyncStackWalk := /EHsc
+  BUILD_JDK_JTREG_LIBRARIES_CFLAGS_libAsyncInvokers := /EHsc
 else
   BUILD_JDK_JTREG_LIBRARIES_LIBS_libstringPlatformChars := -ljava
   BUILD_JDK_JTREG_LIBRARIES_LIBS_libDirectIO := -ljava

--- a/src/hotspot/cpu/aarch64/frame_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/frame_aarch64.cpp
@@ -362,7 +362,7 @@ frame frame::sender_for_entry_frame(RegisterMap* map) const {
   return fr;
 }
 
-JavaFrameAnchor* OptimizedEntryBlob::jfa_for_frame(const frame& frame) const {
+OptimizedEntryBlob::FrameData* OptimizedEntryBlob::frame_data_for_frame(const frame& frame) const {
   ShouldNotCallThis();
   return nullptr;
 }

--- a/src/hotspot/cpu/arm/frame_arm.cpp
+++ b/src/hotspot/cpu/arm/frame_arm.cpp
@@ -313,6 +313,11 @@ frame frame::sender_for_entry_frame(RegisterMap* map) const {
   return fr;
 }
 
+OptimizedEntryBlob::FrameData* OptimizedEntryBlob::frame_data_for_frame(const frame& frame) const {
+  ShouldNotCallThis();
+  return nullptr;
+}
+
 bool frame::optimized_entry_frame_is_first() const {
   ShouldNotCallThis();
   return false;

--- a/src/hotspot/cpu/ppc/frame_ppc.cpp
+++ b/src/hotspot/cpu/ppc/frame_ppc.cpp
@@ -197,6 +197,11 @@ frame frame::sender_for_entry_frame(RegisterMap *map) const {
   return fr;
 }
 
+OptimizedEntryBlob::FrameData* OptimizedEntryBlob::frame_data_for_frame(const frame& frame) const {
+  ShouldNotCallThis();
+  return nullptr;
+}
+
 bool frame::optimized_entry_frame_is_first() const {
   ShouldNotCallThis();
   return false;

--- a/src/hotspot/cpu/s390/frame_s390.cpp
+++ b/src/hotspot/cpu/s390/frame_s390.cpp
@@ -208,6 +208,11 @@ frame frame::sender_for_entry_frame(RegisterMap *map) const {
   return fr;
 }
 
+OptimizedEntryBlob::FrameData* OptimizedEntryBlob::frame_data_for_frame(const frame& frame) const {
+  ShouldNotCallThis();
+  return nullptr;
+}
+
 bool frame::optimized_entry_frame_is_first() const {
   ShouldNotCallThis();
   return false;

--- a/src/hotspot/cpu/x86/frame_x86.cpp
+++ b/src/hotspot/cpu/x86/frame_x86.cpp
@@ -353,9 +353,10 @@ frame frame::sender_for_entry_frame(RegisterMap* map) const {
   return fr;
 }
 
-JavaFrameAnchor* OptimizedEntryBlob::jfa_for_frame(const frame& frame) const {
+OptimizedEntryBlob::FrameData* OptimizedEntryBlob::frame_data_for_frame(const frame& frame) const {
   // need unextended_sp here, since normal sp is wrong for interpreter callees
-  return reinterpret_cast<JavaFrameAnchor*>(reinterpret_cast<char*>(frame.unextended_sp()) + in_bytes(jfa_sp_offset()));
+  return reinterpret_cast<OptimizedEntryBlob::FrameData*>(
+    reinterpret_cast<char*>(frame.unextended_sp()) + in_bytes(_frame_data_offset));
 }
 
 bool frame::optimized_entry_frame_is_first() const {

--- a/src/hotspot/cpu/x86/universalUpcallHandler_x86_64.cpp
+++ b/src/hotspot/cpu/x86/universalUpcallHandler_x86_64.cpp
@@ -316,47 +316,6 @@ static void print_arg_moves(const GrowableArray<ArgMove>& arg_moves, Method* ent
 }
 #endif
 
-void save_java_frame_anchor(MacroAssembler* _masm, ByteSize store_offset, Register thread) {
-  __ block_comment("{ save_java_frame_anchor ");
-  // upcall->jfa._last_Java_fp = _thread->_anchor._last_Java_fp;
-  __ movptr(rscratch1, Address(thread, JavaThread::last_Java_fp_offset()));
-  __ movptr(Address(rsp, store_offset + JavaFrameAnchor::last_Java_fp_offset()), rscratch1);
-
-  // upcall->jfa._last_Java_pc = _thread->_anchor._last_Java_pc;
-  __ movptr(rscratch1, Address(thread, JavaThread::last_Java_pc_offset()));
-  __ movptr(Address(rsp, store_offset + JavaFrameAnchor::last_Java_pc_offset()), rscratch1);
-
-  // upcall->jfa._last_Java_sp = _thread->_anchor._last_Java_sp;
-  __ movptr(rscratch1, Address(thread, JavaThread::last_Java_sp_offset()));
-  __ movptr(Address(rsp, store_offset + JavaFrameAnchor::last_Java_sp_offset()), rscratch1);
-  __ block_comment("} save_java_frame_anchor ");
-}
-
-void restore_java_frame_anchor(MacroAssembler* _masm, ByteSize load_offset, Register thread) {
-  __ block_comment("{ restore_java_frame_anchor ");
-  // thread->_last_Java_sp = NULL
-  __ movptr(Address(thread, JavaThread::last_Java_sp_offset()), NULL_WORD);
-
-  // ThreadStateTransition::transition_from_java(_thread, _thread_in_vm);
-  // __ movl(Address(r15_thread, JavaThread::thread_state_offset()), _thread_in_native_trans);
-  __ movl(Address(r15_thread, JavaThread::thread_state_offset()), _thread_in_native);
-
-  //_thread->frame_anchor()->copy(&_anchor);
-//  _thread->_last_Java_fp = upcall->_last_Java_fp;
-//  _thread->_last_Java_pc = upcall->_last_Java_pc;
-//  _thread->_last_Java_sp = upcall->_last_Java_sp;
-
-  __ movptr(rscratch1, Address(rsp, load_offset + JavaFrameAnchor::last_Java_fp_offset()));
-  __ movptr(Address(thread, JavaThread::last_Java_fp_offset()), rscratch1);
-
-  __ movptr(rscratch1, Address(rsp, load_offset + JavaFrameAnchor::last_Java_pc_offset()));
-  __ movptr(Address(thread, JavaThread::last_Java_pc_offset()), rscratch1);
-
-  __ movptr(rscratch1, Address(rsp, load_offset + JavaFrameAnchor::last_Java_sp_offset()));
-  __ movptr(Address(thread, JavaThread::last_Java_sp_offset()), rscratch1);
-  __ block_comment("} restore_java_frame_anchor ");
-}
-
 static void save_native_arguments(MacroAssembler* _masm, const CallRegs& conv, int arg_save_area_offset) {
   __ block_comment("{ save_native_args ");
   int store_offset = arg_save_area_offset;
@@ -440,6 +399,60 @@ static int compute_arg_save_area_size(const CallRegs& conv) {
     // do nothing for stack
   }
   return result_size;
+}
+
+static int compute_res_save_area_size(const CallRegs& conv) {
+  int result_size = 0;
+  for (int i = 0; i < conv._rets_length; i++) {
+    VMReg reg = conv._ret_regs[i];
+    if (reg->is_Register()) {
+      result_size += 8;
+    } else if (reg->is_XMMRegister()) {
+      // Java API doesn't support vector args
+      result_size += 16;
+    } else {
+      ShouldNotReachHere(); // unhandled type
+    }
+  }
+  return result_size;
+}
+
+static void save_java_result(MacroAssembler* _masm, const CallRegs& conv, int res_save_area_offset) {
+  int offset = res_save_area_offset;
+  __ block_comment("{ save java result ");
+  for (int i = 0; i < conv._rets_length; i++) {
+    VMReg reg = conv._ret_regs[i];
+    if (reg->is_Register()) {
+      __ movptr(Address(rsp, offset), reg->as_Register());
+      offset += 8;
+    } else if (reg->is_XMMRegister()) {
+      // Java API doesn't support vector args
+      __ movdqu(Address(rsp, offset), reg->as_XMMRegister());
+      offset += 16;
+    } else {
+      ShouldNotReachHere(); // unhandled type
+    }
+  }
+  __ block_comment("} save java result ");
+}
+
+static void restore_java_result(MacroAssembler* _masm, const CallRegs& conv, int res_save_area_offset) {
+  int offset = res_save_area_offset;
+  __ block_comment("{ restore java result ");
+  for (int i = 0; i < conv._rets_length; i++) {
+    VMReg reg = conv._ret_regs[i];
+    if (reg->is_Register()) {
+      __ movptr(reg->as_Register(), Address(rsp, offset));
+      offset += 8;
+    } else if (reg->is_XMMRegister()) {
+      // Java API doesn't support vector args
+      __ movdqu(reg->as_XMMRegister(), Address(rsp, offset));
+      offset += 16;
+    } else {
+      ShouldNotReachHere(); // unhandled type
+    }
+  }
+  __ block_comment("} restore java result ");
 }
 
 constexpr int MXCSR_MASK = 0xFFC0;  // Mask out any pending exceptions
@@ -574,12 +587,6 @@ static void shuffle_arguments(MacroAssembler* _masm, const GrowableArray<ArgMove
   }
 }
 
-struct AuxiliarySaves {
-  JavaFrameAnchor jfa;
-  uintptr_t thread;
-  bool should_detach;
-};
-
 address ProgrammableUpcallHandler::generate_optimized_upcall_stub(jobject receiver, Method* entry, jobject jabi, jobject jconv) {
   ResourceMark rm;
   const ABIDescriptor abi = ForeignGlobals::parse_abi_descriptor(jabi);
@@ -604,19 +611,17 @@ address ProgrammableUpcallHandler::generate_optimized_upcall_stub(jobject receiv
 
   int reg_save_area_size = compute_reg_save_area_size(abi);
   int arg_save_area_size = compute_arg_save_area_size(conv);
+  int res_save_area_size = compute_res_save_area_size(conv);
   // To spill receiver during deopt
   int deopt_spill_size = 1 * BytesPerWord;
 
   int shuffle_area_offset    = 0;
   int deopt_spill_offset     = shuffle_area_offset    + out_arg_area;
-  int arg_save_area_offset   = deopt_spill_offset     + deopt_spill_size;
+  int res_save_area_offset   = deopt_spill_offset     + deopt_spill_size;
+  int arg_save_area_offset   = res_save_area_offset   + res_save_area_size;
   int reg_save_area_offset   = arg_save_area_offset   + arg_save_area_size;
-  int auxiliary_saves_offset = reg_save_area_offset   + reg_save_area_size;
-  int frame_bottom_offset    = auxiliary_saves_offset + sizeof(AuxiliarySaves);
-
-  ByteSize jfa_offset           = in_ByteSize(auxiliary_saves_offset) + byte_offset_of(AuxiliarySaves, jfa);
-  ByteSize thread_offset        = in_ByteSize(auxiliary_saves_offset) + byte_offset_of(AuxiliarySaves, thread);
-  ByteSize should_detach_offset = in_ByteSize(auxiliary_saves_offset) + byte_offset_of(AuxiliarySaves, should_detach);
+  int frame_data_offset      = reg_save_area_offset   + reg_save_area_size;
+  int frame_bottom_offset    = frame_data_offset      + sizeof(OptimizedEntryBlob::FrameData);
 
   int frame_size = frame_bottom_offset;
   frame_size = align_up(frame_size, StackAlignmentInBytes);
@@ -627,14 +632,17 @@ address ProgrammableUpcallHandler::generate_optimized_upcall_stub(jobject receiv
   // FP-> |                     |
   //      |---------------------| = frame_bottom_offset = frame_size
   //      |                     |
-  //      | AuxiliarySaves      |
-  //      |---------------------| = auxiliary_saves_offset
+  //      | FrameData           |
+  //      |---------------------| = frame_data_offset
   //      |                     |
   //      | reg_save_area       |
   //      |---------------------| = reg_save_are_offset
   //      |                     |
   //      | arg_save_area       |
   //      |---------------------| = arg_save_are_offset
+  //      |                     |
+  //      | res_save_area       |
+  //      |---------------------| = res_save_are_offset
   //      |                     |
   //      | deopt_spill         |
   //      |---------------------| = deopt_spill_offset
@@ -646,7 +654,6 @@ address ProgrammableUpcallHandler::generate_optimized_upcall_stub(jobject receiv
   //////////////////////////////////////////////////////////////////////////////
 
   MacroAssembler* _masm = new MacroAssembler(&buffer);
-  Label call_return;
   address start = __ pc();
   __ enter(); // set up frame
   if ((abi._stack_alignment_bytes % 16) != 0) {
@@ -662,53 +669,14 @@ address ProgrammableUpcallHandler::generate_optimized_upcall_stub(jobject receiv
 
   preserve_callee_saved_registers(_masm, abi, reg_save_area_offset);
 
-  __ block_comment("{ get_thread");
+  __ block_comment("{ on_entry");
   __ vzeroupper();
-  __ lea(c_rarg0, Address(rsp, should_detach_offset));
+  __ lea(c_rarg0, Address(rsp, frame_data_offset));
   // stack already aligned
-  __ call(RuntimeAddress(CAST_FROM_FN_PTR(address, ProgrammableUpcallHandler::maybe_attach_and_get_thread)));
+  __ call(RuntimeAddress(CAST_FROM_FN_PTR(address, ProgrammableUpcallHandler::on_entry)));
   __ movptr(r15_thread, rax);
   __ reinit_heapbase();
-  __ movptr(Address(rsp, thread_offset), r15_thread);
-  __ block_comment("} get_thread");
-
-  // TODO:
-  // We expect not to be coming from JNI code, but we might be.
-  // We should figure out what our stance is on supporting that and then maybe add
-  // some more handling here for:
-  //   - handle blocks
-  //   - check for active exceptions (and emit an error)
-
-  __ block_comment("{ safepoint poll");
-  __ movl(Address(r15_thread, JavaThread::thread_state_offset()), _thread_in_native_trans);
-
-  if (os::is_MP()) {
-    __ membar(Assembler::Membar_mask_bits(
-                Assembler::LoadLoad  | Assembler::StoreLoad |
-                Assembler::LoadStore | Assembler::StoreStore));
-   }
-
-  // check for safepoint operation in progress and/or pending suspend requests
-  Label L_after_safepoint_poll;
-  Label L_safepoint_poll_slow_path;
-
-  __ safepoint_poll(L_safepoint_poll_slow_path, r15_thread, false /* at_return */, false /* in_nmethod */);
-
-  __ cmpl(Address(r15_thread, JavaThread::suspend_flags_offset()), 0);
-  __ jcc(Assembler::notEqual, L_safepoint_poll_slow_path);
-
-  __ bind(L_after_safepoint_poll);
-  __ block_comment("} safepoint poll");
-  // change thread state
-  __ movl(Address(r15_thread, JavaThread::thread_state_offset()), _thread_in_Java);
-
-  __ block_comment("{ reguard stack check");
-  Label L_reguard;
-  Label L_after_reguard;
-  __ cmpl(Address(r15_thread, JavaThread::stack_guard_state_offset()), StackOverflow::stack_guard_yellow_reserved_disabled);
-  __ jcc(Assembler::equal, L_reguard);
-  __ bind(L_after_reguard);
-  __ block_comment("} reguard stack check");
+  __ block_comment("} on_entry");
 
   __ block_comment("{ argument shuffle");
   // TODO merge these somehow
@@ -724,13 +692,24 @@ address ProgrammableUpcallHandler::generate_optimized_upcall_stub(jobject receiv
 
   __ mov_metadata(rbx, entry);
   __ movptr(Address(r15_thread, JavaThread::callee_target_offset()), rbx); // just in case callee is deoptimized
-  __ reinit_heapbase();
-
-  save_java_frame_anchor(_masm, jfa_offset, r15_thread);
-  __ reset_last_Java_frame(r15_thread, true);
 
   __ call(Address(rbx, Method::from_compiled_offset()));
 
+  save_java_result(_masm, conv, res_save_area_offset);
+
+  __ block_comment("{ on_exit");
+  __ vzeroupper();
+  __ lea(c_rarg0, Address(rsp, frame_data_offset));
+  // stack already aligned
+  __ call(RuntimeAddress(CAST_FROM_FN_PTR(address, ProgrammableUpcallHandler::on_exit)));
+  __ reinit_heapbase();
+  __ block_comment("} on_exit");
+
+  restore_callee_saved_registers(_masm, abi, reg_save_area_offset);
+
+  restore_java_result(_masm, conv, res_save_area_offset);
+
+  // return value shuffle
 #ifdef ASSERT
   if (conv._rets_length == 1) { // 0 or 1
     VMReg j_expected_result_reg;
@@ -757,52 +736,8 @@ address ProgrammableUpcallHandler::generate_optimized_upcall_stub(jobject receiv
   }
 #endif
 
-  __ bind(call_return);
-
-  // also sets last Java frame
-  __ movptr(r15_thread, Address(rsp, thread_offset));
-  // TODO corrupted thread pointer causes havoc. Can we verify it here?
-  restore_java_frame_anchor(_masm, jfa_offset, r15_thread); // also transitions to native state
-
-  __ block_comment("{ maybe_detach_thread");
-  Label L_after_detach;
-  __ cmpb(Address(rsp, should_detach_offset), 0);
-  __ jcc(Assembler::equal, L_after_detach);
-  __ vzeroupper();
-  __ mov(c_rarg0, r15_thread);
-  // stack already aligned
-  __ call(RuntimeAddress(CAST_FROM_FN_PTR(address, ProgrammableUpcallHandler::detach_thread)));
-  __ reinit_heapbase();
-  __ bind(L_after_detach);
-  __ block_comment("} maybe_detach_thread");
-
-  restore_callee_saved_registers(_masm, abi, reg_save_area_offset);
-
   __ leave();
   __ ret(0);
-
-  //////////////////////////////////////////////////////////////////////////////
-
-  __ block_comment("{ L_safepoint_poll_slow_path");
-  __ bind(L_safepoint_poll_slow_path);
-  __ vzeroupper();
-  __ mov(c_rarg0, r15_thread);
-  // stack already aligned
-  __ call(RuntimeAddress(CAST_FROM_FN_PTR(address, JavaThread::check_special_condition_for_native_trans)));
-  __ reinit_heapbase();
-  __ jmp(L_after_safepoint_poll);
-  __ block_comment("} L_safepoint_poll_slow_path");
-
-  //////////////////////////////////////////////////////////////////////////////
-
-  __ block_comment("{ L_reguard");
-  __ bind(L_reguard);
-  __ vzeroupper();
-  // stack already aligned
-  __ call(RuntimeAddress(CAST_FROM_FN_PTR(address, SharedRuntime::reguard_yellow_pages)));
-  __ reinit_heapbase();
-  __ jmp(L_after_reguard);
-  __ block_comment("} L_reguard");
 
   //////////////////////////////////////////////////////////////////////////////
 
@@ -835,7 +770,7 @@ address ProgrammableUpcallHandler::generate_optimized_upcall_stub(jobject receiv
   const char* name = "optimized_upcall_stub";
 #endif // PRODUCT
 
-  OptimizedEntryBlob* blob = OptimizedEntryBlob::create(name, &buffer, exception_handler_offset, receiver, jfa_offset);
+  OptimizedEntryBlob* blob = OptimizedEntryBlob::create(name, &buffer, exception_handler_offset, receiver, in_ByteSize(frame_data_offset));
 
   if (TraceOptimizedUpcallStubs) {
     blob->print_on(tty);

--- a/src/hotspot/cpu/zero/frame_zero.cpp
+++ b/src/hotspot/cpu/zero/frame_zero.cpp
@@ -61,6 +61,11 @@ frame frame::sender_for_entry_frame(RegisterMap *map) const {
   return frame(zeroframe()->next(), sender_sp());
 }
 
+OptimizedEntryBlob::FrameData* OptimizedEntryBlob::frame_data_for_frame(const frame& frame) const {
+  ShouldNotCallThis();
+  return nullptr;
+}
+
 bool frame::optimized_entry_frame_is_first() const {
   ShouldNotCallThis();
   return false;

--- a/src/hotspot/share/code/codeBlob.cpp
+++ b/src/hotspot/share/code/codeBlob.cpp
@@ -41,6 +41,8 @@
 #include "prims/jvmtiExport.hpp"
 #include "runtime/handles.inline.hpp"
 #include "runtime/interfaceSupport.inline.hpp"
+#include "runtime/javaFrameAnchor.hpp"
+#include "runtime/jniHandles.hpp"
 #include "runtime/mutexLocker.hpp"
 #include "runtime/safepoint.hpp"
 #include "runtime/sharedRuntime.hpp"
@@ -713,26 +715,34 @@ void DeoptimizationBlob::print_value_on(outputStream* st) const {
 // Implementation of OptimizedEntryBlob
 
 OptimizedEntryBlob::OptimizedEntryBlob(const char* name, int size, CodeBuffer* cb, intptr_t exception_handler_offset,
-                     jobject receiver, ByteSize jfa_sp_offset) :
+                                       jobject receiver, ByteSize frame_data_offset) :
   BufferBlob(name, size, cb),
   _exception_handler_offset(exception_handler_offset),
   _receiver(receiver),
-  _jfa_sp_offset(jfa_sp_offset) {
+  _frame_data_offset(frame_data_offset) {
   CodeCache::commit(this);
 }
 
 OptimizedEntryBlob* OptimizedEntryBlob::create(const char* name, CodeBuffer* cb, intptr_t exception_handler_offset,
-                             jobject receiver, ByteSize jfa_sp_offset) {
+                                               jobject receiver, ByteSize frame_data_offset) {
   ThreadInVMfromUnknown __tiv;  // get to VM state in case we block on CodeCache_lock
 
   OptimizedEntryBlob* blob = nullptr;
   unsigned int size = CodeBlob::allocation_size(cb, sizeof(OptimizedEntryBlob));
   {
     MutexLocker mu(CodeCache_lock, Mutex::_no_safepoint_check_flag);
-    blob = new (size) OptimizedEntryBlob(name, size, cb, exception_handler_offset, receiver, jfa_sp_offset);
+    blob = new (size) OptimizedEntryBlob(name, size, cb, exception_handler_offset, receiver, frame_data_offset);
   }
   // Track memory usage statistic after releasing CodeCache_lock
   MemoryService::track_code_cache_memory_usage();
 
   return blob;
+}
+
+void OptimizedEntryBlob::oops_do(OopClosure* f, const frame& frame) {
+  frame_data_for_frame(frame)->old_handles->oops_do(f);
+}
+
+JavaFrameAnchor* OptimizedEntryBlob::jfa_for_frame(const frame& frame) const {
+  return &frame_data_for_frame(frame)->jfa;
 }

--- a/src/hotspot/share/prims/universalUpcallHandler.cpp
+++ b/src/hotspot/share/prims/universalUpcallHandler.cpp
@@ -195,6 +195,7 @@ ProgrammableUpcallHandler::ProgrammableUpcallHandler() {
 }
 
 void ProgrammableUpcallHandler::handle_uncaught_exception(oop exception) {
+  ResourceMark rm;
   // Based on CATCH macro
   tty->print_cr("Uncaught exception:");
   exception->print();

--- a/src/hotspot/share/prims/universalUpcallHandler.cpp
+++ b/src/hotspot/share/prims/universalUpcallHandler.cpp
@@ -60,6 +60,7 @@ Thread* ProgrammableUpcallHandler::maybe_attach_and_get_thread(bool* should_deta
     guarantee(result == JNI_OK, "Could not attach thread for upcall. JNI error code: %d", result);
     *should_detach = true;
     thread = Thread::current();
+    assert(!JavaThread::cast(thread)->has_last_Java_frame(), "newly-attached thread not expected to have last Java frame");
   } else {
     *should_detach = false;
   }
@@ -69,6 +70,93 @@ Thread* ProgrammableUpcallHandler::maybe_attach_and_get_thread(bool* should_deta
 void ProgrammableUpcallHandler::detach_thread(Thread* thread) {
   JavaVM_ *vm = (JavaVM *)(&main_vm);
   vm->functions->DetachCurrentThread(vm);
+}
+
+// modelled after JavaCallWrapper::JavaCallWrapper
+Thread* ProgrammableUpcallHandler::on_entry(OptimizedEntryBlob::FrameData* context) {
+  JavaThread* thread = JavaThread::cast(maybe_attach_and_get_thread(&context->should_detach));
+  context->thread = thread;
+
+  assert(thread->can_call_java(), "must be able to call Java");
+
+  // Allocate handle block for Java code. This must be done before we change thread_state to _thread_in_Java,
+  // since it can potentially block.
+  context->new_handles = JNIHandleBlock::allocate_block(thread);
+
+  // After this, we are official in Java Code. This needs to be done before we change any of the thread local
+  // info, since we cannot find oops before the new information is set up completely.
+  ThreadStateTransition::transition_from_native(thread, _thread_in_Java);
+
+  // Make sure that we handle asynchronous stops and suspends _before_ we clear all thread state
+  // in OptimizedEntryBlob::FrameData. This way, we can decide if we need to do any pd actions
+  // to prepare for stop/suspend (flush register windows on sparcs, cache sp, or other state).
+  bool clear_pending_exception = true;
+  if (thread->has_special_runtime_exit_condition()) {
+    thread->handle_special_runtime_exit_condition();
+    if (thread->has_pending_exception()) {
+      clear_pending_exception = false;
+    }
+  }
+
+  context->old_handles = thread->active_handles();
+
+  // For the profiler, the last_Java_frame information in thread must always be in
+  // legal state. We have no last Java frame if last_Java_sp == NULL so
+  // the valid transition is to clear _last_Java_sp and then reset the rest of
+  // the (platform specific) state.
+
+  context->jfa.copy(thread->frame_anchor());
+  thread->frame_anchor()->clear();
+
+  debug_only(thread->inc_java_call_counter());
+  thread->set_active_handles(context->new_handles);     // install new handle block and reset Java frame linkage
+
+  assert (thread->thread_state() != _thread_in_native, "cannot set native pc to NULL");
+
+  // clear any pending exception in thread (native calls start with no exception pending)
+  if(clear_pending_exception) {
+    thread->clear_pending_exception();
+  }
+
+  MACOS_AARCH64_ONLY(thread->enable_wx(WXExec));
+
+  return thread;
+}
+
+// modelled after JavaCallWrapper::~JavaCallWrapper
+void ProgrammableUpcallHandler::on_exit(OptimizedEntryBlob::FrameData* context) {
+  JavaThread* thread = context->thread;
+  assert(thread == JavaThread::current(), "must still be the same thread");
+
+  MACOS_AARCH64_ONLY(thread->enable_wx(WXWrite));
+
+  // restore previous handle block
+  thread->set_active_handles(context->old_handles);
+
+  thread->frame_anchor()->zap();
+
+  debug_only(thread->dec_java_call_counter());
+
+  // Old thread-local info. has been restored. We are not back in native code.
+  ThreadStateTransition::transition_from_java(thread, _thread_in_native);
+
+  // State has been restored now make the anchor frame visible for the profiler.
+  // Do this after the transition because this allows us to put an assert
+  // the Java->native transition which checks to see that stack is not walkable
+  // on sparc/ia64 which will catch violations of the reseting of last_Java_frame
+  // invariants (i.e. _flags always cleared on return to Java)
+
+  thread->frame_anchor()->copy(&context->jfa);
+
+  // Release handles after we are marked as being in native code again, since this
+  // operation might block
+  JNIHandleBlock::release_block(context->new_handles, thread);
+
+  assert(!thread->has_pending_exception(), "Upcall can not throw an exception");
+
+  if (context->should_detach) {
+    detach_thread(thread);
+  }
 }
 
 void ProgrammableUpcallHandler::attach_thread_and_do_upcall(jobject rec, address buff) {

--- a/src/hotspot/share/prims/universalUpcallHandler.hpp
+++ b/src/hotspot/share/prims/universalUpcallHandler.hpp
@@ -25,6 +25,7 @@
 #define SHARE_VM_PRIMS_UNIVERSALUPCALLHANDLER_HPP
 
 #include "asm/codeBuffer.hpp"
+#include "code/codeBlob.hpp"
 #include "prims/foreign_globals.hpp"
 
 class JavaThread;
@@ -49,6 +50,9 @@ private:
   static void handle_uncaught_exception(oop exception);
   static Thread* maybe_attach_and_get_thread(bool* should_detach);
   static void detach_thread(Thread* thread);
+
+  static Thread* on_entry(OptimizedEntryBlob::FrameData* context);
+  static void on_exit(OptimizedEntryBlob::FrameData* context);
 public:
   static address generate_optimized_upcall_stub(jobject mh, Method* entry, jobject jabi, jobject jconv);
   static address generate_upcall_stub(jobject rec, jobject abi, jobject buffer_layout);

--- a/src/hotspot/share/runtime/frame.cpp
+++ b/src/hotspot/share/runtime/frame.cpp
@@ -1068,9 +1068,7 @@ void frame::oops_do_internal(OopClosure* f, CodeBlobClosure* cf, const RegisterM
   } else if (is_entry_frame()) {
     oops_entry_do(f, map);
   } else if (is_optimized_entry_frame()) {
-   // Nothing to do
-   // receiver is a global ref
-   // handle block is for JNI
+    _cb->as_optimized_entry_blob()->oops_do(f, *this);
   } else if (CodeCache::contains(pc())) {
     oops_code_blob_do(f, cf, map, derived_mode);
   } else {

--- a/src/hotspot/share/runtime/javaFrameAnchor.hpp
+++ b/src/hotspot/share/runtime/javaFrameAnchor.hpp
@@ -34,6 +34,7 @@
 //
 class JavaThread;
 class MacroAssembler;
+class ProgrammableUpcallHandler;
 
 class JavaFrameAnchor {
 // Too many friends...
@@ -52,6 +53,7 @@ friend class VMStructs;
 friend class JVMCIVMStructs;
 friend class BytecodeInterpreter;
 friend class JavaCallWrapper;
+friend class ProgrammableUpcallHandler;
 
  private:
   //

--- a/src/hotspot/share/runtime/safepoint.cpp
+++ b/src/hotspot/share/runtime/safepoint.cpp
@@ -928,6 +928,7 @@ void ThreadSafepointState::handle_polling_page_exception() {
   if( nm->is_at_poll_return(real_return_addr) ) {
     // See if return type is an oop.
     bool return_oop = nm->method()->is_returning_oop();
+    HandleMark hm(self);
     Handle return_value;
     if (return_oop) {
       // The oop result has been saved on the stack together with all

--- a/src/hotspot/share/runtime/thread.cpp
+++ b/src/hotspot/share/runtime/thread.cpp
@@ -1916,6 +1916,15 @@ void JavaThread::deoptimize_marked_methods() {
   }
 }
 
+#ifdef ASSERT
+void JavaThread::verify_frame_info() {
+  assert((!has_last_Java_frame() && java_call_counter() == 0) ||
+         (has_last_Java_frame() && java_call_counter() > 0),
+         "unexpected frame info: has_last_frame=%d, java_call_counter=%d",
+         has_last_Java_frame(), java_call_counter());
+}
+#endif
+
 void JavaThread::oops_do_no_frames(OopClosure* f, CodeBlobClosure* cf) {
   // Verify that the deferred card marks have been flushed.
   assert(deferred_card_mark().is_empty(), "Should be empty during GC");
@@ -1923,8 +1932,7 @@ void JavaThread::oops_do_no_frames(OopClosure* f, CodeBlobClosure* cf) {
   // Traverse the GCHandles
   Thread::oops_do_no_frames(f, cf);
 
-  assert((!has_last_Java_frame() && java_call_counter() == 0) ||
-         (has_last_Java_frame() && java_call_counter() > 0), "wrong java_sp info!");
+  DEBUG_ONLY(verify_frame_info();)
 
   if (has_last_Java_frame()) {
     // Traverse the monitor chunks
@@ -1972,18 +1980,12 @@ void JavaThread::oops_do_frames(OopClosure* f, CodeBlobClosure* cf) {
 #ifdef ASSERT
 void JavaThread::verify_states_for_handshake() {
   // This checks that the thread has a correct frame state during a handshake.
-  assert((!has_last_Java_frame() && java_call_counter() == 0) ||
-         (has_last_Java_frame() && java_call_counter() > 0),
-         "unexpected frame info: has_last_frame=%d, java_call_counter=%d",
-         has_last_Java_frame(), java_call_counter());
+  verify_frame_info();
 }
 #endif
 
 void JavaThread::nmethods_do(CodeBlobClosure* cf) {
-  assert((!has_last_Java_frame() && java_call_counter() == 0) ||
-         (has_last_Java_frame() && java_call_counter() > 0),
-         "unexpected frame info: has_last_frame=%d, java_call_counter=%d",
-         has_last_Java_frame(), java_call_counter());
+  DEBUG_ONLY(verify_frame_info();)
 
   if (has_last_Java_frame()) {
     // Traverse the execution stack

--- a/src/hotspot/share/runtime/thread.hpp
+++ b/src/hotspot/share/runtime/thread.hpp
@@ -1127,6 +1127,8 @@ class JavaThread: public Thread {
   void set_requires_cross_modify_fence(bool val) PRODUCT_RETURN NOT_PRODUCT({ _requires_cross_modify_fence = val; })
 
  private:
+  DEBUG_ONLY(void verify_frame_info();)
+
   // Support for thread handshake operations
   HandshakeState _handshake;
  public:

--- a/test/jdk/java/foreign/TestByteBuffer.java
+++ b/test/jdk/java/foreign/TestByteBuffer.java
@@ -326,7 +326,7 @@ public class TestByteBuffer {
             segment.isLoaded();
         } catch(IOException e) {
             if (e.getMessage().equals("Function not implemented"))
-                throw new SkipException("No madvise on this platform");
+                throw new SkipException(e.getMessage(), e);
         }
     }
 

--- a/test/jdk/java/foreign/TestByteBuffer.java
+++ b/test/jdk/java/foreign/TestByteBuffer.java
@@ -324,6 +324,9 @@ public class TestByteBuffer {
             segment.isLoaded();
             segment.unload();
             segment.isLoaded();
+        } catch(IOException e) {
+            if (e.getMessage().equals("Function not implemented"))
+                throw new SkipException("No madvise on this platform");
         }
     }
 

--- a/test/jdk/java/foreign/TestUpcallHighArity.java
+++ b/test/jdk/java/foreign/TestUpcallHighArity.java
@@ -123,7 +123,7 @@ public class TestUpcallHighArity extends CallGeneratorHelper {
                 if (upcallType.parameterType(i) == MemorySegment.class) {
                     assertStructEquals((MemorySegment) capturedArgsArr[i], (MemorySegment) args[i + 1], argLayouts.get(i));
                 } else {
-                    assertEquals(capturedArgsArr[i], args[i + 1]);
+                    assertEquals(capturedArgsArr[i], args[i + 1], "For index " + i);
                 }
             }
         }

--- a/test/jdk/java/foreign/libAsyncInvokers.cpp
+++ b/test/jdk/java/foreign/libAsyncInvokers.cpp
@@ -1,0 +1,146 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+#include <thread>
+
+#include "libTestUpcall.h"
+#ifdef __clang__
+#pragma clang optimize off
+#elif defined __GNUC__
+#pragma GCC optimize ("O0")
+#elif defined _MSC_BUILD
+#pragma optimize( "", off )
+#endif
+
+template<typename CB>
+void launch_v(CB cb) {
+    std::thread thrd(cb);
+    thrd.join();
+}
+
+template<typename O, typename CB>
+void start(O& out, CB cb) {
+    out = cb();
+}
+
+template<typename O, typename CB>
+O launch(CB cb) {
+    O result;
+    std::thread thrd(&start<O, CB>, std::ref(result), cb);
+    thrd.join();
+    return result;
+}
+
+extern "C" {
+EXPORT void call_async_V(void (*cb)(void)) { launch_v(cb); }
+
+EXPORT int call_async_I(int (*cb)(void)) { return launch<int>(cb); }
+EXPORT float call_async_F(float (*cb)(void)) { return launch<float>(cb); }
+EXPORT double call_async_D(double (*cb)(void)) { return launch<double>(cb); }
+EXPORT void* call_async_P(void* (*cb)(void)) { return launch<void*>(cb); }
+
+EXPORT struct S_I call_async_S_I(struct S_I (*cb)(void)) { return launch<struct S_I>(cb); }
+EXPORT struct S_F call_async_S_F(struct S_F (*cb)(void)) { return launch<struct S_F>(cb); }
+EXPORT struct S_D call_async_S_D(struct S_D (*cb)(void)) { return launch<struct S_D>(cb); }
+EXPORT struct S_P call_async_S_P(struct S_P (*cb)(void)) { return launch<struct S_P>(cb); }
+EXPORT struct S_II call_async_S_II(struct S_II (*cb)(void)) { return launch<struct S_II>(cb); }
+EXPORT struct S_IF call_async_S_IF(struct S_IF (*cb)(void)) { return launch<struct S_IF>(cb); }
+EXPORT struct S_ID call_async_S_ID(struct S_ID (*cb)(void)) { return launch<struct S_ID>(cb); }
+EXPORT struct S_IP call_async_S_IP(struct S_IP (*cb)(void)) { return launch<struct S_IP>(cb); }
+EXPORT struct S_FI call_async_S_FI(struct S_FI (*cb)(void)) { return launch<struct S_FI>(cb); }
+EXPORT struct S_FF call_async_S_FF(struct S_FF (*cb)(void)) { return launch<struct S_FF>(cb); }
+EXPORT struct S_FD call_async_S_FD(struct S_FD (*cb)(void)) { return launch<struct S_FD>(cb); }
+EXPORT struct S_FP call_async_S_FP(struct S_FP (*cb)(void)) { return launch<struct S_FP>(cb); }
+EXPORT struct S_DI call_async_S_DI(struct S_DI (*cb)(void)) { return launch<struct S_DI>(cb); }
+EXPORT struct S_DF call_async_S_DF(struct S_DF (*cb)(void)) { return launch<struct S_DF>(cb); }
+EXPORT struct S_DD call_async_S_DD(struct S_DD (*cb)(void)) { return launch<struct S_DD>(cb); }
+EXPORT struct S_DP call_async_S_DP(struct S_DP (*cb)(void)) { return launch<struct S_DP>(cb); }
+EXPORT struct S_PI call_async_S_PI(struct S_PI (*cb)(void)) { return launch<struct S_PI>(cb); }
+EXPORT struct S_PF call_async_S_PF(struct S_PF (*cb)(void)) { return launch<struct S_PF>(cb); }
+EXPORT struct S_PD call_async_S_PD(struct S_PD (*cb)(void)) { return launch<struct S_PD>(cb); }
+EXPORT struct S_PP call_async_S_PP(struct S_PP (*cb)(void)) { return launch<struct S_PP>(cb); }
+EXPORT struct S_III call_async_S_III(struct S_III (*cb)(void)) { return launch<struct S_III>(cb); }
+EXPORT struct S_IIF call_async_S_IIF(struct S_IIF (*cb)(void)) { return launch<struct S_IIF>(cb); }
+EXPORT struct S_IID call_async_S_IID(struct S_IID (*cb)(void)) { return launch<struct S_IID>(cb); }
+EXPORT struct S_IIP call_async_S_IIP(struct S_IIP (*cb)(void)) { return launch<struct S_IIP>(cb); }
+EXPORT struct S_IFI call_async_S_IFI(struct S_IFI (*cb)(void)) { return launch<struct S_IFI>(cb); }
+EXPORT struct S_IFF call_async_S_IFF(struct S_IFF (*cb)(void)) { return launch<struct S_IFF>(cb); }
+EXPORT struct S_IFD call_async_S_IFD(struct S_IFD (*cb)(void)) { return launch<struct S_IFD>(cb); }
+EXPORT struct S_IFP call_async_S_IFP(struct S_IFP (*cb)(void)) { return launch<struct S_IFP>(cb); }
+EXPORT struct S_IDI call_async_S_IDI(struct S_IDI (*cb)(void)) { return launch<struct S_IDI>(cb); }
+EXPORT struct S_IDF call_async_S_IDF(struct S_IDF (*cb)(void)) { return launch<struct S_IDF>(cb); }
+EXPORT struct S_IDD call_async_S_IDD(struct S_IDD (*cb)(void)) { return launch<struct S_IDD>(cb); }
+EXPORT struct S_IDP call_async_S_IDP(struct S_IDP (*cb)(void)) { return launch<struct S_IDP>(cb); }
+EXPORT struct S_IPI call_async_S_IPI(struct S_IPI (*cb)(void)) { return launch<struct S_IPI>(cb); }
+EXPORT struct S_IPF call_async_S_IPF(struct S_IPF (*cb)(void)) { return launch<struct S_IPF>(cb); }
+EXPORT struct S_IPD call_async_S_IPD(struct S_IPD (*cb)(void)) { return launch<struct S_IPD>(cb); }
+EXPORT struct S_IPP call_async_S_IPP(struct S_IPP (*cb)(void)) { return launch<struct S_IPP>(cb); }
+EXPORT struct S_FII call_async_S_FII(struct S_FII (*cb)(void)) { return launch<struct S_FII>(cb); }
+EXPORT struct S_FIF call_async_S_FIF(struct S_FIF (*cb)(void)) { return launch<struct S_FIF>(cb); }
+EXPORT struct S_FID call_async_S_FID(struct S_FID (*cb)(void)) { return launch<struct S_FID>(cb); }
+EXPORT struct S_FIP call_async_S_FIP(struct S_FIP (*cb)(void)) { return launch<struct S_FIP>(cb); }
+EXPORT struct S_FFI call_async_S_FFI(struct S_FFI (*cb)(void)) { return launch<struct S_FFI>(cb); }
+EXPORT struct S_FFF call_async_S_FFF(struct S_FFF (*cb)(void)) { return launch<struct S_FFF>(cb); }
+EXPORT struct S_FFD call_async_S_FFD(struct S_FFD (*cb)(void)) { return launch<struct S_FFD>(cb); }
+EXPORT struct S_FFP call_async_S_FFP(struct S_FFP (*cb)(void)) { return launch<struct S_FFP>(cb); }
+EXPORT struct S_FDI call_async_S_FDI(struct S_FDI (*cb)(void)) { return launch<struct S_FDI>(cb); }
+EXPORT struct S_FDF call_async_S_FDF(struct S_FDF (*cb)(void)) { return launch<struct S_FDF>(cb); }
+EXPORT struct S_FDD call_async_S_FDD(struct S_FDD (*cb)(void)) { return launch<struct S_FDD>(cb); }
+EXPORT struct S_FDP call_async_S_FDP(struct S_FDP (*cb)(void)) { return launch<struct S_FDP>(cb); }
+EXPORT struct S_FPI call_async_S_FPI(struct S_FPI (*cb)(void)) { return launch<struct S_FPI>(cb); }
+EXPORT struct S_FPF call_async_S_FPF(struct S_FPF (*cb)(void)) { return launch<struct S_FPF>(cb); }
+EXPORT struct S_FPD call_async_S_FPD(struct S_FPD (*cb)(void)) { return launch<struct S_FPD>(cb); }
+EXPORT struct S_FPP call_async_S_FPP(struct S_FPP (*cb)(void)) { return launch<struct S_FPP>(cb); }
+EXPORT struct S_DII call_async_S_DII(struct S_DII (*cb)(void)) { return launch<struct S_DII>(cb); }
+EXPORT struct S_DIF call_async_S_DIF(struct S_DIF (*cb)(void)) { return launch<struct S_DIF>(cb); }
+EXPORT struct S_DID call_async_S_DID(struct S_DID (*cb)(void)) { return launch<struct S_DID>(cb); }
+EXPORT struct S_DIP call_async_S_DIP(struct S_DIP (*cb)(void)) { return launch<struct S_DIP>(cb); }
+EXPORT struct S_DFI call_async_S_DFI(struct S_DFI (*cb)(void)) { return launch<struct S_DFI>(cb); }
+EXPORT struct S_DFF call_async_S_DFF(struct S_DFF (*cb)(void)) { return launch<struct S_DFF>(cb); }
+EXPORT struct S_DFD call_async_S_DFD(struct S_DFD (*cb)(void)) { return launch<struct S_DFD>(cb); }
+EXPORT struct S_DFP call_async_S_DFP(struct S_DFP (*cb)(void)) { return launch<struct S_DFP>(cb); }
+EXPORT struct S_DDI call_async_S_DDI(struct S_DDI (*cb)(void)) { return launch<struct S_DDI>(cb); }
+EXPORT struct S_DDF call_async_S_DDF(struct S_DDF (*cb)(void)) { return launch<struct S_DDF>(cb); }
+EXPORT struct S_DDD call_async_S_DDD(struct S_DDD (*cb)(void)) { return launch<struct S_DDD>(cb); }
+EXPORT struct S_DDP call_async_S_DDP(struct S_DDP (*cb)(void)) { return launch<struct S_DDP>(cb); }
+EXPORT struct S_DPI call_async_S_DPI(struct S_DPI (*cb)(void)) { return launch<struct S_DPI>(cb); }
+EXPORT struct S_DPF call_async_S_DPF(struct S_DPF (*cb)(void)) { return launch<struct S_DPF>(cb); }
+EXPORT struct S_DPD call_async_S_DPD(struct S_DPD (*cb)(void)) { return launch<struct S_DPD>(cb); }
+EXPORT struct S_DPP call_async_S_DPP(struct S_DPP (*cb)(void)) { return launch<struct S_DPP>(cb); }
+EXPORT struct S_PII call_async_S_PII(struct S_PII (*cb)(void)) { return launch<struct S_PII>(cb); }
+EXPORT struct S_PIF call_async_S_PIF(struct S_PIF (*cb)(void)) { return launch<struct S_PIF>(cb); }
+EXPORT struct S_PID call_async_S_PID(struct S_PID (*cb)(void)) { return launch<struct S_PID>(cb); }
+EXPORT struct S_PIP call_async_S_PIP(struct S_PIP (*cb)(void)) { return launch<struct S_PIP>(cb); }
+EXPORT struct S_PFI call_async_S_PFI(struct S_PFI (*cb)(void)) { return launch<struct S_PFI>(cb); }
+EXPORT struct S_PFF call_async_S_PFF(struct S_PFF (*cb)(void)) { return launch<struct S_PFF>(cb); }
+EXPORT struct S_PFD call_async_S_PFD(struct S_PFD (*cb)(void)) { return launch<struct S_PFD>(cb); }
+EXPORT struct S_PFP call_async_S_PFP(struct S_PFP (*cb)(void)) { return launch<struct S_PFP>(cb); }
+EXPORT struct S_PDI call_async_S_PDI(struct S_PDI (*cb)(void)) { return launch<struct S_PDI>(cb); }
+EXPORT struct S_PDF call_async_S_PDF(struct S_PDF (*cb)(void)) { return launch<struct S_PDF>(cb); }
+EXPORT struct S_PDD call_async_S_PDD(struct S_PDD (*cb)(void)) { return launch<struct S_PDD>(cb); }
+EXPORT struct S_PDP call_async_S_PDP(struct S_PDP (*cb)(void)) { return launch<struct S_PDP>(cb); }
+EXPORT struct S_PPI call_async_S_PPI(struct S_PPI (*cb)(void)) { return launch<struct S_PPI>(cb); }
+EXPORT struct S_PPF call_async_S_PPF(struct S_PPF (*cb)(void)) { return launch<struct S_PPF>(cb); }
+EXPORT struct S_PPD call_async_S_PPD(struct S_PPD (*cb)(void)) { return launch<struct S_PPD>(cb); }
+EXPORT struct S_PPP call_async_S_PPP(struct S_PPP (*cb)(void)) { return launch<struct S_PPP>(cb); }
+}

--- a/test/jdk/java/foreign/stackwalk/TestAsyncStackWalk.java
+++ b/test/jdk/java/foreign/stackwalk/TestAsyncStackWalk.java
@@ -22,7 +22,7 @@
  */
 
 /*
- * @test
+ * @test id=default_gc
  * @requires ((os.arch == "amd64" | os.arch == "x86_64") & sun.arch.data.model == "64") | os.arch == "aarch64"
  * @library /test/lib
  * @build sun.hotspot.WhiteBox
@@ -44,6 +44,63 @@
  *   -Djdk.internal.foreign.ProgrammableInvoker.USE_INTRINSICS=false
  *   --enable-native-access=ALL-UNNAMED
  *   -Xbatch
+ *   TestAsyncStackWalk
+ */
+
+/*
+ * @test id=zgc
+ * @requires (((os.arch == "amd64" | os.arch == "x86_64") & sun.arch.data.model == "64") | os.arch == "aarch64")
+ * @requires vm.gc.Z
+ * @library /test/lib
+ * @build sun.hotspot.WhiteBox
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller sun.hotspot.WhiteBox
+ *
+ * @run main/othervm
+ *   -Xbootclasspath/a:.
+ *   -XX:+UnlockDiagnosticVMOptions
+ *   -XX:+WhiteBoxAPI
+ *   -Djdk.internal.foreign.ProgrammableInvoker.USE_INTRINSICS=true
+ *   --enable-native-access=ALL-UNNAMED
+ *   -Xbatch
+ *   -XX:+UseZGC
+ *   TestAsyncStackWalk
+ *
+ * @run main/othervm
+ *   -Xbootclasspath/a:.
+ *   -XX:+UnlockDiagnosticVMOptions
+ *   -XX:+WhiteBoxAPI
+ *   -Djdk.internal.foreign.ProgrammableInvoker.USE_INTRINSICS=false
+ *   --enable-native-access=ALL-UNNAMED
+ *   -Xbatch
+ *   -XX:+UseZGC
+ *   TestAsyncStackWalk
+ */
+/*
+ * @test id=shenandoah
+ * @requires (((os.arch == "amd64" | os.arch == "x86_64") & sun.arch.data.model == "64") | os.arch == "aarch64")
+ * @requires vm.gc.Shenandoah
+ * @library /test/lib
+ * @build sun.hotspot.WhiteBox
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller sun.hotspot.WhiteBox
+ *
+ * @run main/othervm
+ *   -Xbootclasspath/a:.
+ *   -XX:+UnlockDiagnosticVMOptions
+ *   -XX:+WhiteBoxAPI
+ *   -Djdk.internal.foreign.ProgrammableInvoker.USE_INTRINSICS=true
+ *   --enable-native-access=ALL-UNNAMED
+ *   -Xbatch
+ *   -XX:+UseShenandoahGC
+ *   TestAsyncStackWalk
+ *
+ * @run main/othervm
+ *   -Xbootclasspath/a:.
+ *   -XX:+UnlockDiagnosticVMOptions
+ *   -XX:+WhiteBoxAPI
+ *   -Djdk.internal.foreign.ProgrammableInvoker.USE_INTRINSICS=false
+ *   --enable-native-access=ALL-UNNAMED
+ *   -Xbatch
+ *   -XX:+UseShenandoahGC
  *   TestAsyncStackWalk
  */
 

--- a/test/jdk/java/foreign/stackwalk/TestStackWalk.java
+++ b/test/jdk/java/foreign/stackwalk/TestStackWalk.java
@@ -22,7 +22,7 @@
  */
 
 /*
- * @test
+ * @test id=default_gc
  * @requires ((os.arch == "amd64" | os.arch == "x86_64") & sun.arch.data.model == "64") | os.arch == "aarch64"
  * @library /test/lib
  * @build sun.hotspot.WhiteBox
@@ -44,6 +44,63 @@
  *   -Djdk.internal.foreign.ProgrammableInvoker.USE_INTRINSICS=false
  *   --enable-native-access=ALL-UNNAMED
  *   -Xbatch
+ *   TestStackWalk
+ */
+
+/*
+ * @test id=zgc
+ * @requires (((os.arch == "amd64" | os.arch == "x86_64") & sun.arch.data.model == "64") | os.arch == "aarch64")
+ * @requires vm.gc.Z
+ * @library /test/lib
+ * @build sun.hotspot.WhiteBox
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller sun.hotspot.WhiteBox
+ *
+ * @run main/othervm
+ *   -Xbootclasspath/a:.
+ *   -XX:+UnlockDiagnosticVMOptions
+ *   -XX:+WhiteBoxAPI
+ *   -Djdk.internal.foreign.ProgrammableInvoker.USE_INTRINSICS=true
+ *   --enable-native-access=ALL-UNNAMED
+ *   -Xbatch
+ *   -XX:+UseZGC
+ *   TestStackWalk
+ *
+ * @run main/othervm
+ *   -Xbootclasspath/a:.
+ *   -XX:+UnlockDiagnosticVMOptions
+ *   -XX:+WhiteBoxAPI
+ *   -Djdk.internal.foreign.ProgrammableInvoker.USE_INTRINSICS=false
+ *   --enable-native-access=ALL-UNNAMED
+ *   -Xbatch
+ *   -XX:+UseZGC
+ *   TestStackWalk
+ */
+/*
+ * @test id=shenandoah
+ * @requires (((os.arch == "amd64" | os.arch == "x86_64") & sun.arch.data.model == "64") | os.arch == "aarch64")
+ * @requires vm.gc.Shenandoah
+ * @library /test/lib
+ * @build sun.hotspot.WhiteBox
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller sun.hotspot.WhiteBox
+ *
+ * @run main/othervm
+ *   -Xbootclasspath/a:.
+ *   -XX:+UnlockDiagnosticVMOptions
+ *   -XX:+WhiteBoxAPI
+ *   -Djdk.internal.foreign.ProgrammableInvoker.USE_INTRINSICS=true
+ *   --enable-native-access=ALL-UNNAMED
+ *   -Xbatch
+ *   -XX:+UseShenandoahGC
+ *   TestStackWalk
+ *
+ * @run main/othervm
+ *   -Xbootclasspath/a:.
+ *   -XX:+UnlockDiagnosticVMOptions
+ *   -XX:+WhiteBoxAPI
+ *   -Djdk.internal.foreign.ProgrammableInvoker.USE_INTRINSICS=false
+ *   --enable-native-access=ALL-UNNAMED
+ *   -Xbatch
+ *   -XX:+UseShenandoahGC
  *   TestStackWalk
  */
 


### PR DESCRIPTION
Hi,

This patch re-writes the prologue and epilogue code of upcalls to model what is done for JNI by `JavaCallWrapper`. The old code did more or less the inverse of what was happening for downcalls, but this is not correct. The new code uses a pair of calls in the prologue and epilogue to `ProgrammableUpcallHandler::on_entry` and `ProgrammableUpcallHandler::on_exit`.

We now also need to save a little bit more information about the entry frame, namely the `JNIHandle` block that the prologue allocates, and the old handle block to restore later and for the GC to inspect. I've expanded the existing `AuxiliarySaves` struct for this and renamed and moved it to be a nested type in `OptimizedEntryBlob`. The move is mostly to avoid circular dependencies between headers.

During this rewrite, I also noticed that the return value of an upcall was not properly spilled around a call to detach a thread in the epilogue (only needed when we attached it in the prologue). Since we now always have a call in the epilogue, I've added the missing spill and fill code.

Since this was not caught by our existing testing, I've added an additional mode to TestUpcall to run test cases on a separate thread as well. I've split the three cases in TestUpcall into separate jtreg tests to keep execution times down, and to make it easier to see what failed if there is a test failure. (I'm not sure if there's a better way to ignore some testng test methods in jtreg other than throwing a `SkipException`, which also fills the console log unfortunately).

I've also added cases for testing with concurrent GCs to the test (`AsyncStackWalk`) against which the original failure was reported.

Besides that, there is a minor cleanup of some existing assert code that was copy/pasted, as well as a change to `TestByteBuffer` that was failing on WSL because of an function not being implemented, which I've now handled by skipping the test in that case.

Thanks,
Jorn

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [JDK-8269807](https://bugs.openjdk.java.net/browse/JDK-8269807): Implement the fix for JDK-8269240 in the panama-foreign repo


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.java.net/census#mcimadamore) (@mcimadamore - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/565/head:pull/565` \
`$ git checkout pull/565`

Update a local copy of the PR: \
`$ git checkout pull/565` \
`$ git pull https://git.openjdk.java.net/panama-foreign pull/565/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 565`

View PR using the GUI difftool: \
`$ git pr show -t 565`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/panama-foreign/pull/565.diff">https://git.openjdk.java.net/panama-foreign/pull/565.diff</a>

</details>
