### PR TITLE
8275382: foreign-memaccess+abi branch fails to build with error Undefined symbol: “typeArrayOopDesc::long_at(int) const”

### DIFF
--- a/src/hotspot/share/prims/nativeEntryPoint.cpp
+++ b/src/hotspot/share/prims/nativeEntryPoint.cpp
@@ -24,18 +24,14 @@
 
 #include "precompiled.hpp"
 #include "runtime/interfaceSupport.inline.hpp"
-#include "classfile/javaClasses.hpp"
 #include "classfile/javaClasses.inline.hpp"
 #include "code/vmreg.hpp"
 #include "logging/logStream.hpp"
 #include "memory/resourceArea.hpp"
-#include "oops/typeArrayOop.hpp"
 #include "oops/typeArrayOop.inline.hpp"
 #include "oops/oopCast.inline.hpp"
-#include "prims/foreign_globals.hpp"
 #include "prims/foreign_globals.inline.hpp"
 #include "prims/universalNativeInvoker.hpp"
-#include "runtime/jniHandles.hpp"
 #include "runtime/jniHandles.inline.hpp"
 
 JNI_LEAF(jlong, NEP_vmStorageToVMReg(JNIEnv* env, jclass _unused, jint type, jint index))


### PR DESCRIPTION
added include directive to nativeEntryPoint.cpp

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [JDK-8275382](https://bugs.openjdk.java.net/browse/JDK-8275382): foreign-memaccess+abi branch fails to build with error Undefined symbol: “typeArrayOopDesc::long_at(int) const”


### Reviewers
 * [Jorn Vernee](https://openjdk.java.net/census#jvernee) (@JornVernee - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/599/head:pull/599` \
`$ git checkout pull/599`

Update a local copy of the PR: \
`$ git checkout pull/599` \
`$ git pull https://git.openjdk.java.net/panama-foreign pull/599/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 599`

View PR using the GUI difftool: \
`$ git pr show -t 599`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/panama-foreign/pull/599.diff">https://git.openjdk.java.net/panama-foreign/pull/599.diff</a>

</details>
