### PR TITLE
8282215: Handle failures when initializing SystemLookup

### DIFF
--- a/src/java.base/share/classes/java/lang/foreign/SequenceLayout.java
+++ b/src/java.base/share/classes/java/lang/foreign/SequenceLayout.java
@@ -91,7 +91,7 @@ public final class SequenceLayout extends AbstractLayout implements MemoryLayout
     }
 
     /**
-     * {@return the element count of this sequence layout (if any)}
+     * {@return the element count of this sequence layout}
      */
     public long elementCount() {
         return elemCount;

--- a/test/jdk/java/foreign/TestFallbackLookup.java
+++ b/test/jdk/java/foreign/TestFallbackLookup.java
@@ -39,6 +39,6 @@ public class TestFallbackLookup {
         // we request a CLinker, forcing OS name to be "Windows". This should trigger an exception when
         // attempting to load a non-existent ucrtbase.dll. Make sure that no error is generated at this stage.
         CLinker linker = CLinker.systemCLinker();
-        assertTrue(linker.lookup("Foo").isEmpty());
+        assertTrue(linker.lookup("nonExistentSymbol").isEmpty());
     }
 }

--- a/test/jdk/java/foreign/TestFallbackLookup.java
+++ b/test/jdk/java/foreign/TestFallbackLookup.java
@@ -22,7 +22,7 @@
  */
 
 /*
- * @test /nodynamiccopyright/
+ * @test
  * @enablePreview
  * @requires ((os.arch == "amd64" | os.arch == "x86_64") & sun.arch.data.model == "64")
  * @run testng/othervm -Dos.name=Windows --enable-native-access=ALL-UNNAMED TestFallbackLookup

--- a/test/jdk/java/foreign/TestFallbackLookup.java
+++ b/test/jdk/java/foreign/TestFallbackLookup.java
@@ -1,0 +1,44 @@
+/*
+ *  Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ *  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ *  This code is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License version 2 only, as
+ *  published by the Free Software Foundation.
+ *
+ *  This code is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ *  version 2 for more details (a copy is included in the LICENSE file that
+ *  accompanied this code).
+ *
+ *  You should have received a copy of the GNU General Public License version
+ *  2 along with this work; if not, write to the Free Software Foundation,
+ *  Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ *  Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ *  or visit www.oracle.com if you need additional information or have any
+ *  questions.
+ */
+
+/*
+ * @test /nodynamiccopyright/
+ * @enablePreview
+ * @requires ((os.arch == "amd64" | os.arch == "x86_64") & sun.arch.data.model == "64")
+ * @run testng/othervm -Dos.name=Windows --enable-native-access=ALL-UNNAMED TestFallbackLookup
+ */
+
+import org.testng.annotations.*;
+import static org.testng.Assert.*;
+
+import java.lang.foreign.CLinker;
+
+public class TestFallbackLookup {
+    @Test
+    void testBadSystemLookupRequest() {
+        // we request a CLinker, forcing OS name to be "Windows". This should trigger an exception when
+        // attempting to load a non-existent ucrtbase.dll. Make sure that no error is generated at this stage.
+        CLinker linker = CLinker.systemCLinker();
+        assertTrue(linker.lookup("Foo").isEmpty());
+    }
+}


### PR DESCRIPTION
This patch handles failures originating from initialization of the SystemLookup class; instead of propagating these failures, we now swallow them, so that initialization of a `CLinker` can proceed. This adds some robustness to client code, and doubles down on the optional return type of the CLinker's lookup method.

The test checks that, when running with `os.name` set to Windows, we always manage to perform a lookup (even if we are executing the test on Linux/MacOS). The test trivially passes on Windows.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [JDK-8282215](https://bugs.openjdk.java.net/browse/JDK-8282215): Handle failures when initializing SystemLookup


### Reviewers
 * [Jorn Vernee](https://openjdk.java.net/census#jvernee) (@JornVernee - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/649/head:pull/649` \
`$ git checkout pull/649`

Update a local copy of the PR: \
`$ git checkout pull/649` \
`$ git pull https://git.openjdk.java.net/panama-foreign pull/649/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 649`

View PR using the GUI difftool: \
`$ git pr show -t 649`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/panama-foreign/pull/649.diff">https://git.openjdk.java.net/panama-foreign/pull/649.diff</a>

</details>
