### PR TITLE
8261972: CLinker.C_VA_LIST layout does not match platform layout for va_list

### DIFF
--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/CLinker.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/CLinker.java
@@ -87,7 +87,6 @@ import static jdk.internal.foreign.PlatformLayouts.*;
  *       the platform's address size (see {@link MemoryLayouts#ADDRESS}). For this purpose, the {@link CLinker#C_POINTER} layout
  *       constant can  be used;</li>
  *       <li>If {@code C} is {@code MemorySegment.class}, then {@code L} must be a {@code GroupLayout}</li>
- *       <li>If {@code C} is {@code VaList.class}, then {@code L} must be {@link CLinker#C_VA_LIST}</li>
  *     </ul>
  *     </li>
  * </ul>
@@ -268,10 +267,6 @@ public sealed interface CLinker permits AbstractCLinker {
      * The {@code T*} native type.
      */
     ValueLayout C_POINTER = pick(SysV.C_POINTER, Win64.C_POINTER, AArch64.C_POINTER);
-    /**
-     * The layout for the {@code va_list} C type
-     */
-    MemoryLayout C_VA_LIST = pick(SysV.C_VA_LIST, Win64.C_VA_LIST, AArch64.C_VA_LIST);
 
     /**
      * Returns a memory layout that is suitable to use as the layout for variadic arguments in a specialized
@@ -432,7 +427,8 @@ public sealed interface CLinker permits AbstractCLinker {
     /**
      * An interface that models a C {@code va_list}.
      * <p>
-     * A va list is a stateful cursor used to iterate over a set of variadic arguments.
+     * A va list is a stateful cursor used to iterate over a set of variadic arguments. A va list can be passed
+     * {@linkplain #address() by reference} e.g. to a downcall method handle.
      * <p>
      * Per the C specification (see C standard 6.5.2.2 Function calls - item 6),
      * arguments to variadic calls are erased by way of 'default argument promotions',

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/SharedUtils.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/SharedUtils.java
@@ -531,25 +531,6 @@ public class SharedUtils {
         return methodType(mt.returnType(), params);
     }
 
-    public static MethodHandle unboxVaLists(MethodType type, MethodHandle handle, MethodHandle unboxer) {
-        for (int i = 0; i < type.parameterCount(); i++) {
-            if (type.parameterType(i) == VaList.class) {
-               handle = filterArguments(handle, i + 1, unboxer); // +1 for leading address
-            }
-        }
-        return handle;
-    }
-
-    public static MethodHandle boxVaLists(MethodHandle handle, MethodHandle boxer) {
-        MethodType type = handle.type();
-        for (int i = 0; i < type.parameterCount(); i++) {
-            if (type.parameterType(i) == VaList.class) {
-               handle = filterArguments(handle, i, boxer);
-            }
-        }
-        return handle;
-    }
-
     static void checkType(Class<?> actualType, Class<?> expectedType) {
         if (expectedType != actualType) {
             throw new IllegalArgumentException(

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/SharedUtils.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/SharedUtils.java
@@ -522,15 +522,6 @@ public class SharedUtils {
         };
     }
 
-    public static MethodType convertVaListCarriers(MethodType mt, Class<?> carrier) {
-        Class<?>[] params = new Class<?>[mt.parameterCount()];
-        for (int i = 0; i < params.length; i++) {
-            Class<?> pType = mt.parameterType(i);
-            params[i] = ((pType == VaList.class) ? carrier : pType);
-        }
-        return methodType(mt.returnType(), params);
-    }
-
     static void checkType(Class<?> actualType, Class<?> expectedType) {
         if (expectedType != actualType) {
             throw new IllegalArgumentException(

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/aarch64/linux/LinuxAArch64Linker.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/aarch64/linux/LinuxAArch64Linker.java
@@ -50,21 +50,6 @@ public final class LinuxAArch64Linker extends AbstractCLinker {
 
     static final long ADDRESS_SIZE = 64; // bits
 
-    private static final MethodHandle MH_unboxVaList;
-    private static final MethodHandle MH_boxVaList;
-
-    static {
-        try {
-            MethodHandles.Lookup lookup = MethodHandles.lookup();
-            MH_unboxVaList = lookup.findVirtual(VaList.class, "address",
-                MethodType.methodType(MemoryAddress.class));
-            MH_boxVaList = MethodHandles.insertArguments(lookup.findStatic(LinuxAArch64Linker.class, "newVaListOfAddress",
-                MethodType.methodType(VaList.class, MemoryAddress.class, ResourceScope.class)), 1, ResourceScope.globalScope());
-        } catch (ReflectiveOperationException e) {
-            throw new ExceptionInInitializerError(e);
-        }
-    }
-
     public static LinuxAArch64Linker getInstance() {
         if (instance == null) {
             instance = new LinuxAArch64Linker();
@@ -76,8 +61,7 @@ public final class LinuxAArch64Linker extends AbstractCLinker {
     public final MethodHandle downcallHandle(MethodType type, FunctionDescriptor function) {
         Objects.requireNonNull(type);
         Objects.requireNonNull(function);
-        MethodType llMt = SharedUtils.convertVaListCarriers(type, LinuxAArch64VaList.CARRIER);
-        MethodHandle handle = CallArranger.arrangeDowncall(llMt, function);
+        MethodHandle handle = CallArranger.arrangeDowncall(type, function);
         if (!type.returnType().equals(MemorySegment.class)) {
             // not returning segment, just insert a throwing allocator
             handle = MethodHandles.insertArguments(handle, 1, SharedUtils.THROWING_ALLOCATOR);

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/aarch64/linux/LinuxAArch64Linker.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/aarch64/linux/LinuxAArch64Linker.java
@@ -82,7 +82,6 @@ public final class LinuxAArch64Linker extends AbstractCLinker {
             // not returning segment, just insert a throwing allocator
             handle = MethodHandles.insertArguments(handle, 1, SharedUtils.THROWING_ALLOCATOR);
         }
-        handle = SharedUtils.unboxVaLists(type, handle, MH_unboxVaList);
         return handle;
     }
 
@@ -92,7 +91,6 @@ public final class LinuxAArch64Linker extends AbstractCLinker {
         Objects.requireNonNull(target);
         Objects.requireNonNull(function);
         SharedUtils.checkExceptions(target);
-        target = SharedUtils.boxVaLists(target, MH_boxVaList);
         return UpcallStubs.upcallAddress(CallArranger.arrangeUpcall(target, target.type(), function), (ResourceScopeImpl) scope);
     }
 

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/aarch64/macos/MacOsAArch64Linker.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/aarch64/macos/MacOsAArch64Linker.java
@@ -54,21 +54,6 @@ public final class MacOsAArch64Linker extends AbstractCLinker {
 
     static final long ADDRESS_SIZE = 64; // bits
 
-    private static final MethodHandle MH_unboxVaList;
-    private static final MethodHandle MH_boxVaList;
-
-    static {
-        try {
-            MethodHandles.Lookup lookup = MethodHandles.lookup();
-            MH_unboxVaList = lookup.findVirtual(VaList.class, "address",
-                MethodType.methodType(MemoryAddress.class));
-            MH_boxVaList = MethodHandles.insertArguments(lookup.findStatic(MacOsAArch64Linker.class, "newVaListOfAddress",
-                MethodType.methodType(VaList.class, MemoryAddress.class, ResourceScope.class)), 1, ResourceScope.globalScope());
-        } catch (ReflectiveOperationException e) {
-            throw new ExceptionInInitializerError(e);
-        }
-    }
-
     public static MacOsAArch64Linker getInstance() {
         if (instance == null) {
             instance = new MacOsAArch64Linker();
@@ -80,8 +65,7 @@ public final class MacOsAArch64Linker extends AbstractCLinker {
     public final MethodHandle downcallHandle(MethodType type, FunctionDescriptor function) {
         Objects.requireNonNull(type);
         Objects.requireNonNull(function);
-        MethodType llMt = SharedUtils.convertVaListCarriers(type, MacOsAArch64VaList.CARRIER);
-        MethodHandle handle = CallArranger.arrangeDowncall(llMt, function);
+        MethodHandle handle = CallArranger.arrangeDowncall(type, function);
         if (!type.returnType().equals(MemorySegment.class)) {
             // not returning segment, just insert a throwing allocator
             handle = MethodHandles.insertArguments(handle, 1, SharedUtils.THROWING_ALLOCATOR);

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/aarch64/macos/MacOsAArch64Linker.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/aarch64/macos/MacOsAArch64Linker.java
@@ -86,7 +86,6 @@ public final class MacOsAArch64Linker extends AbstractCLinker {
             // not returning segment, just insert a throwing allocator
             handle = MethodHandles.insertArguments(handle, 1, SharedUtils.THROWING_ALLOCATOR);
         }
-        handle = SharedUtils.unboxVaLists(type, handle, MH_unboxVaList);
         return handle;
     }
 
@@ -95,7 +94,6 @@ public final class MacOsAArch64Linker extends AbstractCLinker {
         Objects.requireNonNull(scope);
         Objects.requireNonNull(target);
         Objects.requireNonNull(function);
-        target = SharedUtils.boxVaLists(target, MH_boxVaList);
         return UpcallStubs.upcallAddress(CallArranger.arrangeUpcall(target, target.type(), function), (ResourceScopeImpl) scope);
     }
 

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/x64/sysv/SysVx64Linker.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/x64/sysv/SysVx64Linker.java
@@ -92,7 +92,6 @@ public final class SysVx64Linker extends AbstractCLinker {
             // not returning segment, just insert a throwing allocator
             handle = MethodHandles.insertArguments(handle, 1, SharedUtils.THROWING_ALLOCATOR);
         }
-        handle = SharedUtils.unboxVaLists(type, handle, MH_unboxVaList);
         return handle;
     }
 
@@ -102,7 +101,6 @@ public final class SysVx64Linker extends AbstractCLinker {
         Objects.requireNonNull(target);
         Objects.requireNonNull(function);
         SharedUtils.checkExceptions(target);
-        target = SharedUtils.boxVaLists(target, MH_boxVaList);
         return UpcallStubs.upcallAddress(CallArranger.arrangeUpcall(target, target.type(), function), (ResourceScopeImpl) scope);
     }
 

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/x64/sysv/SysVx64Linker.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/x64/sysv/SysVx64Linker.java
@@ -54,21 +54,6 @@ public final class SysVx64Linker extends AbstractCLinker {
 
     static final long ADDRESS_SIZE = 64; // bits
 
-    private static final MethodHandle MH_unboxVaList;
-    private static final MethodHandle MH_boxVaList;
-
-    static {
-        try {
-            MethodHandles.Lookup lookup = MethodHandles.lookup();
-            MH_unboxVaList = lookup.findVirtual(VaList.class, "address",
-                MethodType.methodType(MemoryAddress.class));
-            MH_boxVaList = MethodHandles.insertArguments(lookup.findStatic(SysVx64Linker.class, "newVaListOfAddress",
-                MethodType.methodType(VaList.class, MemoryAddress.class, ResourceScope.class)), 1, ResourceScope.globalScope());
-        } catch (ReflectiveOperationException e) {
-            throw new ExceptionInInitializerError(e);
-        }
-    }
-
     public static SysVx64Linker getInstance() {
         if (instance == null) {
             instance = new SysVx64Linker();
@@ -86,8 +71,7 @@ public final class SysVx64Linker extends AbstractCLinker {
     public final MethodHandle downcallHandle(MethodType type, FunctionDescriptor function) {
         Objects.requireNonNull(type);
         Objects.requireNonNull(function);
-        MethodType llMt = SharedUtils.convertVaListCarriers(type, SysVVaList.CARRIER);
-        MethodHandle handle = CallArranger.arrangeDowncall(llMt, function);
+        MethodHandle handle = CallArranger.arrangeDowncall(type, function);
         if (!type.returnType().equals(MemorySegment.class)) {
             // not returning segment, just insert a throwing allocator
             handle = MethodHandles.insertArguments(handle, 1, SharedUtils.THROWING_ALLOCATOR);

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/x64/windows/Windowsx64Linker.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/x64/windows/Windowsx64Linker.java
@@ -93,7 +93,6 @@ public final class Windowsx64Linker extends AbstractCLinker {
             // not returning segment, just insert a throwing allocator
             handle = MethodHandles.insertArguments(handle, 1, SharedUtils.THROWING_ALLOCATOR);
         }
-        handle = SharedUtils.unboxVaLists(type, handle, MH_unboxVaList);
         return handle;
     }
 
@@ -103,7 +102,6 @@ public final class Windowsx64Linker extends AbstractCLinker {
         Objects.requireNonNull(target);
         Objects.requireNonNull(function);
         SharedUtils.checkExceptions(target);
-        target = SharedUtils.boxVaLists(target, MH_boxVaList);
         return UpcallStubs.upcallAddress(CallArranger.arrangeUpcall(target, target.type(), function), (ResourceScopeImpl) scope);
     }
 

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/x64/windows/Windowsx64Linker.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/x64/windows/Windowsx64Linker.java
@@ -55,21 +55,6 @@ public final class Windowsx64Linker extends AbstractCLinker {
 
     static final long ADDRESS_SIZE = 64; // bits
 
-    private static final MethodHandle MH_unboxVaList;
-    private static final MethodHandle MH_boxVaList;
-
-    static {
-        try {
-            MethodHandles.Lookup lookup = MethodHandles.lookup();
-            MH_unboxVaList = lookup.findVirtual(VaList.class, "address",
-                MethodType.methodType(MemoryAddress.class));
-            MH_boxVaList = MethodHandles.insertArguments(lookup.findStatic(Windowsx64Linker.class, "newVaListOfAddress",
-                MethodType.methodType(VaList.class, MemoryAddress.class, ResourceScope.class)), 1, ResourceScope.globalScope());
-        } catch (ReflectiveOperationException e) {
-            throw new ExceptionInInitializerError(e);
-        }
-    }
-
     public static Windowsx64Linker getInstance() {
         if (instance == null) {
             instance = new Windowsx64Linker();
@@ -87,8 +72,7 @@ public final class Windowsx64Linker extends AbstractCLinker {
     public final MethodHandle downcallHandle(MethodType type, FunctionDescriptor function) {
         Objects.requireNonNull(type);
         Objects.requireNonNull(function);
-        MethodType llMt = SharedUtils.convertVaListCarriers(type, WinVaList.CARRIER);
-        MethodHandle handle = CallArranger.arrangeDowncall(llMt, function);
+        MethodHandle handle = CallArranger.arrangeDowncall(type, function);
         if (!type.returnType().equals(MemorySegment.class)) {
             // not returning segment, just insert a throwing allocator
             handle = MethodHandles.insertArguments(handle, 1, SharedUtils.THROWING_ALLOCATOR);

--- a/test/jdk/java/foreign/StdLibTest.java
+++ b/test/jdk/java/foreign/StdLibTest.java
@@ -191,7 +191,7 @@ public class StdLibTest {
 
         final static MethodHandle vprintf = abi.downcallHandle(LOOKUP.lookup("vprintf").get(),
                 MethodType.methodType(int.class, MemoryAddress.class, VaList.class),
-                FunctionDescriptor.of(C_INT, C_POINTER, C_VA_LIST));
+                FunctionDescriptor.of(C_INT, C_POINTER, C_POINTER));
 
         final static MemoryAddress printfAddr = LOOKUP.lookup("printf").get();
 
@@ -328,7 +328,7 @@ public class StdLibTest {
             try (ResourceScope scope = ResourceScope.newConfinedScope()) {
                 MemorySegment formatStr = toCString(format, scope);
                 VaList vaList = VaList.make(b -> args.forEach(a -> a.accept(b, scope)), scope);
-                return (int)vprintf.invokeExact(formatStr.address(), vaList);
+                return (int)vprintf.invokeExact(formatStr.address(), vaList.address());
             }
         }
 

--- a/test/jdk/java/foreign/StdLibTest.java
+++ b/test/jdk/java/foreign/StdLibTest.java
@@ -190,7 +190,7 @@ public class StdLibTest {
                 FunctionDescriptor.of(C_INT));
 
         final static MethodHandle vprintf = abi.downcallHandle(LOOKUP.lookup("vprintf").get(),
-                MethodType.methodType(int.class, MemoryAddress.class, VaList.class),
+                MethodType.methodType(int.class, MemoryAddress.class, MemoryAddress.class),
                 FunctionDescriptor.of(C_INT, C_POINTER, C_POINTER));
 
         final static MemoryAddress printfAddr = LOOKUP.lookup("printf").get();

--- a/test/micro/org/openjdk/bench/jdk/incubator/foreign/VaList.java
+++ b/test/micro/org/openjdk/bench/jdk/incubator/foreign/VaList.java
@@ -42,7 +42,7 @@ import java.util.concurrent.TimeUnit;
 import static jdk.incubator.foreign.CLinker.C_DOUBLE;
 import static jdk.incubator.foreign.CLinker.C_INT;
 import static jdk.incubator.foreign.CLinker.C_LONG_LONG;
-import static jdk.incubator.foreign.CLinker.C_VA_LIST;
+import static jdk.incubator.foreign.CLinker.C_POINTER;
 import static jdk.incubator.foreign.CLinker.asVarArg;
 
 @BenchmarkMode(Mode.AverageTime)
@@ -68,7 +68,7 @@ public class VaList {
                 FunctionDescriptor.ofVoid(C_INT, asVarArg(C_INT), asVarArg(C_DOUBLE), asVarArg(C_LONG_LONG)));
         MH_vaList = linker.downcallHandle(lookup.lookup("vaList").get(),
                 MethodType.methodType(void.class, int.class, CLinker.VaList.class),
-                FunctionDescriptor.ofVoid(C_INT, C_VA_LIST));
+                FunctionDescriptor.ofVoid(C_INT, C_POINTER));
     }
 
     @Benchmark
@@ -85,7 +85,7 @@ public class VaList {
                             .vargFromDouble(C_DOUBLE, 2D)
                             .vargFromLong(C_LONG_LONG, 3L), scope);
             MH_vaList.invokeExact(3,
-                    vaList);
+                    vaList.address());
         }
     }
 }


### PR DESCRIPTION
This change removes the `CLinker::VA_LIST` layout. This layout was just an alias for a pointer layout, and was not the correct layout of a `VaList` in given platform. In fact, in some platforms a `VaList` is defined as a one-array element, whereas in other platforms it is defined as a pointer. In all cases, a VaList is always passed to a function by reference, so using `C_POINTER` as a layout, and using `VaList::address` is enough to satisfy the downcall/upcall use cases. Storing valists inside struct fields is a different topic, but it's such a rare/corner/odd use case that I don't think we should distort the API because of that.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [JDK-8261972](https://bugs.openjdk.java.net/browse/JDK-8261972): CLinker.C_VA_LIST layout does not match platform layout for va_list


### Reviewers
 * [Athijegannathan Sundararajan](https://openjdk.java.net/census#sundar) (@sundararajana - Committer) ⚠️ Review applies to 58b571419289d0a31f6d8476f785fa6cbed98f16
 * [Jorn Vernee](https://openjdk.java.net/census#jvernee) (@JornVernee - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/567/head:pull/567` \
`$ git checkout pull/567`

Update a local copy of the PR: \
`$ git checkout pull/567` \
`$ git pull https://git.openjdk.java.net/panama-foreign pull/567/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 567`

View PR using the GUI difftool: \
`$ git pr show -t 567`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/panama-foreign/pull/567.diff">https://git.openjdk.java.net/panama-foreign/pull/567.diff</a>

</details>
