### PR TITLE
8282626: Revert semantic of session accessors

### DIFF
--- a/src/hotspot/share/prims/scopedMemoryAccess.cpp
+++ b/src/hotspot/share/prims/scopedMemoryAccess.cpp
@@ -201,10 +201,10 @@ JVM_END
 /// JVM_RegisterUnsafeMethods
 
 #define PKG_MISC "Ljdk/internal/misc/"
-#define PKG_FOREIGN "Ljava/lang/foreign/"
+#define PKG_FOREIGN "Ljdk/internal/foreign/"
 
 #define MEMACCESS "ScopedMemoryAccess"
-#define SCOPE PKG_FOREIGN "MemorySession;"
+#define SCOPE PKG_FOREIGN "MemorySessionImpl;"
 
 #define CC (char*)  /*cast a literal from (const char*)*/
 #define FN_PTR(f) CAST_FROM_FN_PTR(void*, &f)

--- a/src/java.base/share/classes/java/lang/foreign/MemorySegment.java
+++ b/src/java.base/share/classes/java/lang/foreign/MemorySegment.java
@@ -41,7 +41,6 @@ import java.util.stream.Stream;
 import jdk.internal.foreign.AbstractMemorySegmentImpl;
 import jdk.internal.foreign.HeapMemorySegmentImpl;
 import jdk.internal.foreign.MappedMemorySegmentImpl;
-import jdk.internal.foreign.Scoped;
 import jdk.internal.foreign.NativeMemorySegmentImpl;
 import jdk.internal.foreign.Utils;
 import jdk.internal.foreign.abi.SharedUtils;
@@ -300,7 +299,7 @@ public sealed interface MemorySegment extends Addressable permits AbstractMemory
     Stream<MemorySegment> elements(MemoryLayout elementLayout);
 
     /**
-     * {@return a non-closeable view of the memory session associated with this memory segment}
+     * {@return the memory session associated with this memory segment}
      */
     MemorySession session();
 
@@ -854,7 +853,7 @@ public sealed interface MemorySegment extends Addressable permits AbstractMemory
         if (bytesSize < 0) {
             throw new IllegalArgumentException("Invalid size : " + bytesSize);
         }
-        return NativeMemorySegmentImpl.makeNativeSegmentUnchecked(address, bytesSize, Scoped.toSessionImpl(session));
+        return NativeMemorySegmentImpl.makeNativeSegmentUnchecked(address, bytesSize, session);
     }
 
     /**
@@ -878,7 +877,7 @@ public sealed interface MemorySegment extends Addressable permits AbstractMemory
     static MemorySegment allocateNative(MemoryLayout layout, MemorySession session) {
         Objects.requireNonNull(session);
         Objects.requireNonNull(layout);
-        return allocateNative(layout.byteSize(), layout.byteAlignment(), Scoped.toSessionImpl(session));
+        return allocateNative(layout.byteSize(), layout.byteAlignment(), session);
     }
 
     /**
@@ -932,7 +931,7 @@ public sealed interface MemorySegment extends Addressable permits AbstractMemory
             throw new IllegalArgumentException("Invalid alignment constraint : " + alignmentBytes);
         }
 
-        return NativeMemorySegmentImpl.makeNativeSegment(bytesSize, alignmentBytes, Scoped.toSessionImpl(session));
+        return NativeMemorySegmentImpl.makeNativeSegment(bytesSize, alignmentBytes, session);
     }
 
     /**
@@ -979,7 +978,7 @@ public sealed interface MemorySegment extends Addressable permits AbstractMemory
      */
     static MemorySegment mapFile(Path path, long bytesOffset, long bytesSize, FileChannel.MapMode mapMode, MemorySession session) throws IOException {
         Objects.requireNonNull(session);
-        return MappedMemorySegmentImpl.makeMappedSegment(path, bytesOffset, bytesSize, mapMode, Scoped.toSessionImpl(session));
+        return MappedMemorySegmentImpl.makeMappedSegment(path, bytesOffset, bytesSize, mapMode, session);
     }
 
     /**

--- a/src/java.base/share/classes/java/lang/foreign/MemorySession.java
+++ b/src/java.base/share/classes/java/lang/foreign/MemorySession.java
@@ -276,7 +276,7 @@ public sealed interface MemorySession extends AutoCloseable, SegmentAllocator pe
      * @return a non-closeable shared memory session, managed by a private {@link Cleaner} instance.
      */
     static MemorySession openImplicit() {
-        return MemorySessionImpl.createShared(CleanerFactory.cleaner()).asNonCloseable();
+        return MemorySessionImpl.createImplicit();
     }
 
     /**

--- a/src/java.base/share/classes/java/lang/foreign/MemorySession.java
+++ b/src/java.base/share/classes/java/lang/foreign/MemorySession.java
@@ -120,7 +120,7 @@ import jdk.internal.ref.CleanerFactory;
  *
  * {@snippet lang=java :
  * MemorySession session = MemorySession.openConfined();
- * MemoryLifetime nonCloseableSession = session.asNonCloseable();
+ * MemorySession nonCloseableSession = session.asNonCloseable();
  * MemorySegment segment = MemorySegment.allocateNative(100, nonCloseableSession);
  * segment.session().close(); // throws
  * session.close(); //ok
@@ -189,9 +189,8 @@ public sealed interface MemorySession extends AutoCloseable, SegmentAllocator pe
     void close();
 
     /**
-     * Returns a non-closeable view of this memory session. The returned session is the same session as this
-     * session, if this session is {@linkplain #isCloseable() non-closeable}, or a new non-closeable view of
-     * this memory session.
+     * Returns a non-closeable view of this memory session. If this session is {@linkplain #isCloseable() non-closeable},
+     * this session is returned. Otherwise, this method returns a new non-closeable view of this memory session.
      * @apiNote a non-closeable view of a memory session {@code S} keeps {@code S} reachable. As such, {@code S}
      * cannot be closed implicitly (e.g. by a {@link Cleaner}) as long as one or more non-closeable views of {@code S}
      * are reachable.

--- a/src/java.base/share/classes/java/lang/foreign/MemorySession.java
+++ b/src/java.base/share/classes/java/lang/foreign/MemorySession.java
@@ -196,6 +196,23 @@ public sealed interface MemorySession extends AutoCloseable, SegmentAllocator pe
     MemorySession asNonCloseable();
 
     /**
+     * Compares the specified object with this memory session for equality. Returns {@code true} if and only if the specified
+     * object is also a memory session, and it refers to the same memory session as this memory session. This method
+     * is especially useful when operating on {@linkplain #asNonCloseable() non-closeable} session views.
+     *
+     * @param that the object to be compared for equality with this memory session.
+     * @return {@code true} if the specified object is equal to this memory session.
+     */
+    @Override
+    boolean equals(Object that);
+
+    /**
+     * {@return the hash code value for this memory session}
+     */
+    @Override
+    int hashCode();
+
+    /**
      * Allocates a new native segment, using this session. Equivalent to the following code:
      * {@snippet lang=java :
      * MemorySegment.allocateNative(size, align, this);

--- a/src/java.base/share/classes/java/lang/foreign/MemorySession.java
+++ b/src/java.base/share/classes/java/lang/foreign/MemorySession.java
@@ -112,10 +112,10 @@ import jdk.internal.javac.PreviewFeature;
  *
  * There are situations in which it might not be desirable for a memory session to be reachable from one or
  * more resources associated with it. For instance, an API might create a private memory session, and allocate
- * a memory segment, and then expose one or more slices of this segment to its clients. If the API's memory session
- * is reachable from the slices (using the {@link MemorySegment#session()} accessor), it might be possible for
+ * a memory segment, and then expose one or more slices of this segment to its clients. Since the API's memory session
+ * would be reachable from the slices (using the {@link MemorySegment#session()} accessor), it might be possible for
  * clients to compromise the API (e.g. by closing the session prematurely). To avoid leaking private memory sessions
- * to untrusted clients, an API can instead wrap a new lifetime over an existing memory session, as follows:
+ * to untrusted clients, an API can instead return segments based on a non-closeable view of the session it created, as follows:
  *
  * {@snippet lang=java :
  * MemorySession session = MemorySession.openConfined();

--- a/src/java.base/share/classes/java/lang/foreign/MemorySession.java
+++ b/src/java.base/share/classes/java/lang/foreign/MemorySession.java
@@ -33,7 +33,6 @@ import java.util.Objects;
 
 import jdk.internal.foreign.MemorySessionImpl;
 import jdk.internal.javac.PreviewFeature;
-import jdk.internal.ref.CleanerFactory;
 
 /**
  * A memory session manages the lifecycle of one or more resources. Resources (e.g. {@link MemorySegment}) associated

--- a/src/java.base/share/classes/java/lang/foreign/SegmentAllocator.java
+++ b/src/java.base/share/classes/java/lang/foreign/SegmentAllocator.java
@@ -33,7 +33,6 @@ import java.util.Objects;
 import java.util.function.Function;
 import jdk.internal.foreign.AbstractMemorySegmentImpl;
 import jdk.internal.foreign.ArenaAllocator;
-import jdk.internal.foreign.Scoped;
 import jdk.internal.foreign.Utils;
 import jdk.internal.javac.PreviewFeature;
 
@@ -412,7 +411,7 @@ public interface SegmentAllocator {
         if (arenaSize <= 0 || arenaSize < blockSize) {
             throw new IllegalArgumentException("Invalid arena size: " + arenaSize);
         }
-        return new ArenaAllocator(blockSize, arenaSize, Scoped.toSessionImpl(session));
+        return new ArenaAllocator(blockSize, arenaSize, session);
     }
 
     /**

--- a/src/java.base/share/classes/java/lang/foreign/VaList.java
+++ b/src/java.base/share/classes/java/lang/foreign/VaList.java
@@ -28,7 +28,6 @@ package java.lang.foreign;
 import java.util.Objects;
 import java.util.function.Consumer;
 
-import jdk.internal.foreign.Scoped;
 import jdk.internal.foreign.abi.SharedUtils;
 import jdk.internal.foreign.abi.aarch64.linux.LinuxAArch64VaList;
 import jdk.internal.foreign.abi.aarch64.macos.MacOsAArch64VaList;
@@ -64,7 +63,7 @@ import jdk.internal.reflect.Reflection;
 sealed public interface VaList extends Addressable permits WinVaList, SysVVaList, LinuxAArch64VaList, MacOsAArch64VaList, SharedUtils.EmptyVaList {
 
     /**
-     * {@return a non-closeable view of the memory session associated with this variable argument list}
+     * {@return the memory session associated with this variable argument list}
      */
     MemorySession session();
 
@@ -187,7 +186,7 @@ sealed public interface VaList extends Addressable permits WinVaList, SysVVaList
         Reflection.ensureNativeAccess(Reflection.getCallerClass(), VaList.class, "ofAddress");
         Objects.requireNonNull(address);
         Objects.requireNonNull(session);
