### PR TITLE
8280460: MemorySegment::allocateNative should be tolerant of zero-sized allocation requests

### DIFF
--- a/src/java.base/share/classes/java/lang/foreign/MemorySegment.java
+++ b/src/java.base/share/classes/java/lang/foreign/MemorySegment.java
@@ -839,7 +839,7 @@ public sealed interface MemorySegment extends Addressable permits AbstractMemory
      * @param bytesSize the desired size.
      * @param session the native segment memory session.
      * @return a new native memory segment with given base address, size and memory session.
-     * @throws IllegalArgumentException if {@code bytesSize <= 0}.
+     * @throws IllegalArgumentException if {@code bytesSize < 0}.
      * @throws IllegalStateException if {@code session} is not {@linkplain MemorySession#isAlive() alive}, or if access occurs from
      * a thread other than the thread {@linkplain MemorySession#ownerThread() owning} {@code session}.
      * @throws IllegalCallerException if access to this method occurs from a module {@code M} and the command line option
@@ -851,7 +851,7 @@ public sealed interface MemorySegment extends Addressable permits AbstractMemory
         Reflection.ensureNativeAccess(Reflection.getCallerClass());
         Objects.requireNonNull(address);
         Objects.requireNonNull(session);
-        if (bytesSize <= 0) {
+        if (bytesSize < 0) {
             throw new IllegalArgumentException("Invalid size : " + bytesSize);
         }
         return NativeMemorySegmentImpl.makeNativeSegmentUnchecked(address, bytesSize, Scoped.toSessionImpl(session));
@@ -872,7 +872,6 @@ public sealed interface MemorySegment extends Addressable permits AbstractMemory
      * @param layout the layout of the off-heap memory block backing the native memory segment.
      * @param session the segment memory session.
      * @return a new native memory segment.
-     * @throws IllegalArgumentException if the specified layout has illegal size or alignment constraint.
      * @throws IllegalStateException if {@code session} is not {@linkplain MemorySession#isAlive() alive}, or if access occurs from
      * a thread other than the thread {@linkplain MemorySession#ownerThread() owning} {@code session}.
      */
@@ -897,7 +896,7 @@ public sealed interface MemorySegment extends Addressable permits AbstractMemory
      * @param bytesSize the size (in bytes) of the off-heap memory block backing the native memory segment.
      * @param session the segment temporal bounds.
      * @return a new native memory segment.
-     * @throws IllegalArgumentException if {@code bytesSize <= 0}.
+     * @throws IllegalArgumentException if {@code bytesSize < 0}.
      * @throws IllegalStateException if {@code session} is not {@linkplain MemorySession#isAlive() alive}, or if access occurs from
      * a thread other than the thread {@linkplain MemorySession#ownerThread() owning} {@code session}.
      */
@@ -917,14 +916,14 @@ public sealed interface MemorySegment extends Addressable permits AbstractMemory
      * @param alignmentBytes the alignment constraint (in bytes) of the off-heap memory block backing the native memory segment.
      * @param session the segment memory session.
      * @return a new native memory segment.
-     * @throws IllegalArgumentException if {@code bytesSize <= 0}, {@code alignmentBytes <= 0}, or if {@code alignmentBytes}
+     * @throws IllegalArgumentException if {@code bytesSize < 0}, {@code alignmentBytes <= 0}, or if {@code alignmentBytes}
      * is not a power of 2.
      * @throws IllegalStateException if {@code session} is not {@linkplain MemorySession#isAlive() alive}, or if access occurs from
      * a thread other than the thread {@linkplain MemorySession#ownerThread() owning} {@code session}.
      */
     static MemorySegment allocateNative(long bytesSize, long alignmentBytes, MemorySession session) {
         Objects.requireNonNull(session);
-        if (bytesSize <= 0) {
+        if (bytesSize < 0) {
             throw new IllegalArgumentException("Invalid allocation size : " + bytesSize);
         }
 

--- a/src/java.base/share/classes/java/lang/foreign/SegmentAllocator.java
+++ b/src/java.base/share/classes/java/lang/foreign/SegmentAllocator.java
@@ -310,6 +310,7 @@ public interface SegmentAllocator {
      * @param elementLayout the array element layout.
      * @param count the array element count.
      * @return a segment for the newly allocated memory block.
+     * @throws IllegalArgumentException if {@code count < 0}.
      */
     default MemorySegment allocateArray(MemoryLayout elementLayout, long count) {
         Objects.requireNonNull(elementLayout);
@@ -322,6 +323,7 @@ public interface SegmentAllocator {
      * @implSpec the default implementation for this method calls {@code this.allocate(bytesSize, 1)}.
      * @param bytesSize the size (in bytes) of the block of memory to be allocated.
      * @return a segment for the newly allocated memory block.
+     * @throws IllegalArgumentException if {@code bytesSize < 0}
      */
     default MemorySegment allocate(long bytesSize) {
         return allocate(bytesSize, 1);
@@ -332,6 +334,8 @@ public interface SegmentAllocator {
      * @param bytesSize the size (in bytes) of the block of memory to be allocated.
      * @param bytesAlignment the alignment (in bytes) of the block of memory to be allocated.
      * @return a segment for the newly allocated memory block.
+     * @throws IllegalArgumentException if {@code bytesSize < 0}, {@code alignmentBytes <= 0},
+     * or if {@code alignmentBytes} is not a power of 2.
      */
     MemorySegment allocate(long bytesSize, long bytesAlignment);
 

--- a/src/java.base/share/classes/jdk/internal/foreign/AbstractMemorySegmentImpl.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/AbstractMemorySegmentImpl.java
@@ -144,6 +144,10 @@ public abstract non-sealed class AbstractMemorySegmentImpl implements MemorySegm
 
     @Override
     public MemorySegment allocate(long bytesSize, long bytesAlignment) {
+        if (bytesAlignment <= 0 ||
+                ((bytesAlignment & (bytesAlignment - 1)) != 0L)) {
+            throw new IllegalArgumentException("Invalid alignment constraint : " + bytesAlignment);
+        }
         return asSlice(0, bytesSize);
     }
 

--- a/src/java.base/share/classes/jdk/internal/foreign/NativeMemorySegmentImpl.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/NativeMemorySegmentImpl.java
@@ -113,9 +113,9 @@ public class NativeMemorySegmentImpl extends AbstractMemorySegmentImpl {
         if (VM.isDirectMemoryPageAligned()) {
             alignmentBytes = Math.max(alignmentBytes, nioAccess.pageSize());
         }
-        long alignedSize = alignmentBytes > MAX_MALLOC_ALIGN ?
+        long alignedSize = Math.max(1L, alignmentBytes > MAX_MALLOC_ALIGN ?
                 bytesSize + (alignmentBytes - 1) :
-                bytesSize;
+                bytesSize);
 
         nioAccess.reserveMemory(alignedSize, bytesSize);
 

--- a/test/jdk/java/foreign/TestNative.java
+++ b/test/jdk/java/foreign/TestNative.java
@@ -200,7 +200,7 @@ public class TestNative extends NativeTestHelper {
     public void testBadResize() {
         try (MemorySession session = MemorySession.openConfined()) {
             MemorySegment segment = MemorySegment.allocateNative(4, 1, session);
-            MemorySegment.ofAddress(segment.address(), 0, MemorySession.global());
+            MemorySegment.ofAddress(segment.address(), -1, MemorySession.global());
         }
     }
 


### PR DESCRIPTION
This patch addresses the issues discussed here:

https://mail.openjdk.java.net/pipermail/panama-dev/2022-January/016071.html

And makes `MemorySegment::allocateNative` tolerand of zero-sized allocation requests. After evaluating a number of alternatives, I have decided to do what `ByteBuffer` also does, that is, always compute the size of the allocation as `max(size, 1L)`.

This means that we always perform some allocation - which works better with alignment constraints (e.g. the address you get back is aligned as per request; this is a corner case, but makes the API more consistent).

I've tweaked the javadoc to reflect that (and also added some javadoc to `SegmentAllocator` as well), and added a test for various kinds of native segments, created both safely and unsafely.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [JDK-8280460](https://bugs.openjdk.java.net/browse/JDK-8280460): MemorySegment::allocateNative should be tolerant of zero-sized allocation requests


### Reviewers
 * [Jorn Vernee](https://openjdk.java.net/census#jvernee) (@JornVernee - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/650/head:pull/650` \
`$ git checkout pull/650`

Update a local copy of the PR: \
`$ git checkout pull/650` \
`$ git pull https://git.openjdk.java.net/panama-foreign pull/650/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 650`

View PR using the GUI difftool: \
`$ git pr show -t 650`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/panama-foreign/pull/650.diff">https://git.openjdk.java.net/panama-foreign/pull/650.diff</a>

</details>
