### PR TITLE
Fix VarHandleTestExact

### DIFF
--- a/test/jdk/java/lang/invoke/VarHandles/VarHandleTestExact.java
+++ b/test/jdk/java/lang/invoke/VarHandles/VarHandleTestExact.java
@@ -47,6 +47,7 @@
  */
 
 import jdk.incubator.foreign.MemoryHandles;
+import jdk.incubator.foreign.MemoryLayout;
 import jdk.incubator.foreign.MemorySegment;
 import jdk.incubator.foreign.ResourceScope;
 import jdk.internal.access.foreign.MemorySegmentProxy;
@@ -170,7 +171,7 @@ public class VarHandleTestExact {
 
     @Test(dataProvider = "dataSetMemorySegment")
     public void testExactSegmentSet(Class<?> carrier, Object testValue, SetSegmentX setter) {
-        VarHandle vh = MemoryHandles.varHandle(carrier, ByteOrder.nativeOrder());
+        VarHandle vh = MemoryHandles.varHandle(MemoryLayout.valueLayout(carrier, ByteOrder.nativeOrder()));
         try (ResourceScope scope = ResourceScope.newConfinedScope()) {
             MemorySegment seg = MemorySegment.allocateNative(8, scope);
             doTest(vh,


### PR DESCRIPTION
This small patch fixes a compilation error in a j.l.i test using memory access var handles.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [Jorn Vernee](https://openjdk.java.net/census#jvernee) (@JornVernee - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/582/head:pull/582` \
`$ git checkout pull/582`

Update a local copy of the PR: \
`$ git checkout pull/582` \
`$ git pull https://git.openjdk.java.net/panama-foreign pull/582/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 582`

View PR using the GUI difftool: \
`$ git pr show -t 582`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/panama-foreign/pull/582.diff">https://git.openjdk.java.net/panama-foreign/pull/582.diff</a>

</details>
