### PR TITLE
8275332: Variadic functions don't work on Linux/AArch64

### DIFF
--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/aarch64/linux/LinuxAArch64Linker.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/aarch64/linux/LinuxAArch64Linker.java
@@ -50,6 +50,8 @@ public final class LinuxAArch64Linker implements CLinker {
 
     static final long ADDRESS_SIZE = 64; // bits
 
+    static final boolean varArgsOnStack = false;
+
     public static LinuxAArch64Linker getInstance() {
         if (instance == null) {
             instance = new LinuxAArch64Linker();
@@ -61,7 +63,7 @@ public final class LinuxAArch64Linker implements CLinker {
     public final MethodHandle downcallHandle(FunctionDescriptor function) {
         Objects.requireNonNull(function);
         MethodType type = SharedUtils.inferMethodType(function, false);
-        MethodHandle handle = CallArranger.arrangeDowncall(type, function);
+        MethodHandle handle = CallArranger.arrangeDowncall(type, function, varArgsOnStack);
         if (!type.returnType().equals(MemorySegment.class)) {
             // not returning segment, just insert a throwing allocator
             handle = MethodHandles.insertArguments(handle, 1, SharedUtils.THROWING_ALLOCATOR);
@@ -79,7 +81,7 @@ public final class LinuxAArch64Linker implements CLinker {
         if (!type.equals(target.type())) {
             throw new IllegalArgumentException("Wrong method handle type: " + target.type());
         }
-        return CallArranger.arrangeUpcall(target, target.type(), function, scope);
+        return CallArranger.arrangeUpcall(target, target.type(), function, scope, varArgsOnStack);
     }
 
     public static VaList newVaList(Consumer<VaList.Builder> actions, ResourceScope scope) {

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/aarch64/linux/LinuxAArch64VaList.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/aarch64/linux/LinuxAArch64VaList.java
@@ -284,7 +284,7 @@ public non-sealed class LinuxAArch64VaList implements VaList, Scoped {
                     for (MemoryLayout elem : group.memberLayouts()) {
                         assert elem.byteSize() <= 8;
                         final long copy = elem.byteSize();
-                        MemorySegment.copy(gpRegsArea, currentFPOffset(), value, offset, copy);
+                        MemorySegment.copy(fpRegsArea, currentFPOffset(), value, offset, copy);
                         consumeFPSlots(1);
                         offset += copy;
                     }
@@ -457,7 +457,7 @@ public non-sealed class LinuxAArch64VaList implements VaList, Scoped {
                         for (MemoryLayout elem : group.memberLayouts()) {
                             assert elem.byteSize() <= 8;
                             final long copy = elem.byteSize();
-                            MemorySegment.copy(valueSegment, offset, gpRegs, currentFPOffset, copy);
+                            MemorySegment.copy(valueSegment, offset, fpRegs, currentFPOffset, copy);
                             currentFPOffset += FP_SLOT_SIZE;
                             offset += copy;
                         }

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/aarch64/macos/MacOsAArch64Linker.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/aarch64/macos/MacOsAArch64Linker.java
@@ -50,6 +50,8 @@ public final class MacOsAArch64Linker implements CLinker {
 
     static final long ADDRESS_SIZE = 64; // bits
 
+    static final boolean varArgsOnStack = true;
+
     public static MacOsAArch64Linker getInstance() {
         if (instance == null) {
             instance = new MacOsAArch64Linker();
@@ -61,7 +63,7 @@ public final class MacOsAArch64Linker implements CLinker {
     public final MethodHandle downcallHandle(FunctionDescriptor function) {
         Objects.requireNonNull(function);
         MethodType type = SharedUtils.inferMethodType(function, false);
-        MethodHandle handle = CallArranger.arrangeDowncall(type, function);
+        MethodHandle handle = CallArranger.arrangeDowncall(type, function, varArgsOnStack);
         if (!type.returnType().equals(MemorySegment.class)) {
             // not returning segment, just insert a throwing allocator
             handle = MethodHandles.insertArguments(handle, 1, SharedUtils.THROWING_ALLOCATOR);
@@ -78,7 +80,7 @@ public final class MacOsAArch64Linker implements CLinker {
         if (!type.equals(target.type())) {
             throw new IllegalArgumentException("Wrong method handle type: " + target.type());
         }
-        return CallArranger.arrangeUpcall(target, target.type(), function, scope);
+        return CallArranger.arrangeUpcall(target, target.type(), function, scope, varArgsOnStack);
     }
 
     public static VaList newVaList(Consumer<VaList.Builder> actions, ResourceScope scope) {

--- a/test/jdk/java/foreign/callarranger/TestAarch64CallArranger.java
+++ b/test/jdk/java/foreign/callarranger/TestAarch64CallArranger.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
  *  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  *  This code is free software; you can redistribute it and/or modify it
@@ -56,7 +56,7 @@ public class TestAarch64CallArranger extends CallArrangerTestBase {
     public void testEmpty() {
         MethodType mt = MethodType.methodType(void.class);
         FunctionDescriptor fd = FunctionDescriptor.ofVoid();
-        CallArranger.Bindings bindings = CallArranger.getBindings(mt, fd, false);
+        CallArranger.Bindings bindings = CallArranger.getBindings(mt, fd, false, false);
 
         assertFalse(bindings.isInMemoryReturn);
         CallingSequence callingSequence = bindings.callingSequence;
@@ -78,7 +78,7 @@ public class TestAarch64CallArranger extends CallArrangerTestBase {
                 C_INT, C_INT, C_INT, C_INT,
                 C_INT, C_INT, C_INT, C_INT,
                 C_INT, C_INT);
-        CallArranger.Bindings bindings = CallArranger.getBindings(mt, fd, false);
+        CallArranger.Bindings bindings = CallArranger.getBindings(mt, fd, false, false);
 
         assertFalse(bindings.isInMemoryReturn);
         CallingSequence callingSequence = bindings.callingSequence;
@@ -103,11 +103,11 @@ public class TestAarch64CallArranger extends CallArrangerTestBase {
 
     @Test
     public void testTwoIntTwoFloat() {
-      MethodType mt = MethodType.methodType(void.class,
+        MethodType mt = MethodType.methodType(void.class,
                 int.class, int.class, float.class, float.class);
         FunctionDescriptor fd = FunctionDescriptor.ofVoid(
                 C_INT, C_INT, C_FLOAT, C_FLOAT);
-        CallArranger.Bindings bindings = CallArranger.getBindings(mt, fd, false);
+        CallArranger.Bindings bindings = CallArranger.getBindings(mt, fd, false, false);
 
         assertFalse(bindings.isInMemoryReturn);
         CallingSequence callingSequence = bindings.callingSequence;
@@ -128,7 +128,7 @@ public class TestAarch64CallArranger extends CallArrangerTestBase {
     public void testStruct(MemoryLayout struct, Binding[] expectedBindings) {
         MethodType mt = MethodType.methodType(void.class, MemorySegment.class);
         FunctionDescriptor fd = FunctionDescriptor.ofVoid(struct);
-        CallArranger.Bindings bindings = CallArranger.getBindings(mt, fd, false);
+        CallArranger.Bindings bindings = CallArranger.getBindings(mt, fd, false, false);
 
         assertFalse(bindings.isInMemoryReturn);
         CallingSequence callingSequence = bindings.callingSequence;
@@ -187,7 +187,7 @@ public class TestAarch64CallArranger extends CallArrangerTestBase {
 
         MethodType mt = MethodType.methodType(void.class, MemorySegment.class, MemorySegment.class, int.class);
         FunctionDescriptor fd = FunctionDescriptor.ofVoid(struct1, struct2, C_INT);
-        CallArranger.Bindings bindings = CallArranger.getBindings(mt, fd, false);
+        CallArranger.Bindings bindings = CallArranger.getBindings(mt, fd, false, false);
 
         assertFalse(bindings.isInMemoryReturn);
         CallingSequence callingSequence = bindings.callingSequence;
@@ -217,7 +217,7 @@ public class TestAarch64CallArranger extends CallArrangerTestBase {
 
         MethodType mt = MethodType.methodType(MemorySegment.class);
         FunctionDescriptor fd = FunctionDescriptor.of(struct);
-        CallArranger.Bindings bindings = CallArranger.getBindings(mt, fd, false);
+        CallArranger.Bindings bindings = CallArranger.getBindings(mt, fd, false, false);
 
         assertTrue(bindings.isInMemoryReturn);
         CallingSequence callingSequence = bindings.callingSequence;
@@ -240,7 +240,7 @@ public class TestAarch64CallArranger extends CallArrangerTestBase {
 
         MethodType mt = MethodType.methodType(MemorySegment.class);
         FunctionDescriptor fd = FunctionDescriptor.of(struct);
-        CallArranger.Bindings bindings = CallArranger.getBindings(mt, fd, false);
+        CallArranger.Bindings bindings = CallArranger.getBindings(mt, fd, false, false);
 
         assertFalse(bindings.isInMemoryReturn);
         CallingSequence callingSequence = bindings.callingSequence;
@@ -266,7 +266,7 @@ public class TestAarch64CallArranger extends CallArrangerTestBase {
 
         MethodType mt = MethodType.methodType(MemorySegment.class, float.class, int.class, MemorySegment.class);
         FunctionDescriptor fd = FunctionDescriptor.of(hfa, C_FLOAT, C_INT, hfa);
-        CallArranger.Bindings bindings = CallArranger.getBindings(mt, fd, false);
+        CallArranger.Bindings bindings = CallArranger.getBindings(mt, fd, false, false);
 
         assertFalse(bindings.isInMemoryReturn);
         CallingSequence callingSequence = bindings.callingSequence;
@@ -302,7 +302,7 @@ public class TestAarch64CallArranger extends CallArrangerTestBase {
 
         MethodType mt = MethodType.methodType(void.class, MemorySegment.class, MemorySegment.class, MemorySegment.class);
         FunctionDescriptor fd = FunctionDescriptor.ofVoid(struct, struct, struct);
-        CallArranger.Bindings bindings = CallArranger.getBindings(mt, fd, false);
+        CallArranger.Bindings bindings = CallArranger.getBindings(mt, fd, false, false);
 
         assertFalse(bindings.isInMemoryReturn);
         CallingSequence callingSequence = bindings.callingSequence;
@@ -355,7 +355,7 @@ public class TestAarch64CallArranger extends CallArrangerTestBase {
             int.class, int.class, int.class, int.class, MemorySegment.class, int.class);
         FunctionDescriptor fd = FunctionDescriptor.ofVoid(
             struct, struct, C_INT, C_INT, C_INT, C_INT, C_INT, C_INT, struct, C_INT);
-        CallArranger.Bindings bindings = CallArranger.getBindings(mt, fd, false);
+        CallArranger.Bindings bindings = CallArranger.getBindings(mt, fd, false, false);
 
         assertFalse(bindings.isInMemoryReturn);
         CallingSequence callingSequence = bindings.callingSequence;
@@ -373,6 +373,50 @@ public class TestAarch64CallArranger extends CallArrangerTestBase {
             { vmStore(r7, int.class) },
             { copy(struct), unboxAddress(MemorySegment.class), vmStore(stackStorage(0), long.class) },
             { vmStore(stackStorage(1), int.class) },
+        });
+
+        checkReturnBindings(callingSequence, new Binding[]{});
+    }
+
+    @Test
+    public void testVarArgsInRegs() {
+        final boolean varArgsOnStack = false;   // Linux ABI
+        MethodType mt = MethodType.methodType(void.class, int.class, int.class, float.class);
+        FunctionDescriptor fd = FunctionDescriptor.ofVoid(C_INT).asVariadic(C_INT, C_FLOAT);
+        CallArranger.Bindings bindings = CallArranger.getBindings(mt, fd, false, varArgsOnStack);
+
+        assertFalse(bindings.isInMemoryReturn);
+        CallingSequence callingSequence = bindings.callingSequence;
+        assertEquals(callingSequence.methodType(), mt);
+        assertEquals(callingSequence.functionDesc(), fd);
+
+        // This is identical to the non-variadic calling sequence
+        checkArgumentBindings(callingSequence, new Binding[][]{
+            { vmStore(r0, int.class) },
+            { vmStore(r1, int.class) },
+            { vmStore(v0, float.class) },
+        });
+
+        checkReturnBindings(callingSequence, new Binding[]{});
+    }
+
+    @Test
+    public void testVarArgsOnStack() {
+        final boolean varArgsOnStack = true;   // Mac/Windows ABI
+        MethodType mt = MethodType.methodType(void.class, int.class, int.class, float.class);
+        FunctionDescriptor fd = FunctionDescriptor.ofVoid(C_INT).asVariadic(C_INT, C_FLOAT);
+        CallArranger.Bindings bindings = CallArranger.getBindings(mt, fd, false, varArgsOnStack);
+
+        assertFalse(bindings.isInMemoryReturn);
+        CallingSequence callingSequence = bindings.callingSequence;
+        assertEquals(callingSequence.methodType(), mt);
+        assertEquals(callingSequence.functionDesc(), fd);
+
+        // The two variadic arguments should be allocated on the stack
+        checkArgumentBindings(callingSequence, new Binding[][]{
+            { vmStore(r0, int.class) },
+            { vmStore(stackStorage(0), int.class) },
+            { vmStore(stackStorage(1), float.class) },
         });
 
         checkReturnBindings(callingSequence, new Binding[]{});


### PR DESCRIPTION
Variable length argument lists are handled differently in the
Mac/Windows and Linux ABIs on AArch64.  Following the recent API refresh
on the foreign-memaccess+abi branch the Mac behaviour was inadvertently
applied on Linux too.  This patch restores the correct behaviour on
Linux and adds a CallArranger unit test so regressions can be more
easily caught.

I just added an extra varArgsOnStack argument to
CallArranger.getBindings() as that seemed the simplest fix, although it
could get unwieldy if there were too many configurable options.