### PR TITLE
TestScopedOperations does not work as expected

### DIFF
--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/SegmentAllocator.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/SegmentAllocator.java
@@ -26,6 +26,7 @@
 package jdk.incubator.foreign;
 
 import jdk.internal.foreign.ArenaAllocator;
+import jdk.internal.foreign.ResourceScopeImpl;
 import jdk.internal.foreign.Utils;
 
 import java.lang.invoke.VarHandle;

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/aarch64/linux/LinuxAArch64VaList.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/aarch64/linux/LinuxAArch64VaList.java
@@ -26,6 +26,7 @@
 package jdk.internal.foreign.abi.aarch64.linux;
 
 import jdk.incubator.foreign.*;
+import jdk.internal.foreign.ResourceScopeImpl;
 import jdk.internal.foreign.Utils;
 import jdk.internal.foreign.abi.SharedUtils;
 import jdk.internal.foreign.abi.aarch64.*;
@@ -322,6 +323,7 @@ public non-sealed class LinuxAArch64VaList implements VaList {
     @Override
     public void skip(MemoryLayout... layouts) {
         Objects.requireNonNull(layouts);
+        ((ResourceScopeImpl)segment.scope()).checkValidStateSlow();
         for (MemoryLayout layout : layouts) {
             Objects.requireNonNull(layout);
             TypeClass typeClass = TypeClass.classifyLayout(layout);

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/aarch64/macos/MacOsAArch64VaList.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/aarch64/macos/MacOsAArch64VaList.java
@@ -127,6 +127,7 @@ public non-sealed class MacOsAArch64VaList implements VaList {
     @Override
     public void skip(MemoryLayout... layouts) {
         Objects.requireNonNull(layouts);
+        ((ResourceScopeImpl)scope).checkValidStateSlow();
 
         for (MemoryLayout layout : layouts) {
             Objects.requireNonNull(layout);

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/x64/sysv/SysVVaList.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/x64/sysv/SysVVaList.java
@@ -26,6 +26,7 @@
 package jdk.internal.foreign.abi.x64.sysv;
 
 import jdk.incubator.foreign.*;
+import jdk.internal.foreign.ResourceScopeImpl;
 import jdk.internal.foreign.Utils;
 import jdk.internal.foreign.abi.SharedUtils;
 import jdk.internal.misc.Unsafe;
@@ -278,6 +279,7 @@ public non-sealed class SysVVaList implements VaList {
     @Override
     public void skip(MemoryLayout... layouts) {
         Objects.requireNonNull(layouts);
+        ((ResourceScopeImpl)segment.scope()).checkValidStateSlow();
         for (MemoryLayout layout : layouts) {
             Objects.requireNonNull(layout);
             TypeClass typeClass = TypeClass.classifyLayout(layout);

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/x64/windows/WinVaList.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/x64/windows/WinVaList.java
@@ -132,6 +132,7 @@ public non-sealed class WinVaList implements VaList {
     @Override
     public void skip(MemoryLayout... layouts) {
         Objects.requireNonNull(layouts);
+        ((ResourceScopeImpl)scope).checkValidStateSlow();
         Stream.of(layouts).forEach(Objects::requireNonNull);
         segment = segment.asSlice(layouts.length * VA_SLOT_SIZE_BYTES);
     }

--- a/test/jdk/java/foreign/TestScopedOperations.java
+++ b/test/jdk/java/foreign/TestScopedOperations.java
@@ -44,10 +44,14 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.function.Function;
+import java.util.function.Supplier;
 
 import static jdk.incubator.foreign.ValueLayout.JAVA_BYTE;
+import static jdk.incubator.foreign.ValueLayout.JAVA_INT;
+import static jdk.incubator.foreign.ValueLayout.JAVA_LONG;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
@@ -68,11 +72,12 @@ public class TestScopedOperations {
     }
 
     @Test(dataProvider = "scopedOperations")
-    public void testOpAfterClose(String name, ScopedOperation scopedOperation) {
+    public <Z> void testOpAfterClose(String name, ScopedOperation<Z> scopedOperation) {
         ResourceScope scope = ResourceScope.newConfinedScope();
+        Z obj = scopedOperation.apply(scope);
         scope.close();
         try {
-            scopedOperation.accept(scope);
+            scopedOperation.accept(obj);
             fail();
         } catch (IllegalStateException ex) {
             assertTrue(ex.getMessage().contains("closed"));
@@ -80,12 +85,13 @@ public class TestScopedOperations {
     }
 
     @Test(dataProvider = "scopedOperations")
-    public void testOpOutsideConfinement(String name, ScopedOperation scopedOperation) {
+    public <Z> void testOpOutsideConfinement(String name, ScopedOperation<Z> scopedOperation) {
         try (ResourceScope scope = ResourceScope.newConfinedScope()) {
+            Z obj = scopedOperation.apply(scope);
             AtomicReference<Throwable> failed = new AtomicReference<>();
             Thread t = new Thread(() -> {
                 try {
-                    scopedOperation.accept(scope);
+                    scopedOperation.accept(obj);
                 } catch (Throwable ex) {
                     failed.set(ex);
                 }
@@ -119,13 +125,12 @@ public class TestScopedOperations {
                 fail();
             }
         }, "MemorySegment::mapFromFile");
-        ScopedOperation.ofScope(scope -> VaList.make(b -> {}, scope), "VaList::make");
+        ScopedOperation.ofScope(scope -> VaList.make(b -> b.addVarg(JAVA_INT, 42), scope), "VaList::make");
         ScopedOperation.ofScope(scope -> VaList.ofAddress(MemoryAddress.ofLong(42), scope), "VaList::make");
         ScopedOperation.ofScope(SegmentAllocator::arenaUnbounded, "SegmentAllocator::arenaAllocator");
         // segment operations
         ScopedOperation.ofSegment(s -> s.toArray(JAVA_BYTE), "MemorySegment::toArray(BYTE)");
         ScopedOperation.ofSegment(MemorySegment::address, "MemorySegment::address");
-        ScopedOperation.ofSegment(s -> MemoryLayout.sequenceLayout(s.byteSize(), JAVA_BYTE), "MemorySegment::spliterator");
         ScopedOperation.ofSegment(s -> s.copyFrom(s), "MemorySegment::copyFrom");
         ScopedOperation.ofSegment(s -> s.mismatch(s), "MemorySegment::mismatch");
         ScopedOperation.ofSegment(s -> s.fill((byte) 0), "MemorySegment::fill");
@@ -164,47 +169,52 @@ public class TestScopedOperations {
         return scopedOperations.stream().map(op -> new Object[] { op.name, op }).toArray(Object[][]::new);
     }
 
-    static class ScopedOperation implements Consumer<ResourceScope> {
+    static class ScopedOperation<X> implements Consumer<X>, Function<ResourceScope, X> {
 
-        final Consumer<ResourceScope> scopeConsumer;
+        final Function<ResourceScope, X> factory;
+        final Consumer<X> operation;
         final String name;
 
-        private ScopedOperation(Consumer<ResourceScope> scopeConsumer, String name) {
-            this.scopeConsumer = scopeConsumer;
+        private ScopedOperation(Function<ResourceScope, X> factory, Consumer<X> operation, String name) {
+            this.factory = factory;
+            this.operation = operation;
             this.name = name;
         }
 
         @Override
-        public void accept(ResourceScope scope) {
-            scopeConsumer.accept(scope);
+        public void accept(X obj) {
+            operation.accept(obj);
+        }
+
+        @Override
+        public X apply(ResourceScope scope) {
+            return factory.apply(scope);
         }
 
         static void ofScope(Consumer<ResourceScope> scopeConsumer, String name) {
-            scopedOperations.add(new ScopedOperation(scopeConsumer::accept, name));
+            scopedOperations.add(new ScopedOperation<>(Function.identity(), scopeConsumer, name));
         }
 
         static void ofVaList(Consumer<VaList> vaListConsumer, String name) {
-            scopedOperations.add(new ScopedOperation(scope -> {
-                VaList vaList = VaList.make((builder) -> {}, scope);
-                vaListConsumer.accept(vaList);
-            }, name));
+            scopedOperations.add(new ScopedOperation<>(scope -> VaList.make(builder -> builder.addVarg(JAVA_LONG, 42), scope),
+                    vaListConsumer, name));
         }
 
         static void ofSegment(Consumer<MemorySegment> segmentConsumer, String name) {
             for (SegmentFactory segmentFactory : SegmentFactory.values()) {
-                scopedOperations.add(new ScopedOperation(scope -> {
-                    MemorySegment segment = segmentFactory.segmentFactory.apply(scope);
-                    segmentConsumer.accept(segment);
-                }, segmentFactory.name() + "/" + name));
+                scopedOperations.add(new ScopedOperation<>(
+                        segmentFactory.segmentFactory,
+                        segmentConsumer,
+                        segmentFactory.name() + "/" + name));
             }
         }
 
         static void ofAllocator(Consumer<SegmentAllocator> allocatorConsumer, String name) {
             for (AllocatorFactory allocatorFactory : AllocatorFactory.values()) {
-                scopedOperations.add(new ScopedOperation(scope -> {
-                    SegmentAllocator allocator = allocatorFactory.allocatorFactory.apply(scope);
-                    allocatorConsumer.accept(allocator);
-                }, allocatorFactory.name() + "/" + name));
+                scopedOperations.add(new ScopedOperation<>(
+                        allocatorFactory.allocatorFactory,
+                        allocatorConsumer,
+                        allocatorFactory.name() + "/" + name));
             }
         }
 
@@ -239,11 +249,7 @@ public class TestScopedOperations {
 
         enum AllocatorFactory {
             ARENA_BOUNDED(scope -> SegmentAllocator.arenaBounded(1000, scope)),
-            ARENA_UNBOUNDED(SegmentAllocator::arenaUnbounded),
-            FROM_SEGMENT(scope -> {
-                MemorySegment segment = MemorySegment.allocateNative(10, scope);
-                return SegmentAllocator.prefixAllocator(segment);
-            });
+            ARENA_UNBOUNDED(SegmentAllocator::arenaUnbounded);
 
             final Function<ResourceScope, SegmentAllocator> allocatorFactory;
 


### PR DESCRIPTION
When Julia started to work on the `MemorySegment::overlap` API, she noticed (thanks!) an issue with the TestScopedOperation. Essentially this test checks that calling methods on various objects should be scope-safe - that is, it shouldn't be possible to call certain methods (e.g. MemorySegment::address) if the scope associated with the object is closed, or from a thread other than the owning thread.

The test had a fatal flaw, which was probably introduced when we moved to the `ResourceScope` API. Since the scoped operation creates the desired object (e.g. a segment) and then performs an operation on it, and since that operation is performed _after_ the scope has been closed, as a result, all tests trivially fail as expected, since the object cannot be created in the first place (the scope is closed!!).

The solution is to separate the logic for creating the object from the logic for testing the scoped operation. In fixing the test I realized that the test was running two combinations which didn't make sense (prefixAllocator::allocate, and segment::spliterator, neither of which is scoped), and found a bug in the VaList implementation - for VaList::skip, which was missing a scope check (which this patch also addresses).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [Jorn Vernee](https://openjdk.java.net/census#jvernee) (@JornVernee - Committer) ⚠️ Review applies to 2e0e4ea0f3d41763734dde440660376cf2e3dc60


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/587/head:pull/587` \
`$ git checkout pull/587`

Update a local copy of the PR: \
`$ git checkout pull/587` \
`$ git pull https://git.openjdk.java.net/panama-foreign pull/587/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 587`

View PR using the GUI difftool: \
`$ git pr show -t 587`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/panama-foreign/pull/587.diff">https://git.openjdk.java.net/panama-foreign/pull/587.diff</a>

</details>
