### PR TITLE
8274592: Performance regression in upcalls

### DIFF
--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/Binding.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/Binding.java
@@ -261,7 +261,7 @@ public abstract class Binding {
          * Create a binding context from given native scope.
          */
         public static Context ofBoundedAllocator(long size) {
-            ResourceScope scope = ResourceScope.newConfinedScope();
+            ResourceScope scope = ResourceScope.newConfinedScope(null);
             return new Context(SegmentAllocator.arenaBounded(size, scope), scope);
         }
 
@@ -283,7 +283,7 @@ public abstract class Binding {
          * the context's allocator is accessed.
          */
         public static Context ofScope() {
-            ResourceScope scope = ResourceScope.newConfinedScope();
+            ResourceScope scope = ResourceScope.newConfinedScope(null);
             return new Context(null, scope) {
                 @Override
                 public SegmentAllocator allocator() { throw new UnsupportedOperationException(); }

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/ProgrammableInvoker.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/ProgrammableInvoker.java
@@ -262,7 +262,7 @@ public class ProgrammableInvoker {
      */
     Object invokeMoves(long addr, Object[] args, Binding.VMStore[] argBindings, Binding.VMLoad[] returnBindings) {
         MemorySegment stackArgsSeg = null;
-        try (ResourceScope scope = ResourceScope.newConfinedScope()) {
+        try (ResourceScope scope = ResourceScope.newConfinedScope(null)) {
             MemorySegment argBuffer = MemorySegment.allocateNative(layout.size, 64, scope);
             if (stackArgsBytes > 0) {
                 stackArgsSeg = MemorySegment.allocateNative(stackArgsBytes, 8, scope);

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/x64/sysv/SysVVaList.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/x64/sysv/SysVVaList.java
@@ -233,7 +233,7 @@ public non-sealed class SysVVaList implements VaList, Scoped {
                 }
                 case POINTER, INTEGER, FLOAT -> {
                     VarHandle reader = layout.varHandle();
-                    try (ResourceScope localScope = ResourceScope.newConfinedScope()) {
+                    try (ResourceScope localScope = ResourceScope.newConfinedScope(null)) {
                         MemorySegment slice = MemorySegment.ofAddressNative(stackPtr(), layout.byteSize(), localScope);
                         Object res = reader.get(slice);
                         postAlignStack(layout);

--- a/test/micro/org/openjdk/bench/jdk/incubator/foreign/BulkMismatchAcquire.java
+++ b/test/micro/org/openjdk/bench/jdk/incubator/foreign/BulkMismatchAcquire.java
@@ -128,7 +128,7 @@ public class BulkMismatchAcquire {
     @Benchmark
     @OutputTimeUnit(TimeUnit.NANOSECONDS)
     public long mismatch_large_segment_acquire() {
-        try (ResourceScope scope = ResourceScope.newConfinedScope()) {
+        try (ResourceScope scope = ResourceScope.newConfinedScope(null)) {
             scope.keepAlive(mismatchSegmentLarge1.scope());
             return mismatchSegmentLarge1.mismatch(mismatchSegmentLarge2);
         }

--- a/test/micro/org/openjdk/bench/jdk/incubator/foreign/ResourceScopeClose.java
+++ b/test/micro/org/openjdk/bench/jdk/incubator/foreign/ResourceScopeClose.java
@@ -104,27 +104,38 @@ public class ResourceScopeClose {
 
     @Benchmark
     public MemorySegment confined_close() {
-        try (ResourceScope scope = ResourceScope.newConfinedScope()) {
+        try (ResourceScope scope = ResourceScope.newConfinedScope(null)) {
             return MemorySegment.allocateNative(ALLOC_SIZE, 4, scope);
         }
     }
 
     @Benchmark
     public MemorySegment shared_close() {
-        try (ResourceScope scope = ResourceScope.newSharedScope()) {
+        try (ResourceScope scope = ResourceScope.newSharedScope(null)) {
             return MemorySegment.allocateNative(ALLOC_SIZE, 4, scope);
         }
     }
 
     @Benchmark
-    public MemorySegment implicit_close() {
+    public MemorySegment confined_implicit() {
         return MemorySegment.allocateNative(ALLOC_SIZE, 4, ResourceScope.newConfinedScope());
     }
 
     @Benchmark
-    public MemorySegment implicit_close_systemgc() {
+    public MemorySegment shared_implicit() {
+        return MemorySegment.allocateNative(ALLOC_SIZE, 4, ResourceScope.newSharedScope());
+    }
+
+    @Benchmark
+    public MemorySegment confined_implicit_systemgc() {
         if (gcCount++ == 0) System.gc(); // GC when we overflow
         return MemorySegment.allocateNative(ALLOC_SIZE, 4, ResourceScope.newConfinedScope());
+    }
+
+    @Benchmark
+    public MemorySegment shared_implicit_systemgc() {
+        if (gcCount++ == 0) System.gc(); // GC when we overflow
+        return MemorySegment.allocateNative(ALLOC_SIZE, 4, ResourceScope.newSharedScope());
     }
 
     // keep

--- a/test/micro/org/openjdk/bench/jdk/incubator/foreign/VaList.java
+++ b/test/micro/org/openjdk/bench/jdk/incubator/foreign/VaList.java
@@ -72,7 +72,7 @@ public class VaList extends CLayouts {
 
     @Benchmark
     public void vaList() throws Throwable {
-        try (ResourceScope scope = ResourceScope.newConfinedScope()) {
+        try (ResourceScope scope = ResourceScope.newConfinedScope(null)) {
             jdk.incubator.foreign.VaList vaList = jdk.incubator.foreign.VaList.make(b ->
                     b.addVarg(C_INT, 1)
                             .addVarg(C_DOUBLE, 2D)

--- a/test/micro/org/openjdk/bench/jdk/incubator/foreign/points/support/PanamaPoint.java
+++ b/test/micro/org/openjdk/bench/jdk/incubator/foreign/points/support/PanamaPoint.java
@@ -66,7 +66,7 @@ public class PanamaPoint extends CLayouts implements AutoCloseable {
     private final MemorySegment segment;
 
     public PanamaPoint(int x, int y) {
-        this(MemorySegment.allocateNative(LAYOUT, ResourceScope.newConfinedScope()), x, y);
+        this(MemorySegment.allocateNative(LAYOUT, ResourceScope.newConfinedScope(null)), x, y);
     }
 
     public PanamaPoint(MemorySegment segment, int x, int y) {

--- a/test/micro/org/openjdk/bench/jdk/incubator/vector/TestLoadStoreBytes.java
+++ b/test/micro/org/openjdk/bench/jdk/incubator/vector/TestLoadStoreBytes.java
@@ -239,7 +239,7 @@ public class TestLoadStoreBytes {
 
   @Benchmark
   public void bufferSegmentConfined() {
-    try (final var scope = ResourceScope.newConfinedScope()) {
+    try (final var scope = ResourceScope.newConfinedScope(null)) {
       final var srcBufferSegmentConfined = MemorySegment.ofAddressNative(srcAddress, size, scope).asByteBuffer();
       final var dstBufferSegmentConfined = MemorySegment.ofAddressNative(dstAddress, size, scope).asByteBuffer();
 

--- a/test/micro/org/openjdk/bench/jdk/incubator/vector/TestLoadStoreShort.java
+++ b/test/micro/org/openjdk/bench/jdk/incubator/vector/TestLoadStoreShort.java
@@ -209,7 +209,7 @@ public class TestLoadStoreShort {
 
   @Benchmark
   public void bufferSegmentConfined() {
-    try (final var scope = ResourceScope.newConfinedScope()) {
+    try (final var scope = ResourceScope.newConfinedScope(null)) {
       final var srcBufferSegmentConfined = MemorySegment.ofAddressNative(srcAddress, size, scope).asByteBuffer();
       final var dstBufferSegmentConfined = MemorySegment.ofAddressNative(dstAddress, size, scope).asByteBuffer();
 


### PR DESCRIPTION
Following the recent API refresh, I noticed that the QSort benchmark was broken (as it passed `MemoryAddress` where `Addressable` was expected). Upon fixing the benchmark, I realized that performance of upcalls dropped significantly (~3x).

After some investigation, I realized that we were using the default scope factory (which uses a cleaner!) inside some classes in the linker implementation.

The solution is to use the explicit factory which disables the cleaner, so as to avoid overhead.

There were similar issues in microbenchmarks; while using the default factory is fine for e.g. fields, using it for benchmark code is not great, as that skews the benchmark (because of the cleaner). So I replaced all usages of the default factories in the benchmark methods, except in places where we explicitly wanted to use them.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [JDK-8274592](https://bugs.openjdk.java.net/browse/JDK-8274592): Performance regression in upcalls


### Reviewers
 * [Jorn Vernee](https://openjdk.java.net/census#jvernee) (@JornVernee - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/588/head:pull/588` \
`$ git checkout pull/588`

Update a local copy of the PR: \
`$ git checkout pull/588` \
`$ git pull https://git.openjdk.java.net/panama-foreign pull/588/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 588`

View PR using the GUI difftool: \
`$ git pr show -t 588`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/panama-foreign/pull/588.diff">https://git.openjdk.java.net/panama-foreign/pull/588.diff</a>

</details>
