### PR TITLE
8275061: Exceptions thrown from non-void upcalls are not handled

### DIFF
--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/SharedUtils.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/SharedUtils.java
@@ -385,7 +385,11 @@ public class SharedUtils {
             insertPos = 1;
         } else {
             closer = identity(specializedHandle.type().returnType()); // (V) -> V
-            closer = dropArguments(closer, 0, Throwable.class); // (Throwable, V) -> V
+            if (!upcall) {
+                closer = dropArguments(closer, 0, Throwable.class); // (Throwable, V) -> V
+            } else {
+                closer = collectArguments(closer, 0, MH_HANDLE_UNCAUGHT_EXCEPTION); // (Throwable, V) -> V
+            }
             insertPos = 2;
         }
 

--- a/test/jdk/java/foreign/TestUpcallException.java
+++ b/test/jdk/java/foreign/TestUpcallException.java
@@ -51,17 +51,17 @@ public class TestUpcallException {
 
     @Test
     public void testExceptionInterpreted() throws InterruptedException, IOException {
-        boolean useSpec = false;
-        run(useSpec);
+        run(/* useSpec = */ false, /* isVoid = */ true);
+        run(/* useSpec = */ false, /* isVoid = */ false);
     }
 
     @Test
     public void testExceptionSpecialized() throws IOException, InterruptedException {
-        boolean useSpec = true;
-        run(useSpec);
+        run(/* useSpec = */ true, /* isVoid = */ true);
+        run(/* useSpec = */ true, /* isVoid = */ false);
     }
 
-    private void run(boolean useSpec) throws IOException, InterruptedException {
+    private void run(boolean useSpec, boolean isVoid) throws IOException, InterruptedException {
         Process process = new ProcessBuilder()
             .command(
                 Paths.get(Utils.TEST_JDK)
@@ -74,7 +74,8 @@ public class TestUpcallException {
                 "-Djava.library.path=" + System.getProperty("java.library.path"),
                 "-Djdk.internal.foreign.ProgrammableUpcallHandler.USE_SPEC=" + useSpec,
                 "-cp", Utils.TEST_CLASS_PATH,
-                "ThrowingUpcall")
+                "ThrowingUpcall",
+                isVoid ? "void" : "non-void")
             .start();
 
         int result = process.waitFor();


### PR DESCRIPTION
Hi,

Exceptions thrown from non-void upcalls are currently not handled, meaning we crash the VM instead without a stack trace (CATCH macro).

Only the void case is currently handled for specialized upcalls. This PR adds the missing call to handle any uncaught exceptions for non-void upcalls as well.

Jorn

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [JDK-8275061](https://bugs.openjdk.java.net/browse/JDK-8275061): Exceptions thrown from non-void upcalls are not handled


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.java.net/census#mcimadamore) (@mcimadamore - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/597/head:pull/597` \
`$ git checkout pull/597`

Update a local copy of the PR: \
`$ git checkout pull/597` \
`$ git pull https://git.openjdk.java.net/panama-foreign pull/597/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 597`

View PR using the GUI difftool: \
`$ git pr show -t 597`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/panama-foreign/pull/597.diff">https://git.openjdk.java.net/panama-foreign/pull/597.diff</a>

</details>
