### PR TITLE
8281412: MemorySegment::map should live in FileChannel

### DIFF
--- a/src/java.base/share/classes/java/lang/foreign/MemorySegment.java
+++ b/src/java.base/share/classes/java/lang/foreign/MemorySegment.java
@@ -26,7 +26,6 @@
 
 package java.lang.foreign;
 
-import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.lang.reflect.Array;
 import java.lang.invoke.MethodHandles;
@@ -34,13 +33,11 @@ import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.nio.channels.FileChannel;
 import java.nio.charset.StandardCharsets;
-import java.nio.file.Path;
 import java.util.Objects;
 import java.util.Spliterator;
 import java.util.stream.Stream;
 import jdk.internal.foreign.AbstractMemorySegmentImpl;
 import jdk.internal.foreign.HeapMemorySegmentImpl;
-import jdk.internal.foreign.MappedMemorySegmentImpl;
 import jdk.internal.foreign.Scoped;
 import jdk.internal.foreign.NativeMemorySegmentImpl;
 import jdk.internal.foreign.Utils;
@@ -90,8 +87,8 @@ import jdk.internal.vm.annotation.ForceInline;
  * <h2>Mapping memory segments from files</h2>
  *
  * It is also possible to obtain a native memory segment backed by a memory-mapped file using the factory method
