### PR TITLE
8273382: jextract should generete alias layout for pointer typedefs

### DIFF
--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/HeaderFileBuilder.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/HeaderFileBuilder.java
@@ -239,6 +239,16 @@ abstract class HeaderFileBuilder extends ClassSourceBuilder {
         }
     }
 
+    void emitPointerTypedef(String name) {
+        incrAlign();
+        indent();
+        append(MEMBER_MODS);
+        append(" ValueLayout ");
+        append(uniqueNestedClassName(name));
+        append(" = C_POINTER;\n");
+        decrAlign();
+    }
+
     private boolean primitiveKindSupported(Type.Primitive.Kind kind) {
         return switch(kind) {
             case Short, Int, Long, LongLong, Float, Double, Char -> true;

--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/OutputFactory.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/OutputFactory.java
@@ -368,6 +368,8 @@ public class OutputFactory implements Declaration.Visitor<Void, Declaration> {
                 if (funcIntfName != null) {
                     addFunctionTypedef(Type.typedef(tree.name(), tree.type()), funcIntfName);
                 }
+            } else if (((TypeImpl)type).isPointer()) {
+                toplevelBuilder.addTypedef(tree.name(), null, type);
             }
         }
         return null;

--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/ToplevelBuilder.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/ToplevelBuilder.java
@@ -106,6 +106,9 @@ class ToplevelBuilder extends JavaSourceBuilder {
         if (type instanceof Type.Primitive) {
             // primitive
             nextHeader().emitPrimitiveTypedef((Type.Primitive)type, name);
+        } else if (((TypeImpl)type).isPointer()) {
+            // pointer typedef
+            nextHeader().emitPointerTypedef(name);
         } else {
             TypedefBuilder builder = new TypedefBuilder(this, name, superClass);
             builders.add(builder);

--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/TypeImpl.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/TypeImpl.java
@@ -336,7 +336,7 @@ public abstract class TypeImpl implements Type {
         }
     }
 
-    public boolean isPointer() { 
+    public boolean isPointer() {
         return this instanceof Type.Delegated delegated &&
                 delegated.kind() == Type.Delegated.Kind.POINTER;
     }

--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/TypeImpl.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/TypeImpl.java
@@ -336,6 +336,11 @@ public abstract class TypeImpl implements Type {
         }
     }
 
+    public boolean isPointer() { 
+        return this instanceof Type.Delegated delegated &&
+                delegated.kind() == Type.Delegated.Kind.POINTER;
+    }
+
     @Override
     public String toString() {
         return PrettyPrinter.type(this);

--- a/test/jdk/tools/jextract/Test8273382.java
+++ b/test/jdk/tools/jextract/Test8273382.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.nio.file.Path;
+import org.testng.annotations.Test;
+import static org.testng.Assert.assertNotNull;
+
+/*
+ * @test
+ * @modules jdk.incubator.jextract
+ * @library /test/lib
+ * @build JextractToolRunner
+ * @bug 8273382
+ * @summary jextract should generete alias layout for pointer typedefs
+ * @run testng/othervm --enable-native-access=jdk.incubator.jextract Test8273382
+ */
+public class Test8273382 extends JextractToolRunner {
+    @Test
+    public void testPointerTypedefs() {
+        Path test8273382Output = getOutputFilePath("test8273382gen");
+        Path test8273382H = getInputFilePath("test8273382.h");
+        run("-d", test8273382Output.toString(), test8273382H.toString()).checkSuccess();
+        try(Loader loader = classLoader(test8273382Output)) {
+            Class<?> headerCls = loader.loadClass("test8273382_h");
+            assertNotNull(findField(headerCls, "int_ptr_t"));
+            assertNotNull(findField(headerCls, "point_ptr_t"));
+        } finally {
+            deleteDir(test8273382Output);
+        }
+    }
+}

--- a/test/jdk/tools/jextract/test8273382.h
+++ b/test/jdk/tools/jextract/test8273382.h
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+typedef int* int_ptr_t;
+
+struct Point {
+    int x, y;
+};
+
+typedef struct Point* point_ptr_t;


### PR DESCRIPTION
Generating C_POINTER layout variables for pointer typedefs in the header

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [JDK-8273382](https://bugs.openjdk.java.net/browse/JDK-8273382): jextract should generete alias layout for pointer typedefs


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.java.net/census#mcimadamore) (@mcimadamore - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/575/head:pull/575` \
`$ git checkout pull/575`

Update a local copy of the PR: \
`$ git checkout pull/575` \
`$ git pull https://git.openjdk.java.net/panama-foreign pull/575/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 575`

View PR using the GUI difftool: \
`$ git pr show -t 575`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/panama-foreign/pull/575.diff">https://git.openjdk.java.net/panama-foreign/pull/575.diff</a>

</details>
