### PR TITLE
8277657: OptimizedEntryBlob should extend RuntimeBlob directly

### DIFF
--- a/src/hotspot/share/code/codeBlob.cpp
+++ b/src/hotspot/share/code/codeBlob.cpp
@@ -159,6 +159,18 @@ RuntimeBlob::RuntimeBlob(
   cb->copy_code_and_locs_to(this);
 }
 
+void RuntimeBlob::free(RuntimeBlob* blob) {
+  assert(blob != NULL, "caller must check for NULL");
+  ThreadInVMfromUnknown __tiv;  // get to VM state in case we block on CodeCache_lock
+  blob->flush();
+  {
+    MutexLocker mu(CodeCache_lock, Mutex::_no_safepoint_check_flag);
+    CodeCache::free(blob);
+  }
+  // Track memory usage statistic after releasing CodeCache_lock
+  MemoryService::track_code_cache_memory_usage();
+}
+
 void CodeBlob::flush() {
   FREE_C_HEAP_ARRAY(unsigned char, _oop_maps);
   _oop_maps = NULL;
@@ -225,8 +237,8 @@ void CodeBlob::print_code() {
 // Implementation of BufferBlob
 
 
-BufferBlob::BufferBlob(const char* name, int header_size, int size)
-: RuntimeBlob(name, header_size, size, CodeOffsets::frame_never_safe, /*locs_size:*/ 0)
+BufferBlob::BufferBlob(const char* name, int size)
+: RuntimeBlob(name, sizeof(BufferBlob), size, CodeOffsets::frame_never_safe, /*locs_size:*/ 0)
 {}
 
 BufferBlob* BufferBlob::create(const char* name, int buffer_size) {
@@ -240,7 +252,7 @@ BufferBlob* BufferBlob::create(const char* name, int buffer_size) {
   assert(name != NULL, "must provide a name");
   {
     MutexLocker mu(CodeCache_lock, Mutex::_no_safepoint_check_flag);
-    blob = new (size) BufferBlob(name, sizeof(BufferBlob), size);
+    blob = new (size) BufferBlob(name, size);
   }
   // Track memory usage statistic after releasing CodeCache_lock
   MemoryService::track_code_cache_memory_usage();
@@ -249,8 +261,8 @@ BufferBlob* BufferBlob::create(const char* name, int buffer_size) {
 }
 
 
-BufferBlob::BufferBlob(const char* name, int header_size, int size, CodeBuffer* cb)
-  : RuntimeBlob(name, cb, header_size, size, CodeOffsets::frame_never_safe, 0, NULL)
+BufferBlob::BufferBlob(const char* name, int size, CodeBuffer* cb)
+  : RuntimeBlob(name, cb, sizeof(BufferBlob), size, CodeOffsets::frame_never_safe, 0, NULL)
 {}
 
 BufferBlob* BufferBlob::create(const char* name, CodeBuffer* cb) {
@@ -261,7 +273,7 @@ BufferBlob* BufferBlob::create(const char* name, CodeBuffer* cb) {
   assert(name != NULL, "must provide a name");
   {
     MutexLocker mu(CodeCache_lock, Mutex::_no_safepoint_check_flag);
-    blob = new (size) BufferBlob(name, sizeof(BufferBlob), size, cb);
+    blob = new (size) BufferBlob(name, size, cb);
   }
   // Track memory usage statistic after releasing CodeCache_lock
   MemoryService::track_code_cache_memory_usage();
@@ -274,15 +286,7 @@ void* BufferBlob::operator new(size_t s, unsigned size) throw() {
 }
 
 void BufferBlob::free(BufferBlob *blob) {
-  assert(blob != NULL, "caller must check for NULL");
-  ThreadInVMfromUnknown __tiv;  // get to VM state in case we block on CodeCache_lock
-  blob->flush();
-  {
-    MutexLocker mu(CodeCache_lock, Mutex::_no_safepoint_check_flag);
-    CodeCache::free((RuntimeBlob*)blob);
-  }
-  // Track memory usage statistic after releasing CodeCache_lock
-  MemoryService::track_code_cache_memory_usage();
+  RuntimeBlob::free(blob);
 }
 
 
@@ -290,7 +294,7 @@ void BufferBlob::free(BufferBlob *blob) {
 // Implementation of AdapterBlob
 
 AdapterBlob::AdapterBlob(int size, CodeBuffer* cb) :
-  BufferBlob("I2C/C2I adapters", sizeof(AdapterBlob), size, cb) {
+  BufferBlob("I2C/C2I adapters", size, cb) {
   CodeCache::commit(this);
 }
 
@@ -320,7 +324,7 @@ void* VtableBlob::operator new(size_t s, unsigned size) throw() {
 }
 
 VtableBlob::VtableBlob(const char* name, int size) :
-  BufferBlob(name, sizeof(VtableBlob), size) {
+  BufferBlob(name, size) {
 }
 
 VtableBlob* VtableBlob::create(const char* name, int buffer_size) {
@@ -719,16 +723,23 @@ void DeoptimizationBlob::print_value_on(outputStream* st) const {
 
 // Implementation of OptimizedEntryBlob
 
-OptimizedEntryBlob::OptimizedEntryBlob(const char* name, int size, CodeBuffer* cb, intptr_t exception_handler_offset,
+OptimizedEntryBlob::OptimizedEntryBlob(const char* name, CodeBuffer* cb, int size,
+                                       intptr_t exception_handler_offset,
                                        jobject receiver, ByteSize frame_data_offset) :
-  BufferBlob(name, sizeof(OptimizedEntryBlob), size, cb),
+  RuntimeBlob(name, cb, sizeof(OptimizedEntryBlob), size, CodeOffsets::frame_never_safe, no_frame_size,
+              /* oop maps = */ nullptr, /* caller must gc arguments = */ false),
   _exception_handler_offset(exception_handler_offset),
   _receiver(receiver),
   _frame_data_offset(frame_data_offset) {
   CodeCache::commit(this);
 }
 
-OptimizedEntryBlob* OptimizedEntryBlob::create(const char* name, CodeBuffer* cb, intptr_t exception_handler_offset,
+void* OptimizedEntryBlob::operator new(size_t s, unsigned size) throw() {
+  return CodeCache::allocate(size, CodeBlobType::NonNMethod);
+}
+
+OptimizedEntryBlob* OptimizedEntryBlob::create(const char* name, CodeBuffer* cb,
+                                               intptr_t exception_handler_offset,
                                                jobject receiver, ByteSize frame_data_offset) {
   ThreadInVMfromUnknown __tiv;  // get to VM state in case we block on CodeCache_lock
 
@@ -736,7 +747,8 @@ OptimizedEntryBlob* OptimizedEntryBlob::create(const char* name, CodeBuffer* cb,
   unsigned int size = CodeBlob::allocation_size(cb, sizeof(OptimizedEntryBlob));
   {
     MutexLocker mu(CodeCache_lock, Mutex::_no_safepoint_check_flag);
-    blob = new (size) OptimizedEntryBlob(name, size, cb, exception_handler_offset, receiver, frame_data_offset);
+    blob = new (size) OptimizedEntryBlob(name, cb, size,
+                                         exception_handler_offset, receiver, frame_data_offset);
   }
   // Track memory usage statistic after releasing CodeCache_lock
   MemoryService::track_code_cache_memory_usage();
@@ -757,5 +769,23 @@ JavaFrameAnchor* OptimizedEntryBlob::jfa_for_frame(const frame& frame) const {
 void OptimizedEntryBlob::free(OptimizedEntryBlob* blob) {
   assert(blob != nullptr, "caller must check for NULL");
   JNIHandles::destroy_global(blob->receiver());
-  BufferBlob::free(blob);
+  RuntimeBlob::free(blob);
+}
+
+void OptimizedEntryBlob::preserve_callee_argument_oops(frame fr, const RegisterMap* reg_map, OopClosure* f) {
+  // do nothing for now
+}
+
+// Misc.
+void OptimizedEntryBlob::verify() {
+  // unimplemented
+}
+
+void OptimizedEntryBlob::print_on(outputStream* st) const {
+  RuntimeBlob::print_on(st);
+  print_value_on(st);
+}
+
+void OptimizedEntryBlob::print_value_on(outputStream* st) const {
+  st->print_cr("OptimizedEntryBlob (" INTPTR_FORMAT  ") used for %s", p2i(this), name());
 }

--- a/src/hotspot/share/code/codeBlob.cpp
+++ b/src/hotspot/share/code/codeBlob.cpp
@@ -726,7 +726,7 @@ void DeoptimizationBlob::print_value_on(outputStream* st) const {
 OptimizedEntryBlob::OptimizedEntryBlob(const char* name, CodeBuffer* cb, int size,
                                        intptr_t exception_handler_offset,
                                        jobject receiver, ByteSize frame_data_offset) :
-  RuntimeBlob(name, cb, sizeof(OptimizedEntryBlob), size, CodeOffsets::frame_never_safe, no_frame_size,
+  RuntimeBlob(name, cb, sizeof(OptimizedEntryBlob), size, CodeOffsets::frame_never_safe, 0 /* no frame size */,
               /* oop maps = */ nullptr, /* caller must gc arguments = */ false),
   _exception_handler_offset(exception_handler_offset),
   _receiver(receiver),

--- a/src/hotspot/share/code/codeBlob.hpp
+++ b/src/hotspot/share/code/codeBlob.hpp
@@ -753,6 +753,8 @@ class OptimizedEntryBlob: public RuntimeBlob {
                      intptr_t exception_handler_offset,
                      jobject receiver, ByteSize frame_data_offset);
 
+  void* operator new(size_t s, unsigned size) throw();
+
   struct FrameData {
     JavaFrameAnchor jfa;
     JavaThread* thread;
@@ -768,12 +770,6 @@ class OptimizedEntryBlob: public RuntimeBlob {
   static OptimizedEntryBlob* create(const char* name, CodeBuffer* cb,
                                     intptr_t exception_handler_offset,
                                     jobject receiver, ByteSize frame_data_offset);
-
-  // This ordinary operator delete is needed even though not used, so the
-  // below two-argument operator delete will be treated as a placement
-  // delete rather than an ordinary sized delete; see C++14 3.7.4.2/p2.
-  void operator delete(void* p);
-  void* operator new(size_t s, unsigned size) throw();
 
   static void free(OptimizedEntryBlob* blob);
 

--- a/src/hotspot/share/code/codeBlob.hpp
+++ b/src/hotspot/share/code/codeBlob.hpp
@@ -60,13 +60,13 @@ struct CodeBlobType {
 //    AdapterBlob        : Used to hold C2I/I2C adapters
 //    VtableBlob         : Used for holding vtable chunks
 //    MethodHandlesAdapterBlob : Used to hold MethodHandles adapters
-//    OptimizedEntryBlob : Used for upcalls from native code
 //   RuntimeStub         : Call to VM runtime methods
 //   SingletonBlob       : Super-class for all blobs that exist in only one instance
 //    DeoptimizationBlob : Used for deoptimization
 //    ExceptionBlob      : Used for stack unrolling
 //    SafepointBlob      : Used to handle illegal instruction exceptions
 //    UncommonTrapBlob   : Used to handle uncommon traps
+//   OptimizedEntryBlob  : Used for upcalls from native code
 //
 //
 // Layout : continuous in the CodeCache
@@ -371,6 +371,8 @@ class RuntimeBlob : public CodeBlob {
     bool        caller_must_gc_arguments = false
   );
 
+  static void free(RuntimeBlob* blob);
+
   // GC support
   virtual bool is_alive() const                  = 0;
 
@@ -401,8 +403,8 @@ class BufferBlob: public RuntimeBlob {
 
  private:
   // Creation support
-  BufferBlob(const char* name, int header_size, int size);
-  BufferBlob(const char* name, int header_size, int size, CodeBuffer* cb);
+  BufferBlob(const char* name, int size);
+  BufferBlob(const char* name, int size, CodeBuffer* cb);
 
   // This ordinary operator delete is needed even though not used, so the
   // below two-argument operator delete will be treated as a placement
@@ -465,7 +467,7 @@ public:
 
 class MethodHandlesAdapterBlob: public BufferBlob {
 private:
-  MethodHandlesAdapterBlob(int size): BufferBlob("MethodHandles adapters", sizeof(MethodHandlesAdapterBlob), size) {}
+  MethodHandlesAdapterBlob(int size): BufferBlob("MethodHandles adapters", size) {}
 
 public:
   // Creation
@@ -740,14 +742,15 @@ class SafepointBlob: public SingletonBlob {
 
 class ProgrammableUpcallHandler;
 
-class OptimizedEntryBlob: public BufferBlob {
+class OptimizedEntryBlob: public RuntimeBlob {
   friend class ProgrammableUpcallHandler;
  private:
   intptr_t _exception_handler_offset;
   jobject _receiver;
   ByteSize _frame_data_offset;
 
-  OptimizedEntryBlob(const char* name, int size, CodeBuffer* cb, intptr_t exception_handler_offset,
+  OptimizedEntryBlob(const char* name, CodeBuffer* cb, int size,
+                     intptr_t exception_handler_offset,
                      jobject receiver, ByteSize frame_data_offset);
 
   struct FrameData {
@@ -763,8 +766,14 @@ class OptimizedEntryBlob: public BufferBlob {
  public:
   // Creation
   static OptimizedEntryBlob* create(const char* name, CodeBuffer* cb,
-                                    intptr_t exception_handler_offset, jobject receiver,
-                                    ByteSize frame_data_offset);
+                                    intptr_t exception_handler_offset,
+                                    jobject receiver, ByteSize frame_data_offset);
+
+  // This ordinary operator delete is needed even though not used, so the
+  // below two-argument operator delete will be treated as a placement
+  // delete rather than an ordinary sized delete; see C++14 3.7.4.2/p2.
+  void operator delete(void* p);
+  void* operator new(size_t s, unsigned size) throw();
 
   static void free(OptimizedEntryBlob* blob);
 
@@ -773,10 +782,18 @@ class OptimizedEntryBlob: public BufferBlob {
 
   JavaFrameAnchor* jfa_for_frame(const frame& frame) const;
 
-  void oops_do(OopClosure* f, const frame& frame);
-
   // Typing
   virtual bool is_optimized_entry_blob() const override { return true; }
+
+  // GC/Verification support
+  void oops_do(OopClosure* f, const frame& frame);
+  virtual void preserve_callee_argument_oops(frame fr, const RegisterMap* reg_map, OopClosure* f) override;
+  virtual bool is_alive() const override { return true; }
+  virtual void verify() override;
+
+  // Misc.
+  virtual void print_on(outputStream* st) const override;
+  virtual void print_value_on(outputStream* st) const override;
 };
 
 #endif // SHARE_CODE_CODEBLOB_HPP

--- a/src/hotspot/share/prims/whitebox.cpp
+++ b/src/hotspot/share/prims/whitebox.cpp
@@ -1545,7 +1545,7 @@ CodeBlob* WhiteBox::allocate_code_blob(int size, int blob_type) {
     MutexLocker mu(CodeCache_lock, Mutex::_no_safepoint_check_flag);
     blob = (BufferBlob*) CodeCache::allocate(full_size, blob_type);
     if (blob != NULL) {
-      ::new (blob) BufferBlob("WB::DummyBlob", sizeof(BufferBlob), full_size);
+      ::new (blob) BufferBlob("WB::DummyBlob", full_size);
     }
   }
   // Track memory usage statistic after releasing CodeCache_lock


### PR DESCRIPTION
This small refactoring makes OptimizedEntryBlob extend RuntimeBlob instead of BufferBlob.

The motivation for doing this is that we don't want to inherit behavior from BufferBlob by accident which is not appropriate for OptimizedEntryBlob, which has happened in the past.

This patch also reverts an earlier fix by Nick which made BufferBlob sub classes pass their header size through the BufferBlob constructor to RuntimeBlob's constructor, since this is no longer needed with this patch.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [JDK-8277657](https://bugs.openjdk.java.net/browse/JDK-8277657): OptimizedEntryBlob should extend RuntimeBlob directly


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.java.net/census#mcimadamore) (@mcimadamore - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/617/head:pull/617` \
`$ git checkout pull/617`

Update a local copy of the PR: \
`$ git checkout pull/617` \
`$ git pull https://git.openjdk.java.net/panama-foreign pull/617/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 617`

View PR using the GUI difftool: \
`$ git pr show -t 617`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/panama-foreign/pull/617.diff">https://git.openjdk.java.net/panama-foreign/pull/617.diff</a>

</details>
