### PR TITLE
8282026: Remove support for unbound sequence layouts

### DIFF
--- a/src/java.base/share/classes/java/lang/foreign/AbstractLayout.java
+++ b/src/java.base/share/classes/java/lang/foreign/AbstractLayout.java
@@ -34,7 +34,6 @@ import java.lang.constant.MethodTypeDesc;
 import java.nio.ByteOrder;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.OptionalLong;
 import jdk.internal.foreign.Utils;
 import jdk.internal.vm.annotation.Stable;
 

--- a/src/java.base/share/classes/java/lang/foreign/AbstractLayout.java
+++ b/src/java.base/share/classes/java/lang/foreign/AbstractLayout.java
@@ -46,13 +46,13 @@ import static java.lang.constant.ConstantDescs.CD_long;
 
 abstract non-sealed class AbstractLayout implements MemoryLayout {
 
-    private final OptionalLong size;
+    private final long size;
     final long alignment;
     private final Optional<String> name;
     @Stable
     long cachedSize;
 
-    public AbstractLayout(OptionalLong size, long alignment, Optional<String> name) {
+    public AbstractLayout(long size, long alignment, Optional<String> name) {
         this.size = size;
         this.alignment = alignment;
         this.name = name;
@@ -109,21 +109,8 @@ abstract non-sealed class AbstractLayout implements MemoryLayout {
     }
 
     @Override
-    public boolean hasSize() {
-        return size.isPresent();
-    }
-
-    @Override
     public long bitSize() {
-        return size.orElseThrow(AbstractLayout::badSizeException);
-    }
-
-    static OptionalLong optSize(MemoryLayout layout) {
-        return ((AbstractLayout)layout).size;
-    }
-
-    private static UnsupportedOperationException badSizeException() {
-        return new UnsupportedOperationException("Cannot compute size of a layout which is, or depends on a sequence layout with unspecified size");
+        return size;
     }
 
     String decorateLayoutString(String s) {
@@ -150,7 +137,7 @@ abstract non-sealed class AbstractLayout implements MemoryLayout {
     }
 
     boolean hasNaturalAlignment() {
-        return size.isPresent() && size.getAsLong() == alignment;
+        return size == alignment;
     }
 
     @Override
@@ -200,9 +187,6 @@ abstract non-sealed class AbstractLayout implements MemoryLayout {
 
     static final MethodHandleDesc MH_SIZED_SEQUENCE = MethodHandleDesc.ofMethod(DirectMethodHandleDesc.Kind.INTERFACE_STATIC, CD_MEMORY_LAYOUT, "sequenceLayout",
                 MethodTypeDesc.of(CD_SEQUENCE_LAYOUT, CD_long, CD_MEMORY_LAYOUT));
-
-    static final MethodHandleDesc MH_UNSIZED_SEQUENCE = MethodHandleDesc.ofMethod(DirectMethodHandleDesc.Kind.INTERFACE_STATIC, CD_MEMORY_LAYOUT, "sequenceLayout",
-                MethodTypeDesc.of(CD_SEQUENCE_LAYOUT, CD_MEMORY_LAYOUT));
 
     static final MethodHandleDesc MH_STRUCT = MethodHandleDesc.ofMethod(DirectMethodHandleDesc.Kind.INTERFACE_STATIC, CD_MEMORY_LAYOUT, "structLayout",
                 MethodTypeDesc.of(CD_GROUP_LAYOUT, CD_MEMORY_LAYOUT.arrayType()));

--- a/src/java.base/share/classes/java/lang/foreign/GroupLayout.java
+++ b/src/java.base/share/classes/java/lang/foreign/GroupLayout.java
@@ -85,16 +85,12 @@ public final class GroupLayout extends AbstractLayout implements MemoryLayout {
             this.sizeOp = sizeOp;
         }
 
-        OptionalLong sizeof(List<MemoryLayout> elems) {
+        long sizeof(List<MemoryLayout> elems) {
             long size = 0;
             for (MemoryLayout elem : elems) {
-                if (AbstractLayout.optSize(elem).isPresent()) {
-                    size = sizeOp.applyAsLong(size, elem.bitSize());
-                } else {
-                    return OptionalLong.empty();
-                }
+                size = sizeOp.applyAsLong(size, elem.bitSize());
             }
-            return OptionalLong.of(size);
+            return size;
         }
 
         long alignof(List<MemoryLayout> elems) {

--- a/src/java.base/share/classes/java/lang/foreign/GroupLayout.java
+++ b/src/java.base/share/classes/java/lang/foreign/GroupLayout.java
@@ -33,7 +33,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.OptionalLong;
 import java.util.function.LongBinaryOperator;
 import java.util.stream.Collectors;
 import jdk.internal.javac.PreviewFeature;

--- a/src/java.base/share/classes/java/lang/foreign/MemoryLayout.java
+++ b/src/java.base/share/classes/java/lang/foreign/MemoryLayout.java
@@ -432,7 +432,7 @@ public sealed interface MemoryLayout extends Constable permits AbstractLayout, S
      * @throws IllegalArgumentException if the layout path in {@code elements} does not select a value layout (see {@link ValueLayout}).
      */
     default VarHandle arrayElementVarHandle(PathElement... elements) {
-        return computePathOp(LayoutPath.rootPath(this, MemoryLayout::bitSize), LayoutPath::dereferenceHandle,
+        return computePathOp(LayoutPath.elementRootPath(this, MemoryLayout::bitSize), LayoutPath::dereferenceHandle,
                 Set.of(), elements);
     }
 

--- a/src/java.base/share/classes/java/lang/foreign/MemoryLayout.java
+++ b/src/java.base/share/classes/java/lang/foreign/MemoryLayout.java
@@ -90,9 +90,8 @@ import jdk.internal.javac.PreviewFeature;
  * always has the same size in bits, regardless of the platform in which it is used. For derived layouts, the size is computed
  * as follows:
  * <ul>
- *     <li>for a <em>finite</em> sequence layout <em>S</em> whose element layout is <em>E</em> and size is L,
+ *     <li>for a sequence layout <em>S</em> whose element layout is <em>E</em> and size is L,
  *     the size of <em>S</em> is that of <em>E</em>, multiplied by <em>L</em></li>
- *     <li>the size of an <em>unbounded</em> sequence layout is <em>unknown</em></li>
  *     <li>for a group layout <em>G</em> with member layouts <em>M1</em>, <em>M2</em>, ... <em>Mn</em> whose sizes are
  *     <em>S1</em>, <em>S2</em>, ... <em>Sn</em>, respectively, the size of <em>G</em> is either <em>S1 + S2 + ... + Sn</em> or
  *     <em>max(S1, S2, ... Sn)</em> depending on whether the group is a <em>struct</em> or an <em>union</em>, respectively</li>
@@ -206,14 +205,12 @@ public sealed interface MemoryLayout extends Constable permits AbstractLayout, S
 
     /**
      * {@return the layout size, in bits}
-     * @throws UnsupportedOperationException if the layout is, or contains, a sequence layout with unspecified size (see {@link SequenceLayout}).
      */
     long bitSize();
 
     /**
      * {@return the layout size, in bytes}
-     * @throws UnsupportedOperationException if the layout is, or contains, a sequence layout with unspecified size (see {@link SequenceLayout}),
-     * or if {@code bitSize()} is not a multiple of 8.
+     * @throws UnsupportedOperationException if {@code bitSize()} is not a multiple of 8.
      */
     long byteSize();
 
@@ -290,7 +287,6 @@ public sealed interface MemoryLayout extends Constable permits AbstractLayout, S
      * @throws IllegalArgumentException if the layout path does not select any layout nested in this layout, or if the
      * layout path contains one or more path elements that select multiple sequence element indices
      * (see {@link PathElement#sequenceElement()} and {@link PathElement#sequenceElement(long, long)}).
-     * @throws UnsupportedOperationException if one of the layouts traversed by the layout path has unspecified size.
      * @throws NullPointerException if either {@code elements == null}, or if any of the elements
      * in {@code elements} is {@code null}.
      */
@@ -325,7 +321,6 @@ public sealed interface MemoryLayout extends Constable permits AbstractLayout, S
      * specified by the given layout path elements, when supplied with the missing sequence element indices.
      * @throws IllegalArgumentException if the layout path contains one or more path elements that select
      * multiple sequence element indices (see {@link PathElement#sequenceElement(long, long)}).
-     * @throws UnsupportedOperationException if one of the layouts traversed by the layout path has unspecified size.
      */
     default MethodHandle bitOffsetHandle(PathElement... elements) {
         return computePathOp(LayoutPath.rootPath(this, MemoryLayout::bitSize), LayoutPath::offsetHandle,
@@ -341,8 +336,7 @@ public sealed interface MemoryLayout extends Constable permits AbstractLayout, S
      * @throws IllegalArgumentException if the layout path does not select any layout nested in this layout, or if the
      * layout path contains one or more path elements that select multiple sequence element indices
      * (see {@link PathElement#sequenceElement()} and {@link PathElement#sequenceElement(long, long)}).
-     * @throws UnsupportedOperationException if one of the layouts traversed by the layout path has unspecified size,
-     * or if {@code bitOffset(elements)} is not a multiple of 8.
+     * @throws UnsupportedOperationException if {@code bitOffset(elements)} is not a multiple of 8.
      * @throws NullPointerException if either {@code elements == null}, or if any of the elements
      * in {@code elements} is {@code null}.
      */
@@ -380,7 +374,6 @@ public sealed interface MemoryLayout extends Constable permits AbstractLayout, S
      * specified by the given layout path elements, when supplied with the missing sequence element indices.
      * @throws IllegalArgumentException if the layout path contains one or more path elements that select
      * multiple sequence element indices (see {@link PathElement#sequenceElement(long, long)}).
-     * @throws UnsupportedOperationException if one of the layouts traversed by the layout path has unspecified size.
      */
     default MethodHandle byteOffsetHandle(PathElement... elements) {
         MethodHandle mh = bitOffsetHandle(elements);
@@ -408,7 +401,7 @@ public sealed interface MemoryLayout extends Constable permits AbstractLayout, S
      *
      * where {@code x_1}, {@code x_2}, ... {@code x_n} are <em>dynamic</em> values provided as {@code long}
      * arguments, whereas {@code c_1}, {@code c_2}, ... {@code c_m} are <em>static</em> offset constants
-     * and {@code s_0}, {@code s_1}, ... {@code s_n} are <em>static</em> stride constants which are derived from
+     * and {@code s_1}, {@code s_2}, ... {@code s_n} are <em>static</em> stride constants which are derived from
      * the layout path.
      *
      * @apiNote the resulting var handle will feature an additional {@code long} access coordinate for every
@@ -417,8 +410,7 @@ public sealed interface MemoryLayout extends Constable permits AbstractLayout, S
      *
      * @param elements the layout path elements.
      * @return a var handle which can be used to dereference memory at the (possibly nested) layout selected by the layout path in {@code elements}.
-     * @throws UnsupportedOperationException if the layout path has one or more elements with incompatible alignment constraints,
-     * or if one of the layouts traversed by the layout path has unspecified size.
+     * @throws UnsupportedOperationException if the layout path has one or more elements with incompatible alignment constraints.
      * @throws IllegalArgumentException if the layout path in {@code elements} does not select a value layout (see {@link ValueLayout}).
      */
     default VarHandle varHandle(PathElement... elements) {
@@ -427,40 +419,20 @@ public sealed interface MemoryLayout extends Constable permits AbstractLayout, S
     }
 
     /**
-     * Creates a memory access var handle that can be used to dereference memory at the layout selected by a given layout path,
-     * where the path is considered rooted in this layout.
-     * <p>
-     * The final memory location accessed by the returned memory access var handle can be computed as follows:
-     *
-     * <blockquote><pre>{@code
-     * address = base + offset
-     * }</pre></blockquote>
-     *
-     * where {@code base} denotes the base address expressed by the {@link MemorySegment} access coordinate
-     * (see {@link MemorySegment#address()} and {@link MemoryAddress#toRawLongValue()}) and {@code offset}
-     * can be expressed in the following form:
-     *
-     * <blockquote><pre>{@code
-     * offset = c_1 + c_2 + ... + c_m + (x_1 * s_1) + (x_2 * s_2) + ... + (x_n * s_n)
-     * }</pre></blockquote>
-     *
-     * where {@code x_1}, {@code x_2}, ... {@code x_n} are <em>dynamic</em> values provided as {@code long}
-     * arguments, whereas {@code c_1}, {@code c_2}, ... {@code c_m} are <em>static</em> offset constants
-     * and {@code s_0}, {@code s_1}, ... {@code s_n} are <em>static</em> stride constants which are derived from
-     * the layout path.
-     *
-     * @apiNote the resulting var handle will feature an additional {@code long} access coordinate for every
-     * unspecified sequence access component contained in this layout path. Moreover, the resulting var handle
-     * features certain <a href="MemoryHandles.html#memaccess-mode">access mode restrictions</a>, which are common to all memory access var handles.
+     * Creates a <em>strided</em> memory access var handle that can be used to dereference memory at the layout selected by a given layout path,
+     * where the path is considered rooted in this layout. Equivalent to the following code:
+     * {@snippet lang=java :
+     * MemoryLayout.sequenceLayout(Long.MAX_VALUE, this)
+     *             .varHandle(PathElement.sequenceElement());
+     * }
      *
      * @param elements the layout path elements.
      * @return a var handle which can be used to dereference memory at the (possibly nested) layout selected by the layout path in {@code elements}.
-     * @throws UnsupportedOperationException if the layout path has one or more elements with incompatible alignment constraints,
-     * or if one of the layouts traversed by the layout path has unspecified size.
+     * @throws UnsupportedOperationException if the layout path has one or more elements with incompatible alignment constraints.
      * @throws IllegalArgumentException if the layout path in {@code elements} does not select a value layout (see {@link ValueLayout}).
      */
     default VarHandle arrayElementVarHandle(PathElement... elements) {
-        return computePathOp(LayoutPath.elementRootPath(this, MemoryLayout::bitSize), LayoutPath::dereferenceHandle,
+        return computePathOp(LayoutPath.rootPath(this, MemoryLayout::bitSize), LayoutPath::dereferenceHandle,
                 Set.of(), elements);
     }
 
@@ -484,7 +456,7 @@ public sealed interface MemoryLayout extends Constable permits AbstractLayout, S
      *
      * where {@code x_1}, {@code x_2}, ... {@code x_n} are <em>dynamic</em> values provided as {@code long}
      * arguments, whereas {@code c_1}, {@code c_2}, ... {@code c_m} are <em>static</em> offset constants
-     * and {@code s_0}, {@code s_1}, ... {@code s_n} are <em>static</em> stride constants which are derived from
+     * and {@code s_1}, {@code s_2}, ... {@code s_n} are <em>static</em> stride constants which are derived from
      * the layout path.
      *
      * <p>After the offset is computed, the returned segment is created as if by calling:
@@ -508,38 +480,13 @@ public sealed interface MemoryLayout extends Constable permits AbstractLayout, S
     }
 
     /**
-     * Creates a method handle which, given a memory segment, returns a {@linkplain MemorySegment#asSlice(long,long) slice}
+     * Creates a <em>strided</em> method handle which, given a memory segment, returns a {@linkplain MemorySegment#asSlice(long,long) slice}
      * corresponding to the layout selected by a given layout path, where the path is considered rooted in this layout.
-     *
-     * <p>The returned method handle has a return type of {@code MemorySegment}, features a {@code MemorySegment}
-     * parameter as leading parameter representing the segment to be sliced, and features as many trailing {@code long}
-     * parameter types as there are free dimensions in the provided layout path (see {@link PathElement#sequenceElement()}),
-     * where the order of the parameters corresponds to the order of the path elements.
-     * The returned method handle can be used to create a slice similar to using {@link MemorySegment#asSlice(long, long)},
-     * but where the offset argument is dynamically compute based on indices specified when invoking the method handle.
-     *
-     * <p>The offset of the returned segment is computed as follows:
-     *
-     * <blockquote><pre>{@code
-     * bitOffset = c_1 + c_2 + ... + c_m + (x_1 * s_1) + (x_2 * s_2) + ... + (x_n * s_n)
-     * offset = bitOffset / 8
-     * }</pre></blockquote>
-     *
-     * where {@code x_1}, {@code x_2}, ... {@code x_n} are <em>dynamic</em> values provided as {@code long}
-     * arguments, whereas {@code c_1}, {@code c_2}, ... {@code c_m} are <em>static</em> offset constants
-     * and {@code s_0}, {@code s_1}, ... {@code s_n} are <em>static</em> stride constants which are derived from
-     * the layout path.
-     *
-     * <p>After the offset is computed, the returned segment is created as if by calling:
+     * Equivalent to the following code:
      * {@snippet lang=java :
-     * segment.asSlice(offset, layout.byteSize());
+     * MemoryLayout.sequenceLayout(Long.MAX_VALUE, this)
+     *             .varHandle(PathElement.sequenceElement());
      * }
-     *
-     * where {@code segment} is the segment to be sliced, and where {@code layout} is the layout selected by the given
-     * layout path, as per {@link MemoryLayout#select(PathElement...)}.
-     *
-     * <p>The method handle will throw an {@link UnsupportedOperationException} if the computed
-     * offset in bits is not a multiple of 8.
      *
      * @param elements the layout path elements.
      * @return a method handle which can be used to create a slice of the selected layout element, given a segment.

--- a/src/java.base/share/classes/java/lang/foreign/MemoryLayout.java
+++ b/src/java.base/share/classes/java/lang/foreign/MemoryLayout.java
@@ -493,7 +493,7 @@ public sealed interface MemoryLayout extends Constable permits AbstractLayout, S
      * Equivalent to the following code:
      * {@snippet lang=java :
      * MemoryLayout.sequenceLayout(Long.MAX_VALUE, this)
-     *             .varHandle(PathElement.sequenceElement());
+     *             .sliceHandle(PathElement.sequenceElement());
      * }
      *
      * @param elements the layout path elements.

--- a/src/java.base/share/classes/java/lang/foreign/MemoryLayout.java
+++ b/src/java.base/share/classes/java/lang/foreign/MemoryLayout.java
@@ -486,31 +486,6 @@ public sealed interface MemoryLayout extends Constable permits AbstractLayout, S
     }
 
     /**
-     * Creates a <em>strided</em> method handle which, given a memory segment, returns a {@linkplain MemorySegment#asSlice(long,long) slice}
-     * corresponding to the layout selected by a given layout path, where the path is considered rooted in this layout.
-     * The returned method handle can effectively slice a given memory segment at multiple starting offsets, using a <em>dynamic</em> index
-     * (of type {@code long}), which is multiplied by this layout size and then added to the offset of the selected layout.
-     * Equivalent to the following code:
-     * {@snippet lang=java :
-     * MemoryLayout.sequenceLayout(Long.MAX_VALUE, this)
-     *             .sliceHandle(PathElement.sequenceElement());
-     * }
-     *
-     * @param elements the layout path elements.
-     * @return a method handle which can be used to create a slice of the selected layout element, given a segment.
-     * @throws UnsupportedOperationException if the size of the selected layout in bits is not a multiple of 8.
-     */
-    default MethodHandle arrayElementSliceHandle(PathElement... elements) {
-        Objects.requireNonNull(elements);
-        PathElement[] newElements = new PathElement[elements.length + 1];
-        newElements[0] = PathElement.sequenceElement();
-        System.arraycopy(elements, 0, newElements, 1, elements.length);
-        return computePathOp(LayoutPath.rootPath(MemoryLayout.sequenceLayout(Long.MAX_VALUE, this), MemoryLayout::bitSize),
-                LayoutPath::sliceHandle, Set.of(), newElements);
-    }
-
-
-    /**
      * Selects the layout from a path rooted in this layout.
      *
      * @param elements the layout path elements.

--- a/src/java.base/share/classes/java/lang/foreign/PaddingLayout.java
+++ b/src/java.base/share/classes/java/lang/foreign/PaddingLayout.java
@@ -55,7 +55,7 @@ import java.util.OptionalLong;
     }
 
     PaddingLayout(long size, long alignment, Optional<String> name) {
-        super(OptionalLong.of(size), alignment, name);
+        super(size, alignment, name);
     }
 
     @Override

--- a/src/java.base/share/classes/java/lang/foreign/PaddingLayout.java
+++ b/src/java.base/share/classes/java/lang/foreign/PaddingLayout.java
@@ -29,7 +29,6 @@ import java.lang.constant.ConstantDescs;
 import java.lang.constant.DynamicConstantDesc;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.OptionalLong;
 
 /**
  * A padding layout. A padding layout specifies the size of extra space which is typically not accessed by applications,

--- a/src/java.base/share/classes/java/lang/foreign/SequenceLayout.java
+++ b/src/java.base/share/classes/java/lang/foreign/SequenceLayout.java
@@ -29,7 +29,7 @@ import java.lang.constant.ConstantDescs;
 import java.lang.constant.DynamicConstantDesc;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.OptionalLong;
+
 import jdk.internal.javac.PreviewFeature;
 
 /**

--- a/src/java.base/share/classes/java/lang/foreign/SequenceLayout.java
+++ b/src/java.base/share/classes/java/lang/foreign/SequenceLayout.java
@@ -34,9 +34,9 @@ import jdk.internal.javac.PreviewFeature;
 
 /**
  * A sequence layout. A sequence layout is used to denote a repetition of a given layout, also called the sequence layout's <em>element layout</em>.
- * The repetition count, where it exists (e.g. for <em>finite</em> sequence layouts) is said to be the sequence layout's <em>element count</em>.
- * A finite sequence layout can be thought of as a group layout where the sequence layout's element layout is repeated a number of times
- * that is equal to the sequence layout's element count. In other words this layout:
+ * The repetition count is said to be the sequence layout's <em>element count</em>. A finite sequence can be thought of as a
+ * group layout where the sequence layout's element layout is repeated a number of times that is equal to the sequence
+ * layout's element count. In other words this layout:
  *
  * {@snippet lang=java :
  * MemoryLayout.sequenceLayout(3, ValueLayout.JAVA_INT.withOrder(ByteOrder.BIG_ENDIAN));
@@ -210,10 +210,6 @@ public final class SequenceLayout extends AbstractLayout implements MemoryLayout
             elemLayout = elemSeq.elementLayout();
         }
         return MemoryLayout.sequenceLayout(count, elemLayout);
-    }
-
-    private UnsupportedOperationException badUnboundSequenceLayout() {
-        return new UnsupportedOperationException("Cannot flatten a sequence layout whose element count is unspecified");
     }
 
     @Override

--- a/src/java.base/share/classes/java/lang/foreign/SequenceLayout.java
+++ b/src/java.base/share/classes/java/lang/foreign/SequenceLayout.java
@@ -70,17 +70,15 @@ import jdk.internal.javac.PreviewFeature;
 @PreviewFeature(feature=PreviewFeature.Feature.FOREIGN)
 public final class SequenceLayout extends AbstractLayout implements MemoryLayout {
 
-    private final OptionalLong elemCount;
+    private final long elemCount;
     private final MemoryLayout elementLayout;
 
-    SequenceLayout(OptionalLong elemCount, MemoryLayout elementLayout) {
+    SequenceLayout(long elemCount, MemoryLayout elementLayout) {
         this(elemCount, elementLayout, elementLayout.bitAlignment(), Optional.empty());
     }
 
-    SequenceLayout(OptionalLong elemCount, MemoryLayout elementLayout, long alignment, Optional<String> name) {
-        super(elemCount.isPresent() && AbstractLayout.optSize(elementLayout).isPresent() ?
-                OptionalLong.of(elemCount.getAsLong() * elementLayout.bitSize()) :
-                OptionalLong.empty(), alignment, name);
+    SequenceLayout(long elemCount, MemoryLayout elementLayout, long alignment, Optional<String> name) {
+        super(elemCount * elementLayout.bitSize(), alignment, name);
         this.elemCount = elemCount;
         this.elementLayout = elementLayout;
     }
@@ -95,7 +93,7 @@ public final class SequenceLayout extends AbstractLayout implements MemoryLayout
     /**
      * {@return the element count of this sequence layout (if any)}
      */
-    public OptionalLong elementCount() {
+    public long elementCount() {
         return elemCount;
     }
 
@@ -108,7 +106,7 @@ public final class SequenceLayout extends AbstractLayout implements MemoryLayout
      */
     public SequenceLayout withElementCount(long elementCount) {
         AbstractLayout.checkSize(elementCount, true);
-        return new SequenceLayout(OptionalLong.of(elementCount), elementLayout, alignment, name());
+        return new SequenceLayout(elementCount, elementLayout, alignment, name());
     }
 
     /**
@@ -149,11 +147,8 @@ public final class SequenceLayout extends AbstractLayout implements MemoryLayout
         if (elementCounts.length == 0) {
             throw new IllegalArgumentException();
         }
-        if (elementCount().isEmpty()) {
-            throw new UnsupportedOperationException("Cannot reshape a sequence layout whose element count is unspecified");
-        }
         SequenceLayout flat = flatten();
-        long expectedCount = flat.elementCount().getAsLong();
+        long expectedCount = flat.elementCount();
 
         long actualCount = 1;
         int inferPosition = -1;
@@ -208,13 +203,10 @@ public final class SequenceLayout extends AbstractLayout implements MemoryLayout
      * flattened, does not have an element count.
      */
     public SequenceLayout flatten() {
-        if (elementCount().isEmpty()) {
-            throw badUnboundSequenceLayout();
-        }
-        long count = elementCount().getAsLong();
+        long count = elementCount();
         MemoryLayout elemLayout = elementLayout();
         while (elemLayout instanceof SequenceLayout elemSeq) {
-            count = count * elemSeq.elementCount().orElseThrow(this::badUnboundSequenceLayout);
+            count = count * elemSeq.elementCount();
             elemLayout = elemSeq.elementLayout();
         }
         return MemoryLayout.sequenceLayout(count, elemLayout);
@@ -227,7 +219,7 @@ public final class SequenceLayout extends AbstractLayout implements MemoryLayout
     @Override
     public String toString() {
         return decorateLayoutString(String.format("[%s:%s]",
-                elemCount.isPresent() ? elemCount.getAsLong() : "", elementLayout));
+                elemCount, elementLayout));
     }
 
     @Override
@@ -241,7 +233,7 @@ public final class SequenceLayout extends AbstractLayout implements MemoryLayout
         if (!(other instanceof SequenceLayout s)) {
             return false;
         }
-        return elemCount.equals(s.elemCount) && elementLayout.equals(s.elementLayout);
+        return elemCount == s.elemCount && elementLayout.equals(s.elementLayout);
     }
 
     @Override
@@ -261,11 +253,9 @@ public final class SequenceLayout extends AbstractLayout implements MemoryLayout
 
     @Override
     public Optional<DynamicConstantDesc<SequenceLayout>> describeConstable() {
-        return Optional.of(decorateLayoutConstant(elemCount.isPresent() ?
+        return Optional.of(decorateLayoutConstant(
                 DynamicConstantDesc.ofNamed(ConstantDescs.BSM_INVOKE, "value",
-                        CD_SEQUENCE_LAYOUT, MH_SIZED_SEQUENCE, elemCount.getAsLong(), elementLayout.describeConstable().get()) :
-                DynamicConstantDesc.ofNamed(ConstantDescs.BSM_INVOKE, "value",
-                        CD_SEQUENCE_LAYOUT, MH_UNSIZED_SEQUENCE, elementLayout.describeConstable().get())));
+                        CD_SEQUENCE_LAYOUT, MH_SIZED_SEQUENCE, elemCount, elementLayout.describeConstable().get())));
     }
 
     //hack: the declarations below are to make javadoc happy; we could have used generics in AbstractLayout

--- a/src/java.base/share/classes/java/lang/foreign/ValueLayout.java
+++ b/src/java.base/share/classes/java/lang/foreign/ValueLayout.java
@@ -31,7 +31,6 @@ import java.lang.invoke.VarHandle;
 import java.nio.ByteOrder;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.OptionalLong;
 
 import jdk.internal.foreign.Utils;
 import jdk.internal.javac.PreviewFeature;

--- a/src/java.base/share/classes/java/lang/foreign/ValueLayout.java
+++ b/src/java.base/share/classes/java/lang/foreign/ValueLayout.java
@@ -79,7 +79,7 @@ public sealed class ValueLayout extends AbstractLayout implements MemoryLayout {
     }
 
     ValueLayout(Class<?> carrier, ByteOrder order, long size, long alignment, Optional<String> name) {
-        super(OptionalLong.of(size), alignment, name);
+        super(size, alignment, name);
         this.carrier = carrier;
         this.order = order;
         checkCarrierSize(carrier, size);

--- a/src/java.base/share/classes/jdk/internal/foreign/LayoutPath.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/LayoutPath.java
@@ -249,6 +249,10 @@ public class LayoutPath {
         return new LayoutPath(layout, 0L, EMPTY_STRIDES, -1, null, sizeFunc);
     }
 
+    public static LayoutPath elementRootPath(MemoryLayout layout, ToLongFunction<MemoryLayout> sizeFunc) {
+        return new LayoutPath(layout, 0L, new long[] { layout.bitSize() }, -1, null, sizeFunc);
+    }
+
     private static LayoutPath nestedPath(MemoryLayout layout, long offset, long[] strides, long elementIndex, LayoutPath encl) {
         return new LayoutPath(layout, offset, strides, elementIndex, encl, encl.sizeFunc);
     }

--- a/src/java.base/share/classes/jdk/internal/foreign/LayoutPath.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/LayoutPath.java
@@ -249,10 +249,6 @@ public class LayoutPath {
         return new LayoutPath(layout, 0L, EMPTY_STRIDES, -1, null, sizeFunc);
     }
 
-    public static LayoutPath elementRootPath(MemoryLayout layout, ToLongFunction<MemoryLayout> sizeFunc) {
-        return new LayoutPath(layout, 0L, new long[] { layout.bitSize() }, -1, null, sizeFunc);
-    }
-
     private static LayoutPath nestedPath(MemoryLayout layout, long offset, long[] strides, long elementIndex, LayoutPath encl) {
         return new LayoutPath(layout, offset, strides, elementIndex, encl, encl.sizeFunc);
     }

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/SharedUtils.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/SharedUtils.java
@@ -145,7 +145,7 @@ public class SharedUtils {
     }
 
     private static long alignmentOfArray(SequenceLayout ar, boolean isVar) {
-        if (ar.elementCount().orElseThrow() == 0) {
+        if (ar.elementCount() == 0) {
             // VLA or incomplete
             return 16;
         } else if ((ar.byteSize()) >= 16 && isVar) {

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/x64/sysv/TypeClass.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/x64/sysv/TypeClass.java
@@ -213,7 +213,7 @@ class TypeClass {
         } else if (l instanceof SequenceLayout) {
             SequenceLayout seq = (SequenceLayout)l;
             MemoryLayout elem = seq.elementLayout();
-            for (long i = 0 ; i < seq.elementCount().getAsLong() ; i++) {
+            for (long i = 0 ; i < seq.elementCount() ; i++) {
                 groupByEightBytes(elem, offset, groups);
                 offset += elem.byteSize();
             }

--- a/test/jdk/java/foreign/TestAdaptVarHandles.java
+++ b/test/jdk/java/foreign/TestAdaptVarHandles.java
@@ -31,7 +31,6 @@
  * @run testng/othervm -Djava.lang.invoke.VarHandle.VAR_HANDLE_GUARDS=false -Djava.lang.invoke.VarHandle.VAR_HANDLE_IDENTITY_ADAPT=true -Xverify:all TestAdaptVarHandles
  */
 
-import java.lang.foreign.MemoryLayout;
 import java.lang.foreign.MemorySegment;
 import java.lang.foreign.ResourceScope;
 import java.lang.foreign.ValueLayout;
@@ -85,8 +84,7 @@ public class TestAdaptVarHandles {
         }
     }
 
-    static final VarHandle intHandleIndexed = MemoryLayout.sequenceLayout(ValueLayout.JAVA_INT)
-            .varHandle(MemoryLayout.PathElement.sequenceElement());
+    static final VarHandle intHandleIndexed = ValueLayout.JAVA_INT.arrayElementVarHandle();
 
     static final VarHandle intHandle = ValueLayout.JAVA_INT.varHandle();
 

--- a/test/jdk/java/foreign/TestArrayCopy.java
+++ b/test/jdk/java/foreign/TestArrayCopy.java
@@ -27,7 +27,6 @@
  * @run testng TestArrayCopy
  */
 
-import java.lang.foreign.MemoryLayout;
 import java.lang.foreign.MemorySegment;
 import java.lang.foreign.ValueLayout;
 import java.lang.invoke.VarHandle;
@@ -275,10 +274,8 @@ public class TestArrayCopy {
     }
 
     public static MemorySegment truthSegment(MemorySegment srcSeg, CopyHelper<?, ?> helper, int indexShifts, CopyMode mode) {
-        VarHandle indexedHandleNO = MemoryLayout.sequenceLayout(helper.elementLayout.withOrder(NATIVE_ORDER))
-                                                .varHandle(MemoryLayout.PathElement.sequenceElement());
-        VarHandle indexedHandleNNO = MemoryLayout.sequenceLayout(helper.elementLayout.withOrder(NON_NATIVE_ORDER))
-                                                 .varHandle(MemoryLayout.PathElement.sequenceElement());
+        VarHandle indexedHandleNO = helper.elementLayout.withOrder(NATIVE_ORDER).arrayElementVarHandle();
+        VarHandle indexedHandleNNO = helper.elementLayout.withOrder(NON_NATIVE_ORDER).arrayElementVarHandle();
         MemorySegment dstSeg = MemorySegment.ofArray(srcSeg.toArray(JAVA_BYTE));
         int indexLength = (int) dstSeg.byteSize() / (int)helper.elementLayout.byteSize();
         if (mode.direction) {

--- a/test/jdk/java/foreign/TestArrays.java
+++ b/test/jdk/java/foreign/TestArrays.java
@@ -91,13 +91,13 @@ public class TestArrays {
     static VarHandle doubleHandle = doubles.varHandle(PathElement.sequenceElement());
 
     static void initBytes(MemorySegment base, SequenceLayout seq, BiConsumer<MemorySegment, Long> handleSetter) {
-        for (long i = 0; i < seq.elementCount().getAsLong() ; i++) {
+        for (long i = 0; i < seq.elementCount() ; i++) {
             handleSetter.accept(base, i);
         }
     }
 
     static void checkBytes(MemorySegment base, SequenceLayout layout, Function<MemorySegment, Object> arrayFactory, BiFunction<MemorySegment, Long, Object> handleGetter) {
-        int nelems = (int)layout.elementCount().getAsLong();
+        int nelems = (int)layout.elementCount();
         Object arr = arrayFactory.apply(base);
         for (int i = 0; i < nelems; i++) {
             Object found = handleGetter.apply(base, (long) i);

--- a/test/jdk/java/foreign/TestByteBuffer.java
+++ b/test/jdk/java/foreign/TestByteBuffer.java
@@ -162,7 +162,7 @@ public class TestByteBuffer {
     }
 
     static void initBytes(MemorySegment base, SequenceLayout seq, BiConsumer<MemorySegment, Long> handleSetter) {
-        for (long i = 0; i < seq.elementCount().getAsLong() ; i++) {
+        for (long i = 0; i < seq.elementCount() ; i++) {
             handleSetter.accept(base, i);
         }
     }
@@ -171,7 +171,7 @@ public class TestByteBuffer {
                                               Function<ByteBuffer, Z> bufFactory,
                                               BiFunction<MemorySegment, Long, Object> handleExtractor,
                                               Function<Z, Object> bufferExtractor) {
-        long nelems = layout.elementCount().getAsLong();
+        long nelems = layout.elementCount();
         long elemSize = layout.elementLayout().byteSize();
         for (long i = 0 ; i < nelems ; i++) {
             long limit = nelems - i;
@@ -196,10 +196,10 @@ public class TestByteBuffer {
     public void testOffheap() {
         try (ResourceScope scope = ResourceScope.newConfinedScope()) {
             MemorySegment segment = MemorySegment.allocateNative(tuples, scope);
-            initTuples(segment, tuples.elementCount().getAsLong());
+            initTuples(segment, tuples.elementCount());
 
             ByteBuffer bb = segment.asByteBuffer();
-            checkTuples(segment, bb, tuples.elementCount().getAsLong());
+            checkTuples(segment, bb, tuples.elementCount());
         }
     }
 
@@ -207,10 +207,10 @@ public class TestByteBuffer {
     public void testHeap() {
         byte[] arr = new byte[(int) tuples.byteSize()];
         MemorySegment region = MemorySegment.ofArray(arr);
-        initTuples(region, tuples.elementCount().getAsLong());
+        initTuples(region, tuples.elementCount());
 
         ByteBuffer bb = region.asByteBuffer();
-        checkTuples(region, bb, tuples.elementCount().getAsLong());
+        checkTuples(region, bb, tuples.elementCount());
     }
 
     @Test
@@ -223,7 +223,7 @@ public class TestByteBuffer {
         try (FileChannel channel = FileChannel.open(f.toPath(), StandardOpenOption.READ, StandardOpenOption.WRITE)) {
             withMappedBuffer(channel, FileChannel.MapMode.READ_WRITE, 0, tuples.byteSize(), mbb -> {
                 MemorySegment segment = MemorySegment.ofByteBuffer(mbb);
-                initTuples(segment, tuples.elementCount().getAsLong());
+                initTuples(segment, tuples.elementCount());
                 mbb.force();
             });
         }
@@ -232,7 +232,7 @@ public class TestByteBuffer {
         try (FileChannel channel = FileChannel.open(f.toPath(), StandardOpenOption.READ)) {
             withMappedBuffer(channel, FileChannel.MapMode.READ_ONLY, 0, tuples.byteSize(), mbb -> {
                 MemorySegment segment = MemorySegment.ofByteBuffer(mbb);
-                checkTuples(segment, mbb, tuples.elementCount().getAsLong());
+                checkTuples(segment, mbb, tuples.elementCount());
             });
         }
     }
@@ -259,14 +259,14 @@ public class TestByteBuffer {
         try (ResourceScope scope = ResourceScope.newConfinedScope()) {
             //write to channel
             MemorySegment segment = MemorySegment.mapFile(f.toPath(), 0L, tuples.byteSize(), FileChannel.MapMode.READ_WRITE, scope);
-            initTuples(segment, tuples.elementCount().getAsLong());
+            initTuples(segment, tuples.elementCount());
             segment.force();
         }
 
         try (ResourceScope scope = ResourceScope.newConfinedScope()) {
             //read from channel
             MemorySegment segment = MemorySegment.mapFile(f.toPath(), 0L, tuples.byteSize(), FileChannel.MapMode.READ_ONLY, scope);
-            checkTuples(segment, segment.asByteBuffer(), tuples.elementCount().getAsLong());
+            checkTuples(segment, segment.asByteBuffer(), tuples.elementCount());
         }
     }
 

--- a/test/jdk/java/foreign/TestCondy.java
+++ b/test/jdk/java/foreign/TestCondy.java
@@ -83,7 +83,6 @@ public class TestCondy {
         testValues.add(MemoryLayout.unionLayout(constants));
 
         for (MemoryLayout ml : constants) {
-            testValues.add(MemoryLayout.sequenceLayout(ml));
             testValues.add(MemoryLayout.sequenceLayout(10, ml));
         }
 

--- a/test/jdk/java/foreign/TestIllegalLink.java
+++ b/test/jdk/java/foreign/TestIllegalLink.java
@@ -68,12 +68,12 @@ public class TestIllegalLink extends NativeTestHelper {
                 "Unsupported layout: x64"
             },
             {
-                    FunctionDescriptor.of(MemoryLayout.sequenceLayout(C_INT)),
-                    "Unsupported layout: [:i32]"
+                    FunctionDescriptor.of(MemoryLayout.sequenceLayout(2, C_INT)),
+                    "Unsupported layout: [2:i32]"
             },
             {
-                    FunctionDescriptor.ofVoid(MemoryLayout.sequenceLayout(C_INT)),
-                    "Unsupported layout: [:i32]"
+                    FunctionDescriptor.ofVoid(MemoryLayout.sequenceLayout(2, C_INT)),
+                    "Unsupported layout: [2:i32]"
             },
         };
     }

--- a/test/jdk/java/foreign/TestLayoutConstants.java
+++ b/test/jdk/java/foreign/TestLayoutConstants.java
@@ -68,7 +68,6 @@ public class TestLayoutConstants {
         return new Object[][] {
                 //padding
                 {MemoryLayout.paddingLayout(32)},
-                { MemoryLayout.sequenceLayout(MemoryLayout.paddingLayout(32)) },
                 { MemoryLayout.sequenceLayout(5, MemoryLayout.paddingLayout(32)) },
                 { MemoryLayout.structLayout(MemoryLayout.paddingLayout(32), MemoryLayout.paddingLayout(32)) },
                 { MemoryLayout.unionLayout(MemoryLayout.paddingLayout(32), MemoryLayout.paddingLayout(32)) },
@@ -96,10 +95,6 @@ public class TestLayoutConstants {
                                 ValueLayout.JAVA_INT.withOrder(ByteOrder.BIG_ENDIAN))) },
                 { MemoryLayout.unionLayout(
                         MemoryLayout.paddingLayout(16),
-                        MemoryLayout.structLayout(
-                                MemoryLayout.paddingLayout(8),
-                                ValueLayout.JAVA_INT.withOrder(ByteOrder.BIG_ENDIAN))) },
-                { MemoryLayout.sequenceLayout(
                         MemoryLayout.structLayout(
                                 MemoryLayout.paddingLayout(8),
                                 ValueLayout.JAVA_INT.withOrder(ByteOrder.BIG_ENDIAN))) },

--- a/test/jdk/java/foreign/TestLayoutPaths.java
+++ b/test/jdk/java/foreign/TestLayoutPaths.java
@@ -52,13 +52,13 @@ public class TestLayoutPaths {
 
     @Test(expectedExceptions = IllegalArgumentException.class)
     public void testBadBitSelectFromSeq() {
-        SequenceLayout seq = MemoryLayout.sequenceLayout(JAVA_INT);
+        SequenceLayout seq = MemoryLayout.sequenceLayout(5, JAVA_INT);
         seq.bitOffset(groupElement("foo"));
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class)
     public void testBadByteSelectFromSeq() {
-        SequenceLayout seq = MemoryLayout.sequenceLayout(JAVA_INT);
+        SequenceLayout seq = MemoryLayout.sequenceLayout(5, JAVA_INT);
         seq.byteOffset(groupElement("foo"));
     }
 
@@ -76,13 +76,13 @@ public class TestLayoutPaths {
 
     @Test(expectedExceptions = IllegalArgumentException.class)
     public void testBadBitSelectFromValue() {
-        SequenceLayout seq = MemoryLayout.sequenceLayout(JAVA_INT);
+        SequenceLayout seq = MemoryLayout.sequenceLayout(5, JAVA_INT);
         seq.bitOffset(sequenceElement(), sequenceElement());
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class)
     public void testBadByteSelectFromValue() {
-        SequenceLayout seq = MemoryLayout.sequenceLayout(JAVA_INT);
+        SequenceLayout seq = MemoryLayout.sequenceLayout(5, JAVA_INT);
         seq.byteOffset(sequenceElement(), sequenceElement());
     }
 
@@ -172,30 +172,6 @@ public class TestLayoutPaths {
     public void testBadMultiple() {
         GroupLayout g = MemoryLayout.structLayout(MemoryLayout.paddingLayout(3), JAVA_INT.withName("foo"));
         g.byteOffset(groupElement("foo"));
-    }
-
-    @Test(expectedExceptions = UnsupportedOperationException.class)
-    public void testBitOffsetBadUnboundedSequenceTraverse() {
-        MemoryLayout layout = MemoryLayout.sequenceLayout(MemoryLayout.sequenceLayout(JAVA_INT));
-        layout.bitOffset(sequenceElement(1), sequenceElement(0));
-    }
-
-    @Test(expectedExceptions = UnsupportedOperationException.class)
-    public void testByteOffsetBadUnboundedSequenceTraverse() {
-        MemoryLayout layout = MemoryLayout.sequenceLayout(MemoryLayout.sequenceLayout(JAVA_INT));
-        layout.byteOffset(sequenceElement(1), sequenceElement(0));
-    }
-
-    @Test(expectedExceptions = UnsupportedOperationException.class)
-    public void testBitOffsetHandleBadUnboundedSequenceTraverse() {
-        MemoryLayout layout = MemoryLayout.sequenceLayout(MemoryLayout.sequenceLayout(JAVA_INT));
-        layout.bitOffsetHandle(sequenceElement(1), sequenceElement(0));
-    }
-
-    @Test(expectedExceptions = UnsupportedOperationException.class)
-    public void testByteOffsetHandleBadUnboundedSequenceTraverse() {
-        MemoryLayout layout = MemoryLayout.sequenceLayout(MemoryLayout.sequenceLayout(JAVA_INT));
-        layout.byteOffsetHandle(sequenceElement(1), sequenceElement(0));
     }
 
     @Test(expectedExceptions = UnsupportedOperationException.class)

--- a/test/jdk/java/foreign/TestLayoutPaths.java
+++ b/test/jdk/java/foreign/TestLayoutPaths.java
@@ -487,28 +487,6 @@ public class TestLayoutPaths {
         }
     }
 
-    @Test(dataProvider = "testLayouts")
-    public void testArrayElementSliceHandle(MemoryLayout layout, PathElement[] pathElements, long[] indexes,
-                                long expectedBitOffset) throws Throwable {
-        if (expectedBitOffset % 8 != 0)
-            throw new SkipException("Offset not a multiple of 8");
-
-        MemoryLayout selected = layout.select(pathElements);
-        MethodHandle sliceHandle = layout.arrayElementSliceHandle(pathElements);
-        sliceHandle = sliceHandle.asSpreader(long[].class, indexes.length);
-
-        long stride = layout.byteSize();
-
-        try (ResourceScope scope = ResourceScope.newConfinedScope()) {
-            MemorySegment segment = MemorySegment.allocateNative(MemoryLayout.sequenceLayout(5, layout), scope);
-            for (long i = 0 ; i < 5 ; i++) {
-                MemorySegment slice = (MemorySegment) sliceHandle.invokeExact(segment, i, indexes);
-                assertEquals(slice.address().toRawLongValue() - segment.address().toRawLongValue(), (expectedBitOffset / 8) + (stride * i));
-                assertEquals(slice.byteSize(), selected.byteSize());
-            }
-        }
-    }
-
     @Test(expectedExceptions = UnsupportedOperationException.class)
     public void testSliceHandleUOEInvalidOffsetEager() throws Throwable {
         MemoryLayout layout = MemoryLayout.structLayout(

--- a/test/jdk/java/foreign/TestLayouts.java
+++ b/test/jdk/java/foreign/TestLayouts.java
@@ -54,15 +54,14 @@ public class TestLayouts {
         MemoryLayout layout = MemoryLayout.structLayout(
                 ValueLayout.JAVA_INT.withName("size"),
                 MemoryLayout.paddingLayout(32),
-                MemoryLayout.sequenceLayout(ValueLayout.JAVA_DOUBLE).withName("arr"));
-        assertFalse(layout.hasSize());
+                ValueLayout.JAVA_DOUBLE.withName("arr"));
         VarHandle size_handle = layout.varHandle(MemoryLayout.PathElement.groupElement("size"));
-        VarHandle array_elem_handle = layout.varHandle(
+        var concreteLayout = layout.map(l -> MemoryLayout.sequenceLayout(4, l).withName("arr"), MemoryLayout.PathElement.groupElement("arr"));
+        VarHandle array_elem_handle = concreteLayout.varHandle(
                 MemoryLayout.PathElement.groupElement("arr"),
                 MemoryLayout.PathElement.sequenceElement());
         try (ResourceScope scope = ResourceScope.newConfinedScope()) {
-            MemorySegment segment = MemorySegment.allocateNative(
-                    layout.map(l -> ((SequenceLayout)l).withElementCount(4), MemoryLayout.PathElement.groupElement("arr")), scope);
+            MemorySegment segment = MemorySegment.allocateNative(concreteLayout, scope);
             size_handle.set(segment, 4);
             for (int i = 0 ; i < 4 ; i++) {
                 array_elem_handle.set(segment, i, (double)i);
@@ -80,16 +79,15 @@ public class TestLayouts {
         MemoryLayout layout = MemoryLayout.structLayout(
                 ValueLayout.JAVA_INT.withName("size"),
                 MemoryLayout.paddingLayout(32),
-                MemoryLayout.sequenceLayout(1, MemoryLayout.sequenceLayout(ValueLayout.JAVA_DOUBLE)).withName("arr"));
-        assertFalse(layout.hasSize());
+                MemoryLayout.sequenceLayout(1, ValueLayout.JAVA_DOUBLE).withName("arr"));
         VarHandle size_handle = layout.varHandle(MemoryLayout.PathElement.groupElement("size"));
-        VarHandle array_elem_handle = layout.varHandle(
+        var concreteLayout = layout.map(l -> MemoryLayout.sequenceLayout(4, l), MemoryLayout.PathElement.groupElement("arr"), MemoryLayout.PathElement.sequenceElement());
+        VarHandle array_elem_handle = concreteLayout.varHandle(
                 MemoryLayout.PathElement.groupElement("arr"),
                 MemoryLayout.PathElement.sequenceElement(0),
                 MemoryLayout.PathElement.sequenceElement());
         try (ResourceScope scope = ResourceScope.newConfinedScope()) {
-            MemorySegment segment = MemorySegment.allocateNative(
-                    layout.map(l -> ((SequenceLayout)l).withElementCount(4), MemoryLayout.PathElement.groupElement("arr"), MemoryLayout.PathElement.sequenceElement()), scope);
+            MemorySegment segment = MemorySegment.allocateNative(concreteLayout, scope);
             size_handle.set(segment, 4);
             for (int i = 0 ; i < 4 ; i++) {
                 array_elem_handle.set(segment, i, (double)i);
@@ -120,32 +118,6 @@ public class TestLayouts {
                 assertEquals(expected, found);
             }
         }
-    }
-
-    @Test(dataProvider = "unboundLayouts", expectedExceptions = UnsupportedOperationException.class)
-    public void testUnboundSize(MemoryLayout layout, long align) {
-        layout.bitSize();
-    }
-
-    @Test(dataProvider = "unboundLayouts")
-    public void testUnboundAlignment(MemoryLayout layout, long align) {
-        assertEquals(align, layout.bitAlignment());
-    }
-
-    @Test(dataProvider = "unboundLayouts")
-    public void testUnboundEquals(MemoryLayout layout, long align) {
-        assertTrue(layout.equals(layout));
-    }
-
-    @Test(dataProvider = "unboundLayouts")
-    public void testUnboundHash(MemoryLayout layout, long align) {
-        layout.hashCode();
-    }
-
-    @Test(expectedExceptions = IllegalArgumentException.class)
-    public void testBadUnboundSequenceLayoutResize() {
-        SequenceLayout seq = MemoryLayout.sequenceLayout(ValueLayout.JAVA_INT);
-        seq.withElementCount(-1);
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class)
@@ -223,22 +195,6 @@ public class TestLayouts {
                 assertEquals(layout.withBitAlignment(a).toString().contains("%"), a != bitAlign);
             }
         }
-    }
-
-    @DataProvider(name = "unboundLayouts")
-    public Object[][] unboundLayouts() {
-        ValueLayout alignedInt = JAVA_INT.withBitAlignment(32);
-        return new Object[][] {
-                { MemoryLayout.sequenceLayout(alignedInt), 32 },
-                { MemoryLayout.sequenceLayout(MemoryLayout.sequenceLayout(alignedInt)), 32 },
-                { MemoryLayout.sequenceLayout(4, MemoryLayout.sequenceLayout(alignedInt)), 32 },
-                { MemoryLayout.structLayout(MemoryLayout.sequenceLayout(alignedInt)), 32 },
-                { MemoryLayout.structLayout(MemoryLayout.sequenceLayout(MemoryLayout.sequenceLayout(alignedInt))), 32 },
-                { MemoryLayout.structLayout(MemoryLayout.sequenceLayout(4, MemoryLayout.sequenceLayout(alignedInt))), 32 },
-                { MemoryLayout.unionLayout(MemoryLayout.sequenceLayout(alignedInt)), 32 },
-                { MemoryLayout.unionLayout(MemoryLayout.sequenceLayout(MemoryLayout.sequenceLayout(alignedInt))), 32 },
-                { MemoryLayout.unionLayout(MemoryLayout.sequenceLayout(4, MemoryLayout.sequenceLayout(alignedInt))), 32 },
-        };
     }
 
     @DataProvider(name = "badAlignments")

--- a/test/jdk/java/foreign/TestLayouts.java
+++ b/test/jdk/java/foreign/TestLayouts.java
@@ -54,14 +54,14 @@ public class TestLayouts {
         MemoryLayout layout = MemoryLayout.structLayout(
                 ValueLayout.JAVA_INT.withName("size"),
                 MemoryLayout.paddingLayout(32),
-                ValueLayout.JAVA_DOUBLE.withName("arr"));
+                MemoryLayout.sequenceLayout(0, ValueLayout.JAVA_DOUBLE).withName("arr"));
         VarHandle size_handle = layout.varHandle(MemoryLayout.PathElement.groupElement("size"));
-        var concreteLayout = layout.map(l -> MemoryLayout.sequenceLayout(4, l).withName("arr"), MemoryLayout.PathElement.groupElement("arr"));
-        VarHandle array_elem_handle = concreteLayout.varHandle(
+        VarHandle array_elem_handle = layout.varHandle(
                 MemoryLayout.PathElement.groupElement("arr"),
                 MemoryLayout.PathElement.sequenceElement());
         try (ResourceScope scope = ResourceScope.newConfinedScope()) {
-            MemorySegment segment = MemorySegment.allocateNative(concreteLayout, scope);
+            MemorySegment segment = MemorySegment.allocateNative(
+                    layout.map(l -> ((SequenceLayout)l).withElementCount(4), MemoryLayout.PathElement.groupElement("arr")), scope);
             size_handle.set(segment, 4);
             for (int i = 0 ; i < 4 ; i++) {
                 array_elem_handle.set(segment, i, (double)i);
@@ -79,15 +79,15 @@ public class TestLayouts {
         MemoryLayout layout = MemoryLayout.structLayout(
                 ValueLayout.JAVA_INT.withName("size"),
                 MemoryLayout.paddingLayout(32),
-                MemoryLayout.sequenceLayout(1, ValueLayout.JAVA_DOUBLE).withName("arr"));
+                MemoryLayout.sequenceLayout(1, MemoryLayout.sequenceLayout(0, ValueLayout.JAVA_DOUBLE)).withName("arr"));
         VarHandle size_handle = layout.varHandle(MemoryLayout.PathElement.groupElement("size"));
-        var concreteLayout = layout.map(l -> MemoryLayout.sequenceLayout(4, l), MemoryLayout.PathElement.groupElement("arr"), MemoryLayout.PathElement.sequenceElement());
-        VarHandle array_elem_handle = concreteLayout.varHandle(
+        VarHandle array_elem_handle = layout.varHandle(
                 MemoryLayout.PathElement.groupElement("arr"),
                 MemoryLayout.PathElement.sequenceElement(0),
                 MemoryLayout.PathElement.sequenceElement());
         try (ResourceScope scope = ResourceScope.newConfinedScope()) {
-            MemorySegment segment = MemorySegment.allocateNative(concreteLayout, scope);
+            MemorySegment segment = MemorySegment.allocateNative(
+                    layout.map(l -> ((SequenceLayout)l).withElementCount(4), MemoryLayout.PathElement.groupElement("arr"), MemoryLayout.PathElement.sequenceElement()), scope);
             size_handle.set(segment, 4);
             for (int i = 0 ; i < 4 ; i++) {
                 array_elem_handle.set(segment, i, (double)i);

--- a/test/jdk/java/foreign/TestMemoryAccess.java
+++ b/test/jdk/java/foreign/TestMemoryAccess.java
@@ -122,7 +122,7 @@ public class TestMemoryAccess {
             MemorySegment segment = viewFactory.apply(MemorySegment.allocateNative(seq, scope));
             boolean isRO = segment.isReadOnly();
             try {
-                for (int i = 0; i < seq.elementCount().getAsLong(); i++) {
+                for (int i = 0; i < seq.elementCount(); i++) {
                     checker.check(handle, segment, i);
                 }
                 if (isRO) {
@@ -135,7 +135,7 @@ public class TestMemoryAccess {
                 return;
             }
             try {
-                checker.check(handle, segment, seq.elementCount().getAsLong());
+                checker.check(handle, segment, seq.elementCount());
                 throw new AssertionError(); //not ok, out of bounds
             } catch (IndexOutOfBoundsException ex) {
                 //ok, should fail (out of bounds)
@@ -184,8 +184,8 @@ public class TestMemoryAccess {
             MemorySegment segment = viewFactory.apply(MemorySegment.allocateNative(seq, scope));
             boolean isRO = segment.isReadOnly();
             try {
-                for (int i = 0; i < seq.elementCount().getAsLong(); i++) {
-                    for (int j = 0; j < ((SequenceLayout) seq.elementLayout()).elementCount().getAsLong(); j++) {
+                for (int i = 0; i < seq.elementCount(); i++) {
+                    for (int j = 0; j < ((SequenceLayout) seq.elementLayout()).elementCount(); j++) {
                         checker.check(handle, segment, i, j);
                     }
                 }
@@ -199,8 +199,8 @@ public class TestMemoryAccess {
                 return;
             }
             try {
-                checker.check(handle, segment, seq.elementCount().getAsLong(),
-                        ((SequenceLayout)seq.elementLayout()).elementCount().getAsLong());
+                checker.check(handle, segment, seq.elementCount(),
+                        ((SequenceLayout)seq.elementLayout()).elementCount());
                 throw new AssertionError(); //not ok, out of bounds
             } catch (IndexOutOfBoundsException ex) {
                 //ok, should fail (out of bounds)

--- a/test/jdk/java/foreign/TestNative.java
+++ b/test/jdk/java/foreign/TestNative.java
@@ -96,7 +96,7 @@ public class TestNative extends NativeTestHelper {
     static VarHandle doubleHandle = doubles.varHandle(PathElement.sequenceElement());
 
     static void initBytes(MemorySegment base, SequenceLayout seq, BiConsumer<MemorySegment, Long> handleSetter) {
-        for (long i = 0; i < seq.elementCount().getAsLong() ; i++) {
+        for (long i = 0; i < seq.elementCount() ; i++) {
             handleSetter.accept(base, i);
         }
     }
@@ -106,7 +106,7 @@ public class TestNative extends NativeTestHelper {
                                               Function<ByteBuffer, Z> bufferFactory,
                                               BiFunction<Z, Integer, Object> nativeBufferExtractor,
                                               BiFunction<Long, Integer, Object> nativeRawExtractor) {
-        long nelems = layout.elementCount().getAsLong();
+        long nelems = layout.elementCount();
         ByteBuffer bb = base.asByteBuffer();
         Z z = bufferFactory.apply(bb);
         for (long i = 0 ; i < nelems ; i++) {

--- a/test/jdk/java/foreign/TestNulls.java
+++ b/test/jdk/java/foreign/TestNulls.java
@@ -174,7 +174,7 @@ public class TestNulls {
         addDefaultMapping(ValueLayout.OfLong.class, JAVA_LONG);
         addDefaultMapping(ValueLayout.OfDouble.class, ValueLayout.JAVA_DOUBLE);
         addDefaultMapping(GroupLayout.class, MemoryLayout.structLayout(ValueLayout.JAVA_INT));
-        addDefaultMapping(SequenceLayout.class, MemoryLayout.sequenceLayout(ValueLayout.JAVA_INT));
+        addDefaultMapping(SequenceLayout.class, MemoryLayout.sequenceLayout(1, ValueLayout.JAVA_INT));
         addDefaultMapping(MemorySegment.class, MemorySegment.ofArray(new byte[10]));
         addDefaultMapping(FunctionDescriptor.class, FunctionDescriptor.ofVoid());
         addDefaultMapping(CLinker.class, CLinker.systemCLinker());

--- a/test/jdk/java/foreign/TestReshape.java
+++ b/test/jdk/java/foreign/TestReshape.java
@@ -76,31 +76,13 @@ public class TestReshape {
         seq.reshape(-2, 2);
     }
 
-    @Test(expectedExceptions = UnsupportedOperationException.class)
-    public void testReshapeOnUnboundSequence() {
-        SequenceLayout seq = MemoryLayout.sequenceLayout(ValueLayout.JAVA_INT);
-        seq.reshape(3, 2);
-    }
-
-    @Test(expectedExceptions = UnsupportedOperationException.class)
-    public void testFlattenOnUnboundSequence() {
-        SequenceLayout seq = MemoryLayout.sequenceLayout(ValueLayout.JAVA_INT);
-        seq.flatten();
-    }
-
-    @Test(expectedExceptions = UnsupportedOperationException.class)
-    public void testFlattenOnUnboundNestedSequence() {
-        SequenceLayout seq = MemoryLayout.sequenceLayout(4, MemoryLayout.sequenceLayout(ValueLayout.JAVA_INT));
-        seq.flatten();
-    }
-
     static void assertDimensions(SequenceLayout layout, long... dims) {
         SequenceLayout prev = null;
         for (int i = 0 ; i < dims.length ; i++) {
             if (prev != null) {
                 layout = (SequenceLayout)prev.elementLayout();
             }
-            assertEquals(layout.elementCount().getAsLong(), dims[i]);
+            assertEquals(layout.elementCount(), dims[i]);
             prev = layout;
         }
     }

--- a/test/jdk/java/foreign/TestSegments.java
+++ b/test/jdk/java/foreign/TestSegments.java
@@ -28,7 +28,6 @@
  * @run testng/othervm -Xmx4G -XX:MaxDirectMemorySize=1M TestSegments
  */
 
-import java.lang.foreign.MemoryLayout;
 import java.lang.foreign.MemorySegment;
 import java.lang.foreign.ResourceScope;
 import java.lang.foreign.ValueLayout;
@@ -65,8 +64,7 @@ public class TestSegments {
 
     @Test
     public void testNativeSegmentIsZeroed() {
-        VarHandle byteHandle = MemoryLayout.sequenceLayout(ValueLayout.JAVA_BYTE)
-                .varHandle(MemoryLayout.PathElement.sequenceElement());
+        VarHandle byteHandle = ValueLayout.JAVA_BYTE.arrayElementVarHandle();
         try (ResourceScope scope = ResourceScope.newConfinedScope()) {
             MemorySegment segment = MemorySegment.allocateNative(1000, 1, scope);
             for (long i = 0 ; i < segment.byteSize() ; i++) {
@@ -77,8 +75,7 @@ public class TestSegments {
 
     @Test
     public void testSlices() {
-        VarHandle byteHandle = MemoryLayout.sequenceLayout(ValueLayout.JAVA_BYTE)
-                .varHandle(MemoryLayout.PathElement.sequenceElement());
+        VarHandle byteHandle = ValueLayout.JAVA_BYTE.arrayElementVarHandle();
         try (ResourceScope scope = ResourceScope.newConfinedScope()) {
             MemorySegment segment = MemorySegment.allocateNative(10, 1, scope);
             //init
@@ -147,8 +144,7 @@ public class TestSegments {
 
     @Test(dataProvider = "segmentFactories")
     public void testFill(Supplier<MemorySegment> memorySegmentSupplier) {
-        VarHandle byteHandle = MemoryLayout.sequenceLayout(ValueLayout.JAVA_BYTE)
-                .varHandle(MemoryLayout.PathElement.sequenceElement());
+        VarHandle byteHandle = ValueLayout.JAVA_BYTE.arrayElementVarHandle();
 
         for (byte value : new byte[] {(byte) 0xFF, (byte) 0x00, (byte) 0x45}) {
             MemorySegment segment = memorySegmentSupplier.get();

--- a/test/jdk/java/foreign/TestSharedAccess.java
+++ b/test/jdk/java/foreign/TestSharedAccess.java
@@ -50,7 +50,7 @@ public class TestSharedAccess {
         SequenceLayout layout = MemoryLayout.sequenceLayout(1024, ValueLayout.JAVA_INT);
         try (ResourceScope scope = ResourceScope.newSharedScope()) {
             MemorySegment s = MemorySegment.allocateNative(layout, scope);
-            for (int i = 0 ; i < layout.elementCount().getAsLong() ; i++) {
+            for (int i = 0 ; i < layout.elementCount() ; i++) {
                 setInt(s.asSlice(i * 4), 42);
             }
             List<Thread> threads = new ArrayList<>();

--- a/test/jdk/java/foreign/TestSpliterator.java
+++ b/test/jdk/java/foreign/TestSpliterator.java
@@ -48,8 +48,7 @@ import static org.testng.Assert.*;
 
 public class TestSpliterator {
 
-    static final VarHandle INT_HANDLE = MemoryLayout.sequenceLayout(ValueLayout.JAVA_INT)
-            .varHandle(MemoryLayout.PathElement.sequenceElement());
+    static final VarHandle INT_HANDLE = ValueLayout.JAVA_INT.arrayElementVarHandle();
 
     final static int CARRIER_SIZE = 4;
 
@@ -60,10 +59,10 @@ public class TestSpliterator {
         //setup
         try (ResourceScope scope = ResourceScope.newSharedScope()) {
             MemorySegment segment = MemorySegment.allocateNative(layout, scope);
-            for (int i = 0; i < layout.elementCount().getAsLong(); i++) {
+            for (int i = 0; i < layout.elementCount(); i++) {
                 INT_HANDLE.set(segment, (long) i, i);
             }
-            long expected = LongStream.range(0, layout.elementCount().getAsLong()).sum();
+            long expected = LongStream.range(0, layout.elementCount()).sum();
             //serial
             long serial = sum(0, segment);
             assertEquals(serial, expected);
@@ -86,10 +85,10 @@ public class TestSpliterator {
 
         //setup
         MemorySegment segment = MemorySegment.allocateNative(layout, ResourceScope.newImplicitScope());
-        for (int i = 0; i < layout.elementCount().getAsLong(); i++) {
+        for (int i = 0; i < layout.elementCount(); i++) {
             INT_HANDLE.set(segment, (long) i, i);
         }
-        long expected = LongStream.range(0, layout.elementCount().getAsLong()).sum();
+        long expected = LongStream.range(0, layout.elementCount()).sum();
 
         //check that a segment w/o ACQUIRE access mode can still be used from same thread
         AtomicLong spliteratorSum = new AtomicLong();

--- a/test/jdk/java/foreign/TestVarArgs.java
+++ b/test/jdk/java/foreign/TestVarArgs.java
@@ -58,7 +58,7 @@ public class TestVarArgs extends NativeTestHelper {
     static final VarHandle VH_CallInfo_writeback = ML_CallInfo.varHandle(groupElement("writeback"));
     static final VarHandle VH_CallInfo_argIDs = ML_CallInfo.varHandle(groupElement("argIDs"));
 
-    static final VarHandle VH_IntArray = MemoryLayout.sequenceLayout(C_INT).varHandle(sequenceElement());
+    static final VarHandle VH_IntArray = C_INT.arrayElementVarHandle();
 
     static final CLinker abi = CLinker.systemCLinker();
     static {

--- a/test/micro/org/openjdk/bench/java/lang/foreign/LoopOverConstant.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/LoopOverConstant.java
@@ -73,7 +73,7 @@ public class LoopOverConstant {
     //setup native memory segment
 
     static final MemorySegment segment = MemorySegment.allocateNative(ALLOC_SIZE, ResourceScope.newImplicitScope());
-    static final VarHandle VH_int = MemoryLayout.sequenceLayout(JAVA_INT).varHandle(sequenceElement());
+    static final VarHandle VH_int = JAVA_INT.arrayElementVarHandle();
 
     static {
         for (int i = 0; i < ELEM_SIZE; i++) {

--- a/test/micro/org/openjdk/bench/java/lang/foreign/LoopOverNew.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/LoopOverNew.java
@@ -61,7 +61,7 @@ public class LoopOverNew {
     static final int ALLOC_SIZE = ELEM_SIZE * CARRIER_SIZE;
     static final MemoryLayout ALLOC_LAYOUT = MemoryLayout.sequenceLayout(ELEM_SIZE, JAVA_INT);
 
-    static final VarHandle VH_int = MemoryLayout.sequenceLayout(JAVA_INT).varHandle(sequenceElement());
+    static final VarHandle VH_int = JAVA_INT.arrayElementVarHandle();
 
     final ResourceScope scope = ResourceScope.newConfinedScope();
     final SegmentAllocator recyclingAlloc = SegmentAllocator.prefixAllocator(MemorySegment.allocateNative(ALLOC_LAYOUT, scope));

--- a/test/micro/org/openjdk/bench/java/lang/foreign/LoopOverNewHeap.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/LoopOverNewHeap.java
@@ -58,7 +58,7 @@ public class LoopOverNewHeap {
     static final int ELEM_SIZE = 1_000_000;
     static final int CARRIER_SIZE = (int)JAVA_INT.byteSize();
 
-    static final VarHandle VH_int = MemoryLayout.sequenceLayout(JAVA_INT).varHandle(sequenceElement());
+    static final VarHandle VH_int = JAVA_INT.arrayElementVarHandle();
 
     @Param(value = {"false", "true"})
     boolean polluteProfile;

--- a/test/micro/org/openjdk/bench/java/lang/foreign/LoopOverNonConstant.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/LoopOverNonConstant.java
@@ -61,10 +61,10 @@ public class LoopOverNonConstant {
     static final int CARRIER_SIZE = (int)JAVA_INT.byteSize();
     static final int ALLOC_SIZE = ELEM_SIZE * CARRIER_SIZE;
 
-    static final VarHandle VH_int = MemoryLayout.sequenceLayout(JAVA_INT).varHandle(sequenceElement());
+    static final VarHandle VH_int = JAVA_INT.arrayElementVarHandle();
 
     static final ValueLayout.OfInt JAVA_INT_ALIGNED = JAVA_INT.withBitAlignment(32);
-    static final VarHandle VH_int_aligned = MemoryLayout.sequenceLayout(JAVA_INT_ALIGNED).varHandle(sequenceElement());
+    static final VarHandle VH_int_aligned = JAVA_INT_ALIGNED.arrayElementVarHandle();
 
     MemorySegment segment;
     long unsafe_addr;

--- a/test/micro/org/openjdk/bench/java/lang/foreign/LoopOverNonConstantHeap.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/LoopOverNonConstantHeap.java
@@ -66,10 +66,10 @@ public class LoopOverNonConstantHeap {
     static final int ALLOC_SIZE = ELEM_SIZE * CARRIER_SIZE;
     static final int UNSAFE_BYTE_BASE = unsafe.arrayBaseOffset(byte[].class);
 
-    static final VarHandle VH_int = MemoryLayout.sequenceLayout(JAVA_INT).varHandle(sequenceElement());
+    static final VarHandle VH_int = JAVA_INT.arrayElementVarHandle();
 
     static final ValueLayout.OfInt JAVA_INT_ALIGNED = JAVA_INT.withBitAlignment(32);
-    static final VarHandle VH_int_aligned = MemoryLayout.sequenceLayout(JAVA_INT_ALIGNED).varHandle(sequenceElement());
+    static final VarHandle VH_int_aligned = JAVA_INT_ALIGNED.arrayElementVarHandle();
     static final int UNSAFE_INT_BASE = unsafe.arrayBaseOffset(int[].class);
 
     MemorySegment segment, alignedSegment;

--- a/test/micro/org/openjdk/bench/java/lang/foreign/LoopOverNonConstantMapped.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/LoopOverNonConstantMapped.java
@@ -80,7 +80,7 @@ public class LoopOverNonConstantMapped {
         }
     }
 
-    static final VarHandle VH_int = MemoryLayout.sequenceLayout(JAVA_INT).varHandle(sequenceElement());
+    static final VarHandle VH_int = JAVA_INT.arrayElementVarHandle();
     MemorySegment segment;
     long unsafe_addr;
 

--- a/test/micro/org/openjdk/bench/java/lang/foreign/LoopOverNonConstantShared.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/LoopOverNonConstantShared.java
@@ -59,7 +59,7 @@ public class LoopOverNonConstantShared {
     static final int CARRIER_SIZE = (int)JAVA_INT.byteSize();
     static final int ALLOC_SIZE = ELEM_SIZE * CARRIER_SIZE;
 
-    static final VarHandle VH_int = MemoryLayout.sequenceLayout(JAVA_INT).varHandle(sequenceElement());
+    static final VarHandle VH_int = JAVA_INT.arrayElementVarHandle();
     MemorySegment segment;
     long unsafe_addr;
 

--- a/test/micro/org/openjdk/bench/java/lang/foreign/LoopOverPollutedSegments.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/LoopOverPollutedSegments.java
@@ -62,7 +62,7 @@ public class LoopOverPollutedSegments {
     byte[] arr;
     long addr;
 
-    static final VarHandle intHandle = MemoryLayout.sequenceLayout(JAVA_INT).varHandle(MemoryLayout.PathElement.sequenceElement());
+    static final VarHandle intHandle = JAVA_INT.arrayElementVarHandle();
 
 
     @Setup

--- a/test/micro/org/openjdk/bench/java/lang/foreign/ParallelSum.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/ParallelSum.java
@@ -65,7 +65,7 @@ public class ParallelSum {
     final static int CARRIER_SIZE = 4;
     final static int ALLOC_SIZE = CARRIER_SIZE * 1024 * 1024 * 256;
     final static int ELEM_SIZE = ALLOC_SIZE / CARRIER_SIZE;
-    static final VarHandle VH_int = MemoryLayout.sequenceLayout(JAVA_INT).varHandle(sequenceElement());
+    static final VarHandle VH_int = JAVA_INT.arrayElementVarHandle();
 
     final static MemoryLayout ELEM_LAYOUT = ValueLayout.JAVA_INT;
     final static int BULK_FACTOR = 512;

--- a/test/micro/org/openjdk/bench/java/lang/foreign/TestAdaptVarHandles.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/TestAdaptVarHandles.java
@@ -84,8 +84,7 @@ public class TestAdaptVarHandles {
 
     static final VarHandle VH_box_int = MethodHandles.filterValue(VH_int, INTBOX_TO_INT, INT_TO_INTBOX);
 
-    static final VarHandle VH_addr_int = MemoryLayout.sequenceLayout(ValueLayout.JAVA_INT)
-            .varHandle(MemoryLayout.PathElement.sequenceElement());
+    static final VarHandle VH_addr_int = ValueLayout.JAVA_INT.arrayElementVarHandle();
 
     static final VarHandle VH_addr_box_int = MethodHandles.filterValue(VH_addr_int, INTBOX_TO_INT, INT_TO_INTBOX);
 


### PR DESCRIPTION
When doing a pass over the memory layout API, I couldn't help noting that the API implementation and specification are made more complex by the fact that we have to specify what happens when a sequence layout *without a size* is found. Support for unbounded sequence layout was added many moons ago, with the understanding that it would have made life for jextract easier.

This is not the case; all cases where jextract is using an unbounded sequence layout today can be replaced with using a simple zero-length sequence (which is allowed by the API, as are empty structs/unions).

I also found that the only real use case for using unbounded sequence layout came from a quirk in the API to obtain var handles from layout. That is, if we want to obtain an indexed var handle into a JAVA_INT, we have to do the following:

```
VarHandle intHandle = MemoryLayout.newSequenceLayout(JAVA_INT)
            .varHandle(PathElement.sequenceLayout());
```

In hindsight, this is just boilerplate: in this case the user only cares about the element layout (`JAVA_INT`), but the API wants the user to wrap that element layout in a new sequence layout, only to then provide a path inside the sequence layout (which will add a free dimension to the resulting var handle).

It is not hard to see that all the above can be simplified, by adding an extra API method on memory layouts:

```
VarHandle intHandle = JAVA_INT.arrayElementVarHandle(JAVA_INT);
```

This more explicit, succint, and provdies less opportunities for bugs to hide.

Therefore, this patch removes support for unbounded sequence element; the net effect is that now _all_ layouts have a size - which significantly simplifies the use sites where layout sizes are computed (no need to use optional there). All without losing much in terms of expressiveness: zero-length sequence layout can be used in basically the same way in which unbounded sequence layouts were used before.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [JDK-8282026](https://bugs.openjdk.java.net/browse/JDK-8282026): Remove support for unbound sequence layouts


### Reviewers
 * [Jorn Vernee](https://openjdk.java.net/census#jvernee) (@JornVernee - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/642/head:pull/642` \
`$ git checkout pull/642`

Update a local copy of the PR: \
`$ git checkout pull/642` \
`$ git pull https://git.openjdk.java.net/panama-foreign pull/642/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 642`

View PR using the GUI difftool: \
`$ git pr show -t 642`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/panama-foreign/pull/642.diff">https://git.openjdk.java.net/panama-foreign/pull/642.diff</a>

</details>
