### PR TITLE
8281595: ASM-ify scope acquire/release for down call parameters

### DIFF
--- a/src/java.base/share/classes/jdk/internal/foreign/abi/AbstractLinker.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/AbstractLinker.java
@@ -54,8 +54,7 @@ public abstract sealed class AbstractLinker implements CLinker permits LinuxAArc
             MethodType type = SharedUtils.inferMethodType(fd, false);
             MethodHandle handle = arrangeDowncall(type, fd);
             handle = SharedUtils.maybeInsertAllocator(handle);
-            MethodHandle mh = SharedUtils.wrapDowncall(handle, fd);
-            return mh;
+            return handle;
         });
     }
     protected abstract MethodHandle arrangeDowncall(MethodType inferredMethodType, FunctionDescriptor function);

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/BindingSpecializer.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/BindingSpecializer.java
@@ -251,17 +251,17 @@ public class BindingSpecializer {
 
             // for downcalls we also acquire/release scoped parameters before/after the call
             // create a bunch of locals here to keep track of their scopes (to release later)
-            scopeSlots = new int[callerMethodType.parameterCount()];
+            int[] initialScopeSlots = new int[callerMethodType.parameterCount()];
             int numScopes = 0;
             for (int i = 0; i < callerMethodType.parameterCount(); i++) {
                 if (shouldAcquire(callerMethodType.parameterType(i))) {
                     int scopeLocal = newLocal(BasicType.L);
-                    scopeSlots[numScopes++] = scopeLocal;
+                    initialScopeSlots[numScopes++] = scopeLocal;
                     emitConst(null);
                     emitStore(BasicType.L, scopeLocal); // need to initialize all scope locals here in case an exception occurs
                 }
             }
-            scopeSlots = Arrays.copyOf(scopeSlots, numScopes); // fit to size
+            scopeSlots = Arrays.copyOf(initialScopeSlots, numScopes); // fit to size
             curScopeLocalIdx = 0; // used from emitGetInput
         }
 

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/BindingSpecializer.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/BindingSpecializer.java
@@ -26,6 +26,7 @@ package jdk.internal.foreign.abi;
 
 import jdk.internal.foreign.MemoryAddressImpl;
 import jdk.internal.foreign.ResourceScopeImpl;
+import jdk.internal.foreign.Scoped;
 import jdk.internal.misc.VM;
 import jdk.internal.org.objectweb.asm.ClassReader;
 import jdk.internal.org.objectweb.asm.ClassWriter;
@@ -45,6 +46,7 @@ import java.lang.constant.ConstantDescs;
 import java.lang.foreign.Addressable;
 import java.lang.foreign.MemoryAddress;
 import java.lang.foreign.MemorySegment;
+import java.lang.foreign.NativeSymbol;
 import java.lang.foreign.ResourceScope;
 import java.lang.foreign.SegmentAllocator;
 import java.lang.foreign.ValueLayout;
@@ -55,6 +57,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Deque;
 import java.util.List;
 import java.util.function.BiPredicate;
