### PR TITLE
8277645: TreeMaker should not call type() on pointer types too early

### DIFF
--- a/test/jdk/tools/jextract/TestAttributedPointerTypedef.java
+++ b/test/jdk/tools/jextract/TestAttributedPointerTypedef.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @modules jdk.incubator.jextract
+ * @library /test/lib
+ * @build BadBitfieldTest
+ * @run testng/othervm --enable-native-access=jdk.incubator.jextract BadBitfieldTest
+ */
+
+import org.testng.annotations.Test;
+
+public class TestAttributedPointerTypedef extends JextractToolRunner {
+    @Test
+    public void testBadBitfield() {
+        run("-C-fms-extensions", "-d", getOutputFilePath("attributedPointerTypedef").toString(),
+                getInputFilePath("attributedPointerTypedef.h").toString()).checkSuccess();
+    }
+}

--- a/test/jdk/tools/jextract/TestAttributedPointerTypedef.java
+++ b/test/jdk/tools/jextract/TestAttributedPointerTypedef.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,15 +25,15 @@
  * @test
  * @modules jdk.incubator.jextract
  * @library /test/lib
- * @build BadBitfieldTest
- * @run testng/othervm --enable-native-access=jdk.incubator.jextract BadBitfieldTest
+ * @build TestAttributedPointerTypedef
+ * @run testng/othervm --enable-native-access=jdk.incubator.jextract TestAttributedPointerTypedef
  */
 
 import org.testng.annotations.Test;
 
 public class TestAttributedPointerTypedef extends JextractToolRunner {
     @Test
-    public void testBadBitfield() {
+    public void testAttributedPointerTypedef() {
         run("-C-fms-extensions", "-d", getOutputFilePath("attributedPointerTypedef").toString(),
                 getInputFilePath("attributedPointerTypedef.h").toString()).checkSuccess();
     }

--- a/test/jdk/tools/jextract/attributedPointerTypedef.h
+++ b/test/jdk/tools/jextract/attributedPointerTypedef.h
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+#define POINTER_64 __ptr64
+typedef void * POINTER_64 PVOID_64;
+
+#define CONST const
+typedef void * CONST PVOID_CONST;


### PR DESCRIPTION
This patch fixes a couple of callsites in TreeMaker which were calling `DelegatedType::type`.

`DelegatedType` is a common supertype for both typedef types and pointer types. The reason why `TreeMaker` calls that method is to recover the *canonical* type of a typedef.

Unfortunately, as `TreeMaker` doesn't check the delegated type kind, it can sometime call `type()` on a delegated type whose kind is `POINTER`. The way in which the jextract parser is setup is such that pointee types can only be accessed *after* parsing has completed.

This issue only occurs under very rare circumstances, that is when a type qualifier (other than the usual ones, such as `const`) is used on a pointer typedef - such as `__ptr64`. In such cases, the clang AST sees an `AttributedType` and not a `QualifiedType`, which throws our parsing logic off-guard.

The solution is to check for the delegated type kind before attempting to call `type()`, and only call it when its kind is `TYPEDEF`. To test this I used the special clang flag `-fms-extensions` which allows to use the MS extensions even on Linux/Mac.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [JDK-8277645](https://bugs.openjdk.java.net/browse/JDK-8277645): TreeMaker should not call type() on pointer types too early


### Reviewers
 * [Jorn Vernee](https://openjdk.java.net/census#jvernee) (@JornVernee - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/616/head:pull/616` \
`$ git checkout pull/616`

Update a local copy of the PR: \
`$ git checkout pull/616` \
`$ git pull https://git.openjdk.java.net/panama-foreign pull/616/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 616`

View PR using the GUI difftool: \
`$ git pr show -t 616`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/panama-foreign/pull/616.diff">https://git.openjdk.java.net/panama-foreign/pull/616.diff</a>

</details>
