### PR TITLE
8276987: Optimized upcall stub should be printed with -XX:+PrintStubCode

### DIFF
--- a/src/hotspot/share/code/codeBlob.cpp
+++ b/src/hotspot/share/code/codeBlob.cpp
@@ -741,6 +741,8 @@ OptimizedEntryBlob* OptimizedEntryBlob::create(const char* name, CodeBuffer* cb,
   // Track memory usage statistic after releasing CodeCache_lock
   MemoryService::track_code_cache_memory_usage();
 
+  trace_new_stub(blob, "OptimizedEntryBlob");
+
   return blob;
 }
 


### PR DESCRIPTION
That would allow it to be found by JMH's profasm which uses `-XX:+PrintStubCode` to collect the addresses of stubs.  Note that JMH at the moment can't actually parse the stubs printed by `trace_new_stub` (because they have a "Decoding ..." prefix and don't include the end address), but that can be fixed on the JMH side.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [JDK-8276987](https://bugs.openjdk.java.net/browse/JDK-8276987): Optimized upcall stub should be printed with -XX:+PrintStubCode


### Reviewers
 * [Jorn Vernee](https://openjdk.java.net/census#jvernee) (@JornVernee - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/611/head:pull/611` \
`$ git checkout pull/611`

Update a local copy of the PR: \
`$ git checkout pull/611` \
`$ git pull https://git.openjdk.java.net/panama-foreign pull/611/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 611`

View PR using the GUI difftool: \
`$ git pr show -t 611`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/panama-foreign/pull/611.diff">https://git.openjdk.java.net/panama-foreign/pull/611.diff</a>

</details>
