### PR TITLE
8276136: functional interface extraction broken after API refresh

### DIFF
--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/HeaderFileBuilder.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/HeaderFileBuilder.java
@@ -192,9 +192,6 @@ abstract class HeaderFileBuilder extends ClassSourceBuilder {
             }
             pExprs.add(pName);
             Class<?> pType = methodType.parameterType(i);
-            if (pType.equals(MemoryAddress.class)) {
-                pType = Addressable.class;
-            }
             append(delim + " " + pType.getSimpleName() + " " + pName);
             delim = ", ";
         }

--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/JavaSourceBuilder.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/JavaSourceBuilder.java
@@ -47,16 +47,17 @@ public abstract class JavaSourceBuilder {
 
     public static record FunctionInfo(
             MethodType methodType,
+            MethodType reverseMethodType,
             FunctionDescriptor descriptor,
             boolean isVarargs,
             Optional<List<String>> parameterNames) {
 
         static FunctionInfo ofFunction(MethodType methodType, FunctionDescriptor functionDescriptor, boolean isVarargs, List<String> parameterNames) {
-            return new FunctionInfo(methodType, functionDescriptor, isVarargs, Optional.of(parameterNames));
+            return new FunctionInfo(methodType, null, functionDescriptor, isVarargs, Optional.of(parameterNames));
         }
 
-        static FunctionInfo ofFunctionPointer(MethodType methodType, FunctionDescriptor functionDescriptor) {
-            return new FunctionInfo(methodType, functionDescriptor, false, Optional.empty());
+        static FunctionInfo ofFunctionPointer(MethodType upcallType, MethodType downcallType, FunctionDescriptor functionDescriptor) {
+            return new FunctionInfo(upcallType, downcallType, functionDescriptor, false, Optional.empty());
         }
     }
 

--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/StructBuilder.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/StructBuilder.java
@@ -116,7 +116,7 @@ class StructBuilder extends ConstantBuilder {
 
     @Override
     public String addFunctionalInterface(String name, FunctionInfo functionInfo) {
-        FunctionalInterfaceBuilder builder = new FunctionalInterfaceBuilder(this, name, functionInfo.methodType(), functionInfo.descriptor());
+        FunctionalInterfaceBuilder builder = new FunctionalInterfaceBuilder(this, name, functionInfo);
         builder.classBegin();
         builder.classEnd();
         return builder.className();

--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/ToplevelBuilder.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/ToplevelBuilder.java
@@ -125,8 +125,7 @@ class ToplevelBuilder extends JavaSourceBuilder {
 
     @Override
     public String addFunctionalInterface(String name, FunctionInfo functionInfo) {
-        FunctionalInterfaceBuilder builder = new FunctionalInterfaceBuilder(this,
-                name, functionInfo.methodType(), functionInfo.descriptor());
+        FunctionalInterfaceBuilder builder = new FunctionalInterfaceBuilder(this, name, functionInfo);
         builders.add(builder);
         builder.classBegin();
         builder.classEnd();

--- a/test/jdk/tools/jextract/funcPointerInvokers/TestFuncPointerInvokers.java
+++ b/test/jdk/tools/jextract/funcPointerInvokers/TestFuncPointerInvokers.java
@@ -21,6 +21,7 @@
  * questions.
  */
 
+import jdk.incubator.foreign.MemoryAddress;
 import jdk.incubator.foreign.MemorySegment;
 import jdk.incubator.foreign.ResourceScope;
 import org.testng.annotations.Test;
@@ -128,6 +129,14 @@ public class TestFuncPointerInvokers {
             fp$set(fp.allocate((i) -> val.set(i), scope).address());
             fp.ofAddress(fp$get(), scope).apply(42);
             assertEquals(val.get(), 42);
+        }
+    }
+
+    @Test
+    public void testGlobalFIFunctionPointerAddress() {
+        try (ResourceScope scope = ResourceScope.newConfinedScope()) {
+            fp_addr$set(fp_addr.allocate((addr) -> MemoryAddress.ofLong(addr.toRawLongValue() + 1), scope).address());
+            assertEquals(fp_addr.ofAddress(fp_addr$get(), scope).apply(MemoryAddress.ofLong(42)), MemoryAddress.ofLong(43));
         }
     }
 }

--- a/test/jdk/tools/jextract/funcPointerInvokers/func.h
+++ b/test/jdk/tools/jextract/funcPointerInvokers/func.h
@@ -45,6 +45,8 @@ struct Baz {
 
 EXPORT void (*fp)(int arg);
 
+EXPORT int* (*fp_addr)(int *arg);
+
 #ifdef __cplusplus
 }
 #endif // __cplusplus


### PR DESCRIPTION
This addresses the issue discovered in this thread:

https://mail.openjdk.java.net/pipermail/panama-dev/2021-September/015144.html

The issue is causes by the fact that the new linker changes introduce an asymmetry between the method type of the downcall and that of an upcall. Downcall have `Addressable` for parameters passed by-reference, and `MemoryAddress` for by-reference returns. Upcalls adopt the dual scheme (`MemoryAddress` for parameters, `Addressable` for return values).

This patch bridges the two schemes by inserting the required casts which keep `invokeExact` happy in the case where we generate a functional interface implementation which calls the upcall stub address.

To do that I had to dig a bit in `TypeTranslator` to make the type translation context-dependent. I also had to enhance `FunctionInfo` so that it could carry the "reverse" method type in the upcall case.

I've added a test which checks a function pointer which takes an address and returns another address - which stresses both argument and return mismatch.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [JDK-8276136](https://bugs.openjdk.java.net/browse/JDK-8276136): functional interface extraction broken after API refresh


### Reviewers
 * [Jorn Vernee](https://openjdk.java.net/census#jvernee) (@JornVernee - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/605/head:pull/605` \
`$ git checkout pull/605`

Update a local copy of the PR: \
`$ git checkout pull/605` \
`$ git pull https://git.openjdk.java.net/panama-foreign pull/605/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 605`

View PR using the GUI difftool: \
`$ git pr show -t 605`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/panama-foreign/pull/605.diff">https://git.openjdk.java.net/panama-foreign/pull/605.diff</a>

</details>
