### PR TITLE
8280596: ScopedMemoryAccess_closeScope: remove exception parameter

### DIFF
--- a/src/hotspot/share/prims/scopedMemoryAccess.cpp
+++ b/src/hotspot/share/prims/scopedMemoryAccess.cpp
@@ -70,15 +70,13 @@ public:
 
 class CloseScopedMemoryClosure : public HandshakeClosure {
   jobject _deopt;
-  jobject _exception;
 
 public:
   jboolean _found;
 
-  CloseScopedMemoryClosure(jobject deopt, jobject exception)
+  CloseScopedMemoryClosure(jobject deopt)
     : HandshakeClosure("CloseScopedMemory")
     , _deopt(deopt)
-    , _exception(exception)
     , _found(false) {}
 
   void do_thread(Thread* thread) {
@@ -147,8 +145,8 @@ public:
  * a less common slow path instead.
  * Top frames containg obj will be deoptimized.
  */
-JVM_ENTRY(jboolean, ScopedMemoryAccess_closeScope(JNIEnv *env, jobject receiver, jobject deopt, jobject exception))
-  CloseScopedMemoryClosure cl(deopt, exception);
+JVM_ENTRY(jboolean, ScopedMemoryAccess_closeScope(JNIEnv *env, jobject receiver, jobject deopt))
+  CloseScopedMemoryClosure cl(deopt);
   Handshake::execute(&cl);
   return !cl._found;
 JVM_END

--- a/src/hotspot/share/prims/scopedMemoryAccess.cpp
+++ b/src/hotspot/share/prims/scopedMemoryAccess.cpp
@@ -160,13 +160,12 @@ JVM_END
 
 #define MEMACCESS "ScopedMemoryAccess"
 #define SCOPE PKG_FOREIGN "ResourceScope;"
-#define SCOPED_ERR PKG_MISC MEMACCESS "$ScopedAccessError;"
 
 #define CC (char*)  /*cast a literal from (const char*)*/
 #define FN_PTR(f) CAST_FROM_FN_PTR(void*, &f)
 
 static JNINativeMethod jdk_internal_misc_ScopedMemoryAccess_methods[] = {
-    {CC "closeScope0",   CC "(" SCOPE SCOPED_ERR ")Z",           FN_PTR(ScopedMemoryAccess_closeScope)},
+    {CC "closeScope0",   CC "(" SCOPE ")Z",           FN_PTR(ScopedMemoryAccess_closeScope)},
 };
 
 #undef CC
@@ -176,7 +175,6 @@ static JNINativeMethod jdk_internal_misc_ScopedMemoryAccess_methods[] = {
 #undef PKG_FOREIGN
 #undef MEMACCESS
 #undef SCOPE
-#undef SCOPED_ERR
 
 // This function is exported, used by NativeLookup.
 

--- a/src/java.base/share/classes/java/lang/foreign/ResourceScope.java
+++ b/src/java.base/share/classes/java/lang/foreign/ResourceScope.java
@@ -79,8 +79,7 @@ import jdk.internal.ref.CleanerFactory;
  *     <li>heap segments created from {@linkplain MemorySegment#ofArray(int[]) arrays} or
  *     {@linkplain MemorySegment#ofByteBuffer(ByteBuffer) buffers};</li>
  *     <li>variable arity lists {@linkplain VaList#ofAddress(MemoryAddress, ResourceScope) obtained} from raw memory addresses;
- *     <li>native symbols {@linkplain SymbolLookup#lookup(String) obtained} from a {@linkplain SymbolLookup#loaderLookup() loader lookup},
- *     or from the {@link CLinker}.</li>
+ *     <li>native symbols obtained from {@linkplain ClassLoader#findNative(String)}, or from {@link CLinker#lookup(String)}.</li>
  * </ul>
  * In other words, the global scope is used to indicate that the lifecycle of one or more resources must, where
  * needed, be managed independently by clients.

--- a/src/java.base/share/classes/java/lang/foreign/package-info.java
+++ b/src/java.base/share/classes/java/lang/foreign/package-info.java
@@ -30,7 +30,7 @@
  * <h2>Foreign memory access</h2>
  *
  * <p>
- * The main abstraction introduced to support foreign memory access is {@link jdk.incubator.foreign.MemorySegment}, which
+ * The main abstraction introduced to support foreign memory access is {@link java.lang.foreign.MemorySegment}, which
  * models a contiguous memory region, which can reside either inside or outside the Java heap.
  * A memory segment represents the main access coordinate of a memory access var handle, which can be obtained
  * using the combinator methods defined in the {@link java.lang.invoke.MethodHandles} class; a set of
@@ -97,10 +97,10 @@
  * operation either succeeds - and accesses a valid memory location - or fails.
  *
  * <h2>Foreign function access</h2>
- * The key abstractions introduced to support foreign function access are {@link java.lang.foreign.SymbolLookup},
- * {@link java.lang.foreign.MemoryAddress} and {@link java.lang.foreign.CLinker}.
- * The first is used to look up symbols inside native libraries; the second is used to model native addresses (more on that later),
- * while the third provides linking capabilities which allows modelling foreign functions as {@link java.lang.invoke.MethodHandle} instances,
+ * The key abstractions introduced to support foreign function access are {@link java.lang.foreign.MemoryAddress} and
+ * {@link java.lang.foreign.CLinker}.
+ * The first is used to model native addresses (more on that later), while the second provides linking capabilities
+ * which allows modelling foreign functions as {@link java.lang.invoke.MethodHandle} instances,
  * so that clients can perform foreign function calls directly in Java, without the need for intermediate layers of native
  * code (as is the case with the <a href="{@docRoot}/../specs/jni/index.html">Java Native Interface (JNI)</a>).
  * <p>
@@ -217,11 +217,11 @@
  * <h2>Restricted methods</h2>
  * Some methods in this package are considered <em>restricted</em>. Restricted methods are typically used to bind native
  * foreign data and/or functions to first-class Java API elements which can then be used directly by clients. For instance
- * the restricted method {@link MemorySegment#ofAddress(MemoryAddress, long, ResourceScope)}
+ * the restricted method {@link java.lang.foreign.MemorySegment#ofAddress(MemoryAddress, long, ResourceScope)}
  * can be used to create a fresh segment with given spatial bounds out of a native address.
  * <p>
  * Binding foreign data and/or functions is generally unsafe and, if done incorrectly, can result in VM crashes, or memory corruption when the bound Java API element is accessed.
- * For instance, in the case of {@link MemorySegment#ofAddress(MemoryAddress, long, ResourceScope)},
+ * For instance, in the case of {@link java.lang.foreign.MemorySegment#ofAddress(MemoryAddress, long, ResourceScope)},
  * if the provided spatial bounds are incorrect, a client of the segment returned by that method might crash the VM, or corrupt
  * memory when attempting to dereference said segment. For these reasons, it is crucial for code that calls a restricted method
  * to never pass arguments that might cause incorrect binding of foreign data and/or functions to a Java API.

--- a/src/java.base/share/classes/jdk/internal/misc/X-ScopedMemoryAccess.java.template
+++ b/src/java.base/share/classes/jdk/internal/misc/X-ScopedMemoryAccess.java.template
@@ -85,10 +85,10 @@ public class ScopedMemoryAccess {
     }
 
     public boolean closeScope(ResourceScope scope) {
-        return closeScope0(scope, ScopedAccessError.INSTANCE);
+        return closeScope0(scope);
     }
 
-    native boolean closeScope0(ResourceScope scope, ScopedAccessError exception);
+    native boolean closeScope0(ResourceScope scope);
 
     private ScopedMemoryAccess() {}
 


### PR DESCRIPTION
This change removes the trailing exception parameter in ScopedMemoryAccess_closeScope, which is now unused. 
(Plus some unrelated minimal doc cleanup that removes mentions of the old SymbolLookup class.)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [JDK-8280596](https://bugs.openjdk.java.net/browse/JDK-8280596): ScopedMemoryAccess_closeScope: remove exception parameter


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.java.net/census#mcimadamore) (@mcimadamore - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/637/head:pull/637` \
`$ git checkout pull/637`

Update a local copy of the PR: \
`$ git checkout pull/637` \
`$ git pull https://git.openjdk.java.net/panama-foreign pull/637/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 637`

View PR using the GUI difftool: \
`$ git pr show -t 637`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/panama-foreign/pull/637.diff">https://git.openjdk.java.net/panama-foreign/pull/637.diff</a>

</details>