@@ -89,6 +92,8 @@ public class BindingSpecializer {
     private static final String HANDLE_UNCAUGHT_EXCEPTION_DESC = methodType(void.class, Throwable.class).descriptorString();
     private static final String METHOD_HANDLES_INTRN = Type.getInternalName(MethodHandles.class);
     private static final String CLASS_DATA_DESC = methodType(Object.class, MethodHandles.Lookup.class, String.class, Class.class).descriptorString();
+    private static final String RELEASE0_DESC = methodType(void.class).descriptorString();
+    private static final String ACQUIRE0_DESC = methodType(void.class).descriptorString();
 
     private static final Handle BSM_CLASS_DATA = new Handle(
             H_INVOKESTATIC,
@@ -117,6 +122,8 @@ public class BindingSpecializer {
     private int localIdx = 0;
     private int[] paramIndex2ParamSlot;
     private int[] leafArgSlots;
+    private int[] scopeSlots;
+    private int curScopeLocalIdx = -1;
     private int RETURN_ALLOCATOR_IDX = -1;
     private int CONTEXT_IDX = -1;
     private int RETURN_BUFFER_IDX = -1;
@@ -241,6 +248,21 @@ public class BindingSpecializer {
         // allocator passed to us for allocating the return MS (downcalls only)
         if (callingSequence.forDowncall()) {
             RETURN_ALLOCATOR_IDX = 0; // first param
+
+            // for downcalls we also acquire/release scoped parameters before/after the call
+            // create a bunch of locals here to keep track of their scopes (to release later)
+            scopeSlots = new int[callerMethodType.parameterCount()];
+            int numScopes = 0;
+            for (int i = 0; i < callerMethodType.parameterCount(); i++) {
+                if (shouldAcquire(callerMethodType.parameterType(i))) {
+                    int scopeLocal = newLocal(BasicType.L);
+                    scopeSlots[numScopes++] = scopeLocal;
+                    emitConst(null);
+                    emitStore(BasicType.L, scopeLocal); // need to initialize all scope locals here in case an exception occurs
+                }
+            }
+            scopeSlots = Arrays.copyOf(scopeSlots, numScopes); // fit to size
+            curScopeLocalIdx = 0; // used from emitGetInput
         }
 
         // create a Binding.Context for this call
@@ -344,7 +366,7 @@ public class BindingSpecializer {
             }
             mv.visitLabel(tryEnd);
             // finally
-            emitCloseContext();
+            emitCleanup();
 
             if (callerMethodType.returnType() == void.class) {
                 // The case for upcalls that return by return buffer
@@ -360,13 +382,13 @@ public class BindingSpecializer {
             assert typeStack.isEmpty();
             mv.visitLabel(tryEnd);
             // finally
-            emitCloseContext();
+            emitCleanup();
             mv.visitInsn(RETURN);
         }
 
         mv.visitLabel(catchStart);
         // finally
-        emitCloseContext();
+        emitCleanup();
         if (callingSequence.forDowncall()) {
             mv.visitInsn(ATHROW);
         } else {
@@ -380,6 +402,17 @@ public class BindingSpecializer {
         }
 
         mv.visitTryCatchBlock(tryStart, tryEnd, catchStart, null);
+    }
+
+    private static boolean shouldAcquire(Class<?> type) {
+        return type == Addressable.class || type == NativeSymbol.class;
+    }
+
+    private void emitCleanup() {
+        emitCloseContext();
+        if (callingSequence.forDowncall()) {
+            emitReleaseScopes();
+        }
     }
 
     private void doBindings(List<Binding> bindings) {
@@ -407,8 +440,59 @@ public class BindingSpecializer {
     private void emitGetInput() {
         Class<?> highLevelType = callerMethodType.parameterType(paramIndex);
         emitLoad(BasicType.of(highLevelType), paramIndex2ParamSlot[paramIndex]);
+
+        if (shouldAcquire(highLevelType)) {
+            emitDup(BasicType.L);
+            emitAcquireScope();
+        }
+
         pushType(highLevelType);
         paramIndex++;
+    }
+
+    private void emitAcquireScope() {
+        emitCheckCast(Scoped.class);
+        emitInvokeInterface(Scoped.class, "scope", SCOPE_DESC);
+        Label skipAcquire = new Label();
+        Label end = new Label();
+
+        // start with 1 scope to maybe acquire on the stack
+        assert curScopeLocalIdx != -1;
+        boolean hasOtherScopes = curScopeLocalIdx != 0;
+        for (int i = 0; i < curScopeLocalIdx; i++) {
+            emitDup(BasicType.L); // dup for comparison
+            emitLoad(BasicType.L, scopeSlots[i]);
+            mv.visitJumpInsn(IF_ACMPEQ, skipAcquire);
+        }
+
+        // 1 scope to acquire on the stack
+        emitDup(BasicType.L);
+        int nextScopeLocal = scopeSlots[curScopeLocalIdx++];
+        emitStore(BasicType.L, nextScopeLocal); // store off one to release later
+        emitCheckCast(ResourceScopeImpl.class);
+        emitInvokeVirtual(ResourceScopeImpl.class, "acquire0", ACQUIRE0_DESC); // call acquire on the other
+
+        if (hasOtherScopes) { // avoid ASM generating a bunch of nops for the dead code
+            mv.visitJumpInsn(GOTO, end);
+
+            mv.visitLabel(skipAcquire);
+            mv.visitInsn(POP); // drop scope
+        }
+
+        mv.visitLabel(end);
+    }
+
+    private void emitReleaseScopes() {
+        for (int scopeLocal : scopeSlots) {
+            Label skipRelease = new Label();
+
+            emitLoad(BasicType.L, scopeLocal);
+            mv.visitJumpInsn(IFNULL, skipRelease);
+            emitLoad(BasicType.L, scopeLocal);
+            emitCheckCast(ResourceScopeImpl.class);
+            emitInvokeVirtual(ResourceScopeImpl.class, "release0", RELEASE0_DESC);
+            mv.visitLabel(skipRelease);
+        }
     }
 
     private void emitSaveReturnValue(Class<?> storeType) {

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/SharedUtils.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/SharedUtils.java
@@ -24,6 +24,17 @@
  */
 package jdk.internal.foreign.abi;
 
+import jdk.internal.access.JavaLangAccess;
+import jdk.internal.access.JavaLangInvokeAccess;
+import jdk.internal.access.SharedSecrets;
+import jdk.internal.foreign.CABI;
+import jdk.internal.foreign.MemoryAddressImpl;
+import jdk.internal.foreign.Scoped;
+import jdk.internal.foreign.abi.aarch64.linux.LinuxAArch64Linker;
+import jdk.internal.foreign.abi.aarch64.macos.MacOsAArch64Linker;
+import jdk.internal.foreign.abi.x64.sysv.SysVx64Linker;
+import jdk.internal.foreign.abi.x64.windows.Windowsx64Linker;
+
 import java.lang.foreign.Addressable;
 import java.lang.foreign.CLinker;
 import java.lang.foreign.FunctionDescriptor;
@@ -43,38 +54,13 @@ import java.lang.invoke.MethodType;
 import java.lang.invoke.VarHandle;
 import java.lang.ref.Reference;
 import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.function.Consumer;
-import java.util.function.UnaryOperator;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
-import jdk.internal.access.JavaLangAccess;
-import jdk.internal.access.JavaLangInvokeAccess;
-import jdk.internal.access.SharedSecrets;
-import jdk.internal.foreign.CABI;
-import jdk.internal.foreign.MemoryAddressImpl;
-import jdk.internal.foreign.ResourceScopeImpl;
-import jdk.internal.foreign.Scoped;
-import jdk.internal.foreign.abi.aarch64.linux.LinuxAArch64Linker;
-import jdk.internal.foreign.abi.aarch64.macos.MacOsAArch64Linker;
-import jdk.internal.foreign.abi.x64.sysv.SysVx64Linker;
-import jdk.internal.foreign.abi.x64.windows.Windowsx64Linker;
-import jdk.internal.vm.annotation.ForceInline;
-import static java.lang.invoke.MethodHandles.collectArguments;
-import static java.lang.invoke.MethodHandles.constant;
-import static java.lang.invoke.MethodHandles.dropArguments;
-import static java.lang.invoke.MethodHandles.dropReturn;
-import static java.lang.invoke.MethodHandles.empty;
-import static java.lang.invoke.MethodHandles.foldArguments;
-import static java.lang.invoke.MethodHandles.identity;
-import static java.lang.invoke.MethodHandles.insertArguments;
-import static java.lang.invoke.MethodHandles.permuteArguments;
-import static java.lang.invoke.MethodHandles.tryFinally;
-import static java.lang.invoke.MethodType.methodType;
+
 import static java.lang.foreign.ValueLayout.ADDRESS;
 import static java.lang.foreign.ValueLayout.JAVA_BOOLEAN;
 import static java.lang.foreign.ValueLayout.JAVA_BYTE;
@@ -84,6 +70,12 @@ import static java.lang.foreign.ValueLayout.JAVA_FLOAT;
 import static java.lang.foreign.ValueLayout.JAVA_INT;
 import static java.lang.foreign.ValueLayout.JAVA_LONG;
 import static java.lang.foreign.ValueLayout.JAVA_SHORT;
+import static java.lang.invoke.MethodHandles.collectArguments;
+import static java.lang.invoke.MethodHandles.dropReturn;
+import static java.lang.invoke.MethodHandles.identity;
+import static java.lang.invoke.MethodHandles.insertArguments;
+import static java.lang.invoke.MethodHandles.permuteArguments;
+import static java.lang.invoke.MethodType.methodType;
 
 public class SharedUtils {
 
@@ -93,13 +85,7 @@ public class SharedUtils {
     private static final MethodHandle MH_ALLOC_BUFFER;
     private static final MethodHandle MH_BASEADDRESS;
     private static final MethodHandle MH_BUFFER_COPY;
-    private static final MethodHandle MH_MAKE_CONTEXT_NO_ALLOCATOR;
-    private static final MethodHandle MH_MAKE_CONTEXT_BOUNDED_ALLOCATOR;
-    private static final MethodHandle MH_CLOSE_CONTEXT;
     private static final MethodHandle MH_REACHBILITY_FENCE;
-    private static final MethodHandle MH_HANDLE_UNCAUGHT_EXCEPTION;
-    private static final MethodHandle ACQUIRE_MH;
-    private static final MethodHandle RELEASE_MH;
 
     static {
         try {
@@ -110,20 +96,8 @@ public class SharedUtils {
                     methodType(MemoryAddress.class));
             MH_BUFFER_COPY = lookup.findStatic(SharedUtils.class, "bufferCopy",
                     methodType(MemoryAddress.class, MemoryAddress.class, MemorySegment.class));
-            MH_MAKE_CONTEXT_NO_ALLOCATOR = lookup.findStatic(Binding.Context.class, "ofScope",
-                    methodType(Binding.Context.class));
-            MH_MAKE_CONTEXT_BOUNDED_ALLOCATOR = lookup.findStatic(Binding.Context.class, "ofBoundedAllocator",
-                    methodType(Binding.Context.class, long.class));
-            MH_CLOSE_CONTEXT = lookup.findVirtual(Binding.Context.class, "close",
-                    methodType(void.class));
             MH_REACHBILITY_FENCE = lookup.findStatic(Reference.class, "reachabilityFence",
                     methodType(void.class, Object.class));
-            MH_HANDLE_UNCAUGHT_EXCEPTION = lookup.findStatic(SharedUtils.class, "handleUncaughtException",
-                    methodType(void.class, Throwable.class));
-            ACQUIRE_MH = MethodHandles.lookup().findStatic(SharedUtils.class, "acquire",
-                    MethodType.methodType(void.class, Scoped[].class));
-            RELEASE_MH = MethodHandles.lookup().findStatic(SharedUtils.class, "release",
-                    MethodType.methodType(void.class, Scoped[].class));
         } catch (ReflectiveOperationException e) {
             throw new BootstrapMethodError(e);
         }
@@ -344,140 +318,6 @@ public class SharedUtils {
         if (t != null) {
             t.printStackTrace();
             JLA.exit(1);
-        }
-    }
-
-    @ForceInline
-    @SuppressWarnings("fallthrough")
-    public static void acquire(Scoped[] args) {
-        ResourceScope scope4 = null;
-        ResourceScope scope3 = null;
-        ResourceScope scope2 = null;
-        ResourceScope scope1 = null;
-        ResourceScope scope0 = null;
-        switch (args.length) {
-            default:
-                // slow path, acquire all remaining addressable parameters in isolation
-                for (int i = 5 ; i < args.length ; i++) {
-                    acquire(args[i].scope());
-                }
-            // fast path, acquire only scopes not seen in other parameters
-            case 5:
-                scope4 = args[4].scope();
-                acquire(scope4);
-            case 4:
-                scope3 = args[3].scope();
-                if (scope3 != scope4)
-                    acquire(scope3);
-            case 3:
-                scope2 = args[2].scope();
-                if (scope2 != scope3 && scope2 != scope4)
-                    acquire(scope2);
-            case 2:
-                scope1 = args[1].scope();
-                if (scope1 != scope2 && scope1 != scope3 && scope1 != scope4)
-                    acquire(scope1);
-            case 1:
-                scope0 = args[0].scope();
-                if (scope0 != scope1 && scope0 != scope2 && scope0 != scope3 && scope0 != scope4)
-                    acquire(scope0);
-            case 0: break;
-        }
-    }
-
-    @ForceInline
-    @SuppressWarnings("fallthrough")
-    public static void release(Scoped[] args) {
-        ResourceScope scope4 = null;
-        ResourceScope scope3 = null;
-        ResourceScope scope2 = null;
-        ResourceScope scope1 = null;
-        ResourceScope scope0 = null;
-        switch (args.length) {
-            default:
-                // slow path, release all remaining addressable parameters in isolation
-                for (int i = 5 ; i < args.length ; i++) {
-                    release(args[i].scope());
-                }
-            // fast path, release only scopes not seen in other parameters
-            case 5:
-                scope4 = args[4].scope();
-                release(scope4);
-            case 4:
-                scope3 = args[3].scope();
-                if (scope3 != scope4)
-                    release(scope3);
-            case 3:
-                scope2 = args[2].scope();
-                if (scope2 != scope3 && scope2 != scope4)
-                    release(scope2);
-            case 2:
-                scope1 = args[1].scope();
-                if (scope1 != scope2 && scope1 != scope3 && scope1 != scope4)
-                    release(scope1);
-            case 1:
-                scope0 = args[0].scope();
-                if (scope0 != scope1 && scope0 != scope2 && scope0 != scope3 && scope0 != scope4)
-                    release(scope0);
-            case 0: break;
-        }
-    }
-
-    @ForceInline
-    private static void acquire(ResourceScope scope) {
-        ((ResourceScopeImpl)scope).acquire0();
-    }
-
-    @ForceInline
-    private static void release(ResourceScope scope) {
-        ((ResourceScopeImpl)scope).release0();
-    }
-
-    /*
-     * This method adds a try/finally block to a downcall method handle, to make sure that all by-reference
-     * parameters (including the target address of the native function) are kept alive for the duration of
-     * the downcall.
-     */
-    public static MethodHandle wrapDowncall(MethodHandle downcallHandle, FunctionDescriptor descriptor) {
-        boolean hasReturn = descriptor.returnLayout().isPresent();
-        MethodHandle tryBlock = downcallHandle;
-        MethodHandle cleanup = hasReturn ?
-                MethodHandles.identity(downcallHandle.type().returnType()) :
-                MethodHandles.empty(MethodType.methodType(void.class));
-        int addressableCount = 0;
-        List<UnaryOperator<MethodHandle>> adapters = new ArrayList<>();
-        for (int i = 0 ; i < downcallHandle.type().parameterCount() ; i++) {
-            Class<?> ptype = downcallHandle.type().parameterType(i);
-            if (ptype == Addressable.class || ptype == NativeSymbol.class) {
-                addressableCount++;
-            } else {
-                int pos = i;
-                adapters.add(mh -> dropArguments(mh, pos, ptype));
-            }
-        }
-
-        if (addressableCount > 0) {
-            cleanup = dropArguments(cleanup, 0, Throwable.class);
-
-            MethodType adapterType = MethodType.methodType(void.class);
-            for (int i = 0 ; i < addressableCount ; i++) {
-                adapterType = adapterType.appendParameterTypes(i == 0 ? NativeSymbol.class : Addressable.class);
-            }
-
-            MethodHandle acquireHandle = ACQUIRE_MH.asCollector(Scoped[].class, addressableCount).asType(adapterType);
-            MethodHandle releaseHandle = RELEASE_MH.asCollector(Scoped[].class, addressableCount).asType(adapterType);
-
-            for (UnaryOperator<MethodHandle> adapter : adapters) {
-                acquireHandle = adapter.apply(acquireHandle);
-                releaseHandle = adapter.apply(releaseHandle);
-            }
-
-            tryBlock = foldArguments(tryBlock, acquireHandle);
-            cleanup = collectArguments(cleanup, hasReturn ? 2 : 1, releaseHandle);
-
-            return tryFinally(tryBlock, cleanup);
-        } else {
-            return downcallHandle;
         }
     }
 

--- a/test/micro/org/openjdk/bench/java/lang/foreign/PointerInvoke.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/PointerInvoke.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/micro/org/openjdk/bench/java/lang/foreign/PointerInvoke.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/PointerInvoke.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package org.openjdk.bench.java.lang.foreign;
+
+import java.lang.foreign.Addressable;
+import java.lang.foreign.CLinker;
+import java.lang.foreign.FunctionDescriptor;
+import java.lang.foreign.MemorySegment;
+import java.lang.foreign.ResourceScope;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+
+import java.lang.invoke.MethodHandle;
+import java.util.concurrent.TimeUnit;
+
+@BenchmarkMode(Mode.AverageTime)
+@Warmup(iterations = 5, time = 500, timeUnit = TimeUnit.MILLISECONDS)
+@Measurement(iterations = 10, time = 500, timeUnit = TimeUnit.MILLISECONDS)
+@State(org.openjdk.jmh.annotations.Scope.Thread)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Fork(value = 3, jvmArgsAppend = { "--enable-native-access=ALL-UNNAMED", "--enable-preview" })
+public class PointerInvoke extends CLayouts {
+
+    ResourceScope scope = ResourceScope.newConfinedScope();
+    MemorySegment segment = MemorySegment.allocateNative(100, scope);
+
+    static {
+        System.loadLibrary("Ptr");
+    }
+
+    static final MethodHandle F_LONG, F_PTR;
+
+    static {
+        CLinker abi = CLinker.systemCLinker();
+        F_LONG = abi.downcallHandle(PointerInvoke.class.getClassLoader().findNative("func_as_long").get(),
+                FunctionDescriptor.of(C_INT, C_LONG_LONG));
+        F_PTR = abi.downcallHandle(PointerInvoke.class.getClassLoader().findNative("func_as_ptr").get(),
+                FunctionDescriptor.of(C_INT, C_POINTER));
+    }
+
+    @TearDown
+    public void tearDown() {
+        scope.close();
+    }
+
+    @Benchmark
+    public int panama_call_as_long() throws Throwable {
+        return (int)F_LONG.invokeExact(segment.address().toRawLongValue());
+    }
+
+    @Benchmark
+    public int panama_call_as_address() throws Throwable {
+        return (int)F_PTR.invokeExact((Addressable)segment.address());
+    }
+
+    @Benchmark
+    public int panama_call_as_segment() throws Throwable {
+        return (int)F_PTR.invokeExact((Addressable)segment);
+    }
+
+    @Benchmark
+    public int panama_call_as_new_segment() throws Throwable {
+        MemorySegment newSegment = MemorySegment.ofAddress(segment.address(), 100, scope);
+        return (int)F_PTR.invokeExact((Addressable)newSegment);
+    }
+}

--- a/test/micro/org/openjdk/bench/java/lang/foreign/libPtr.c
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/libPtr.c
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+#ifdef _WIN64
+#define EXPORT __declspec(dllexport)
+#else
+#define EXPORT
+#endif
+
+EXPORT int func_as_long(long long value) {
+  return 0;
+}
+
+EXPORT int func_as_ptr(void* ptr) {
+  return 0;
+}


### PR DESCRIPTION
Hi,

This patch rewrites the scope acquire/release logic that we do for downcalls inside ASM, in the generated specialized binding class. This also drops the fallback path we had for more than 5 scopes. The new code now always checks to see if every scope is unique. (I think that should be okay, but please let me know if otherwise).

I've also added a benchmark by Maurizio to this patch, which was showing a failure to scalar replace some scoped arguments with the old MH logic (reason discussed in [JDK-8281387](https://bugs.openjdk.java.net/browse/JDK-8281387)). With the new ASM-based logic, there is no sign of allocations (other than some noise):

```
Benchmark                                                     Mode  Cnt   Score    Error   Units
PointerInvoke.panama_call_as_address                          avgt   30  13.181 ±  0.320   ns/op
PointerInvoke.panama_call_as_address:·gc.alloc.rate           avgt   30   0.043 ±  0.049  MB/sec
PointerInvoke.panama_call_as_address:·gc.alloc.rate.norm      avgt   30   0.001 ±  0.001    B/op
PointerInvoke.panama_call_as_address:·gc.count                avgt   30     ≈ 0           counts
PointerInvoke.panama_call_as_long                             avgt   30  12.943 ±  0.287   ns/op
PointerInvoke.panama_call_as_long:·gc.alloc.rate              avgt   30   0.065 ±  0.054  MB/sec
PointerInvoke.panama_call_as_long:·gc.alloc.rate.norm         avgt   30   0.002 ±  0.001    B/op
PointerInvoke.panama_call_as_long:·gc.count                   avgt   30     ≈ 0           counts
PointerInvoke.panama_call_as_new_segment                      avgt   30  14.309 ±  0.177   ns/op
PointerInvoke.panama_call_as_new_segment:·gc.alloc.rate       avgt   30   0.173 ±  0.144  MB/sec
PointerInvoke.panama_call_as_new_segment:·gc.alloc.rate.norm  avgt   30   0.005 ±  0.004    B/op
PointerInvoke.panama_call_as_new_segment:·gc.count            avgt   30     ≈ 0           counts
PointerInvoke.panama_call_as_segment                          avgt   30  13.273 ±  0.191   ns/op
PointerInvoke.panama_call_as_segment:·gc.alloc.rate           avgt   30  ≈ 10??           MB/sec
PointerInvoke.panama_call_as_segment:·gc.alloc.rate.norm      avgt   30  ≈ 10??             B/op
PointerInvoke.panama_call_as_segment:·gc.count                avgt   30     ≈ 0           counts
```

Thanks,
Jorn

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issues
 * [JDK-8281595](https://bugs.openjdk.java.net/browse/JDK-8281595): ASM-ify scope acquire/release for down call parameters
 * [JDK-8281387](https://bugs.openjdk.java.net/browse/JDK-8281387): Some downcall shapes show unexpected allocations


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.java.net/census#mcimadamore) (@mcimadamore - Committer)


### Contributors
 * Maurizio Cimadamore `<mcimadamore@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/640/head:pull/640` \
`$ git checkout pull/640`

Update a local copy of the PR: \
`$ git checkout pull/640` \
`$ git pull https://git.openjdk.java.net/panama-foreign pull/640/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 640`

View PR using the GUI difftool: \
`$ git pr show -t 640`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/panama-foreign/pull/640.diff">https://git.openjdk.java.net/panama-foreign/pull/640.diff</a>

</details>
