### PR TITLE
Replace `ofAddressNative` with `ofAddress`

### DIFF
--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/clang/TranslationUnit.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/clang/TranslationUnit.java
@@ -169,7 +169,7 @@ public class TranslationUnit implements AutoCloseable {
 
         public MemorySegment getTokenSegment(int idx) {
             MemoryAddress p = ar.addOffset(idx * CXToken.$LAYOUT().byteSize());
-            return MemorySegment.ofAddressNative(p, CXToken.$LAYOUT().byteSize(), ResourceScope.newConfinedScope());
+            return MemorySegment.ofAddress(p, CXToken.$LAYOUT().byteSize(), ResourceScope.newConfinedScope());
         }
 
         public Token getToken(int index) {

--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/clang/libclang/RuntimeHelper.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/clang/libclang/RuntimeHelper.java
@@ -81,7 +81,7 @@ final class RuntimeHelper {
     private final static SegmentAllocator THROWING_ALLOCATOR = (x, y) -> { throw new AssertionError("should not reach here"); };
 
     static final MemorySegment lookupGlobalVariable(String name, MemoryLayout layout) {
-        return SYMBOL_LOOKUP.lookup(name).map(symbol -> MemorySegment.ofAddressNative(symbol.address(), layout.byteSize(), ResourceScope.newSharedScope())).orElse(null);
+        return SYMBOL_LOOKUP.lookup(name).map(symbol -> MemorySegment.ofAddress(symbol.address(), layout.byteSize(), ResourceScope.newSharedScope())).orElse(null);
     }
 
     static final MethodHandle downcallHandle(String name, FunctionDescriptor fdesc, boolean variadic) {
@@ -112,7 +112,7 @@ final class RuntimeHelper {
     }
 
     static MemorySegment asArray(MemoryAddress addr, MemoryLayout layout, int numElements, ResourceScope scope) {
-         return MemorySegment.ofAddressNative(addr, numElements * layout.byteSize(), scope);
+         return MemorySegment.ofAddress(addr, numElements * layout.byteSize(), scope);
     }
 
     // Internals only below this point

--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/resources/RuntimeHelper.java.template
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/resources/RuntimeHelper.java.template
@@ -52,7 +52,7 @@ final class RuntimeHelper {
     private final static SegmentAllocator THROWING_ALLOCATOR = (x, y) -> { throw new AssertionError("should not reach here"); };
 
     static final MemorySegment lookupGlobalVariable(String name, MemoryLayout layout) {
-        return SYMBOL_LOOKUP.lookup(name).map(symbol -> MemorySegment.ofAddressNative(symbol.address(), layout.byteSize(), ResourceScope.newSharedScope())).orElse(null);
+        return SYMBOL_LOOKUP.lookup(name).map(symbol -> MemorySegment.ofAddress(symbol.address(), layout.byteSize(), ResourceScope.newSharedScope())).orElse(null);
     }
 
     static final MethodHandle downcallHandle(String name, FunctionDescriptor fdesc, boolean variadic) {
@@ -83,7 +83,7 @@ final class RuntimeHelper {
     }
 
     static MemorySegment asArray(MemoryAddress addr, MemoryLayout layout, int numElements, ResourceScope scope) {
-         return MemorySegment.ofAddressNative(addr, numElements * layout.byteSize(), scope);
+         return MemorySegment.ofAddress(addr, numElements * layout.byteSize(), scope);
     }
 
     // Internals only below this point

--- a/test/jdk/tools/jextract/test8246341/LibTest8246341Test.java
+++ b/test/jdk/tools/jextract/test8246341/LibTest8246341Test.java
@@ -57,7 +57,7 @@ public class LibTest8246341Test {
         try (ResourceScope scope = ResourceScope.newConfinedScope()) {
             var callback = func$callback.allocate((argc, argv) -> {
                 callbackCalled[0] = true;
-                var addr = MemorySegment.ofAddressNative(argv, C_POINTER.byteSize() * argc, scope);
+                var addr = MemorySegment.ofAddress(argv, C_POINTER.byteSize() * argc, scope);
                 assertEquals(argc, 4);
                 assertEquals(addr.get(C_POINTER, 0).getUtf8String(0), "java");
                 assertEquals(addr.get(C_POINTER, C_POINTER.byteSize() * 1).getUtf8String(0), "python");

--- a/test/jdk/tools/jextract/test8257892/LibUnsupportedTest.java
+++ b/test/jdk/tools/jextract/test8257892/LibUnsupportedTest.java
@@ -67,7 +67,7 @@ public class LibUnsupportedTest {
     @Test
     public void testGetFoo() {
         try (ResourceScope scope = ResourceScope.newConfinedScope()) {
-            var seg = MemorySegment.ofAddressNative(getFoo(), Foo.sizeof(), scope);
+            var seg = MemorySegment.ofAddress(getFoo(), Foo.sizeof(), scope);
             Foo.i$set(seg, 42);
             Foo.c$set(seg, (byte)'j');
             assertEquals(Foo.i$get(seg), 42);


### PR DESCRIPTION
The PR for JEP-419 tweaked the name of an API method, namely `MemorySegment.ofAddressNative` which was renamed to `MemorySegment::ofAddress` (which is consistent with other restricted factories).

This change updates the jextract code and tests so that the old method name is no longer used.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [Jorn Vernee](https://openjdk.java.net/census#jvernee) (@JornVernee - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/619/head:pull/619` \
`$ git checkout pull/619`

Update a local copy of the PR: \
`$ git checkout pull/619` \
`$ git pull https://git.openjdk.java.net/panama-foreign pull/619/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 619`

View PR using the GUI difftool: \
`$ git pr show -t 619`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/panama-foreign/pull/619.diff">https://git.openjdk.java.net/panama-foreign/pull/619.diff</a>

</details>
