### PR TITLE
8281334: MemorySegment.ofBuffer does not keep byte buffer alive

### DIFF
--- a/src/java.base/share/classes/jdk/internal/foreign/AbstractMemorySegmentImpl.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/AbstractMemorySegmentImpl.java
@@ -543,7 +543,7 @@ public abstract non-sealed class AbstractMemorySegmentImpl implements MemorySegm
             bufferScope = bufferSegment.scope;
             modes = bufferSegment.mask;
         } else {
-            bufferScope = ResourceScopeImpl.GLOBAL;
+            bufferScope = ResourceScopeImpl.heapScope(bb);
             modes = defaultAccessModes(size);
         }
         if (bb.isReadOnly()) {

--- a/test/jdk/java/foreign/TestByteBuffer.java
+++ b/test/jdk/java/foreign/TestByteBuffer.java
@@ -41,6 +41,7 @@ import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.VarHandle;
 import java.lang.ref.Cleaner;
+import java.lang.ref.Reference;
 import java.lang.ref.WeakReference;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
@@ -65,6 +66,8 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.BiConsumer;
 import java.util.function.BiFunction;
 import java.util.function.Consumer;
@@ -605,6 +608,28 @@ public class TestByteBuffer {
             ByteBuffer roBuffer = rwBuffer.asReadOnlyBuffer();
             MemorySegment segment = MemorySegment.ofByteBuffer(roBuffer);
             assertTrue(segment.isReadOnly());
+        }
+    }
+
+    @Test
+    public void testOfBufferScopeReachable() throws InterruptedException {
+        ByteBuffer buffer = ByteBuffer.allocateDirect(1000);
+        MemorySegment segment = MemorySegment.ofByteBuffer(buffer);
+        try {
+            AtomicBoolean reachable = new AtomicBoolean(true);
+            Cleaner.create().register(buffer, () -> {
+                reachable.set(false);
+            });
+            buffer = null;
+            System.gc();
+            // let's sleep to let cleaner run
+            Thread.sleep(100);
+            segment.get(JAVA_BYTE, 0);
+            if (!reachable.get()) {
+                throw new IllegalStateException();
+            }
+        } finally {
+            Reference.reachabilityFence(segment);
         }
     }
 

--- a/test/jdk/java/foreign/TestByteBuffer.java
+++ b/test/jdk/java/foreign/TestByteBuffer.java
@@ -67,7 +67,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.BiConsumer;
 import java.util.function.BiFunction;
 import java.util.function.Consumer;


### PR DESCRIPTION
This patch tweaks AbstractMemorySegmentImpl::ofBuffer to create an heap scope which keeps the input ByteBuffer alive, in case the returned segment has to be associated with a global scope.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [JDK-8281334](https://bugs.openjdk.java.net/browse/JDK-8281334): MemorySegment.ofBuffer does not keep byte buffer alive


### Reviewers
 * [Jorn Vernee](https://openjdk.java.net/census#jvernee) (@JornVernee - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/639/head:pull/639` \
`$ git checkout pull/639`

Update a local copy of the PR: \
`$ git checkout pull/639` \
`$ git pull https://git.openjdk.java.net/panama-foreign pull/639/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 639`

View PR using the GUI difftool: \
`$ git pr show -t 639`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/panama-foreign/pull/639.diff">https://git.openjdk.java.net/panama-foreign/pull/639.diff</a>

</details>
