### PR TITLE
8274219: Add back generic factory to create value layouts

### DIFF
--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/AbstractLayout.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/AbstractLayout.java
@@ -41,6 +41,7 @@ import java.util.OptionalLong;
 
 import static java.lang.constant.ConstantDescs.BSM_GET_STATIC_FINAL;
 import static java.lang.constant.ConstantDescs.BSM_INVOKE;
+import static java.lang.constant.ConstantDescs.CD_Class;
 import static java.lang.constant.ConstantDescs.CD_String;
 import static java.lang.constant.ConstantDescs.CD_long;
 
@@ -209,6 +210,9 @@ abstract non-sealed class AbstractLayout implements MemoryLayout {
 
     static final MethodHandleDesc MH_UNION = MethodHandleDesc.ofMethod(DirectMethodHandleDesc.Kind.INTERFACE_STATIC, CD_MEMORY_LAYOUT, "unionLayout",
                 MethodTypeDesc.of(CD_GROUP_LAYOUT, CD_MEMORY_LAYOUT.arrayType()));
+
+    static final MethodHandleDesc MH_VALUE = MethodHandleDesc.ofMethod(DirectMethodHandleDesc.Kind.INTERFACE_STATIC, CD_MEMORY_LAYOUT, "valueLayout",
+            MethodTypeDesc.of(CD_VALUE_LAYOUT, CD_Class, CD_BYTEORDER));
 
     static final MethodHandleDesc MH_VOID_FUNCTION = MethodHandleDesc.ofMethod(DirectMethodHandleDesc.Kind.STATIC, CD_FUNCTION_DESC, "ofVoid",
                 MethodTypeDesc.of(CD_FUNCTION_DESC, CD_MEMORY_LAYOUT.arrayType()));

--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/MemoryLayout.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/MemoryLayout.java
@@ -682,7 +682,7 @@ E * (S + I * F)
     }
 
     /**
-     * Create a value layout of given Java carrier and byte order. The type of resulting value layout is determined
+     * Creates a value layout of given Java carrier and byte order. The type of resulting value layout is determined
      * by the carrier provided:
      * <ul>
      *     <li>{@link ValueLayout.OfBoolean}, for {@code boolean.class}</li>

--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/MemoryLayout.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/MemoryLayout.java
@@ -34,6 +34,7 @@ import java.lang.constant.DynamicConstantDesc;
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.VarHandle;
+import java.nio.ByteOrder;
 import java.util.EnumSet;
 import java.util.Objects;
 import java.util.Optional;
@@ -678,6 +679,51 @@ E * (S + I * F)
     static MemoryLayout paddingLayout(long size) {
         AbstractLayout.checkSize(size);
         return new PaddingLayout(size);
+    }
+
+    /**
+     * Create a value layout of given Java carrier and byte order. The type of resulting value layout is determined
+     * by the carrier provided:
+     * <ul>
+     *     <li>{@link ValueLayout.OfBoolean}, for {@code boolean.class}</li>
+     *     <li>{@link ValueLayout.OfByte}, for {@code byte.class}</li>
+     *     <li>{@link ValueLayout.OfShort}, for {@code short.class}</li>
+     *     <li>{@link ValueLayout.OfChar}, for {@code char.class}</li>
+     *     <li>{@link ValueLayout.OfInt}, for {@code int.class}</li>
+     *     <li>{@link ValueLayout.OfFloat}, for {@code float.class}</li>
+     *     <li>{@link ValueLayout.OfLong}, for {@code long.class}</li>
+     *     <li>{@link ValueLayout.OfDouble}, for {@code double.class}</li>
+     *     <li>{@link ValueLayout.OfAddress}, for {@code MemoryAddress.class}</li>
+     * </ul>
+     * @param carrier the value layout carrier.
+     * @param order the value layout's byte order.
+     * @return a new value layout.
+     * @throws IllegalArgumentException if the carrier type is not supported.
+     */
+    static ValueLayout valueLayout(Class<?> carrier, ByteOrder order) {
+        Objects.requireNonNull(carrier);
+        Objects.requireNonNull(order);
+        if (carrier == boolean.class) {
+            return new ValueLayout.OfBoolean(order);
+        } else if (carrier == char.class) {
+            return new ValueLayout.OfChar(order);
+        } else if (carrier == byte.class) {
+            return new ValueLayout.OfByte(order);
+        } else if (carrier == short.class) {
+            return new ValueLayout.OfShort(order);
+        } else if (carrier == int.class) {
+            return new ValueLayout.OfInt(order);
+        } else if (carrier == float.class) {
+            return new ValueLayout.OfFloat(order);
+        } else if (carrier == long.class) {
+            return new ValueLayout.OfLong(order);
+        } else if (carrier == double.class) {
+            return new ValueLayout.OfDouble(order);
+        } else if (carrier == MemoryAddress.class) {
+            return new ValueLayout.OfAddress(order);
+        } else {
+            throw new IllegalArgumentException("Unsupported carrier: " + carrier.getName());
+        }
     }
 
     /**

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/Binding.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/Binding.java
@@ -629,29 +629,8 @@ public abstract class Binding {
             // alignment is set to 1 byte here to avoid exceptions for cases where we do super word
             // copies of e.g. 2 int fields of a struct as a single long, while the struct is only
             // 4-byte-aligned (since it only contains ints)
-            ValueLayout layout;
-            if (type() == boolean.class) {
-                layout = ValueLayout.JAVA_BOOLEAN;
-            } else if (type() == char.class) {
-                layout = ValueLayout.JAVA_CHAR;
-            } else if (type() == byte.class) {
-                layout = ValueLayout.JAVA_BYTE;
-            } else if (type() == short.class) {
-                layout = ValueLayout.JAVA_SHORT;
-            } else if (type() == int.class) {
-                layout = ValueLayout.JAVA_INT;
-            } else if (type() == float.class) {
-                layout = ValueLayout.JAVA_FLOAT;
-            } else if (type() == long.class) {
-                layout = ValueLayout.JAVA_LONG;
-            } else if (type() == double.class) {
-                layout = ValueLayout.JAVA_DOUBLE;
-            } else if (type() == MemoryAddress.class) {
-                layout = ValueLayout.ADDRESS;
-            } else {
-                throw new IllegalStateException("Unsupported carrier: " + type().getName());
-            }
-            return MemoryHandles.insertCoordinates(MemoryHandles.varHandle(layout.withOrder(ByteOrder.nativeOrder()).withBitAlignment(8)), 1, offset);
+            ValueLayout layout = MemoryLayout.valueLayout(type(), ByteOrder.nativeOrder()).withBitAlignment(8);
+            return MemoryHandles.insertCoordinates(MemoryHandles.varHandle(layout), 1, offset);
         }
     }
 


### PR DESCRIPTION
This patch adds back a factory to create value layouts in a generic way. While we cannot make the API 100% type safe, some dynamic usages can greatly benefit from this. The `Binding` class provides a good example (greatly simplified here). Also, the logic for reconstructing layouts (see `describeConstable`) becomes a lot more regular.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [JDK-8274219](https://bugs.openjdk.java.net/browse/JDK-8274219): Add back generic factory to create value layouts


### Reviewers
 * [Jorn Vernee](https://openjdk.java.net/census#jvernee) (@JornVernee - Committer) ⚠️ Review applies to 6c477aedce489a77137a82d7e359e2a95358fa25
 * [Paul Sandoz](https://openjdk.java.net/census#psandoz) (@PaulSandoz - Committer) ⚠️ Review applies to 6c477aedce489a77137a82d7e359e2a95358fa25


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/579/head:pull/579` \
`$ git checkout pull/579`

Update a local copy of the PR: \
`$ git checkout pull/579` \
`$ git pull https://git.openjdk.java.net/panama-foreign pull/579/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 579`

View PR using the GUI difftool: \
`$ git pr show -t 579`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/panama-foreign/pull/579.diff">https://git.openjdk.java.net/panama-foreign/pull/579.diff</a>

</details>
