### PR TITLE
8280597: Refactor java.lang.invoke.MethodHandles::memoryAccessVarHandle

### DIFF
--- a/make/modules/java.base/gensrc/GensrcVarHandles.gmk
+++ b/make/modules/java.base/gensrc/GensrcVarHandles.gmk
@@ -160,14 +160,14 @@ endef
 ################################################################################
 
 ################################################################################
-# Setup a rule for generating a memory access var handle helper classes
+# Setup a rule for generating a memory segment var handle view class
 # Param 1 - Variable declaration prefix
 # Param 2 - Type with first letter capitalized
-define GenerateVarHandleMemoryAccess
+define GenerateVarHandleMemorySegment
 
   $1_Type := $2
 
-  $1_FILENAME := $(VARHANDLES_GENSRC_DIR)/MemoryAccessVarHandle$$($1_Type)Helper.java
+  $1_FILENAME := $(VARHANDLES_GENSRC_DIR)/VarHandleSegmentAs$$($1_Type)s.java
 
   ifeq ($$($1_Type), Byte)
     $1_type := byte
@@ -248,7 +248,7 @@ define GenerateVarHandleMemoryAccess
     $1_ARGS += -KfloatingPoint
   endif
 
-  $$($1_FILENAME): $(VARHANDLES_SRC_DIR)/X-VarHandleMemoryAccess.java.template $(BUILD_TOOLS_JDK)
+  $$($1_FILENAME): $(VARHANDLES_SRC_DIR)/X-VarHandleSegmentView.java.template $(BUILD_TOOLS_JDK)
 	$$(call MakeDir, $$(@D))
 	$(RM) $$@
 	$(TOOL_SPP) -nel -K$$($1_type) \
@@ -272,8 +272,8 @@ $(foreach t, $(VARHANDLES_BYTE_ARRAY_TYPES), \
   $(eval $(call GenerateVarHandleByteArray,VAR_HANDLE_BYTE_ARRAY_$t,$t)))
 
 # List the types to generate source for, with capitalized first letter
-VARHANDLES_MEMORY_ADDRESS_TYPES := Byte Short Char Int Long Float Double
-$(foreach t, $(VARHANDLES_MEMORY_ADDRESS_TYPES), \
-  $(eval $(call GenerateVarHandleMemoryAccess,VAR_HANDLE_MEMORY_ADDRESS_$t,$t)))
+VARHANDLES_MEMORY_SEGMENT_TYPES := Byte Short Char Int Long Float Double
+$(foreach t, $(VARHANDLES_MEMORY_SEGMENT_TYPES), \
+  $(eval $(call GenerateVarHandleMemorySegment,VAR_HANDLE_MEMORY_SEGMENT_$t,$t)))
 
 TARGETS += $(GENSRC_VARHANDLES)

