### PR TITLE
8282211: SegmentAllocator array factories should use varargs

### DIFF
--- a/src/java.base/share/classes/java/lang/foreign/SegmentAllocator.java
+++ b/src/java.base/share/classes/java/lang/foreign/SegmentAllocator.java
@@ -209,77 +209,77 @@ public interface SegmentAllocator {
      * Allocate a memory segment with given layout and initialize it with given byte array.
      * @implSpec the default implementation for this method calls {@code this.allocateArray(layout, array.length)}.
      * @param elementLayout the element layout of the array to be allocated.
-     * @param array the array to be copied on the newly allocated memory block.
+     * @param elements the byte elements to be copied to the newly allocated memory block.
      * @return a segment for the newly allocated memory block.
      */
-    default MemorySegment allocateArray(ValueLayout.OfByte elementLayout, byte[] array) {
-        return copyArrayWithSwapIfNeeded(array, elementLayout, MemorySegment::ofArray);
+    default MemorySegment allocateArray(ValueLayout.OfByte elementLayout, byte... elements) {
+        return copyArrayWithSwapIfNeeded(elements, elementLayout, MemorySegment::ofArray);
     }
 
     /**
      * Allocate a memory segment with given layout and initialize it with given short array.
      * @implSpec the default implementation for this method calls {@code this.allocateArray(layout, array.length)}.
      * @param elementLayout the element layout of the array to be allocated.
-     * @param array the array to be copied on the newly allocated memory block.
+     * @param elements the short elements to be copied to the newly allocated memory block.
      * @return a segment for the newly allocated memory block.
      */
-    default MemorySegment allocateArray(ValueLayout.OfShort elementLayout, short[] array) {
-        return copyArrayWithSwapIfNeeded(array, elementLayout, MemorySegment::ofArray);
+    default MemorySegment allocateArray(ValueLayout.OfShort elementLayout, short... elements) {
+        return copyArrayWithSwapIfNeeded(elements, elementLayout, MemorySegment::ofArray);
     }
 
     /**
      * Allocate a memory segment with given layout and initialize it with given char array.
      * @implSpec the default implementation for this method calls {@code this.allocateArray(layout, array.length)}.
      * @param elementLayout the element layout of the array to be allocated.
-     * @param array the array to be copied on the newly allocated memory block.
+     * @param elements the char elements to be copied to the newly allocated memory block.
      * @return a segment for the newly allocated memory block.
      */
-    default MemorySegment allocateArray(ValueLayout.OfChar elementLayout, char[] array) {
-        return copyArrayWithSwapIfNeeded(array, elementLayout, MemorySegment::ofArray);
+    default MemorySegment allocateArray(ValueLayout.OfChar elementLayout, char... elements) {
+        return copyArrayWithSwapIfNeeded(elements, elementLayout, MemorySegment::ofArray);
     }
 
     /**
      * Allocate a memory segment with given layout and initialize it with given int array.
      * @implSpec the default implementation for this method calls {@code this.allocateArray(layout, array.length)}.
      * @param elementLayout the element layout of the array to be allocated.
-     * @param array the array to be copied on the newly allocated memory block.
+     * @param elements the int elements to be copied to the newly allocated memory block.
      * @return a segment for the newly allocated memory block.
      */
-    default MemorySegment allocateArray(ValueLayout.OfInt elementLayout, int[] array) {
-        return copyArrayWithSwapIfNeeded(array, elementLayout, MemorySegment::ofArray);
+    default MemorySegment allocateArray(ValueLayout.OfInt elementLayout, int... elements) {
+        return copyArrayWithSwapIfNeeded(elements, elementLayout, MemorySegment::ofArray);
     }
 
     /**
      * Allocate a memory segment with given layout and initialize it with given float array.
      * @implSpec the default implementation for this method calls {@code this.allocateArray(layout, array.length)}.
      * @param elementLayout the element layout of the array to be allocated.
-     * @param array the array to be copied on the newly allocated memory block.
+     * @param elements the float elements to be copied to the newly allocated memory block.
      * @return a segment for the newly allocated memory block.
      */
-    default MemorySegment allocateArray(ValueLayout.OfFloat elementLayout, float[] array) {
-        return copyArrayWithSwapIfNeeded(array, elementLayout, MemorySegment::ofArray);
+    default MemorySegment allocateArray(ValueLayout.OfFloat elementLayout, float... elements) {
+        return copyArrayWithSwapIfNeeded(elements, elementLayout, MemorySegment::ofArray);
     }
 
     /**
      * Allocate a memory segment with given layout and initialize it with given long array.
      * @implSpec the default implementation for this method calls {@code this.allocateArray(layout, array.length)}.
      * @param elementLayout the element layout of the array to be allocated.
-     * @param array the array to be copied on the newly allocated memory block.
+     * @param elements the long elements to be copied to the newly allocated memory block.
      * @return a segment for the newly allocated memory block.
      */
-    default MemorySegment allocateArray(ValueLayout.OfLong elementLayout, long[] array) {
-        return copyArrayWithSwapIfNeeded(array, elementLayout, MemorySegment::ofArray);
+    default MemorySegment allocateArray(ValueLayout.OfLong elementLayout, long... elements) {
+        return copyArrayWithSwapIfNeeded(elements, elementLayout, MemorySegment::ofArray);
     }
 
     /**
      * Allocate a memory segment with given layout and initialize it with given double array.
      * @implSpec the default implementation for this method calls {@code this.allocateArray(layout, array.length)}.
      * @param elementLayout the element layout of the array to be allocated.
-     * @param array the array to be copied on the newly allocated memory block.
+     * @param elements the double elements to be copied to the newly allocated memory block.
      * @return a segment for the newly allocated memory block.
      */
-    default MemorySegment allocateArray(ValueLayout.OfDouble elementLayout, double[] array) {
-        return copyArrayWithSwapIfNeeded(array, elementLayout, MemorySegment::ofArray);
+    default MemorySegment allocateArray(ValueLayout.OfDouble elementLayout, double... elements) {
+        return copyArrayWithSwapIfNeeded(elements, elementLayout, MemorySegment::ofArray);
     }
 
     private <Z> MemorySegment copyArrayWithSwapIfNeeded(Z array, ValueLayout elementLayout,


### PR DESCRIPTION
This is a trivial patch which replaces array parameter types in `SegmentAllocator::allocateArray` methods with varargs ones.
This makes very trivial use cases of the API more compact and succint, as in:

```
MemorySegment segment = allocator.allocateArray(JAVA_INT, 1, 2, 3);
```

Of course in the general (and more common) case, passing arrays is still possible.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [JDK-8282211](https://bugs.openjdk.java.net/browse/JDK-8282211): SegmentAllocator array factories should use varargs


### Reviewers
 * [Paul Sandoz](https://openjdk.java.net/census#psandoz) (@PaulSandoz - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/664/head:pull/664` \
`$ git checkout pull/664`

Update a local copy of the PR: \
`$ git checkout pull/664` \
`$ git pull https://git.openjdk.java.net/panama-foreign pull/664/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 664`

View PR using the GUI difftool: \
`$ git pr show -t 664`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/panama-foreign/pull/664.diff">https://git.openjdk.java.net/panama-foreign/pull/664.diff</a>

</details>
