### PR TITLE
Address failures in jdk.incubator.foreign benchmarks

### DIFF
--- a/test/micro/org/openjdk/bench/jdk/incubator/foreign/BulkOps.java
+++ b/test/micro/org/openjdk/bench/jdk/incubator/foreign/BulkOps.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ *  Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
  *  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  *  This code is free software; you can redistribute it and/or modify it
@@ -43,7 +43,6 @@ import java.nio.ByteBuffer;
 import java.nio.IntBuffer;
 import java.util.concurrent.TimeUnit;
 
-import static jdk.incubator.foreign.ValueLayout.JAVA_BYTE;
 import static jdk.incubator.foreign.ValueLayout.JAVA_INT;
 
 @BenchmarkMode(Mode.AverageTime)
@@ -138,20 +137,20 @@ public class BulkOps {
     @Benchmark
     @OutputTimeUnit(TimeUnit.NANOSECONDS)
     public void segment_copy_static() {
-        MemorySegment.copy(bytes, 0, segment, JAVA_BYTE, 0, bytes.length);
+        MemorySegment.copy(bytes, 0, segment, JAVA_INT, 0, bytes.length);
     }
 
     @Benchmark
     @OutputTimeUnit(TimeUnit.NANOSECONDS)
     public void segment_copy_static_small() {
-        MemorySegment.copy(bytes, 0, segment, JAVA_BYTE, 0, 10);
+        MemorySegment.copy(bytes, 0, segment, JAVA_INT, 0, 10);
     }
 
     @Benchmark
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     @OutputTimeUnit(TimeUnit.NANOSECONDS)
     public void segment_copy_static_small_dontinline() {
-        MemorySegment.copy(bytes, 0, segment, JAVA_BYTE, 0, 10);
+        MemorySegment.copy(bytes, 0, segment, JAVA_INT, 0, 10);
     }
 
     @Benchmark
@@ -176,7 +175,7 @@ public class BulkOps {
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     @OutputTimeUnit(TimeUnit.NANOSECONDS)
     public void segment_copy_static_dontinline() {
-        MemorySegment.copy(bytes, 0, segment, JAVA_BYTE, 0, bytes.length);
+        MemorySegment.copy(bytes, 0, segment, JAVA_INT, 0, bytes.length);
     }
 
     @Benchmark

--- a/test/micro/org/openjdk/bench/jdk/incubator/foreign/CallOverheadVirtual.java
+++ b/test/micro/org/openjdk/bench/jdk/incubator/foreign/CallOverheadVirtual.java
@@ -72,12 +72,12 @@ public class CallOverheadVirtual {
 
     @Benchmark
     public MemorySegment panama_identity_struct_confined_3() throws Throwable {
-        return (MemorySegment) identity_struct_v.invokeExact(identity_struct_addr, recycling_allocator, confinedPoint, confinedPoint, confinedPoint);
+        return (MemorySegment) identity_struct_3_v.invokeExact(identity_struct_3_addr, recycling_allocator, confinedPoint, confinedPoint, confinedPoint);
     }
 
     @Benchmark
     public MemorySegment panama_identity_struct_shared_3() throws Throwable {
-        return (MemorySegment) identity_struct_v.invokeExact(identity_struct_addr, recycling_allocator, sharedPoint, sharedPoint, sharedPoint);
+        return (MemorySegment) identity_struct_3_v.invokeExact(identity_struct_3_addr, recycling_allocator, sharedPoint, sharedPoint, sharedPoint);
     }
 
     @Benchmark
@@ -102,22 +102,22 @@ public class CallOverheadVirtual {
 
     @Benchmark
     public MemoryAddress panama_identity_struct_ref_shared() throws Throwable {
-        return (MemoryAddress) identity_memory_address_v.invokeExact((Addressable)sharedPoint);
+        return (MemoryAddress) identity_memory_address_v.invokeExact(identity_struct_addr, (Addressable)sharedPoint);
     }
 
     @Benchmark
     public MemoryAddress panama_identity_struct_ref_confined() throws Throwable {
-        return (MemoryAddress) identity_memory_address_v.invokeExact((Addressable)confinedPoint);
+        return (MemoryAddress) identity_memory_address_v.invokeExact(identity_struct_addr, (Addressable)confinedPoint);
     }
 
     @Benchmark
     public MemoryAddress panama_identity_struct_ref_shared_3() throws Throwable {
-        return (MemoryAddress) identity_memory_address_3_v.invokeExact((Addressable)sharedPoint, (Addressable)sharedPoint, (Addressable)sharedPoint);
+        return (MemoryAddress) identity_memory_address_3_v.invokeExact(identity_struct_3_addr, (Addressable)sharedPoint, (Addressable)sharedPoint, (Addressable)sharedPoint);
     }
 
     @Benchmark
     public MemoryAddress panama_identity_struct_ref_confined_3() throws Throwable {
-        return (MemoryAddress) identity_memory_address_3_v.invokeExact((Addressable)confinedPoint, (Addressable)confinedPoint, (Addressable)confinedPoint);
+        return (MemoryAddress) identity_memory_address_3_v.invokeExact(identity_struct_3_addr, (Addressable)confinedPoint, (Addressable)confinedPoint, (Addressable)confinedPoint);
     }
 
     @Benchmark
@@ -132,7 +132,7 @@ public class CallOverheadVirtual {
 
     @Benchmark
     public MemoryAddress panama_identity_memory_address_null() throws Throwable {
-        return (MemoryAddress) identity_memory_address_v.invokeExact(identity_memory_address_addr, MemoryAddress.NULL);
+        return (MemoryAddress) identity_memory_address_v.invokeExact(identity_memory_address_addr, (Addressable)MemoryAddress.NULL);
     }
 
     @Benchmark

--- a/test/micro/org/openjdk/bench/jdk/incubator/foreign/LoopOverNonConstant.java
+++ b/test/micro/org/openjdk/bench/jdk/incubator/foreign/LoopOverNonConstant.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -51,7 +51,7 @@ import static jdk.incubator.foreign.ValueLayout.JAVA_INT;
 @Measurement(iterations = 10, time = 500, timeUnit = TimeUnit.MILLISECONDS)
 @State(org.openjdk.jmh.annotations.Scope.Thread)
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
-@Fork(value = 3, jvmArgsAppend = { "--add-modules=jdk.incubator.foreign" })
+@Fork(value = 3, jvmArgsAppend = { "--add-modules=jdk.incubator.foreign", "--enable-native-access=ALL-UNNAMED" })
 public class LoopOverNonConstant {
 
     static final Unsafe unsafe = Utils.unsafe;

--- a/test/micro/org/openjdk/bench/jdk/incubator/foreign/LoopOverNonConstantHeap.java
+++ b/test/micro/org/openjdk/bench/jdk/incubator/foreign/LoopOverNonConstantHeap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -140,15 +140,6 @@ public class LoopOverNonConstantHeap {
         int res = 0;
         for (int i = 0; i < ELEM_SIZE; i ++) {
             res += segment.get(JAVA_INT, i * CARRIER_SIZE);
-        }
-        return res;
-    }
-
-    @Benchmark
-    public int segment_loop_instance_address() {
-        int res = 0;
-        for (int i = 0; i < ELEM_SIZE; i ++) {
-            res += segment.address().get(JAVA_INT, i * CARRIER_SIZE);
         }
         return res;
     }

--- a/test/micro/org/openjdk/bench/jdk/incubator/foreign/LoopOverNonConstantMapped.java
+++ b/test/micro/org/openjdk/bench/jdk/incubator/foreign/LoopOverNonConstantMapped.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -57,7 +57,7 @@ import static jdk.incubator.foreign.ValueLayout.JAVA_INT;
 @Measurement(iterations = 10, time = 500, timeUnit = TimeUnit.MILLISECONDS)
 @State(org.openjdk.jmh.annotations.Scope.Thread)
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
-@Fork(value = 3, jvmArgsAppend = { "--add-modules=jdk.incubator.foreign" })
+@Fork(value = 3, jvmArgsAppend = { "--add-modules=jdk.incubator.foreign", "--enable-native-access=ALL-UNNAMED" })
 public class LoopOverNonConstantMapped {
 
     static final Unsafe unsafe = Utils.unsafe;

--- a/test/micro/org/openjdk/bench/jdk/incubator/foreign/QSort.java
+++ b/test/micro/org/openjdk/bench/jdk/incubator/foreign/QSort.java
@@ -104,7 +104,7 @@ public class QSort extends CLayouts {
 
     @Benchmark
     public void native_qsort() throws Throwable {
-         clib_qsort.invokeExact((Addressable)INPUT_SEGMENT, (long) INPUT.length, JAVA_INT.byteSize(), native_compar);
+         clib_qsort.invokeExact((Addressable)INPUT_SEGMENT, (long) INPUT.length, JAVA_INT.byteSize(), (Addressable)native_compar);
     }
 
     @Benchmark
@@ -119,7 +119,7 @@ public class QSort extends CLayouts {
 
     @Benchmark
     public void panama_upcall_qsort() throws Throwable {
-        clib_qsort.invokeExact((Addressable)INPUT_SEGMENT, (long) INPUT.length, JAVA_INT.byteSize(), panama_upcall_compar);
+        clib_qsort.invokeExact((Addressable)INPUT_SEGMENT, (long) INPUT.length, JAVA_INT.byteSize(), (Addressable)panama_upcall_compar);
     }
 
     private static int getIntAbsolute(MemoryAddress addr) {

--- a/test/micro/org/openjdk/bench/jdk/incubator/foreign/UnrolledAccess.java
+++ b/test/micro/org/openjdk/bench/jdk/incubator/foreign/UnrolledAccess.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -40,7 +40,7 @@ import static jdk.incubator.foreign.ValueLayout.JAVA_LONG;
 @Measurement(iterations = 10, time = 500, timeUnit = TimeUnit.MILLISECONDS)
 @State(org.openjdk.jmh.annotations.Scope.Thread)
 @OutputTimeUnit(TimeUnit.MICROSECONDS)
-@Fork(3)
+@Fork(value = 3, jvmArgsAppend = { "--enable-native-access=ALL-UNNAMED" })
 public class UnrolledAccess {
 
     static final Unsafe U = Utils.unsafe;

--- a/test/micro/org/openjdk/bench/jdk/incubator/foreign/Upcalls.java
+++ b/test/micro/org/openjdk/bench/jdk/incubator/foreign/Upcalls.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -148,7 +148,7 @@ public class Upcalls extends CLayouts {
 
     @Benchmark
     public void panama_blank() throws Throwable {
-        blank.invokeExact(cb_blank);
+        blank.invokeExact((Addressable)cb_blank);
     }
 
     @Benchmark
@@ -168,17 +168,17 @@ public class Upcalls extends CLayouts {
 
     @Benchmark
     public int panama_identity() throws Throwable {
-        return (int) identity.invokeExact(10, cb_identity);
+        return (int) identity.invokeExact(10, (Addressable)cb_identity);
     }
 
     @Benchmark
     public void panama_args5() throws Throwable {
-        args5.invokeExact(1L, 2D, 3L, 4D, 5L, cb_args5);
+        args5.invokeExact(1L, 2D, 3L, 4D, 5L, (Addressable)cb_args5);
     }
 
     @Benchmark
     public void panama_args10() throws Throwable {
-        args10.invokeExact(1L, 2D, 3L, 4D, 5L, 6D, 7L, 8D, 9L, 10D, cb_args10);
+        args10.invokeExact(1L, 2D, 3L, 4D, 5L, 6D, 7L, 8D, 9L, 10D, (Addressable)cb_args10);
     }
 
     static void blank() {}

--- a/test/micro/org/openjdk/bench/jdk/incubator/foreign/points/support/PanamaPoint.java
+++ b/test/micro/org/openjdk/bench/jdk/incubator/foreign/points/support/PanamaPoint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,6 +22,7 @@
  */
 package org.openjdk.bench.jdk.incubator.foreign.points.support;
 
+import jdk.incubator.foreign.Addressable;
 import jdk.incubator.foreign.CLinker;
 import jdk.incubator.foreign.FunctionDescriptor;
 import jdk.incubator.foreign.MemoryAddress;
@@ -105,7 +106,7 @@ public class PanamaPoint extends CLayouts implements AutoCloseable {
 
     public double distanceToPtrs(PanamaPoint other) {
         try {
-            return (double) MH_distance_ptrs.invokeExact(segment.address(), other.segment.address());
+            return (double) MH_distance_ptrs.invokeExact((Addressable)segment.address(), (Addressable)other.segment.address());
         } catch (Throwable throwable) {
             throw new InternalError(throwable);
         }


### PR DESCRIPTION
This change addresses some failures in the jdk.incubator.foreign benchmarks, mainly caused by missing casts and missing native access.