### PR TITLE
Generalize UpcallStub into NativeSymbol (jextract version)

### DIFF
--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/clang/libclang/CXCursorVisitor.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/clang/libclang/CXCursorVisitor.java
@@ -27,24 +27,21 @@
 
 package jdk.internal.clang.libclang;
 
-import java.lang.invoke.MethodHandle;
-import java.lang.invoke.VarHandle;
-import java.nio.ByteOrder;
 import jdk.incubator.foreign.*;
-import static jdk.incubator.foreign.ValueLayout.*;
 public interface CXCursorVisitor {
 
     int apply(jdk.incubator.foreign.MemorySegment x0, jdk.incubator.foreign.MemorySegment x1, jdk.incubator.foreign.MemoryAddress x2);
-    static CLinker.UpcallStub allocate(CXCursorVisitor fi) {
+    static NativeSymbol allocate(CXCursorVisitor fi) {
         return RuntimeHelper.upcallStub(CXCursorVisitor.class, fi, constants$13.CXCursorVisitor$FUNC, "(Ljdk/incubator/foreign/MemorySegment;Ljdk/incubator/foreign/MemorySegment;Ljdk/incubator/foreign/MemoryAddress;)I");
     }
-    static CLinker.UpcallStub allocate(CXCursorVisitor fi, ResourceScope scope) {
+    static NativeSymbol allocate(CXCursorVisitor fi, ResourceScope scope) {
         return RuntimeHelper.upcallStub(CXCursorVisitor.class, fi, constants$13.CXCursorVisitor$FUNC, "(Ljdk/incubator/foreign/MemorySegment;Ljdk/incubator/foreign/MemorySegment;Ljdk/incubator/foreign/MemoryAddress;)I", scope);
     }
-    static CXCursorVisitor ofAddress(MemoryAddress addr) {
+    static CXCursorVisitor ofAddress(MemoryAddress addr, ResourceScope scope) {
+        NativeSymbol symbol = NativeSymbol.ofAddress("CXCursorVisitor::" + Long.toHexString(addr.toRawLongValue()), addr, scope);
         return (jdk.incubator.foreign.MemorySegment x0, jdk.incubator.foreign.MemorySegment x1, jdk.incubator.foreign.MemoryAddress x2) -> {
             try {
-                return (int)constants$13.CXCursorVisitor$MH.invokeExact((Addressable)addr, x0, x1, x2);
+                return (int)constants$13.CXCursorVisitor$MH.invokeExact(symbol, x0, x1, x2);
             } catch (Throwable ex$) {
                 throw new AssertionError("should not reach here", ex$);
             }

--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/FunctionalInterfaceBuilder.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/FunctionalInterfaceBuilder.java
@@ -76,16 +76,7 @@ public class FunctionalInterfaceBuilder extends ClassSourceBuilder {
             Constant functionDesc = constantBuilder.addFunctionDesc(className(), fiDesc);
             incrAlign();
             indent();
-            append(MEMBER_MODS + " CLinker.UpcallStub allocate(" + className() + " fi) {\n");
-            incrAlign();
-            indent();
-            append("return RuntimeHelper.upcallStub(" + className() + ".class, fi, " + functionDesc.accessExpression() + ", " +
-                    "\"" + fiType.toMethodDescriptorString() + "\");\n");
-            decrAlign();
-            indent();
-            append("}\n");
-            indent();
-            append(MEMBER_MODS + " CLinker.UpcallStub allocate(" + className() + " fi, ResourceScope scope) {\n");
+            append(MEMBER_MODS + " NativeSymbol allocate(" + className() + " fi, ResourceScope scope) {\n");
             incrAlign();
             indent();
             append("return RuntimeHelper.upcallStub(" + className() + ".class, fi, " + functionDesc.accessExpression() + ", " +
@@ -102,9 +93,11 @@ public class FunctionalInterfaceBuilder extends ClassSourceBuilder {
             Constant mhConstant = constantBuilder.addMethodHandle(className(), className(), FunctionInfo.ofFunctionPointer(fiType, fiDesc), true);
             incrAlign();
             indent();
-            append(MEMBER_MODS + " " + className() + " ofAddress(MemoryAddress addr) {\n");
+            append(MEMBER_MODS + " " + className() + " ofAddress(MemoryAddress addr, ResourceScope scope) {\n");
             incrAlign();
             indent();
+            append("NativeSymbol symbol = NativeSymbol.ofAddress(");
+            append("\"" + className() + "::\" + Long.toHexString(addr.toRawLongValue()), addr, scope);");
             append("return (");
             String delim = "";
             for (int i = 0 ; i < fiType.parameterCount(); i++) {
@@ -120,7 +113,7 @@ public class FunctionalInterfaceBuilder extends ClassSourceBuilder {
             if (!fiType.returnType().equals(void.class)) {
                 append("return (" + fiType.returnType().getName() + ")");
             }
-            append(mhConstant.accessExpression() + ".invokeExact((Addressable)addr");
+            append(mhConstant.accessExpression() + ".invokeExact(symbol");
             if (fiType.parameterCount() > 0) {
                 String params = IntStream.range(0, fiType.parameterCount())
                         .mapToObj(i -> "x" + i)

--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/HeaderFileBuilder.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/HeaderFileBuilder.java
@@ -185,7 +185,7 @@ abstract class HeaderFileBuilder extends ClassSourceBuilder {
         append(fiName + " " + javaName + " () {\n");
         incrAlign();
         indent();
-        append("return " + fiName + ".ofAddress(" + javaName + "$get());\n");
+        append("return " + fiName + ".ofAddress(" + javaName + "$get(), ResourceScope.globalScope());\n");
         decrAlign();
         indent();
         append("}\n");

--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/StructBuilder.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/StructBuilder.java
@@ -148,10 +148,10 @@ class StructBuilder extends ConstantBuilder {
         incrAlign();
         indent();
         append(MEMBER_MODS + " ");
-        append(fiName + " " + javaName + " (MemorySegment segment) {\n");
+        append(fiName + " " + javaName + " (MemorySegment segment, ResourceScope scope) {\n");
         incrAlign();
         indent();
-        append("return " + fiName + ".ofAddress(" + javaName + "$get(segment));\n");
+        append("return " + fiName + ".ofAddress(" + javaName + "$get(segment), scope);\n");
         decrAlign();
         indent();
         append("}\n");

--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/resources/RuntimeHelper.java.template
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/resources/RuntimeHelper.java.template
@@ -4,6 +4,7 @@ import jdk.incubator.foreign.Addressable;
 import jdk.incubator.foreign.CLinker;
 import jdk.incubator.foreign.FunctionDescriptor;
 import jdk.incubator.foreign.GroupLayout;
+import jdk.incubator.foreign.NativeSymbol;
 import jdk.incubator.foreign.SymbolLookup;
 import jdk.incubator.foreign.MemoryAddress;
 import jdk.incubator.foreign.MemoryLayout;
@@ -48,7 +49,7 @@ final class RuntimeHelper {
     private final static SegmentAllocator THROWING_ALLOCATOR = (x, y) -> { throw new AssertionError("should not reach here"); };
 
     static final MemorySegment lookupGlobalVariable(String name, MemoryLayout layout) {
-        return SYMBOL_LOOKUP.lookup(name).map(addr -> MemorySegment.ofAddressNative(addr, layout.byteSize(), ResourceScope.newSharedScope())).orElse(null);
+        return SYMBOL_LOOKUP.lookup(name).map(symbol -> MemorySegment.ofAddressNative(symbol.address(), layout.byteSize(), ResourceScope.newSharedScope())).orElse(null);
     }
 
     static final MethodHandle downcallHandle(String name, FunctionDescriptor fdesc, boolean variadic) {
@@ -67,11 +68,7 @@ final class RuntimeHelper {
         return LINKER.downcallHandle(fdesc);
     }
 
-    static final <Z> CLinker.UpcallStub upcallStub(Class<Z> fi, Z z, FunctionDescriptor fdesc, String mtypeDesc) {
-        return upcallStub(fi, z, fdesc, mtypeDesc, ResourceScope.newConfinedScope());
-    }
-
-    static final <Z> CLinker.UpcallStub upcallStub(Class<Z> fi, Z z, FunctionDescriptor fdesc, String mtypeDesc, ResourceScope scope) {
+    static final <Z> NativeSymbol upcallStub(Class<Z> fi, Z z, FunctionDescriptor fdesc, String mtypeDesc, ResourceScope scope) {
         try {
             MethodHandle handle = MH_LOOKUP.findVirtual(fi, "apply",
                     MethodType.fromMethodDescriptorString(mtypeDesc, LOADER));
@@ -90,10 +87,10 @@ final class RuntimeHelper {
 
     private static class VarargsInvoker {
         private static final MethodHandle INVOKE_MH;
-        private final Addressable symbol;
+        private final NativeSymbol symbol;
         private final FunctionDescriptor function;
 
-        private VarargsInvoker(Addressable symbol, FunctionDescriptor function) {
+        private VarargsInvoker(NativeSymbol symbol, FunctionDescriptor function) {
             this.symbol = symbol;
             this.function = function;
         }
@@ -106,7 +103,7 @@ final class RuntimeHelper {
             }
         }
 
-        static MethodHandle make(Addressable symbol, FunctionDescriptor function) {
+        static MethodHandle make(NativeSymbol symbol, FunctionDescriptor function) {
             VarargsInvoker invoker = new VarargsInvoker(symbol, function);
             MethodHandle handle = INVOKE_MH.bindTo(invoker).asCollector(Object[].class, function.argumentLayouts().size() + 1);
             MethodType mtype = MethodType.methodType(function.returnLayout().isPresent() ? carrier(function.returnLayout().get(), true) : void.class);

--- a/test/jdk/tools/jextract/funcPointerInvokers/TestFuncPointerInvokers.java
+++ b/test/jdk/tools/jextract/funcPointerInvokers/TestFuncPointerInvokers.java
@@ -53,7 +53,7 @@ public class TestFuncPointerInvokers {
             AtomicInteger val = new AtomicInteger(-1);
             MemorySegment bar = Bar.allocate(scope);
             Bar.foo$set(bar, Foo.allocate((i) -> val.set(i), scope).address());
-            Bar.foo(bar).apply(42);
+            Bar.foo(bar, scope).apply(42);
             assertEquals(val.get(), 42);
         }
     }
@@ -64,7 +64,7 @@ public class TestFuncPointerInvokers {
             AtomicInteger val = new AtomicInteger(-1);
             MemorySegment bar = Bar.allocate(scope);
             Bar.foo$set(bar, Foo.allocate((i) -> val.set(i), scope).address());
-            Foo.ofAddress(Bar.foo$get(bar)).apply(42);
+            Foo.ofAddress(Bar.foo$get(bar), scope).apply(42);
             assertEquals(val.get(), 42);
         }
     }
@@ -84,7 +84,7 @@ public class TestFuncPointerInvokers {
         try (ResourceScope scope = ResourceScope.newConfinedScope()) {
             AtomicInteger val = new AtomicInteger(-1);
             f$set(Foo.allocate((i) -> val.set(i), scope).address());
-            Foo.ofAddress(f$get()).apply(42);
+            Foo.ofAddress(f$get(), scope).apply(42);
             assertEquals(val.get(), 42);
         }
     }
@@ -95,7 +95,7 @@ public class TestFuncPointerInvokers {
             AtomicInteger val = new AtomicInteger(-1);
             MemorySegment baz = Baz.allocate(scope);
             Baz.fp$set(baz, Baz.fp.allocate((i) -> val.set(i), scope).address());
-            Baz.fp(baz).apply(42);
+            Baz.fp(baz, scope).apply(42);
             assertEquals(val.get(), 42);
         }
     }
@@ -106,7 +106,7 @@ public class TestFuncPointerInvokers {
             AtomicInteger val = new AtomicInteger(-1);
             MemorySegment baz = Baz.allocate(scope);
             Baz.fp$set(baz, Baz.fp.allocate((i) -> val.set(i), scope).address());
-            Baz.fp.ofAddress(Baz.fp$get(baz)).apply(42);
+            Baz.fp.ofAddress(Baz.fp$get(baz), scope).apply(42);
             assertEquals(val.get(), 42);
         }
     }
@@ -126,7 +126,7 @@ public class TestFuncPointerInvokers {
         try (ResourceScope scope = ResourceScope.newConfinedScope()) {
             AtomicInteger val = new AtomicInteger(-1);
             fp$set(fp.allocate((i) -> val.set(i), scope).address());
-            fp.ofAddress(fp$get()).apply(42);
+            fp.ofAddress(fp$get(), scope).apply(42);
             assertEquals(val.get(), 42);
         }
     }

--- a/test/jdk/tools/jextract/test8261511/Test8261511.java
+++ b/test/jdk/tools/jextract/test8261511/Test8261511.java
@@ -50,7 +50,7 @@ public class Test8261511 {
     public void test() {
         try (ResourceScope scope = ResourceScope.newConfinedScope()) {
             var funcPtr = Foo.sum$get(get_foo(scope));
-            var sumIface = Foo.sum.ofAddress(funcPtr);
+            var sumIface = Foo.sum.ofAddress(funcPtr, scope);
             assertEquals(sumIface.apply(15,20), 35);
             assertEquals(sum(1.2, 4.5), 5.7, 0.001);
         }

--- a/test/jdk/tools/jextract/testClassGen/TestClassGeneration.java
+++ b/test/jdk/tools/jextract/testClassGen/TestClassGeneration.java
@@ -38,6 +38,7 @@ import jdk.incubator.foreign.CLinker;
 import jdk.incubator.foreign.MemoryAddress;
 import jdk.incubator.foreign.MemoryLayout;
 import jdk.incubator.foreign.MemorySegment;
+import jdk.incubator.foreign.NativeSymbol;
 import jdk.incubator.foreign.ResourceScope;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
@@ -213,7 +214,7 @@ public class TestClassGeneration extends JextractToolRunner {
         Class<?> fiClass = loader.loadClass("com.acme." + name);
         assertNotNull(fiClass);
         checkMethod(fiClass, "apply", type);
-        checkMethod(fiClass, "allocate", CLinker.UpcallStub.class, fiClass);
+        checkMethod(fiClass, "allocate", NativeSymbol.class, fiClass, ResourceScope.class);
     }
 
     @BeforeClass


### PR DESCRIPTION
This patch fixes jextract to use NativeSymbol.

Overall it was a useful exercise, as it pointed out some inconsistencies in our generation startegy for upcalls. Jextract currently generates the following two methods:

```
static NativeSymbol allocate(CXCursorVisitor fi) { ... }
static NativeSymbol allocate(CXCursorVisitor fi, ResourceScope scope) { ... }
static CXCursorVisitor ofAddress(MemoryAddress addr) { ... }
```

The first two are used to jusr create an upcall from a lambda; while the third is used to turn an address into a functional interface which can be called from Java code.

In both the first and last case, there's a `ResourceScope` parameter missing, I think. Creating an upcall always needs a scope; similarly, when creating a custom `NativeSymbol` from a native address, we need to associate a scope to it too (which determines when it's ok to call the native symbol).

I've rectified jextract to take scopes in all the right places. Since for structs and global variables we emit functional interface getters, some changes went in there too. In the case of global variables, there's no need to pass a scope (as a global variable has the global scope). But in the case of a struct access, the user does need to pass a scope (inferring the scope from the struct segment is possible, but most likely not the right/general thing to do).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [Athijegannathan Sundararajan](https://openjdk.java.net/census#sundar) (@sundararajana - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/592/head:pull/592` \
`$ git checkout pull/592`

Update a local copy of the PR: \
`$ git checkout pull/592` \
`$ git pull https://git.openjdk.java.net/panama-foreign pull/592/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 592`

View PR using the GUI difftool: \
`$ git pr show -t 592`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/panama-foreign/pull/592.diff">https://git.openjdk.java.net/panama-foreign/pull/592.diff</a>

</details>
