### PR TITLE
8277070: Regularize logic for cursor -> position conversion

### DIFF
--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/Parser.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/Parser.java
@@ -91,7 +91,7 @@ public class Parser {
                 } else if (isMacro(c) && src.path() != null) {
                     SourceRange range = c.getExtent();
                     String[] tokens = c.getTranslationUnit().tokens(range);
-                    Optional<Declaration.Constant> constant = macroParser.parseConstant(TreeMaker.toPos(c), c.spelling(), tokens);
+                    Optional<Declaration.Constant> constant = macroParser.parseConstant(TreeMaker.CursorPosition.of(c), c.spelling(), tokens);
                     if (constant.isPresent()) {
                         decls.add(constant.get());
                     }

--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/Parser.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/Parser.java
@@ -91,7 +91,7 @@ public class Parser {
                 } else if (isMacro(c) && src.path() != null) {
                     SourceRange range = c.getExtent();
                     String[] tokens = c.getTranslationUnit().tokens(range);
-                    Optional<Declaration.Constant> constant = macroParser.parseConstant(treeMaker.toPos(c), c.spelling(), tokens);
+                    Optional<Declaration.Constant> constant = macroParser.parseConstant(TreeMaker.toPos(c), c.spelling(), tokens);
                     if (constant.isPresent()) {
                         decls.add(constant.get());
                     }

--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/RecordLayoutComputer.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/RecordLayoutComputer.java
@@ -28,13 +28,11 @@ package jdk.internal.jextract.impl;
 
 import jdk.incubator.foreign.MemoryLayout;
 import jdk.incubator.jextract.Declaration;
-import jdk.incubator.jextract.Position;
 import jdk.internal.clang.Cursor;
 import jdk.internal.clang.CursorKind;
 import jdk.internal.clang.Type;
 import jdk.internal.clang.TypeKind;
 
-import java.nio.ByteOrder;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -151,11 +149,11 @@ abstract class RecordLayoutComputer {
         String name = c.spelling();
         if (c.isBitField()) {
             MemoryLayout sublayout = MemoryLayout.paddingLayout(c.getBitFieldWidth());
-            return Declaration.bitfield(TreeMaker.toPos(c), name, type, sublayout.withName(name));
+            return Declaration.bitfield(TreeMaker.CursorPosition.of(c), name, type, sublayout.withName(name));
         } else if (c.isAnonymousStruct() && type instanceof jdk.incubator.jextract.Type.Declared decl) {
             return decl.tree();
         } else {
-            return Declaration.field(TreeMaker.toPos(c), name, type);
+            return Declaration.field(TreeMaker.CursorPosition.of(c), name, type);
         }
     }
 

--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/RecordLayoutComputer.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/RecordLayoutComputer.java
@@ -151,11 +151,11 @@ abstract class RecordLayoutComputer {
         String name = c.spelling();
         if (c.isBitField()) {
             MemoryLayout sublayout = MemoryLayout.paddingLayout(c.getBitFieldWidth());
-            return Declaration.bitfield(new TreeMaker.CursorPosition(c), name, type, sublayout.withName(name));
+            return Declaration.bitfield(TreeMaker.toPos(c), name, type, sublayout.withName(name));
         } else if (c.isAnonymousStruct() && type instanceof jdk.incubator.jextract.Type.Declared decl) {
             return decl.tree();
         } else {
-            return Declaration.field(new TreeMaker.CursorPosition(c), name, type);
+            return Declaration.field(TreeMaker.toPos(c), name, type);
         }
     }
 

--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/StructLayoutComputer.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/StructLayoutComputer.java
@@ -148,7 +148,7 @@ final class StructLayoutComputer extends RecordLayoutComputer {
         } else if (anonName != null) {
             g = g.withName(anonName);
         }
-        return jdk.incubator.jextract.Type.declared(Declaration.struct(new TreeMaker.CursorPosition(cursor), cursor.spelling(), g, fieldDecls.stream().toArray(Declaration[]::new)));
+        return jdk.incubator.jextract.Type.declared(Declaration.struct(TreeMaker.toPos(cursor), cursor.spelling(), g, fieldDecls.stream().toArray(Declaration[]::new)));
     }
 
     // process bitfields if any and clear bitfield layouts

--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/StructLayoutComputer.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/StructLayoutComputer.java
@@ -148,7 +148,7 @@ final class StructLayoutComputer extends RecordLayoutComputer {
         } else if (anonName != null) {
             g = g.withName(anonName);
         }
-        return jdk.incubator.jextract.Type.declared(Declaration.struct(TreeMaker.toPos(cursor), cursor.spelling(), g, fieldDecls.stream().toArray(Declaration[]::new)));
+        return jdk.incubator.jextract.Type.declared(Declaration.struct(TreeMaker.CursorPosition.of(cursor), cursor.spelling(), g, fieldDecls.stream().toArray(Declaration[]::new)));
     }
 
     // process bitfields if any and clear bitfield layouts

