### PR TITLE
8278962: Support for _Bool not working correctly

### DIFF
--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/HeaderFileBuilder.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/HeaderFileBuilder.java
@@ -252,7 +252,9 @@ abstract class HeaderFileBuilder extends ClassSourceBuilder {
 
     private String getConstantString(Class<?> type, Object value) {
         StringBuilder buf = new StringBuilder();
-        if (type == float.class) {
+        if (type == boolean.class) {
+            buf.append(value);
+        } else if (type == float.class) {
             float f = ((Number)value).floatValue();
             if (Float.isFinite(f)) {
                 buf.append(value);

--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/MacroParserImpl.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/MacroParserImpl.java
@@ -37,6 +37,7 @@ import jdk.internal.clang.EvalResult;
 import jdk.internal.clang.Index;
 import jdk.internal.clang.LibClang;
 import jdk.internal.clang.TranslationUnit;
+import jdk.internal.clang.TypeKind;
 
 import java.io.IOException;
 import java.nio.file.Files;
@@ -322,7 +323,12 @@ class MacroParserImpl {
                 Entry newEntry = switch (result.getKind()) {
                     case Integral -> {
                         long value = result.getAsInt();
-                        yield entry.success(typeMaker.makeType(decl.type()), value);
+                        if (decl.type().spelling().equals("_Bool")) {
+                            // special case boolean constants
+                            yield entry.success(typeMaker.makeType(decl.type()), value == 0L);
+                        } else {
+                            yield entry.success(typeMaker.makeType(decl.type()), value);
+                        }
                     }
                     case FloatingPoint -> {
                         double value = result.getAsFloat();

--- a/test/jdk/tools/jextract/ConstantsTest.java
+++ b/test/jdk/tools/jextract/ConstantsTest.java
@@ -96,7 +96,7 @@ public class ConstantsTest extends JextractToolRunner {
                 { "DOUBLE_VALUE", double.class, (Consumer<Double>) (actual -> assertEquals(actual, 1.32, 0.1)) },
                 { "CHAR_VALUE", int.class, equalsTo(104) }, //integer char constants have type int
                 { "MULTICHAR_VALUE", int.class, equalsTo(26728) },  //integer char constants have type int
-                { "BOOL_VALUE", byte.class, equalsTo((byte)1) },
+                { "BOOL_VALUE", boolean.class, equalsTo(false) },
                 { "SUB", int.class, equalsTo( 7 ) },
                 // pointer type values
                 { "STR", MemorySegment.class, equalsToJavaStr("Hello") },


### PR DESCRIPTION
TypeTranslator does not deal with _Bool layout correctly. Instead of turning it into the `boolean.class` carrier, it turns it into a `byte.class` carrier. This is caused by the fact that we still have some old logic for deriving carriers from layouts which does not take into account the fact that the carrier is now attached to the layout.

Fixing this breaks the macro `ConstantTest` - as one `_Bool` constant is not generated correctly. Again the solution is to take the `_Bool` case into account when reparsing a macro, so that we can generate a macro whose value is a Boolean, not just a numeric value.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [JDK-8278962](https://bugs.openjdk.java.net/browse/JDK-8278962): Support for _Bool not working correctly


### Reviewers
 * [Athijegannathan Sundararajan](https://openjdk.java.net/census#sundar) (@sundararajana - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/627/head:pull/627` \
`$ git checkout pull/627`

Update a local copy of the PR: \
`$ git checkout pull/627` \
`$ git pull https://git.openjdk.java.net/panama-foreign pull/627/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 627`

View PR using the GUI difftool: \
`$ git pr show -t 627`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/panama-foreign/pull/627.diff">https://git.openjdk.java.net/panama-foreign/pull/627.diff</a>

</details>
