### PR TITLE
8281228: Preview branch's CLinker.downcallHandle crashes inside asm

### DIFF
--- a/src/java.base/share/classes/jdk/internal/foreign/abi/BindingSpecializer.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/BindingSpecializer.java
@@ -57,9 +57,7 @@ import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Deque;
 import java.util.List;
-import java.util.function.BiConsumer;
 import java.util.function.BiPredicate;
-import java.util.function.Predicate;
 
 import static java.lang.invoke.MethodType.methodType;
 import static jdk.internal.org.objectweb.asm.Opcodes.*;

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/BindingSpecializer.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/BindingSpecializer.java
@@ -150,7 +150,7 @@ public class BindingSpecializer {
 
         new BindingSpecializer(mv, callerMethodType, callingSequence, abi, leafHandle.type()).specialize();
 
-        mv.visitMaxs(-1, -1);
+        mv.visitMaxs(0, 0);
         mv.visitEnd();
 
         cw.visitEnd();
@@ -218,7 +218,7 @@ public class BindingSpecializer {
         }
         return found;
     }
-    
+
     // specialization
 
     private void specialize() {

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/ProgrammableInvoker.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/ProgrammableInvoker.java
@@ -110,7 +110,7 @@ public class ProgrammableInvoker {
             if (callingSequence.needsReturnBuffer()) {
                 // Return buffer is supplied by invokeInterpBindings
                 assert interpType.parameterType(0) == MemorySegment.class;
-                interpType.dropParameterTypes(0, 1);
+                interpType = interpType.dropParameterTypes(0, 1);
             }
             MethodHandle collectorInterp = makeCollectorHandle(interpType);
             handle = collectArguments(handle, 1, collectorInterp);

--- a/test/jdk/java/foreign/TestMatrix.java
+++ b/test/jdk/java/foreign/TestMatrix.java
@@ -154,7 +154,7 @@
  * @requires ((os.arch == "amd64" | os.arch == "x86_64") & sun.arch.data.model == "64") | os.arch == "aarch64"
  * @build NativeTestHelper CallGeneratorHelper TestUpcallBase
  *
- * @run testng/othervm/native/manual/timeout=960
+ * @run testng/othervm/native/manual
  *   --enable-native-access=ALL-UNNAMED
  *   -Djdk.internal.foreign.ProgrammableInvoker.USE_SPEC=false
  *   -Djdk.internal.foreign.ProgrammableUpcallHandler.USE_SPEC=false
@@ -166,7 +166,7 @@
  * @requires ((os.arch == "amd64" | os.arch == "x86_64") & sun.arch.data.model == "64") | os.arch == "aarch64"
  * @build NativeTestHelper CallGeneratorHelper TestUpcallBase
  *
- * @run testng/othervm/native/manual/timeout=960
+ * @run testng/othervm/native/manual
  *   --enable-native-access=ALL-UNNAMED
  *   -Djdk.internal.foreign.ProgrammableInvoker.USE_SPEC=true
  *   -Djdk.internal.foreign.ProgrammableUpcallHandler.USE_SPEC=false
@@ -178,7 +178,7 @@
  * @requires ((os.arch == "amd64" | os.arch == "x86_64") & sun.arch.data.model == "64") | os.arch == "aarch64"
  * @build NativeTestHelper CallGeneratorHelper TestUpcallBase
  *
- * @run testng/othervm/native/manual/timeout=960
+ * @run testng/othervm/native/manual
  *   --enable-native-access=ALL-UNNAMED
  *   -Djdk.internal.foreign.ProgrammableInvoker.USE_SPEC=false
  *   -Djdk.internal.foreign.ProgrammableUpcallHandler.USE_SPEC=true
@@ -190,7 +190,7 @@
  * @requires ((os.arch == "amd64" | os.arch == "x86_64") & sun.arch.data.model == "64") | os.arch == "aarch64"
  * @build NativeTestHelper CallGeneratorHelper TestUpcallBase
  *
- * @run testng/othervm/native/manual/timeout=960
+ * @run testng/othervm/native/manual
  *   --enable-native-access=ALL-UNNAMED
  *   -Djdk.internal.foreign.ProgrammableInvoker.USE_SPEC=true
  *   -Djdk.internal.foreign.ProgrammableUpcallHandler.USE_SPEC=true


### PR DESCRIPTION
This patch addresses a low level crash occuring in the ASM library, triggered by the new binding specialization logic. After some debugging I realized that there was no real "bug", but something subtle that we missed during review. The binding specializer uses an internal operand stack to keep track of the types maniupulated when processing ABI bindings. Most of the "pop" operation on this stack were done inside an `assert` statement, which meant that the pop operation would not be executed when running without `-esa`. Unfortunately this issue was not caught because the makefile always runs tests with assertions enabled.

After fixing this, I have also verified that the existing test (if ran without assertion enabled) would indeed have been enough to trigger the failure; in other words, the failure has not been detected because of *the way* in which tests were ran, and not because we were lacking in test coverage (for instance, TestDowncall showed 812 failures without the fix). For these reasons I did not include any test in the fix.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [JDK-8281228](https://bugs.openjdk.java.net/browse/JDK-8281228): Preview branch's CLinker.downcallHandle crashes inside asm


### Reviewers
 * [Athijegannathan Sundararajan](https://openjdk.java.net/census#sundar) (@sundararajana - Committer) ⚠️ Review applies to a015dc4173c11ddf0937076e34fb5ed7b649aba5
 * [Jorn Vernee](https://openjdk.java.net/census#jvernee) (@JornVernee - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/638/head:pull/638` \
`$ git checkout pull/638`

Update a local copy of the PR: \
`$ git checkout pull/638` \
`$ git pull https://git.openjdk.java.net/panama-foreign pull/638/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 638`

View PR using the GUI difftool: \
`$ git pr show -t 638`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/panama-foreign/pull/638.diff">https://git.openjdk.java.net/panama-foreign/pull/638.diff</a>

</details>
