### PR TITLE
Fix jextract test after arena allocator API change

### DIFF
--- a/test/jdk/tools/jextract/test8246341/LibTest8246341Test.java
+++ b/test/jdk/tools/jextract/test8246341/LibTest8246341Test.java
@@ -72,7 +72,7 @@ public class LibTest8246341Test {
     @Test
     public void testPointerAllocate() {
         try (var scope = ResourceScope.newConfinedScope()) {
-            var allocator = SegmentAllocator.arenaAllocator(C_POINTER.byteSize(), scope);
+            var allocator = SegmentAllocator.arenaBounded(C_POINTER.byteSize(), scope);
             var addr = allocator.allocate(C_POINTER);
             addr.set(C_POINTER, 0, MemoryAddress.NULL);
             fillin(addr);


### PR DESCRIPTION
As the subject says, this simple change tweaks one jextract test to use the new arena allocator method name.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [Athijegannathan Sundararajan](https://openjdk.java.net/census#sundar) (@sundararajana - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/584/head:pull/584` \
`$ git checkout pull/584`

Update a local copy of the PR: \
`$ git checkout pull/584` \
`$ git pull https://git.openjdk.java.net/panama-foreign pull/584/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 584`

View PR using the GUI difftool: \
`$ git pr show -t 584`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/panama-foreign/pull/584.diff">https://git.openjdk.java.net/panama-foreign/pull/584.diff</a>

</details>
