### PR TITLE
8274285: By reference parameters should be kept alive during downcalls

### DIFF
--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/CLinker.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/CLinker.java
@@ -68,13 +68,19 @@ import java.util.Optional;
  * <li>or, if {@code L} is a {@link GroupLayout}, then {@code C} is set to {@code MemorySegment.class}</li>
  * </ul>
  * <p>
+ * All the arguments of type {@link Addressable} passed to a downcall method handle are {@linkplain ResourceScope#keepAlive(ResourceScope) kept alive}
+ * by the linker implementation. This ensures that the resource scopes associated with a by-reference parameters passed
+ * to a downcall method handle can never be closed, either implicitly or {@linkplain ResourceScope#close() explicitly}
+ * until the downcall method handle completes.
+ * <p>
  * Furthermore, if the function descriptor's return layout is a group layout, the resulting downcall method handle accepts
  * an extra parameter of type {@link SegmentAllocator}, which is used by the linker runtime to allocate the
  * memory region associated with the struct returned by  the downcall method handle.
  * <p>
  * Finally, downcall method handles feature a leading parameter of type {@link Addressable}, from which the
  * address of the target native function can be derived. The address, when known statically, can also be provided by
- * clients at link time.
+ * clients at link time. As for other by-reference parameters (see above) this leading parameter will be
+ * {@linkplain ResourceScope#keepAlive(ResourceScope) kept alive} by the linker implementation.
  * <p>Variadic functions, declared in C either with a trailing ellipses ({@code ...}) at the end of the formal parameter
  * list or with an empty formal parameter list, are not supported directly. However, it is possible to link a native
  * variadic function by using a {@linkplain FunctionDescriptor#asVariadic(MemoryLayout...) <em>variadic</em>} function descriptor,

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/ProgrammableInvoker.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/ProgrammableInvoker.java
@@ -331,10 +331,6 @@ public class ProgrammableInvoker {
 
             // call leaf
             Object o = leaf.invokeWithArguments(leafArgs);
-            // make sure arguments are reachable during the call
-            // technically we only need to do all Addressable parameters here
-            Reference.reachabilityFence(address);
-            Reference.reachabilityFence(args);
 
             // return value processing
             if (o == null) {

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/aarch64/linux/LinuxAArch64Linker.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/aarch64/linux/LinuxAArch64Linker.java
@@ -68,7 +68,7 @@ public final class LinuxAArch64Linker implements CLinker {
             // not returning segment, just insert a throwing allocator
             handle = MethodHandles.insertArguments(handle, 1, SharedUtils.THROWING_ALLOCATOR);
         }
-        return handle;
+        return SharedUtils.wrapDowncall(handle, function);
     }
 
     @Override

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/aarch64/macos/MacOsAArch64Linker.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/aarch64/macos/MacOsAArch64Linker.java
@@ -68,7 +68,7 @@ public final class MacOsAArch64Linker implements CLinker {
             // not returning segment, just insert a throwing allocator
             handle = MethodHandles.insertArguments(handle, 1, SharedUtils.THROWING_ALLOCATOR);
         }
-        return handle;
+        return SharedUtils.wrapDowncall(handle, function);
     }
 
     @Override

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/x64/sysv/SysVx64Linker.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/x64/sysv/SysVx64Linker.java
@@ -78,7 +78,7 @@ public final class SysVx64Linker implements CLinker {
             // not returning segment, just insert a throwing allocator
             handle = MethodHandles.insertArguments(handle, 1, SharedUtils.THROWING_ALLOCATOR);
         }
-        return handle;
+        return SharedUtils.wrapDowncall(handle, function);
     }
 
     @Override

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/x64/windows/Windowsx64Linker.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/x64/windows/Windowsx64Linker.java
@@ -79,7 +79,7 @@ public final class Windowsx64Linker implements CLinker {
             // not returning segment, just insert a throwing allocator
             handle = MethodHandles.insertArguments(handle, 1, SharedUtils.THROWING_ALLOCATOR);
         }
-        return handle;
+        return SharedUtils.wrapDowncall(handle, function);
     }
 
     @Override

--- a/test/jdk/java/foreign/libSafeAccess.c
+++ b/test/jdk/java/foreign/libSafeAccess.c
@@ -36,3 +36,7 @@ struct Point {
 EXPORT void struct_func(struct Point p) { }
 
 EXPORT void addr_func(struct Point* p) { }
+
+EXPORT void addr_func_cb(void* p, void (*callback)()) {
+   callback();
+}

--- a/test/micro/org/openjdk/bench/jdk/incubator/foreign/CallOverheadConstant.java
+++ b/test/micro/org/openjdk/bench/jdk/incubator/foreign/CallOverheadConstant.java
@@ -67,17 +67,72 @@ public class CallOverheadConstant {
     }
 
     @Benchmark
-    public MemorySegment panama_identity_struct() throws Throwable {
-        return (MemorySegment) identity_struct.invokeExact(recycling_allocator, point);
+    public MemorySegment panama_identity_struct_confined() throws Throwable {
+        return (MemorySegment) identity_struct.invokeExact(recycling_allocator, confinedPoint);
     }
 
     @Benchmark
-    public MemoryAddress panama_identity_memory_address() throws Throwable {
+    public MemorySegment panama_identity_struct_shared() throws Throwable {
+        return (MemorySegment) identity_struct.invokeExact(recycling_allocator, sharedPoint);
+    }
+
+    @Benchmark
+    public MemorySegment panama_identity_struct_confined_3() throws Throwable {
+        return (MemorySegment) identity_struct_3.invokeExact(recycling_allocator, confinedPoint, confinedPoint, confinedPoint);
+    }
+
+    @Benchmark
+    public MemorySegment panama_identity_struct_shared_3() throws Throwable {
+        return (MemorySegment) identity_struct_3.invokeExact(recycling_allocator, sharedPoint, sharedPoint, sharedPoint);
+    }
+
+    @Benchmark
+    public MemoryAddress panama_identity_memory_address_shared() throws Throwable {
+        return (MemoryAddress) identity_memory_address.invokeExact((Addressable)sharedPoint.address());
+    }
+
+    @Benchmark
+    public MemoryAddress panama_identity_memory_address_confined() throws Throwable {
+        return (MemoryAddress) identity_memory_address.invokeExact((Addressable)confinedPoint.address());
+    }
+
+    @Benchmark
+    public MemoryAddress panama_identity_memory_address_shared_3() throws Throwable {
+        return (MemoryAddress) identity_memory_address_3.invokeExact((Addressable)sharedPoint.address(), (Addressable)sharedPoint.address(), (Addressable)sharedPoint.address());
+    }
+
+    @Benchmark
+    public MemoryAddress panama_identity_memory_address_confined_3() throws Throwable {
+        return (MemoryAddress) identity_memory_address_3.invokeExact((Addressable)confinedPoint.address(), (Addressable)confinedPoint.address(), (Addressable)confinedPoint.address());
+    }
+
+    @Benchmark
+    public MemoryAddress panama_identity_struct_ref_shared() throws Throwable {
+        return (MemoryAddress) identity_memory_address.invokeExact((Addressable)sharedPoint);
+    }
+
+    @Benchmark
+    public MemoryAddress panama_identity_struct_ref_confined() throws Throwable {
+        return (MemoryAddress) identity_memory_address.invokeExact((Addressable)confinedPoint);
+    }
+
+    @Benchmark
+    public MemoryAddress panama_identity_struct_ref_shared_3() throws Throwable {
+        return (MemoryAddress) identity_memory_address_3.invokeExact((Addressable)sharedPoint, (Addressable)sharedPoint, (Addressable)sharedPoint);
+    }
+
+    @Benchmark
+    public MemoryAddress panama_identity_struct_ref_confined_3() throws Throwable {
+        return (MemoryAddress) identity_memory_address_3.invokeExact((Addressable)confinedPoint, (Addressable)confinedPoint, (Addressable)confinedPoint);
+    }
+
+    @Benchmark
+    public MemoryAddress panama_identity_memory_address_null() throws Throwable {
         return (MemoryAddress) identity_memory_address.invokeExact((Addressable)MemoryAddress.NULL);
     }
 
     @Benchmark
-    public MemoryAddress panama_identity_memory_address_non_exact() throws Throwable {
+    public MemoryAddress panama_identity_memory_address_null_non_exact() throws Throwable {
         return (MemoryAddress) identity_memory_address.invoke(MemoryAddress.NULL);
     }
 

--- a/test/micro/org/openjdk/bench/jdk/incubator/foreign/CallOverheadHelper.java
+++ b/test/micro/org/openjdk/bench/jdk/incubator/foreign/CallOverheadHelper.java
@@ -50,9 +50,15 @@ public class CallOverheadHelper extends CLayouts {
     static final MethodHandle identity_struct;
     static final MethodHandle identity_struct_v;
     static Addressable identity_struct_addr;
+    static final MethodHandle identity_struct_3;
+    static final MethodHandle identity_struct_3_v;
+    static Addressable identity_struct_3_addr;
     static final MethodHandle identity_memory_address;
     static final MethodHandle identity_memory_address_v;
     static Addressable identity_memory_address_addr;
+    static final MethodHandle identity_memory_address_3;
+    static final MethodHandle identity_memory_address_3_v;
+    static Addressable identity_memory_address_3_addr;
     static final MethodHandle args1;
     static final MethodHandle args1_v;
     static Addressable args1_addr;
@@ -73,8 +79,11 @@ public class CallOverheadHelper extends CLayouts {
     static Addressable args10_addr;
 
     static final MemoryLayout POINT_LAYOUT = MemoryLayout.structLayout(
-            C_LONG_LONG, C_LONG_LONG
+            C_INT, C_INT
     );
+
+    static final MemorySegment sharedPoint = MemorySegment.allocateNative(POINT_LAYOUT, ResourceScope.newSharedScope());
+    static final MemorySegment confinedPoint = MemorySegment.allocateNative(POINT_LAYOUT, ResourceScope.newConfinedScope());
 
     static final MemorySegment point = MemorySegment.allocateNative(POINT_LAYOUT, ResourceScope.newConfinedScope());
 
@@ -103,10 +112,20 @@ public class CallOverheadHelper extends CLayouts {
                 FunctionDescriptor.of(POINT_LAYOUT, POINT_LAYOUT));
         identity_struct = insertArguments(identity_struct_v, 0, identity_struct_addr);
 
+        identity_struct_3_addr = lookup.lookup("identity_struct_3").orElseThrow();
+        identity_struct_3_v = abi.downcallHandle(
+                FunctionDescriptor.of(POINT_LAYOUT, POINT_LAYOUT, POINT_LAYOUT, POINT_LAYOUT));
+        identity_struct_3 = insertArguments(identity_struct_3_v, 0, identity_struct_3_addr);
+
         identity_memory_address_addr = lookup.lookup("identity_memory_address").orElseThrow();
         identity_memory_address_v = abi.downcallHandle(
                 FunctionDescriptor.of(C_POINTER, C_POINTER));
         identity_memory_address = insertArguments(identity_memory_address_v, 0, identity_memory_address_addr);
+
+        identity_memory_address_3_addr = lookup.lookup("identity_memory_address_3").orElseThrow();
+        identity_memory_address_3_v = abi.downcallHandle(
+                FunctionDescriptor.of(C_POINTER, C_POINTER, C_POINTER, C_POINTER));
+        identity_memory_address_3 = insertArguments(identity_memory_address_3_v, 0, identity_memory_address_3_addr);
 
         args1_addr = lookup.lookup("args1").orElseThrow();
         args1_v = abi.downcallHandle(

--- a/test/micro/org/openjdk/bench/jdk/incubator/foreign/CallOverheadVirtual.java
+++ b/test/micro/org/openjdk/bench/jdk/incubator/foreign/CallOverheadVirtual.java
@@ -22,6 +22,7 @@
  */
 package org.openjdk.bench.jdk.incubator.foreign;
 
+import jdk.incubator.foreign.Addressable;
 import jdk.incubator.foreign.MemoryAddress;
 import jdk.incubator.foreign.MemorySegment;
 import org.openjdk.jmh.annotations.Benchmark;
@@ -58,6 +59,65 @@ public class CallOverheadVirtual {
     @Benchmark
     public int jni_identity() throws Throwable {
         return identity(10);
+    }
+
+    public MemorySegment panama_identity_struct_confined() throws Throwable {
+        return (MemorySegment) identity_struct_v.invokeExact(identity_struct_addr, recycling_allocator, confinedPoint);
+    }
+
+    @Benchmark
+    public MemorySegment panama_identity_struct_shared() throws Throwable {
+        return (MemorySegment) identity_struct_v.invokeExact(identity_struct_addr, recycling_allocator, sharedPoint);
+    }
+
+    @Benchmark
+    public MemorySegment panama_identity_struct_confined_3() throws Throwable {
+        return (MemorySegment) identity_struct_v.invokeExact(identity_struct_addr, recycling_allocator, confinedPoint, confinedPoint, confinedPoint);
+    }
+
+    @Benchmark
+    public MemorySegment panama_identity_struct_shared_3() throws Throwable {
+        return (MemorySegment) identity_struct_v.invokeExact(identity_struct_addr, recycling_allocator, sharedPoint, sharedPoint, sharedPoint);
+    }
+
+    @Benchmark
+    public MemoryAddress panama_identity_memory_address_shared() throws Throwable {
+        return (MemoryAddress) identity_memory_address_v.invokeExact(identity_memory_address_addr, (Addressable)sharedPoint.address());
+    }
+
+    @Benchmark
+    public MemoryAddress panama_identity_memory_address_confined() throws Throwable {
+        return (MemoryAddress) identity_memory_address_v.invokeExact(identity_memory_address_addr, (Addressable)confinedPoint.address());
+    }
+
+    @Benchmark
+    public MemoryAddress panama_identity_memory_address_shared_3() throws Throwable {
+        return (MemoryAddress) identity_memory_address_3_v.invokeExact(identity_memory_address_3_addr, (Addressable)sharedPoint.address(), (Addressable)sharedPoint.address(), (Addressable)sharedPoint.address());
+    }
+
+    @Benchmark
+    public MemoryAddress panama_identity_memory_address_confined_3() throws Throwable {
+        return (MemoryAddress) identity_memory_address_3_v.invokeExact(identity_memory_address_3_addr, (Addressable)confinedPoint.address(), (Addressable)confinedPoint.address(), (Addressable)confinedPoint.address());
+    }
+
+    @Benchmark
+    public MemoryAddress panama_identity_struct_ref_shared() throws Throwable {
+        return (MemoryAddress) identity_memory_address_v.invokeExact((Addressable)sharedPoint);
+    }
+
+    @Benchmark
+    public MemoryAddress panama_identity_struct_ref_confined() throws Throwable {
+        return (MemoryAddress) identity_memory_address_v.invokeExact((Addressable)confinedPoint);
+    }
+
+    @Benchmark
+    public MemoryAddress panama_identity_struct_ref_shared_3() throws Throwable {
+        return (MemoryAddress) identity_memory_address_3_v.invokeExact((Addressable)sharedPoint, (Addressable)sharedPoint, (Addressable)sharedPoint);
+    }
+
+    @Benchmark
+    public MemoryAddress panama_identity_struct_ref_confined_3() throws Throwable {
+        return (MemoryAddress) identity_memory_address_3_v.invokeExact((Addressable)confinedPoint, (Addressable)confinedPoint, (Addressable)confinedPoint);
     }
 
     @Benchmark

--- a/test/micro/org/openjdk/bench/jdk/incubator/foreign/CallOverheadVirtual.java
+++ b/test/micro/org/openjdk/bench/jdk/incubator/foreign/CallOverheadVirtual.java
@@ -131,7 +131,7 @@ public class CallOverheadVirtual {
     }
 
     @Benchmark
-    public MemoryAddress panama_identity_memory_address() throws Throwable {
+    public MemoryAddress panama_identity_memory_address_null() throws Throwable {
         return (MemoryAddress) identity_memory_address_v.invokeExact(identity_memory_address_addr, MemoryAddress.NULL);
     }
 

--- a/test/micro/org/openjdk/bench/jdk/incubator/foreign/libCallOverhead.c
+++ b/test/micro/org/openjdk/bench/jdk/incubator/foreign/libCallOverhead.c
@@ -34,16 +34,24 @@ EXPORT int identity(int x) {
 }
 
 typedef struct {
-    long long x;
-    long long y;
+    int x;
+    int y;
 } Point;
 
 EXPORT Point identity_struct(Point p) {
     return p;
 }
 
+EXPORT Point identity_struct_3(Point p1, Point p2, Point p3) {
+    return p1;
+}
+
 EXPORT void* identity_memory_address(void* p) {
     return p;
+}
+
+EXPORT void* identity_memory_address_3(void* p1, void* p2, void* p3) {
+    return p1;
 }
 
 EXPORT void args1(long long a0) {}


### PR DESCRIPTION
This patch adds an adapter around the downcall method handle which keeps alive all by-reference arguments by acquiring/releasing their associated scopes.

I've implemented the adapted in a separate method in `SharedUtils`, because `SharedUtils::wrapWithAllocator` is relatively complex, and has mostly to do with creating a scope and closing it after the call.
Also, `wrapWithAllocator` is only called when specialized method handles are active, which means adding logic there doesn't fix the programmable fallback case.

Since we plan to do more implementation restructuring in this area, I preferred to keep things simple for now.

Also note that the acquire/release logic isn't too smart - if multiple arguments backed by the same scoped are passed, we do separate acquire/release for each of them. Again, I didn't want to spend too many cycles given that the implementation of this area might change, so my aim for now was to make things safe; we can improve efficiency later.

Here are some benchmarks, for now, which compare the difference between passing a struct by reference using the struct's address (e.g. calling `MemorySegment::address` before the downcall), vs. passing the struct directly. In the first case, the scope is the global scope, so acquiring/relesing is a no-op. In the latter case we have a real scope, which we need to acquire and release.

```
Benchmark                                                           Mode  Cnt   Score   Error  Units
CallOverheadConstant.panama_identity_memory_address_confined        avgt   30  13.094 ? 0.220  ns/op
CallOverheadConstant.panama_identity_memory_address_confined_3      avgt   30  16.051 ? 0.230  ns/op
CallOverheadConstant.panama_identity_memory_address_shared          avgt   30  13.287 ? 0.172  ns/op
CallOverheadConstant.panama_identity_memory_address_shared_3        avgt   30  15.812 ? 0.365  ns/op

Benchmark
CallOverheadConstant.panama_identity_struct_ref_confined    avgt   30  11.544 ? 0.170  ns/op
CallOverheadConstant.panama_identity_struct_ref_confined_3  avgt   30  12.213 ? 0.228  ns/op
CallOverheadConstant.panama_identity_struct_ref_shared      avgt   30  17.214 ? 0.560  ns/op
CallOverheadConstant.panama_identity_struct_ref_shared_3    avgt   30  33.132 ? 0.934  ns/op
```

As it can be seen, in the confined case the numbers are good. In the shared case there's more overhead - that's the price for safety. We will be able to make this faster (by only acquiring scopes which have not already been acquired) - but note that users can always opt out of safety by projecting the `Addressable` down to a raw memory address, which would remove all the costs.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [JDK-8274285](https://bugs.openjdk.java.net/browse/JDK-8274285): By reference parameters should be kept alive during downcalls


### Reviewers
 * [Jorn Vernee](https://openjdk.java.net/census#jvernee) (@JornVernee - Committer) ⚠️ Review applies to 24ae457c3f3a8f8c3c24b633656ae8537bf216f6


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/581/head:pull/581` \
`$ git checkout pull/581`

Update a local copy of the PR: \
`$ git checkout pull/581` \
`$ git pull https://git.openjdk.java.net/panama-foreign pull/581/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 581`

View PR using the GUI difftool: \
`$ git pr show -t 581`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/panama-foreign/pull/581.diff">https://git.openjdk.java.net/panama-foreign/pull/581.diff</a>

</details>
