### PR TITLE
8274287: Add a way to specify block size of unbounded arena allocator

### DIFF
--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/ResourceScope.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/ResourceScope.java
@@ -52,7 +52,7 @@ import java.util.Spliterator;
  * Moreover, closing a resource scope might trigger the releasing of the underlying memory resources associated with said scope; for instance:
  * <ul>
  *     <li>closing the scope associated with a native memory segment results in <em>freeing</em> the native memory associated with it
- *     (see {@link MemorySegment#allocateNative(long, ResourceScope)}, or {@link SegmentAllocator#arenaAllocator(ResourceScope)})</li>
+ *     (see {@link MemorySegment#allocateNative(long, ResourceScope)}, or {@link SegmentAllocator#arenaUnbounded(ResourceScope)})</li>
  *     <li>closing the scope associated with a mapped memory segment results in the backing memory-mapped file to be unmapped
  *     (see {@link MemorySegment#mapFile(Path, long, long, FileChannel.MapMode, ResourceScope)})</li>
  *     <li>closing the scope associated with an upcall stub results in releasing the stub

--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/SegmentAllocator.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/SegmentAllocator.java
@@ -319,8 +319,8 @@ public interface SegmentAllocator {
     MemorySegment allocate(long bytesSize, long bytesAlignment);
 
     /**
-     * Returns a native arena-based allocator which allocates a single memory segment, of given size (using malloc),
-     * and then responds to allocation request by returning different slices of that same segment
+     * Returns a native arena-based allocator which {@linkplain MemorySegment#allocateNative(long, ResourceScope) allocates}
+     * a single memory segment, of given size, and then responds to allocation request by returning different slices of that same segment
      * (until no further allocation is possible).
      * This can be useful when clients want to perform multiple allocation requests while avoiding the cost associated
      * with allocating a new off-heap memory region upon each allocation request.
@@ -355,10 +355,10 @@ public interface SegmentAllocator {
      *     <li>if the size of the allocation requests is smaller than the size of {@code S}, and {@code S} has a <em>free</em>
      *     slice {@code S'} which fits that allocation request, return that {@code S'}.
      *     <li>if the size of the allocation requests is smaller than the size of {@code S}, and {@code S} has no <em>free</em>
-     *     slices which fits that allocation request, allocate a new segment {@code S'} (using malloc), which has same size as {@code S}
+     *     slices which fits that allocation request, allocate a new segment {@code S'}, which has same size as {@code S}
      *     and set {@code S = S'}; the allocator then tries to respond to the same allocation request again.
-     *     <li>if the size of the allocation requests is bigger than the size of {@code S}, allocate a new segment {@code S'}
-     *     (using malloc), which has a sufficient size to satisfy the allocation request, and return {@code S'}.
+     *     <li>if the size of the allocation requests is bigger than the size of {@code S}, allocate a new segment {@code S'},
+     *     which has a sufficient size to satisfy the allocation request, and return {@code S'}.
      * </ul>
      * <p>
      * The block size of the returned arena-based allocator is unspecified, can be platform-dependent, and should generally
@@ -393,10 +393,10 @@ public interface SegmentAllocator {
      *     <li>if the size of the allocation requests is smaller than the size of {@code S}, and {@code S} has a <em>free</em>
      *     slice {@code S'} which fits that allocation request, return that {@code S'}.
      *     <li>if the size of the allocation requests is smaller than the size of {@code S}, and {@code S} has no <em>free</em>
-     *     slices which fits that allocation request, allocate a new segment {@code S'} (using malloc), which has same size as {@code S}
+     *     slices which fits that allocation request, allocate a new segment {@code S'}, which has same size as {@code S}
      *     and set {@code S = S'}; the allocator then tries to respond to the same allocation request again.
-     *     <li>if the size of the allocation requests is bigger than the size of {@code S}, allocate a new segment {@code S'}
-     *     (using malloc), which has a sufficient size to satisfy the allocation request, and return {@code S'}.
+     *     <li>if the size of the allocation requests is bigger than the size of {@code S}, allocate a new segment {@code S'},
+     *     which has a sufficient size to satisfy the allocation request, and return {@code S'}.
      * </ul>
      * <p>
      * This segment allocator can be useful when clients want to perform multiple allocation requests while avoiding the

--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/SegmentAllocator.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/SegmentAllocator.java
@@ -349,8 +349,8 @@ public interface SegmentAllocator {
     /**
      * Returns a native unbounded arena-based allocator, with predefined block size.
      * <p>
-     * The returned allocator allocates a memory segment {@code S} of a certain fixed size (using malloc) and then
-     * responds to allocation requests in one of the following ways:
+     * The returned allocator {@linkplain MemorySegment#allocateNative(long, ResourceScope) allocates} a memory segment
+     * {@code S} of a certain (fixed) block size and then responds to allocation requests in one of the following ways:
      * <ul>
      *     <li>if the size of the allocation requests is smaller than the size of {@code S}, and {@code S} has a <em>free</em>
      *     slice {@code S'} which fits that allocation request, return that {@code S'}.
@@ -387,8 +387,8 @@ public interface SegmentAllocator {
     /**
      * Returns a native unbounded arena-based allocator, with given block size.
      * <p>
-     * The returned allocator allocates a memory segment {@code S} of the specified block size (using malloc) and then
-     * responds to allocation requests in one of the following ways:
+     * The returned allocator {@linkplain MemorySegment#allocateNative(long, ResourceScope) allocates} a memory segment
+     * {@code S} of the specified block size and then responds to allocation requests in one of the following ways:
      * <ul>
      *     <li>if the size of the allocation requests is smaller than the size of {@code S}, and {@code S} has a <em>free</em>
      *     slice {@code S'} which fits that allocation request, return that {@code S'}.
@@ -412,11 +412,15 @@ public interface SegmentAllocator {
      * @param blockSize the block size associated with the arena-based allocator.
      * @param scope the scope associated with the segments returned by the arena-based allocator.
      * @return a new unbounded arena-based allocator
+     * @throws IllegalArgumentException if {@code blockSize <= 0}.
      * @throws IllegalStateException if {@code scope} has been already closed, or if access occurs from a thread other
      * than the thread owning {@code scope}.
      */
     static SegmentAllocator arenaUnbounded(long blockSize, ResourceScope scope) {
         Objects.requireNonNull(scope);
+        if (blockSize <= 0) {
+            throw new IllegalArgumentException("Invalid block size: " + blockSize);
+        }
         return scope.ownerThread() == null ?
                 new ArenaAllocator.UnboundedSharedArenaAllocator(blockSize, scope) :
                 new ArenaAllocator.UnboundedArenaAllocator(blockSize, scope);

--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/SegmentAllocator.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/SegmentAllocator.java
@@ -43,8 +43,8 @@ import java.util.function.Function;
  * (e.g. {@link MemorySegment#allocateNative(long, long, ResourceScope)}); since {@link SegmentAllocator} is a <em>functional interface</em>,
  * clients can easily obtain a native allocator by using either a lambda expression or a method reference.
  * <p>
- * This interface also defines factories for commonly used allocators; for instance {@link #arenaAllocator(ResourceScope)}
- * and {@link #arenaAllocator(long, ResourceScope)} are arena-style native allocators. Finally {@link #prefixAllocator(MemorySegment)}
+ * This interface also defines factories for commonly used allocators; for instance {@link #arenaUnbounded(ResourceScope)}
+ * and {@link #arenaBounded(long, ResourceScope)} are arena-style native allocators. Finally {@link #prefixAllocator(MemorySegment)}
  * returns an allocator which wraps a segment (either on-heap or off-heap) and recycles its content upon each new allocation request.
  */
 @FunctionalInterface
@@ -333,13 +333,13 @@ public interface SegmentAllocator {
      * the allocator capacity.
      *
      * @param size the size (in bytes) of the allocation arena.
-     * @param scope the scope associated with the segments returned by this allocator.
+     * @param scope the scope associated with the segments returned by the arena-based allocator.
      * @return a new bounded arena-based allocator
      * @throws IllegalArgumentException if {@code size <= 0}.
      * @throws IllegalStateException if {@code scope} has been already closed, or if access occurs from a thread other
      * than the thread owning {@code scope}.
      */
-    static SegmentAllocator arenaAllocator(long size, ResourceScope scope) {
+    static SegmentAllocator arenaBounded(long size, ResourceScope scope) {
         Objects.requireNonNull(scope);
         return scope.ownerThread() == null ?
                 new ArenaAllocator.BoundedSharedArenaAllocator(scope, size) :
@@ -347,9 +347,47 @@ public interface SegmentAllocator {
     }
 
     /**
-     * Returns a native unbounded arena-based allocator.
+     * Returns a native unbounded arena-based allocator, with predefined block size.
      * <p>
      * The returned allocator allocates a memory segment {@code S} of a certain fixed size (using malloc) and then
+     * responds to allocation requests in one of the following ways:
+     * <ul>
+     *     <li>if the size of the allocation requests is smaller than the size of {@code S}, and {@code S} has a <em>free</em>
+     *     slice {@code S'} which fits that allocation request, return that {@code S'}.
+     *     <li>if the size of the allocation requests is smaller than the size of {@code S}, and {@code S} has no <em>free</em>
+     *     slices which fits that allocation request, allocate a new segment {@code S'} (using malloc), which has same size as {@code S}
+     *     and set {@code S = S'}; the allocator then tries to respond to the same allocation request again.
+     *     <li>if the size of the allocation requests is bigger than the size of {@code S}, allocate a new segment {@code S'}
+     *     (using malloc), which has a sufficient size to satisfy the allocation request, and return {@code S'}.
+     * </ul>
+     * <p>
+     * The block size of the returned arena-based allocator is unspecified, can be platform-dependent, and should generally
+     * not be relied upon. Clients can {@linkplain #arenaUnbounded(long, ResourceScope) obtain} an unbounded arena-based allocator
+     * with specific block size, if they so wish.
+     * <p>
+     * This segment allocator can be useful when clients want to perform multiple allocation requests while avoiding the
+     * cost associated with allocating a new off-heap memory region upon each allocation request.
+     * <p>
+     * An allocator associated with a <em>shared</em> resource scope is thread-safe and allocation requests may be
+     * performed concurrently; conversely, if the arena allocator is associated with a <em>confined</em> resource scope,
+     * allocation requests can only occur from the thread owning the allocator's resource scope.
+     * <p>
+     * The returned allocator might throw an {@link OutOfMemoryError} if an incoming allocation request exceeds
+     * the system capacity.
+     *
+     * @param scope the scope associated with the segments returned by the arena-based allocator.
+     * @return a new unbounded arena-based allocator
+     * @throws IllegalStateException if {@code scope} has been already closed, or if access occurs from a thread other
+     * than the thread owning {@code scope}.
+     */
+    static SegmentAllocator arenaUnbounded(ResourceScope scope) {
+        return arenaUnbounded(ArenaAllocator.DEFAULT_BLOCK_SIZE, scope);
+    }
+
+    /**
+     * Returns a native unbounded arena-based allocator, with given block size.
+     * <p>
+     * The returned allocator allocates a memory segment {@code S} of the specified block size (using malloc) and then
      * responds to allocation requests in one of the following ways:
      * <ul>
      *     <li>if the size of the allocation requests is smaller than the size of {@code S}, and {@code S} has a <em>free</em>
@@ -371,16 +409,17 @@ public interface SegmentAllocator {
      * The returned allocator might throw an {@link OutOfMemoryError} if an incoming allocation request exceeds
      * the system capacity.
      *
-     * @param scope the scope associated with the segments returned by this allocator.
+     * @param blockSize the block size associated with the arena-based allocator.
+     * @param scope the scope associated with the segments returned by the arena-based allocator.
      * @return a new unbounded arena-based allocator
      * @throws IllegalStateException if {@code scope} has been already closed, or if access occurs from a thread other
      * than the thread owning {@code scope}.
      */
-    static SegmentAllocator arenaAllocator(ResourceScope scope) {
+    static SegmentAllocator arenaUnbounded(long blockSize, ResourceScope scope) {
         Objects.requireNonNull(scope);
         return scope.ownerThread() == null ?
-                new ArenaAllocator.UnboundedSharedArenaAllocator(scope) :
-                new ArenaAllocator.UnboundedArenaAllocator(scope);
+                new ArenaAllocator.UnboundedSharedArenaAllocator(blockSize, scope) :
+                new ArenaAllocator.UnboundedArenaAllocator(blockSize, scope);
     }
 
     /**

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/Binding.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/Binding.java
@@ -262,7 +262,7 @@ public abstract class Binding {
          */
         public static Context ofBoundedAllocator(long size) {
             ResourceScope scope = ResourceScope.newConfinedScope();
-            return new Context(SegmentAllocator.arenaAllocator(size, scope), scope);
+            return new Context(SegmentAllocator.arenaBounded(size, scope), scope);
         }
 
         /**

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/aarch64/linux/LinuxAArch64VaList.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/aarch64/linux/LinuxAArch64VaList.java
@@ -494,7 +494,7 @@ public non-sealed class LinuxAArch64VaList implements VaList {
                 return EMPTY;
             }
 
-            SegmentAllocator allocator = SegmentAllocator.arenaAllocator(scope);
+            SegmentAllocator allocator = SegmentAllocator.arenaUnbounded(scope);
             MemorySegment vaListSegment = allocator.allocate(LAYOUT);
             MemoryAddress stackArgsPtr = MemoryAddress.NULL;
             if (!stackArgs.isEmpty()) {

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/aarch64/macos/MacOsAArch64VaList.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/aarch64/macos/MacOsAArch64VaList.java
@@ -209,7 +209,7 @@ public non-sealed class MacOsAArch64VaList implements VaList {
                 return EMPTY;
             }
 
-            SegmentAllocator allocator = SegmentAllocator.arenaAllocator(scope);
+            SegmentAllocator allocator = SegmentAllocator.arenaUnbounded(scope);
 
             // Each argument may occupy up to four slots
             MemorySegment segment = allocator.allocate(VA_SLOT_SIZE_BYTES * args.size() * 4);

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/x64/sysv/SysVVaList.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/x64/sysv/SysVVaList.java
@@ -419,7 +419,7 @@ public non-sealed class SysVVaList implements VaList {
                 return EMPTY;
             }
 
-            SegmentAllocator allocator = SegmentAllocator.arenaAllocator(scope);
+            SegmentAllocator allocator = SegmentAllocator.arenaUnbounded(scope);
             MemorySegment vaListSegment = allocator.allocate(LAYOUT);
             MemoryAddress stackArgsPtr = MemoryAddress.NULL;
             if (!stackArgs.isEmpty()) {

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/x64/windows/WinVaList.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/x64/windows/WinVaList.java
@@ -207,7 +207,7 @@ public non-sealed class WinVaList implements VaList {
             if (args.isEmpty()) {
                 return EMPTY;
             }
-            SegmentAllocator allocator = SegmentAllocator.arenaAllocator(scope);
+            SegmentAllocator allocator = SegmentAllocator.arenaUnbounded(scope);
             MemorySegment segment = allocator.allocate(VA_SLOT_SIZE_BYTES * args.size());
             List<MemorySegment> attachedSegments = new ArrayList<>();
             attachedSegments.add(segment);

--- a/test/jdk/java/foreign/NativeTestHelper.java
+++ b/test/jdk/java/foreign/NativeTestHelper.java
@@ -60,7 +60,7 @@ public class NativeTestHelper {
             this.resourceScope = ResourceScope.newConfinedScope();
             this.privateScope = ResourceScope.newConfinedScope();
             privateScope.keepAlive(resourceScope);
-            this.allocator = SegmentAllocator.arenaAllocator(resourceScope);
+            this.allocator = SegmentAllocator.arenaUnbounded(resourceScope);
         }
 
         @Override

--- a/test/jdk/java/foreign/TestScopedOperations.java
+++ b/test/jdk/java/foreign/TestScopedOperations.java
@@ -121,7 +121,7 @@ public class TestScopedOperations {
         }, "MemorySegment::mapFromFile");
         ScopedOperation.ofScope(scope -> VaList.make(b -> {}, scope), "VaList::make");
         ScopedOperation.ofScope(scope -> VaList.ofAddress(MemoryAddress.ofLong(42), scope), "VaList::make");
-        ScopedOperation.ofScope(SegmentAllocator::arenaAllocator, "SegmentAllocator::arenaAllocator");
+        ScopedOperation.ofScope(SegmentAllocator::arenaUnbounded, "SegmentAllocator::arenaAllocator");
         // segment operations
         ScopedOperation.ofSegment(s -> s.toArray(JAVA_BYTE), "MemorySegment::toArray(BYTE)");
         ScopedOperation.ofSegment(MemorySegment::address, "MemorySegment::address");
@@ -238,8 +238,8 @@ public class TestScopedOperations {
         }
 
         enum AllocatorFactory {
-            ARENA_BOUNDED(scope -> SegmentAllocator.arenaAllocator(1000, scope)),
-            ARENA_UNBOUNDED(SegmentAllocator::arenaAllocator),
+            ARENA_BOUNDED(scope -> SegmentAllocator.arenaBounded(1000, scope)),
+            ARENA_UNBOUNDED(SegmentAllocator::arenaUnbounded),
             FROM_SEGMENT(scope -> {
                 MemorySegment segment = MemorySegment.allocateNative(10, scope);
                 return SegmentAllocator.prefixAllocator(segment);

--- a/test/jdk/java/foreign/TestSegmentAllocators.java
+++ b/test/jdk/java/foreign/TestSegmentAllocators.java
@@ -103,7 +103,7 @@ public class TestSegmentAllocators {
     @Test
     public void testBigAllocationInUnboundedScope() {
         try (ResourceScope scope = ResourceScope.newConfinedScope()) {
-            SegmentAllocator allocator = SegmentAllocator.arenaAllocator(scope);
+            SegmentAllocator allocator = SegmentAllocator.arenaUnbounded(scope);
             for (int i = 8 ; i < SIZE_256M ; i *= 8) {
                 MemorySegment address = allocator.allocate(i, i);
                 //check size
@@ -117,7 +117,7 @@ public class TestSegmentAllocators {
     @Test(expectedExceptions = OutOfMemoryError.class)
     public void testTooBigForBoundedArena() {
         try (ResourceScope scope = ResourceScope.newConfinedScope()) {
-            SegmentAllocator allocator = SegmentAllocator.arenaAllocator(10, scope);
+            SegmentAllocator allocator = SegmentAllocator.arenaBounded(10, scope);
             allocator.allocate(12);
         }
     }
@@ -125,7 +125,7 @@ public class TestSegmentAllocators {
     @Test
     public void testBiggerThanBlockForBoundedArena() {
         try (ResourceScope scope = ResourceScope.newConfinedScope()) {
-            SegmentAllocator allocator = SegmentAllocator.arenaAllocator(4 * 1024 * 2, scope);
+            SegmentAllocator allocator = SegmentAllocator.arenaBounded(4 * 1024 * 2, scope);
             allocator.allocate(4 * 1024 + 1); // should be ok
         }
     }
@@ -380,8 +380,8 @@ public class TestSegmentAllocators {
             return isBound;
         }
 
-        static AllocationFactory BOUNDED = new AllocationFactory(true, SegmentAllocator::arenaAllocator);
-        static AllocationFactory UNBOUNDED = new AllocationFactory(false, (size, scope) -> SegmentAllocator.arenaAllocator(scope));
+        static AllocationFactory BOUNDED = new AllocationFactory(true, SegmentAllocator::arenaBounded);
+        static AllocationFactory UNBOUNDED = new AllocationFactory(false, (size, scope) -> SegmentAllocator.arenaUnbounded(scope));
     }
 
     interface ToArrayHelper<T> {

--- a/test/jdk/java/foreign/TestSegmentAllocators.java
+++ b/test/jdk/java/foreign/TestSegmentAllocators.java
@@ -130,6 +130,11 @@ public class TestSegmentAllocators {
         }
     }
 
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testBadUnboundedArenaSize() {
+        SegmentAllocator.arenaUnbounded(-1, ResourceScope.globalScope());
+    }
+
     @Test(dataProvider = "arrayScopes")
     public <Z> void testArray(AllocationFactory allocationFactory, ValueLayout layout, AllocationFunction<Object, ValueLayout> allocationFunction, ToArrayHelper<Z> arrayHelper) {
         Z arr = arrayHelper.array();

--- a/test/micro/org/openjdk/bench/jdk/incubator/foreign/StrLenTest.java
+++ b/test/micro/org/openjdk/bench/jdk/incubator/foreign/StrLenTest.java
@@ -60,7 +60,7 @@ public class StrLenTest extends CLayouts {
     ResourceScope scope = ResourceScope.newConfinedScope();
 
     SegmentAllocator segmentAllocator;
-    SegmentAllocator arenaAllocator = SegmentAllocator.arenaAllocator(scope);
+    SegmentAllocator arenaAllocator = SegmentAllocator.arenaUnbounded(scope);
 
     @Param({"5", "20", "100"})
     public int size;


### PR DESCRIPTION
Following the discussion here:

https://mail.openjdk.java.net/pipermail/panama-dev/2021-May/013815.html

This patch renames arena allocator factories, to make room for new unbounded factory which allows clients to specify a custom block size.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [JDK-8274287](https://bugs.openjdk.java.net/browse/JDK-8274287): Add a way to specify block size of unbounded arena allocator


### Reviewers
 * [Jorn Vernee](https://openjdk.java.net/census#jvernee) (@JornVernee - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/583/head:pull/583` \
`$ git checkout pull/583`

Update a local copy of the PR: \
`$ git checkout pull/583` \
`$ git pull https://git.openjdk.java.net/panama-foreign pull/583/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 583`

View PR using the GUI difftool: \
`$ git pr show -t 583`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/panama-foreign/pull/583.diff">https://git.openjdk.java.net/panama-foreign/pull/583.diff</a>

</details>
