### PR TITLE
Remove unused functions and includes

### DIFF
--- a/src/hotspot/share/prims/foreign_globals.cpp
+++ b/src/hotspot/share/prims/foreign_globals.cpp
@@ -24,30 +24,11 @@
 #include "precompiled.hpp"
 #include "foreign_globals.hpp"
 #include "classfile/javaClasses.hpp"
-#include "classfile/symbolTable.hpp"
-#include "classfile/systemDictionary.hpp"
-#include "classfile/vmSymbols.hpp"
 #include "memory/resourceArea.hpp"
 #include "prims/foreign_globals.inline.hpp"
-#include "runtime/fieldDescriptor.inline.hpp"
 #include "runtime/jniHandles.inline.hpp"
 
 #define FOREIGN_ABI "jdk/internal/foreign/abi/"
-
-static int field_offset(InstanceKlass* cls, const char* fieldname, Symbol* sigsym) {
-  TempNewSymbol fieldnamesym = SymbolTable::new_symbol(fieldname, (int)strlen(fieldname));
-  fieldDescriptor fd;
-  bool success = cls->find_field(fieldnamesym, sigsym, false, &fd);
-  assert(success, "Field not found");
-  return fd.offset();
-}
-
-static InstanceKlass* find_InstanceKlass(const char* name, TRAPS) {
-  TempNewSymbol sym = SymbolTable::new_symbol(name, (int)strlen(name));
-  Klass* k = SystemDictionary::resolve_or_null(sym, Handle(), Handle(), THREAD);
-  assert(k != nullptr, "Can not find class: %s", name);
-  return InstanceKlass::cast(k);
-}
 
 const CallRegs ForeignGlobals::parse_call_regs(jobject jconv) {
   oop conv_oop = JNIHandles::resolve_non_null(jconv);


### PR DESCRIPTION
This patch removes some unused functions and includes which GCC was issuing warnings about.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [Maurizio Cimadamore](https://openjdk.java.net/census#mcimadamore) (@mcimadamore - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/648/head:pull/648` \
`$ git checkout pull/648`

Update a local copy of the PR: \
`$ git checkout pull/648` \
`$ git pull https://git.openjdk.java.net/panama-foreign pull/648/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 648`

View PR using the GUI difftool: \
`$ git pr show -t 648`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/panama-foreign/pull/648.diff">https://git.openjdk.java.net/panama-foreign/pull/648.diff</a>

</details>
