### PR TITLE
8271922: After var handle support for boolean and MemoryAddress carrier jextract fails to compile

### DIFF
--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/ConstantBuilder.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/ConstantBuilder.java
@@ -369,17 +369,7 @@ public class ConstantBuilder extends ClassSourceBuilder {
         } else {
             CLinker.TypeKind kind = (CLinker.TypeKind) vl.attribute(CLinker.TypeKind.ATTR_NAME).orElseThrow(
                     () -> new IllegalStateException("Unexpected value layout: could not determine ABI class"));
-            return switch (kind) {
-                case BOOL -> "C_BOOL";
-                case CHAR -> "C_CHAR";
-                case SHORT -> "C_SHORT";
-                case INT -> "C_INT";
-                case LONG -> "C_LONG";
-                case LONG_LONG -> "C_LONG_LONG";
-                case FLOAT -> "C_FLOAT";
-                case DOUBLE -> "C_DOUBLE";
-                case POINTER -> "C_POINTER";
-            };
+            return "C_" + kind.name();
         }
     }
 

--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/ConstantBuilder.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/ConstantBuilder.java
@@ -370,6 +370,7 @@ public class ConstantBuilder extends ClassSourceBuilder {
             CLinker.TypeKind kind = (CLinker.TypeKind) vl.attribute(CLinker.TypeKind.ATTR_NAME).orElseThrow(
                     () -> new IllegalStateException("Unexpected value layout: could not determine ABI class"));
             return switch (kind) {
+                case BOOL -> "C_BOOL";
                 case CHAR -> "C_CHAR";
                 case SHORT -> "C_SHORT";
                 case INT -> "C_INT";


### PR DESCRIPTION
added BOOL case

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [JDK-8271922](https://bugs.openjdk.java.net/browse/JDK-8271922): After var handle support for boolean and MemoryAddress carrier jextract fails to compile


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.java.net/census#mcimadamore) (@mcimadamore - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/574/head:pull/574` \
`$ git checkout pull/574`

Update a local copy of the PR: \
`$ git checkout pull/574` \
`$ git pull https://git.openjdk.java.net/panama-foreign pull/574/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 574`

View PR using the GUI difftool: \
`$ git pr show -t 574`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/panama-foreign/pull/574.diff">https://git.openjdk.java.net/panama-foreign/pull/574.diff</a>

</details>
