### PR TITLE
nativeEntryPoint.cpp is missing an include

### DIFF
--- a/src/hotspot/share/prims/nativeEntryPoint.cpp
+++ b/src/hotspot/share/prims/nativeEntryPoint.cpp
@@ -25,6 +25,7 @@
 #include "precompiled.hpp"
 #include "runtime/interfaceSupport.inline.hpp"
 #include "classfile/javaClasses.inline.hpp"
+#include "code/codeCache.hpp"
 #include "code/vmreg.hpp"
 #include "logging/logStream.hpp"
 #include "memory/resourceArea.hpp"


### PR DESCRIPTION
Our internal build infra has pixked up an issue when compiling nativeEntryPointer.cpp, probably following JDK-8275648:

```
error C2653: 'CodeCache': is not a class or namespace name
error C3861: 'find_blob': identifier not found
```

This patch adds an include for codeCache.hpp in nativeEntryPointer.cpp.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [Jorn Vernee](https://openjdk.java.net/census#jvernee) (@JornVernee - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/659/head:pull/659` \
`$ git checkout pull/659`

Update a local copy of the PR: \
`$ git checkout pull/659` \
`$ git pull https://git.openjdk.java.net/panama-foreign pull/659/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 659`

View PR using the GUI difftool: \
`$ git pr show -t 659`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/panama-foreign/pull/659.diff">https://git.openjdk.java.net/panama-foreign/pull/659.diff</a>

</details>
