### PR TITLE
Check for mixed access - remove mem barriers

### DIFF
--- a/src/hotspot/share/opto/vectorIntrinsics.cpp
+++ b/src/hotspot/share/opto/vectorIntrinsics.cpp
@@ -760,8 +760,19 @@ bool LibraryCallKit::inline_vector_mem_operation(bool is_store) {
   SafePointNode* old_map = clone_map();
 
   Node* addr = make_unsafe_address(base, offset, (is_mask ? T_BOOLEAN : elem_bt), true);
+  
+  // This check is repetition of some checks from inline_unsafe_access(), used to determine if barriers are needed
+  // Not full scope of checks is performed, we check only if access can be mixed
+  const Type *const base_type = gvn().type(base);
+
+  // Is off heap access (true implies can_access_non_heap = true)
+  const bool off_heap_access = TypePtr::NULL_PTR == base_type;
+
   // Can base be NULL? Otherwise, always on-heap access.
-  bool can_access_non_heap = TypePtr::NULL_PTR->higher_equal(gvn().type(base));
+  const bool can_access_non_heap = TypePtr::NULL_PTR->higher_equal(base_type);
+
+  // Not determined access base can and can not be null.
+  const bool mixed_access = !(off_heap_access == can_access_non_heap);
 
   const TypePtr *addr_type = gvn().type(addr)->isa_ptr();
   const TypeAryPtr* arr_type = addr_type->isa_aryptr();
@@ -823,7 +834,7 @@ bool LibraryCallKit::inline_vector_mem_operation(bool is_store) {
 
   const TypeInstPtr* vbox_type = TypeInstPtr::make_exact(TypePtr::NotNull, vbox_klass);
 
-  if (can_access_non_heap) {
+  if (mixed_access) {
     insert_mem_bar(Op_MemBarCPUOrder);
   }
 
@@ -870,7 +881,7 @@ bool LibraryCallKit::inline_vector_mem_operation(bool is_store) {
 
   old_map->destruct(&_gvn);
 
-  if (can_access_non_heap) {
+  if (mixed_access) {
     insert_mem_bar(Op_MemBarCPUOrder);
   }
 

--- a/src/hotspot/share/opto/vectorIntrinsics.cpp
+++ b/src/hotspot/share/opto/vectorIntrinsics.cpp
@@ -760,7 +760,7 @@ bool LibraryCallKit::inline_vector_mem_operation(bool is_store) {
   SafePointNode* old_map = clone_map();
 
   Node* addr = make_unsafe_address(base, offset, (is_mask ? T_BOOLEAN : elem_bt), true);
-  
+
   // This check is repetition of some checks from inline_unsafe_access(), used to determine if barriers are needed
   // Not full scope of checks is performed, we check only if access can be mixed
   const Type *const base_type = gvn().type(base);

--- a/src/java.base/share/classes/jdk/internal/misc/X-ScopedMemoryAccess.java.template
+++ b/src/java.base/share/classes/jdk/internal/misc/X-ScopedMemoryAccess.java.template
@@ -406,10 +406,15 @@ public class ScopedMemoryAccess {
                 scope.checkValidState();
             }
 
-            return VectorSupport.load(vmClass, e, length,
-                    BufferAccess.bufferBase(bb), BufferAccess.bufferAddress(bb, offset),
-                    bb, offset, s,
-                    defaultImpl);
+            Object base = BufferAccess.bufferBase(bb);
+            if (base == null) {
+              return VectorSupport.load(vmClass, e, length,
+                      null, BufferAccess.bufferAddress(bb, offset),
+                      bb, offset, s,
+                      defaultImpl);
+            } else {
+              throw new IllegalStateException("Only off-heap segments are supported");
+            }
         } finally {
             Reference.reachabilityFence(scope);
         }
@@ -448,11 +453,17 @@ public class ScopedMemoryAccess {
                 scope.checkValidState();
             }
 
-            VectorSupport.store(vmClass, e, length,
-                    BufferAccess.bufferBase(bb), BufferAccess.bufferAddress(bb, offset),
-                    v,
-                    bb, offset,
-                    defaultImpl);
+            final Object base = BufferAccess.bufferBase(bb);
+
+            if (base == null) {
+              VectorSupport.store(vmClass, e, length,
+                                  null, BufferAccess.bufferAddress(bb, offset),
+                                  v,
+                                  bb, offset,
+                                  defaultImpl);
+            } else {
+              throw new IllegalStateException("Only off-heap segments are supported");
+            }
         } finally {
             Reference.reachabilityFence(scope);
         }

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/ShortVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/ShortVector.java
@@ -3532,6 +3532,7 @@ public abstract class ShortVector extends AbstractVector<Short> {
     @ForceInline
     final
     ShortVector fromByteArray0Template(byte[] a, int offset) {
+        Objects.requireNonNull(a);
         ShortSpecies vsp = vspecies();
         return VectorSupport.load(
             vsp.vectorType(), vsp.elementType(), vsp.laneCount(),
@@ -3550,14 +3551,18 @@ public abstract class ShortVector extends AbstractVector<Short> {
     final
     ShortVector fromByteBuffer0Template(ByteBuffer bb, int offset) {
         ShortSpecies vsp = vspecies();
-        return ScopedMemoryAccess.loadFromByteBuffer(
-                vsp.vectorType(), vsp.elementType(), vsp.laneCount(),
-                bb, offset, vsp,
-                (buf, off, s) -> {
-                    ByteBuffer wb = wrapper(buf, NATIVE_ENDIAN);
-                    return s.ldOp(wb, off,
-                            (wb_, o, i) -> wb_.getShort(o + i * 2));
-                });
+        if (!bb.isDirect()) {
+          return fromByteArray0(bb.array(), offset);
+        } else {
+          return ScopedMemoryAccess.loadFromByteBuffer(
+                  vsp.vectorType(), vsp.elementType(), vsp.laneCount(),
+                  bb, offset, vsp,
+                  (buf, off, s) -> {
+                      ByteBuffer wb = wrapper(buf, NATIVE_ENDIAN);
+                      return s.ldOp(wb, off,
+                              (wb_, o, i) -> wb_.getShort(o + i * 2));
+                  });
+        }
     }
 
     // Unchecked storing operations in native byte order.
@@ -3584,6 +3589,7 @@ public abstract class ShortVector extends AbstractVector<Short> {
     @ForceInline
     final
     void intoByteArray0Template(byte[] a, int offset) {
+        Objects.requireNonNull(a);
         ShortSpecies vsp = vspecies();
         VectorSupport.store(
             vsp.vectorType(), vsp.elementType(), vsp.laneCount(),
@@ -3599,15 +3605,19 @@ public abstract class ShortVector extends AbstractVector<Short> {
     @ForceInline
     final
     void intoByteBuffer0(ByteBuffer bb, int offset) {
-        ShortSpecies vsp = vspecies();
-        ScopedMemoryAccess.storeIntoByteBuffer(
-                vsp.vectorType(), vsp.elementType(), vsp.laneCount(),
-                this, bb, offset,
-                (buf, off, v) -> {
-                    ByteBuffer wb = wrapper(buf, NATIVE_ENDIAN);
-                    v.stOp(wb, off,
-                            (wb_, o, i, e) -> wb_.putShort(o + i * 2, e));
-                });
+        if (!bb.isDirect()) {
+          intoByteArray0(bb.array(), offset);
+        } else {
+          ShortSpecies vsp = vspecies();
+          ScopedMemoryAccess.storeIntoByteBuffer(
+                  vsp.vectorType(), vsp.elementType(), vsp.laneCount(),
+                  this, bb, offset,
+                  (buf, off, v) -> {
+                      ByteBuffer wb = wrapper(buf, NATIVE_ENDIAN);
+                      v.stOp(wb, off,
+                              (wb_, o, i, e) -> wb_.putShort(o + i * 2, e));
+                  });
+        }
     }
 
     // End of low-level memory operations.

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/X-Vector.java.template
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/X-Vector.java.template
@@ -4500,6 +4500,7 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
     @ForceInline
     final
     $abstractvectortype$ fromByteArray0Template(byte[] a, int offset) {
+        Objects.requireNonNull(a);
         $Type$Species vsp = vspecies();
         return VectorSupport.load(
             vsp.vectorType(), vsp.elementType(), vsp.laneCount(),
@@ -4518,14 +4519,18 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
     final
     $abstractvectortype$ fromByteBuffer0Template(ByteBuffer bb, int offset) {
         $Type$Species vsp = vspecies();
-        return ScopedMemoryAccess.loadFromByteBuffer(
-                vsp.vectorType(), vsp.elementType(), vsp.laneCount(),
-                bb, offset, vsp,
-                (buf, off, s) -> {
-                    ByteBuffer wb = wrapper(buf, NATIVE_ENDIAN);
-                    return s.ldOp(wb, off,
-                            (wb_, o, i) -> wb_.get{#if[byte]?(:$Type$(}o + i * $sizeInBytes$));
-                });
+        if (!bb.isDirect()) {
+          return fromByteArray0(bb.array(), offset);
+        } else {
+          return ScopedMemoryAccess.loadFromByteBuffer(
+                  vsp.vectorType(), vsp.elementType(), vsp.laneCount(),
+                  bb, offset, vsp,
+                  (buf, off, s) -> {
+                      ByteBuffer wb = wrapper(buf, NATIVE_ENDIAN);
+                      return s.ldOp(wb, off,
+                              (wb_, o, i) -> wb_.get{#if[byte]?(:$Type$(}o + i * $sizeInBytes$));
+                  });
+        }
     }
 
     // Unchecked storing operations in native byte order.
@@ -4552,6 +4557,7 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
     @ForceInline
     final
     void intoByteArray0Template(byte[] a, int offset) {
+        Objects.requireNonNull(a);
         $Type$Species vsp = vspecies();
         VectorSupport.store(
             vsp.vectorType(), vsp.elementType(), vsp.laneCount(),
@@ -4567,15 +4573,19 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
     @ForceInline
     final
     void intoByteBuffer0(ByteBuffer bb, int offset) {
-        $Type$Species vsp = vspecies();
-        ScopedMemoryAccess.storeIntoByteBuffer(
-                vsp.vectorType(), vsp.elementType(), vsp.laneCount(),
-                this, bb, offset,
-                (buf, off, v) -> {
-                    ByteBuffer wb = wrapper(buf, NATIVE_ENDIAN);
-                    v.stOp(wb, off,
-                            (wb_, o, i, e) -> wb_.put{#if[byte]?(:$Type$(}o + i * $sizeInBytes$, e));
-                });
+        if (!bb.isDirect()) {
+          intoByteArray0(bb.array(), offset);
+        } else {
+          $Type$Species vsp = vspecies();
+          ScopedMemoryAccess.storeIntoByteBuffer(
+                  vsp.vectorType(), vsp.elementType(), vsp.laneCount(),
+                  this, bb, offset,
+                  (buf, off, v) -> {
+                      ByteBuffer wb = wrapper(buf, NATIVE_ENDIAN);
+                      v.stOp(wb, off,
+                              (wb_, o, i, e) -> wb_.put{#if[byte]?(:$Type$(}o + i * $sizeInBytes$, e));
+                  });
+        }
     }
 
     // End of low-level memory operations.

--- a/test/micro/org/openjdk/bench/jdk/incubator/vector/ByteBufferVectorAccess.java
+++ b/test/micro/org/openjdk/bench/jdk/incubator/vector/ByteBufferVectorAccess.java
@@ -1,0 +1,96 @@
+/*
+ *  Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ *  Copyright (c) 2021, Rado Smogura. All rights reserved.
+ *
+ *  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ *  This code is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License version 2 only, as
+ *  published by the Free Software Foundation.
+ *
+ *  This code is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ *  version 2 for more details (a copy is included in the LICENSE file that
+ *  accompanied this code).
+ *
+ *  You should have received a copy of the GNU General Public License version
+ *  2 along with this work; if not, write to the Free Software Foundation,
+ *  Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ *  Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ *  or visit www.oracle.com if you need additional information or have any
+ *  questions.
+ *
+ */
+package org.openjdk.bench.jdk.incubator.vector;
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.util.concurrent.TimeUnit;
+import jdk.incubator.vector.ByteVector;
+import jdk.incubator.vector.VectorSpecies;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.CompilerControl;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+
+@BenchmarkMode(Mode.AverageTime)
+@Warmup(iterations = 5, time = 500, timeUnit = TimeUnit.MILLISECONDS)
+@Measurement(iterations = 10, time = 500, timeUnit = TimeUnit.MILLISECONDS)
+@State(org.openjdk.jmh.annotations.Scope.Thread)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Fork(value = 1, jvmArgsAppend = {
+    "--add-modules=jdk.incubator.foreign,jdk.incubator.vector",
+    "-Dforeign.restricted=permit",
+    "--enable-native-access", "ALL-UNNAMED",
+    "-Djdk.incubator.vector.VECTOR_ACCESS_OOB_CHECK=1"})
+public class ByteBufferVectorAccess {
+  private static final VectorSpecies<Byte> SPECIES = VectorSpecies.ofLargestShape(byte.class);
+
+  @Param("1024")
+  private int size;
+
+  ByteBuffer directIn, directOut;
+  ByteBuffer heapIn, heapOut;
+
+  @Setup
+  public void setup() {
+    directIn = ByteBuffer.allocateDirect(size);
+    directOut = ByteBuffer.allocateDirect(size);
+
+    heapIn = ByteBuffer.wrap(new byte[size]);
+    heapOut = ByteBuffer.wrap(new byte[size]);
+  }
+
+  @Benchmark
+  public void directBuffers() {
+    copyMemory(directIn, directOut);
+  }
+
+  @Benchmark
+  public void heapBuffers() {
+    copyMemory(heapIn, heapOut);
+  }
+
+  @Benchmark
+  public void pollutedBuffers() {
+    copyMemory(directIn, directOut);
+    copyMemory(heapIn, heapOut);
+  }
+
+  @CompilerControl(CompilerControl.Mode.DONT_INLINE)
+  protected void copyMemory(ByteBuffer in, ByteBuffer out) {
+    for (int i=0; i < SPECIES.loopBound(in.limit()); i += SPECIES.vectorByteSize()) {
+      final var v = ByteVector.fromByteBuffer(SPECIES, in, i, ByteOrder.nativeOrder());
+      v.intoByteBuffer(out, i, ByteOrder.nativeOrder());
+    }
+  }
+}


### PR DESCRIPTION
That's for previous PR, which I destroyed with bad merge from master.

I wonder if this can look like this?

```
Benchmark                               (size)  Mode  Cnt   Score    Error  Units
ByteBufferVectorAccess.directBuffers      1024  avgt   10  27.119 ?  0.186  ns/op
ByteBufferVectorAccess.heapBuffers        1024  avgt   10  28.501 ?  0.118  ns/op
ByteBufferVectorAccess.pollutedBuffers    1024  avgt   10  64.354 ? 27.778  ns/op
Finished running test 'micro:ByteBufferVectorAccess'
```

https://github.com/openjdk/panama-foreign/pull/566

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Integration blocker
&nbsp;⚠️ Whitespace errors (failed with the updated jcheck configuration)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/panama-foreign.git pull/573/head:pull/573` \
`$ git checkout pull/573`

Update a local copy of the PR: \
`$ git checkout pull/573` \
`$ git pull https://git.openjdk.org/panama-foreign.git pull/573/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 573`

View PR using the GUI difftool: \
`$ git pr show -t 573`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/panama-foreign/pull/573.diff">https://git.openjdk.org/panama-foreign/pull/573.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/panama-foreign/pull/573#issuecomment-886079403)