-        return SharedUtils.newVaListOfAddress(address, Scoped.toSessionImpl(session));
+        return SharedUtils.newVaListOfAddress(address, session);
     }
 
     /**
@@ -210,7 +209,7 @@ sealed public interface VaList extends Addressable permits WinVaList, SysVVaList
     static VaList make(Consumer<Builder> actions, MemorySession session) {
         Objects.requireNonNull(actions);
         Objects.requireNonNull(session);
-        return SharedUtils.newVaList(actions, Scoped.toSessionImpl(session));
+        return SharedUtils.newVaList(actions, session);
     }
 
     /**

--- a/src/java.base/share/classes/java/lang/invoke/X-VarHandleByteArrayView.java.template
+++ b/src/java.base/share/classes/java/lang/invoke/X-VarHandleByteArrayView.java.template
@@ -27,6 +27,7 @@ package java.lang.invoke;
 import jdk.internal.access.JavaNioAccess;
 import jdk.internal.access.SharedSecrets;
 import jdk.internal.foreign.AbstractMemorySegmentImpl;
+import jdk.internal.foreign.MemorySessionImpl;
 import jdk.internal.misc.ScopedMemoryAccess;
 import jdk.internal.misc.Unsafe;
 import jdk.internal.util.Preconditions;
@@ -613,7 +614,7 @@ final class VarHandleByteArrayAs$Type$s extends VarHandleByteArrayBase {
         }
 
         @ForceInline
-        static MemorySession session(ByteBuffer bb) {
+        static MemorySessionImpl session(ByteBuffer bb) {
             MemorySegment segment = NIO_ACCESS.bufferSegment(bb);
             return segment != null ?
                     ((AbstractMemorySegmentImpl)segment).sessionImpl() : null;

--- a/src/java.base/share/classes/java/nio/Buffer.java
+++ b/src/java.base/share/classes/java/nio/Buffer.java
@@ -758,7 +758,7 @@ public abstract class Buffer {
     }
 
     @ForceInline
-    final MemorySession session() {
+    final MemorySessionImpl session() {
         if (segment != null) {
             return ((AbstractMemorySegmentImpl)segment).sessionImpl();
         } else {
@@ -767,10 +767,10 @@ public abstract class Buffer {
     }
 
     final void checkSession() {
-        MemorySession session = session();
+        MemorySessionImpl session = session();
         if (session != null) {
             try {
-                ((MemorySessionImpl)session).checkValidState();
+                session.checkValidState();
             } catch (ScopedMemoryAccess.ScopedAccessError e) {
                 throw new IllegalStateException("This segment is already closed");
             }
@@ -834,8 +834,8 @@ public abstract class Buffer {
                     if (async && session.ownerThread() != null) {
                         throw new IllegalStateException("Confined session not supported");
                     }
-                    ((MemorySessionImpl)session).acquire0();
-                    return ((MemorySessionImpl) session)::release0;
+                    session.acquire0();
+                    return session::release0;
                 }
 
                 @Override

--- a/src/java.base/share/classes/java/nio/Direct-X-Buffer.java.template
+++ b/src/java.base/share/classes/java/nio/Direct-X-Buffer.java.template
@@ -303,7 +303,7 @@ class Direct$Type$Buffer$RW$$BO$
         MemorySessionImpl session = session();
         if (session != null) {
             if (session.ownerThread() == null && session.isCloseable()) {
-                throw new UnsupportedOperationException("ByteBuffer derived from closeable shared segments not supported");
+                throw new UnsupportedOperationException("ByteBuffer derived from closeable shared sessions not supported");
             }
             try {
                 session.checkValidState();

--- a/src/java.base/share/classes/java/nio/Direct-X-Buffer.java.template
+++ b/src/java.base/share/classes/java/nio/Direct-X-Buffer.java.template
@@ -300,13 +300,13 @@ class Direct$Type$Buffer$RW$$BO$
 #if[rw]
 
     public long address() {
-        MemorySession session = session();
+        MemorySessionImpl session = session();
         if (session != null) {
             if (session.ownerThread() == null && session.isCloseable()) {
                 throw new UnsupportedOperationException("ByteBuffer derived from closeable shared segments not supported");
             }
             try {
-                ((MemorySessionImpl)session).checkValidState();
+                session.checkValidState();
             } catch (ScopedAccessError e) {
                 throw new IllegalStateException("This segment is already closed");
             }

--- a/src/java.base/share/classes/jdk/internal/foreign/AbstractMemorySegmentImpl.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/AbstractMemorySegmentImpl.java
@@ -138,7 +138,7 @@ public abstract non-sealed class AbstractMemorySegmentImpl implements MemorySegm
     @Override
     public final MemorySegment fill(byte value){
         checkAccess(0, length, false);
-        SCOPED_MEMORY_ACCESS.setMemory(session, base(), min(), length, value);
+        SCOPED_MEMORY_ACCESS.setMemory(sessionImpl(), base(), min(), length, value);
         return this;
     }
 

--- a/src/java.base/share/classes/jdk/internal/foreign/AbstractMemorySegmentImpl.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/AbstractMemorySegmentImpl.java
@@ -45,7 +45,7 @@ import jdk.internal.access.foreign.UnmapperProxy;
 import jdk.internal.misc.ScopedMemoryAccess;
 import jdk.internal.util.ArraysSupport;
 import jdk.internal.vm.annotation.ForceInline;
-import sun.security.action.GetPropertyAction;
+
 import static java.lang.foreign.ValueLayout.JAVA_BYTE;
 
 /**
@@ -70,10 +70,10 @@ public abstract non-sealed class AbstractMemorySegmentImpl implements MemorySegm
 
     final long length;
     final int mask;
-    final MemorySessionImpl session;
+    final MemorySession session;
 
     @ForceInline
-    AbstractMemorySegmentImpl(long length, int mask, MemorySessionImpl session) {
+    AbstractMemorySegmentImpl(long length, int mask, MemorySession session) {
         this.length = length;
         this.mask = mask;
         this.session = session;
@@ -83,7 +83,7 @@ public abstract non-sealed class AbstractMemorySegmentImpl implements MemorySegm
 
     abstract Object base();
 
-    abstract AbstractMemorySegmentImpl dup(long offset, long size, int mask, MemorySessionImpl session);
+    abstract AbstractMemorySegmentImpl dup(long offset, long size, int mask, MemorySession session);
 
     abstract ByteBuffer makeByteBuffer();
 
@@ -169,7 +169,7 @@ public abstract non-sealed class AbstractMemorySegmentImpl implements MemorySegm
             if (get(JAVA_BYTE, 0) != that.get(JAVA_BYTE, 0)) {
                 return 0;
             }
-            i = vectorizedMismatchLargeForBytes(session, that.session,
+            i = vectorizedMismatchLargeForBytes(sessionImpl(), that.sessionImpl(),
                     this.base(), this.min(),
                     that.base(), that.min(),
                     length);
@@ -349,7 +349,7 @@ public abstract non-sealed class AbstractMemorySegmentImpl implements MemorySegm
     }
 
     public void checkValidState() {
-        session.checkValidStateSlow();
+        sessionImpl().checkValidStateSlow();
     }
 
     public long unsafeGetOffset() {
@@ -396,12 +396,12 @@ public abstract non-sealed class AbstractMemorySegmentImpl implements MemorySegm
 
     @Override
     public MemorySessionImpl sessionImpl() {
-        return session;
+        return MemorySessionImpl.toSessionImpl(session);
     }
 
     @Override
     public MemorySession session() {
-        return new MemorySessionImpl.NonCloseableView(sessionImpl());
+        return session;
     }
 
     private IndexOutOfBoundsException outOfBoundException(long offset, long length) {
@@ -509,7 +509,7 @@ public abstract non-sealed class AbstractMemorySegmentImpl implements MemorySegm
         final MemorySessionImpl bufferSession;
         int modes;
         if (bufferSegment != null) {
-            bufferSession = bufferSegment.session;
+            bufferSession = bufferSegment.sessionImpl();
             modes = bufferSegment.mask;
         } else {
             bufferSession = MemorySessionImpl.heapSession(bb);

--- a/src/java.base/share/classes/jdk/internal/foreign/HeapMemorySegmentImpl.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/HeapMemorySegmentImpl.java
@@ -27,6 +27,7 @@
 package jdk.internal.foreign;
 
 import java.lang.foreign.MemorySegment;
+import java.lang.foreign.MemorySession;
 import java.nio.ByteBuffer;
 import java.util.Objects;
 import jdk.internal.access.JavaNioAccess;
@@ -43,7 +44,7 @@ import jdk.internal.vm.annotation.ForceInline;
  * the field type storing the 'base' coordinate is just Object; similarly, all the constructor in the subclasses
  * accept an Object 'base' parameter instead of a sharper type (e.g. {@code byte[]}). This is deliberate, as
  * using sharper types would require use of type-conversions, which in turn would inhibit some C2 optimizations,
- * such as the elimination of store barriers in methods like {@link HeapMemorySegmentImpl#dup(long, long, int, MemorySessionImpl)}.
+ * such as the elimination of store barriers in methods like {@link HeapMemorySegmentImpl#dup(long, long, int, MemorySession)}.
  */
 public abstract class HeapMemorySegmentImpl extends AbstractMemorySegmentImpl {
 
@@ -74,7 +75,7 @@ public abstract class HeapMemorySegmentImpl extends AbstractMemorySegmentImpl {
     }
 
     @Override
-    abstract HeapMemorySegmentImpl dup(long offset, long size, int mask, MemorySessionImpl session);
+    abstract HeapMemorySegmentImpl dup(long offset, long size, int mask, MemorySession session);
 
     @Override
     ByteBuffer makeByteBuffer() {
@@ -94,7 +95,7 @@ public abstract class HeapMemorySegmentImpl extends AbstractMemorySegmentImpl {
         }
 
         @Override
-        OfByte dup(long offset, long size, int mask, MemorySessionImpl session) {
+        OfByte dup(long offset, long size, int mask, MemorySession session) {
             return new OfByte(this.offset + offset, base, size, mask);
         }
 
@@ -122,7 +123,7 @@ public abstract class HeapMemorySegmentImpl extends AbstractMemorySegmentImpl {
         }
 
         @Override
-        OfChar dup(long offset, long size, int mask, MemorySessionImpl session) {
+        OfChar dup(long offset, long size, int mask, MemorySession session) {
             return new OfChar(this.offset + offset, base, size, mask);
         }
 
@@ -150,7 +151,7 @@ public abstract class HeapMemorySegmentImpl extends AbstractMemorySegmentImpl {
         }
 
         @Override
-        OfShort dup(long offset, long size, int mask, MemorySessionImpl session) {
+        OfShort dup(long offset, long size, int mask, MemorySession session) {
             return new OfShort(this.offset + offset, base, size, mask);
         }
 
@@ -178,7 +179,7 @@ public abstract class HeapMemorySegmentImpl extends AbstractMemorySegmentImpl {
         }
 
         @Override
-        OfInt dup(long offset, long size, int mask, MemorySessionImpl session) {
+        OfInt dup(long offset, long size, int mask, MemorySession session) {
             return new OfInt(this.offset + offset, base, size, mask);
         }
 
@@ -206,7 +207,7 @@ public abstract class HeapMemorySegmentImpl extends AbstractMemorySegmentImpl {
         }
 
         @Override
-        OfLong dup(long offset, long size, int mask, MemorySessionImpl session) {
+        OfLong dup(long offset, long size, int mask, MemorySession session) {
             return new OfLong(this.offset + offset, base, size, mask);
         }
 
@@ -234,7 +235,7 @@ public abstract class HeapMemorySegmentImpl extends AbstractMemorySegmentImpl {
         }
 
         @Override
-        OfFloat dup(long offset, long size, int mask, MemorySessionImpl session) {
+        OfFloat dup(long offset, long size, int mask, MemorySession session) {
             return new OfFloat(this.offset + offset, base, size, mask);
         }
 
@@ -262,7 +263,7 @@ public abstract class HeapMemorySegmentImpl extends AbstractMemorySegmentImpl {
         }
 
         @Override
-        OfDouble dup(long offset, long size, int mask, MemorySessionImpl session) {
+        OfDouble dup(long offset, long size, int mask, MemorySession session) {
             return new OfDouble(this.offset + offset, base, size, mask);
         }
 

--- a/src/java.base/share/classes/jdk/internal/foreign/MappedMemorySegmentImpl.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/MappedMemorySegmentImpl.java
@@ -89,19 +89,19 @@ public class MappedMemorySegmentImpl extends NativeMemorySegmentImpl {
     }
 
     public void load() {
-        SCOPED_MEMORY_ACCESS.load(session, min, unmapper.isSync(), length);
+        SCOPED_MEMORY_ACCESS.load(sessionImpl(), min, unmapper.isSync(), length);
     }
 
     public void unload() {
-        SCOPED_MEMORY_ACCESS.unload(session, min, unmapper.isSync(), length);
+        SCOPED_MEMORY_ACCESS.unload(sessionImpl(), min, unmapper.isSync(), length);
     }
 
     public boolean isLoaded() {
-        return SCOPED_MEMORY_ACCESS.isLoaded(session, min, unmapper.isSync(), length);
+        return SCOPED_MEMORY_ACCESS.isLoaded(sessionImpl(), min, unmapper.isSync(), length);
     }
 
     public void force() {
-        SCOPED_MEMORY_ACCESS.force(session, unmapper.fileDescriptor(), min, unmapper.isSync(), 0, length);
+        SCOPED_MEMORY_ACCESS.force(sessionImpl(), unmapper.fileDescriptor(), min, unmapper.isSync(), 0, length);
     }
 
     // factories

--- a/src/java.base/share/classes/jdk/internal/foreign/MappedMemorySegmentImpl.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/MappedMemorySegmentImpl.java
@@ -27,6 +27,7 @@ package jdk.internal.foreign;
 
 import java.io.IOException;
 import java.lang.foreign.MemorySegment;
+import java.lang.foreign.MemorySession;
 import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
 import java.nio.file.FileSystem;
@@ -52,7 +53,7 @@ public class MappedMemorySegmentImpl extends NativeMemorySegmentImpl {
 
     static ScopedMemoryAccess SCOPED_MEMORY_ACCESS = ScopedMemoryAccess.getScopedMemoryAccess();
 
-    MappedMemorySegmentImpl(long min, UnmapperProxy unmapper, long length, int mask, MemorySessionImpl session) {
+    MappedMemorySegmentImpl(long min, UnmapperProxy unmapper, long length, int mask, MemorySession session) {
         super(min, length, mask, session);
         this.unmapper = unmapper;
     }
@@ -64,7 +65,7 @@ public class MappedMemorySegmentImpl extends NativeMemorySegmentImpl {
     }
 
     @Override
-    MappedMemorySegmentImpl dup(long offset, long size, int mask, MemorySessionImpl session) {
+    MappedMemorySegmentImpl dup(long offset, long size, int mask, MemorySession session) {
         return new MappedMemorySegmentImpl(min + offset, unmapper, size, mask, session);
     }
 
@@ -105,10 +106,11 @@ public class MappedMemorySegmentImpl extends NativeMemorySegmentImpl {
 
     // factories
 
-    public static MemorySegment makeMappedSegment(Path path, long bytesOffset, long bytesSize, FileChannel.MapMode mapMode, MemorySessionImpl session) throws IOException {
+    public static MemorySegment makeMappedSegment(Path path, long bytesOffset, long bytesSize, FileChannel.MapMode mapMode, MemorySession session) throws IOException {
         Objects.requireNonNull(path);
         Objects.requireNonNull(mapMode);
-        session.checkValidStateSlow();
+        MemorySessionImpl sessionImpl = MemorySessionImpl.toSessionImpl(session);
+        sessionImpl.checkValidStateSlow();
         if (bytesSize < 0) throw new IllegalArgumentException("Requested bytes size must be >= 0.");
         if (bytesOffset < 0) throw new IllegalArgumentException("Requested bytes offset must be >= 0.");
         FileSystem fs = path.getFileSystem();
@@ -125,7 +127,7 @@ public class MappedMemorySegmentImpl extends NativeMemorySegmentImpl {
             if (unmapperProxy != null) {
                 AbstractMemorySegmentImpl segment = new MappedMemorySegmentImpl(unmapperProxy.address(), unmapperProxy, bytesSize,
                         modes, session);
-                session.addOrCleanupIfFail(new MemorySessionImpl.ResourceList.ResourceCleanup() {
+                sessionImpl.addOrCleanupIfFail(new MemorySessionImpl.ResourceList.ResourceCleanup() {
                     @Override
                     public void cleanup() {
                         unmapperProxy.unmap();
@@ -153,7 +155,7 @@ public class MappedMemorySegmentImpl extends NativeMemorySegmentImpl {
 
     static class EmptyMappedMemorySegmentImpl extends MappedMemorySegmentImpl {
 
-        public EmptyMappedMemorySegmentImpl(int modes, MemorySessionImpl session) {
+        public EmptyMappedMemorySegmentImpl(int modes, MemorySession session) {
             super(0, null, 0, modes, session);
         }
 

--- a/src/java.base/share/classes/jdk/internal/foreign/MemoryAddressImpl.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/MemoryAddressImpl.java
@@ -28,6 +28,7 @@ package jdk.internal.foreign;
 import java.lang.foreign.Addressable;
 import java.lang.foreign.MemoryAddress;
 import java.lang.foreign.MemorySegment;
+import java.lang.foreign.MemorySession;
 import java.lang.foreign.ValueLayout;
 import jdk.internal.foreign.abi.SharedUtils;
 import jdk.internal.reflect.CallerSensitive;
@@ -85,7 +86,7 @@ public final class MemoryAddressImpl implements MemoryAddress, Scoped {
         return ofLongUnchecked(value, Long.MAX_VALUE);
     }
 
-    public static MemorySegment ofLongUnchecked(long value, long byteSize, MemorySessionImpl session) {
+    public static MemorySegment ofLongUnchecked(long value, long byteSize, MemorySession session) {
         return NativeMemorySegmentImpl.makeNativeSegmentUnchecked(MemoryAddress.ofLong(value), byteSize, session);
     }
 

--- a/src/java.base/share/classes/jdk/internal/foreign/MemorySessionImpl.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/MemorySessionImpl.java
@@ -137,7 +137,8 @@ public abstract non-sealed class MemorySessionImpl implements Scoped, MemorySess
 
     @Override
     public boolean equals(Object o) {
-        return o == this;
+        return (o instanceof MemorySession other) &&
+            toSessionImpl(other) == this;
     }
 
     @Override
@@ -361,6 +362,16 @@ public abstract non-sealed class MemorySessionImpl implements Scoped, MemorySess
         @Override
         public Thread ownerThread() {
             return session.ownerThread();
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            return session.equals(o);
+        }
+
+        @Override
+        public int hashCode() {
+            return session.hashCode();
         }
 
         @Override

--- a/src/java.base/share/classes/jdk/internal/foreign/MemorySessionImpl.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/MemorySessionImpl.java
@@ -128,7 +128,7 @@ public abstract non-sealed class MemorySessionImpl implements Scoped, MemorySess
 
     @Override
     public MemorySegment allocate(long bytesSize, long bytesAlignment) {
-        return NativeMemorySegmentImpl.makeNativeSegment(bytesSize, bytesAlignment, this);
+        return MemorySegment.allocateNative(bytesSize, bytesAlignment, this);
     }
 
     public abstract void release0();

--- a/src/java.base/share/classes/jdk/internal/foreign/Scoped.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/Scoped.java
@@ -25,12 +25,6 @@
 
 package jdk.internal.foreign;
 
-import java.lang.foreign.MemorySession;
-
 public interface Scoped {
     MemorySessionImpl sessionImpl();
-
-    static MemorySessionImpl toSessionImpl(MemorySession session) {
-        return ((Scoped)session).sessionImpl();
-    }
 }

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/AbstractLinker.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/AbstractLinker.java
@@ -24,7 +24,6 @@
  */
 package jdk.internal.foreign.abi;
 
-import jdk.internal.foreign.Scoped;
 import jdk.internal.foreign.abi.aarch64.linux.LinuxAArch64Linker;
 import jdk.internal.foreign.abi.aarch64.macos.MacOsAArch64Linker;
 import jdk.internal.foreign.abi.x64.sysv.SysVx64Linker;
@@ -67,7 +66,7 @@ public abstract sealed class AbstractLinker implements CLinker permits LinuxAArc
         if (!type.equals(target.type())) {
             throw new IllegalArgumentException("Wrong method handle type: " + target.type());
         }
-        MemorySegment symb =  arrangeUpcall(target, target.type(), function, Scoped.toSessionImpl(session));
+        MemorySegment symb =  arrangeUpcall(target, target.type(), function, session);
         return symb;
     }
 

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/Binding.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/Binding.java
@@ -898,7 +898,7 @@ public abstract class Binding {
         }
 
         private static MemorySegment toSegment(MemoryAddress operand, long size, Context context) {
-            return MemoryAddressImpl.ofLongUnchecked(operand.toRawLongValue(), size, (MemorySessionImpl) context.session);
+            return MemoryAddressImpl.ofLongUnchecked(operand.toRawLongValue(), size, context.session);
         }
 
         @Override

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/BindingSpecializer.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/BindingSpecializer.java
@@ -96,7 +96,7 @@ public class BindingSpecializer {
     private static final String COPY_DESC = methodType(void.class, MemorySegment.class, long.class, MemorySegment.class, long.class, long.class).descriptorString();
     private static final String TO_RAW_LONG_VALUE_DESC = methodType(long.class).descriptorString();
     private static final String OF_LONG_DESC = methodType(MemoryAddress.class, long.class).descriptorString();
-    private static final String OF_LONG_UNCHECKED_DESC = methodType(MemorySegment.class, long.class, long.class, MemorySessionImpl.class).descriptorString();
+    private static final String OF_LONG_UNCHECKED_DESC = methodType(MemorySegment.class, long.class, long.class, MemorySession.class).descriptorString();
     private static final String ALLOCATE_DESC = methodType(MemorySegment.class, long.class, long.class).descriptorString();
     private static final String HANDLE_UNCAUGHT_EXCEPTION_DESC = methodType(void.class, Throwable.class).descriptorString();
     private static final String METHOD_HANDLES_INTRN = Type.getInternalName(MethodHandles.class);
@@ -550,7 +550,6 @@ public class BindingSpecializer {
         emitToRawLongValue();
         emitConst(size);
         emitLoadInternalSession();
-        emitCheckCast(MemorySessionImpl.class);
         emitInvokeStatic(MemoryAddressImpl.class, "ofLongUnchecked", OF_LONG_UNCHECKED_DESC);
 
         pushType(MemorySegment.class);

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/SharedUtils.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/SharedUtils.java
@@ -477,7 +477,7 @@ public class SharedUtils {
 
         @Override
         public MemorySessionImpl sessionImpl() {
-            return (MemorySessionImpl)MemorySession.global();
+            return MemorySessionImpl.GLOBAL;
         }
 
         @Override

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/UpcallStubs.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/UpcallStubs.java
@@ -49,8 +49,8 @@ public class UpcallStubs {
     }
 
     static MemorySegment makeUpcall(long entry, MemorySession session) {
-        // The cast below should always pass, as we should have a real session by now (see AbstractLinker::upcallStub)
-        ((MemorySessionImpl)session).addOrCleanupIfFail(new MemorySessionImpl.ResourceList.ResourceCleanup() {
+        MemorySessionImpl sessionImpl = MemorySessionImpl.toSessionImpl(session);
+        sessionImpl.addOrCleanupIfFail(new MemorySessionImpl.ResourceList.ResourceCleanup() {
             @Override
             public void cleanup() {
                 freeUpcallStub(entry);

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/aarch64/linux/LinuxAArch64VaList.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/aarch64/linux/LinuxAArch64VaList.java
@@ -355,12 +355,12 @@ public non-sealed class LinuxAArch64VaList implements VaList, Scoped {
 
     @Override
     public MemorySessionImpl sessionImpl() {
-        return Scoped.toSessionImpl(segment.session());
+        return ((AbstractMemorySegmentImpl)segment).sessionImpl();
     }
 
     @Override
     public MemorySession session() {
-        return new MemorySessionImpl.NonCloseableView(sessionImpl());
+        return segment.session();
     }
 
     @Override

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/aarch64/macos/MacOsAArch64VaList.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/aarch64/macos/MacOsAArch64VaList.java
@@ -181,7 +181,7 @@ public non-sealed class MacOsAArch64VaList implements VaList, Scoped {
         private final List<SimpleVaArg> args = new ArrayList<>();
 
         public Builder(MemorySession session) {
-            ((MemorySessionImpl)session).checkValidStateSlow();
+            MemorySessionImpl.toSessionImpl(session).checkValidStateSlow();
             this.session = session;
         }
 

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/aarch64/macos/MacOsAArch64VaList.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/aarch64/macos/MacOsAArch64VaList.java
@@ -156,12 +156,12 @@ public non-sealed class MacOsAArch64VaList implements VaList, Scoped {
 
     @Override
     public MemorySessionImpl sessionImpl() {
-        return Scoped.toSessionImpl(segment.session());
+        return ((AbstractMemorySegmentImpl)segment).sessionImpl();
     }
 
     @Override
     public MemorySession session() {
-        return new MemorySessionImpl.NonCloseableView(sessionImpl());
+        return segment.session();
     }
 
     @Override

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/x64/sysv/SysVVaList.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/x64/sysv/SysVVaList.java
@@ -307,12 +307,12 @@ public non-sealed class SysVVaList implements VaList, Scoped {
 
     @Override
     public MemorySessionImpl sessionImpl() {
-        return Scoped.toSessionImpl(segment.session());
+        return ((AbstractMemorySegmentImpl)segment).sessionImpl();
     }
 
     @Override
     public MemorySession session() {
-        return new MemorySessionImpl.NonCloseableView(sessionImpl());
+        return segment.session();
     }
 
     @Override

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/x64/windows/WinVaList.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/x64/windows/WinVaList.java
@@ -154,12 +154,12 @@ public non-sealed class WinVaList implements VaList, Scoped {
 
     @Override
     public MemorySessionImpl sessionImpl() {
-        return Scoped.toSessionImpl(segment.session());
+        return ((AbstractMemorySegmentImpl)segment).sessionImpl();
     }
 
     @Override
     public MemorySession session() {
-        return new MemorySessionImpl.NonCloseableView(sessionImpl());
+        return segment.session();
     }
 
     @Override

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/x64/windows/WinVaList.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/x64/windows/WinVaList.java
@@ -179,7 +179,7 @@ public non-sealed class WinVaList implements VaList, Scoped {
         private final List<SimpleVaArg> args = new ArrayList<>();
 
         public Builder(MemorySession session) {
-            ((MemorySessionImpl)session).checkValidStateSlow();
+            MemorySessionImpl.toSessionImpl(session).checkValidStateSlow();
             this.session = session;
         }
 

--- a/src/java.base/share/classes/jdk/internal/misc/X-ScopedMemoryAccess-bin.java.template
+++ b/src/java.base/share/classes/jdk/internal/misc/X-ScopedMemoryAccess-bin.java.template
@@ -1,5 +1,5 @@
     @ForceInline
-    public $type$ get$Type$(MemorySession session, Object base, long offset) {
+    public $type$ get$Type$(MemorySessionImpl session, Object base, long offset) {
         try {
             return get$Type$Internal(session, base, offset);
         } catch (ScopedAccessError ex) {
@@ -8,10 +8,10 @@
     }
 
     @ForceInline @Scoped
-    private $type$ get$Type$Internal(MemorySession session, Object base, long offset) {
+    private $type$ get$Type$Internal(MemorySessionImpl session, Object base, long offset) {
         try {
             if (session != null) {
-                ((MemorySessionImpl)session).checkValidState();
+                session.checkValidState();
             }
             return UNSAFE.get$Type$(base, offset);
         } finally {
@@ -20,7 +20,7 @@
     }
 
     @ForceInline
-    public void put$Type$(MemorySession session, Object base, long offset, $type$ value) {
+    public void put$Type$(MemorySessionImpl session, Object base, long offset, $type$ value) {
         try {
             put$Type$Internal(session, base, offset, value);
         } catch (ScopedAccessError ex) {
@@ -29,10 +29,10 @@
     }
 
     @ForceInline @Scoped
-    private void put$Type$Internal(MemorySession session, Object base, long offset, $type$ value) {
+    private void put$Type$Internal(MemorySessionImpl session, Object base, long offset, $type$ value) {
         try {
             if (session != null) {
-                ((MemorySessionImpl)session).checkValidState();
+                session.checkValidState();
             }
             UNSAFE.put$Type$(base, offset, value);
         } finally {
@@ -42,7 +42,7 @@
 
 #if[Unaligned]
     @ForceInline
-    public $type$ get$Type$Unaligned(MemorySession session, Object base, long offset, boolean be) {
+    public $type$ get$Type$Unaligned(MemorySessionImpl session, Object base, long offset, boolean be) {
         try {
             return get$Type$UnalignedInternal(session, base, offset, be);
         } catch (ScopedAccessError ex) {
@@ -51,10 +51,10 @@
     }
 
     @ForceInline @Scoped
-    private $type$ get$Type$UnalignedInternal(MemorySession session, Object base, long offset, boolean be) {
+    private $type$ get$Type$UnalignedInternal(MemorySessionImpl session, Object base, long offset, boolean be) {
         try {
             if (session != null) {
-                ((MemorySessionImpl)session).checkValidState();
+                session.checkValidState();
             }
             return UNSAFE.get$Type$Unaligned(base, offset, be);
         } finally {
@@ -63,7 +63,7 @@
     }
 
     @ForceInline
-    public void put$Type$Unaligned(MemorySession session, Object base, long offset, $type$ value, boolean be) {
+    public void put$Type$Unaligned(MemorySessionImpl session, Object base, long offset, $type$ value, boolean be) {
         try {
             put$Type$UnalignedInternal(session, base, offset, value, be);
         } catch (ScopedAccessError ex) {
@@ -72,10 +72,10 @@
     }
 
     @ForceInline @Scoped
-    private void put$Type$UnalignedInternal(MemorySession session, Object base, long offset, $type$ value, boolean be) {
+    private void put$Type$UnalignedInternal(MemorySessionImpl session, Object base, long offset, $type$ value, boolean be) {
         try {
             if (session != null) {
-                ((MemorySessionImpl)session).checkValidState();
+                session.checkValidState();
             }
             UNSAFE.put$Type$Unaligned(base, offset, value, be);
         } finally {
@@ -85,7 +85,7 @@
 #end[Unaligned]
 
     @ForceInline
-    public $type$ get$Type$Volatile(MemorySession session, Object base, long offset) {
+    public $type$ get$Type$Volatile(MemorySessionImpl session, Object base, long offset) {
         try {
             return get$Type$VolatileInternal(session, base, offset);
         } catch (ScopedAccessError ex) {
@@ -94,10 +94,10 @@
     }
 
     @ForceInline @Scoped
-    private $type$ get$Type$VolatileInternal(MemorySession session, Object base, long offset) {
+    private $type$ get$Type$VolatileInternal(MemorySessionImpl session, Object base, long offset) {
         try {
             if (session != null) {
-                ((MemorySessionImpl)session).checkValidState();
+                session.checkValidState();
             }
             return UNSAFE.get$Type$Volatile(base, offset);
         } finally {
@@ -106,7 +106,7 @@
     }
 
     @ForceInline
-    public void put$Type$Volatile(MemorySession session, Object base, long offset, $type$ value) {
+    public void put$Type$Volatile(MemorySessionImpl session, Object base, long offset, $type$ value) {
         try {
             put$Type$VolatileInternal(session, base, offset, value);
         } catch (ScopedAccessError ex) {
@@ -115,10 +115,10 @@
     }
 
     @ForceInline @Scoped
-    private void put$Type$VolatileInternal(MemorySession session, Object base, long offset, $type$ value) {
+    private void put$Type$VolatileInternal(MemorySessionImpl session, Object base, long offset, $type$ value) {
         try {
             if (session != null) {
-                ((MemorySessionImpl)session).checkValidState();
+                session.checkValidState();
             }
             UNSAFE.put$Type$Volatile(base, offset, value);
         } finally {
@@ -127,7 +127,7 @@
     }
 
     @ForceInline
-    public $type$ get$Type$Acquire(MemorySession session, Object base, long offset) {
+    public $type$ get$Type$Acquire(MemorySessionImpl session, Object base, long offset) {
         try {
             return get$Type$AcquireInternal(session, base, offset);
         } catch (ScopedAccessError ex) {
@@ -136,10 +136,10 @@
     }
 
     @ForceInline @Scoped
-    private $type$ get$Type$AcquireInternal(MemorySession session, Object base, long offset) {
+    private $type$ get$Type$AcquireInternal(MemorySessionImpl session, Object base, long offset) {
         try {
             if (session != null) {
-                ((MemorySessionImpl)session).checkValidState();
+                session.checkValidState();
             }
             return UNSAFE.get$Type$Acquire(base, offset);
         } finally {
@@ -148,7 +148,7 @@
     }
 
     @ForceInline
-    public void put$Type$Release(MemorySession session, Object base, long offset, $type$ value) {
+    public void put$Type$Release(MemorySessionImpl session, Object base, long offset, $type$ value) {
         try {
             put$Type$ReleaseInternal(session, base, offset, value);
         } catch (ScopedAccessError ex) {
@@ -157,10 +157,10 @@
     }
 
     @ForceInline @Scoped
-    private void put$Type$ReleaseInternal(MemorySession session, Object base, long offset, $type$ value) {
+    private void put$Type$ReleaseInternal(MemorySessionImpl session, Object base, long offset, $type$ value) {
         try {
             if (session != null) {
-                ((MemorySessionImpl)session).checkValidState();
+                session.checkValidState();
             }
             UNSAFE.put$Type$Release(base, offset, value);
         } finally {
@@ -169,7 +169,7 @@
     }
 
     @ForceInline
-    public $type$ get$Type$Opaque(MemorySession session, Object base, long offset) {
+    public $type$ get$Type$Opaque(MemorySessionImpl session, Object base, long offset) {
         try {
             return get$Type$OpaqueInternal(session, base, offset);
         } catch (ScopedAccessError ex) {
@@ -178,10 +178,10 @@
     }
 
     @ForceInline @Scoped
-    private $type$ get$Type$OpaqueInternal(MemorySession session, Object base, long offset) {
+    private $type$ get$Type$OpaqueInternal(MemorySessionImpl session, Object base, long offset) {
         try {
             if (session != null) {
-                ((MemorySessionImpl)session).checkValidState();
+                session.checkValidState();
             }
             return UNSAFE.get$Type$Opaque(base, offset);
         } finally {
@@ -189,7 +189,7 @@
         }
     }
     @ForceInline
-    public void put$Type$Opaque(MemorySession session, Object base, long offset, $type$ value) {
+    public void put$Type$Opaque(MemorySessionImpl session, Object base, long offset, $type$ value) {
         try {
             put$Type$OpaqueInternal(session, base, offset, value);
         } catch (ScopedAccessError ex) {
@@ -198,10 +198,10 @@
     }
 
     @ForceInline @Scoped
-    private void put$Type$OpaqueInternal(MemorySession session, Object base, long offset, $type$ value) {
+    private void put$Type$OpaqueInternal(MemorySessionImpl session, Object base, long offset, $type$ value) {
         try {
             if (session != null) {
-                ((MemorySessionImpl)session).checkValidState();
+                session.checkValidState();
             }
             UNSAFE.put$Type$Opaque(base, offset, value);
         } finally {
@@ -210,7 +210,7 @@
     }
 #if[CAS]
     @ForceInline
-    public boolean compareAndSet$Type$(MemorySession session, Object base, long offset, $type$ expected, $type$ value) {
+    public boolean compareAndSet$Type$(MemorySessionImpl session, Object base, long offset, $type$ expected, $type$ value) {
         try {
             return compareAndSet$Type$Internal(session, base, offset, expected, value);
         } catch (ScopedAccessError ex) {
@@ -219,10 +219,10 @@
     }
 
     @ForceInline @Scoped
-    private boolean compareAndSet$Type$Internal(MemorySession session, Object base, long offset, $type$ expected, $type$ value) {
+    private boolean compareAndSet$Type$Internal(MemorySessionImpl session, Object base, long offset, $type$ expected, $type$ value) {
         try {
             if (session != null) {
-                ((MemorySessionImpl)session).checkValidState();
+                session.checkValidState();
             }
             return UNSAFE.compareAndSet$Type$(base, offset, expected, value);
         } finally {
@@ -231,7 +231,7 @@
     }
 
     @ForceInline
-    public $type$ compareAndExchange$Type$(MemorySession session, Object base, long offset, $type$ expected, $type$ value) {
+    public $type$ compareAndExchange$Type$(MemorySessionImpl session, Object base, long offset, $type$ expected, $type$ value) {
         try {
             return compareAndExchange$Type$Internal(session, base, offset, expected, value);
         } catch (ScopedAccessError ex) {
@@ -240,10 +240,10 @@
     }
 
     @ForceInline @Scoped
-    private $type$ compareAndExchange$Type$Internal(MemorySession session, Object base, long offset, $type$ expected, $type$ value) {
+    private $type$ compareAndExchange$Type$Internal(MemorySessionImpl session, Object base, long offset, $type$ expected, $type$ value) {
         try {
             if (session != null) {
-                ((MemorySessionImpl)session).checkValidState();
+                session.checkValidState();
             }
             return UNSAFE.compareAndExchange$Type$(base, offset, expected, value);
         } finally {
@@ -252,7 +252,7 @@
     }
 
     @ForceInline
-    public $type$ compareAndExchange$Type$Acquire(MemorySession session, Object base, long offset, $type$ expected, $type$ value) {
+    public $type$ compareAndExchange$Type$Acquire(MemorySessionImpl session, Object base, long offset, $type$ expected, $type$ value) {
         try {
             return compareAndExchange$Type$AcquireInternal(session, base, offset, expected, value);
         } catch (ScopedAccessError ex) {
@@ -261,10 +261,10 @@
     }
 
     @ForceInline @Scoped
-    private $type$ compareAndExchange$Type$AcquireInternal(MemorySession session, Object base, long offset, $type$ expected, $type$ value) {
+    private $type$ compareAndExchange$Type$AcquireInternal(MemorySessionImpl session, Object base, long offset, $type$ expected, $type$ value) {
         try {
             if (session != null) {
-                ((MemorySessionImpl)session).checkValidState();
+                session.checkValidState();
             }
             return UNSAFE.compareAndExchange$Type$Acquire(base, offset, expected, value);
         } finally {
@@ -273,7 +273,7 @@
     }
 
     @ForceInline
-    public $type$ compareAndExchange$Type$Release(MemorySession session, Object base, long offset, $type$ expected, $type$ value) {
+    public $type$ compareAndExchange$Type$Release(MemorySessionImpl session, Object base, long offset, $type$ expected, $type$ value) {
         try {
             return compareAndExchange$Type$ReleaseInternal(session, base, offset, expected, value);
         } catch (ScopedAccessError ex) {
@@ -282,10 +282,10 @@
     }
 
     @ForceInline @Scoped
-    private $type$ compareAndExchange$Type$ReleaseInternal(MemorySession session, Object base, long offset, $type$ expected, $type$ value) {
+    private $type$ compareAndExchange$Type$ReleaseInternal(MemorySessionImpl session, Object base, long offset, $type$ expected, $type$ value) {
         try {
             if (session != null) {
-                ((MemorySessionImpl)session).checkValidState();
+                session.checkValidState();
             }
             return UNSAFE.compareAndExchange$Type$Release(base, offset, expected, value);
         } finally {
@@ -294,7 +294,7 @@
     }
 
     @ForceInline
-    public boolean weakCompareAndSet$Type$Plain(MemorySession session, Object base, long offset, $type$ expected, $type$ value) {
+    public boolean weakCompareAndSet$Type$Plain(MemorySessionImpl session, Object base, long offset, $type$ expected, $type$ value) {
         try {
             return weakCompareAndSet$Type$PlainInternal(session, base, offset, expected, value);
         } catch (ScopedAccessError ex) {
@@ -303,10 +303,10 @@
     }
 
     @ForceInline @Scoped
-    private boolean weakCompareAndSet$Type$PlainInternal(MemorySession session, Object base, long offset, $type$ expected, $type$ value) {
+    private boolean weakCompareAndSet$Type$PlainInternal(MemorySessionImpl session, Object base, long offset, $type$ expected, $type$ value) {
         try {
             if (session != null) {
-                ((MemorySessionImpl)session).checkValidState();
+                session.checkValidState();
             }
             return UNSAFE.weakCompareAndSet$Type$Plain(base, offset, expected, value);
         } finally {
@@ -315,7 +315,7 @@
     }
 
     @ForceInline
-    public boolean weakCompareAndSet$Type$(MemorySession session, Object base, long offset, $type$ expected, $type$ value) {
+    public boolean weakCompareAndSet$Type$(MemorySessionImpl session, Object base, long offset, $type$ expected, $type$ value) {
         try {
             return weakCompareAndSet$Type$Internal(session, base, offset, expected, value);
         } catch (ScopedAccessError ex) {
@@ -324,10 +324,10 @@
     }
 
     @ForceInline @Scoped
-    private boolean weakCompareAndSet$Type$Internal(MemorySession session, Object base, long offset, $type$ expected, $type$ value) {
+    private boolean weakCompareAndSet$Type$Internal(MemorySessionImpl session, Object base, long offset, $type$ expected, $type$ value) {
         try {
             if (session != null) {
-                ((MemorySessionImpl)session).checkValidState();
+                session.checkValidState();
             }
             return UNSAFE.weakCompareAndSet$Type$(base, offset, expected, value);
         } finally {
@@ -336,7 +336,7 @@
     }
 
     @ForceInline
-    public boolean weakCompareAndSet$Type$Acquire(MemorySession session, Object base, long offset, $type$ expected, $type$ value) {
+    public boolean weakCompareAndSet$Type$Acquire(MemorySessionImpl session, Object base, long offset, $type$ expected, $type$ value) {
         try {
             return weakCompareAndSet$Type$AcquireInternal(session, base, offset, expected, value);
         } catch (ScopedAccessError ex) {
@@ -345,10 +345,10 @@
     }
 
     @ForceInline @Scoped
-    private boolean weakCompareAndSet$Type$AcquireInternal(MemorySession session, Object base, long offset, $type$ expected, $type$ value) {
+    private boolean weakCompareAndSet$Type$AcquireInternal(MemorySessionImpl session, Object base, long offset, $type$ expected, $type$ value) {
         try {
             if (session != null) {
-                ((MemorySessionImpl)session).checkValidState();
+                session.checkValidState();
             }
             return UNSAFE.weakCompareAndSet$Type$Acquire(base, offset, expected, value);
         } finally {
@@ -357,7 +357,7 @@
     }
 
     @ForceInline
-    public boolean weakCompareAndSet$Type$Release(MemorySession session, Object base, long offset, $type$ expected, $type$ value) {
+    public boolean weakCompareAndSet$Type$Release(MemorySessionImpl session, Object base, long offset, $type$ expected, $type$ value) {
         try {
             return weakCompareAndSet$Type$ReleaseInternal(session, base, offset, expected, value);
         } catch (ScopedAccessError ex) {
@@ -366,10 +366,10 @@
     }
 
     @ForceInline @Scoped
-    private boolean weakCompareAndSet$Type$ReleaseInternal(MemorySession session, Object base, long offset, $type$ expected, $type$ value) {
+    private boolean weakCompareAndSet$Type$ReleaseInternal(MemorySessionImpl session, Object base, long offset, $type$ expected, $type$ value) {
         try {
             if (session != null) {
-                ((MemorySessionImpl)session).checkValidState();
+                session.checkValidState();
             }
             return UNSAFE.weakCompareAndSet$Type$Release(base, offset, expected, value);
         } finally {
@@ -378,7 +378,7 @@
     }
 
     @ForceInline
-    public $type$ getAndSet$Type$(MemorySession session, Object base, long offset, $type$ value) {
+    public $type$ getAndSet$Type$(MemorySessionImpl session, Object base, long offset, $type$ value) {
         try {
             return getAndSet$Type$Internal(session, base, offset, value);
         } catch (ScopedAccessError ex) {
@@ -387,10 +387,10 @@
     }
 
     @ForceInline @Scoped
-    private $type$ getAndSet$Type$Internal(MemorySession session, Object base, long offset, $type$ value) {
+    private $type$ getAndSet$Type$Internal(MemorySessionImpl session, Object base, long offset, $type$ value) {
         try {
             if (session != null) {
-                ((MemorySessionImpl)session).checkValidState();
+                session.checkValidState();
             }
             return UNSAFE.getAndSet$Type$(base, offset, value);
         } finally {
@@ -399,7 +399,7 @@
     }
 
     @ForceInline
-    public $type$ getAndSet$Type$Acquire(MemorySession session, Object base, long offset, $type$ value) {
+    public $type$ getAndSet$Type$Acquire(MemorySessionImpl session, Object base, long offset, $type$ value) {
         try {
             return getAndSet$Type$AcquireInternal(session, base, offset, value);
         } catch (ScopedAccessError ex) {
@@ -408,10 +408,10 @@
     }
 
     @ForceInline @Scoped
-    private $type$ getAndSet$Type$AcquireInternal(MemorySession session, Object base, long offset, $type$ value) {
+    private $type$ getAndSet$Type$AcquireInternal(MemorySessionImpl session, Object base, long offset, $type$ value) {
         try {
             if (session != null) {
-                ((MemorySessionImpl)session).checkValidState();
+                session.checkValidState();
             }
             return UNSAFE.getAndSet$Type$Acquire(base, offset, value);
         } finally {
@@ -420,7 +420,7 @@
     }
 
     @ForceInline
-    public $type$ getAndSet$Type$Release(MemorySession session, Object base, long offset, $type$ value) {
+    public $type$ getAndSet$Type$Release(MemorySessionImpl session, Object base, long offset, $type$ value) {
         try {
             return getAndSet$Type$ReleaseInternal(session, base, offset, value);
         } catch (ScopedAccessError ex) {
@@ -429,10 +429,10 @@
     }
 
     @ForceInline @Scoped
-    private $type$ getAndSet$Type$ReleaseInternal(MemorySession session, Object base, long offset, $type$ value) {
+    private $type$ getAndSet$Type$ReleaseInternal(MemorySessionImpl session, Object base, long offset, $type$ value) {
         try {
             if (session != null) {
-                ((MemorySessionImpl)session).checkValidState();
+                session.checkValidState();
             }
             return UNSAFE.getAndSet$Type$Release(base, offset, value);
         } finally {
@@ -443,7 +443,7 @@
 
 #if[AtomicAdd]
     @ForceInline
-    public $type$ getAndAdd$Type$(MemorySession session, Object base, long offset, $type$ delta) {
+    public $type$ getAndAdd$Type$(MemorySessionImpl session, Object base, long offset, $type$ delta) {
         try {
             return getAndAdd$Type$Internal(session, base, offset, delta);
         } catch (ScopedAccessError ex) {
@@ -452,10 +452,10 @@
     }
 
     @ForceInline @Scoped
-    private $type$ getAndAdd$Type$Internal(MemorySession session, Object base, long offset, $type$ delta) {
+    private $type$ getAndAdd$Type$Internal(MemorySessionImpl session, Object base, long offset, $type$ delta) {
         try {
             if (session != null) {
-                ((MemorySessionImpl)session).checkValidState();
+                session.checkValidState();
             }
             return UNSAFE.getAndAdd$Type$(base, offset, delta);
         } finally {
@@ -464,7 +464,7 @@
     }
 
     @ForceInline
-    public $type$ getAndAdd$Type$Acquire(MemorySession session, Object base, long offset, $type$ delta) {
+    public $type$ getAndAdd$Type$Acquire(MemorySessionImpl session, Object base, long offset, $type$ delta) {
         try {
             return getAndAdd$Type$AcquireInternal(session, base, offset, delta);
         } catch (ScopedAccessError ex) {
@@ -473,10 +473,10 @@
     }
 
     @ForceInline @Scoped
-    private $type$ getAndAdd$Type$AcquireInternal(MemorySession session, Object base, long offset, $type$ delta) {
+    private $type$ getAndAdd$Type$AcquireInternal(MemorySessionImpl session, Object base, long offset, $type$ delta) {
         try {
             if (session != null) {
-                ((MemorySessionImpl)session).checkValidState();
+                session.checkValidState();
             }
             return UNSAFE.getAndAdd$Type$Acquire(base, offset, delta);
         } finally {
@@ -485,7 +485,7 @@
     }
 
     @ForceInline
-    public $type$ getAndAdd$Type$Release(MemorySession session, Object base, long offset, $type$ delta) {
+    public $type$ getAndAdd$Type$Release(MemorySessionImpl session, Object base, long offset, $type$ delta) {
         try {
             return getAndAdd$Type$ReleaseInternal(session, base, offset, delta);
         } catch (ScopedAccessError ex) {
@@ -494,10 +494,10 @@
     }
 
     @ForceInline @Scoped
-    private $type$ getAndAdd$Type$ReleaseInternal(MemorySession session, Object base, long offset, $type$ delta) {
+    private $type$ getAndAdd$Type$ReleaseInternal(MemorySessionImpl session, Object base, long offset, $type$ delta) {
         try {
             if (session != null) {
-                ((MemorySessionImpl)session).checkValidState();
+                session.checkValidState();
             }
             return UNSAFE.getAndAdd$Type$Release(base, offset, delta);
         } finally {
@@ -508,7 +508,7 @@
 
 #if[Bitwise]
     @ForceInline
-    public $type$ getAndBitwiseOr$Type$(MemorySession session, Object base, long offset, $type$ value) {
+    public $type$ getAndBitwiseOr$Type$(MemorySessionImpl session, Object base, long offset, $type$ value) {
         try {
             return getAndBitwiseOr$Type$Internal(session, base, offset, value);
         } catch (ScopedAccessError ex) {
@@ -517,10 +517,10 @@
     }
 
     @ForceInline @Scoped
-    private $type$ getAndBitwiseOr$Type$Internal(MemorySession session, Object base, long offset, $type$ value) {
+    private $type$ getAndBitwiseOr$Type$Internal(MemorySessionImpl session, Object base, long offset, $type$ value) {
         try {
             if (session != null) {
-                ((MemorySessionImpl)session).checkValidState();
+                session.checkValidState();
             }
             return UNSAFE.getAndBitwiseOr$Type$(base, offset, value);
         } finally {
@@ -529,7 +529,7 @@
     }
 
     @ForceInline
-    public $type$ getAndBitwiseOr$Type$Acquire(MemorySession session, Object base, long offset, $type$ value) {
+    public $type$ getAndBitwiseOr$Type$Acquire(MemorySessionImpl session, Object base, long offset, $type$ value) {
         try {
             return getAndBitwiseOr$Type$AcquireInternal(session, base, offset, value);
         } catch (ScopedAccessError ex) {
@@ -538,10 +538,10 @@
     }
 
     @ForceInline @Scoped
-    private $type$ getAndBitwiseOr$Type$AcquireInternal(MemorySession session, Object base, long offset, $type$ value) {
+    private $type$ getAndBitwiseOr$Type$AcquireInternal(MemorySessionImpl session, Object base, long offset, $type$ value) {
         try {
             if (session != null) {
-                ((MemorySessionImpl)session).checkValidState();
+                session.checkValidState();
             }
             return UNSAFE.getAndBitwiseOr$Type$Acquire(base, offset, value);
         } finally {
@@ -550,7 +550,7 @@
     }
 
     @ForceInline
-    public $type$ getAndBitwiseOr$Type$Release(MemorySession session, Object base, long offset, $type$ value) {
+    public $type$ getAndBitwiseOr$Type$Release(MemorySessionImpl session, Object base, long offset, $type$ value) {
         try {
             return getAndBitwiseOr$Type$ReleaseInternal(session, base, offset, value);
         } catch (ScopedAccessError ex) {
@@ -559,10 +559,10 @@
     }
 
     @ForceInline @Scoped
-    private $type$ getAndBitwiseOr$Type$ReleaseInternal(MemorySession session, Object base, long offset, $type$ value) {
+    private $type$ getAndBitwiseOr$Type$ReleaseInternal(MemorySessionImpl session, Object base, long offset, $type$ value) {
         try {
             if (session != null) {
-                ((MemorySessionImpl)session).checkValidState();
+                session.checkValidState();
             }
             return UNSAFE.getAndBitwiseOr$Type$Release(base, offset, value);
         } finally {
@@ -571,7 +571,7 @@
     }
 
     @ForceInline
-    public $type$ getAndBitwiseAnd$Type$(MemorySession session, Object base, long offset, $type$ value) {
+    public $type$ getAndBitwiseAnd$Type$(MemorySessionImpl session, Object base, long offset, $type$ value) {
         try {
             return getAndBitwiseAnd$Type$Internal(session, base, offset, value);
         } catch (ScopedAccessError ex) {
@@ -580,10 +580,10 @@
     }
 
     @ForceInline @Scoped
-    private $type$ getAndBitwiseAnd$Type$Internal(MemorySession session, Object base, long offset, $type$ value) {
+    private $type$ getAndBitwiseAnd$Type$Internal(MemorySessionImpl session, Object base, long offset, $type$ value) {
         try {
             if (session != null) {
-                ((MemorySessionImpl)session).checkValidState();
+                session.checkValidState();
             }
             return UNSAFE.getAndBitwiseAnd$Type$(base, offset, value);
         } finally {
@@ -592,7 +592,7 @@
     }
 
     @ForceInline
-    public $type$ getAndBitwiseAnd$Type$Acquire(MemorySession session, Object base, long offset, $type$ value) {
+    public $type$ getAndBitwiseAnd$Type$Acquire(MemorySessionImpl session, Object base, long offset, $type$ value) {
         try {
             return getAndBitwiseAnd$Type$AcquireInternal(session, base, offset, value);
         } catch (ScopedAccessError ex) {
@@ -601,10 +601,10 @@
     }
 
     @ForceInline @Scoped
-    private $type$ getAndBitwiseAnd$Type$AcquireInternal(MemorySession session, Object base, long offset, $type$ value) {
+    private $type$ getAndBitwiseAnd$Type$AcquireInternal(MemorySessionImpl session, Object base, long offset, $type$ value) {
         try {
             if (session != null) {
-                ((MemorySessionImpl)session).checkValidState();
+                session.checkValidState();
             }
             return UNSAFE.getAndBitwiseAnd$Type$Acquire(base, offset, value);
         } finally {
@@ -613,7 +613,7 @@
     }
 
     @ForceInline
-    public $type$ getAndBitwiseAnd$Type$Release(MemorySession session, Object base, long offset, $type$ value) {
+    public $type$ getAndBitwiseAnd$Type$Release(MemorySessionImpl session, Object base, long offset, $type$ value) {
         try {
             return getAndBitwiseAnd$Type$ReleaseInternal(session, base, offset, value);
         } catch (ScopedAccessError ex) {
@@ -622,10 +622,10 @@
     }
 
     @ForceInline @Scoped
-    private $type$ getAndBitwiseAnd$Type$ReleaseInternal(MemorySession session, Object base, long offset, $type$ value) {
+    private $type$ getAndBitwiseAnd$Type$ReleaseInternal(MemorySessionImpl session, Object base, long offset, $type$ value) {
         try {
             if (session != null) {
-                ((MemorySessionImpl)session).checkValidState();
+                session.checkValidState();
             }
             return UNSAFE.getAndBitwiseAnd$Type$Release(base, offset, value);
         } finally {
@@ -634,7 +634,7 @@
     }
 
     @ForceInline
-    public $type$ getAndBitwiseXor$Type$(MemorySession session, Object base, long offset, $type$ value) {
+    public $type$ getAndBitwiseXor$Type$(MemorySessionImpl session, Object base, long offset, $type$ value) {
         try {
             return getAndBitwiseXor$Type$Internal(session, base, offset, value);
         } catch (ScopedAccessError ex) {
@@ -643,10 +643,10 @@
     }
 
     @ForceInline @Scoped
-    private $type$ getAndBitwiseXor$Type$Internal(MemorySession session, Object base, long offset, $type$ value) {
+    private $type$ getAndBitwiseXor$Type$Internal(MemorySessionImpl session, Object base, long offset, $type$ value) {
         try {
             if (session != null) {
-                ((MemorySessionImpl)session).checkValidState();
+                session.checkValidState();
             }
             return UNSAFE.getAndBitwiseXor$Type$(base, offset, value);
         } finally {
@@ -655,7 +655,7 @@
     }
 
     @ForceInline
-    public $type$ getAndBitwiseXor$Type$Acquire(MemorySession session, Object base, long offset, $type$ value) {
+    public $type$ getAndBitwiseXor$Type$Acquire(MemorySessionImpl session, Object base, long offset, $type$ value) {
         try {
             return getAndBitwiseXor$Type$AcquireInternal(session, base, offset, value);
         } catch (ScopedAccessError ex) {
@@ -664,10 +664,10 @@
     }
 
     @ForceInline @Scoped
-    private $type$ getAndBitwiseXor$Type$AcquireInternal(MemorySession session, Object base, long offset, $type$ value) {
+    private $type$ getAndBitwiseXor$Type$AcquireInternal(MemorySessionImpl session, Object base, long offset, $type$ value) {
         try {
             if (session != null) {
-                ((MemorySessionImpl)session).checkValidState();
+                session.checkValidState();
             }
             return UNSAFE.getAndBitwiseXor$Type$Acquire(base, offset, value);
         } finally {
@@ -676,7 +676,7 @@
     }
 
     @ForceInline
-    public $type$ getAndBitwiseXor$Type$Release(MemorySession session, Object base, long offset, $type$ value) {
+    public $type$ getAndBitwiseXor$Type$Release(MemorySessionImpl session, Object base, long offset, $type$ value) {
         try {
             return getAndBitwiseXor$Type$ReleaseInternal(session, base, offset, value);
         } catch (ScopedAccessError ex) {
@@ -685,10 +685,10 @@
     }
 
     @ForceInline @Scoped
-    private $type$ getAndBitwiseXor$Type$ReleaseInternal(MemorySession session, Object base, long offset, $type$ value) {
+    private $type$ getAndBitwiseXor$Type$ReleaseInternal(MemorySessionImpl session, Object base, long offset, $type$ value) {
         try {
             if (session != null) {
-                ((MemorySessionImpl)session).checkValidState();
+                session.checkValidState();
             }
             return UNSAFE.getAndBitwiseXor$Type$Release(base, offset, value);
         } finally {

--- a/src/java.base/share/classes/jdk/internal/misc/X-ScopedMemoryAccess.java.template
+++ b/src/java.base/share/classes/jdk/internal/misc/X-ScopedMemoryAccess.java.template
@@ -30,7 +30,6 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 import java.lang.foreign.MemorySegment;
-import java.lang.foreign.MemorySession;
 import java.lang.ref.Reference;
 import java.io.FileDescriptor;
 import java.nio.Buffer;
@@ -48,7 +47,7 @@ import jdk.internal.vm.vector.VectorSupport;
 /**
  * This class defines low-level methods to access on-heap and off-heap memory. The methods in this class
  * can be thought of as thin wrappers around methods provided in the {@link Unsafe} class. All the methods in this
- * class accept one or more {@link MemorySession} parameter, which is used to validate as to whether access to memory
+ * class accept one or more {@link MemorySessionImpl} parameter, which is used to validate as to whether access to memory
  * can be performed in a safe fashion - more specifically, to ensure that the memory being accessed has not
  * already been released (which would result in a hard VM crash).
  * <p>
@@ -59,7 +58,7 @@ import jdk.internal.vm.vector.VectorSupport;
  * <p>
  * This class provides tools to manage races when multiple threads are accessing and/or releasing the same memory
  * region concurrently. More specifically, when a thread wants to release a memory region, it should call the
- * {@link MemorySession#close()} method. This method initiates thread-local handshakes with all the other VM threads,
+ * {@link MemorySessionImpl#close()} method. This method initiates thread-local handshakes with all the other VM threads,
  * which are then stopped one by one. If any thread is found accessing a resource associated to the very memory session
  * being closed, the handshake is retried on the problematic threads, until it succeeds.
  * <p>
@@ -85,11 +84,11 @@ public class ScopedMemoryAccess {
         registerNatives();
     }
 
-    public void closeScope(MemorySession session) {
+    public void closeScope(MemorySessionImpl session) {
         closeScope0(session);
     }
 
-    native void closeScope0(MemorySession session);
+    native void closeScope0(MemorySessionImpl session);
 
     private ScopedMemoryAccess() {}
 
@@ -115,7 +114,7 @@ public class ScopedMemoryAccess {
     // bulk ops
 
     @ForceInline
-    public void copyMemory(MemorySession srcScope, MemorySession dstScope,
+    public void copyMemory(MemorySessionImpl srcScope, MemorySessionImpl dstScope,
                                    Object srcBase, long srcOffset,
                                    Object destBase, long destOffset,
                                    long bytes) {
@@ -127,16 +126,16 @@ public class ScopedMemoryAccess {
     }
 
     @ForceInline @Scoped
-    private void copyMemoryInternal(MemorySession srcScope, MemorySession dstScope,
+    private void copyMemoryInternal(MemorySessionImpl srcScope, MemorySessionImpl dstScope,
                                Object srcBase, long srcOffset,
                                Object destBase, long destOffset,
                                long bytes) {
         try {
             if (srcScope != null) {
-                ((MemorySessionImpl)srcScope).checkValidState();
+                srcScope.checkValidState();
             }
             if (dstScope != null) {
-                ((MemorySessionImpl)dstScope).checkValidState();
+                dstScope.checkValidState();
             }
             UNSAFE.copyMemory(srcBase, srcOffset, destBase, destOffset, bytes);
         } finally {
@@ -146,7 +145,7 @@ public class ScopedMemoryAccess {
     }
 
     @ForceInline
-    public void copySwapMemory(MemorySession srcScope, MemorySession dstScope,
+    public void copySwapMemory(MemorySessionImpl srcScope, MemorySessionImpl dstScope,
                                    Object srcBase, long srcOffset,
                                    Object destBase, long destOffset,
                                    long bytes, long elemSize) {
@@ -158,16 +157,16 @@ public class ScopedMemoryAccess {
     }
 
     @ForceInline @Scoped
-    private void copySwapMemoryInternal(MemorySession srcScope, MemorySession dstScope,
+    private void copySwapMemoryInternal(MemorySessionImpl srcScope, MemorySessionImpl dstScope,
                                Object srcBase, long srcOffset,
                                Object destBase, long destOffset,
                                long bytes, long elemSize) {
         try {
             if (srcScope != null) {
-                ((MemorySessionImpl)srcScope).checkValidState();
+                srcScope.checkValidState();
             }
             if (dstScope != null) {
-                ((MemorySessionImpl)dstScope).checkValidState();
+                dstScope.checkValidState();
             }
             UNSAFE.copySwapMemory(srcBase, srcOffset, destBase, destOffset, bytes, elemSize);
         } finally {
@@ -177,7 +176,7 @@ public class ScopedMemoryAccess {
     }
 
     @ForceInline
-    public void setMemory(MemorySession session, Object o, long offset, long bytes, byte value) {
+    public void setMemory(MemorySessionImpl session, Object o, long offset, long bytes, byte value) {
         try {
             setMemoryInternal(session, o, offset, bytes, value);
         } catch (ScopedAccessError ex) {
@@ -186,10 +185,10 @@ public class ScopedMemoryAccess {
     }
 
     @ForceInline @Scoped
-    private void setMemoryInternal(MemorySession session, Object o, long offset, long bytes, byte value) {
+    private void setMemoryInternal(MemorySessionImpl session, Object o, long offset, long bytes, byte value) {
         try {
             if (session != null) {
-                ((MemorySessionImpl)session).checkValidState();
+                session.checkValidState();
             }
             UNSAFE.setMemory(o, offset, bytes, value);
         } finally {
@@ -198,7 +197,7 @@ public class ScopedMemoryAccess {
     }
 
     @ForceInline
-    public int vectorizedMismatch(MemorySession aScope, MemorySession bScope,
+    public int vectorizedMismatch(MemorySessionImpl aScope, MemorySessionImpl bScope,
                                              Object a, long aOffset,
                                              Object b, long bOffset,
                                              int length,
@@ -211,17 +210,17 @@ public class ScopedMemoryAccess {
     }
 
     @ForceInline @Scoped
-    private int vectorizedMismatchInternal(MemorySession aScope, MemorySession bScope,
+    private int vectorizedMismatchInternal(MemorySessionImpl aScope, MemorySessionImpl bScope,
                                              Object a, long aOffset,
                                              Object b, long bOffset,
                                              int length,
                                              int log2ArrayIndexScale) {
         try {
             if (aScope != null) {
-                ((MemorySessionImpl)aScope).checkValidState();
+                aScope.checkValidState();
             }
             if (bScope != null) {
-                ((MemorySessionImpl)bScope).checkValidState();
+                bScope.checkValidState();
             }
             return ArraysSupport.vectorizedMismatch(a, aOffset, b, bOffset, length, log2ArrayIndexScale);
         } finally {
@@ -231,7 +230,7 @@ public class ScopedMemoryAccess {
     }
 
     @ForceInline
-    public boolean isLoaded(MemorySession session, long address, boolean isSync, long size) {
+    public boolean isLoaded(MemorySessionImpl session, long address, boolean isSync, long size) {
         try {
             return isLoadedInternal(session, address, isSync, size);
         } catch (ScopedAccessError ex) {
@@ -240,10 +239,10 @@ public class ScopedMemoryAccess {
     }
 
     @ForceInline @Scoped
-    public boolean isLoadedInternal(MemorySession session, long address, boolean isSync, long size) {
+    public boolean isLoadedInternal(MemorySessionImpl session, long address, boolean isSync, long size) {
         try {
             if (session != null) {
-                ((MemorySessionImpl)session).checkValidState();
+                session.checkValidState();
             }
             return SharedSecrets.getJavaNioAccess().isLoaded(address, isSync, size);
         } finally {
@@ -252,7 +251,7 @@ public class ScopedMemoryAccess {
     }
 
     @ForceInline
-    public void load(MemorySession session, long address, boolean isSync, long size) {
+    public void load(MemorySessionImpl session, long address, boolean isSync, long size) {
         try {
             loadInternal(session, address, isSync, size);
         } catch (ScopedAccessError ex) {
@@ -261,10 +260,10 @@ public class ScopedMemoryAccess {
     }
 
     @ForceInline @Scoped
-    public void loadInternal(MemorySession session, long address, boolean isSync, long size) {
+    public void loadInternal(MemorySessionImpl session, long address, boolean isSync, long size) {
         try {
             if (session != null) {
-                ((MemorySessionImpl)session).checkValidState();
+                session.checkValidState();
             }
             SharedSecrets.getJavaNioAccess().load(address, isSync, size);
         } finally {
@@ -273,7 +272,7 @@ public class ScopedMemoryAccess {
     }
 
     @ForceInline
-    public void unload(MemorySession session, long address, boolean isSync, long size) {
+    public void unload(MemorySessionImpl session, long address, boolean isSync, long size) {
         try {
             unloadInternal(session, address, isSync, size);
         } catch (ScopedAccessError ex) {
@@ -282,10 +281,10 @@ public class ScopedMemoryAccess {
     }
 
     @ForceInline @Scoped
-    public void unloadInternal(MemorySession session, long address, boolean isSync, long size) {
+    public void unloadInternal(MemorySessionImpl session, long address, boolean isSync, long size) {
         try {
             if (session != null) {
-                ((MemorySessionImpl)session).checkValidState();
+                session.checkValidState();
             }
             SharedSecrets.getJavaNioAccess().unload(address, isSync, size);
         } finally {
@@ -294,7 +293,7 @@ public class ScopedMemoryAccess {
     }
 
     @ForceInline
-    public void force(MemorySession session, FileDescriptor fd, long address, boolean isSync, long index, long length) {
+    public void force(MemorySessionImpl session, FileDescriptor fd, long address, boolean isSync, long index, long length) {
         try {
             forceInternal(session, fd, address, isSync, index, length);
         } catch (ScopedAccessError ex) {
@@ -303,10 +302,10 @@ public class ScopedMemoryAccess {
     }
 
     @ForceInline @Scoped
-    public void forceInternal(MemorySession session, FileDescriptor fd, long address, boolean isSync, long index, long length) {
+    public void forceInternal(MemorySessionImpl session, FileDescriptor fd, long address, boolean isSync, long index, long length) {
         try {
             if (session != null) {
-                ((MemorySessionImpl)session).checkValidState();
+                session.checkValidState();
             }
             SharedSecrets.getJavaNioAccess().force(fd, address, isSync, index, length);
         } finally {
@@ -343,7 +342,7 @@ public class ScopedMemoryAccess {
         static final JavaNioAccess NIO_ACCESS = SharedSecrets.getJavaNioAccess();
 
         @ForceInline
-        static MemorySession session(ByteBuffer bb) {
+        static MemorySessionImpl session(ByteBuffer bb) {
             MemorySegment segment = NIO_ACCESS.bufferSegment(bb);
             return segment != null ?
                     ((AbstractMemorySegmentImpl)segment).sessionImpl() : null;
@@ -378,14 +377,14 @@ public class ScopedMemoryAccess {
     @ForceInline
     private static
     <V extends VectorSupport.Vector<E>, E, S extends VectorSupport.VectorSpecies<E>>
-    V loadFromByteBufferScoped(MemorySession session,
+    V loadFromByteBufferScoped(MemorySessionImpl session,
                           Class<? extends V> vmClass, Class<E> e, int length,
                           ByteBuffer bb, int offset,
                           S s,
                           VectorSupport.LoadOperation<ByteBuffer, V, S> defaultImpl) {
         try {
             if (session != null) {
-                ((MemorySessionImpl)session).checkValidState();
+                session.checkValidState();
             }
 
             final byte[] base = (byte[]) BufferAccess.bufferBase(bb);
@@ -423,14 +422,14 @@ public class ScopedMemoryAccess {
     private static
     <V extends VectorSupport.Vector<E>, E, S extends VectorSupport.VectorSpecies<E>,
      M extends VectorSupport.VectorMask<E>>
-    V loadFromByteBufferMaskedScoped(MemorySession session, Class<? extends V> vmClass,
+    V loadFromByteBufferMaskedScoped(MemorySessionImpl session, Class<? extends V> vmClass,
                                      Class<M> maskClass, Class<E> e, int length,
                                      ByteBuffer bb, int offset, M m,
                                      S s,
                                      VectorSupport.LoadVectorMaskedOperation<ByteBuffer, V, S, M> defaultImpl) {
         try {
             if (session != null) {
-                ((MemorySessionImpl)session).checkValidState();
+                session.checkValidState();
             }
 
             return VectorSupport.loadMasked(vmClass, maskClass, e, length,
@@ -465,14 +464,14 @@ public class ScopedMemoryAccess {
     @ForceInline
     private static
     <V extends VectorSupport.Vector<E>, E>
-    void storeIntoByteBufferScoped(MemorySession session,
+    void storeIntoByteBufferScoped(MemorySessionImpl session,
                                    Class<? extends V> vmClass, Class<E> e, int length,
                                    V v,
                                    ByteBuffer bb, int offset,
                                    VectorSupport.StoreVectorOperation<ByteBuffer, V> defaultImpl) {
         try {
             if (session != null) {
-                ((MemorySessionImpl)session).checkValidState();
+                session.checkValidState();
             }
 
             final byte[] base = (byte[]) BufferAccess.bufferBase(bb);
@@ -510,14 +509,14 @@ public class ScopedMemoryAccess {
     @ForceInline
     private static
     <V extends VectorSupport.Vector<E>, E, M extends VectorSupport.VectorMask<E>>
-    void storeIntoByteBufferMaskedScoped(MemorySession session,
+    void storeIntoByteBufferMaskedScoped(MemorySessionImpl session,
                                          Class<? extends V> vmClass, Class<M> maskClass,
                                          Class<E> e, int length, V v, M m,
                                          ByteBuffer bb, int offset,
                                          VectorSupport.StoreVectorMaskedOperation<ByteBuffer, V, M> defaultImpl) {
         try {
             if (session != null) {
-                ((MemorySessionImpl)session).checkValidState();
+                session.checkValidState();
             }
 
             VectorSupport.storeMasked(vmClass, maskClass, e, length,

--- a/test/jdk/java/foreign/SafeFunctionAccessTest.java
+++ b/test/jdk/java/foreign/SafeFunctionAccessTest.java
@@ -74,26 +74,24 @@ public class SafeFunctionAccessTest extends NativeTestHelper {
                 findNativeOrThrow(SafeFunctionAccessTest.class, "addr_func_6"),
                 FunctionDescriptor.ofVoid(C_POINTER, C_POINTER, C_POINTER, C_POINTER, C_POINTER, C_POINTER));
         for (int i = 0 ; i < 6 ; i++) {
-            MemorySession[] sessions = new MemorySession[] {
-                    MemorySession.openShared(),
-                    MemorySession.openShared(),
-                    MemorySession.openShared(),
-                    MemorySession.openShared(),
-                    MemorySession.openShared(),
-                    MemorySession.openShared()
+            MemorySegment[] segments = new MemorySegment[]{
+                    MemorySegment.allocateNative(POINT, MemorySession.openShared()),
+                    MemorySegment.allocateNative(POINT, MemorySession.openShared()),
+                    MemorySegment.allocateNative(POINT, MemorySession.openShared()),
+                    MemorySegment.allocateNative(POINT, MemorySession.openShared()),
+                    MemorySegment.allocateNative(POINT, MemorySession.openShared()),
+                    MemorySegment.allocateNative(POINT, MemorySession.openShared())
             };
             // check liveness
-            sessions[i].close();
+            segments[i].session().close();
             for (int j = 0 ; j < 6 ; j++) {
                 if (i == j) {
-                    assertFalse(sessions[j].isAlive());
+                    assertFalse(segments[j].session().isAlive());
                 } else {
-                    assertTrue(sessions[j].isAlive());
+                    assertTrue(segments[j].session().isAlive());
                 }
             }
             try {
-                MemorySegment[] segments = Arrays.stream(sessions).map(session -> MemorySegment.allocateNative(POINT, session))
-                        .toArray(MemorySegment[]::new);
                 handle.invokeWithArguments(segments);
                 fail();
             } catch (IllegalStateException ex) {
@@ -101,7 +99,7 @@ public class SafeFunctionAccessTest extends NativeTestHelper {
             }
             for (int j = 0 ; j < 6 ; j++) {
                 if (i != j) {
-                    sessions[j].close(); // should succeed!
+                    segments[j].session().close(); // should succeed!
                 }
             }
         }

--- a/test/jdk/java/foreign/TestArrays.java
+++ b/test/jdk/java/foreign/TestArrays.java
@@ -136,9 +136,8 @@ public class TestArrays {
     @Test(dataProvider = "elemLayouts",
             expectedExceptions = IllegalStateException.class)
     public void testArrayFromClosedSegment(MemoryLayout layout, Function<MemorySegment, Object> arrayFactory) {
-        var session = MemorySession.openConfined();
-        MemorySegment segment = MemorySegment.allocateNative(layout, session);
-        session.close();
+        MemorySegment segment = MemorySegment.allocateNative(layout, MemorySession.openConfined());
+        segment.session().close();
         arrayFactory.apply(segment);
     }
 

--- a/test/jdk/java/foreign/TestMemorySession.java
+++ b/test/jdk/java/foreign/TestMemorySession.java
@@ -354,12 +354,13 @@ public class TestMemorySession {
                 { (Supplier<MemorySession>) MemorySession::openConfined},
                 { (Supplier<MemorySession>) MemorySession::openShared},
                 { (Supplier<MemorySession>) MemorySession::openImplicit},
-                { (Supplier<MemorySession>) MemorySession::global}
+                { (Supplier<MemorySession>) MemorySession::global},
         };
     }
 
     private void keepAlive(MemorySession child, MemorySession parent) {
-        ((MemorySessionImpl)parent).acquire0();
-        child.addCloseAction(() -> ((MemorySessionImpl)parent).release0());
+        MemorySessionImpl sessionImpl = (MemorySessionImpl)parent;
+        sessionImpl.acquire0();
+        child.addCloseAction(sessionImpl::release0);
     }
 }

--- a/test/jdk/java/foreign/TestMemorySession.java
+++ b/test/jdk/java/foreign/TestMemorySession.java
@@ -43,7 +43,9 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Function;
 import java.util.function.Supplier;
+import java.util.function.UnaryOperator;
 import java.util.stream.IntStream;
 
 public class TestMemorySession {
@@ -51,12 +53,13 @@ public class TestMemorySession {
     final static int N_THREADS = 100;
 
     @Test(dataProvider = "cleaners")
-    public void testConfined(Supplier<Cleaner> cleanerSupplier) {
+    public void testConfined(Supplier<Cleaner> cleanerSupplier, UnaryOperator<MemorySession> sessionFunc) {
         AtomicInteger acc = new AtomicInteger();
         Cleaner cleaner = cleanerSupplier.get();
         MemorySession session = cleaner != null ?
                 MemorySession.openConfined(cleaner) :
                 MemorySession.openConfined();
+        session = sessionFunc.apply(session);
         for (int i = 0 ; i < N_THREADS ; i++) {
             int delta = i;
             session.addCloseAction(() -> acc.addAndGet(delta));
@@ -76,12 +79,13 @@ public class TestMemorySession {
     }
 
     @Test(dataProvider = "cleaners")
-    public void testSharedSingleThread(Supplier<Cleaner> cleanerSupplier) {
+    public void testSharedSingleThread(Supplier<Cleaner> cleanerSupplier, UnaryOperator<MemorySession> sessionFunc) {
         AtomicInteger acc = new AtomicInteger();
         Cleaner cleaner = cleanerSupplier.get();
         MemorySession session = cleaner != null ?
                 MemorySession.openShared(cleaner) :
                 MemorySession.openShared();
+        session = sessionFunc.apply(session);
         for (int i = 0 ; i < N_THREADS ; i++) {
             int delta = i;
             session.addCloseAction(() -> acc.addAndGet(delta));
@@ -101,13 +105,14 @@ public class TestMemorySession {
     }
 
     @Test(dataProvider = "cleaners")
-    public void testSharedMultiThread(Supplier<Cleaner> cleanerSupplier) {
+    public void testSharedMultiThread(Supplier<Cleaner> cleanerSupplier, UnaryOperator<MemorySession> sessionFunc) {
         AtomicInteger acc = new AtomicInteger();
         Cleaner cleaner = cleanerSupplier.get();
         List<Thread> threads = new ArrayList<>();
         MemorySession session = cleaner != null ?
                 MemorySession.openShared(cleaner) :
                 MemorySession.openShared();
+        session = sessionFunc.apply(session);
         AtomicReference<MemorySession> sessionRef = new AtomicReference<>(session);
         for (int i = 0 ; i < N_THREADS ; i++) {
             int delta = i;
@@ -342,9 +347,11 @@ public class TestMemorySession {
     @DataProvider
     static Object[][] cleaners() {
         return new Object[][] {
-                { (Supplier<Cleaner>)() -> null },
-                { (Supplier<Cleaner>)Cleaner::create },
-                { (Supplier<Cleaner>)CleanerFactory::cleaner }
+                { (Supplier<Cleaner>)() -> null, UnaryOperator.identity() },
+                { (Supplier<Cleaner>)Cleaner::create, UnaryOperator.identity() },
+                { (Supplier<Cleaner>)CleanerFactory::cleaner, UnaryOperator.identity() },
+                { (Supplier<Cleaner>)Cleaner::create, (UnaryOperator<MemorySession>)MemorySession::asNonCloseable },
+                { (Supplier<Cleaner>)CleanerFactory::cleaner, (UnaryOperator<MemorySession>)MemorySession::asNonCloseable }
         };
     }
 
@@ -355,11 +362,15 @@ public class TestMemorySession {
                 { (Supplier<MemorySession>) MemorySession::openShared},
                 { (Supplier<MemorySession>) MemorySession::openImplicit},
                 { (Supplier<MemorySession>) MemorySession::global},
+                { (Supplier<MemorySession>) () -> MemorySession.openConfined().asNonCloseable() },
+                { (Supplier<MemorySession>) () -> MemorySession.openShared().asNonCloseable() },
+                { (Supplier<MemorySession>) () -> MemorySession.openImplicit().asNonCloseable() },
+                { (Supplier<MemorySession>) () -> MemorySession.global().asNonCloseable()},
         };
     }
 
     private void keepAlive(MemorySession child, MemorySession parent) {
-        MemorySessionImpl sessionImpl = (MemorySessionImpl)parent;
+        MemorySessionImpl sessionImpl = MemorySessionImpl.toSessionImpl(parent);
         sessionImpl.acquire0();
         child.addCloseAction(sessionImpl::release0);
     }

--- a/test/jdk/java/foreign/TestSegments.java
+++ b/test/jdk/java/foreign/TestSegments.java
@@ -285,6 +285,17 @@ public class TestSegments {
         assertTrue(segment.byteSize() > 0);
     }
 
+    @Test
+    public void testSegmentAccessorWithWrappedLifetime() {
+        MemorySession session = MemorySession.openConfined();
+        MemorySession publicSession = session.asNonCloseable();
+        MemorySegment segment = publicSession.allocate(100);
+        assertThrows(UnsupportedOperationException.class, publicSession::close);
+        assertThrows(UnsupportedOperationException.class, segment.session()::close);
+        session.close();
+        assertFalse(publicSession.isAlive());
+    }
+
     @DataProvider(name = "badSizeAndAlignments")
     public Object[][] sizesAndAlignments() {
         return new Object[][] {

--- a/test/jdk/java/foreign/TestSegments.java
+++ b/test/jdk/java/foreign/TestSegments.java
@@ -293,6 +293,7 @@ public class TestSegments {
     public void testSegmentAccessorWithWrappedLifetime() {
         MemorySession session = MemorySession.openConfined();
         MemorySession publicSession = session.asNonCloseable();
+        assertEquals(session, publicSession);
         MemorySegment segment = publicSession.allocate(100);
         assertThrows(UnsupportedOperationException.class, publicSession::close);
         assertThrows(UnsupportedOperationException.class, segment.session()::close);

--- a/test/jdk/java/foreign/TestSegments.java
+++ b/test/jdk/java/foreign/TestSegments.java
@@ -129,26 +129,35 @@ public class TestSegments {
     }
 
     @Test(dataProvider = "segmentFactories")
-    public void testAccessModesOfFactories(Supplier<SegmentFactory> segmentFactorySupplier) {
-        SegmentFactory segmentFactory = segmentFactorySupplier.get();
-        MemorySegment segment = segmentFactory.segment();
+    public void testAccessModesOfFactories(Supplier<MemorySegment> segmentSupplier) {
+        MemorySegment segment = segmentSupplier.get();
         assertFalse(segment.isReadOnly());
-        segmentFactory.tryClose();
+        tryClose(segment);
+    }
+
+    static void tryClose(MemorySegment segment) {
+        if (segment.session().isCloseable()) {
+            segment.session().close();
+        }
     }
 
     @DataProvider(name = "segmentFactories")
     public Object[][] segmentFactories() {
-        List<Supplier<SegmentFactory>> l = List.of(
-                () -> SegmentFactory.ofArray(() -> MemorySegment.ofArray(new byte[] { 0x00, 0x01, 0x02, 0x03 })),
-                () -> SegmentFactory.ofArray(() -> MemorySegment.ofArray(new char[] {'a', 'b', 'c', 'd' })),
-                () -> SegmentFactory.ofArray(() -> MemorySegment.ofArray(new double[] { 1d, 2d, 3d, 4d} )),
-                () -> SegmentFactory.ofArray(() -> MemorySegment.ofArray(new float[] { 1.0f, 2.0f, 3.0f, 4.0f })),
-                () -> SegmentFactory.ofArray(() -> MemorySegment.ofArray(new int[] { 1, 2, 3, 4 })),
-                () -> SegmentFactory.ofArray(() -> MemorySegment.ofArray(new long[] { 1l, 2l, 3l, 4l } )),
-                () -> SegmentFactory.ofArray(() -> MemorySegment.ofArray(new short[] { 1, 2, 3, 4 } )),
-                () -> SegmentFactory.ofImplicitSession(session -> MemorySegment.allocateNative(4, 8, session)),
-                () -> SegmentFactory.ofImplicitSession(session -> MemorySegment.allocateNative(JAVA_INT, session)),
-                () -> SegmentFactory.ofImplicitSession(session -> MemorySegment.allocateNative(4, session))
+        List<Supplier<MemorySegment>> l = List.of(
+                () -> MemorySegment.ofArray(new byte[] { 0x00, 0x01, 0x02, 0x03 }),
+                () -> MemorySegment.ofArray(new char[] {'a', 'b', 'c', 'd' }),
+                () -> MemorySegment.ofArray(new double[] { 1d, 2d, 3d, 4d} ),
+                () -> MemorySegment.ofArray(new float[] { 1.0f, 2.0f, 3.0f, 4.0f }),
+                () -> MemorySegment.ofArray(new int[] { 1, 2, 3, 4 }),
+                () -> MemorySegment.ofArray(new long[] { 1l, 2l, 3l, 4l } ),
+                () -> MemorySegment.ofArray(new short[] { 1, 2, 3, 4 } ),
+                () -> MemorySegment.allocateNative(4, MemorySession.openImplicit()),
+                () -> MemorySegment.allocateNative(4, 8, MemorySession.openImplicit()),
+                () -> MemorySegment.allocateNative(JAVA_INT, MemorySession.openImplicit()),
+                () -> MemorySegment.allocateNative(4, MemorySession.openImplicit()),
+                () -> MemorySegment.allocateNative(4, 8, MemorySession.openImplicit()),
+                () -> MemorySegment.allocateNative(JAVA_INT, MemorySession.openImplicit())
+
         );
         return l.stream().map(s -> new Object[] { s }).toArray(Object[][]::new);
     }
@@ -182,12 +191,11 @@ public class TestSegments {
     }
 
     @Test(dataProvider = "segmentFactories")
-    public void testFill(Supplier<SegmentFactory> segmentFactorySupplier) {
+    public void testFill(Supplier<MemorySegment> segmentSupplier) {
         VarHandle byteHandle = ValueLayout.JAVA_BYTE.arrayElementVarHandle();
 
         for (byte value : new byte[] {(byte) 0xFF, (byte) 0x00, (byte) 0x45}) {
-            SegmentFactory segmentFactory = segmentFactorySupplier.get();
-            MemorySegment segment = segmentFactory.segment();
+            MemorySegment segment = segmentSupplier.get();
             segment.fill(value);
             for (long l = 0; l < segment.byteSize(); l++) {
                 assertEquals((byte) byteHandle.get(segment, l), value);
@@ -204,15 +212,14 @@ public class TestSegments {
                 assertEquals((byte) byteHandle.get(segment, l), (byte) ~value);
             }
             assertEquals((byte) byteHandle.get(segment, segment.byteSize() - 1L), value);
-            segmentFactory.tryClose();
+            tryClose(segment);
         }
     }
 
     @Test(dataProvider = "segmentFactories")
-    public void testFillClosed(Supplier<SegmentFactory> segmentFactorySupplier) {
-        SegmentFactory segmentFactory = segmentFactorySupplier.get();
-        MemorySegment segment = segmentFactory.segment();
-        segmentFactory.tryClose();
+    public void testFillClosed(Supplier<MemorySegment> segmentSupplier) {
+        MemorySegment segment = segmentSupplier.get();
+        tryClose(segment);
         if (!segment.session().isAlive()) {
             try {
                 segment.fill((byte) 0xFF);
@@ -224,30 +231,27 @@ public class TestSegments {
     }
 
     @Test(dataProvider = "segmentFactories")
-    public void testNativeSegments(Supplier<SegmentFactory> segmentFactorySupplier) {
-        SegmentFactory segmentFactory = segmentFactorySupplier.get();
-        MemorySegment segment = segmentFactory.segment();
+    public void testNativeSegments(Supplier<MemorySegment> segmentSupplier) {
+        MemorySegment segment = segmentSupplier.get();
         try {
             segment.address();
             assertTrue(segment.isNative());
         } catch (UnsupportedOperationException exception) {
             assertFalse(segment.isNative());
         }
-        segmentFactory.tryClose();
+        tryClose(segment);
     }
 
     @Test(dataProvider = "segmentFactories", expectedExceptions = UnsupportedOperationException.class)
-    public void testFillIllegalAccessMode(Supplier<SegmentFactory> segmentFactorySupplier) {
-        SegmentFactory segmentFactory = segmentFactorySupplier.get();
-        MemorySegment segment = segmentFactory.segment();
+    public void testFillIllegalAccessMode(Supplier<MemorySegment> segmentSupplier) {
+        MemorySegment segment = segmentSupplier.get();
         segment.asReadOnly().fill((byte) 0xFF);
-        segmentFactory.tryClose();
+        tryClose(segment);
     }
 
     @Test(dataProvider = "segmentFactories")
-    public void testFillThread(Supplier<SegmentFactory> segmentFactorySupplier) throws Exception {
-        SegmentFactory segmentFactory = segmentFactorySupplier.get();
-        MemorySegment segment = segmentFactory.segment();
+    public void testFillThread(Supplier<MemorySegment> segmentSupplier) throws Exception {
+        MemorySegment segment = segmentSupplier.get();
         AtomicReference<RuntimeException> exception = new AtomicReference<>();
         Runnable action = () -> {
             try {
@@ -268,7 +272,7 @@ public class TestSegments {
         } else {
             assertNull(exception.get());
         }
-        segmentFactory.tryClose();
+        tryClose(segment);
     }
 
     @Test

--- a/test/micro/org/openjdk/bench/java/lang/foreign/LoopOverNonConstant.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/LoopOverNonConstant.java
@@ -66,7 +66,6 @@ public class LoopOverNonConstant {
     static final ValueLayout.OfInt JAVA_INT_ALIGNED = JAVA_INT.withBitAlignment(32);
     static final VarHandle VH_int_aligned = JAVA_INT_ALIGNED.arrayElementVarHandle();
 
-    MemorySession session;
     MemorySegment segment;
     long unsafe_addr;
 
@@ -78,8 +77,7 @@ public class LoopOverNonConstant {
         for (int i = 0; i < ELEM_SIZE; i++) {
             unsafe.putInt(unsafe_addr + (i * CARRIER_SIZE) , i);
         }
-        session = MemorySession.openConfined();
-        segment = MemorySegment.allocateNative(ALLOC_SIZE, session);
+        segment = MemorySegment.allocateNative(ALLOC_SIZE, MemorySession.openConfined());
         for (int i = 0; i < ELEM_SIZE; i++) {
             VH_int.set(segment, (long) i, i);
         }
@@ -91,7 +89,7 @@ public class LoopOverNonConstant {
 
     @TearDown
     public void tearDown() {
-        session.close();
+        segment.session().close();
         unsafe.invokeCleaner(byteBuffer);
         unsafe.freeMemory(unsafe_addr);
     }

--- a/test/micro/org/openjdk/bench/java/lang/foreign/LoopOverNonConstantMapped.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/LoopOverNonConstantMapped.java
@@ -81,7 +81,6 @@ public class LoopOverNonConstantMapped {
     }
 
     static final VarHandle VH_int = JAVA_INT.arrayElementVarHandle();
-    MemorySession session;
     MemorySegment segment;
     long unsafe_addr;
 
@@ -96,13 +95,13 @@ public class LoopOverNonConstantMapped {
             }
             ((MappedByteBuffer)byteBuffer).force();
         }
-        segment = MemorySegment.mapFile(tempPath, 0L, ALLOC_SIZE, FileChannel.MapMode.READ_WRITE, session = MemorySession.openConfined());
+        segment = MemorySegment.mapFile(tempPath, 0L, ALLOC_SIZE, FileChannel.MapMode.READ_WRITE, MemorySession.openConfined());
         unsafe_addr = segment.address().toRawLongValue();
     }
 
     @TearDown
     public void tearDown() {
-        session.close();
+        segment.session().close();
         unsafe.invokeCleaner(byteBuffer);
     }
 

--- a/test/micro/org/openjdk/bench/java/lang/foreign/LoopOverNonConstantShared.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/LoopOverNonConstantShared.java
@@ -60,7 +60,6 @@ public class LoopOverNonConstantShared {
     static final int ALLOC_SIZE = ELEM_SIZE * CARRIER_SIZE;
 
     static final VarHandle VH_int = JAVA_INT.arrayElementVarHandle();
-    MemorySession session;
     MemorySegment segment;
     long unsafe_addr;
 
@@ -72,7 +71,7 @@ public class LoopOverNonConstantShared {
         for (int i = 0; i < ELEM_SIZE; i++) {
             unsafe.putInt(unsafe_addr + (i * CARRIER_SIZE) , i);
         }
-        segment = MemorySegment.allocateNative(ALLOC_SIZE, CARRIER_SIZE, session = MemorySession.openConfined());
+        segment = MemorySegment.allocateNative(ALLOC_SIZE, CARRIER_SIZE, MemorySession.openConfined());
         for (int i = 0; i < ELEM_SIZE; i++) {
             VH_int.set(segment, (long) i, i);
         }
@@ -84,7 +83,7 @@ public class LoopOverNonConstantShared {
 
     @TearDown
     public void tearDown() {
-        session.close();
+        segment.session().close();
         unsafe.invokeCleaner(byteBuffer);
         unsafe.freeMemory(unsafe_addr);
     }

--- a/test/micro/org/openjdk/bench/java/lang/foreign/LoopOverSlice.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/LoopOverSlice.java
@@ -58,20 +58,17 @@ public class LoopOverSlice {
 
     MemorySegment nativeSegment, heapSegment;
     IntBuffer nativeBuffer, heapBuffer;
-    MemorySession session;
 
     @Setup
     public void setup() {
-        session = MemorySession.openConfined();
-        nativeSegment = MemorySegment.allocateNative(ALLOC_SIZE, session);
+        nativeSegment = MemorySegment.allocateNative(ALLOC_SIZE, MemorySession.openConfined());
         heapSegment = MemorySegment.ofArray(new int[ELEM_SIZE]);
         nativeBuffer = ByteBuffer.allocateDirect(ALLOC_SIZE).order(ByteOrder.LITTLE_ENDIAN).asIntBuffer();
         heapBuffer = IntBuffer.wrap(new int[ELEM_SIZE]);
     }
 
     @TearDown
-    public void tearDown() {
-        session.close();
+    public void tearDown() { nativeSegment.session().close();
     }
 
     @Benchmark

--- a/test/micro/org/openjdk/bench/java/lang/foreign/ParallelSum.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/ParallelSum.java
@@ -73,7 +73,6 @@ public class ParallelSum {
 
     static final Unsafe unsafe = Utils.unsafe;
 
-    MemorySession session;
     MemorySegment segment;
     long address;
 
@@ -83,7 +82,7 @@ public class ParallelSum {
         for (int i = 0; i < ELEM_SIZE; i++) {
             unsafe.putInt(address + (i * CARRIER_SIZE), i);
         }
-        segment = MemorySegment.allocateNative(ALLOC_SIZE, CARRIER_SIZE, session = MemorySession.openShared());
+        segment = MemorySegment.allocateNative(ALLOC_SIZE, CARRIER_SIZE, MemorySession.openShared());
         for (int i = 0; i < ELEM_SIZE; i++) {
             VH_int.set(segment, (long) i, i);
         }
@@ -92,7 +91,7 @@ public class ParallelSum {
     @TearDown
     public void tearDown() throws Throwable {
         unsafe.freeMemory(address);
-        session.close();
+        segment.session().close();
     }
 
     @Benchmark

--- a/test/micro/org/openjdk/bench/java/lang/foreign/VarHandleExact.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/VarHandleExact.java
@@ -58,17 +58,16 @@ public class VarHandleExact {
         exact = generic.withInvokeExactBehavior();
     }
 
-    MemorySession session;
     MemorySegment data;
 
     @Setup
     public void setup() {
-        data = MemorySegment.allocateNative(JAVA_INT, session = MemorySession.openConfined());
+        data = MemorySegment.allocateNative(JAVA_INT, MemorySession.openConfined());
     }
 
     @TearDown
     public void tearDown() {
-        session.close();
+        data.session().close();
     }
 
     @Benchmark

--- a/test/micro/org/openjdk/bench/java/lang/foreign/points/support/PanamaPoint.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/points/support/PanamaPoint.java
@@ -60,12 +60,10 @@ public class PanamaPoint extends CLayouts implements AutoCloseable {
         );
     }
 
-    private final MemorySession session;
     private final MemorySegment segment;
 
     public PanamaPoint(int x, int y) {
-        this.session = MemorySession.openConfined();
-        this.segment = MemorySegment.allocateNative(LAYOUT, session);
+        this.segment = MemorySegment.allocateNative(LAYOUT, MemorySession.openConfined());
         setX(x);
         setY(y);
     }
@@ -104,6 +102,6 @@ public class PanamaPoint extends CLayouts implements AutoCloseable {
 
     @Override
     public void close() {
-        session.close();
+        segment.session().close();
     }
 }


### PR DESCRIPTION
This patch reverts the hook to make session accessors return a non-closeable session view.

This hook makes it harder to use segments that are backed by a one-off session; consider this case:

```java
SegmentAllocator malloc = MemorySegment::allocateNative;
MemorySegment segment = malloc.allocate(100); // no way to close this
```

In other words, the asymmetry we added to the API requires clients to perform a lot of tracking to be able to associate segments back to their sessions, creating an obvious scalability problem.

Moreover, the existing hook only protects against close. Clients of a segment can still allocate on a session they might not supposed to, or make the session uncloseable, by registering an infinite close action on it.

At the same time, when looking at how sessions might be used by APIs, usage patterns seem to fall in two categories:

* **External session**. APIs that need to create a resource (e.g. a matrix) will take as input a session, which indicates the lifecycle associated with the resource they want to create. In this case, securing the session is not necessary, as the API is getting the session from somewhere else. It is the *client* of the API that has to trust the API not to mess up with its session (but if the API does something shady with the client session, that's arguably a bug in the API). Code generated by jextract falls in this category, as well as [pooled allocators](https://github.com/openjdk/panama-foreign/pull/509).

* **Internal session**. Some APIs might want to hide sessions from clients; in such cases, the session will be created in the constructor, along with all the resources associated with it. In these cases, as the API has already provided some encapsulation, it seems sensible for the API to keep encapsulating resources associated with the session created internally. The code I've seen for both Lucene and Netty falls in this category.

In other words, making memory segments more principled only provides real benefit for APIs that combine both approaches; so far we don't have much evidence that such APIs exist (but if you have some use cases, we'd be interested to know!).

Considering all this, it makes sense to revert the API so that session accessor retain full powers.

This patch leaves the `isCloseable` predicate (still useful to query if a session can be used) as well as `equals/hashcode` (as moving away from `==` will keep our options more open).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [JDK-8282626](https://bugs.openjdk.java.net/browse/JDK-8282626): Revert semantic of session accessors


### Reviewers
 * [Paul Sandoz](https://openjdk.java.net/census#psandoz) (@PaulSandoz - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/661/head:pull/661` \
`$ git checkout pull/661`

Update a local copy of the PR: \
`$ git checkout pull/661` \
`$ git pull https://git.openjdk.java.net/panama-foreign pull/661/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 661`

View PR using the GUI difftool: \
`$ git pr show -t 661`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/panama-foreign/pull/661.diff">https://git.openjdk.java.net/panama-foreign/pull/661.diff</a>

</details>
