### PR TITLE
Add missing include for Linux

### DIFF
--- a/src/hotspot/cpu/x86/foreign_globals_x86.cpp
+++ b/src/hotspot/cpu/x86/foreign_globals_x86.cpp
@@ -27,6 +27,7 @@
 #include "oops/oopCast.inline.hpp"
 #include "prims/foreign_globals.inline.hpp"
 #include "runtime/sharedRuntime.hpp"
+#include "utilities/formatBuffer.hpp"
 
 bool ABIDescriptor::is_volatile_reg(Register reg) const {
     return _integer_argument_registers.contains(reg)


### PR DESCRIPTION
This PR adds a missing include that is needed on Linux, which didn't show up when compiling under WSL.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [Maurizio Cimadamore](https://openjdk.java.net/census#mcimadamore) (@mcimadamore - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/614/head:pull/614` \
`$ git checkout pull/614`

Update a local copy of the PR: \
`$ git checkout pull/614` \
`$ git pull https://git.openjdk.java.net/panama-foreign pull/614/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 614`

View PR using the GUI difftool: \
`$ git pr show -t 614`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/panama-foreign/pull/614.diff">https://git.openjdk.java.net/panama-foreign/pull/614.diff</a>

</details>
