### PR TITLE
8281764: jextract does not generate parameter names for function pointer typedefs

### DIFF
--- a/src/jdk.incubator.jextract/share/classes/jdk/incubator/jextract/Type.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/incubator/jextract/Type.java
@@ -218,6 +218,14 @@ public interface Type {
          * @return The optional list of function parameter names.
          */
         Optional<List<String>> parameterNames();
+
+        /**
+         * Returns a Function type that has the given parameter names.
+         *
+         * @param paramNames parameter names for this function type.
+         * @return new Function type with the given parameter names.
+         */
+        Function withParameterNames(List<String> paramNames);
     }
 
     /**
@@ -470,19 +478,7 @@ public interface Type {
      * @return a new function type with given parameter types and return type.
      */
     static Type.Function function(boolean varargs, Type returnType, Type... arguments) {
-        return new TypeImpl.FunctionImpl(varargs, Stream.of(arguments).collect(Collectors.toList()), returnType, Optional.empty());
-    }
-
-    /**
-     * Creates a new function type with given parameter types and return type.
-     * @param varargs is this function type variable-arity?
-     * @param returnType the function type return type.
-     * @param arguments the function type formal parameter types.
-     * @param paramNames the function type formal parameter names. It can be null.
-     * @return a new function type with given parameter types and return type.
-     */
-    static Type.Function function(boolean varargs, Type returnType, List<Type> arguments, List<String> paramNames) {
-        return new TypeImpl.FunctionImpl(varargs, arguments, returnType, Optional.ofNullable(paramNames));
+        return new TypeImpl.FunctionImpl(varargs, Stream.of(arguments).collect(Collectors.toList()), returnType, null);
     }
 
     /**

--- a/src/jdk.incubator.jextract/share/classes/jdk/incubator/jextract/Type.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/incubator/jextract/Type.java
@@ -212,6 +212,12 @@ public interface Type {
          * @return The function return type.
          */
         Type returnType();
+
+        /**
+         * Names of function parameters (from typedef), if any
+         * @return The optional list of function parameter names.
+         */
+        Optional<List<String>> parameterNames();
     }
 
     /**
@@ -464,7 +470,19 @@ public interface Type {
      * @return a new function type with given parameter types and return type.
      */
     static Type.Function function(boolean varargs, Type returnType, Type... arguments) {
-        return new TypeImpl.FunctionImpl(varargs, Stream.of(arguments).collect(Collectors.toList()), returnType);
+        return new TypeImpl.FunctionImpl(varargs, Stream.of(arguments).collect(Collectors.toList()), returnType, Optional.empty());
+    }
+
+    /**
+     * Creates a new function type with given parameter types and return type.
+     * @param varargs is this function type variable-arity?
+     * @param returnType the function type return type.
+     * @param arguments the function type formal parameter types.
+     * @param paramNames the function type formal parameter names. It can be null.
+     * @return a new function type with given parameter types and return type.
+     */
+    static Type.Function function(boolean varargs, Type returnType, List<Type> arguments, List<String> paramNames) {
+        return new TypeImpl.FunctionImpl(varargs, arguments, returnType, Optional.ofNullable(paramNames));
     }
 
     /**

--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/clang/CursorKind.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/clang/CursorKind.java
@@ -44,6 +44,7 @@ public enum CursorKind {
     ParmDecl(CXCursor_ParmDecl()),
     TypedefDecl(CXCursor_TypedefDecl()),
     Namespace(CXCursor_Namespace()),
+    TypeRef(CXCursor_TypeRef()),
     IntegerLiteral(CXCursor_IntegerLiteral()),
     FloatingLiteral(CXCursor_FloatingLiteral()),
     ImaginaryLiteral(CXCursor_ImaginaryLiteral()),

--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/JavaSourceBuilder.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/JavaSourceBuilder.java
@@ -56,8 +56,9 @@ public abstract class JavaSourceBuilder {
             return new FunctionInfo(methodType, null, functionDescriptor, isVarargs, Optional.of(parameterNames));
         }
 
-        static FunctionInfo ofFunctionPointer(MethodType upcallType, MethodType downcallType, FunctionDescriptor functionDescriptor) {
-            return new FunctionInfo(upcallType, downcallType, functionDescriptor, false, Optional.empty());
+        static FunctionInfo ofFunctionPointer(MethodType upcallType, MethodType downcallType, FunctionDescriptor functionDescriptor,
+                 Optional<List<String>> parameterNames) {
+            return new FunctionInfo(upcallType, downcallType, functionDescriptor, false, parameterNames);
         }
     }
 

--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/OutputFactory.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/OutputFactory.java
@@ -282,11 +282,7 @@ public class OutputFactory implements Declaration.Visitor<Void, Declaration> {
     }
 
     Type.Function getAsFunctionPointer(Type type) {
-        if (type instanceof Type.Delegated) {
-            Type.Delegated delegated = (Type.Delegated) type;
-            return (delegated.kind() == Type.Delegated.Kind.POINTER) ?
-                    getAsFunctionPointer(delegated.type()) : null;
-        } else if (type instanceof Type.Function) {
+        if (type instanceof Type.Function) {
             /*
              * // pointer to function declared as function like this
              *
@@ -294,6 +290,8 @@ public class OutputFactory implements Declaration.Visitor<Void, Declaration> {
              * void func(CB cb);
              */
             return (Type.Function) type;