--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/TreeMaker.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/TreeMaker.java
@@ -109,7 +109,7 @@ class TreeMaker {
         }
     }
 
-    Position toPos(Cursor cursor) {
+    static Position toPos(Cursor cursor) {
         SourceLocation loc = cursor.getSourceLocation();
         if (loc == null) {
             return Position.NO_POSITION;
@@ -127,7 +127,7 @@ class TreeMaker {
         private final int line;
         private final int column;
 
-        CursorPosition(Cursor cursor) {
+        private CursorPosition(Cursor cursor) {
             this.cursor = cursor;
             SourceLocation.Location loc = cursor.getSourceLocation().getFileLocation();
             this.path = loc.path();

--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/UnionLayoutComputer.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/UnionLayoutComputer.java
@@ -102,6 +102,6 @@ final class UnionLayoutComputer extends RecordLayoutComputer {
         } else if (anonName != null) {
             g = g.withName(anonName);
         }
-        return jdk.incubator.jextract.Type.declared(Declaration.union(TreeMaker.toPos(cursor), cursor.spelling(), g, fieldDecls.stream().toArray(Declaration[]::new)));
+        return jdk.incubator.jextract.Type.declared(Declaration.union(TreeMaker.CursorPosition.of(cursor), cursor.spelling(), g, fieldDecls.stream().toArray(Declaration[]::new)));
     }
 }

--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/UnionLayoutComputer.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/UnionLayoutComputer.java
@@ -102,6 +102,6 @@ final class UnionLayoutComputer extends RecordLayoutComputer {
         } else if (anonName != null) {
             g = g.withName(anonName);
         }
-        return jdk.incubator.jextract.Type.declared(Declaration.union(new TreeMaker.CursorPosition(cursor), cursor.spelling(), g, fieldDecls.stream().toArray(Declaration[]::new)));
+        return jdk.incubator.jextract.Type.declared(Declaration.union(TreeMaker.toPos(cursor), cursor.spelling(), g, fieldDecls.stream().toArray(Declaration[]::new)));
     }
 }


### PR DESCRIPTION
TreeMaker::toPos has the correct logic to extract a Position from a cursor, which avoids any potential NPEs. Unfortunately jextract code does not use it uniformly, especially `RecordLayoutComputer` and its subclasses. This patch turns the method into a static helper and makes the `CursorPosition` constructor private, so that other clients have to go through the static factory.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [JDK-8277070](https://bugs.openjdk.java.net/browse/JDK-8277070): Regularize logic for cursor -> position conversion


### Reviewers
 * [Jorn Vernee](https://openjdk.java.net/census#jvernee) (@JornVernee - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/613/head:pull/613` \
`$ git checkout pull/613`

Update a local copy of the PR: \
`$ git checkout pull/613` \
`$ git pull https://git.openjdk.java.net/panama-foreign pull/613/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 613`

View PR using the GUI difftool: \
`$ git pr show -t 613`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/panama-foreign/pull/613.diff">https://git.openjdk.java.net/panama-foreign/pull/613.diff</a>

</details>
