### PR TITLE
8277830: jextract generated code should not depend on Java layouts

### DIFF
--- a/src/jdk.incubator.jextract/share/classes/jdk/incubator/jextract/Type.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/incubator/jextract/Type.java
@@ -107,19 +107,21 @@ public interface Type {
             /**
              * {@code short} type.
              */
-            Short("short", ValueLayout.JAVA_SHORT),
+            Short("short", ValueLayout.JAVA_SHORT.withBitAlignment(16)),
             /**
              * {@code int} type.
              */
-            Int("int", ValueLayout.JAVA_INT),
+            Int("int", ValueLayout.JAVA_INT.withBitAlignment(32)),
             /**
              * {@code long} type.
              */
-            Long("long", TypeImpl.IS_WINDOWS ? ValueLayout.JAVA_INT : ValueLayout.JAVA_LONG),
+            Long("long", TypeImpl.IS_WINDOWS ?
+                    ValueLayout.JAVA_INT.withBitAlignment(32) :
+                    ValueLayout.JAVA_LONG.withBitAlignment(64)),
             /**
              * {@code long long} type.
              */
-            LongLong("long long", ValueLayout.JAVA_LONG),
+            LongLong("long long", ValueLayout.JAVA_LONG.withBitAlignment(64)),
             /**
              * {@code int128} type.
              */
@@ -127,11 +129,11 @@ public interface Type {
             /**
              * {@code float} type.
              */
-            Float("float", ValueLayout.JAVA_FLOAT),
+            Float("float", ValueLayout.JAVA_FLOAT.withBitAlignment(32)),
             /**
              * {@code double} type.
              */
-            Double("double", ValueLayout.JAVA_DOUBLE),
+            Double("double", ValueLayout.JAVA_DOUBLE.withBitAlignment(64)),
             /**
               * {@code long double} type.
               */

--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/ConstantBuilder.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/ConstantBuilder.java
@@ -240,7 +240,8 @@ public class ConstantBuilder extends ClassSourceBuilder {
         String fieldName = Constant.Kind.LAYOUT.fieldName(javaName);
         incrAlign();
         indent();
-        append(memberMods() + "MemoryLayout " + fieldName + " = ");
+        String layoutClassName = layout.getClass().getSimpleName();
+        append(memberMods() + " " + layoutClassName + " " + fieldName + " = ");
         emitLayoutString(layout);
         append(";\n");
         decrAlign();

--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/ConstantBuilder.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/ConstantBuilder.java
@@ -248,9 +248,17 @@ public class ConstantBuilder extends ClassSourceBuilder {
         return new Constant(className(), javaName, Constant.Kind.LAYOUT);
     }
 
+    // initialized by TopLevelBuilder
+    public static HashMap<ValueLayout, Constant> primitiveLayoutConstants = new HashMap<>();
+
     private void emitLayoutString(MemoryLayout l) {
         if (l instanceof ValueLayout val) {
-            append(typeToLayoutName(val));
+            Constant constant = primitiveLayoutConstants.get(val);
+            if (constant == null) {
+                append(Utils.layoutToConstant(val));
+            } else {
+                append(constant.accessExpression());
+            }
         } else if (l instanceof SequenceLayout seq) {
             append("MemoryLayout.sequenceLayout(");
             if (seq.elementCount().isPresent()) {
@@ -348,10 +356,6 @@ public class ConstantBuilder extends ClassSourceBuilder {
         append("L);\n");
         decrAlign();
         return new Constant(className(), javaName, Constant.Kind.ADDRESS);
-    }
-
-    private static String typeToLayoutName(ValueLayout vl) {
-        return Utils.layoutToConstant(vl);
     }
 
     private Constant emitSegmentField(String javaName, String nativeName, MemoryLayout layout) {

--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/ConstantBuilder.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/ConstantBuilder.java
@@ -25,7 +25,6 @@
 
 package jdk.internal.jextract.impl;
 
-import jdk.incubator.foreign.CLinker;
 import jdk.incubator.foreign.FunctionDescriptor;
 import jdk.incubator.foreign.GroupLayout;
 import jdk.incubator.foreign.MemoryAddress;
@@ -248,17 +247,13 @@ public class ConstantBuilder extends ClassSourceBuilder {
         return new Constant(className(), javaName, Constant.Kind.LAYOUT);
     }
 
-    // initialized by TopLevelBuilder
-    public static HashMap<ValueLayout, Constant> primitiveLayoutConstants = new HashMap<>();
+    protected String primitiveLayoutString(ValueLayout layout) {
+        return toplevel().rootConstants().resolvePrimitiveLayout(layout).accessExpression();
+    }
 
     private void emitLayoutString(MemoryLayout l) {
         if (l instanceof ValueLayout val) {
-            Constant constant = primitiveLayoutConstants.get(val);
-            if (constant == null) {
-                append(Utils.layoutToConstant(val));
-            } else {
-                append(constant.accessExpression());
-            }
+            append(primitiveLayoutString(val));
         } else if (l instanceof SequenceLayout seq) {
             append("MemoryLayout.sequenceLayout(");
             if (seq.elementCount().isPresent()) {

--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/HeaderFileBuilder.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/HeaderFileBuilder.java
@@ -228,7 +228,8 @@ abstract class HeaderFileBuilder extends ClassSourceBuilder {
             append(primType.kind().layout().orElseThrow().getClass().getSimpleName());
             append(" " + uniqueNestedClassName(name));
             append(" = ");
-            append(TypeTranslator.typeToLayoutName(kind));
+            append("(" + primType.kind().layout().orElseThrow().getClass().getSimpleName() + ")");
+            append(ConstantBuilder.primitiveLayoutConstants.get(kind.layout().get()).accessExpression());
             append(";\n");
             decrAlign();
         }

--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/HeaderFileBuilder.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/HeaderFileBuilder.java
@@ -24,7 +24,6 @@
  */
 package jdk.internal.jextract.impl;
 
-import jdk.incubator.foreign.Addressable;
 import jdk.incubator.foreign.MemoryAddress;
 import jdk.incubator.foreign.MemorySegment;
 import jdk.incubator.foreign.ResourceScope;
@@ -37,7 +36,6 @@ import jdk.internal.jextract.impl.ConstantBuilder.Constant;
 import java.lang.invoke.MethodType;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 
 /**
  * A helper class to generate header interface class in source form.
@@ -229,7 +227,7 @@ abstract class HeaderFileBuilder extends ClassSourceBuilder {
             append(" " + uniqueNestedClassName(name));
             append(" = ");
             append("(" + primType.kind().layout().orElseThrow().getClass().getSimpleName() + ")");
-            append(ConstantBuilder.primitiveLayoutConstants.get(kind.layout().get()).accessExpression());
+            append(toplevel().rootConstants().resolvePrimitiveLayout((ValueLayout)kind.layout().get()).accessExpression());
             append(";\n");
             decrAlign();
         }
@@ -241,7 +239,10 @@ abstract class HeaderFileBuilder extends ClassSourceBuilder {
         append(MEMBER_MODS);
         append(" ValueLayout.OfAddress ");
         append(uniqueNestedClassName(name));
-        append(" = ValueLayout.ADDRESS;\n");
+        append(" = ");
+        append("(" + TypeImpl.PointerImpl.POINTER_LAYOUT.getClass().getSimpleName() + ")");
+        append(toplevel().rootConstants().resolvePrimitiveLayout(TypeImpl.PointerImpl.POINTER_LAYOUT).accessExpression());
+        append(";\n");
         decrAlign();
     }
 

--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/HeaderFileBuilder.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/HeaderFileBuilder.java
@@ -222,11 +222,9 @@ abstract class HeaderFileBuilder extends ClassSourceBuilder {
             incrAlign();
             indent();
             append(MEMBER_MODS);
-            append(" ValueLayout.");
-            append(primType.kind().layout().orElseThrow().getClass().getSimpleName());
+            append(" " + primType.kind().layout().orElseThrow().getClass().getSimpleName());
             append(" " + uniqueNestedClassName(name));
             append(" = ");
-            append("(" + primType.kind().layout().orElseThrow().getClass().getSimpleName() + ")");
             append(toplevel().rootConstants().resolvePrimitiveLayout((ValueLayout)kind.layout().get()).accessExpression());
             append(";\n");
             decrAlign();
@@ -237,10 +235,9 @@ abstract class HeaderFileBuilder extends ClassSourceBuilder {
         incrAlign();
         indent();
         append(MEMBER_MODS);
-        append(" ValueLayout.OfAddress ");
+        append(" OfAddress ");
         append(uniqueNestedClassName(name));
         append(" = ");
-        append("(" + TypeImpl.PointerImpl.POINTER_LAYOUT.getClass().getSimpleName() + ")");
         append(toplevel().rootConstants().resolvePrimitiveLayout(TypeImpl.PointerImpl.POINTER_LAYOUT).accessExpression());
         append(";\n");
         decrAlign();

--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/ToplevelBuilder.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/ToplevelBuilder.java
@@ -25,13 +25,13 @@
 package jdk.internal.jextract.impl;
 
 import jdk.incubator.foreign.GroupLayout;
+import jdk.incubator.foreign.MemoryAddress;
 import jdk.incubator.foreign.MemoryLayout;
 import jdk.incubator.foreign.ValueLayout;
 import jdk.incubator.jextract.Declaration;
 import jdk.incubator.jextract.Type;
 
 import javax.tools.JavaFileObject;
-import java.io.File;
 import java.lang.constant.ClassDesc;
 import java.util.*;
 import java.util.function.Consumer;
@@ -47,6 +47,7 @@ class ToplevelBuilder extends JavaSourceBuilder {
     private int declCount;
     private final List<JavaSourceBuilder> builders = new ArrayList<>();
     private SplitHeader lastHeader;
+    private RootConstants rootConstants;
     private int headersCount;
     private final ClassDesc headerDesc;
 
@@ -55,8 +56,13 @@ class ToplevelBuilder extends JavaSourceBuilder {
     ToplevelBuilder(String packageName, String headerClassName) {
         this.headerDesc = ClassDesc.of(packageName, headerClassName);
         SplitHeader first = lastHeader = new FirstHeader(headerClassName);
+        rootConstants = new RootConstants();
         first.classBegin();
         builders.add(first);
+    }
+
+    public RootConstants rootConstants() {
+        return rootConstants;
     }
 
     public List<JavaFileObject> toFiles() {
@@ -65,6 +71,7 @@ class ToplevelBuilder extends JavaSourceBuilder {
         }
         lastHeader.classEnd();
         builders.addAll(constantBuilders);
+        builders.add(rootConstants);
         List<JavaFileObject> files = new ArrayList<>();
         files.addAll(builders.stream()
                 .flatMap(b -> b.toFiles().stream())
@@ -178,47 +185,15 @@ class ToplevelBuilder extends JavaSourceBuilder {
             super.classBegin();
             emitConstructor();
             // emit basic primitive types
-            emitWithConstantClass(constantBuilder -> {
-                class PrimitiveLayoutDeclaration {
-                    private final String declName;
-                    private final MemoryLayout layout;
-                    private final ConstantBuilder.Constant constant;
-
-                    PrimitiveLayoutDeclaration(String declName, MemoryLayout layout) {
-                        this.declName = declName;
-                        this.layout = layout;
-                        constant = constantBuilder.addLayout(declName, layout);
-                        ConstantBuilder.primitiveLayoutConstants.put((ValueLayout)layout, constant);
-                    }
-
-                    PrimitiveLayoutDeclaration(String declName, Type.Primitive.Kind kind) {
-                        this(declName, kind.layout().get());
-                    }
-
-                    void emit() {
-                        incrAlign();
-                        indent();
-                        append(MEMBER_MODS);
-                        append(" ValueLayout.");
-                        append(layout.getClass().getSimpleName());
-                        append(" " + uniqueNestedClassName(declName));
-                        append(" = ");
-                        append("(" + layout.getClass().getSimpleName() + ")" + constant.accessExpression());
-                        append(";\n");
-                        decrAlign();
-                    }
-                }
-
-                new PrimitiveLayoutDeclaration("C_BOOL", Type.Primitive.Kind.Bool).emit();
-                new PrimitiveLayoutDeclaration("C_CHAR", Type.Primitive.Kind.Char).emit();
-                new PrimitiveLayoutDeclaration("C_SHORT", Type.Primitive.Kind.Short).emit();
-                new PrimitiveLayoutDeclaration("C_INT", Type.Primitive.Kind.Int).emit();
-                new PrimitiveLayoutDeclaration("C_LONG", Type.Primitive.Kind.Long).emit();
-                new PrimitiveLayoutDeclaration("C_LONG_LONG", Type.Primitive.Kind.LongLong).emit();
-                new PrimitiveLayoutDeclaration("C_FLOAT", Type.Primitive.Kind.Float).emit();
-                new PrimitiveLayoutDeclaration("C_DOUBLE", Type.Primitive.Kind.Double).emit();
-                new PrimitiveLayoutDeclaration("C_POINTER", ValueLayout.ADDRESS.withBitAlignment(ValueLayout.ADDRESS.bitSize())).emit();
-            });
+            emitPrimitiveTypedef(Type.primitive(Type.Primitive.Kind.Bool), "C_BOOL");
+            emitPrimitiveTypedef(Type.primitive(Type.Primitive.Kind.Char), "C_CHAR");
+            emitPrimitiveTypedef(Type.primitive(Type.Primitive.Kind.Short), "C_SHORT");
+            emitPrimitiveTypedef(Type.primitive(Type.Primitive.Kind.Int), "C_INT");
+            emitPrimitiveTypedef(Type.primitive(Type.Primitive.Kind.Long), "C_LONG");
+            emitPrimitiveTypedef(Type.primitive(Type.Primitive.Kind.LongLong), "C_LONG_LONG");
+            emitPrimitiveTypedef(Type.primitive(Type.Primitive.Kind.Float), "C_FLOAT");
+            emitPrimitiveTypedef(Type.primitive(Type.Primitive.Kind.Double), "C_DOUBLE");
+            emitPointerTypedef("C_POINTER");
         }
 
         void emitConstructor() {
@@ -240,6 +215,74 @@ class ToplevelBuilder extends JavaSourceBuilder {
     }
 
     // constant support
+
+    class RootConstants extends ConstantBuilder {
+
+        private final Map<ValueLayout, Constant> primitiveLayouts = new HashMap<>();
+
+        public RootConstants() {
+            super(ToplevelBuilder.this, "Constants$root");
+            classBegin();
+            addPrimitiveLayout("C_BOOL", Type.Primitive.Kind.Bool);
+            addPrimitiveLayout("C_CHAR", Type.Primitive.Kind.Char);
+            addPrimitiveLayout("C_SHORT", Type.Primitive.Kind.Short);
+            addPrimitiveLayout("C_INT", Type.Primitive.Kind.Int);
+            addPrimitiveLayout("C_LONG", Type.Primitive.Kind.Long);
+            addPrimitiveLayout("C_LONG_LONG", Type.Primitive.Kind.LongLong);
+            addPrimitiveLayout("C_FLOAT", Type.Primitive.Kind.Float);
+            addPrimitiveLayout("C_DOUBLE", Type.Primitive.Kind.Double);
+            addPrimitiveLayout("C_POINTER", TypeImpl.PointerImpl.POINTER_LAYOUT);
+            classEnd();
+        }
+
+        @Override
+        protected String primitiveLayoutString(ValueLayout vl) {
+            if (vl.carrier() == boolean.class) {
+                return "JAVA_BOOLEAN";
+            } else if (vl.carrier() == char.class) {
+                return "JAVA_CHAR.withBitAlignment(" + vl.bitAlignment() + ")";
+            } else if (vl.carrier() == byte.class) {
+                return "JAVA_BYTE";
+            } else if (vl.carrier() == short.class) {
+                return "JAVA_SHORT.withBitAlignment(" + vl.bitAlignment() + ")";
+            } else if (vl.carrier() == int.class) {
+                return "JAVA_INT.withBitAlignment(" + vl.bitAlignment() + ")";
+            } else if (vl.carrier() == float.class) {
+                return "JAVA_FLOAT.withBitAlignment(" + vl.bitAlignment() + ")";
+            } else if (vl.carrier() == long.class) {
+                return "JAVA_LONG.withBitAlignment(" + vl.bitAlignment() + ")";
+            } else if (vl.carrier() == double.class) {
+                return "JAVA_DOUBLE.withBitAlignment(" + vl.bitAlignment() + ")";
+            } else if (vl.carrier() == MemoryAddress.class) {
+                return "ADDRESS.withBitAlignment(" + vl.bitAlignment() + ")";
+            } else {
+                return "MemoryLayout.paddingLayout(" + vl.bitSize() +  ")";
+            }
+        }
+
+        private Constant addPrimitiveLayout(String javaName, ValueLayout layout) {
+            ValueLayout layoutNoName = layoutNoName(layout);
+            Constant layoutConstant = super.addLayout(javaName, layoutNoName);
+            primitiveLayouts.put(layoutNoName, layoutConstant);
+            return layoutConstant;
+        }
+
+        private Constant addPrimitiveLayout(String javaName, Type.Primitive.Kind kind) {
+            return addPrimitiveLayout(javaName, (ValueLayout)kind.layout().get());
+        }
+
+        private ValueLayout layoutNoName(ValueLayout layout) {
+            // drop name if present
+            return MemoryLayout.valueLayout(layout.carrier(), layout.order())
+                    .withBitAlignment(layout.bitAlignment());
+        }
+
+        public Constant resolvePrimitiveLayout(ValueLayout layout) {
+            return primitiveLayouts.get(layoutNoName(layout));
+        }
+    }
+
+    // other constants
 
     int constant_counter = 0;
     int constant_class_index = 0;

--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/TypeImpl.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/TypeImpl.java
@@ -34,6 +34,7 @@ import java.util.function.Supplier;
 
 import jdk.incubator.foreign.FunctionDescriptor;
 import jdk.incubator.foreign.MemoryLayout;
+import jdk.incubator.foreign.ValueLayout;
 import jdk.incubator.jextract.Declaration;
 import jdk.incubator.jextract.Type;
 
@@ -181,6 +182,8 @@ public abstract class TypeImpl implements Type {
     }
 
     public static final class PointerImpl extends DelegatedBase {
+        public static final ValueLayout.OfAddress POINTER_LAYOUT = ADDRESS.withBitAlignment(64);
+
         private final Supplier<Type> pointeeFactory;
 
         public PointerImpl(Supplier<Type> pointeeFactory) {
@@ -402,7 +405,7 @@ public abstract class TypeImpl implements Type {
         @Override
         public MemoryLayout visitDelegated(jdk.incubator.jextract.Type.Delegated t, Void _ignored) {
             if (t.kind() == jdk.incubator.jextract.Type.Delegated.Kind.POINTER) {
-                return ADDRESS.withBitAlignment(64);
+                return PointerImpl.POINTER_LAYOUT;
             } else {
                 return t.type().accept(this, null);
             }
@@ -416,7 +419,7 @@ public abstract class TypeImpl implements Type {
              * typedef void CB(int);
              * void func(CB cb);
              */
-            return ADDRESS;
+            return PointerImpl.POINTER_LAYOUT;
         }
 
         @Override

--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/TypeImpl.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/TypeImpl.java
@@ -402,7 +402,7 @@ public abstract class TypeImpl implements Type {
         @Override
         public MemoryLayout visitDelegated(jdk.incubator.jextract.Type.Delegated t, Void _ignored) {
             if (t.kind() == jdk.incubator.jextract.Type.Delegated.Kind.POINTER) {
-                return ADDRESS;
+                return ADDRESS.withBitAlignment(64);
             } else {
                 return t.type().accept(this, null);
             }

--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/TypeTranslator.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/TypeTranslator.java
@@ -58,10 +58,6 @@ public class TypeTranslator implements Type.Visitor<Class<?>, Boolean> {
         }
     }
 
-    static String typeToLayoutName(Primitive.Kind type) {
-        return Utils.layoutToConstant((ValueLayout)type.layout().orElseThrow());
-    }
-
     static Class<?> layoutToClass(boolean fp, MemoryLayout layout) {
         switch ((int)layout.bitSize()) {
             case 8: return byte.class;

--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/Utils.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/Utils.java
@@ -333,21 +333,21 @@ class Utils {
         if (vl.carrier() == boolean.class) {
             return "JAVA_BOOLEAN";
         } else if (vl.carrier() == char.class) {
-            return "JAVA_CHAR";
+            return "JAVA_CHAR.withBitAlignment(" + vl.bitAlignment() + ")";
         } else if (vl.carrier() == byte.class) {
             return "JAVA_BYTE";
         } else if (vl.carrier() == short.class) {
-            return "JAVA_SHORT";
+            return "JAVA_SHORT.withBitAlignment(" + vl.bitAlignment() + ")";
         } else if (vl.carrier() == int.class) {
-            return "JAVA_INT";
+            return "JAVA_INT.withBitAlignment(" + vl.bitAlignment() + ")";
         } else if (vl.carrier() == float.class) {
-            return "JAVA_FLOAT";
+            return "JAVA_FLOAT.withBitAlignment(" + vl.bitAlignment() + ")";
         } else if (vl.carrier() == long.class) {
-            return "JAVA_LONG";
+            return "JAVA_LONG.withBitAlignment(" + vl.bitAlignment() + ")";
         } else if (vl.carrier() == double.class) {
-            return "JAVA_DOUBLE";
+            return "JAVA_DOUBLE.withBitAlignment(" + vl.bitAlignment() + ")";
         } else if (vl.carrier() == MemoryAddress.class) {
-            return "ADDRESS";
+            return "ADDRESS.withBitAlignment(" + vl.bitAlignment() + ")";
         } else {
             return "MemoryLayout.paddingLayout(" + vl.bitSize() +  ")";
         }

--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/Utils.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/Utils.java
@@ -328,28 +328,4 @@ class Utils {
     private static boolean isPrintableAscii(char ch) {
         return ch >= ' ' && ch <= '~';
     }
-
-    public static String layoutToConstant(ValueLayout vl) {
-        if (vl.carrier() == boolean.class) {
-            return "JAVA_BOOLEAN";
-        } else if (vl.carrier() == char.class) {
-            return "JAVA_CHAR.withBitAlignment(" + vl.bitAlignment() + ")";
-        } else if (vl.carrier() == byte.class) {
-            return "JAVA_BYTE";
-        } else if (vl.carrier() == short.class) {
-            return "JAVA_SHORT.withBitAlignment(" + vl.bitAlignment() + ")";
-        } else if (vl.carrier() == int.class) {
-            return "JAVA_INT.withBitAlignment(" + vl.bitAlignment() + ")";
-        } else if (vl.carrier() == float.class) {
-            return "JAVA_FLOAT.withBitAlignment(" + vl.bitAlignment() + ")";
-        } else if (vl.carrier() == long.class) {
-            return "JAVA_LONG.withBitAlignment(" + vl.bitAlignment() + ")";
-        } else if (vl.carrier() == double.class) {
-            return "JAVA_DOUBLE.withBitAlignment(" + vl.bitAlignment() + ")";
-        } else if (vl.carrier() == MemoryAddress.class) {
-            return "ADDRESS.withBitAlignment(" + vl.bitAlignment() + ")";
-        } else {
-            return "MemoryLayout.paddingLayout(" + vl.bitSize() +  ")";
-        }
-    }
 }

--- a/test/jdk/tools/jextract/JextractToolRunner.java
+++ b/test/jdk/tools/jextract/JextractToolRunner.java
@@ -58,13 +58,13 @@ public class JextractToolRunner {
 
     public static final ValueLayout.OfBoolean C_BOOL = ValueLayout.JAVA_BOOLEAN;
     public static final ValueLayout.OfByte C_CHAR = ValueLayout.JAVA_BYTE;
-    public static final ValueLayout.OfShort C_SHORT = ValueLayout.JAVA_SHORT;
-    public static final ValueLayout.OfInt C_INT = ValueLayout.JAVA_INT;
-    public static final ValueLayout C_LONG = IS_WINDOWS ? ValueLayout.JAVA_INT : ValueLayout.JAVA_LONG;
-    public static final ValueLayout.OfLong C_LONG_LONG = ValueLayout.JAVA_LONG;
-    public static final ValueLayout.OfFloat C_FLOAT = ValueLayout.JAVA_FLOAT;
-    public static final ValueLayout.OfDouble C_DOUBLE = ValueLayout.JAVA_DOUBLE;
-    public static final ValueLayout.OfAddress C_POINTER = ValueLayout.ADDRESS;
+    public static final ValueLayout.OfShort C_SHORT = ValueLayout.JAVA_SHORT.withBitAlignment(16);
+    public static final ValueLayout.OfInt C_INT = ValueLayout.JAVA_INT.withBitAlignment(32);
+    public static final ValueLayout C_LONG = IS_WINDOWS ? ValueLayout.JAVA_INT.withBitAlignment(32) : ValueLayout.JAVA_LONG.withBitAlignment(64);
+    public static final ValueLayout.OfLong C_LONG_LONG = ValueLayout.JAVA_LONG.withBitAlignment(64);
+    public static final ValueLayout.OfFloat C_FLOAT = ValueLayout.JAVA_FLOAT.withBitAlignment(32);
+    public static final ValueLayout.OfDouble C_DOUBLE = ValueLayout.JAVA_DOUBLE.withBitAlignment(64);
+    public static final ValueLayout.OfAddress C_POINTER = ValueLayout.ADDRESS.withBitAlignment(ValueLayout.ADDRESS.bitSize());
 
     // (private) exit codes from jextract tool. Copied from JextractTool.
     static final int SUCCESS       = 0;


### PR DESCRIPTION
This patch tweaks jextract generation, so that a new constant class is emitted, namely `Constant$root`, which contains the definition of all basic C primitive types. These are declared with the correct alignment constraints, depending on platforms.

Every other layout created by jextract will depend on these shared layouts constants, so that jextract code doesn't depend on alignment choices in `ValueLayout` constants.

In the future, we should probably generalize this approach, so that e.g. layouts are emitted only once, and then referred to afterwards - not just for primitive types, but also for everything else (struct, typedef, etc.). This would minimize the amount of layouts we store in the constant classes.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [JDK-8277830](https://bugs.openjdk.java.net/browse/JDK-8277830): jextract generated code should not depend on Java layouts


### Reviewers
 * [Athijegannathan Sundararajan](https://openjdk.java.net/census#sundar) (@sundararajana - Committer)
 * [Jorn Vernee](https://openjdk.java.net/census#jvernee) (@JornVernee - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/620/head:pull/620` \
`$ git checkout pull/620`

Update a local copy of the PR: \
`$ git checkout pull/620` \
`$ git pull https://git.openjdk.java.net/panama-foreign pull/620/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 620`

View PR using the GUI difftool: \
`$ git pr show -t 620`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/panama-foreign/pull/620.diff">https://git.openjdk.java.net/panama-foreign/pull/620.diff</a>

</details>
