### PR TITLE
8275875: jextract branch fails to build due to javac serialization warning

### DIFF
--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/clang/Index.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/clang/Index.java
@@ -70,12 +70,12 @@ public class Index implements AutoCloseable {
 
     public static class ParsingFailedException extends RuntimeException {
         private static final long serialVersionUID = -1L;
-        private final Path srcFile;
+        private final String srcFile;
         private final ErrorCode code;
 
         public ParsingFailedException(Path srcFile, ErrorCode code) {
             super("Failed to parse " + srcFile.toAbsolutePath().toString() + ": " + code);
-            this.srcFile = srcFile;
+            this.srcFile = srcFile.toAbsolutePath().toString();
             this.code = code;
         }
     }


### PR DESCRIPTION
Changed Path type to String type for the instance field.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [JDK-8275875](https://bugs.openjdk.java.net/browse/JDK-8275875): jextract branch fails to build due to javac serialization warning


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.java.net/census#mcimadamore) (@mcimadamore - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/604/head:pull/604` \
`$ git checkout pull/604`

Update a local copy of the PR: \
`$ git checkout pull/604` \
`$ git pull https://git.openjdk.java.net/panama-foreign pull/604/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 604`

View PR using the GUI difftool: \
`$ git pr show -t 604`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/panama-foreign/pull/604.diff">https://git.openjdk.java.net/panama-foreign/pull/604.diff</a>

</details>
