### PR TITLE
8282235: jextract crashes when a Java keyword is used in as a function pointer typedef parameter name

### DIFF
--- a/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/FunctionalInterfaceBuilder.java
+++ b/src/jdk.incubator.jextract/share/classes/jdk/internal/jextract/impl/FunctionalInterfaceBuilder.java
@@ -69,7 +69,7 @@ public class FunctionalInterfaceBuilder extends ClassSourceBuilder {
         if (parameterNames.isPresent()) {
             name = parameterNames.get().get(i);
         }
-        return name.isEmpty()? "_x" + i : name;
+        return name.isEmpty()? "_x" + i : Utils.javaSafeIdentifier(name);
     }
 
     private void emitFunctionalInterfaceMethod() {

--- a/test/jdk/tools/jextract/test8282235/Test8282235.java
+++ b/test/jdk/tools/jextract/test8282235/Test8282235.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import org.testng.annotations.Test;
+import static org.testng.Assert.assertEquals;
+import test.jextract.test8282235.*;
+
+/*
+ * @test id=sources
+ * @bug 8282235
+ * @summary jextract crashes when a Java keyword is used in as a function pointer typedef parameter name
+ * @library ..
+ * @modules jdk.incubator.jextract
+ * @run main/othervm JtregJextractSources -l Test8282235 -t test.jextract.test8282235 -- test8282235.h
+ * @run testng/othervm --enable-native-access=jdk.incubator.jextract,ALL-UNNAMED Test8282235
+ */
+public class Test8282235 {
+    @Test
+    public void testFunctionalInterfaceParameterNames() throws NoSuchMethodException {
+        var apply = func.class.getMethod("apply", int.class);
+        assertEquals(apply.getParameters()[0].getName(), "abstract_");
+        apply = fptr.class.getMethod("apply", int.class, int.class);
+        assertEquals(apply.getParameters()[0].getName(), "public_");
+        assertEquals(apply.getParameters()[1].getName(), "interface_");
+    }
+}

--- a/test/jdk/tools/jextract/test8282235/test8282235.h
+++ b/test/jdk/tools/jextract/test8282235/test8282235.h
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+typedef void func(int abstract);
+typedef void (*fptr)(int public, int interface);


### PR DESCRIPTION
Missed transforming function typedef parameter names as java safe identifiers.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [JDK-8282235](https://bugs.openjdk.java.net/browse/JDK-8282235): jextract crashes when a Java keyword is used in as a function pointer typedef parameter name


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.java.net/census#mcimadamore) (@mcimadamore - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/653/head:pull/653` \
`$ git checkout pull/653`

Update a local copy of the PR: \
`$ git checkout pull/653` \
`$ git pull https://git.openjdk.java.net/panama-foreign pull/653/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 653`

View PR using the GUI difftool: \
`$ git pr show -t 653`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/panama-foreign/pull/653.diff">https://git.openjdk.java.net/panama-foreign/pull/653.diff</a>

</details>