+        } else if (Utils.isPointerType(type)) {
+            return getAsFunctionPointer(((Type.Delegated)type).type());
         } else {
             return null;
         }

--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/OutputFactory.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/OutputFactory.java
@@ -228,9 +228,10 @@ public class OutputFactory implements Declaration.Visitor<Void, Declaration> {
     }
 
     private String generateFunctionalInterface(Type.Function func, String name) {
-        return functionInfo(func, name, false, (mtype, desc) -> FunctionInfo.ofFunctionPointer(mtype, getMethodType(func, true), desc))
-                .map(fInfo -> currentBuilder.addFunctionalInterface(Utils.javaSafeIdentifier(name), fInfo))
-                .orElse(null);
+        return functionInfo(func, name, false,
+                 (mtype, desc) -> FunctionInfo.ofFunctionPointer(mtype, getMethodType(func, true), desc, func.parameterNames()))
+                 .map(fInfo -> currentBuilder.addFunctionalInterface(Utils.javaSafeIdentifier(name), fInfo))
+                 .orElse(null);
     }
 
     @Override

--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/TreeMaker.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/TreeMaker.java
@@ -261,8 +261,7 @@ class TreeMaker {
         boolean isFuncPtrType = false;
         if (canonicalType instanceof Type.Function) {
             funcType = (Type.Function)canonicalType;
-        } else if (canonicalType instanceof Type.Delegated &&
-                ((Type.Delegated)canonicalType).kind() == Type.Delegated.Kind.POINTER) {
+        } else if (Utils.isPointerType(canonicalType)) {
             Type pointeeType = null;
             try {
                 pointeeType = ((Type.Delegated)canonicalType).type();

--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/TreeMaker.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/TreeMaker.java
@@ -248,7 +248,12 @@ class TreeMaker {
     }
 
     private Declaration.Typedef createTypedef(Cursor c) {
-        Type cursorType = toType(c);
+        List<Declaration.Variable> params = c.children().
+             filter(ch -> ch.kind() == CursorKind.ParmDecl).
+             map(this::createTree).
+             map(Declaration.Variable.class::cast).
+             collect(Collectors.toList());
+        Type cursorType = toType(c, params);
         Type canonicalType = canonicalType(cursorType);
         if (canonicalType instanceof Type.Declared) {
             Declaration.Scoped s = ((Type.Declared) canonicalType).tree();
@@ -287,8 +292,12 @@ class TreeMaker {
         }
     }
 
+    private Type toType(Cursor c, List<Declaration.Variable> params) {
+        return typeMaker.makeType(c.type(), params == null || params.isEmpty()? null : params);
+    }
+
     private Type toType(Cursor c) {
-        return typeMaker.makeType(c.type());
+        return toType(c, null);
     }
 
     private void checkCursor(Cursor c, CursorKind k) {

--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/TypeImpl.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/TypeImpl.java
@@ -241,12 +241,19 @@ public abstract class TypeImpl implements Type {
         private final boolean varargs;
         private final List<Type> argtypes;
         private final Type restype;
+        private final Optional<List<String>> paramNames;
 
-        public FunctionImpl(boolean varargs, List<Type> argtypes, Type restype) {
+        public FunctionImpl(boolean varargs, List<Type> argtypes, Type restype,
+                Optional<List<String>> paramNames) {
             super();
             this.varargs = varargs;
             this.argtypes = Objects.requireNonNull(argtypes);
             this.restype = Objects.requireNonNull(restype);
+            this.paramNames = Objects.requireNonNull(paramNames);
+        }
+
+        public FunctionImpl(boolean varargs, List<Type> argtypes, Type restype) {
+            this(varargs, argtypes, restype, Optional.empty());
         }
 
         @Override
@@ -267,6 +274,11 @@ public abstract class TypeImpl implements Type {
         @Override
         public Type returnType() {
             return restype;
+        }
+
+        @Override
+        public Optional<List<String>> parameterNames() {
+            return paramNames;
         }
 
         @Override

--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/TypeImpl.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/TypeImpl.java
@@ -243,17 +243,16 @@ public abstract class TypeImpl implements Type {
         private final Type restype;
         private final Optional<List<String>> paramNames;
 
-        public FunctionImpl(boolean varargs, List<Type> argtypes, Type restype,
-                Optional<List<String>> paramNames) {
+        public FunctionImpl(boolean varargs, List<Type> argtypes, Type restype, List<String> paramNames) {
             super();
             this.varargs = varargs;
             this.argtypes = Objects.requireNonNull(argtypes);
             this.restype = Objects.requireNonNull(restype);
-            this.paramNames = Objects.requireNonNull(paramNames);
+            this.paramNames = Optional.ofNullable(paramNames);
         }
 
         public FunctionImpl(boolean varargs, List<Type> argtypes, Type restype) {
-            this(varargs, argtypes, restype, Optional.empty());
+            this(varargs, argtypes, restype, null);
         }
 
         @Override
@@ -274,6 +273,12 @@ public abstract class TypeImpl implements Type {
         @Override
         public Type returnType() {
             return restype;
+        }
+
+        @Override
+        public Type.Function withParameterNames(List<String> paramNames) {
+            Objects.requireNonNull(paramNames);
+            return new FunctionImpl(varargs, argtypes, restype, paramNames);
         }
 
         @Override

--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/Utils.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/Utils.java
@@ -29,6 +29,7 @@ package jdk.internal.jextract.impl;
 import jdk.incubator.foreign.MemoryAddress;
 import jdk.incubator.foreign.VaList;
 import jdk.incubator.foreign.ValueLayout;
+import jdk.incubator.jextract.Type.Delegated;
 import jdk.internal.clang.Cursor;
 import jdk.internal.clang.CursorKind;
 import jdk.internal.clang.SourceLocation;
@@ -319,6 +320,15 @@ class Utils {
             return (isPrintableAscii(ch))
                 ? String.valueOf(ch)
                 : String.format("\\u%04x", (int) ch);
+        }
+    }
+
+    static boolean isPointerType(jdk.incubator.jextract.Type type) {
+        if (type instanceof Delegated) {
+            Delegated delegated = (Delegated) type;
+            return delegated.kind() == Delegated.Kind.POINTER;
+        } else {
+            return false;
         }
     }
 

--- a/test/jdk/tools/jextract/JtregJextractSources.java
+++ b/test/jdk/tools/jextract/JtregJextractSources.java
@@ -56,6 +56,7 @@ public class JtregJextractSources {
         System.err.println("compiling jextracted sources @ " + sourcePath.toAbsolutePath());
         List<String> commands = new ArrayList<>();
         commands.add(Paths.get(System.getProperty("test.jdk"), "bin", "javac").toString());
+        commands.add("-parameters");
         commands.add("--add-modules");
         commands.add("jdk.incubator.foreign");
         commands.add("-d");

--- a/test/jdk/tools/jextract/test8281764/Test8281764.java
+++ b/test/jdk/tools/jextract/test8281764/Test8281764.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import org.testng.annotations.Test;
+import static org.testng.Assert.assertEquals;
+import test.jextract.test8281764.*;
+
+/*
+ * @test id=sources
+ * @bug 8281764
+ * @summary jextract does not generate parameter names for function pointer typedefs
+ * @library ..
+ * @modules jdk.incubator.jextract
+ * @run main/othervm JtregJextractSources -l Test8281764 -t test.jextract.test8281764 -- test8281764.h
+ * @run testng/othervm --enable-native-access=jdk.incubator.jextract,ALL-UNNAMED Test8281764
+ */
+public class Test8281764 {
+    @Test
+    public void testFunctionalInterfaceParameterNames() throws NoSuchMethodException {
+        var apply = func.class.getMethod("apply", int.class);
+        assertEquals(apply.getParameters()[0].getName(), "foo");
+        apply = fptr.class.getMethod("apply", int.class, int.class);
+        assertEquals(apply.getParameters()[0].getName(), "x");
+        assertEquals(apply.getParameters()[1].getName(), "y");
+    }
+}

--- a/test/jdk/tools/jextract/test8281764/test8281764.h
+++ b/test/jdk/tools/jextract/test8281764/test8281764.h
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+typedef void func(int foo);
+typedef void (*fptr)(int x, int y);


### PR DESCRIPTION
Propagating TypedefDecl's ParmDecl child cursors to Types.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [JDK-8281764](https://bugs.openjdk.java.net/browse/JDK-8281764): jextract does not generate parameter names for function pointer typedefs


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.java.net/census#mcimadamore) (@mcimadamore - Committer) ⚠️ Review applies to 0a8d2e20cd3782d9287018cc2f0a5dbd1cf26c7a


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/646/head:pull/646` \
`$ git checkout pull/646`

Update a local copy of the PR: \
`$ git checkout pull/646` \
`$ git pull https://git.openjdk.java.net/panama-foreign pull/646/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 646`

View PR using the GUI difftool: \
`$ git pr show -t 646`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/panama-foreign/pull/646.diff">https://git.openjdk.java.net/panama-foreign/pull/646.diff</a>

</details>