- * {@link MemorySegment#mapFile(Path, long, long, FileChannel.MapMode, MemorySession)}. Such native memory segments are
- * called <em>mapped memory segments</em>; mapped memory segments are associated with an underlying file descriptor.
+ * {@link FileChannel#map(FileChannel.MapMode, long, long, MemorySession)}. Such native memory segments are called
+ * <em>mapped memory segments</em>; mapped memory segments are associated with an underlying file descriptor.
  * <p>
  * Contents of mapped memory segments can be {@linkplain #force() persisted} and {@linkplain #load() loaded} to and from the underlying file;
  * these capabilities are suitable replacements for some capabilities in the {@link java.nio.MappedByteBuffer} class.
@@ -366,7 +363,7 @@ public sealed interface MemorySegment extends Addressable permits AbstractMemory
 
     /**
      * Returns {@code true} if this segment is a mapped segment. A mapped memory segment is
-     * created using the {@link #mapFile(Path, long, long, FileChannel.MapMode, MemorySession)} factory, or a buffer segment
+     * created using the {@link FileChannel#map(FileChannel.MapMode, long, long, MemorySession)} factory, or a buffer segment
      * derived from a {@link java.nio.MappedByteBuffer} using the {@link #ofByteBuffer(ByteBuffer)} factory.
      * @return {@code true} if this segment is a mapped segment.
      */
@@ -936,53 +933,6 @@ public sealed interface MemorySegment extends Addressable permits AbstractMemory
     }
 
     /**
-     * Creates a new mapped memory segment that models a memory-mapped region of a file from a given path,
-     * size, offset and memory session.
-     * <p>
-     * If the specified mapping mode is {@linkplain FileChannel.MapMode#READ_ONLY READ_ONLY}, the resulting segment
-     * will be read-only (see {@link #isReadOnly()}).
-     * <p>
-     * The content of a mapped memory segment can change at any time, for example
-     * if the content of the corresponding region of the mapped file is changed by
-     * this (or another) program.  Whether such changes occur, and when they
-     * occur, is operating-system dependent and therefore unspecified.
-     * <p>
-     * All or part of a mapped memory segment may become
-     * inaccessible at any time, for example if the backing mapped file is truncated.  An
-     * attempt to access an inaccessible region of a mapped memory segment will not
-     * change the segment's content and will cause an unspecified exception to be
-     * thrown either at the time of the access or at some later time.  It is
-     * therefore strongly recommended that appropriate precautions be taken to
-     * avoid the manipulation of a mapped file by this (or another) program, except to read or write
-     * the file's content.
-     *
-     * @implNote When obtaining a mapped segment from a newly created file, the initialization state of the contents of the block
-     * of mapped memory associated with the returned mapped memory segment is unspecified and should not be relied upon.
-     *
-     * @param path the path to the file to memory map.
-     * @param bytesOffset the offset (expressed in bytes) within the file at which the mapped segment is to start.
-     * @param bytesSize the size (in bytes) of the mapped memory backing the memory segment.
-     * @param mapMode a file mapping mode, see {@link FileChannel#map(FileChannel.MapMode, long, long)}; the mapping mode
-     *                might affect the behavior of the returned memory mapped segment (see {@link #force()}).
-     * @param session the segment memory session.
-     * @return a new mapped memory segment.
-     * @throws IllegalArgumentException if {@code bytesOffset < 0}, {@code bytesSize < 0}, or if {@code path} is not associated
-     * with the default file system.
-     * @throws IllegalStateException if {@code session} is not {@linkplain MemorySession#isAlive() alive}, or if access occurs from
-     * a thread other than the thread {@linkplain MemorySession#ownerThread() owning} {@code session}.
-     * @throws UnsupportedOperationException if an unsupported map mode is specified.
-     * @throws IOException if the specified path does not point to an existing file, or if some other I/O error occurs.
-     * @throws  SecurityException If a security manager is installed, and it denies an unspecified permission required by the implementation.
-     * In the case of the default provider, the {@link SecurityManager#checkRead(String)} method is invoked to check
-     * read access if the file is opened for reading. The {@link SecurityManager#checkWrite(String)} method is invoked to check
-     * write access if the file is opened for writing.
-     */
-    static MemorySegment mapFile(Path path, long bytesOffset, long bytesSize, FileChannel.MapMode mapMode, MemorySession session) throws IOException {
-        Objects.requireNonNull(session);
-        return MappedMemorySegmentImpl.makeMappedSegment(path, bytesOffset, bytesSize, mapMode, Scoped.toSessionImpl(session));
-    }
-
-    /**
      * Performs a bulk copy from source segment to destination segment. More specifically, the bytes at offset
      * {@code srcOffset} through {@code srcOffset + bytes - 1} in the source segment are copied into the destination
      * segment at offset {@code dstOffset} through {@code dstOffset + bytes - 1}.
@@ -994,7 +944,7 @@ public sealed interface MemorySegment extends Addressable permits AbstractMemory
      * <p>
      * The result of a bulk copy is unspecified if, in the uncommon case, the source segment and the destination segment
      * do not overlap, but refer to overlapping regions of the same backing storage using different addresses.
-     * For example, this may occur if the same file is {@linkplain MemorySegment#mapFile mapped} to two segments.
+     * For example, this may occur if the same file is {@linkplain FileChannel#map mapped} to two segments.
      * <p>
      * Calling this method is equivalent to the following code:
      * {@snippet lang=java :
@@ -1037,7 +987,7 @@ public sealed interface MemorySegment extends Addressable permits AbstractMemory
      * <p>
      * The result of a bulk copy is unspecified if, in the uncommon case, the source segment and the destination segment
      * do not overlap, but refer to overlapping regions of the same backing storage using different addresses.
-     * For example, this may occur if the same file is {@linkplain MemorySegment#mapFile mapped} to two segments.
+     * For example, this may occur if the same file is {@linkplain FileChannel#map mapped} to two segments.
      * @param srcSegment the source segment.
      * @param srcElementLayout the element layout associated with the source segment.
      * @param srcOffset the starting offset, in bytes, of the source segment.

--- a/src/java.base/share/classes/java/lang/foreign/MemorySession.java
+++ b/src/java.base/share/classes/java/lang/foreign/MemorySession.java
@@ -48,7 +48,7 @@ import jdk.internal.javac.PreviewFeature;
  * <ul>
  *     <li>closing the memory session associated with a {@linkplain MemorySegment#allocateNative(long, long, MemorySession) native memory segment}
  *     results in <em>freeing</em> the native memory associated with it;</li>
- *     <li>closing the memory session associated with a {@linkplain MemorySegment#mapFile(Path, long, long, FileChannel.MapMode, MemorySession) mapped memory segment}
+ *     <li>closing the memory session associated with a {@linkplain FileChannel#map(FileChannel.MapMode, long, long, MemorySession) mapped memory segment}
  *     results in the backing memory-mapped file to be unmapped;</li>
  *     <li>closing the memory session associated with an {@linkplain CLinker#upcallStub(MethodHandle, FunctionDescriptor, MemorySession) upcall stub}
  *     results in releasing the stub;</li>

--- a/src/java.base/share/classes/java/nio/channels/FileChannel.java
+++ b/src/java.base/share/classes/java/nio/channels/FileChannel.java
@@ -1017,30 +1017,32 @@ public abstract class FileChannel
      * @return A new mapped memory segment.
      *
      * @throws IllegalArgumentException
-     *         If {@code bytesOffset < 0}, {@code bytesSize < 0},
-     *         or if {@code path} is not associated with the default file system.
+     *         If {@code offset < 0}, {@code size < 0} or
+     *         {@code offset + size < 0}.
      *
      * @throws IllegalStateException
-     *         If {@code session} is not
+     *         If the {@code session} is not
      *         {@linkplain MemorySession#isAlive() alive}, or if access occurs
      *         from a thread other than the thread
-     *         {@linkplain MemorySession#ownerThread() owning} {@code session}.
+     *         {@linkplain MemorySession#ownerThread() owning} the
+     *         {@code session}.
+     *
+     * @throws NonReadableChannelException
+     *         If the {@code mode} is {@link MapMode#READ_ONLY READ_ONLY} or
+     *         an implementation specific map mode requiring read access
+     *         but this channel was not opened for reading.
+     *
+     * @throws NonWritableChannelException
+     *         If the {@code mode} is {@link MapMode#READ_WRITE READ_WRITE}.
+     *         {@link MapMode#PRIVATE PRIVATE} or an implementation specific
+     *         map mode requiring write access but this channel was not
+     *         opened for both reading and writing.
+     *
+     * @throws IOException
+     *         If some other I/O error occurs.
      *
      * @throws UnsupportedOperationException
      *         If an unsupported map mode is specified.
-     *
-     * @throws IOException
-     *         If the specified path does not point to an existing file, or if
-     *         some other I/O error occurs.
-     *
-     * @throws  SecurityException
-     *          If a security manager is installed, and it denies an unspecified
-     *          permission required by the implementation. In the case of the
-     *          default provider, the {@link SecurityManager#checkRead(String)}
-     *          method is invoked to check read access if the file is opened for
-     *          reading. The {@link SecurityManager#checkWrite(String)} method
-     *          is invoked to check write access if the file is opened for
-     *          writing.
      *
      * @since 19
      */

--- a/src/java.base/share/classes/java/nio/channels/FileChannel.java
+++ b/src/java.base/share/classes/java/nio/channels/FileChannel.java
@@ -26,6 +26,8 @@
 package java.nio.channels;
 
 import java.io.IOException;
+import java.lang.foreign.MemorySegment;
+import java.lang.foreign.MemorySession;
 import java.nio.ByteBuffer;
 import java.nio.MappedByteBuffer;
 import java.nio.channels.spi.AbstractInterruptibleChannel;
@@ -38,6 +40,7 @@ import java.nio.file.spi.FileSystemProvider;
 import java.util.Set;
 import java.util.HashSet;
 import java.util.Collections;
+import jdk.internal.javac.PreviewFeature;
 
 /**
  * A channel for reading, writing, mapping, and manipulating a file.
@@ -967,6 +970,87 @@ public abstract class FileChannel
     public abstract MappedByteBuffer map(MapMode mode, long position, long size)
         throws IOException;
 
+    /**
+     * Maps a region of this channel's file into a new mapped memory segment,
+     * with a given offset, size and memory session.
+     *
+     * <p> If the specified mapping mode is
+     * {@linkplain FileChannel.MapMode#READ_ONLY READ_ONLY}, the resulting
+     * segment will be read-only (see {@link MemorySegment#isReadOnly()}).
+     *
+     * <p> The content of a mapped memory segment can change at any time, for
+     * example if the content of the corresponding region of the mapped file is
+     * changed by this (or another) program.  Whether such changes occur, and
+     * when they occur, is operating-system dependent and therefore unspecified.
+     *
+     * <p> All or part of a mapped memory segment may become inaccessible at any
+     * time, for example if the backing mapped file is truncated. An attempt to
+     * access an inaccessible region of a mapped memory segment will not change
+     * the segment's content and will cause an unspecified exception to be
+     * thrown either at the time of the access or at some later time. It is
+     * therefore strongly recommended that appropriate precautions be taken to
+     * avoid the manipulation of a mapped file by this (or another) program,
+     * except to read or write the file's content.
+     *
+     * @implNote When obtaining a mapped segment from a newly created file
+     *           channel, the initialization state of the contents of the block
+     *           of mapped memory associated with the returned mapped memory
+     *           segment is unspecified and should not be relied upon.
+     *
+     * @param mode
+     *        The file mapping mode, see
+     *        {@link FileChannel#map(FileChannel.MapMode, long, long)};
+     *        the mapping mode might affect the behavior of the returned memory
+     *        mapped segment (see {@link MemorySegment#force()}).
+     *
+     * @param offset
+     *        The offset (expressed in bytes) within the file at which the
+     *        mapped segment is to start.
+     *
+     * @param size
+     *        The size (in bytes) of the mapped memory backing the memory
+     *        segment.
+
+     * @param session
+     *        The segment memory session.
+     *
+     * @return A new mapped memory segment.
+     *
+     * @throws IllegalArgumentException
+     *         If {@code bytesOffset < 0}, {@code bytesSize < 0},
+     *         or if {@code path} is not associated with the default file system.
+     *
+     * @throws IllegalStateException
+     *         If {@code session} is not
+     *         {@linkplain MemorySession#isAlive() alive}, or if access occurs
+     *         from a thread other than the thread
+     *         {@linkplain MemorySession#ownerThread() owning} {@code session}.
+     *
+     * @throws UnsupportedOperationException
+     *         If an unsupported map mode is specified.
+     *
+     * @throws IOException
+     *         If the specified path does not point to an existing file, or if
+     *         some other I/O error occurs.
+     *
+     * @throws  SecurityException
+     *          If a security manager is installed, and it denies an unspecified
+     *          permission required by the implementation. In the case of the
+     *          default provider, the {@link SecurityManager#checkRead(String)}
+     *          method is invoked to check read access if the file is opened for
+     *          reading. The {@link SecurityManager#checkWrite(String)} method
+     *          is invoked to check write access if the file is opened for
+     *          writing.
+     *
+     * @since 19
+     */
+    @PreviewFeature(feature=PreviewFeature.Feature.FOREIGN)
+    public MemorySegment map(MapMode mode, long offset, long size,
+                                      MemorySession session)
+            throws IOException, UnsupportedOperationException
+    {
+        throw new UnsupportedOperationException();
+    }
 
     // -- Locks --
 

--- a/src/java.base/share/classes/java/nio/channels/FileChannel.java
+++ b/src/java.base/share/classes/java/nio/channels/FileChannel.java
@@ -946,13 +946,13 @@ public abstract class FileChannel
      *
      * @throws NonReadableChannelException
      *         If the {@code mode} is {@link MapMode#READ_ONLY READ_ONLY} or
-     *         an implementation specific map mode requiring read access
+     *         an implementation specific map mode requiring read access,
      *         but this channel was not opened for reading
      *
      * @throws NonWritableChannelException
-     *         If the {@code mode} is {@link MapMode#READ_WRITE READ_WRITE}.
+     *         If the {@code mode} is {@link MapMode#READ_WRITE READ_WRITE},
      *         {@link MapMode#PRIVATE PRIVATE} or an implementation specific
-     *         map mode requiring write access but this channel was not
+     *         map mode requiring write access, but this channel was not
      *         opened for both reading and writing
      *
      * @throws IllegalArgumentException
@@ -1029,13 +1029,13 @@ public abstract class FileChannel
      *
      * @throws NonReadableChannelException
      *         If the {@code mode} is {@link MapMode#READ_ONLY READ_ONLY} or
-     *         an implementation specific map mode requiring read access
+     *         an implementation specific map mode requiring read access,
      *         but this channel was not opened for reading.
      *
      * @throws NonWritableChannelException
-     *         If the {@code mode} is {@link MapMode#READ_WRITE READ_WRITE}.
+     *         If the {@code mode} is {@link MapMode#READ_WRITE READ_WRITE},
      *         {@link MapMode#PRIVATE PRIVATE} or an implementation specific
-     *         map mode requiring write access but this channel was not
+     *         map mode requiring write access, but this channel was not
      *         opened for both reading and writing.
      *
      * @throws IOException

--- a/src/java.base/share/classes/sun/nio/ch/FileChannelImpl.java
+++ b/src/java.base/share/classes/sun/nio/ch/FileChannelImpl.java
@@ -1069,27 +1069,25 @@ public class FileChannelImpl
         if (offset < 0) throw new IllegalArgumentException("Requested bytes offset must be >= 0.");
         if (size < 0) throw new IllegalArgumentException("Requested bytes size must be >= 0.");
 
-        try (this) {
-            boolean isSync = isSync(mode);
-            int prot = toProt(mode);
-            Unmapper unmapper = mapInternal(mode, offset, size, prot, isSync);
-            int modes = MAP_MEM_SEG_DEFAULT_MODES;
-            if (mode == MapMode.READ_ONLY) {
-                modes |= MAP_MEM_SEG_READ_ONLY;
-            }
-            if (unmapper != null) {
-                AbstractMemorySegmentImpl segment = new MappedMemorySegmentImpl(unmapper.address(), unmapper, size,
-                        modes, (MemorySessionImpl)session);
-                ((MemorySessionImpl)session).addOrCleanupIfFail(new MemorySessionImpl.ResourceList.ResourceCleanup() {
-                    @Override
-                    public void cleanup() {
-                        unmapper.unmap();
-                    }
-                });
-                return segment;
-            } else {
-                return new MappedMemorySegmentImpl.EmptyMappedMemorySegmentImpl(modes, (MemorySessionImpl)session);
-            }
+        boolean isSync = isSync(mode);
+        int prot = toProt(mode);
+        Unmapper unmapper = mapInternal(mode, offset, size, prot, isSync);
+        int modes = MAP_MEM_SEG_DEFAULT_MODES;
+        if (mode == MapMode.READ_ONLY) {
+            modes |= MAP_MEM_SEG_READ_ONLY;
+        }
+        if (unmapper != null) {
+            AbstractMemorySegmentImpl segment = new MappedMemorySegmentImpl(unmapper.address(), unmapper, size,
+                    modes, (MemorySessionImpl)session);
+            ((MemorySessionImpl)session).addOrCleanupIfFail(new MemorySessionImpl.ResourceList.ResourceCleanup() {
+                @Override
+                public void cleanup() {
+                    unmapper.unmap();
+                }
+            });
+            return segment;
+        } else {
+            return new MappedMemorySegmentImpl.EmptyMappedMemorySegmentImpl(modes, (MemorySessionImpl)session);
         }
     }
 

--- a/src/java.base/share/classes/sun/nio/ch/FileChannelImpl.java
+++ b/src/java.base/share/classes/sun/nio/ch/FileChannelImpl.java
@@ -28,6 +28,8 @@ package sun.nio.ch;
 import java.io.FileDescriptor;
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.lang.foreign.MemorySegment;
+import java.lang.foreign.MemorySession;
 import java.lang.ref.Cleaner.Cleanable;
 import java.nio.ByteBuffer;
 import java.nio.MappedByteBuffer;
@@ -46,6 +48,9 @@ import java.util.Objects;
 
 import jdk.internal.access.JavaIOFileDescriptorAccess;
 import jdk.internal.access.SharedSecrets;
+import jdk.internal.foreign.AbstractMemorySegmentImpl;
+import jdk.internal.foreign.MappedMemorySegmentImpl;
+import jdk.internal.foreign.MemorySessionImpl;
 import jdk.internal.misc.ExtendedMapMode;
 import jdk.internal.misc.Unsafe;
 import jdk.internal.misc.VM;
@@ -1050,10 +1055,42 @@ public class FileChannelImpl
         }
     }
 
-    public Unmapper mapInternal(MapMode mode, long position, long size) throws IOException {
-        boolean isSync = isSync(Objects.requireNonNull(mode, "Mode is null"));
-        int prot = toProt(mode);
-        return mapInternal(mode, position, size, prot, isSync);
+    private static final int MAP_MEM_SEG_DEFAULT_MODES = 0;
+    private static final int MAP_MEM_SEG_READ_ONLY = 1;
+
+    @Override
+    public MemorySegment map(MapMode mode, long offset, long size,
+                             MemorySession session)
+            throws IOException, UnsupportedOperationException
+    {
+        Objects.requireNonNull(mode,"Mode is null");
+        Objects.requireNonNull(session, "Session is null");
+        ((MemorySessionImpl)session).checkValidStateSlow();
+        if (offset < 0) throw new IllegalArgumentException("Requested bytes offset must be >= 0.");
+        if (size < 0) throw new IllegalArgumentException("Requested bytes size must be >= 0.");
+
+        try (this) {
+            boolean isSync = isSync(mode);
+            int prot = toProt(mode);
+            Unmapper unmapper = mapInternal(mode, offset, size, prot, isSync);
+            int modes = MAP_MEM_SEG_DEFAULT_MODES;
+            if (mode == MapMode.READ_ONLY) {
+                modes |= MAP_MEM_SEG_READ_ONLY;
+            }
+            if (unmapper != null) {
+                AbstractMemorySegmentImpl segment = new MappedMemorySegmentImpl(unmapper.address(), unmapper, size,
+                        modes, (MemorySessionImpl)session);
+                ((MemorySessionImpl)session).addOrCleanupIfFail(new MemorySessionImpl.ResourceList.ResourceCleanup() {
+                    @Override
+                    public void cleanup() {
+                        unmapper.unmap();
+                    }
+                });
+                return segment;
+            } else {
+                return new MappedMemorySegmentImpl.EmptyMappedMemorySegmentImpl(modes, (MemorySessionImpl)session);
+            }
+        }
     }
 
     private Unmapper mapInternal(MapMode mode, long position, long size, int prot, boolean isSync)

--- a/test/jdk/java/foreign/TestScopedOperations.java
+++ b/test/jdk/java/foreign/TestScopedOperations.java
@@ -114,8 +114,7 @@ public class TestScopedOperations {
         }), "MemorySession::addCloseAction");
         ScopedOperation.ofScope(session -> MemorySegment.allocateNative(100, session), "MemorySegment::allocateNative");
         ScopedOperation.ofScope(session -> {
-            try {
-                FileChannel fileChannel = FileChannel.open(tempPath, StandardOpenOption.READ, StandardOpenOption.WRITE);
+            try (FileChannel fileChannel = FileChannel.open(tempPath, StandardOpenOption.READ, StandardOpenOption.WRITE)) {
                 fileChannel.map(FileChannel.MapMode.READ_WRITE, 0L, 10L, session);
             } catch (IOException ex) {
                 fail();
@@ -223,8 +222,7 @@ public class TestScopedOperations {
 
             NATIVE(session -> MemorySegment.allocateNative(10, session)),
             MAPPED(session -> {
-                try {
-                    FileChannel fileChannel = FileChannel.open(Path.of("foo.txt"), StandardOpenOption.READ, StandardOpenOption.WRITE);
+                try (FileChannel fileChannel = FileChannel.open(Path.of("foo.txt"), StandardOpenOption.READ, StandardOpenOption.WRITE)) {
                     return fileChannel.map(FileChannel.MapMode.READ_WRITE, 0L, 10L, session);
                 } catch (IOException ex) {
                     throw new AssertionError(ex);

--- a/test/jdk/java/foreign/TestSegmentOverlap.java
+++ b/test/jdk/java/foreign/TestSegmentOverlap.java
@@ -64,7 +64,8 @@ public class TestSegmentOverlap {
                 () -> MemorySegment.allocateNative(16, MemorySession.openConfined()),
                 () -> {
                     try {
-                        return MemorySegment.mapFile(tempPath, 0L, 16, FileChannel.MapMode.READ_WRITE, MemorySession.openConfined());
+                        FileChannel fileChannel = FileChannel.open(tempPath, StandardOpenOption.READ, StandardOpenOption.WRITE);
+                        return fileChannel.map(FileChannel.MapMode.READ_WRITE, 0L, 16L, MemorySession.openConfined());
                     } catch (IOException e) {
                         throw new RuntimeException(e);
                     }

--- a/test/jdk/java/foreign/TestSegmentOverlap.java
+++ b/test/jdk/java/foreign/TestSegmentOverlap.java
@@ -63,8 +63,7 @@ public class TestSegmentOverlap {
         List<Supplier<MemorySegment>> l = List.of(
                 () -> MemorySegment.allocateNative(16, MemorySession.openConfined()),
                 () -> {
-                    try {
-                        FileChannel fileChannel = FileChannel.open(tempPath, StandardOpenOption.READ, StandardOpenOption.WRITE);
+                    try (FileChannel fileChannel = FileChannel.open(tempPath, StandardOpenOption.READ, StandardOpenOption.WRITE)) {
                         return fileChannel.map(FileChannel.MapMode.READ_WRITE, 0L, 16L, MemorySession.openConfined());
                     } catch (IOException e) {
                         throw new RuntimeException(e);

--- a/test/jdk/java/nio/channels/FileChannel/MapToMemorySegmentTest.java
+++ b/test/jdk/java/nio/channels/FileChannel/MapToMemorySegmentTest.java
@@ -1,0 +1,169 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/* @test
+ * @enablePreview
+ * @bug 8281412
+ * @summary Test FileChannel::map to MemorySegment with custom file channel
+ * @run testng/othervm MapToMemorySegmentTest
+ */
+
+import java.io.File;
+import java.io.IOException;
+import java.lang.foreign.MemorySegment;
+import java.lang.foreign.MemorySession;
+import java.nio.ByteBuffer;
+import java.nio.MappedByteBuffer;
+import java.nio.channels.FileChannel;
+import java.nio.channels.FileLock;
+import java.nio.channels.ReadableByteChannel;
+import java.nio.channels.WritableByteChannel;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
+
+public class MapToMemorySegmentTest {
+
+    static Path tempPath;
+
+    static {
+        try {
+            File file = File.createTempFile("foo", "txt");
+            file.deleteOnExit();
+            tempPath = file.toPath();
+        } catch (IOException ex) {
+            throw new ExceptionInInitializerError(ex);
+        }
+    }
+
+    @Test(expectedExceptions = UnsupportedOperationException.class)
+    public void testCustomFileChannel() throws IOException {
+        var session = MemorySession.openConfined();
+        var fc = FileChannel.open(tempPath, StandardOpenOption.WRITE, StandardOpenOption.READ);
+        var fileChannel = new CustomFileChannel(fc);
+        try (session; fileChannel){
+            fileChannel.map(FileChannel.MapMode.READ_WRITE, 1L, 10L, session);
+        }
+    }
+
+    @Test
+    public void testCustomFileChannelOverride() throws IOException {
+        var session = MemorySession.openConfined();
+        var fc = FileChannel.open(tempPath, StandardOpenOption.WRITE, StandardOpenOption.READ);
+        var fileChannel = new CustomFileChannelOverride(fc);
+        try (session; fileChannel){
+            fileChannel.map(FileChannel.MapMode.READ_WRITE, 1L, 10L, session);
+        }
+    }
+
+    static class CustomFileChannel extends FileChannel {
+        FileChannel fc;
+
+        public CustomFileChannel(FileChannel fc) {
+            this.fc = fc;
+        }
+
+        public int read(ByteBuffer dst) throws IOException {
+            return fc.read(dst);
+        }
+
+        public long read(ByteBuffer[] dsts, int offset, int length) throws IOException {
+            return fc.read(dsts, offset, length);
+        }
+
+        public int write(ByteBuffer src) throws IOException {
+            return fc.write(src);
+        }
+
+        public long write(ByteBuffer[] srcs, int offset, int length) throws IOException {
+            return fc.write(srcs, offset, length);
+        }
+
+        public long position() throws IOException {
+            return fc.position();
+        }
+
+        public FileChannel position(long newPosition) throws IOException {
+            return fc.position(newPosition);
+        }
+
+        public long size() throws IOException {
+            return fc.size();
+        }
+
+        public FileChannel truncate(long size) throws IOException {
+            return fc.truncate(size);
+        }
+
+        public void force(boolean metaData) throws IOException {
+            this.fc.force(metaData);
+        }
+
+        public long transferTo(long position, long count, WritableByteChannel target) throws IOException {
+            return fc.transferTo(position, count, target);
+        }
+
+        public long transferFrom(ReadableByteChannel src, long position, long count) throws IOException {
+            return fc.transferFrom(src, position, count);
+        }
+
+        public int read(ByteBuffer dst, long position) throws IOException {
+            return fc.read(dst, position);
+        }
+
+        public int write(ByteBuffer src, long position) throws IOException {
+            return fc.write(src, position);
+        }
+
+        public MappedByteBuffer map(MapMode mode, long position, long size) throws IOException {
+            return fc.map(mode, position, size);
+        }
+
+        public FileLock lock(long position, long size, boolean shared) throws IOException {
+            return fc.lock(position, size, shared);
+        }
+
+        public FileLock tryLock(long position, long size, boolean shared) throws IOException {
+            return fc.tryLock(position , size, shared);
+        }
+
+        protected void implCloseChannel() throws IOException {
+            fc.close();
+        }
+    }
+
+    static class CustomFileChannelOverride extends CustomFileChannel {
+
+        public CustomFileChannelOverride(FileChannel fc) { super(fc); }
+
+        @Override
+        public MemorySegment map(MapMode mode, long offset, long size, MemorySession session)
+                throws IOException, UnsupportedOperationException
+        {
+            return fc.map(mode, offset, size, session);
+        }
+    }
+}

--- a/test/micro/org/openjdk/bench/java/lang/foreign/LoopOverNonConstantMapped.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/LoopOverNonConstantMapped.java
@@ -81,6 +81,7 @@ public class LoopOverNonConstantMapped {
     }
 
     static final VarHandle VH_int = JAVA_INT.arrayElementVarHandle();
+    FileChannel fileChannel;
     MemorySegment segment;
     long unsafe_addr;
 
@@ -95,13 +96,14 @@ public class LoopOverNonConstantMapped {
             }
             ((MappedByteBuffer)byteBuffer).force();
         }
-        FileChannel fileChannel = FileChannel.open(tempPath, StandardOpenOption.READ, StandardOpenOption.WRITE);
+        fileChannel = FileChannel.open(tempPath, StandardOpenOption.READ, StandardOpenOption.WRITE);
         segment = fileChannel.map(FileChannel.MapMode.READ_WRITE, 0L, ALLOC_SIZE, MemorySession.openConfined());
         unsafe_addr = segment.address().toRawLongValue();
     }
 
     @TearDown
-    public void tearDown() {
+    public void tearDown() throws IOException {
+        fileChannel.close();
         segment.session().close();
         unsafe.invokeCleaner(byteBuffer);
     }

--- a/test/micro/org/openjdk/bench/java/lang/foreign/LoopOverNonConstantMapped.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/LoopOverNonConstantMapped.java
@@ -96,7 +96,8 @@ public class LoopOverNonConstantMapped {
             }
             ((MappedByteBuffer)byteBuffer).force();
         }
-        segment = MemorySegment.mapFile(tempPath, 0L, ALLOC_SIZE, FileChannel.MapMode.READ_WRITE, session = MemorySession.openConfined());
+        FileChannel fileChannel = FileChannel.open(tempPath, StandardOpenOption.READ, StandardOpenOption.WRITE);
+        segment = fileChannel.map(FileChannel.MapMode.READ_WRITE, 0L, ALLOC_SIZE, session = MemorySession.openConfined());
         unsafe_addr = segment.address().toRawLongValue();
     }
 
@@ -189,5 +190,4 @@ public class LoopOverNonConstantMapped {
         }
         return sum;
     }
-
 }


### PR DESCRIPTION
This change moves the factory for mapped memory segments to `FileChannel`, as a new instance method `map`, which moves it closer to the existing `FileChannel::map` that returns a `MappedByteBuffer`.  

Tests are adjusted accordingly and a new test for custom file channels (that do/don't override the method) is added.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [JDK-8281412](https://bugs.openjdk.java.net/browse/JDK-8281412): MemorySegment::map should live in FileChannel


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.java.net/census#mcimadamore) (@mcimadamore - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/668/head:pull/668` \
`$ git checkout pull/668`

Update a local copy of the PR: \
`$ git checkout pull/668` \
`$ git pull https://git.openjdk.java.net/panama-foreign pull/668/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 668`

View PR using the GUI difftool: \
`$ git pr show -t 668`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/panama-foreign/pull/668.diff">https://git.openjdk.java.net/panama-foreign/pull/668.diff</a>

</details>
