### PR TITLE
8276648: Downcall stubs are never freed

### DIFF
--- a/src/hotspot/share/code/codeBlob.hpp
+++ b/src/hotspot/share/code/codeBlob.hpp
@@ -79,6 +79,7 @@ struct CodeBlobType {
 
 class CodeBlobLayout;
 class OptimizedEntryBlob; // for as_optimized_entry_blob()
+class RuntimeStub; // for as_runtime_stub()
 class JavaFrameAnchor; // for OptimizedEntryBlob::jfa_for_frame
 
 class CodeBlob {
@@ -148,7 +149,7 @@ public:
   virtual bool is_vtable_blob() const                 { return false; }
   virtual bool is_method_handles_adapter_blob() const { return false; }
   virtual bool is_compiled() const                    { return false; }
-  virtual bool is_optimized_entry_blob() const                  { return false; }
+  virtual bool is_optimized_entry_blob() const        { return false; }
 
   inline bool is_compiled_by_c1() const    { return _type == compiler_c1; };
   inline bool is_compiled_by_c2() const    { return _type == compiler_c2; };
@@ -157,12 +158,13 @@ public:
   CompilerType compiler_type() const { return _type; }
 
   // Casting
-  nmethod* as_nmethod_or_null()                { return is_nmethod() ? (nmethod*) this : NULL; }
-  nmethod* as_nmethod()                        { assert(is_nmethod(), "must be nmethod"); return (nmethod*) this; }
-  CompiledMethod* as_compiled_method_or_null() { return is_compiled() ? (CompiledMethod*) this : NULL; }
-  CompiledMethod* as_compiled_method()         { assert(is_compiled(), "must be compiled"); return (CompiledMethod*) this; }
-  CodeBlob* as_codeblob_or_null() const        { return (CodeBlob*) this; }
-  OptimizedEntryBlob* as_optimized_entry_blob() const             { assert(is_optimized_entry_blob(), "must be entry blob"); return (OptimizedEntryBlob*) this; }
+  nmethod* as_nmethod_or_null()                       { return is_nmethod() ? (nmethod*) this : NULL; }
+  nmethod* as_nmethod()                               { assert(is_nmethod(), "must be nmethod"); return (nmethod*) this; }
+  CompiledMethod* as_compiled_method_or_null()        { return is_compiled() ? (CompiledMethod*) this : NULL; }
+  CompiledMethod* as_compiled_method()                { assert(is_compiled(), "must be compiled"); return (CompiledMethod*) this; }
+  CodeBlob* as_codeblob_or_null() const               { return (CodeBlob*) this; }
+  OptimizedEntryBlob* as_optimized_entry_blob() const { assert(is_optimized_entry_blob(), "must be entry blob"); return (OptimizedEntryBlob*) this; }
+  RuntimeStub* as_runtime_stub() const                { assert(is_runtime_stub(), "must be runtime blob"); return (RuntimeStub*) this; }
 
   // Boundaries
   address header_begin() const        { return (address) this; }
@@ -511,6 +513,8 @@ class RuntimeStub: public RuntimeBlob {
     OopMapSet*  oop_maps,
     bool        caller_must_gc_arguments
   );
+
+  static void free(RuntimeStub* stub) { RuntimeBlob::free(stub); }
 
   // Typing
   bool is_runtime_stub() const                   { return true; }

--- a/src/hotspot/share/prims/nativeEntryPoint.cpp
+++ b/src/hotspot/share/prims/nativeEntryPoint.cpp
@@ -105,6 +105,16 @@ JNI_ENTRY(jlong, NEP_makeInvoker(JNIEnv* env, jclass _unused, jobject method_typ
     basic_type, pslots, ret_bt, abi, input_regs, output_regs, needs_return_buffer)->code_begin();
 JNI_END
 
+JNI_ENTRY(jboolean, NEP_freeInvoker(JNIEnv* env, jclass _unused, jlong invoker))
+  // safe to call without code cache lock, because stub is always alive
+  CodeBlob* cb = CodeCache::find_blob((char*) invoker);
+  if (cb == nullptr) {
+    return false;
+  }
+  RuntimeStub::free(cb->as_runtime_stub());
+  return true;
+JNI_END
+
 #define CC (char*)  /*cast a literal from (const char*)*/
 #define FN_PTR(f) CAST_FROM_FN_PTR(void*, &f)
 #define METHOD_TYPE "Ljava/lang/invoke/MethodType;"
@@ -113,6 +123,7 @@ JNI_END
 
 static JNINativeMethod NEP_methods[] = {
   {CC "makeInvoker", CC "(" METHOD_TYPE ABI_DESC VM_STORAGE_ARR VM_STORAGE_ARR "Z)J", FN_PTR(NEP_makeInvoker)},
+  {CC "freeInvoker0", CC "(J)Z", FN_PTR(NEP_freeInvoker)},
 };
 
 #undef METHOD_TYPE

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/AbstractLinker.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/AbstractLinker.java
@@ -36,11 +36,7 @@ import java.lang.foreign.MemorySession;
 import java.lang.foreign.NativeSymbol;
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodType;
-import java.lang.ref.SoftReference;
-import java.util.Map;
 import java.util.Objects;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.function.Function;
 
 public abstract sealed class AbstractLinker implements CLinker permits LinuxAArch64Linker, MacOsAArch64Linker,
                                                                        SysVx64Linker, Windowsx64Linker {
@@ -78,33 +74,4 @@ public abstract sealed class AbstractLinker implements CLinker permits LinuxAArc
     protected abstract NativeSymbol arrangeUpcall(MethodHandle target, MethodType targetType,
                                                   FunctionDescriptor function, MemorySession session);
 
-    private static class SoftReferenceCache<K, V> {
-        private final Map<K, Node> cache = new ConcurrentHashMap<>();
-
-        public V get(K key, Function<K, V> valueFactory) {
-            return cache
-                    .computeIfAbsent(key, k -> new Node()) // short lock (has to be according to ConcurrentHashMap)
-                    .get(key, valueFactory); // long lock, but just for the particular key
-        }
-
-        private class Node {
-            private SoftReference<V> ref;
-
-            public Node() {
-            }
-
-            public V get(K key, Function<K, V> valueFactory) {
-                V result;
-                if (ref == null || (result = ref.get()) == null) {
-                    synchronized (this) { // don't let threads race on the valueFactory::apply call
-                        if (ref == null || (result = ref.get()) == null) {
-                            result = valueFactory.apply(key); // keep alive
-                            ref = new SoftReference<>(result);
-                        }
-                    }
-                }
-                return result;
-            }
-        }
-    }
 }

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/SoftReferenceCache.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/SoftReferenceCache.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package jdk.internal.foreign.abi;
+
+import java.lang.ref.SoftReference;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Function;
+
+class SoftReferenceCache<K, V> {
+    private final Map<K, Node> cache = new ConcurrentHashMap<>();
+
+    public V get(K key, Function<K, V> valueFactory) {
+        return cache
+                .computeIfAbsent(key, k -> new Node()) // short lock (has to be according to ConcurrentHashMap)
+                .get(key, valueFactory); // long lock, but just for the particular key
+    }
+
+    private class Node {
+        private SoftReference<V> ref;
+
+        public Node() {
+        }
+
+        public V get(K key, Function<K, V> valueFactory) {
+            V result;
+            if (ref == null || (result = ref.get()) == null) {
+                synchronized (this) { // don't let threads race on the valueFactory::apply call
+                    if (ref == null || (result = ref.get()) == null) {
+                        result = valueFactory.apply(key); // keep alive
+                        ref = new SoftReference<>(result);
+                    }
+                }
+            }
+            return result;
+        }
+    }
+}


### PR DESCRIPTION
Hi,

The current code adds native invokers (downcall stubs) to a CocurrentHashMap cache, and they stay there until the application exits.

This patch replaces that cache with a SoftReferenceCache (brought to the top level from AbstractLinker), which allows at least the values to be evicted when they become unreachable.

Those value, which are NativeEntryPoint instances, are also registered with a cleaner, whose cleanup action will free the stub from the code cache.

Thanks,
Jorn