### PR TITLE
8282953: Drop MemoryLayout::map

### DIFF
--- a/src/java.base/share/classes/java/lang/foreign/MemoryLayout.java
+++ b/src/java.base/share/classes/java/lang/foreign/MemoryLayout.java
@@ -55,7 +55,10 @@ import jdk.internal.javac.PreviewFeature;
  * element layout (see {@link SequenceLayout}); a <em>group layout</em> denotes an aggregation of (typically) heterogeneous
  * member layouts (see {@link GroupLayout}).
  * <p>
- * For instance, consider the following struct declaration in C:
+ * Layouts can be optionally associated with a <em>name</em>. A layout name can be referred to when
+ * constructing <a href="MemoryLayout.html#layout-paths"><em>layout paths</em></a>.
+ * <p>
+ * Consider the following struct declaration in C:
  *
  * {@snippet lang=c :
  * typedef struct {
@@ -165,11 +168,6 @@ import jdk.internal.javac.PreviewFeature;
  * long offset1 = (long) offsetHandle.invokeExact(1L); // 8
  * long offset2 = (long) offsetHandle.invokeExact(2L); // 16
  * }
- *
- * <h2>Layout attributes</h2>
- *
- * Layouts can be optionally associated with a <em>name</em>. A layout name can be referred to when
- * constructing <a href="MemoryLayout.html#layout-paths"><em>layout paths</em></a>.
  *
  * @implSpec
  * Implementations of this interface are immutable, thread-safe and <a href="{@docRoot}/java.base/java/lang/doc-files/ValueBased.html">value-based</a>.

--- a/src/java.base/share/classes/jdk/internal/foreign/LayoutPath.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/LayoutPath.java
@@ -189,7 +189,7 @@ public class LayoutPath {
     // Layout path construction
 
     public static LayoutPath rootPath(MemoryLayout layout) {
-        return new LayoutPath(layout, 0L, EMPTY_STRIDES,null);
+        return new LayoutPath(layout, 0L, EMPTY_STRIDES, null);
     }
 
     private static LayoutPath nestedPath(MemoryLayout layout, long offset, long[] strides, LayoutPath encl) {

--- a/src/java.base/share/classes/jdk/internal/foreign/LayoutPath.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/LayoutPath.java
@@ -138,7 +138,7 @@ public class LayoutPath {
         checkAlignment(this);
 
         VarHandle handle = Utils.makeSegmentViewVarHandle(valueLayout);
-        for (int i = strides.length - 1; i >=0; i--) {
+        for (int i = strides.length - 1; i >= 0; i--) {
             MethodHandle collector = MethodHandles.insertArguments(MH_ADD_SCALED_OFFSET, 2,
                     Utils.bitsToBytesOrThrow(strides[i], IllegalArgumentException::new));
             // (J, ...) -> J to (J, J, ...) -> J

--- a/src/java.base/share/classes/jdk/internal/foreign/LayoutPath.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/LayoutPath.java
@@ -34,15 +34,10 @@ import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.MethodType;
 import java.lang.invoke.VarHandle;
-import java.util.ArrayDeque;
-import java.util.ArrayList;
-import java.util.Deque;
-import java.util.List;
-import java.util.function.ToLongFunction;
 import java.util.function.UnaryOperator;
 
 /**
- * This class provide support for constructing layout paths; that is, starting from a root path (see {@link #rootPath(MemoryLayout, ToLongFunction)},
+ * This class provide support for constructing layout paths; that is, starting from a root path (see {@link #rootPath(MemoryLayout)},
  * a path can be constructed by selecting layout elements using the selector methods provided by this class
  * (see {@link #sequenceElement()}, {@link #sequenceElement(long)}, {@link #sequenceElement(long, long)}, {@link #groupElement(String)}).
  * Once a path has been fully constructed, clients can ask for the offset associated with the layout element selected
@@ -51,17 +46,12 @@ import java.util.function.UnaryOperator;
  */
 public class LayoutPath {
 
-    private static final MethodHandle ADD_STRIDE;
     private static final MethodHandle MH_ADD_SCALED_OFFSET;
     private static final MethodHandle MH_SLICE;
-
-    private static final int UNSPECIFIED_ELEM_INDEX = -1;
 
     static {
         try {
             MethodHandles.Lookup lookup = MethodHandles.lookup();
-            ADD_STRIDE = lookup.findStatic(LayoutPath.class, "addStride",
-                    MethodType.methodType(long.class, MemorySegment.class, long.class, long.class, long.class));
             MH_ADD_SCALED_OFFSET = lookup.findStatic(LayoutPath.class, "addScaledOffset",
                     MethodType.methodType(long.class, long.class, long.class, long.class));
             MH_SLICE = lookup.findVirtual(MemorySegment.class, "asSlice",
@@ -75,16 +65,12 @@ public class LayoutPath {
     private final long offset;
     private final LayoutPath enclosing;
     private final long[] strides;
-    private final long elementIndex;
-    private final ToLongFunction<MemoryLayout> sizeFunc;
 
-    private LayoutPath(MemoryLayout layout, long offset, long[] strides, long elementIndex, LayoutPath enclosing, ToLongFunction<MemoryLayout> sizeFunc) {
+    private LayoutPath(MemoryLayout layout, long offset, long[] strides, LayoutPath enclosing) {
         this.layout = layout;
         this.offset = offset;
         this.strides = strides;
         this.enclosing = enclosing;
-        this.elementIndex = elementIndex;
-        this.sizeFunc = sizeFunc;
     }
 
     // Layout path selector methods
@@ -93,7 +79,7 @@ public class LayoutPath {
         check(SequenceLayout.class, "attempting to select a sequence element from a non-sequence layout");
         SequenceLayout seq = (SequenceLayout)layout;
         MemoryLayout elem = seq.elementLayout();
-        return LayoutPath.nestedPath(elem, offset, addStride(sizeFunc.applyAsLong(elem)), UNSPECIFIED_ELEM_INDEX, this);
+        return LayoutPath.nestedPath(elem, offset, addStride(elem.bitSize()), this);
     }
 
     public LayoutPath sequenceElement(long start, long step) {
@@ -101,9 +87,8 @@ public class LayoutPath {
         SequenceLayout seq = (SequenceLayout)layout;
         checkSequenceBounds(seq, start);
         MemoryLayout elem = seq.elementLayout();
-        long elemSize = sizeFunc.applyAsLong(elem);
-        return LayoutPath.nestedPath(elem, offset + (start * elemSize), addStride(elemSize * step),
-                UNSPECIFIED_ELEM_INDEX, this);
+        long elemSize = elem.bitSize();
+        return LayoutPath.nestedPath(elem, offset + (start * elemSize), addStride(elemSize * step), this);
     }
 
     public LayoutPath sequenceElement(long index) {
@@ -113,10 +98,10 @@ public class LayoutPath {
         long elemOffset = 0;
         if (index > 0) {
             //if index == 0, we do not depend on sequence element size, so skip
-            long elemSize = sizeFunc.applyAsLong(seq.elementLayout());
+            long elemSize = seq.elementLayout().bitSize();
             elemOffset = elemSize * index;
         }
-        return LayoutPath.nestedPath(seq.elementLayout(), offset + elemOffset, strides, index, this);
+        return LayoutPath.nestedPath(seq.elementLayout(), offset + elemOffset, strides, this);
     }
 
     public LayoutPath groupElement(String name) {
@@ -124,22 +109,20 @@ public class LayoutPath {
         GroupLayout g = (GroupLayout)layout;
         long offset = 0;
         MemoryLayout elem = null;
-        int index = -1;
         for (int i = 0; i < g.memberLayouts().size(); i++) {
             MemoryLayout l = g.memberLayouts().get(i);
             if (l.name().isPresent() &&
                 l.name().get().equals(name)) {
                 elem = l;
-                index = i;
                 break;
             } else if (g.isStruct()) {
-                offset += sizeFunc.applyAsLong(l);
+                offset += l.bitSize();
             }
         }
         if (elem == null) {
             throw badLayoutPath("cannot resolve '" + name + "' in layout " + layout);
         }
-        return LayoutPath.nestedPath(elem, this.offset + offset, strides, index, this);
+        return LayoutPath.nestedPath(elem, this.offset + offset, strides, this);
     }
 
     // Layout path projections
@@ -154,28 +137,16 @@ public class LayoutPath {
         }
         checkAlignment(this);
 
-        List<Class<?>> expectedCoordinates = new ArrayList<>();
-        Deque<Integer> perms = new ArrayDeque<>();
-        perms.addFirst(0);
-        expectedCoordinates.add(MemorySegment.class);
-
         VarHandle handle = Utils.makeSegmentViewVarHandle(valueLayout);
-
-        for (int i = 0 ; i < strides.length ; i++) {
-            expectedCoordinates.add(long.class);
-            perms.addFirst(0);
-            perms.addLast(i + 1);
-            //add stride
-            handle = MethodHandles.collectCoordinates(handle, 1 + i,
-                    MethodHandles.insertArguments(ADD_STRIDE, 1, Utils.bitsToBytesOrThrow(strides[strides.length - 1 - i], IllegalStateException::new))); // MS, long, MS_n, long_n, long
+        for (int i = strides.length - 1; i >=0; i--) {
+            MethodHandle collector = MethodHandles.insertArguments(MH_ADD_SCALED_OFFSET, 2,
+                    Utils.bitsToBytesOrThrow(strides[i], IllegalArgumentException::new));
+            // (J, ...) -> J to (J, J, ...) -> J
+            // i.e. new coord is prefixed. Last coord will correspond to innermost layout
+            handle = MethodHandles.collectCoordinates(handle, 1, collector);
         }
-        //add offset
-        handle = MethodHandles.insertCoordinates(handle, 1 + strides.length, Utils.bitsToBytesOrThrow(offset, IllegalStateException::new));
-
-        if (strides.length > 0) {
-            // remove duplicate MS args
-            handle = MethodHandles.permuteCoordinates(handle, expectedCoordinates, perms.stream().mapToInt(i -> i).toArray());
-        }
+        handle = MethodHandles.insertCoordinates(handle, 1,
+                Utils.bitsToBytesOrThrow(offset, IllegalArgumentException::new));
         return handle;
     }
 
@@ -215,42 +186,14 @@ public class LayoutPath {
         return layout;
     }
 
-    public MemoryLayout map(UnaryOperator<MemoryLayout> op) {
-        MemoryLayout newLayout = op.apply(layout);
-        if (enclosing == null) {
-            return newLayout;
-        } else if (enclosing.layout instanceof SequenceLayout seq) {
-            return enclosing.map(l -> dup(l, MemoryLayout.sequenceLayout(seq.elementCount(), newLayout)));
-        } else if (enclosing.layout instanceof GroupLayout g) {
-            List<MemoryLayout> newElements = new ArrayList<>(g.memberLayouts());
-            //if we selected a layout in a group we must have a valid index
-            newElements.set((int)elementIndex, newLayout);
-            if (g.isUnion()) {
-                return enclosing.map(l -> dup(l, MemoryLayout.unionLayout(newElements.toArray(new MemoryLayout[0]))));
-            } else {
-                return enclosing.map(l -> dup(l, MemoryLayout.structLayout(newElements.toArray(new MemoryLayout[0]))));
-            }
-        } else {
-            return newLayout;
-        }
-    }
-
-    private MemoryLayout dup(MemoryLayout oldLayout, MemoryLayout newLayout) {
-        newLayout = newLayout.withBitAlignment(oldLayout.bitAlignment());
-        if (oldLayout.name().isPresent()) {
-            newLayout = newLayout.withName(oldLayout.name().get());
-        }
-        return newLayout;
-    }
-
     // Layout path construction
 
-    public static LayoutPath rootPath(MemoryLayout layout, ToLongFunction<MemoryLayout> sizeFunc) {
-        return new LayoutPath(layout, 0L, EMPTY_STRIDES, -1, null, sizeFunc);
+    public static LayoutPath rootPath(MemoryLayout layout) {
+        return new LayoutPath(layout, 0L, EMPTY_STRIDES,null);
     }
 
-    private static LayoutPath nestedPath(MemoryLayout layout, long offset, long[] strides, long elementIndex, LayoutPath encl) {
-        return new LayoutPath(layout, offset, strides, elementIndex, encl, encl.sizeFunc);
+    private static LayoutPath nestedPath(MemoryLayout layout, long offset, long[] strides, LayoutPath encl) {
+        return new LayoutPath(layout, offset, strides, encl);
     }
 
     // Helper methods
@@ -339,9 +282,5 @@ public class LayoutPath {
         public PathKind kind() {
             return kind;
         }
-    }
-
-    private static long addStride(MemorySegment segment, long stride, long base, long index) {
-        return base + (stride * index);
     }
 }

--- a/test/jdk/java/foreign/TestLayoutPaths.java
+++ b/test/jdk/java/foreign/TestLayoutPaths.java
@@ -259,19 +259,6 @@ public class TestLayoutPaths {
     }
 
     @Test
-    public void testBadSequencePathInMap() {
-        SequenceLayout seq = MemoryLayout.sequenceLayout(10, JAVA_INT);
-        for (PathElement e : List.of( sequenceElement(0), sequenceElement(0, 2) )) {
-            try {
-                seq.map(l -> l, e);
-                fail();
-            } catch (IllegalArgumentException ex) {
-                assertTrue(true);
-            }
-        }
-    }
-
-    @Test
     public void testStructPaths() {
         long[] offsets = { 0, 8, 24, 56 };
         GroupLayout g = MemoryLayout.structLayout(
@@ -295,20 +282,6 @@ public class TestLayoutPaths {
             assertEquals(offsets[i - 1], bitOffset);
             long byteOffset = g.byteOffset(groupElement(String.valueOf(i)));
             assertEquals((offsets[i - 1]) >>> 3, byteOffset);
-        }
-
-        // test map
-
-        for (int i = 1 ; i <= 4 ; i++) {
-            GroupLayout g2 = (GroupLayout)g.map(l -> ValueLayout.JAVA_DOUBLE, groupElement(String.valueOf(i)));
-            assertTrue(g2.isStruct());
-            for (int j = 0 ; j < 4 ; j++) {
-                if (j == i - 1) {
-                    assertEquals(g2.memberLayouts().get(j), ValueLayout.JAVA_DOUBLE);
-                } else {
-                    assertEquals(g2.memberLayouts().get(j), g.memberLayouts().get(j));
-                }
-            }
         }
     }
 
@@ -337,20 +310,6 @@ public class TestLayoutPaths {
             long byteOffset = g.byteOffset(groupElement(String.valueOf(i)));
             assertEquals((offsets[i - 1]) >>> 3, byteOffset);
         }
-
-        // test map
-
-        for (int i = 1 ; i <= 4 ; i++) {
-            GroupLayout g2 = (GroupLayout)g.map(l -> ValueLayout.JAVA_DOUBLE, groupElement(String.valueOf(i)));
-            assertTrue(g2.isUnion());
-            for (int j = 0 ; j < 4 ; j++) {
-                if (j == i - 1) {
-                    assertEquals(g2.memberLayouts().get(j), ValueLayout.JAVA_DOUBLE);
-                } else {
-                    assertEquals(g2.memberLayouts().get(j), g.memberLayouts().get(j));
-                }
-            }
-        }
     }
 
     @Test
@@ -371,11 +330,6 @@ public class TestLayoutPaths {
             long byteOffset = g.byteOffset(sequenceElement(i));
             assertEquals((offsets[i]) >>> 3, byteOffset);
         }
-
-        // test map
-
-        SequenceLayout seq2 = (SequenceLayout)g.map(l -> ValueLayout.JAVA_DOUBLE, sequenceElement());
-        assertTrue(seq2.elementLayout() == ValueLayout.JAVA_DOUBLE);
     }
 
     @Test(dataProvider = "testLayouts")

--- a/test/jdk/java/foreign/TestLayouts.java
+++ b/test/jdk/java/foreign/TestLayouts.java
@@ -50,57 +50,6 @@ public class TestLayouts {
     }
 
     @Test
-    public void testVLAInStruct() {
-        MemoryLayout layout = MemoryLayout.structLayout(
-                ValueLayout.JAVA_INT.withName("size"),
-                MemoryLayout.paddingLayout(32),
-                MemoryLayout.sequenceLayout(0, ValueLayout.JAVA_DOUBLE).withName("arr"));
-        VarHandle size_handle = layout.varHandle(MemoryLayout.PathElement.groupElement("size"));
-        VarHandle array_elem_handle = layout.varHandle(
-                MemoryLayout.PathElement.groupElement("arr"),
-                MemoryLayout.PathElement.sequenceElement());
-        try (MemorySession session = MemorySession.openConfined()) {
-            MemorySegment segment = MemorySegment.allocateNative(
-                    layout.map(l -> ((SequenceLayout)l).withElementCount(4), MemoryLayout.PathElement.groupElement("arr")), session);
-            size_handle.set(segment, 4);
-            for (int i = 0 ; i < 4 ; i++) {
-                array_elem_handle.set(segment, i, (double)i);
-            }
-            //check
-            assertEquals(4, (int)size_handle.get(segment));
-            for (int i = 0 ; i < 4 ; i++) {
-                assertEquals((double)i, (double)array_elem_handle.get(segment, i));
-            }
-        }
-    }
-
-    @Test
-    public void testVLAInSequence() {
-        MemoryLayout layout = MemoryLayout.structLayout(
-                ValueLayout.JAVA_INT.withName("size"),
-                MemoryLayout.paddingLayout(32),
-                MemoryLayout.sequenceLayout(1, MemoryLayout.sequenceLayout(0, ValueLayout.JAVA_DOUBLE)).withName("arr"));
-        VarHandle size_handle = layout.varHandle(MemoryLayout.PathElement.groupElement("size"));
-        VarHandle array_elem_handle = layout.varHandle(
-                MemoryLayout.PathElement.groupElement("arr"),
-                MemoryLayout.PathElement.sequenceElement(0),
-                MemoryLayout.PathElement.sequenceElement());
-        try (MemorySession session = MemorySession.openConfined()) {
-            MemorySegment segment = MemorySegment.allocateNative(
-                    layout.map(l -> ((SequenceLayout)l).withElementCount(4), MemoryLayout.PathElement.groupElement("arr"), MemoryLayout.PathElement.sequenceElement()), session);
-            size_handle.set(segment, 4);
-            for (int i = 0 ; i < 4 ; i++) {
-                array_elem_handle.set(segment, i, (double)i);
-            }
-            //check
-            assertEquals(4, (int)size_handle.get(segment));
-            for (int i = 0 ; i < 4 ; i++) {
-                assertEquals((double)i, (double)array_elem_handle.get(segment, i));
-            }
-        }
-    }
-
-    @Test
     public void testIndexedSequencePath() {
         MemoryLayout seq = MemoryLayout.sequenceLayout(10, ValueLayout.JAVA_INT);
         try (MemorySession session = MemorySession.openConfined()) {


### PR DESCRIPTION
This patch removes the `MemoryLayout::map` method. This method was introduced to add some support for VLA (back when we had unbounded sequence layouts).

This method is quite limited when it comes to define transformations, as it can only alter one layout per call. As such, it is not useful to define global transformations to e.g. flip the endianness of all value layouts nested in a given layout.

We believe we can do much better than this (and have few ideas floating around) - but for the time being we'd like not to take the "good" name for a method that just doesn't seem all that useful.

When removing the method, I realized that the `LayoutPath` class had a lot of unneeded complexity:

* the size function is no longer needed, given that all layouts have a size
* keeping track of selected indices while navigating layout was only useful for the map operation, so I removed it
* we had two static methods `addStride` and `addScaledOffset` which did same thing; I dropped the first - the duplication was introduced when we dropped workarounds for "small" segments, in fact the leading `MemorySegment` parameter in the first method is now unused;
* I have greatly simplified the logic to create var handles from layouts; there is no need to do permutations (a similar simpler scheme was also used in the logic for computing offset method handles)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [JDK-8282953](https://bugs.openjdk.java.net/browse/JDK-8282953): Drop MemoryLayout::map


### Reviewers
 * [Paul Sandoz](https://openjdk.java.net/census#psandoz) (@PaulSandoz - Committer) ⚠️ Review applies to b0d0f4393ecba0fa218a8b898bdccddd76c21304


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/667/head:pull/667` \
`$ git checkout pull/667`

Update a local copy of the PR: \
`$ git checkout pull/667` \
`$ git pull https://git.openjdk.java.net/panama-foreign pull/667/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 667`

View PR using the GUI difftool: \
`$ git pr show -t 667`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/panama-foreign/pull/667.diff">https://git.openjdk.java.net/panama-foreign/pull/667.diff</a>

</details>
