### PR TITLE
Remove workarounds for issue surrounding upcalls and deoptimizations.

### DIFF
--- a/src/hotspot/cpu/aarch64/universalUpcallHandler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/universalUpcallHandler_aarch64.cpp
@@ -151,12 +151,9 @@ address ProgrammableUpcallHandler::generate_optimized_upcall_stub(jobject receiv
   int reg_save_area_size = compute_reg_save_area_size(abi);
   RegSpiller arg_spilller(call_regs._arg_regs, call_regs._args_length);
   RegSpiller result_spiller(call_regs._ret_regs, call_regs._rets_length);
-  // To spill receiver during deopt
-  int deopt_spill_size = 1 * BytesPerWord;
 
   int shuffle_area_offset    = 0;
-  int deopt_spill_offset     = shuffle_area_offset    + out_arg_area;
-  int res_save_area_offset   = deopt_spill_offset     + deopt_spill_size;
+  int res_save_area_offset   = shuffle_area_offset    + out_arg_area;
   int arg_save_area_offset   = res_save_area_offset   + result_spiller.spill_size_bytes();
   int reg_save_area_offset   = arg_save_area_offset   + arg_spilller.spill_size_bytes();
   int frame_data_offset      = reg_save_area_offset   + reg_save_area_size;
@@ -191,9 +188,6 @@ address ProgrammableUpcallHandler::generate_optimized_upcall_stub(jobject receiv
   //      |                     |
   //      | res_save_area       |
   //      |---------------------| = res_save_are_offset
-  //      |                     |
-  //      | deopt_spill         |
-  //      |---------------------| = deopt_spill_offset
   //      |                     |
   // SP-> | out_arg_area        |   needs to be at end for shadow space
   //

--- a/src/java.base/share/classes/java/lang/invoke/MethodHandleImpl.java
+++ b/src/java.base/share/classes/java/lang/invoke/MethodHandleImpl.java
@@ -1581,11 +1581,6 @@ abstract class MethodHandleImpl {
             }
 
             @Override
-            public void ensureCustomized(MethodHandle mh) {
-                mh.customize();
-            }
-
-            @Override
             public VarHandle memoryAccessVarHandle(Class<?> carrier, boolean skipAlignmentMaskCheck, long alignmentMask,
                                                    ByteOrder order) {
                 return VarHandles.makeMemoryAddressViewHandle(carrier, skipAlignmentMaskCheck, alignmentMask, order);

--- a/src/java.base/share/classes/jdk/internal/access/JavaLangInvokeAccess.java
+++ b/src/java.base/share/classes/jdk/internal/access/JavaLangInvokeAccess.java
@@ -136,13 +136,6 @@ public interface JavaLangInvokeAccess {
     MethodHandle nativeMethodHandle(NativeEntryPoint nep);
 
     /**
-     * Ensure given method handle is customized
-     *
-     * @param mh the method handle
-     */
-    void ensureCustomized(MethodHandle mh);
-
-    /**
      * Produces a method handle unreflecting from a {@code Constructor} with
      * the trusted lookup
      */

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/ProgrammableUpcallHandler.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/ProgrammableUpcallHandler.java
@@ -46,6 +46,7 @@ import java.util.stream.Stream;
 import static java.lang.invoke.MethodHandles.collectArguments;
 import static java.lang.invoke.MethodHandles.dropArguments;
 import static java.lang.invoke.MethodHandles.empty;
+import static java.lang.invoke.MethodHandles.exactInvoker;
 import static java.lang.invoke.MethodHandles.identity;
 import static java.lang.invoke.MethodHandles.insertArguments;
 import static java.lang.invoke.MethodHandles.lookup;

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/ProgrammableUpcallHandler.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/ProgrammableUpcallHandler.java
@@ -30,8 +30,6 @@ import java.lang.foreign.MemorySegment;
 import java.lang.foreign.NativeSymbol;
 import java.lang.foreign.ResourceScope;
 import java.lang.foreign.ValueLayout;
-import jdk.internal.access.JavaLangInvokeAccess;
-import jdk.internal.access.SharedSecrets;
 import sun.security.action.GetPropertyAction;
 
 import java.lang.invoke.MethodHandle;
@@ -62,8 +60,6 @@ public class ProgrammableUpcallHandler {
         GetPropertyAction.privilegedGetProperty("jdk.internal.foreign.ProgrammableUpcallHandler.USE_SPEC", "true"));
 
     private static final MethodHandle MH_invokeInterpBindings;
-
-    private static final JavaLangInvokeAccess JLI = SharedSecrets.getJavaLangInvokeAccess();
 
     static {
         try {
@@ -102,7 +98,7 @@ public class ProgrammableUpcallHandler {
         }
 
         checkPrimitive(doBindings.type());
-        JLI.ensureCustomized(doBindings);
+        doBindings = insertArguments(exactInvoker(doBindings.type()), 0, doBindings);
         VMStorage[] args = Arrays.stream(argMoves).map(Binding.Move::storage).toArray(VMStorage[]::new);
         VMStorage[] rets = Arrays.stream(retMoves).map(Binding.Move::storage).toArray(VMStorage[]::new);
         CallRegs conv = new CallRegs(args, rets);


### PR DESCRIPTION
Please review this patch which removes the (partial) workaround in aarch64 upcall code for spilling the receiver during a deopt. This has been properly fixed in the mainline by: https://github.com/openjdk/jdk/pull/6522 instead.

It also restores the lazy-customization behavior of upcalls which was removed to work around the same issue (originally added by: https://github.com/openjdk/panama-foreign/pull/553).

Thanks,
Jorn

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [Maurizio Cimadamore](https://openjdk.java.net/census#mcimadamore) (@mcimadamore - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/625/head:pull/625` \
`$ git checkout pull/625`

Update a local copy of the PR: \
`$ git checkout pull/625` \
`$ git pull https://git.openjdk.java.net/panama-foreign pull/625/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 625`

View PR using the GUI difftool: \
`$ git pr show -t 625`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/panama-foreign/pull/625.diff">https://git.openjdk.java.net/panama-foreign/pull/625.diff</a>

</details>
