### PR TITLE
8277601: OptimizedEntryBlob should implement preserve_callee_argument_oops

### DIFF
--- a/src/hotspot/share/code/codeBlob.cpp
+++ b/src/hotspot/share/code/codeBlob.cpp
@@ -773,7 +773,7 @@ void OptimizedEntryBlob::free(OptimizedEntryBlob* blob) {
 }
 
 void OptimizedEntryBlob::preserve_callee_argument_oops(frame fr, const RegisterMap* reg_map, OopClosure* f) {
-  // do nothing for now
+  ShouldNotReachHere(); // caller should never have to gc arguments
 }
 
 // Misc.


### PR DESCRIPTION
Hi,

preserve_callee_argument_oops is currently not implemented, but it is also never called in practice.

Rather than leaving the implementation empty, or writing an implementation that is never actually called, this patch adds a `ShouldNotReachHere()` to the implementation so that we fail-fast in the case this function starts being called in the future.

Thanks,
Jorn

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [JDK-8277601](https://bugs.openjdk.java.net/browse/JDK-8277601): OptimizedEntryBlob should implement preserve_callee_argument_oops


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.java.net/census#mcimadamore) (@mcimadamore - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/652/head:pull/652` \
`$ git checkout pull/652`

Update a local copy of the PR: \
`$ git checkout pull/652` \
`$ git pull https://git.openjdk.java.net/panama-foreign pull/652/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 652`

View PR using the GUI difftool: \
`$ git pr show -t 652`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/panama-foreign/pull/652.diff">https://git.openjdk.java.net/panama-foreign/pull/652.diff</a>

</details>
