### PR TITLE
8275646: Implement optimized upcall stubs on AArch64

### DIFF
--- a/src/hotspot/cpu/aarch64/foreign_globals_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/foreign_globals_aarch64.cpp
@@ -106,17 +106,11 @@ const CallRegs ForeignGlobals::parse_call_regs_impl(jobject jconv) const {
   result._ret_regs = NEW_RESOURCE_ARRAY(VMReg, result._rets_length);
 
   for (int i = 0; i < result._args_length; i++) {
-    oop storage = arg_regs_oop->obj_at(i);
-    jint index = storage->int_field(VMS.index_offset);
-    jint type = storage->int_field(VMS.type_offset);
-    result._arg_regs[i] = vmstorage_to_vmreg(type, index);
+    result._arg_regs[i] = parse_vmstorage(arg_regs_oop->obj_at(i));
   }
 
   for (int i = 0; i < result._rets_length; i++) {
-    oop storage = ret_regs_oop->obj_at(i);
-    jint index = storage->int_field(VMS.index_offset);
-    jint type = storage->int_field(VMS.type_offset);
-    result._ret_regs[i] = vmstorage_to_vmreg(type, index);
+    result._ret_regs[i] = parse_vmstorage(ret_regs_oop->obj_at(i));
   }
 
   return result;

--- a/src/hotspot/cpu/aarch64/foreign_globals_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/foreign_globals_aarch64.cpp
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2019, Arm Limited. All rights reserved.
+ * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2021, Arm Limited. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -94,8 +94,32 @@ const BufferLayout ForeignGlobals::parse_buffer_layout_impl(jobject jlayout) con
 }
 
 const CallRegs ForeignGlobals::parse_call_regs_impl(jobject jconv) const {
-  ShouldNotCallThis();
-  return {};
+  oop conv_oop = JNIHandles::resolve_non_null(jconv);
+  objArrayOop arg_regs_oop = oop_cast<objArrayOop>(conv_oop->obj_field(CallConvOffsets.arg_regs_offset));
+  objArrayOop ret_regs_oop = oop_cast<objArrayOop>(conv_oop->obj_field(CallConvOffsets.ret_regs_offset));
+
+  CallRegs result;
+  result._args_length = arg_regs_oop->length();
+  result._arg_regs = NEW_RESOURCE_ARRAY(VMReg, result._args_length);
+
+  result._rets_length = ret_regs_oop->length();
+  result._ret_regs = NEW_RESOURCE_ARRAY(VMReg, result._rets_length);
+
+  for (int i = 0; i < result._args_length; i++) {
+    oop storage = arg_regs_oop->obj_at(i);
+    jint index = storage->int_field(VMS.index_offset);
+    jint type = storage->int_field(VMS.type_offset);
+    result._arg_regs[i] = vmstorage_to_vmreg(type, index);
+  }
+
+  for (int i = 0; i < result._rets_length; i++) {
+    oop storage = ret_regs_oop->obj_at(i);
+    jint index = storage->int_field(VMS.index_offset);
+    jint type = storage->int_field(VMS.type_offset);
+    result._ret_regs[i] = vmstorage_to_vmreg(type, index);
+  }
+
+  return result;
 }
 
 enum class RegType {

--- a/src/hotspot/cpu/aarch64/frame_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/frame_aarch64.cpp
@@ -115,6 +115,8 @@ bool frame::safe_for_sender(JavaThread *thread) {
     if (is_entry_frame()) {
       // an entry frame must have a valid fp.
       return fp_safe && is_entry_frame_valid(thread);
+    } else if (is_optimized_entry_frame()) {
+      return fp_safe;
     }
 
     intptr_t* sender_sp = NULL;
@@ -211,6 +213,8 @@ bool frame::safe_for_sender(JavaThread *thread) {
       address jcw = (address)sender.entry_frame_call_wrapper();
 
       return thread->is_in_stack_range_excl(jcw, (address)sender.fp());
+    } else if (sender_blob->is_optimized_entry_blob()) {
+      return false;
     }
 
     CompiledMethod* nm = sender_blob->as_compiled_method_or_null();
@@ -363,18 +367,39 @@ frame frame::sender_for_entry_frame(RegisterMap* map) const {
 }
 
 OptimizedEntryBlob::FrameData* OptimizedEntryBlob::frame_data_for_frame(const frame& frame) const {
-  ShouldNotCallThis();
-  return nullptr;
+  assert(frame.is_optimized_entry_frame(), "wrong frame");
+  // need unextended_sp here, since normal sp is wrong for interpreter callees
+  return reinterpret_cast<OptimizedEntryBlob::FrameData*>(
+    reinterpret_cast<char*>(frame.unextended_sp()) + in_bytes(_frame_data_offset));
 }
 
 bool frame::optimized_entry_frame_is_first() const {
-  ShouldNotCallThis();
-  return false;
+  assert(is_optimized_entry_frame(), "must be optimzed entry frame");
+  OptimizedEntryBlob* blob = _cb->as_optimized_entry_blob();
+  JavaFrameAnchor* jfa = blob->jfa_for_frame(*this);
+  return jfa->last_Java_sp() == NULL;
 }
 
 frame frame::sender_for_optimized_entry_frame(RegisterMap* map) const {
-  ShouldNotCallThis();
-  return {};
+  assert(map != NULL, "map must be set");
+  OptimizedEntryBlob* blob = _cb->as_optimized_entry_blob();
+  // Java frame called from C; skip all C frames and return top C
+  // frame of that chunk as the sender
+  JavaFrameAnchor* jfa = blob->jfa_for_frame(*this);
+  assert(!optimized_entry_frame_is_first(), "must have a frame anchor to go back to");
+  assert(jfa->last_Java_sp() > sp(), "must be above this frame on stack");
+  // Since we are walking the stack now this nested anchor is obviously walkable
+  // even if it wasn't when it was stacked.
+  if (!jfa->walkable()) {
+    // Capture _last_Java_pc (if needed) and mark anchor walkable.
+    jfa->capture_last_Java_pc();
+  }
+  map->clear();
+  assert(map->include_argument_oops(), "should be set by clear");
+  vmassert(jfa->last_Java_pc() != NULL, "not walkable");
+  frame fr(jfa->last_Java_sp(), jfa->last_Java_fp(), jfa->last_Java_pc());
+
+  return fr;
 }
 
 //------------------------------------------------------------------------------
@@ -507,6 +532,8 @@ frame frame::sender_raw(RegisterMap* map) const {
 
   if (is_entry_frame())
     return sender_for_entry_frame(map);
+  if (is_optimized_entry_frame())
+    return sender_for_optimized_entry_frame(map);
   if (is_interpreted_frame())
     return sender_for_interpreter_frame(map);
   assert(_cb == CodeCache::find_blob(pc()),"Must be the same");

--- a/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
@@ -2075,7 +2075,7 @@ void MacroAssembler::resolve_jobject(Register value, Register thread, Register t
   cbz(value, done);           // Use NULL as-is.
 
   STATIC_ASSERT(JNIHandles::weak_tag_mask == 1u);
-  tbz(r0, 0, not_weak);    // Test for jweak tag.
+  tbz(value, 0, not_weak);    // Test for jweak tag.
 
   // Resolve jweak.
   access_load_at(T_OBJECT, IN_NATIVE | ON_PHANTOM_OOP_REF, value,

--- a/src/hotspot/cpu/aarch64/universalUpcallHandler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/universalUpcallHandler_aarch64.cpp
@@ -24,7 +24,6 @@
 
 #include "precompiled.hpp"
 #include "asm/macroAssembler.hpp"
-#include "compiler/disassembler.hpp"
 #include "logging/logStream.hpp"
 #include "memory/resourceArea.hpp"
 #include "prims/universalUpcallHandler.hpp"
@@ -391,7 +390,6 @@ address ProgrammableUpcallHandler::generate_optimized_upcall_stub(jobject receiv
 
   if (TraceOptimizedUpcallStubs) {
     blob->print_on(tty);
-    Disassembler::decode(blob, tty);
   }
 
   return blob->code_begin();

--- a/src/hotspot/cpu/aarch64/universalUpcallHandler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/universalUpcallHandler_aarch64.cpp
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2019, Arm Limited. All rights reserved.
+ * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2021, Arm Limited. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,8 +24,17 @@
 
 #include "precompiled.hpp"
 #include "asm/macroAssembler.hpp"
+#include "compiler/disassembler.hpp"
+#include "logging/logStream.hpp"
 #include "memory/resourceArea.hpp"
 #include "prims/universalUpcallHandler.hpp"
+#include "runtime/sharedRuntime.hpp"
+#include "runtime/signature.hpp"
+#include "runtime/signature.hpp"
+#include "runtime/stubRoutines.hpp"
+#include "utilities/formatBuffer.hpp"
+#include "utilities/globalDefinitions.hpp"
+#include "vmreg_aarch64.inline.hpp"
 
 #define __ _masm->
 
@@ -100,11 +109,294 @@ address ProgrammableUpcallHandler::generate_upcall_stub(jobject rec, jobject jab
   return blob->code_begin();
 }
 
-address ProgrammableUpcallHandler::generate_optimized_upcall_stub(jobject mh, Method* entry, jobject jabi, jobject jconv) {
-  ShouldNotCallThis();
-  return nullptr;
+// for callee saved regs, according to the caller's ABI
+static int compute_reg_save_area_size(const ABIDescriptor& abi) {
+  int size = 0;
+  for (int i = 0; i < RegisterImpl::number_of_registers; i++) {
+    Register reg = as_Register(i);
+    if (reg == rfp || reg == sp) continue; // saved/restored by prologue/epilogue
+    if (!abi.is_volatile_reg(reg)) {
+      size += 8; // bytes
+    }
+  }
+
+  for (int i = 0; i < FloatRegisterImpl::number_of_registers; i++) {
+    FloatRegister reg = as_FloatRegister(i);
+    if (!abi.is_volatile_reg(reg)) {
+      // Only the lower 64 bits of vector registers need to be preserved.
+      size += 8; // bytes
+    }
+  }
+
+  return size;
+}
+
+static void preserve_callee_saved_registers(MacroAssembler* _masm, const ABIDescriptor& abi, int reg_save_area_offset) {
+  // 1. iterate all registers in the architecture
+  //     - check if they are volatile or not for the given abi
+  //     - if NOT, we need to save it here
+
+  int offset = reg_save_area_offset;
+
+  __ block_comment("{ preserve_callee_saved_regs ");
+  for (int i = 0; i < RegisterImpl::number_of_registers; i++) {
+    Register reg = as_Register(i);
+    if (reg == rfp || reg == sp) continue; // saved/restored by prologue/epilogue
+    if (!abi.is_volatile_reg(reg)) {
+      __ str(reg, Address(sp, offset));
+      offset += 8;
+    }
+  }
+
+  for (int i = 0; i < FloatRegisterImpl::number_of_registers; i++) {
+    FloatRegister reg = as_FloatRegister(i);
+    if (!abi.is_volatile_reg(reg)) {
+      __ strd(reg, Address(sp, offset));
+      offset += 8;
+    }
+  }
+
+  __ block_comment("} preserve_callee_saved_regs ");
+}
+
+static void restore_callee_saved_registers(MacroAssembler* _masm, const ABIDescriptor& abi, int reg_save_area_offset) {
+  // 1. iterate all registers in the architecture
+  //     - check if they are volatile or not for the given abi
+  //     - if NOT, we need to restore it here
+
+  int offset = reg_save_area_offset;
+
+  __ block_comment("{ restore_callee_saved_regs ");
+  for (int i = 0; i < RegisterImpl::number_of_registers; i++) {
+    Register reg = as_Register(i);
+    if (reg == rfp || reg == sp) continue; // saved/restored by prologue/epilogue
+    if (!abi.is_volatile_reg(reg)) {
+      __ ldr(reg, Address(sp, offset));
+      offset += 8;
+    }
+  }
+
+  for (int i = 0; i < FloatRegisterImpl::number_of_registers; i++) {
+    FloatRegister reg = as_FloatRegister(i);
+    if (!abi.is_volatile_reg(reg)) {
+      __ ldrd(reg, Address(sp, offset));
+      offset += 8;
+    }
+  }
+
+  __ block_comment("} restore_callee_saved_regs ");
+}
+
+address ProgrammableUpcallHandler::generate_optimized_upcall_stub(jobject receiver, Method* entry, jobject jabi, jobject jconv) {
+  ResourceMark rm;
+  const ABIDescriptor abi = ForeignGlobals::parse_abi_descriptor(jabi);
+  const CallRegs call_regs = ForeignGlobals::parse_call_regs(jconv);
+  assert(call_regs._rets_length <= 1, "no multi reg returns");
+  CodeBuffer buffer("upcall_stub_linkToNative", /* code_size = */ 2048, /* locs_size = */ 1024);
+
+  assert(entry->is_static(), "static only");
+  // Fill in the signature array, for the calling-convention call.
+  const int total_out_args = entry->size_of_parameters();
+  assert(total_out_args > 0, "receiver arg");
+
+  BasicType* out_sig_bt = NEW_RESOURCE_ARRAY(BasicType, total_out_args);
+  BasicType ret_type;
+  {
+    int i = 0;
+    SignatureStream ss(entry->signature());
+    for (; !ss.at_return_type(); ss.next()) {
+      out_sig_bt[i++] = ss.type();  // Collect remaining bits of signature
+      if (ss.type() == T_LONG || ss.type() == T_DOUBLE)
+        out_sig_bt[i++] = T_VOID;   // Longs & doubles take 2 Java slots
+    }
+    assert(i == total_out_args, "");
+    ret_type = ss.type();
+  }
+  // skip receiver
+  BasicType* in_sig_bt = out_sig_bt + 1;
+  int total_in_args = total_out_args - 1;
+
+  Register shuffle_reg = r19;
+  JavaCallConv out_conv;
+  NativeCallConv in_conv(call_regs._arg_regs, call_regs._args_length);
+  ArgumentShuffle arg_shuffle(in_sig_bt, total_in_args, out_sig_bt, total_out_args, &in_conv, &out_conv, shuffle_reg->as_VMReg());
+  int stack_slots = SharedRuntime::out_preserve_stack_slots() + arg_shuffle.out_arg_stack_slots();
+  int out_arg_area = align_up(stack_slots * VMRegImpl::stack_slot_size, StackAlignmentInBytes);
+
+#ifdef ASSERT
+  LogTarget(Trace, panama) lt;
+  if (lt.is_enabled()) {
+    ResourceMark rm;
+    LogStream ls(lt);
+    arg_shuffle.print_on(&ls);
+  }
+#endif
+
+  // out_arg_area (for stack arguments) doubles as shadow space for native calls.
+  // make sure it is big enough.
+  if (out_arg_area < frame::arg_reg_save_area_bytes) {
+    out_arg_area = frame::arg_reg_save_area_bytes;
+  }
+
+  int reg_save_area_size = compute_reg_save_area_size(abi);
+  RegSpiller arg_spilller(call_regs._arg_regs, call_regs._args_length);
+  RegSpiller result_spiller(call_regs._ret_regs, call_regs._rets_length);
+  // To spill receiver during deopt
+  int deopt_spill_size = 1 * BytesPerWord;
+
+  int shuffle_area_offset    = 0;
+  int deopt_spill_offset     = shuffle_area_offset    + out_arg_area;
+  int res_save_area_offset   = deopt_spill_offset     + deopt_spill_size;
+  int arg_save_area_offset   = res_save_area_offset   + result_spiller.spill_size_bytes();
+  int reg_save_area_offset   = arg_save_area_offset   + arg_spilller.spill_size_bytes();
+  int frame_data_offset      = reg_save_area_offset   + reg_save_area_size;
+  int frame_bottom_offset    = frame_data_offset      + sizeof(OptimizedEntryBlob::FrameData);
+
+  int frame_size = frame_bottom_offset;
+  frame_size = align_up(frame_size, StackAlignmentInBytes);
+
+  // The space we have allocated will look like:
+  //
+  //
+  // FP-> |                     |
+  //      |---------------------| = frame_bottom_offset = frame_size
+  //      |                     |
+  //      | FrameData           |
+  //      |---------------------| = frame_data_offset
+  //      |                     |
+  //      | reg_save_area       |
+  //      |---------------------| = reg_save_are_offset
+  //      |                     |
+  //      | arg_save_area       |
+  //      |---------------------| = arg_save_are_offset
+  //      |                     |
+  //      | res_save_area       |
+  //      |---------------------| = res_save_are_offset
+  //      |                     |
+  //      | deopt_spill         |
+  //      |---------------------| = deopt_spill_offset
+  //      |                     |
+  // SP-> | out_arg_area        |   needs to be at end for shadow space
+  //
+  //
+
+  //////////////////////////////////////////////////////////////////////////////
+
+  MacroAssembler* _masm = new MacroAssembler(&buffer);
+  address start = __ pc();
+  __ enter(); // set up frame
+  assert((abi._stack_alignment_bytes % 16) == 0, "must be 16 byte aligned");
+  // allocate frame (frame_size is also aligned, so stack is still aligned)
+  __ sub(sp, sp, frame_size);
+
+  // we have to always spill args since we need to do a call to get the thread
+  // (and maybe attach it).
+  arg_spilller.generate_spill(_masm, arg_save_area_offset);
+  preserve_callee_saved_registers(_masm, abi, reg_save_area_offset);
+
+  __ block_comment("{ on_entry");
+  __ lea(c_rarg0, Address(sp, frame_data_offset));
+  __ movptr(rscratch1, CAST_FROM_FN_PTR(uint64_t, ProgrammableUpcallHandler::on_entry));
+  __ blr(rscratch1);
+  __ mov(rthread, r0);
+  __ reinit_heapbase();
+  __ block_comment("} on_entry");
+
+  __ block_comment("{ argument shuffle");
+  arg_spilller.generate_fill(_masm, arg_save_area_offset);
+  arg_shuffle.generate(_masm, shuffle_reg->as_VMReg(), abi._shadow_space_bytes, 0);
+  __ block_comment("} argument shuffle");
+
+  __ block_comment("{ receiver ");
+  __ movptr(shuffle_reg, (intptr_t)receiver);
+  __ resolve_jobject(shuffle_reg, rthread, rscratch2);
+  __ mov(j_rarg0, shuffle_reg);
+  __ block_comment("} receiver ");
+
+  __ mov_metadata(rmethod, entry);
+  __ str(rmethod, Address(rthread, JavaThread::callee_target_offset())); // just in case callee is deoptimized
+
+  __ ldr(rscratch1, Address(rmethod, Method::from_compiled_offset()));
+  __ blr(rscratch1);
+
+  result_spiller.generate_spill(_masm, res_save_area_offset);
+
+  __ block_comment("{ on_exit");
+  __ lea(c_rarg0, Address(sp, frame_data_offset));
+  // stack already aligned
+  __ movptr(rscratch1, CAST_FROM_FN_PTR(uint64_t, ProgrammableUpcallHandler::on_exit));
+  __ blr(rscratch1);
+  __ block_comment("} on_exit");
+
+  restore_callee_saved_registers(_masm, abi, reg_save_area_offset);
+
+  result_spiller.generate_fill(_masm, res_save_area_offset);
+
+  // return value shuffle
+#ifdef ASSERT
+  if (call_regs._rets_length == 1) { // 0 or 1
+    VMReg j_expected_result_reg;
+    switch (ret_type) {
+      case T_BOOLEAN:
+      case T_BYTE:
+      case T_SHORT:
+      case T_CHAR:
+      case T_INT:
+      case T_LONG:
+       j_expected_result_reg = r0->as_VMReg();
+       break;
+      case T_FLOAT:
+      case T_DOUBLE:
+        j_expected_result_reg = v0->as_VMReg();
+        break;
+      default:
+        fatal("unexpected return type: %s", type2name(ret_type));
+    }
+    // No need to move for now, since CallArranger can pick a return type
+    // that goes in the same reg for both CCs. But, at least assert they are the same
+    assert(call_regs._ret_regs[0] == j_expected_result_reg,
+     "unexpected result register: %s != %s", call_regs._ret_regs[0]->name(), j_expected_result_reg->name());
+  }
+#endif
+
+  __ leave();
+  __ ret(lr);
+
+  //////////////////////////////////////////////////////////////////////////////
+
+  __ block_comment("{ exception handler");
+
+  intptr_t exception_handler_offset = __ pc() - start;
+
+  // Native caller has no idea how to handle exceptions,
+  // so we just crash here. Up to callee to catch exceptions.
+  __ verify_oop(r0);
+  __ movptr(rscratch1, CAST_FROM_FN_PTR(uint64_t, ProgrammableUpcallHandler::handle_uncaught_exception));
+  __ blr(rscratch1);
+  __ should_not_reach_here();
+
+  __ block_comment("} exception handler");
+
+  _masm->flush();
+
+#ifndef PRODUCT
+  stringStream ss;
+  ss.print("optimized_upcall_stub_%s", entry->signature()->as_C_string());
+  const char* name = _masm->code_string(ss.as_string());
+#else // PRODUCT
+  const char* name = "optimized_upcall_stub";
+#endif // PRODUCT
+
+  OptimizedEntryBlob* blob = OptimizedEntryBlob::create(name, &buffer, exception_handler_offset, receiver, in_ByteSize(frame_data_offset));
+
+  if (TraceOptimizedUpcallStubs) {
+    blob->print_on(tty);
+    Disassembler::decode(blob, tty);
+  }
+
+  return blob->code_begin();
 }
 
 bool ProgrammableUpcallHandler::supports_optimized_upcalls() {
-  return false;
+  return true;
 }

--- a/src/hotspot/share/code/codeBlob.cpp
+++ b/src/hotspot/share/code/codeBlob.cpp
@@ -225,8 +225,8 @@ void CodeBlob::print_code() {
 // Implementation of BufferBlob
 
 
-BufferBlob::BufferBlob(const char* name, int size)
-: RuntimeBlob(name, sizeof(BufferBlob), size, CodeOffsets::frame_never_safe, /*locs_size:*/ 0)
+BufferBlob::BufferBlob(const char* name, int header_size, int size)
+: RuntimeBlob(name, header_size, size, CodeOffsets::frame_never_safe, /*locs_size:*/ 0)
 {}
 
 BufferBlob* BufferBlob::create(const char* name, int buffer_size) {
@@ -240,7 +240,7 @@ BufferBlob* BufferBlob::create(const char* name, int buffer_size) {
   assert(name != NULL, "must provide a name");
   {
     MutexLocker mu(CodeCache_lock, Mutex::_no_safepoint_check_flag);
-    blob = new (size) BufferBlob(name, size);
+    blob = new (size) BufferBlob(name, sizeof(BufferBlob), size);
   }
   // Track memory usage statistic after releasing CodeCache_lock
   MemoryService::track_code_cache_memory_usage();
@@ -249,8 +249,8 @@ BufferBlob* BufferBlob::create(const char* name, int buffer_size) {
 }
 
 
-BufferBlob::BufferBlob(const char* name, int size, CodeBuffer* cb)
-  : RuntimeBlob(name, cb, sizeof(BufferBlob), size, CodeOffsets::frame_never_safe, 0, NULL)
+BufferBlob::BufferBlob(const char* name, int header_size, int size, CodeBuffer* cb)
+  : RuntimeBlob(name, cb, header_size, size, CodeOffsets::frame_never_safe, 0, NULL)
 {}
 
 BufferBlob* BufferBlob::create(const char* name, CodeBuffer* cb) {
@@ -261,7 +261,7 @@ BufferBlob* BufferBlob::create(const char* name, CodeBuffer* cb) {
   assert(name != NULL, "must provide a name");
   {
     MutexLocker mu(CodeCache_lock, Mutex::_no_safepoint_check_flag);
-    blob = new (size) BufferBlob(name, size, cb);
+    blob = new (size) BufferBlob(name, sizeof(BufferBlob), size, cb);
   }
   // Track memory usage statistic after releasing CodeCache_lock
   MemoryService::track_code_cache_memory_usage();
@@ -290,7 +290,7 @@ void BufferBlob::free(BufferBlob *blob) {
 // Implementation of AdapterBlob
 
 AdapterBlob::AdapterBlob(int size, CodeBuffer* cb) :
-  BufferBlob("I2C/C2I adapters", size, cb) {
+  BufferBlob("I2C/C2I adapters", sizeof(AdapterBlob), size, cb) {
   CodeCache::commit(this);
 }
 
@@ -320,7 +320,7 @@ void* VtableBlob::operator new(size_t s, unsigned size) throw() {
 }
 
 VtableBlob::VtableBlob(const char* name, int size) :
-  BufferBlob(name, size) {
+  BufferBlob(name, sizeof(VtableBlob), size) {
 }
 
 VtableBlob* VtableBlob::create(const char* name, int buffer_size) {
@@ -721,7 +721,7 @@ void DeoptimizationBlob::print_value_on(outputStream* st) const {
 
 OptimizedEntryBlob::OptimizedEntryBlob(const char* name, int size, CodeBuffer* cb, intptr_t exception_handler_offset,
                                        jobject receiver, ByteSize frame_data_offset) :
-  BufferBlob(name, size, cb),
+  BufferBlob(name, sizeof(OptimizedEntryBlob), size, cb),
   _exception_handler_offset(exception_handler_offset),
   _receiver(receiver),
   _frame_data_offset(frame_data_offset) {

--- a/src/hotspot/share/code/codeBlob.hpp
+++ b/src/hotspot/share/code/codeBlob.hpp
@@ -401,8 +401,8 @@ class BufferBlob: public RuntimeBlob {
 
  private:
   // Creation support
-  BufferBlob(const char* name, int size);
-  BufferBlob(const char* name, int size, CodeBuffer* cb);
+  BufferBlob(const char* name, int header_size, int size);
+  BufferBlob(const char* name, int header_size, int size, CodeBuffer* cb);
 
   // This ordinary operator delete is needed even though not used, so the
   // below two-argument operator delete will be treated as a placement
@@ -465,7 +465,7 @@ public:
 
 class MethodHandlesAdapterBlob: public BufferBlob {
 private:
-  MethodHandlesAdapterBlob(int size)                 : BufferBlob("MethodHandles adapters", size) {}
+  MethodHandlesAdapterBlob(int size): BufferBlob("MethodHandles adapters", sizeof(MethodHandlesAdapterBlob), size) {}
 
 public:
   // Creation

--- a/src/hotspot/share/prims/universalUpcallHandler.cpp
+++ b/src/hotspot/share/prims/universalUpcallHandler.cpp
@@ -103,8 +103,6 @@ JavaThread* ProgrammableUpcallHandler::on_entry(OptimizedEntryBlob::FrameData* c
   debug_only(thread->inc_java_call_counter());
   thread->set_active_handles(context->new_handles);     // install new handle block and reset Java frame linkage
 
-  MACOS_AARCH64_ONLY(thread->enable_wx(WXExec));
-
   return thread;
 }
 
@@ -112,8 +110,6 @@ JavaThread* ProgrammableUpcallHandler::on_entry(OptimizedEntryBlob::FrameData* c
 void ProgrammableUpcallHandler::on_exit(OptimizedEntryBlob::FrameData* context) {
   JavaThread* thread = context->thread;
   assert(thread == JavaThread::current(), "must still be the same thread");
-
-  MACOS_AARCH64_ONLY(thread->enable_wx(WXWrite));
 
   // restore previous handle block
   thread->set_active_handles(context->old_handles);

--- a/src/hotspot/share/prims/whitebox.cpp
+++ b/src/hotspot/share/prims/whitebox.cpp
@@ -1545,7 +1545,7 @@ CodeBlob* WhiteBox::allocate_code_blob(int size, int blob_type) {
     MutexLocker mu(CodeCache_lock, Mutex::_no_safepoint_check_flag);
     blob = (BufferBlob*) CodeCache::allocate(full_size, blob_type);
     if (blob != NULL) {
-      ::new (blob) BufferBlob("WB::DummyBlob", full_size);
+      ::new (blob) BufferBlob("WB::DummyBlob", sizeof(BufferBlob), full_size);
     }
   }
   // Track memory usage statistic after releasing CodeCache_lock

--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -537,6 +537,7 @@ java/beans/XMLEncoder/Test6570354.java 8015593 macosx-all
 # jdk_foreign
 
 java/foreign/TestMismatch.java 8249684 macosx-all
+java/foreign/TestUpcall.java#stack 8275584 macosx-aarch64
 
 ############################################################################
 


### PR DESCRIPTION
This is a fairly direct port of the X86 code.  The changes to
frame_aarch64 and foreign_globals_aarch64 are identical: perhaps
ForeignGlobals::parse_call_regs_impl() could be moved to shared code?

The X86 version has a call to reinit_heapbase() before the return from
the stub.  I think this is redundant because the heap base register will
be clobbered immediately by the native code?

I hit a really weird bug in release builds where the first few
instructions in the code buffer were overwritten by the fields of
OptimizedEntryBlob.  I think we need to pass sizeof(OptimizedEntryBlob)
instead of sizeof(BufferBlob) as the header_size argument to the
RuntimeBlob constructor (none of the other subclasses of BufferBlob have
extra fields).  I added a header_size argument to BufferBlob's
constructor to thread this through.

I removed the calls to change the W^X state in on_entry/on_exit calls:
in the on_entry case the stub must already be executable because we
called into the VM from there, and for on_exit we need the code to be
executable not writable otherwise we'll get a SIGBUS as soon as we
return to the stub.  The newly added stack tests in TestUpcall hit
JDK-8275584 on MacOS/AArch64 so I've problem-listed that for now.

JMH results from org.openjdk.bench.jdk.incubator.foreign.Upcalls before:

```
Benchmark                Mode  Cnt     Score    Error  Units
Upcalls.jni_args10       avgt   30   450.417 ?  4.755  ns/op
Upcalls.jni_args5        avgt   30   245.898 ?  3.171  ns/op
Upcalls.jni_blank        avgt   30   195.606 ?  5.459  ns/op
Upcalls.jni_identity     avgt   30   369.788 ? 15.165  ns/op
Upcalls.panama_args10    avgt   30  1253.189 ? 62.261  ns/op
Upcalls.panama_args5     avgt   30   927.101 ? 35.369  ns/op
Upcalls.panama_blank     avgt   30   637.708 ? 11.353  ns/op
Upcalls.panama_identity  avgt   30   697.109 ?  9.971  ns/op
```

After:

```
Benchmark                Mode  Cnt    Score    Error  Units
Upcalls.jni_args10       avgt   30  455.304 ? 21.838  ns/op
Upcalls.jni_args5        avgt   30  247.279 ?  2.513  ns/op
Upcalls.jni_blank        avgt   30  194.113 ?  4.317  ns/op
Upcalls.jni_identity     avgt   30  366.145 ?  4.912  ns/op
Upcalls.panama_args10    avgt   30  236.337 ? 11.072  ns/op
Upcalls.panama_args5     avgt   30  223.858 ? 12.345  ns/op
Upcalls.panama_blank     avgt   30  203.631 ?  8.840  ns/op
Upcalls.panama_identity  avgt   30  208.783 ?  9.914  ns/op
```

Tested tier1 and jdk_foreign on Linux/AArch64 and MacOS/AArch64.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [JDK-8275646](https://bugs.openjdk.java.net/browse/JDK-8275646): Implement optimized upcall stubs on AArch64


### Reviewers
 * [Jorn Vernee](https://openjdk.java.net/census#jvernee) (@JornVernee - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/610/head:pull/610` \
`$ git checkout pull/610`

Update a local copy of the PR: \
`$ git checkout pull/610` \
`$ git pull https://git.openjdk.java.net/panama-foreign pull/610/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 610`

View PR using the GUI difftool: \
`$ git pr show -t 610`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/panama-foreign/pull/610.diff">https://git.openjdk.java.net/panama-foreign/pull/610.diff</a>

</details>
