### PR TITLE
Tweak warning text for restricted method access

### DIFF
--- a/src/java.base/share/classes/jdk/internal/reflect/Reflection.java
+++ b/src/java.base/share/classes/jdk/internal/reflect/Reflection.java
@@ -131,11 +131,12 @@ public class Reflection {
                     String cls = owner.getName();
                     String mtd = cls + "::" + methodName;
                     String mod = module.isNamed() ? "module " + module.getName() : "the unnamed module";
+                    String modflag = module.isNamed() ? module.getName() : "ALL-UNNAMED";
                     System.err.printf("""
                             WARNING: A restricted method in %s has been called
                             WARNING: %s has been called by %s
-                            WARNING: Use --enable-native-access to allow this module to use restricted methods
-                            %n""", cls, mtd, mod);
+                            WARNING: Use --enable-native-access=%s to avoid a warning for this module
+                            %n""", cls, mtd, mod, modflag);
                     if (module.isNamed()) {
                         SharedSecrets.getJavaLangAccess().addEnableNativeAccess(module);
                     } else {

--- a/test/jdk/java/foreign/enablenativeaccess/TestEnableNativeAccess.java
+++ b/test/jdk/java/foreign/enablenativeaccess/TestEnableNativeAccess.java
@@ -116,8 +116,8 @@ public class TestEnableNativeAccess {
         return success().doNotExpect("WARNING");
     }
 
-    static Result successWithWarning() {
-        return success().expect("WARNING");
+    static Result successWithWarning(String moduleName) {
+        return success().expect("WARNING").expect("--enable-native-access=" + moduleName);
     }
 
     static Result failWithWarning(String expectedOutput) {
@@ -135,11 +135,11 @@ public class TestEnableNativeAccess {
                 { "panama_comma_separated_enable_reflection", PANAMA_REFLECTION, successNoWarning(), new String[]{"--enable-native-access=java.base,panama_module"} },
                 { "panama_comma_separated_enable_invoke", PANAMA_INVOKE, successNoWarning(), new String[]{"--enable-native-access=java.base,panama_module"} },
 
-                { "panama_enable_native_access_warn", PANAMA_MAIN, successWithWarning(), new String[]{} },
-                { "panama_enable_native_access_warn_reflection", PANAMA_REFLECTION, successWithWarning(), new String[]{} },
-                { "panama_enable_native_access_warn_invoke", PANAMA_INVOKE, successWithWarning(), new String[]{} },
+                { "panama_enable_native_access_warn", PANAMA_MAIN, successWithWarning("panama"), new String[]{} },
+                { "panama_enable_native_access_warn_reflection", PANAMA_REFLECTION, successWithWarning("panama"), new String[]{} },
+                { "panama_enable_native_access_warn_invoke", PANAMA_INVOKE, successWithWarning("panama"), new String[]{} },
 
-                { "panama_no_unnamed_module_native_access", UNNAMED, successWithWarning(), new String[]{} },
+                { "panama_no_unnamed_module_native_access", UNNAMED, successWithWarning("ALL-UNNAMED"), new String[]{} },
                 { "panama_all_unnamed_module_native_access", UNNAMED, successNoWarning(), new String[]{"--enable-native-access=ALL-UNNAMED"} },
         };
     }
@@ -190,7 +190,7 @@ public class TestEnableNativeAccess {
      */
     public void testWarnFirstAccess() throws Exception {
         List<String> output1 = run("panama_enable_native_access_first", PANAMA_MAIN,
-                successWithWarning()).asLines();
+                successWithWarning("panama")).asLines();
         assertTrue(count(output1, "WARNING") == 3);  // 3 on first access, none on subsequent access
     }
 


### PR DESCRIPTION
Following some internal feedback, the new warning for restricted method access has been tweaked to this:

```
WARNING: A restricted method in <class> has been called
WARNING: <method> has been called by <module>
WARNING: Use --enable-native-access=<module> to avoid a warning for this module
```

For instance:

```
WARNING: A restricted method in java.lang.foreign.CLinker has been called
WARNING: java.lang.foreign.CLinker::systemCLinker has been called by module panama_module
WARNING: Use --enable-native-access=panama_module to avoid a warning for this module
```

or, for unnamed modules:

```
WARNING: A restricted method in java.lang.foreign.CLinker has been called
WARNING: java.lang.foreign.CLinker::systemCLinker has been called by the unnamed module
WARNING: Use --enable-native-access=ALL-UNNAMED to avoid a warning for this module
```

This new text helps better connecting the warning with the action that a developer might want to take to get rid of the warning.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [Athijegannathan Sundararajan](https://openjdk.java.net/census#sundar) (@sundararajana - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/660/head:pull/660` \
`$ git checkout pull/660`

Update a local copy of the PR: \
`$ git checkout pull/660` \
`$ git pull https://git.openjdk.java.net/panama-foreign pull/660/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 660`

View PR using the GUI difftool: \
`$ git pr show -t 660`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/panama-foreign/pull/660.diff">https://git.openjdk.java.net/panama-foreign/pull/660.diff</a>

</details>