--- a/src/java.base/share/classes/java/lang/foreign/MemoryAddress.java
+++ b/src/java.base/share/classes/java/lang/foreign/MemoryAddress.java
@@ -43,7 +43,7 @@ import java.lang.invoke.MethodHandle;
  * </ul>
  * A memory address is backed by a raw machine pointer, expressed as a {@linkplain #toRawLongValue() long value}.
  *
- * <h2>Dereference</h2>
+ * <h2>Dereferencing memory addresses</h2>
  *
  * A memory address can be read or written using various methods provided in this class (e.g. {@link #get(ValueLayout.OfInt, long)}).
  * Each dereference method takes a {@linkplain ValueLayout value layout}, which specifies the size,

--- a/src/java.base/share/classes/java/lang/foreign/MemoryLayout.java
+++ b/src/java.base/share/classes/java/lang/foreign/MemoryLayout.java
@@ -157,7 +157,8 @@ import jdk.internal.javac.PreviewFeature;
  * Layout paths can feature one or more <em>free dimensions</em>. For instance, a layout path traversing
  * an unspecified sequence element (that is, where one of the path component was obtained with the
  * {@link PathElement#sequenceElement()} method) features an additional free dimension, which will have to be bound at runtime.
- * This is important when obtaining memory access var handle from layouts, as in the following code:
+ * This is important when obtaining a {@linkplain MethodHandles#memorySegmentViewVarHandle(ValueLayout) memory segment view var handle}
+ * from layouts, as in the following code:
  *
  * {@snippet lang=java :
  * VarHandle valueHandle = taggedValues.varHandle(PathElement.sequenceElement(),
@@ -166,7 +167,7 @@ import jdk.internal.javac.PreviewFeature;
  *
  * Since the layout path constructed in the above example features exactly one free dimension (as it doesn't specify
  * <em>which</em> member layout named {@code value} should be selected from the enclosing sequence layout),
- * it follows that the memory access var handle {@code valueHandle} will feature an <em>additional</em> {@code long}
+ * it follows that the var handle {@code valueHandle} will feature an <em>additional</em> {@code long}
  * access coordinate.
  *
  * <p>A layout path with free dimensions can also be used to create an offset-computing method handle, using the
@@ -382,10 +383,10 @@ public sealed interface MemoryLayout extends Constable permits AbstractLayout, S
     }
 
     /**
-     * Creates a memory access var handle that can be used to dereference memory at the layout selected by a given layout path,
+     * Creates an access var handle that can be used to dereference memory at the layout selected by a given layout path,
      * where the path is considered rooted in this layout.
      * <p>
-     * The final memory location accessed by the returned memory access var handle can be computed as follows:
+     * The final memory location accessed by the returned var handle can be computed as follows:
      *
      * <blockquote><pre>{@code
      * address = base + offset
@@ -406,12 +407,13 @@ public sealed interface MemoryLayout extends Constable permits AbstractLayout, S
      *
      * @apiNote the resulting var handle will feature an additional {@code long} access coordinate for every
      * unspecified sequence access component contained in this layout path. Moreover, the resulting var handle
-     * features certain <a href="MemoryHandles.html#memaccess-mode">access mode restrictions</a>, which are common to all memory access var handles.
+     * features certain <em>access mode restrictions</em>, which are common to all memory segment view handles.
      *
      * @param elements the layout path elements.
      * @return a var handle which can be used to dereference memory at the (possibly nested) layout selected by the layout path in {@code elements}.
      * @throws UnsupportedOperationException if the layout path has one or more elements with incompatible alignment constraints.
      * @throws IllegalArgumentException if the layout path in {@code elements} does not select a value layout (see {@link ValueLayout}).
+     * @see MethodHandles#memorySegmentViewVarHandle(ValueLayout)
      */
     default VarHandle varHandle(PathElement... elements) {
         return computePathOp(LayoutPath.rootPath(this, MemoryLayout::bitSize), LayoutPath::dereferenceHandle,
@@ -419,7 +421,7 @@ public sealed interface MemoryLayout extends Constable permits AbstractLayout, S
     }
 
     /**
-     * Creates a <em>strided</em> memory access var handle that can be used to dereference memory at the layout selected by a given layout path,
+     * Creates a <em>strided</em> access var handle that can be used to dereference memory at the layout selected by a given layout path,
      * where the path is considered rooted in this layout. The returned var handle can effectively dereference multiple memory
      * locations, using a <em>dynamic</em> index (of type {@code long}), which is multiplied by this layout size and then added
      * to the offset of the selected layout. Equivalent to the following code:
@@ -432,6 +434,7 @@ public sealed interface MemoryLayout extends Constable permits AbstractLayout, S
      * @return a var handle which can be used to dereference memory at the (possibly nested) layout selected by the layout path in {@code elements}.
      * @throws UnsupportedOperationException if the layout path has one or more elements with incompatible alignment constraints.
      * @throws IllegalArgumentException if the layout path in {@code elements} does not select a value layout (see {@link ValueLayout}).
+     * @see MethodHandles#memorySegmentViewVarHandle
      */
     default VarHandle arrayElementVarHandle(PathElement... elements) {
         Objects.requireNonNull(elements);

--- a/src/java.base/share/classes/java/lang/foreign/MemorySegment.java
+++ b/src/java.base/share/classes/java/lang/foreign/MemorySegment.java
@@ -134,7 +134,7 @@ import jdk.internal.vm.annotation.ForceInline;
  * For more complex dereference operations (e.g. structured memory access), clients can obtain a
  * {@linkplain MethodHandles#memorySegmentViewVarHandle(ValueLayout) memory segment view var handle},
  * that is, a var handle that accepts a segment and a {@code long} offset. More complex access var handles
- * can be obtained by adapt a segment var handle view using the var handle combinator functions defined in the
+ * can be obtained by adapting a segment var handle view using the var handle combinator functions defined in the
  * {@link java.lang.invoke.MethodHandles} class:
  *
  * {@snippet lang=java :

--- a/src/java.base/share/classes/java/lang/foreign/MemorySegment.java
+++ b/src/java.base/share/classes/java/lang/foreign/MemorySegment.java
@@ -113,7 +113,7 @@ import jdk.internal.vm.annotation.ForceInline;
  * caution: for instance, an incorrect segment size could result in a VM crash when attempting to dereference
  * the memory segment.
  *
- * <h2>Dereference</h2>
+ * <h2><a id = "segment-deref">Dereferencing memory segments</a></h2>
  *
  * A memory segment can be read or written using various methods provided in this class (e.g. {@link #get(ValueLayout.OfInt, long)}).
  * Each dereference method takes a {@linkplain ValueLayout value layout}, which specifies the size,
@@ -131,13 +131,32 @@ import jdk.internal.vm.annotation.ForceInline;
  * int value = segment.get(ValueLayout.JAVA_INT.withOrder(BIG_ENDIAN), 0);
  * }
  *
- * For more complex dereference operations (e.g. structured memory access), clients can obtain a <em>memory access var handle</em>,
- * that is, a var handle that accepts a segment and, optionally, one or more additional {@code long} coordinates. Memory
- * access var handles can be obtained from {@linkplain MemoryLayout#varHandle(MemoryLayout.PathElement...) memory layouts}
- * by providing a so called <a href="MemoryLayout.html#layout-paths"><em>layout path</em></a>.
- * Alternatively, clients can obtain raw memory access var handles from a given
- * {@linkplain MethodHandles#memoryAccessVarHandle(ValueLayout) value layout}, and then adapt it using the var handle combinator
- * functions defined in the {@link java.lang.invoke.MethodHandles} class.
+ * For more complex dereference operations (e.g. structured memory access), clients can obtain a
+ * {@linkplain MethodHandles#memorySegmentViewVarHandle(ValueLayout) memory segment view var handle},
+ * that is, a var handle that accepts a segment and a {@code long} offset. More complex access var handles
+ * can be obtained by adapt a segment var handle view using the var handle combinator functions defined in the
+ * {@link java.lang.invoke.MethodHandles} class:
+ *
+ * {@snippet lang=java :
+ * MemorySegment segment = ...
+ * VarHandle intHandle = MethodHandles.memorySegmentViewVarHandle(ValueLayout.JAVA_INT);
+ * MethodHandle multiplyExact = MethodHandles.lookup()
+ *                                           .findStatic(Math.class, "multiplyExact",
+ *                                                                   MethodType.methodType(long.class, long.class, long.class));
+ * intHandle = MethodHandles.filterCoordinates(intHandle, 1,
+ *                                             MethodHandles.insertArguments(multiplyExact, 0, 4L));
+ * intHandle.get(segment, 3L); // get int element at offset 3 * 4 = 12
+ * }
+ *
+ * Alternatively, complex access var handles can can be obtained
+ * from {@linkplain MemoryLayout#varHandle(MemoryLayout.PathElement...) memory layouts}
+ * by providing a so called <a href="MemoryLayout.html#layout-paths"><em>layout path</em></a>:
+ *
+ * {@snippet lang=java :
+ * MemorySegment segment = ...
+ * VarHandle intHandle = ValueLayout.JAVA_INT.arrayElementVarHandle();
+ * intHandle.get(segment, 3L); // get int element at offset 3 * 4 = 12
+ * }
  *
  * <h2 id="segment-alignment">Alignment</h2>
  *

--- a/src/java.base/share/classes/java/lang/foreign/ValueLayout.java
+++ b/src/java.base/share/classes/java/lang/foreign/ValueLayout.java
@@ -203,7 +203,7 @@ public sealed class ValueLayout extends AbstractLayout implements MemoryLayout {
     VarHandle accessHandle() {
         if (handle == null) {
             // this store to stable field is safe, because return value of 'makeMemoryAccessVarHandle' has stable identity
-            handle = Utils.makeMemoryAccessVarHandle(this);
+            handle = Utils.makeSegmentViewVarHandle(this);
         }
         return handle;
     }

--- a/src/java.base/share/classes/java/lang/foreign/package-info.java
+++ b/src/java.base/share/classes/java/lang/foreign/package-info.java
@@ -31,14 +31,12 @@
  *
  * <p>
  * The main abstraction introduced to support foreign memory access is {@link java.lang.foreign.MemorySegment}, which
- * models a contiguous memory region, which can reside either inside or outside the Java heap.
- * A memory segment represents the main access coordinate of a memory access var handle, which can be obtained
- * using the combinator methods defined in the {@link java.lang.invoke.MethodHandles} class; a set of
- * common dereference and copy operations is provided also by the {@link java.lang.foreign.MemorySegment} class, which can
- * be useful for simple, non-structured access. Finally, the {@link java.lang.foreign.MemoryLayout} class
- * hierarchy enables description of <em>memory layouts</em> and basic operations such as computing the size in bytes of a given
- * layout, obtain its alignment requirements, and so on. Memory layouts also provide an alternate, more abstract way, to produce
- * memory access var handles, e.g. using <a href="MemoryLayout.html#layout-paths"><em>layout paths</em></a>.
+ * models a contiguous memory region, which can reside either inside or outside the Java heap. Moreover,
+ * the {@link java.lang.foreign.MemoryLayout} class hierarchy enables description of <em>memory layouts</em>
+ * and basic operations such as computing the size in bytes of a given layout, obtain its alignment requirements.
+ * Memory layouts also provide an alternate, more abstract way, to <a href=MemorySegment.html#segment-deref>dereference memory segments</a>
+ * using {@linkplain java.lang.foreign.MemoryLayout#varHandle(java.lang.foreign.MemoryLayout.PathElement...) access var handles},
+ * which can be computed using <a href="MemoryLayout.html#layout-paths"><em>layout paths</em></a>.
  *
  * For example, to allocate an off-heap memory region big enough to hold 10 values of the primitive type {@code int}, and fill it with values
  * ranging from {@code 0} to {@code 9}, we can use the following code:

--- a/src/java.base/share/classes/java/lang/foreign/package-info.java
+++ b/src/java.base/share/classes/java/lang/foreign/package-info.java
@@ -31,10 +31,10 @@
  *
  * <p>
  * The main abstraction introduced to support foreign memory access is {@link java.lang.foreign.MemorySegment}, which
- * models a contiguous memory region, which can reside either inside or outside the Java heap. Moreover,
- * the {@link java.lang.foreign.MemoryLayout} class hierarchy enables description of <em>memory layouts</em>
- * and basic operations such as computing the size in bytes of a given layout, obtain its alignment requirements.
- * Memory layouts also provide an alternate, more abstract way, to <a href=MemorySegment.html#segment-deref>dereference memory segments</a>
+ * models a contiguous memory region, residing either inside or outside the Java heap. The contents of a memory
+ * segment can be described using a {@link java.lang.foreign.MemoryLayout memory layout}, which provides
+ * basic operations to query sizes, offsets and alignment constraints. Memory layouts also provide
+ * an alternate, more abstract way, to <a href=MemorySegment.html#segment-deref>dereference memory segments</a>
  * using {@linkplain java.lang.foreign.MemoryLayout#varHandle(java.lang.foreign.MemoryLayout.PathElement...) access var handles},
  * which can be computed using <a href="MemoryLayout.html#layout-paths"><em>layout paths</em></a>.
  *

--- a/src/java.base/share/classes/java/lang/invoke/MethodHandleImpl.java
+++ b/src/java.base/share/classes/java/lang/invoke/MethodHandleImpl.java
@@ -1580,8 +1580,8 @@ abstract class MethodHandleImpl {
             }
 
             @Override
-            public VarHandle memoryAccessVarHandle(Class<?> carrier, long alignmentMask, ByteOrder order) {
-                return VarHandles.makeMemoryAddressViewHandle(carrier, alignmentMask, order);
+            public VarHandle memorySegmentViewHandle(Class<?> carrier, long alignmentMask, ByteOrder order) {
+                return VarHandles.memorySegmentViewHandle(carrier, alignmentMask, order);
             }
 
             @Override

--- a/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
+++ b/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
@@ -7867,7 +7867,8 @@ assertEquals("boojum", (String) catTrace.invokeExact("boo", "jum"));
     }
 
     /**
-     * Creates a <i>memory access var handle</i> from the given value layout.
+     * Creates a var handle object, which can be used to dereference a {@linkplain java.lang.foreign.MemorySegment memory segment}
+     * by viewing its contents as a sequence of the provided value layout.
      *
      * <p>The provided layout specifies the {@linkplain ValueLayout#carrier() carrier type},
      * the {@linkplain ValueLayout#byteSize() byte size},
@@ -7878,7 +7879,7 @@ assertEquals("boojum", (String) catTrace.invokeExact("boo", "jum"));
      * {@code (MemorySegment, long)}, where the {@code long} coordinate type corresponds to byte offset into
      * a given memory segment. The returned var handle accesses bytes at an offset in a given
      * memory segment, composing bytes to or from a value of the type {@code carrier} according to the given endianness;
-     * the alignment constraint (in bytes) for the resulting memory access var handle is given by {@code alignmentBytes}.
+     * the alignment constraint (in bytes) for the resulting var handle is given by {@code alignmentBytes}.
      *
      * <p>As an example, consider the memory layout expressed by a {@link GroupLayout} instance constructed as follows:
      * <blockquote><pre>{@code
@@ -7887,14 +7888,14 @@ assertEquals("boojum", (String) catTrace.invokeExact("boo", "jum"));
      *             ValueLayout.JAVA_INT.withOrder(ByteOrder.BIG_ENDIAN).withName("value")
      *     );
      * }</pre></blockquote>
-     * To access the member layout named {@code value}, we can construct a memory access var handle as follows:
+     * To access the member layout named {@code value}, we can construct a memory segment view var handle as follows:
      * <blockquote><pre>{@code
-     *     VarHandle handle = MethodHandles.memoryAccessVarHandle(ValueLayout.JAVA_INT.withOrder(ByteOrder.BIG_ENDIAN)); //(MemorySegment, long) -> int
+     *     VarHandle handle = MethodHandles.memorySegmentViewVarHandle(ValueLayout.JAVA_INT.withOrder(ByteOrder.BIG_ENDIAN)); //(MemorySegment, long) -> int
      *     handle = MethodHandles.insertCoordinates(handle, 1, 4); //(MemorySegment) -> int
      * }</pre></blockquote>
      *
      * @apiNote The resulting var handle features certain <i>access mode restrictions</i>,
-     * which are common to all memory access var handles. A memory access var handle is associated
+     * which are common to all memory segment view var handles. A memory segment view var handle is associated
      * with an access size {@code S} and an alignment constraint {@code B}
      * (both expressed in bytes). We say that a memory access operation is <em>fully aligned</em> if it occurs
      * at a memory address {@code A} which is compatible with both alignment constraints {@code S} and {@code B}.
@@ -7930,15 +7931,15 @@ assertEquals("boojum", (String) catTrace.invokeExact("boo", "jum"));
      * {@code IllegalStateException} is thrown, irrespective of the access mode being used.
      *
      * @param layout the value layout for which a memory access handle is to be obtained.
-     * @return the new memory access var handle.
+     * @return the new memory segment view var handle.
      * @throws IllegalArgumentException if an illegal carrier type is used, or if {@code alignmentBytes} is not a power of two.
      * @throws NullPointerException if {@code layout} is {@code null}.
      * @since 19
      */
     @PreviewFeature(feature=PreviewFeature.Feature.FOREIGN)
-    public static VarHandle memoryAccessVarHandle(ValueLayout layout) {
+    public static VarHandle memorySegmentViewVarHandle(ValueLayout layout) {
         Objects.requireNonNull(layout);
-        return Utils.makeMemoryAccessVarHandle(layout);
+        return Utils.makeSegmentViewVarHandle(layout);
     }
 
     /**

--- a/src/java.base/share/classes/java/lang/invoke/VarHandleSegmentViewBase.java
+++ b/src/java.base/share/classes/java/lang/invoke/VarHandleSegmentViewBase.java
@@ -26,9 +26,9 @@
 package java.lang.invoke;
 
 /**
- * Base class for memory access var handle implementations.
+ * Base class for memory segment var handle view implementations.
  */
-abstract class MemoryAccessVarHandleBase extends VarHandle {
+abstract class VarHandleSegmentViewBase extends VarHandle {
 
     /** endianness **/
     final boolean be;
@@ -39,7 +39,7 @@ abstract class MemoryAccessVarHandleBase extends VarHandle {
     /** alignment constraint (in bytes, expressed as a bit mask) **/
     final long alignmentMask;
 
-    MemoryAccessVarHandleBase(VarForm form, boolean be, long length, long alignmentMask, boolean exact) {
+    VarHandleSegmentViewBase(VarForm form, boolean be, long length, long alignmentMask, boolean exact) {
         super(form, exact);
         this.be = be;
         this.length = length;

--- a/src/java.base/share/classes/java/lang/invoke/VarHandles.java
+++ b/src/java.base/share/classes/java/lang/invoke/VarHandles.java
@@ -300,22 +300,18 @@ final class VarHandles {
     }
 
     /**
-     * Creates a memory access VarHandle.
+     * Creates a memory segment view var handle.
      *
-     * Resulting VarHandle will take a memory address as first argument,
-     * and a certain number of coordinate {@code long} parameters, depending on the length
-     * of the {@code strides} argument array.
-     *
-     * Coordinates are multiplied with corresponding scale factors ({@code strides}) and added
-     * to a single fixed offset to compute an effective offset from the given MemoryAddress for the access.
+     * Resulting var handle will take a memory segment as first argument (the segment to be dereferenced),
+     * and a {@code long} as second argument (the offset into the segment).
      *
      * @param carrier the Java carrier type.
      * @param alignmentMask alignment requirement to be checked upon access. In bytes. Expressed as a mask.
      * @param byteOrder the byte order.
      * @return the created VarHandle.
      */
-    static VarHandle makeMemoryAddressViewHandle(Class<?> carrier, long alignmentMask,
-                                                 ByteOrder byteOrder) {
+    static VarHandle memorySegmentViewHandle(Class<?> carrier, long alignmentMask,
+                                             ByteOrder byteOrder) {
         if (!carrier.isPrimitive() || carrier == void.class || carrier == boolean.class) {
             throw new IllegalArgumentException("Invalid carrier: " + carrier.getName());
         }
@@ -324,19 +320,19 @@ final class VarHandles {
         boolean exact = false;
 
         if (carrier == byte.class) {
-            return maybeAdapt(new MemoryAccessVarHandleByteHelper(be, size, alignmentMask, exact));
+            return maybeAdapt(new VarHandleSegmentAsBytes(be, size, alignmentMask, exact));
         } else if (carrier == char.class) {
-            return maybeAdapt(new MemoryAccessVarHandleCharHelper(be, size, alignmentMask, exact));
+            return maybeAdapt(new VarHandleSegmentAsChars(be, size, alignmentMask, exact));
         } else if (carrier == short.class) {
-            return maybeAdapt(new MemoryAccessVarHandleShortHelper(be, size, alignmentMask, exact));
+            return maybeAdapt(new VarHandleSegmentAsShorts(be, size, alignmentMask, exact));
         } else if (carrier == int.class) {
-            return maybeAdapt(new MemoryAccessVarHandleIntHelper(be, size, alignmentMask, exact));
+            return maybeAdapt(new VarHandleSegmentAsInts(be, size, alignmentMask, exact));
         } else if (carrier == float.class) {
-            return maybeAdapt(new MemoryAccessVarHandleFloatHelper(be, size, alignmentMask, exact));
+            return maybeAdapt(new VarHandleSegmentAsFloats(be, size, alignmentMask, exact));
         } else if (carrier == long.class) {
-            return maybeAdapt(new MemoryAccessVarHandleLongHelper(be, size, alignmentMask, exact));
+            return maybeAdapt(new VarHandleSegmentAsLongs(be, size, alignmentMask, exact));
         } else if (carrier == double.class) {
-            return maybeAdapt(new MemoryAccessVarHandleDoubleHelper(be, size, alignmentMask, exact));
+            return maybeAdapt(new VarHandleSegmentAsDoubles(be, size, alignmentMask, exact));
         } else {
             throw new IllegalStateException("Cannot get here");
         }

--- a/src/java.base/share/classes/java/lang/invoke/VarHandles.java
+++ b/src/java.base/share/classes/java/lang/invoke/VarHandles.java
@@ -302,7 +302,7 @@ final class VarHandles {
     /**
      * Creates a memory segment view var handle.
      *
-     * Resulting var handle will take a memory segment as first argument (the segment to be dereferenced),
+     * The resulting var handle will take a memory segment as first argument (the segment to be dereferenced),
      * and a {@code long} as second argument (the offset into the segment).
      *
      * @param carrier the Java carrier type.

--- a/src/java.base/share/classes/java/lang/invoke/X-VarHandleSegmentView.java.template
+++ b/src/java.base/share/classes/java/lang/invoke/X-VarHandleSegmentView.java.template
@@ -37,7 +37,7 @@ import static java.lang.invoke.MethodHandleStatics.UNSAFE;
 
 #warn
 
-final class MemoryAccessVarHandle$Type$Helper extends MemoryAccessVarHandleBase {
+final class VarHandleSegmentAs$Type$s extends VarHandleSegmentViewBase {
 
     static final boolean BE = UNSAFE.isBigEndian();
 
@@ -45,9 +45,9 @@ final class MemoryAccessVarHandle$Type$Helper extends MemoryAccessVarHandleBase 
 
     static final int VM_ALIGN = $BoxType$.BYTES - 1;
 
-    static final VarForm FORM = new VarForm(MemoryAccessVarHandle$Type$Helper.class, MemorySegment.class, $type$.class, long.class);
+    static final VarForm FORM = new VarForm(VarHandleSegmentAs$Type$s.class, MemorySegment.class, $type$.class, long.class);
 
-    MemoryAccessVarHandle$Type$Helper(boolean be, long length, long alignmentMask, boolean exact) {
+    VarHandleSegmentAs$Type$s(boolean be, long length, long alignmentMask, boolean exact) {
         super(FORM, be, length, alignmentMask, exact);
     }
 
@@ -57,17 +57,17 @@ final class MemoryAccessVarHandle$Type$Helper extends MemoryAccessVarHandleBase 
     }
 
     @Override
-    public MemoryAccessVarHandle$Type$Helper withInvokeExactBehavior() {
+    public VarHandleSegmentAs$Type$s withInvokeExactBehavior() {
         return hasInvokeExactBehavior() ?
                 this :
-                new MemoryAccessVarHandle$Type$Helper(be, length, alignmentMask, true);
+                new VarHandleSegmentAs$Type$s(be, length, alignmentMask, true);
     }
 
     @Override
-    public MemoryAccessVarHandle$Type$Helper withInvokeBehavior() {
+    public VarHandleSegmentAs$Type$s withInvokeBehavior() {
         return !hasInvokeExactBehavior() ?
                 this :
-                new MemoryAccessVarHandle$Type$Helper(be, length, alignmentMask, false);
+                new VarHandleSegmentAs$Type$s(be, length, alignmentMask, false);
     }
 
 #if[floatingPoint]
@@ -107,7 +107,7 @@ final class MemoryAccessVarHandle$Type$Helper extends MemoryAccessVarHandleBase 
     static long offset(AbstractMemorySegmentImpl bb, long offset, long alignmentMask) {
         long address = offsetNoVMAlignCheck(bb, offset, alignmentMask);
         if ((address & VM_ALIGN) != 0) {
-            throw MemoryAccessVarHandleBase.newIllegalArgumentExceptionForMisalignedAccess(address);
+            throw VarHandleSegmentViewBase.newIllegalArgumentExceptionForMisalignedAccess(address);
         }
         return address;
     }
@@ -118,14 +118,14 @@ final class MemoryAccessVarHandle$Type$Helper extends MemoryAccessVarHandleBase 
         long address = base + offset;
         long maxAlignMask = bb.maxAlignMask();
         if (((address | maxAlignMask) & alignmentMask) != 0) {
-            throw MemoryAccessVarHandleBase.newIllegalArgumentExceptionForMisalignedAccess(address);
+            throw VarHandleSegmentViewBase.newIllegalArgumentExceptionForMisalignedAccess(address);
         }
         return address;
     }
 
     @ForceInline
     static $type$ get(VarHandle ob, Object obb, long base) {
-        MemoryAccessVarHandleBase handle = (MemoryAccessVarHandleBase)ob;
+        VarHandleSegmentViewBase handle = (VarHandleSegmentViewBase)ob;
         AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, true);
 #if[floatingPoint]
         $rawType$ rawValue = SCOPED_MEMORY_ACCESS.get$RawType$Unaligned(bb.sessionImpl(),
@@ -149,7 +149,7 @@ final class MemoryAccessVarHandle$Type$Helper extends MemoryAccessVarHandleBase 
 
     @ForceInline
     static void set(VarHandle ob, Object obb, long base, $type$ value) {
-        MemoryAccessVarHandleBase handle = (MemoryAccessVarHandleBase)ob;
+        VarHandleSegmentViewBase handle = (VarHandleSegmentViewBase)ob;
         AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, false);
 #if[floatingPoint]
         SCOPED_MEMORY_ACCESS.put$RawType$Unaligned(bb.sessionImpl(),
@@ -175,7 +175,7 @@ final class MemoryAccessVarHandle$Type$Helper extends MemoryAccessVarHandleBase 
 
     @ForceInline
     static $type$ getVolatile(VarHandle ob, Object obb, long base) {
-        MemoryAccessVarHandleBase handle = (MemoryAccessVarHandleBase)ob;
+        VarHandleSegmentViewBase handle = (VarHandleSegmentViewBase)ob;
         AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, true);
         return convEndian(handle.be,
                           SCOPED_MEMORY_ACCESS.get$RawType$Volatile(bb.sessionImpl(),
@@ -185,7 +185,7 @@ final class MemoryAccessVarHandle$Type$Helper extends MemoryAccessVarHandleBase 
 
     @ForceInline
     static void setVolatile(VarHandle ob, Object obb, long base, $type$ value) {
-        MemoryAccessVarHandleBase handle = (MemoryAccessVarHandleBase)ob;
+        VarHandleSegmentViewBase handle = (VarHandleSegmentViewBase)ob;
         AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, false);
         SCOPED_MEMORY_ACCESS.put$RawType$Volatile(bb.sessionImpl(),
                 bb.unsafeGetBase(),
@@ -195,7 +195,7 @@ final class MemoryAccessVarHandle$Type$Helper extends MemoryAccessVarHandleBase 
 
     @ForceInline
     static $type$ getAcquire(VarHandle ob, Object obb, long base) {
-        MemoryAccessVarHandleBase handle = (MemoryAccessVarHandleBase)ob;
+        VarHandleSegmentViewBase handle = (VarHandleSegmentViewBase)ob;
         AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, true);
         return convEndian(handle.be,
                           SCOPED_MEMORY_ACCESS.get$RawType$Acquire(bb.sessionImpl(),
@@ -205,7 +205,7 @@ final class MemoryAccessVarHandle$Type$Helper extends MemoryAccessVarHandleBase 
 
     @ForceInline
     static void setRelease(VarHandle ob, Object obb, long base, $type$ value) {
-        MemoryAccessVarHandleBase handle = (MemoryAccessVarHandleBase)ob;
+        VarHandleSegmentViewBase handle = (VarHandleSegmentViewBase)ob;
         AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, false);
         SCOPED_MEMORY_ACCESS.put$RawType$Release(bb.sessionImpl(),
                 bb.unsafeGetBase(),
@@ -215,7 +215,7 @@ final class MemoryAccessVarHandle$Type$Helper extends MemoryAccessVarHandleBase 
 
     @ForceInline
     static $type$ getOpaque(VarHandle ob, Object obb, long base) {
-        MemoryAccessVarHandleBase handle = (MemoryAccessVarHandleBase)ob;
+        VarHandleSegmentViewBase handle = (VarHandleSegmentViewBase)ob;
         AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, true);
         return convEndian(handle.be,
                           SCOPED_MEMORY_ACCESS.get$RawType$Opaque(bb.sessionImpl(),
@@ -225,7 +225,7 @@ final class MemoryAccessVarHandle$Type$Helper extends MemoryAccessVarHandleBase 
 
     @ForceInline
     static void setOpaque(VarHandle ob, Object obb, long base, $type$ value) {
-        MemoryAccessVarHandleBase handle = (MemoryAccessVarHandleBase)ob;
+        VarHandleSegmentViewBase handle = (VarHandleSegmentViewBase)ob;
         AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, false);
         SCOPED_MEMORY_ACCESS.put$RawType$Opaque(bb.sessionImpl(),
                 bb.unsafeGetBase(),
@@ -236,7 +236,7 @@ final class MemoryAccessVarHandle$Type$Helper extends MemoryAccessVarHandleBase 
 
     @ForceInline
     static boolean compareAndSet(VarHandle ob, Object obb, long base, $type$ expected, $type$ value) {
-        MemoryAccessVarHandleBase handle = (MemoryAccessVarHandleBase)ob;
+        VarHandleSegmentViewBase handle = (VarHandleSegmentViewBase)ob;
         AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, false);
         return SCOPED_MEMORY_ACCESS.compareAndSet$RawType$(bb.sessionImpl(),
                 bb.unsafeGetBase(),
@@ -246,7 +246,7 @@ final class MemoryAccessVarHandle$Type$Helper extends MemoryAccessVarHandleBase 
 
     @ForceInline
     static $type$ compareAndExchange(VarHandle ob, Object obb, long base, $type$ expected, $type$ value) {
-        MemoryAccessVarHandleBase handle = (MemoryAccessVarHandleBase)ob;
+        VarHandleSegmentViewBase handle = (VarHandleSegmentViewBase)ob;
         AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, false);
         return convEndian(handle.be,
                           SCOPED_MEMORY_ACCESS.compareAndExchange$RawType$(bb.sessionImpl(),
@@ -257,7 +257,7 @@ final class MemoryAccessVarHandle$Type$Helper extends MemoryAccessVarHandleBase 
 
     @ForceInline
     static $type$ compareAndExchangeAcquire(VarHandle ob, Object obb, long base, $type$ expected, $type$ value) {
-        MemoryAccessVarHandleBase handle = (MemoryAccessVarHandleBase)ob;
+        VarHandleSegmentViewBase handle = (VarHandleSegmentViewBase)ob;
         AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, false);
         return convEndian(handle.be,
                           SCOPED_MEMORY_ACCESS.compareAndExchange$RawType$Acquire(bb.sessionImpl(),
@@ -268,7 +268,7 @@ final class MemoryAccessVarHandle$Type$Helper extends MemoryAccessVarHandleBase 
 
     @ForceInline
     static $type$ compareAndExchangeRelease(VarHandle ob, Object obb, long base, $type$ expected, $type$ value) {
-        MemoryAccessVarHandleBase handle = (MemoryAccessVarHandleBase)ob;
+        VarHandleSegmentViewBase handle = (VarHandleSegmentViewBase)ob;
         AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, false);
         return convEndian(handle.be,
                           SCOPED_MEMORY_ACCESS.compareAndExchange$RawType$Release(bb.sessionImpl(),
@@ -279,7 +279,7 @@ final class MemoryAccessVarHandle$Type$Helper extends MemoryAccessVarHandleBase 
 
     @ForceInline
     static boolean weakCompareAndSetPlain(VarHandle ob, Object obb, long base, $type$ expected, $type$ value) {
-        MemoryAccessVarHandleBase handle = (MemoryAccessVarHandleBase)ob;
+        VarHandleSegmentViewBase handle = (VarHandleSegmentViewBase)ob;
         AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, false);
         return SCOPED_MEMORY_ACCESS.weakCompareAndSet$RawType$Plain(bb.sessionImpl(),
                 bb.unsafeGetBase(),
@@ -289,7 +289,7 @@ final class MemoryAccessVarHandle$Type$Helper extends MemoryAccessVarHandleBase 
 
     @ForceInline
     static boolean weakCompareAndSet(VarHandle ob, Object obb, long base, $type$ expected, $type$ value) {
-        MemoryAccessVarHandleBase handle = (MemoryAccessVarHandleBase)ob;
+        VarHandleSegmentViewBase handle = (VarHandleSegmentViewBase)ob;
         AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, false);
         return SCOPED_MEMORY_ACCESS.weakCompareAndSet$RawType$(bb.sessionImpl(),
                 bb.unsafeGetBase(),
@@ -299,7 +299,7 @@ final class MemoryAccessVarHandle$Type$Helper extends MemoryAccessVarHandleBase 
 
     @ForceInline
     static boolean weakCompareAndSetAcquire(VarHandle ob, Object obb, long base, $type$ expected, $type$ value) {
-        MemoryAccessVarHandleBase handle = (MemoryAccessVarHandleBase)ob;
+        VarHandleSegmentViewBase handle = (VarHandleSegmentViewBase)ob;
         AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, false);
         return SCOPED_MEMORY_ACCESS.weakCompareAndSet$RawType$Acquire(bb.sessionImpl(),
                 bb.unsafeGetBase(),
@@ -309,7 +309,7 @@ final class MemoryAccessVarHandle$Type$Helper extends MemoryAccessVarHandleBase 
 
     @ForceInline
     static boolean weakCompareAndSetRelease(VarHandle ob, Object obb, long base, $type$ expected, $type$ value) {
-        MemoryAccessVarHandleBase handle = (MemoryAccessVarHandleBase)ob;
+        VarHandleSegmentViewBase handle = (VarHandleSegmentViewBase)ob;
         AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, false);
         return SCOPED_MEMORY_ACCESS.weakCompareAndSet$RawType$Release(bb.sessionImpl(),
                 bb.unsafeGetBase(),
@@ -319,7 +319,7 @@ final class MemoryAccessVarHandle$Type$Helper extends MemoryAccessVarHandleBase 
 
     @ForceInline
     static $type$ getAndSet(VarHandle ob, Object obb, long base, $type$ value) {
-        MemoryAccessVarHandleBase handle = (MemoryAccessVarHandleBase)ob;
+        VarHandleSegmentViewBase handle = (VarHandleSegmentViewBase)ob;
         AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, false);
         return convEndian(handle.be,
                           SCOPED_MEMORY_ACCESS.getAndSet$RawType$(bb.sessionImpl(),
@@ -330,7 +330,7 @@ final class MemoryAccessVarHandle$Type$Helper extends MemoryAccessVarHandleBase 
 
     @ForceInline
     static $type$ getAndSetAcquire(VarHandle ob, Object obb, long base, $type$ value) {
-        MemoryAccessVarHandleBase handle = (MemoryAccessVarHandleBase)ob;
+        VarHandleSegmentViewBase handle = (VarHandleSegmentViewBase)ob;
         AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, false);
         return convEndian(handle.be,
                           SCOPED_MEMORY_ACCESS.getAndSet$RawType$Acquire(bb.sessionImpl(),
@@ -341,7 +341,7 @@ final class MemoryAccessVarHandle$Type$Helper extends MemoryAccessVarHandleBase 
 
     @ForceInline
     static $type$ getAndSetRelease(VarHandle ob, Object obb, long base, $type$ value) {
-        MemoryAccessVarHandleBase handle = (MemoryAccessVarHandleBase)ob;
+        VarHandleSegmentViewBase handle = (VarHandleSegmentViewBase)ob;
         AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, false);
         return convEndian(handle.be,
                           SCOPED_MEMORY_ACCESS.getAndSet$RawType$Release(bb.sessionImpl(),
@@ -354,7 +354,7 @@ final class MemoryAccessVarHandle$Type$Helper extends MemoryAccessVarHandleBase 
 
     @ForceInline
     static $type$ getAndAdd(VarHandle ob, Object obb, long base, $type$ delta) {
-        MemoryAccessVarHandleBase handle = (MemoryAccessVarHandleBase)ob;
+        VarHandleSegmentViewBase handle = (VarHandleSegmentViewBase)ob;
         AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, false);
         if (handle.be == BE) {
             return SCOPED_MEMORY_ACCESS.getAndAdd$RawType$(bb.sessionImpl(),
@@ -368,7 +368,7 @@ final class MemoryAccessVarHandle$Type$Helper extends MemoryAccessVarHandleBase 
 
     @ForceInline
     static $type$ getAndAddAcquire(VarHandle ob, Object obb, long base, $type$ delta) {
-        MemoryAccessVarHandleBase handle = (MemoryAccessVarHandleBase)ob;
+        VarHandleSegmentViewBase handle = (VarHandleSegmentViewBase)ob;
         AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, false);
         if (handle.be == BE) {
             return SCOPED_MEMORY_ACCESS.getAndAdd$RawType$Acquire(bb.sessionImpl(),
@@ -382,7 +382,7 @@ final class MemoryAccessVarHandle$Type$Helper extends MemoryAccessVarHandleBase 
 
     @ForceInline
     static $type$ getAndAddRelease(VarHandle ob, Object obb, long base, $type$ delta) {
-        MemoryAccessVarHandleBase handle = (MemoryAccessVarHandleBase)ob;
+        VarHandleSegmentViewBase handle = (VarHandleSegmentViewBase)ob;
         AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, false);
         if (handle.be == BE) {
             return SCOPED_MEMORY_ACCESS.getAndAdd$RawType$Release(bb.sessionImpl(),
@@ -410,7 +410,7 @@ final class MemoryAccessVarHandle$Type$Helper extends MemoryAccessVarHandleBase 
 
     @ForceInline
     static $type$ getAndBitwiseOr(VarHandle ob, Object obb, long base, $type$ value) {
-        MemoryAccessVarHandleBase handle = (MemoryAccessVarHandleBase)ob;
+        VarHandleSegmentViewBase handle = (VarHandleSegmentViewBase)ob;
         AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, false);
         if (handle.be == BE) {
             return SCOPED_MEMORY_ACCESS.getAndBitwiseOr$RawType$(bb.sessionImpl(),
@@ -424,7 +424,7 @@ final class MemoryAccessVarHandle$Type$Helper extends MemoryAccessVarHandleBase 
 
     @ForceInline
     static $type$ getAndBitwiseOrRelease(VarHandle ob, Object obb, long base, $type$ value) {
-        MemoryAccessVarHandleBase handle = (MemoryAccessVarHandleBase)ob;
+        VarHandleSegmentViewBase handle = (VarHandleSegmentViewBase)ob;
         AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, false);
         if (handle.be == BE) {
             return SCOPED_MEMORY_ACCESS.getAndBitwiseOr$RawType$Release(bb.sessionImpl(),
@@ -438,7 +438,7 @@ final class MemoryAccessVarHandle$Type$Helper extends MemoryAccessVarHandleBase 
 
     @ForceInline
     static $type$ getAndBitwiseOrAcquire(VarHandle ob, Object obb, long base, $type$ value) {
-        MemoryAccessVarHandleBase handle = (MemoryAccessVarHandleBase)ob;
+        VarHandleSegmentViewBase handle = (VarHandleSegmentViewBase)ob;
         AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, false);
         if (handle.be == BE) {
             return SCOPED_MEMORY_ACCESS.getAndBitwiseOr$RawType$Acquire(bb.sessionImpl(),
@@ -464,7 +464,7 @@ final class MemoryAccessVarHandle$Type$Helper extends MemoryAccessVarHandleBase 
 
     @ForceInline
     static $type$ getAndBitwiseAnd(VarHandle ob, Object obb, long base, $type$ value) {
-        MemoryAccessVarHandleBase handle = (MemoryAccessVarHandleBase)ob;
+        VarHandleSegmentViewBase handle = (VarHandleSegmentViewBase)ob;
         AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, false);
         if (handle.be == BE) {
             return SCOPED_MEMORY_ACCESS.getAndBitwiseAnd$RawType$(bb.sessionImpl(),
@@ -478,7 +478,7 @@ final class MemoryAccessVarHandle$Type$Helper extends MemoryAccessVarHandleBase 
 
     @ForceInline
     static $type$ getAndBitwiseAndRelease(VarHandle ob, Object obb, long base, $type$ value) {
-        MemoryAccessVarHandleBase handle = (MemoryAccessVarHandleBase)ob;
+        VarHandleSegmentViewBase handle = (VarHandleSegmentViewBase)ob;
         AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, false);
         if (handle.be == BE) {
             return SCOPED_MEMORY_ACCESS.getAndBitwiseAnd$RawType$Release(bb.sessionImpl(),
@@ -492,7 +492,7 @@ final class MemoryAccessVarHandle$Type$Helper extends MemoryAccessVarHandleBase 
 
     @ForceInline
     static $type$ getAndBitwiseAndAcquire(VarHandle ob, Object obb, long base, $type$ value) {
-        MemoryAccessVarHandleBase handle = (MemoryAccessVarHandleBase)ob;
+        VarHandleSegmentViewBase handle = (VarHandleSegmentViewBase)ob;
         AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, false);
         if (handle.be == BE) {
             return SCOPED_MEMORY_ACCESS.getAndBitwiseAnd$RawType$Acquire(bb.sessionImpl(),
@@ -519,7 +519,7 @@ final class MemoryAccessVarHandle$Type$Helper extends MemoryAccessVarHandleBase 
 
     @ForceInline
     static $type$ getAndBitwiseXor(VarHandle ob, Object obb, long base, $type$ value) {
-        MemoryAccessVarHandleBase handle = (MemoryAccessVarHandleBase)ob;
+        VarHandleSegmentViewBase handle = (VarHandleSegmentViewBase)ob;
         AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, false);
         if (handle.be == BE) {
             return SCOPED_MEMORY_ACCESS.getAndBitwiseXor$RawType$(bb.sessionImpl(),
@@ -533,7 +533,7 @@ final class MemoryAccessVarHandle$Type$Helper extends MemoryAccessVarHandleBase 
 
     @ForceInline
     static $type$ getAndBitwiseXorRelease(VarHandle ob, Object obb, long base, $type$ value) {
-        MemoryAccessVarHandleBase handle = (MemoryAccessVarHandleBase)ob;
+        VarHandleSegmentViewBase handle = (VarHandleSegmentViewBase)ob;
         AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, false);
         if (handle.be == BE) {
             return SCOPED_MEMORY_ACCESS.getAndBitwiseXor$RawType$Release(bb.sessionImpl(),
@@ -547,7 +547,7 @@ final class MemoryAccessVarHandle$Type$Helper extends MemoryAccessVarHandleBase 
 
     @ForceInline
     static $type$ getAndBitwiseXorAcquire(VarHandle ob, Object obb, long base, $type$ value) {
-        MemoryAccessVarHandleBase handle = (MemoryAccessVarHandleBase)ob;
+        VarHandleSegmentViewBase handle = (VarHandleSegmentViewBase)ob;
         AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, false);
         if (handle.be == BE) {
             return SCOPED_MEMORY_ACCESS.getAndBitwiseXor$RawType$Acquire(bb.sessionImpl(),

--- a/src/java.base/share/classes/jdk/internal/access/JavaLangInvokeAccess.java
+++ b/src/java.base/share/classes/jdk/internal/access/JavaLangInvokeAccess.java
@@ -82,11 +82,11 @@ public interface JavaLangInvokeAccess {
     Map<String, byte[]> generateHolderClasses(Stream<String> traces);
 
     /**
-     * Returns a var handle view of a given memory address.
+     * Returns a var handle view of a given memory segment.
      * Used by {@code jdk.internal.foreign.LayoutPath} and
      * {@code java.lang.invoke.MethodHandles}.
      */
-    VarHandle memoryAccessVarHandle(Class<?> carrier, long alignmentMask, ByteOrder order);
+    VarHandle memorySegmentViewHandle(Class<?> carrier, long alignmentMask, ByteOrder order);
 
     /**
      * Var handle carrier combinator.

--- a/src/java.base/share/classes/jdk/internal/foreign/LayoutPath.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/LayoutPath.java
@@ -46,7 +46,7 @@ import java.util.function.UnaryOperator;
  * a path can be constructed by selecting layout elements using the selector methods provided by this class
  * (see {@link #sequenceElement()}, {@link #sequenceElement(long)}, {@link #sequenceElement(long, long)}, {@link #groupElement(String)}).
  * Once a path has been fully constructed, clients can ask for the offset associated with the layout element selected
- * by the path (see {@link #offset}), or obtain a memory access var handle to access the selected layout element
+ * by the path (see {@link #offset}), or obtain var handle to access the selected layout element
  * given an address pointing to a segment associated with the root layout (see {@link #dereferenceHandle()}).
  */
 public class LayoutPath {
@@ -159,7 +159,7 @@ public class LayoutPath {
         perms.addFirst(0);
         expectedCoordinates.add(MemorySegment.class);
 
-        VarHandle handle = Utils.makeMemoryAccessVarHandle(valueLayout);
+        VarHandle handle = Utils.makeSegmentViewVarHandle(valueLayout);
 
         for (int i = 0 ; i < strides.length ; i++) {
             expectedCoordinates.add(long.class);

--- a/src/java.base/share/classes/jdk/internal/foreign/Utils.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/Utils.java
@@ -98,7 +98,7 @@ public final class Utils {
         }
     }
 
-    public static VarHandle makeMemoryAccessVarHandle(ValueLayout layout) {
+    public static VarHandle makeSegmentViewVarHandle(ValueLayout layout) {
         class VarHandleCache {
             private static final Map<ValueLayout, VarHandle> handleMap = new ConcurrentHashMap<>();
 
@@ -118,7 +118,7 @@ public final class Utils {
             baseCarrier = byte.class;
         }
 
-        VarHandle handle = SharedSecrets.getJavaLangInvokeAccess().memoryAccessVarHandle(baseCarrier,
+        VarHandle handle = SharedSecrets.getJavaLangInvokeAccess().memorySegmentViewHandle(baseCarrier,
                 layout.byteAlignment() - 1, layout.order());
 
         if (layout.carrier() == boolean.class) {

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/Binding.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/Binding.java
@@ -42,9 +42,7 @@ import java.util.List;
 import java.util.Objects;
 import jdk.internal.foreign.MemoryAddressImpl;
 import jdk.internal.foreign.MemorySessionImpl;
-import static java.lang.invoke.MethodHandles.collectArguments;
-import static java.lang.invoke.MethodHandles.filterArguments;
-import static java.lang.invoke.MethodHandles.insertArguments;
+
 import static java.lang.invoke.MethodType.methodType;
 
 /**
@@ -595,7 +593,7 @@ public abstract class Binding {
             // copies of e.g. 2 int fields of a struct as a single long, while the struct is only
             // 4-byte-aligned (since it only contains ints)
             ValueLayout layout = MemoryLayout.valueLayout(type(), ByteOrder.nativeOrder()).withBitAlignment(8);
-            return MethodHandles.insertCoordinates(MethodHandles.memoryAccessVarHandle(layout), 1, offset);
+            return MethodHandles.insertCoordinates(MethodHandles.memorySegmentViewVarHandle(layout), 1, offset);
         }
     }
 

--- a/test/jdk/java/foreign/TestNulls.java
+++ b/test/jdk/java/foreign/TestNulls.java
@@ -153,7 +153,7 @@ public class TestNulls {
         addDefaultMapping(Class.class, String.class);
         addDefaultMapping(Runnable.class, () -> {});
         addDefaultMapping(Object.class, new Object());
-        addDefaultMapping(VarHandle.class, MethodHandles.memoryAccessVarHandle(JAVA_INT));
+        addDefaultMapping(VarHandle.class, MethodHandles.memorySegmentViewVarHandle(JAVA_INT));
         addDefaultMapping(MethodHandle.class, MethodHandles.identity(int.class));
         addDefaultMapping(List.class, List.of());
         addDefaultMapping(Charset.class, Charset.defaultCharset());

--- a/test/jdk/java/foreign/TestSegmentCopy.java
+++ b/test/jdk/java/foreign/TestSegmentCopy.java
@@ -129,7 +129,7 @@ public class TestSegmentCopy {
         }
 
         VarHandle handle() {
-            return MethodHandles.memoryAccessVarHandle(layout);
+            return MethodHandles.memorySegmentViewVarHandle(layout);
         }
 
         void set(SegmentSlice slice, int index, int val) {

--- a/test/jdk/java/foreign/TestVarHandleCombinators.java
+++ b/test/jdk/java/foreign/TestVarHandleCombinators.java
@@ -30,7 +30,7 @@
 
 import java.lang.foreign.MemorySession;
 import java.lang.foreign.ValueLayout;
-import org.testng.annotations.DataProvider;
+
 import org.testng.annotations.Test;
 
 import java.lang.foreign.MemorySegment;
@@ -44,7 +44,7 @@ public class TestVarHandleCombinators {
 
     @Test
     public void testElementAccess() {
-        VarHandle vh = MethodHandles.memoryAccessVarHandle(ValueLayout.JAVA_BYTE);
+        VarHandle vh = MethodHandles.memorySegmentViewVarHandle(ValueLayout.JAVA_BYTE);
 
         byte[] arr = { 0, 0, -1, 0 };
         MemorySegment segment = MemorySegment.ofArray(arr);
@@ -53,7 +53,7 @@ public class TestVarHandleCombinators {
 
     @Test(expectedExceptions = IllegalArgumentException.class)
     public void testUnalignedElement() {
-        VarHandle vh = MethodHandles.memoryAccessVarHandle(ValueLayout.JAVA_BYTE.withBitAlignment(32));
+        VarHandle vh = MethodHandles.memorySegmentViewVarHandle(ValueLayout.JAVA_BYTE.withBitAlignment(32));
         MemorySegment segment = MemorySegment.ofArray(new byte[4]);
         vh.get(segment, 2L); //should throw
         //FIXME: the VH only checks the alignment of the segment, which is fine if the VH is derived from layouts,
@@ -63,7 +63,7 @@ public class TestVarHandleCombinators {
 
     @Test
     public void testAlign() {
-        VarHandle vh = MethodHandles.memoryAccessVarHandle(ValueLayout.JAVA_BYTE.withBitAlignment(16));
+        VarHandle vh = MethodHandles.memorySegmentViewVarHandle(ValueLayout.JAVA_BYTE.withBitAlignment(16));
 
         MemorySegment segment = MemorySegment.allocateNative(1, 2, MemorySession.openImplicit());
         vh.set(segment, 0L, (byte) 10); // fine, memory region is aligned
@@ -72,7 +72,7 @@ public class TestVarHandleCombinators {
 
     @Test
     public void testByteOrderLE() {
-        VarHandle vh = MethodHandles.memoryAccessVarHandle(ValueLayout.JAVA_SHORT
+        VarHandle vh = MethodHandles.memorySegmentViewVarHandle(ValueLayout.JAVA_SHORT
                 .withOrder(ByteOrder.LITTLE_ENDIAN).withBitAlignment(8));
         byte[] arr = new byte[2];
         MemorySegment segment = MemorySegment.ofArray(arr);
@@ -83,7 +83,7 @@ public class TestVarHandleCombinators {
 
     @Test
     public void testByteOrderBE() {
-        VarHandle vh = MethodHandles.memoryAccessVarHandle(ValueLayout.JAVA_SHORT
+        VarHandle vh = MethodHandles.memorySegmentViewVarHandle(ValueLayout.JAVA_SHORT
                 .withOrder(ByteOrder.BIG_ENDIAN).withBitAlignment(8));
         byte[] arr = new byte[2];
         MemorySegment segment = MemorySegment.ofArray(arr);
@@ -99,7 +99,7 @@ public class TestVarHandleCombinators {
 
         //[10 : [5 : [x32 i32]]]
 
-        VarHandle vh = MethodHandles.memoryAccessVarHandle(ValueLayout.JAVA_INT.withBitAlignment(32));
+        VarHandle vh = MethodHandles.memorySegmentViewVarHandle(ValueLayout.JAVA_INT.withBitAlignment(32));
         int count = 0;
         try (MemorySession session = MemorySession.openConfined()) {
             MemorySegment segment = MemorySegment.allocateNative(inner_size * outer_size * 8, 4, session);

--- a/test/jdk/java/lang/invoke/VarHandles/VarHandleTestExact.java
+++ b/test/jdk/java/lang/invoke/VarHandles/VarHandleTestExact.java
@@ -169,7 +169,7 @@ public class VarHandleTestExact {
 
     @Test(dataProvider = "dataSetMemorySegment")
     public void testExactSegmentSet(Class<?> carrier, Object testValue, SetSegmentX setter) {
-        VarHandle vh = MethodHandles.memoryAccessVarHandle(MemoryLayout.valueLayout(carrier, ByteOrder.nativeOrder()));
+        VarHandle vh = MethodHandles.memorySegmentViewVarHandle(MemoryLayout.valueLayout(carrier, ByteOrder.nativeOrder()));
         try (MemorySession session = MemorySession.openConfined()) {
             MemorySegment seg = MemorySegment.allocateNative(8, session);
             doTest(vh,

--- a/test/micro/org/openjdk/bench/java/lang/foreign/VarHandleExact.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/VarHandleExact.java
@@ -37,7 +37,6 @@ import org.openjdk.jmh.annotations.Warmup;
 
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.VarHandle;
-import java.nio.ByteOrder;
 import java.util.concurrent.TimeUnit;
 
 import static java.lang.foreign.ValueLayout.JAVA_INT;
@@ -54,7 +53,7 @@ public class VarHandleExact {
     static final VarHandle generic;
 
     static {
-        generic = MethodHandles.memoryAccessVarHandle(JAVA_INT);
+        generic = MethodHandles.memorySegmentViewVarHandle(JAVA_INT);
         exact = generic.withInvokeExactBehavior();
     }
 


### PR DESCRIPTION
This patch renames `MethodHandles::memoryAccessVarHandle` to `MethodHandles:memorySegmentViewVarHandle`, which is consistent with other methods in that class like `byteArrayViewVarHandle` and `byteBufferViewVarHandle`.

When doing this, I also renamed several implementation classes and methods (included some automatically generated ones) to use the new names, and be more consistent with the naming scheme adopted for byte buffer var handle views.

Finally, I tweaked the javadoc to use the new name. When doing this, I realized that the toplevel package javadoc was diving into var handles and combinators way too soon, so I have beefed up the memory segment dereference section (in the `MemorySegment` javadoc) and added a link from the package javadoc to that section.

I'm still not 100% happy about how the memory segment javadoc looks, but for unrelated reasons, and I will deal with that in a separate pass.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [JDK-8280597](https://bugs.openjdk.java.net/browse/JDK-8280597): Refactor java.lang.invoke.MethodHandles::memoryAccessVarHandle


### Reviewers
 * [Athijegannathan Sundararajan](https://openjdk.java.net/census#sundar) (@sundararajana - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/663/head:pull/663` \
`$ git checkout pull/663`

Update a local copy of the PR: \
`$ git checkout pull/663` \
`$ git pull https://git.openjdk.java.net/panama-foreign pull/663/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 663`

View PR using the GUI difftool: \
`$ git pr show -t 663`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/panama-foreign/pull/663.diff">https://git.openjdk.java.net/panama-foreign/pull/663.diff</a>

</details>
