### PR TITLE
Make Addressable sealed again

### DIFF
--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/Addressable.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/Addressable.java
@@ -30,13 +30,6 @@ package jdk.incubator.foreign;
  * a {@linkplain #address() memory address}. Examples of addressable types are {@link MemorySegment},
  * {@link MemoryAddress}, {@link VaList} and {@link CLinker.UpcallStub}.
  * <p>
- * An addressable instance is associated with a {@linkplain ResourceScope resource scope}; the resource scope determines the
- * lifecycle of the addressable instance, as well as whether the instance can be used from multiple threads. Some
- * addressable instances might not be associated with a lifecycle, in which case {@link #scope()} returns the
- * {@linkplain ResourceScope#globalScope() global scope}. Attempting to obtain a memory address
- * from an addressable instance whose backing scope has already been {@linkplain ResourceScope#isAlive() closed} always
- * results in an exception.
- * <p>
  * The {@link Addressable} type is used by the {@link CLinker C linker} to model the types of
  * {@link CLinker#downcallHandle(FunctionDescriptor) downcall handle} parameters that must be passed <em>by reference</em>
  * (e.g. memory addresses, va lists and upcall stubs).
@@ -44,19 +37,11 @@ package jdk.incubator.foreign;
  * @implSpec
  * Implementations of this interface are <a href="{@docRoot}/java.base/java/lang/doc-files/ValueBased.html">value-based</a>.
  */
-public interface Addressable {
+public sealed interface Addressable permits MemorySegment, MemoryAddress, CLinker.UpcallStub, VaList {
 
     /**
      * Returns the memory address associated with this addressable.
      * @return The memory address associated with this addressable.
-     * @throws IllegalStateException if the scope associated with this addressable has been closed, or if access occurs from
-     * a thread other than the thread owning that scope.
      */
     MemoryAddress address();
-
-    /**
-     * Obtains the resource scope associated with this addressable.
-     * @return the resource scope associated with this addressable.
-     */
-    ResourceScope scope();
 }

--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/CLinker.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/CLinker.java
@@ -68,9 +68,9 @@ import java.util.Optional;
  * <li>or, if {@code L} is a {@link GroupLayout}, then {@code C} is set to {@code MemorySegment.class}</li>
  * </ul>
  * <p>
- * All the arguments of type {@link Addressable} passed to a downcall method handle are {@linkplain ResourceScope#keepAlive(ResourceScope) kept alive}
- * by the linker implementation. This ensures that the resource scopes associated with a by-reference parameters passed
- * to a downcall method handle can never be closed, either implicitly or {@linkplain ResourceScope#close() explicitly}
+ * Arguments of type {@link MemorySegment}, {@link VaList} and {@link UpcallStub} passed by-reference to a downcall method handle
+ * are {@linkplain ResourceScope#keepAlive(ResourceScope) kept alive} by the linker implementation. That is, the resource
+ * scope associated with such arguments cannot be closed, either implicitly or {@linkplain ResourceScope#close() explicitly}
  * until the downcall method handle completes.
  * <p>
  * Furthermore, if the function descriptor's return layout is a group layout, the resulting downcall method handle accepts
@@ -243,5 +243,20 @@ public sealed interface CLinker extends SymbolLookup permits Windowsx64Linker, S
          * @return the target Java method handle invoked by this upcall stub.
          */
         MethodHandle target();
+
+        /**
+         * Returns the resource scope associated with this instance.
+         * @return the resource scope associated with this instance.
+         */
+        ResourceScope scope();
+
+        /**
+         * Returns the memory address associated with this upcall stub.
+         * @throws IllegalStateException if the scope associated with this upcall stub has been closed, or if access occurs from
+         * a thread other than the thread owning that scope.
+         * @return The memory address associated with this upcall stub.
+         */
+        @Override
+        MemoryAddress address();
     }
 }

--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/MemoryAddress.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/MemoryAddress.java
@@ -738,13 +738,4 @@ public sealed interface MemoryAddress extends Addressable permits MemoryAddressI
      */
     @CallerSensitive
     void setAtIndex(ValueLayout.OfAddress layout, long index, Addressable value);
-
-    /**
-     * Returns the {@linkplain ResourceScope#globalScope() global scope}.
-     * @return the {@linkplain ResourceScope#globalScope() global scope}.
-     */
-    @Override
-    default ResourceScope scope() {
-        return ResourceScope.globalScope();
-    }
 }

--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/VaList.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/VaList.java
@@ -143,6 +143,15 @@ sealed public interface VaList extends Addressable permits WinVaList, SysVVaList
     VaList copy();
 
     /**
+     * Returns the memory address associated with this va list.
+     * @throws IllegalStateException if the scope associated with this va list has been closed, or if access occurs from
+     * a thread other than the thread owning that scope.
+     * @return The memory address associated with this va list.
+     */
+    @Override
+    MemoryAddress address();
+
+    /**
      * Constructs a new {@code VaList} instance out of a memory address pointing to an existing C {@code va_list}.
      * <p>
      * This method is <a href="package-summary.html#restricted"><em>restricted</em></a>.

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/AbstractMemorySegmentImpl.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/AbstractMemorySegmentImpl.java
@@ -31,8 +31,6 @@ import jdk.internal.access.SharedSecrets;
 import jdk.internal.access.foreign.MemorySegmentProxy;
 import jdk.internal.access.foreign.UnmapperProxy;
 import jdk.internal.misc.ScopedMemoryAccess;
-import jdk.internal.reflect.CallerSensitive;
-import jdk.internal.reflect.Reflection;
 import jdk.internal.util.ArraysSupport;
 import jdk.internal.vm.annotation.ForceInline;
 import sun.security.action.GetPropertyAction;
@@ -57,7 +55,7 @@ import static jdk.incubator.foreign.ValueLayout.JAVA_BYTE;
  * are defined for each memory segment kind, see {@link NativeMemorySegmentImpl}, {@link HeapMemorySegmentImpl} and
  * {@link MappedMemorySegmentImpl}.
  */
-public abstract non-sealed class AbstractMemorySegmentImpl extends MemorySegmentProxy implements MemorySegment {
+public abstract non-sealed class AbstractMemorySegmentImpl extends MemorySegmentProxy implements MemorySegment, Scoped {
 
     private static final ScopedMemoryAccess SCOPED_MEMORY_ACCESS = ScopedMemoryAccess.getScopedMemoryAccess();
 

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/MemoryAddressImpl.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/MemoryAddressImpl.java
@@ -28,6 +28,7 @@ package jdk.internal.foreign;
 import jdk.incubator.foreign.Addressable;
 import jdk.incubator.foreign.MemoryAddress;
 import jdk.incubator.foreign.MemorySegment;
+import jdk.incubator.foreign.ResourceScope;
 import jdk.incubator.foreign.ValueLayout;
 import jdk.internal.foreign.abi.SharedUtils;
 import jdk.internal.reflect.CallerSensitive;
@@ -39,7 +40,7 @@ import jdk.internal.vm.annotation.ForceInline;
  * This class provides an immutable implementation for the {@code MemoryAddress} interface. This class contains information
  * about the segment this address is associated with, as well as an offset into such segment.
  */
-public final class MemoryAddressImpl implements MemoryAddress {
+public final class MemoryAddressImpl implements MemoryAddress, Scoped {
 
     private final long offset;
 
@@ -92,6 +93,11 @@ public final class MemoryAddressImpl implements MemoryAddress {
 
     public static MemorySegment ofLongUnchecked(long value, long byteSize) {
         return NativeMemorySegmentImpl.makeNativeSegmentUnchecked(MemoryAddress.ofLong(value), byteSize, ResourceScopeImpl.GLOBAL);
+    }
+
+    @Override
+    public ResourceScope scope() {
+        return ResourceScopeImpl.GLOBAL;
     }
 
     @Override

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/Scoped.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/Scoped.java
@@ -1,3 +1,28 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
 package jdk.internal.foreign;
 
 import jdk.incubator.foreign.ResourceScope;

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/Scoped.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/Scoped.java
@@ -1,0 +1,7 @@
+package jdk.internal.foreign;
+
+import jdk.incubator.foreign.ResourceScope;
+
+public interface Scoped {
+    ResourceScope scope();
+}

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/SharedUtils.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/SharedUtils.java
@@ -39,6 +39,7 @@ import jdk.incubator.foreign.ValueLayout;
 import jdk.internal.access.JavaLangAccess;
 import jdk.internal.access.JavaLangInvokeAccess;
 import jdk.internal.access.SharedSecrets;
+import jdk.internal.foreign.Scoped;
 import jdk.internal.foreign.CABI;
 import jdk.internal.foreign.MemoryAddressImpl;
 import jdk.internal.foreign.ResourceScopeImpl;
@@ -409,13 +410,13 @@ public class SharedUtils {
 
     @ForceInline
     public static Addressable acquire(Addressable addressable) {
-        ((ResourceScopeImpl)addressable.scope()).acquire0();
+        ((ResourceScopeImpl)((Scoped)addressable).scope()).acquire0();
         return addressable;
     }
 
     @ForceInline
     public static void release(Addressable addressable) {
-        ((ResourceScopeImpl)addressable.scope()).release0();
+        ((ResourceScopeImpl)((Scoped)addressable).scope()).release0();
     }
 
     /*
@@ -564,7 +565,7 @@ public class SharedUtils {
         }
     }
 
-    public static non-sealed class EmptyVaList implements VaList {
+    public static non-sealed class EmptyVaList implements VaList, Scoped {
 
         private final MemoryAddress address;
 

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/UpcallStubs.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/UpcallStubs.java
@@ -24,12 +24,11 @@
  */
 package jdk.internal.foreign.abi;
 
-import jdk.incubator.foreign.Addressable;
 import jdk.incubator.foreign.CLinker;
 import jdk.incubator.foreign.FunctionDescriptor;
 import jdk.incubator.foreign.MemoryAddress;
-import jdk.incubator.foreign.MemorySegment;
 import jdk.incubator.foreign.ResourceScope;
+import jdk.internal.foreign.Scoped;
 import jdk.internal.foreign.ResourceScopeImpl;
 
 import java.lang.invoke.MethodHandle;
@@ -54,7 +53,7 @@ public class UpcallStubs {
 
 
     // where
-    public record UpcallStubImpl(long entry, FunctionDescriptor descriptor, MethodHandle target, ResourceScope scope) implements CLinker.UpcallStub {
+    public record UpcallStubImpl(long entry, FunctionDescriptor descriptor, MethodHandle target, ResourceScope scope) implements Scoped, CLinker.UpcallStub {
         public UpcallStubImpl {
             ((ResourceScopeImpl)scope).addOrCleanupIfFail(new ResourceScopeImpl.ResourceList.ResourceCleanup() {
                 @Override

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/aarch64/linux/LinuxAArch64VaList.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/aarch64/linux/LinuxAArch64VaList.java
@@ -26,6 +26,7 @@
 package jdk.internal.foreign.abi.aarch64.linux;
 
 import jdk.incubator.foreign.*;
+import jdk.internal.foreign.Scoped;
 import jdk.internal.foreign.Utils;
 import jdk.internal.foreign.abi.SharedUtils;
 import jdk.internal.foreign.abi.aarch64.*;
@@ -49,7 +50,7 @@ import static jdk.internal.foreign.abi.aarch64.CallArranger.MAX_REGISTER_ARGUMEN
  * Standard va_list implementation as defined by AAPCS document and used on
  * Linux. Variadic parameters may be passed in registers or on the stack.
  */
-public non-sealed class LinuxAArch64VaList implements VaList {
+public non-sealed class LinuxAArch64VaList implements VaList, Scoped {
     private static final Unsafe U = Unsafe.getUnsafe();
 
     static final Class<?> CARRIER = MemoryAddress.class;

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/aarch64/macos/MacOsAArch64VaList.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/aarch64/macos/MacOsAArch64VaList.java
@@ -27,6 +27,7 @@ package jdk.internal.foreign.abi.aarch64.macos;
 
 import jdk.incubator.foreign.*;
 import jdk.incubator.foreign.VaList;
+import jdk.internal.foreign.Scoped;
 import jdk.internal.foreign.ResourceScopeImpl;
 import jdk.internal.foreign.abi.SharedUtils;
 import jdk.internal.foreign.abi.SharedUtils.SimpleVaArg;
@@ -45,7 +46,7 @@ import static jdk.internal.foreign.abi.SharedUtils.alignUp;
  * parameters are passed on the stack and the type of va_list decays to
  * char* instead of the structure defined in the AAPCS.
  */
-public non-sealed class MacOsAArch64VaList implements VaList {
+public non-sealed class MacOsAArch64VaList implements VaList, Scoped {
     public static final Class<?> CARRIER = MemoryAddress.class;
     private static final long VA_SLOT_SIZE_BYTES = 8;
     private static final VarHandle VH_address = C_POINTER.varHandle();

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/x64/sysv/SysVVaList.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/x64/sysv/SysVVaList.java
@@ -26,6 +26,7 @@
 package jdk.internal.foreign.abi.x64.sysv;
 
 import jdk.incubator.foreign.*;
+import jdk.internal.foreign.Scoped;
 import jdk.internal.foreign.Utils;
 import jdk.internal.foreign.abi.SharedUtils;
 import jdk.internal.misc.Unsafe;
@@ -44,7 +45,7 @@ import static jdk.internal.foreign.abi.SharedUtils.SimpleVaArg;
 import static jdk.internal.foreign.abi.SharedUtils.THROWING_ALLOCATOR;
 
 // See https://software.intel.com/sites/default/files/article/402129/mpx-linux64-abi.pdf "3.5.7 Variable Argument Lists"
-public non-sealed class SysVVaList implements VaList {
+public non-sealed class SysVVaList implements VaList, Scoped {
     private static final Unsafe U = Unsafe.getUnsafe();
 
     static final Class<?> CARRIER = MemoryAddress.class;

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/x64/windows/WinVaList.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/x64/windows/WinVaList.java
@@ -27,6 +27,7 @@ package jdk.internal.foreign.abi.x64.windows;
 
 import jdk.incubator.foreign.*;
 import jdk.incubator.foreign.VaList;
+import jdk.internal.foreign.Scoped;
 import jdk.internal.foreign.ResourceScopeImpl;
 import jdk.internal.foreign.abi.SharedUtils;
 import jdk.internal.foreign.abi.SharedUtils.SimpleVaArg;
@@ -55,7 +56,7 @@ import static jdk.internal.foreign.PlatformLayouts.Win64.C_POINTER;
 //            ? **(t**)((ap += sizeof(__int64)) - sizeof(__int64))             \
 //            :  *(t* )((ap += sizeof(__int64)) - sizeof(__int64)))
 //
-public non-sealed class WinVaList implements VaList {
+public non-sealed class WinVaList implements VaList, Scoped {
     public static final Class<?> CARRIER = MemoryAddress.class;
     private static final long VA_SLOT_SIZE_BYTES = 8;
     private static final VarHandle VH_address = C_POINTER.varHandle();


### PR DESCRIPTION
Following the API refresh, I realized that making `Addressable` non-sealed was perhaps a step too far, at least for the time being. It forces a `scope()` accessor on the interface, which in turns pollutes the `MemoryAddress` interface (since a memory address has no scope).
While the API, as currently defined is sound, I'd prefer to make things tighter for now, as I realized that the need to define custom `Addressable` is perhaps limited. For instance, one place I thought they would have been useful was to model structs - but thinking more, a struct is probably backed by a segment anyway - and the segment is addressable. So, assuming the struct exposes a segment accessor, we still have ways to pass it around w/o necessarily having it implement the `Addressable` interface directly.

In the implementation we do have a new internal `Scoped` interface, which is used to keep all by-reference parameters alive by the linker. Basically, this interface re-adds the scope accessor which has been removed from the public API.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [Jorn Vernee](https://openjdk.java.net/census#jvernee) (@JornVernee - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/586/head:pull/586` \
`$ git checkout pull/586`

Update a local copy of the PR: \
`$ git checkout pull/586` \
`$ git pull https://git.openjdk.java.net/panama-foreign pull/586/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 586`

View PR using the GUI difftool: \
`$ git pr show -t 586`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/panama-foreign/pull/586.diff">https://git.openjdk.java.net/panama-foreign/pull/586.diff</a>

</details>
