### PR TITLE
More javadoc cleanup.

### DIFF
--- a/src/java.base/share/classes/java/lang/foreign/Addressable.java
+++ b/src/java.base/share/classes/java/lang/foreign/Addressable.java
@@ -31,8 +31,8 @@ import jdk.internal.javac.PreviewFeature;
  * An object that may be projected down to a {@linkplain #address() memory address}.
  * Examples of addressable types are {@link MemorySegment}, {@link MemoryAddress} and {@link VaList}.
  * <p>
- * The {@link Addressable} type is used by the {@link CLinker C linker} to model the types of
- * {@link CLinker#downcallHandle(FunctionDescriptor) downcall handle} parameters that must be passed <em>by reference</em>
+ * The {@link Addressable} type is used by the {@linkplain CLinker C linker} to model the types of
+ * {@linkplain CLinker#downcallHandle(FunctionDescriptor) downcall handle} parameters that must be passed <em>by reference</em>
  * (e.g. memory addresses, va lists and upcall stubs).
  *
  * @since 19

--- a/src/java.base/share/classes/java/lang/foreign/CLinker.java
+++ b/src/java.base/share/classes/java/lang/foreign/CLinker.java
@@ -45,7 +45,7 @@ import jdk.internal.reflect.Reflection;
  * On unsupported platforms this class will fail to initialize with an {@link ExceptionInInitializerError}.
  * <p>
  * Unless otherwise specified, passing a {@code null} argument, or an array argument containing one or more {@code null}
- * elements to a method in this class causes a {@link NullPointerException NullPointerException} to be thrown.</p>
+ * elements to a method in this class causes a {@link NullPointerException} to be thrown.</p>
  *
  * <h2><a id = "downcall-method-handles">Downcall method handles</a></h2>
  * <p>
@@ -103,7 +103,7 @@ import jdk.internal.reflect.Reflection;
  * </ul>
  * Upcall stubs are modelled by instances of type {@link MemorySegment}; upcall stubs can be passed by reference to other
  * downcall method handles (as {@link MemorySegment} implements the {@link Addressable} interface) and,
- * when no longer required, they can be {@link MemorySession#close() released}, via their associated {@linkplain MemorySession session}.
+ * when no longer required, they can be {@linkplain MemorySession#close() released}, via their associated {@linkplain MemorySession session}.
  *
  * <h2>Safety considerations</h2>
  *
@@ -117,7 +117,7 @@ import jdk.internal.reflect.Reflection;
  * <ul>
  *     <li>The memory session of {@code R} is {@linkplain MemorySession#isAlive() alive}. Otherwise, the invocation throws
  *     {@link IllegalStateException};</li>
- *     <li>The invocation occurs in same thread as the one {@link MemorySession#ownerThread() owning} the memory session of {@code R},
+ *     <li>The invocation occurs in same thread as the one {@linkplain MemorySession#ownerThread() owning} the memory session of {@code R},
  *     if said session is confined. Otherwise, the invocation throws {@link IllegalStateException}; and</li>
  *     <li>The memory session of {@code R} is {@linkplain MemorySession#whileAlive(Runnable) kept alive} (and cannot be closed) during the invocation.
  *</ul>

--- a/src/java.base/share/classes/java/lang/foreign/FunctionDescriptor.java
+++ b/src/java.base/share/classes/java/lang/foreign/FunctionDescriptor.java
@@ -45,8 +45,9 @@ import jdk.internal.javac.PreviewFeature;
  * {@linkplain CLinker#upcallStub(MethodHandle, FunctionDescriptor, MemorySession) upcall stubs}.
  *
  * @implSpec
- * This class is immutable and thread-safe and <a href="{@docRoot}/java.base/java/lang/doc-files/ValueBased.html">value-based</a>.
+ * This class is immutable, thread-safe and <a href="{@docRoot}/java.base/java/lang/doc-files/ValueBased.html">value-based</a>.
  *
+ * @see MemoryLayout
  * @since 19
  */
 @PreviewFeature(feature=PreviewFeature.Feature.FOREIGN)

--- a/src/java.base/share/classes/java/lang/foreign/GroupLayout.java
+++ b/src/java.base/share/classes/java/lang/foreign/GroupLayout.java
@@ -42,16 +42,9 @@ import jdk.internal.javac.PreviewFeature;
  * can be combined: if member layouts are laid out one after the other, the resulting group layout is said to be a <em>struct</em>
  * (see {@link MemoryLayout#structLayout(MemoryLayout...)}); conversely, if all member layouts are laid out at the same starting offset,
  * the resulting group layout is said to be a <em>union</em> (see {@link MemoryLayout#unionLayout(MemoryLayout...)}).
- * <p>
- * This is a <a href="{@docRoot}/java.base/java/lang/doc-files/ValueBased.html">value-based</a>
- * class; programmers should treat instances that are
- * {@linkplain #equals(Object) equal} as interchangeable and should not
- * use instances for synchronization, or unpredictable behavior may
- * occur. For example, in a future release, synchronization may fail.
- * The {@code equals} method should be used for comparisons.
  *
  * @implSpec
- * This class is immutable and thread-safe and <a href="{@docRoot}/java.base/java/lang/doc-files/ValueBased.html">value-based</a>.
+ * This class is immutable, thread-safe and <a href="{@docRoot}/java.base/java/lang/doc-files/ValueBased.html">value-based</a>.
  *
  * @since 19
  */

--- a/src/java.base/share/classes/java/lang/foreign/MemoryAddress.java
+++ b/src/java.base/share/classes/java/lang/foreign/MemoryAddress.java
@@ -49,7 +49,7 @@ import java.lang.invoke.MethodHandle;
  * A memory address can be read or written using various methods provided in this class (e.g. {@link #get(ValueLayout.OfInt, long)}).
  * Each dereference method takes a {@linkplain ValueLayout value layout}, which specifies the size,
  * alignment constraints, byte order as well as the Java type associated with the dereference operation, and an offset.
- * For instance, to read an int from a segment, using {@link ByteOrder#nativeOrder() default endianness}, the following code can be used:
+ * For instance, to read an int from a segment, using {@linkplain ByteOrder#nativeOrder() default endianness}, the following code can be used:
  * {@snippet lang=java :
  * MemoryAddress address = ...
  * int value = address.get(ValueLayout.JAVA_INT, 0);

--- a/src/java.base/share/classes/java/lang/foreign/MemoryAddress.java
+++ b/src/java.base/share/classes/java/lang/foreign/MemoryAddress.java
@@ -39,8 +39,8 @@ import java.lang.invoke.MethodHandle;
  * <ul>
  *     <li>By calling {@link Addressable#address()} on an instance of type {@link Addressable} (e.g. a memory segment);</li>
  *     <li>By invoking a {@linkplain CLinker#downcallHandle(FunctionDescriptor) downcall method handle} which returns a pointer;</li>
- *     <li>By reading an address from memory, e.g. via {@link MemorySegment#get(ValueLayout.OfAddress, long)}.</li>
- *     <li>By the invocation of an {@linkplain CLinker#upcallStub(MethodHandle, FunctionDescriptor, MemorySession) upcall stub} which accepts a pointer.
+ *     <li>By reading an address from memory, e.g. via {@link MemorySegment#get(ValueLayout.OfAddress, long)}; and</li>
+ *     <li>By the invocation of an {@linkplain CLinker#upcallStub(MethodHandle, FunctionDescriptor, MemorySession) upcall stub} which accepts a pointer.</li>
  * </ul>
  * A memory address is backed by a raw machine pointer, expressed as a {@linkplain #toRawLongValue() long value}.
  *

--- a/src/java.base/share/classes/java/lang/foreign/MemoryAddress.java
+++ b/src/java.base/share/classes/java/lang/foreign/MemoryAddress.java
@@ -65,11 +65,6 @@ import java.lang.invoke.MethodHandle;
  * All the dereference methods in this class are <a href="package-summary.html#restricted"><em>restricted</em></a>: since
  * a memory address does not feature temporal nor spatial bounds, the runtime has no way to check the correctness
  * of the memory dereference operation.
- * <p>
- * All implementations of this interface must be <a href="{@docRoot}/java.base/java/lang/doc-files/ValueBased.html">value-based</a>;
- * programmers should treat instances that are {@linkplain #equals(Object) equal} as interchangeable and should not
- * use instances for synchronization, or unpredictable behavior may occur. For example, in a future release,
- * synchronization may fail. The {@code equals} method should be used for comparisons.
  *
  * @implSpec
  * Implementations of this interface are immutable, thread-safe and <a href="{@docRoot}/java.base/java/lang/doc-files/ValueBased.html">value-based</a>.

--- a/src/java.base/share/classes/java/lang/foreign/MemoryLayout.java
+++ b/src/java.base/share/classes/java/lang/foreign/MemoryLayout.java
@@ -503,7 +503,7 @@ public sealed interface MemoryLayout extends Constable permits AbstractLayout, S
      * sequence path elements, it acquires additional <em>free dimensions</em>.
      *
      * <p> Unless otherwise specified, passing a {@code null} argument, or an array argument containing one or more {@code null}
-     * elements to a method in this class causes a {@link NullPointerException NullPointerException} to be thrown.</p>
+     * elements to a method in this class causes a {@link NullPointerException} to be thrown.</p>
      *
      * @implSpec
      * Implementations of this interface are immutable, thread-safe and <a href="{@docRoot}/java.base/java/lang/doc-files/ValueBased.html">value-based</a>.

--- a/src/java.base/share/classes/java/lang/foreign/MemorySegment.java
+++ b/src/java.base/share/classes/java/lang/foreign/MemorySegment.java
@@ -64,7 +64,7 @@ import jdk.internal.vm.annotation.ForceInline;
  *     <li>{@linkplain MemorySegment#ofByteBuffer(ByteBuffer) buffer segments}, wrapping an existing {@link ByteBuffer} instance;
  * buffer memory segments might be backed by either off-heap memory or on-heap memory, depending on the characteristics of the
  * wrapped byte buffer instance. For instance, a buffer memory segment obtained from a byte buffer created with the
- * {@link ByteBuffer#allocateDirect(int)} method will be backed by off-heap memory.
+ * {@link ByteBuffer#allocateDirect(int)} method will be backed by off-heap memory.</li>
  * </ul>
  *
  * <h2>Lifecycle and confinement</h2>

--- a/src/java.base/share/classes/java/lang/foreign/MemorySegment.java
+++ b/src/java.base/share/classes/java/lang/foreign/MemorySegment.java
@@ -223,7 +223,7 @@ import jdk.internal.vm.annotation.ForceInline;
  * caution: for instance, an incorrect segment size could result in a VM crash when attempting to dereference
  * the memory segment.
  * <p>
- * For instance, clients requiring sophisticated, low-level control over mapped memory segments, might consider writing
+ * Clients requiring sophisticated, low-level control over mapped memory segments, might consider writing
  * custom mapped memory segment factories; using {@link CLinker}, e.g. on Linux, it is possible to call {@code mmap}
  * with the desired parameters; the returned address can be easily wrapped into a memory segment, using
  * {@link MemoryAddress#ofLong(long)} and {@link MemorySegment#ofAddress(MemoryAddress, long, MemorySession)}.

--- a/src/java.base/share/classes/java/lang/foreign/MemorySegment.java
+++ b/src/java.base/share/classes/java/lang/foreign/MemorySegment.java
@@ -53,58 +53,38 @@ import jdk.internal.vm.annotation.ForceInline;
  * and temporal bounds (e.g. a {@link MemorySession}). Spatial bounds ensure that memory access operations on a memory segment cannot affect a memory location
  * which falls <em>outside</em> the boundaries of the memory segment being accessed. Temporal bounds ensure that memory access
  * operations on a segment cannot occur after the memory session associated with a memory segment has been closed (see {@link MemorySession#close()}).
- * <p>
- * All implementations of this interface must be <a href="{@docRoot}/java.base/java/lang/doc-files/ValueBased.html">value-based</a>;
- * programmers should treat instances that are {@linkplain Object#equals(Object) equal} as interchangeable and should not
- * use instances for synchronization, or unpredictable behavior may occur. For example, in a future release,
- * synchronization may fail. The {@code equals} method should be used for comparisons.
- * <p>
- * Non-platform classes should not implement {@linkplain MemorySegment} directly.
  *
- * <h2>Constructing memory segments</h2>
+ * There are many kinds of memory segments:
+ * <ul>
+ *     <li>{@linkplain MemorySegment#allocateNative(long, long, MemorySession) native memory segments}, backed by off-heap memory;</li>
+ *     <li>{@linkplain FileChannel#map(FileChannel.MapMode, long, long, MemorySession) mapped memory segments}, obtained by mapping
+ * a file into main memory ({@code mmap}); tha contents of a mapped memory segments can be {@linkplain #force() persisted} and
+ * {@linkplain #load() loaded} to and from the underlying memory-mapped file;</li>
+ *     <li>{@linkplain MemorySegment#ofArray(int[]) array segments}, wrapping an existing, heap-allocated Java array; and</li>
+ *     <li>{@linkplain MemorySegment#ofByteBuffer(ByteBuffer) buffer segments}, wrapping an existing {@link ByteBuffer} instance;
+ * buffer memory segments might be backed by either off-heap memory or on-heap memory, depending on the characteristics of the
+ * wrapped byte buffer instance. For instance, a buffer memory segment obtained from a byte buffer created with the
+ * {@link ByteBuffer#allocateDirect(int)} method will be backed by off-heap memory.
+ * </ul>
  *
- * There are multiple ways to obtain a memory segment. First, memory segments backed by off-heap memory can
- * be allocated using one of the many factory methods provided (see {@link MemorySegment#allocateNative(MemoryLayout, MemorySession)},
- * {@link MemorySegment#allocateNative(long, MemorySession)} and {@link MemorySegment#allocateNative(long, long, MemorySession)}). Memory segments obtained
- * in this way are called <em>native memory segments</em>.
+ * <h2>Lifecycle and confinement</h2>
+ *
+ * Memory segments are associated with a {@link MemorySegment#session() memory session}. As for all resources associated
+ * with a memory session, a segment cannot be accessed after its underlying session has been closed. For instance,
+ * the following code will result in an exception:
+ * {@snippet lang=java :
+ * MemorySegment segment = null;
+ * try (MemorySession session = MemorySession.openConfined()) {
+ *     segment = MemorySegment.allocateNative(8, session);
+ * }
+ * segment.get(ValueLayout.JAVA_LONG, 0); // already closed!
+ * }
+ * Additionally, access to a memory segment is subject to the thread-confinement checks enforced by the owning memory
+ * session; that is, if the segment is associated with a shared session, it can be accessed by multiple threads;
+ * if it is associated with a confined session, it can only be accessed by the thread which owns the memory session.
  * <p>
- * It is also possible to obtain a memory segment backed by an existing heap-allocated Java array,
- * using one of the provided factory methods (e.g. {@link MemorySegment#ofArray(int[])}). Memory segments obtained
- * in this way are called <em>array memory segments</em>.
- * <p>
- * It is possible to obtain a memory segment backed by an existing Java byte buffer (see {@link ByteBuffer}),
- * using the factory method {@link MemorySegment#ofByteBuffer(ByteBuffer)}.
- * Memory segments obtained in this way are called <em>buffer memory segments</em>. Note that buffer memory segments might
- * be backed by native memory (as in the case of native memory segments) or heap memory (as in the case of array memory segments),
- * depending on the characteristics of the byte buffer instance the segment is associated with. For instance, a buffer memory
- * segment obtained from a byte buffer created with the {@link ByteBuffer#allocateDirect(int)} method will be backed
- * by native memory.
- *
- * <h2>Mapping memory segments from files</h2>
- *
- * It is also possible to obtain a native memory segment backed by a memory-mapped file using the factory method
- * {@link FileChannel#map(FileChannel.MapMode, long, long, MemorySession)}. Such native memory segments are called
- * <em>mapped memory segments</em>; mapped memory segments are associated with an underlying file descriptor.
- * <p>
- * Contents of mapped memory segments can be {@linkplain #force() persisted} and {@linkplain #load() loaded} to and from the underlying file;
- * these capabilities are suitable replacements for some capabilities in the {@link java.nio.MappedByteBuffer} class.
- * Note that, while it is possible to map a segment into a byte buffer (see {@link MemorySegment#asByteBuffer()}),
- * and then call e.g. {@link java.nio.MappedByteBuffer#force()} that way, this can only be done when the source segment
- * is small enough, due to the size limitation inherent to the ByteBuffer API.
- * <p>
- * Clients requiring sophisticated, low-level control over mapped memory segments, should consider writing
- * custom mapped memory segment factories; using {@link CLinker}, e.g. on Linux, it is possible to call {@code mmap}
- * with the desired parameters; the returned address can be easily wrapped into a memory segment, using
- * {@link MemoryAddress#ofLong(long)} and {@link MemorySegment#ofAddress(MemoryAddress, long, MemorySession)}.
- *
- * <h2>Restricted native segments</h2>
- *
- * Sometimes it is necessary to turn a memory address obtained from native code into a memory segment with
- * full spatial, temporal and confinement bounds. To do this, clients can {@link #ofAddress(MemoryAddress, long, MemorySession) obtain}
- * a native segment <em>unsafely</em> from a give memory address, by providing the segment size, as well as the segment {@linkplain MemorySession session}.
- * This is a <a href="package-summary.html#restricted"><em>restricted</em></a> operation and should be used with
- * caution: for instance, an incorrect segment size could result in a VM crash when attempting to dereference
- * the memory segment.
+ * Heap and buffer segments are always associated with a <em>global</em>, shared memory session. This session cannot be closed,
+ * and segments associated with it can be considered as <em>always alive</em>.
  *
  * <h2><a id = "segment-deref">Dereferencing memory segments</a></h2>
  *
@@ -151,6 +131,40 @@ import jdk.internal.vm.annotation.ForceInline;
  * intHandle.get(segment, 3L); // get int element at offset 3 * 4 = 12
  * }
  *
+ * <h2>Slicing memory segments</h2>
+ *
+ * Memory segments support <em>slicing</em>. A memory segment can be used to {@link MemorySegment#asSlice(long, long) obtain}
+ * other segments backed by the same underlying memory region, but with <em>stricter</em> spatial bounds than the ones
+ * of the original segment:
+ * {@snippet lang=java :
+ * MemorySession session = ...
+ * MemorySegment segment = MemorySegment.allocateNative(100, session);
+ * MemorySegment slice = segment.asSlice(50, 10);
+ * slice.get(ValueLayout.JAVA_INT, 20); // Out of bounds!
+ * session.close();
+ * slice.get(ValueLayout.JAVA_INT, 0); // Already closed!
+ * }
+ * The above code creates a native segment that is 100 bytes long; then, it creates a slice that starts at offset 50
+ * of {@code segment}, and is 10 bytes long. As a result, attempting to read an int value at offset 20 of the
+ * {@code slice} segment will result in an exception. The {@linkplain MemorySession temporal bounds} of the original segment
+ * are inherited by its slices; that is, when the memory session associated with {@code segment} is closed, {@code slice}
+ * will also be become inaccessible.
+ * <p>
+ * A client might obtain a {@link Stream} from a segment, which can then be used to slice the segment (according to a given
+ * element layout) and even allow multiple threads to work in parallel on disjoint segment slices
+ * (to do this, the segment has to be associated with a shared memory session). The following code can be used to sum all int
+ * values in a memory segment in parallel:
+ *
+ * {@snippet lang=java :
+ * try (MemorySession session = MemorySession.openShared()) {
+ *     SequenceLayout SEQUENCE_LAYOUT = MemoryLayout.sequenceLayout(1024, ValueLayout.JAVA_INT);
+ *     MemorySegment segment = MemorySegment.allocateNative(SEQUENCE_LAYOUT, session);
+ *     int sum = segment.elements(ValueLayout.JAVA_INT).parallel()
+ *                      .mapToInt(s -> s.get(ValueLayout.JAVA_INT, 0))
+ *                      .sum();
+ * }
+ * }
+ *
  * <h2 id="segment-alignment">Alignment</h2>
  *
  * When dereferencing a memory segment using a layout, the runtime must check that the segment address being dereferenced
@@ -158,11 +172,11 @@ import jdk.internal.vm.annotation.ForceInline;
  * dereferenced is a native segment, then it has a concrete {@linkplain #address() base address}, which can
  * be used to perform the alignment check. The pseudo-function below demonstrates this:
  *
- * <blockquote><pre>{@code
-boolean isAligned(MemorySegment segment, long offset, MemoryLayout layout) {
-   return ((segment.address().toRawLongValue() + offset) % layout.byteAlignment()) == 0
-}
- * }</pre></blockquote>
+ * {@snippet lang=java :
+ * boolean isAligned(MemorySegment segment, long offset, MemoryLayout layout) {
+ *   return ((segment.address().toRawLongValue() + offset) % layout.byteAlignment()) == 0
+ * }
+ * }
  *
  * If, however, the segment being dereferenced is a heap segment, the above function will not work: a heap
  * segment's base address is <em>virtualized</em> and, as such, cannot be used to construct an alignment check. Instead,
@@ -201,59 +215,18 @@ boolean isAligned(MemorySegment segment, long offset, MemoryLayout layout) {
  * constructed from a {@code byte[]} might have a subset of addresses {@code S} which happen to be 8-byte aligned. But determining
  * which segment addresses belong to {@code S} requires reasoning about details which are ultimately implementation-dependent.
  *
- * <h2>Lifecycle and confinement</h2>
- *
- * Memory segments are associated with a {@link MemorySegment#session() memory session}. As for all resources associated
- * with a memory session, a segment cannot be accessed after its underlying session has been closed. For instance,
- * the following code will result in an exception:
- * {@snippet lang=java :
- * MemorySegment segment = null;
- * try (MemorySession session = MemorySession.openConfined()) {
- *     segment = MemorySegment.allocateNative(8, session);
- * }
- * segment.get(ValueLayout.JAVA_LONG, 0); // already closed!
- * }
- * Additionally, access to a memory segment is subject to the thread-confinement checks enforced by the owning memory
- * session; that is, if the segment is associated with a shared session, it can be accessed by multiple threads;
- * if it is associated with a confined session, it can only be accessed by the thread which owns the memory session.
+ * <h2>Restricted memory segments</h2>
+ * Sometimes it is necessary to turn a memory address obtained from native code into a memory segment with
+ * full spatial, temporal and confinement bounds. To do this, clients can {@link #ofAddress(MemoryAddress, long, MemorySession) obtain}
+ * a native segment <em>unsafely</em> from a give memory address, by providing the segment size, as well as the segment {@linkplain MemorySession session}.
+ * This is a <a href="package-summary.html#restricted"><em>restricted</em></a> operation and should be used with
+ * caution: for instance, an incorrect segment size could result in a VM crash when attempting to dereference
+ * the memory segment.
  * <p>
- * Heap and buffer segments are always associated with a <em>global</em>, shared memory session. This session cannot be closed,
- * and segments associated with it can be considered as <em>always alive</em>.
- *
- * <h2>Memory segment views</h2>
- *
- * Memory segments support <em>views</em>. For instance, it is possible to create an <em>immutable</em> view of a memory segment, as follows:
- * {@snippet lang=java :
- * MemorySegment segment = ...
- * MemorySegment roSegment = segment.asReadOnly();
- * }
- * It is also possible to create views whose spatial bounds are stricter than the ones of the original segment
- * (see {@link MemorySegment#asSlice(long, long)}).
- * <p>
- * Temporal bounds of the original segment are inherited by the views; that is, when the memory session associated with a segment
- * is closed, all the views associated with that segment will also be rendered inaccessible.
- * <p>
- * To allow for interoperability with existing code, a byte buffer view can be obtained from a memory segment
- * (see {@link #asByteBuffer()}). This can be useful, for instance, for those clients that want to keep using the
- * {@link ByteBuffer} API, but need to operate on large memory segments. Byte buffers obtained in such a way support
- * the same spatial and temporal access restrictions associated with the memory segment from which they originated.
- *
- * <h2>Stream support</h2>
- *
- * A client might obtain a {@link Stream} from a segment, which can then be used to slice the segment (according to a given
- * element layout) and even allow multiple threads to work in parallel on disjoint segment slices
- * (to do this, the segment has to be associated with a shared memory session). The following code can be used to sum all int
- * values in a memory segment in parallel:
- *
- * {@snippet lang=java :
- * try (MemorySession session = MemorySession.openShared()) {
- *     SequenceLayout SEQUENCE_LAYOUT = MemoryLayout.sequenceLayout(1024, ValueLayout.JAVA_INT);
- *     MemorySegment segment = MemorySegment.allocateNative(SEQUENCE_LAYOUT, session);
- *     int sum = segment.elements(ValueLayout.JAVA_INT).parallel()
- *                      .mapToInt(s -> s.get(ValueLayout.JAVA_INT, 0))
- *                      .sum();
- * }
- * }
+ * For instance, clients requiring sophisticated, low-level control over mapped memory segments, might consider writing
+ * custom mapped memory segment factories; using {@link CLinker}, e.g. on Linux, it is possible to call {@code mmap}
+ * with the desired parameters; the returned address can be easily wrapped into a memory segment, using
+ * {@link MemoryAddress#ofLong(long)} and {@link MemorySegment#ofAddress(MemoryAddress, long, MemorySession)}.
  *
  * @implSpec
  * Implementations of this interface are immutable, thread-safe and <a href="{@docRoot}/java.base/java/lang/doc-files/ValueBased.html">value-based</a>.

--- a/src/java.base/share/classes/java/lang/foreign/MemorySegment.java
+++ b/src/java.base/share/classes/java/lang/foreign/MemorySegment.java
@@ -69,7 +69,7 @@ import jdk.internal.vm.annotation.ForceInline;
  *
  * <h2>Lifecycle and confinement</h2>
  *
- * Memory segments are associated with a {@link MemorySegment#session() memory session}. As for all resources associated
+ * Memory segments are associated with a {@linkplain MemorySegment#session() memory session}. As for all resources associated
  * with a memory session, a segment cannot be accessed after its underlying session has been closed. For instance,
  * the following code will result in an exception:
  * {@snippet lang=java :
@@ -91,13 +91,13 @@ import jdk.internal.vm.annotation.ForceInline;
  * A memory segment can be read or written using various methods provided in this class (e.g. {@link #get(ValueLayout.OfInt, long)}).
  * Each dereference method takes a {@linkplain ValueLayout value layout}, which specifies the size,
  * alignment constraints, byte order as well as the Java type associated with the dereference operation, and an offset.
- * For instance, to read an int from a segment, using {@link ByteOrder#nativeOrder() default endianness}, the following code can be used:
+ * For instance, to read an int from a segment, using {@linkplain ByteOrder#nativeOrder() default endianness}, the following code can be used:
  * {@snippet lang=java :
  * MemorySegment segment = ...
  * int value = segment.get(ValueLayout.JAVA_INT, 0);
  * }
  *
- * If the value to be read is stored in memory using {@link ByteOrder#BIG_ENDIAN big-endian} encoding, the dereference operation
+ * If the value to be read is stored in memory using {@linkplain ByteOrder#BIG_ENDIAN big-endian} encoding, the dereference operation
  * can be expressed as follows:
  * {@snippet lang=java :
  * MemorySegment segment = ...
@@ -133,7 +133,7 @@ import jdk.internal.vm.annotation.ForceInline;
  *
  * <h2>Slicing memory segments</h2>
  *
- * Memory segments support <em>slicing</em>. A memory segment can be used to {@link MemorySegment#asSlice(long, long) obtain}
+ * Memory segments support <em>slicing</em>. A memory segment can be used to {@linkplain MemorySegment#asSlice(long, long) obtain}
  * other segments backed by the same underlying memory region, but with <em>stricter</em> spatial bounds than the ones
  * of the original segment:
  * {@snippet lang=java :
@@ -217,7 +217,7 @@ import jdk.internal.vm.annotation.ForceInline;
  *
  * <h2>Restricted memory segments</h2>
  * Sometimes it is necessary to turn a memory address obtained from native code into a memory segment with
- * full spatial, temporal and confinement bounds. To do this, clients can {@link #ofAddress(MemoryAddress, long, MemorySession) obtain}
+ * full spatial, temporal and confinement bounds. To do this, clients can {@linkplain #ofAddress(MemoryAddress, long, MemorySession) obtain}
  * a native segment <em>unsafely</em> from a give memory address, by providing the segment size, as well as the segment {@linkplain MemorySession session}.
  * This is a <a href="package-summary.html#restricted"><em>restricted</em></a> operation and should be used with
  * caution: for instance, an incorrect segment size could result in a VM crash when attempting to dereference
@@ -343,7 +343,7 @@ public sealed interface MemorySegment extends Addressable permits AbstractMemory
     /**
      * Returns {@code true} if this segment is a native segment. A native memory segment is
      * created using the {@link #allocateNative(long, MemorySession)} (and related) factory, or a buffer segment
-     * derived from a direct {@link java.nio.ByteBuffer} using the {@link #ofByteBuffer(ByteBuffer)} factory,
+     * derived from a {@linkplain ByteBuffer#allocateDirect(int) direct byte buffer} using the {@link #ofByteBuffer(ByteBuffer)} factory,
      * or if this is a {@linkplain #isMapped() mapped} segment.
      * @return {@code true} if this segment is native segment.
      */
@@ -364,7 +364,7 @@ public sealed interface MemorySegment extends Addressable permits AbstractMemory
      * <p>Two segments {@code S1} and {@code S2} are said to overlap if it is possible to find
      * at least two slices {@code L1} (from {@code S1}) and {@code L2} (from {@code S2}) that are backed by the
      * same memory region. As such, it is not possible for a
-     * {@link #isNative() native} segment to overlap with a heap segment; in
+     * {@linkplain #isNative() native} segment to overlap with a heap segment; in
      * this case, or when no overlap occurs, {@code null} is returned.
      *
      * @param other the segment to test for an overlap with this segment.
@@ -710,8 +710,8 @@ public sealed interface MemorySegment extends Addressable permits AbstractMemory
      * buffer. The segment starts relative to the buffer's position (inclusive)
      * and ends relative to the buffer's limit (exclusive).
      * <p>
-     * If the buffer is {@link ByteBuffer#isReadOnly() read-only}, the resulting segment will also be
-     * {@link ByteBuffer#isReadOnly() read-only}. The memory session associated with this segment can either be the
+     * If the buffer is {@linkplain ByteBuffer#isReadOnly() read-only}, the resulting segment will also be
+     * {@linkplain ByteBuffer#isReadOnly() read-only}. The memory session associated with this segment can either be the
      * {@linkplain MemorySession#global() global} memory session, in case the buffer has been created independently,
      * or some other memory session, in case the buffer has been obtained using {@link #asByteBuffer()}.
      * <p>

--- a/src/java.base/share/classes/java/lang/foreign/MemorySession.java
+++ b/src/java.base/share/classes/java/lang/foreign/MemorySession.java
@@ -30,6 +30,7 @@ import java.lang.ref.Cleaner;
 import java.nio.channels.FileChannel;
 import java.nio.file.Path;
 import java.util.Objects;
+import java.util.function.Consumer;
 
 import jdk.internal.foreign.MemorySessionImpl;
 import jdk.internal.javac.PreviewFeature;
@@ -43,18 +44,16 @@ import jdk.internal.javac.PreviewFeature;
  * When a memory session is closed, it is no longer {@link #isAlive() alive}, and subsequent operations on resources
  * associated with that session (e.g. attempting to access a {@link MemorySegment} instance) will fail with {@link IllegalStateException}.
  * <p>
- * When a memory session is closed (either explicitly, or implicitly), all the {@linkplain #addCloseAction(Runnable) close actions} associated with that session will be called.
- * and underlying memory resources associated with said session might be released; for instance:
- * <ul>
- *     <li>closing the memory session associated with a {@linkplain MemorySegment#allocateNative(long, long, MemorySession) native memory segment}
- *     results in <em>freeing</em> the native memory associated with it;</li>
- *     <li>closing the memory session associated with a {@linkplain FileChannel#map(FileChannel.MapMode, long, long, MemorySession) mapped memory segment}
- *     results in the backing memory-mapped file to be unmapped;</li>
- *     <li>closing the memory session associated with an {@linkplain CLinker#upcallStub(MethodHandle, FunctionDescriptor, MemorySession) upcall stub}
- *     results in releasing the stub;</li>
- *     <li>closing the memory session associated with a {@linkplain VaList variable arity list} results in releasing the memory
- *     associated with that variable arity list instance.</li>
- * </ul>
+ * A memory session is associated with one or more {@linkplain #addCloseAction(Runnable) close actions}. Close actions
+ * can be used to specify the cleanup code that must run when a given resource (or set of resources) is no longer in use.
+ * When a memory session is closed (either explicitly, or implicitly), the {@linkplain #addCloseAction(Runnable) close actions}
+ * associated with that session are executed (in unspecified order). For instance, closing the memory session associated with
+ * one or more {@linkplain MemorySegment#allocateNative(long, long, MemorySession) native memory segments} results in releasing
+ * the off-heap memory associated with said segments.
+ * <p>
+ * The {@linkplain #global() global session} is a memory session that cannot be closed, either explicitly or implicitly.
+ * As a result, resources associated with the global session are never released. Examples of resources associated with
+ * the global memory session are {@linkplain MemorySegment#ofArray(int[]) heap segments}.
  *
  * <h2><a id = "thread-confinement">Thread confinement</a></h2>
  *
@@ -101,13 +100,6 @@ import jdk.internal.javac.PreviewFeature;
  * the session becomes unreachable; that is, {@linkplain #addCloseAction(Runnable) close actions} associated with a
  * memory session, whether managed or not, are called <em>exactly once</em>.
  *
- * <h2>Global session</h2>
- *
- * An important memory session is the so called {@linkplain #global() global session}; the global session is
- * a memory session that cannot be closed, either explicitly or implicitly. As a result, the global session will never
- * attempt to release resources associated with it. Examples of resources associated with the global memory session are
- * {@linkplain MemorySegment#ofArray(int[]) heap segments}.
- *
  * <h2>Restricting access to memory sessions</h2>
  *
  * There are situations in which it might not be desirable for a memory session to be reachable from one or
@@ -130,6 +122,11 @@ import jdk.internal.javac.PreviewFeature;
  *
  * @implSpec
  * Implementations of this interface are thread-safe.
+ * 
+ * @see MemorySegment
+ * @see SymbolLookup
+ * @see CLinker
+ * @see VaList
  *
  * @since 19
  */

--- a/src/java.base/share/classes/java/lang/foreign/MemorySession.java
+++ b/src/java.base/share/classes/java/lang/foreign/MemorySession.java
@@ -122,7 +122,7 @@ import jdk.internal.javac.PreviewFeature;
  *
  * @implSpec
  * Implementations of this interface are thread-safe.
- * 
+ *
  * @see MemorySegment
  * @see SymbolLookup
  * @see CLinker

--- a/src/java.base/share/classes/java/lang/foreign/MemorySession.java
+++ b/src/java.base/share/classes/java/lang/foreign/MemorySession.java
@@ -41,7 +41,7 @@ import jdk.internal.javac.PreviewFeature;
  * and by the {@linkplain #ownerThread() thread} associated with the memory session (if any).
  * <p>
  * Memory sessions can be closed, either implicitly (e.g. when a session is no longer reachable), or explicitly.
- * When a memory session is closed, it is no longer {@link #isAlive() alive}, and subsequent operations on resources
+ * When a memory session is closed, it is no longer {@linkplain #isAlive() alive}, and subsequent operations on resources
  * associated with that session (e.g. attempting to access a {@link MemorySegment} instance) will fail with {@link IllegalStateException}.
  * <p>
  * A memory session is associated with one or more {@linkplain #addCloseAction(Runnable) close actions}. Close actions
@@ -75,7 +75,7 @@ import jdk.internal.javac.PreviewFeature;
  * When a session is associated with off-heap resources, it is often desirable for said resources to be released in a timely fashion,
  * rather than waiting for the session to be deemed <a href="../../../java/lang/ref/package.html#reachability">unreachable</a>
  * by the garbage collector. In this scenario, a client might consider using a {@linkplain #isCloseable() <em>closeable</em>} memory session.
- * Closeable memory sessions are memory sessions that can be {@link MemorySession#close() closed} explicitly, as demonstrated
+ * Closeable memory sessions are memory sessions that can be {@linkplain MemorySession#close() closed} explicitly, as demonstrated
  * in the following example:
  *
  * {@snippet lang=java :

--- a/src/java.base/share/classes/java/lang/foreign/PaddingLayout.java
+++ b/src/java.base/share/classes/java/lang/foreign/PaddingLayout.java
@@ -33,16 +33,9 @@ import java.util.Optional;
 /**
  * A padding layout. A padding layout specifies the size of extra space which is typically not accessed by applications,
  * and is typically used for aligning member layouts around word boundaries.
- * <p>
- * This is a <a href="{@docRoot}/java.base/java/lang/doc-files/ValueBased.html">value-based</a>
- * class; programmers should treat instances that are
- * {@linkplain #equals(Object) equal} as interchangeable and should not
- * use instances for synchronization, or unpredictable behavior may
- * occur. For example, in a future release, synchronization may fail.
- * The {@code equals} method should be used for comparisons.
  *
  * @implSpec
- * This class is immutable and thread-safe.
+ * This class is immutable, thread-safe and <a href="{@docRoot}/java.base/java/lang/doc-files/ValueBased.html">value-based</a>.
  */
 /* package-private */ final class PaddingLayout extends AbstractLayout implements MemoryLayout {
 

--- a/src/java.base/share/classes/java/lang/foreign/SegmentAllocator.java
+++ b/src/java.base/share/classes/java/lang/foreign/SegmentAllocator.java
@@ -204,7 +204,7 @@ public interface SegmentAllocator {
     }
 
     /**
-     * Allocates a memory segment with the given layout and initializes it with the given byte array.
+     * Allocates a memory segment with the given layout and initializes it with the given byte elements.
      * @implSpec the default implementation for this method calls {@code this.allocateArray(layout, array.length)}.
      * @param elementLayout the element layout of the array to be allocated.
      * @param elements the byte elements to be copied to the newly allocated memory block.
@@ -215,7 +215,7 @@ public interface SegmentAllocator {
     }
 
     /**
-     * Allocates a memory segment with the given layout and initializes it with the given short array.
+     * Allocates a memory segment with the given layout and initializes it with the given short elements.
      * @implSpec the default implementation for this method calls {@code this.allocateArray(layout, array.length)}.
      * @param elementLayout the element layout of the array to be allocated.
      * @param elements the short elements to be copied to the newly allocated memory block.
@@ -226,7 +226,7 @@ public interface SegmentAllocator {
     }
 
     /**
-     * Allocates a memory segment with the given layout and initializes it with the given char array.
+     * Allocates a memory segment with the given layout and initializes it with the given char elements.
      * @implSpec the default implementation for this method calls {@code this.allocateArray(layout, array.length)}.
      * @param elementLayout the element layout of the array to be allocated.
      * @param elements the char elements to be copied to the newly allocated memory block.
@@ -237,7 +237,7 @@ public interface SegmentAllocator {
     }
 
     /**
-     * Allocates a memory segment with the given layout and initializes it with the given int array.
+     * Allocates a memory segment with the given layout and initializes it with the given int elements.
      * @implSpec the default implementation for this method calls {@code this.allocateArray(layout, array.length)}.
      * @param elementLayout the element layout of the array to be allocated.
      * @param elements the int elements to be copied to the newly allocated memory block.
@@ -248,7 +248,7 @@ public interface SegmentAllocator {
     }
 
     /**
-     * Allocates a memory segment with the given layout and initializes it with the given float array.
+     * Allocates a memory segment with the given layout and initializes it with the given float elements.
      * @implSpec the default implementation for this method calls {@code this.allocateArray(layout, array.length)}.
      * @param elementLayout the element layout of the array to be allocated.
      * @param elements the float elements to be copied to the newly allocated memory block.
@@ -259,7 +259,7 @@ public interface SegmentAllocator {
     }
 
     /**
-     * Allocates a memory segment with the given layout and initializes it with the given long array.
+     * Allocates a memory segment with the given layout and initializes it with the given long elements.
      * @implSpec the default implementation for this method calls {@code this.allocateArray(layout, array.length)}.
      * @param elementLayout the element layout of the array to be allocated.
      * @param elements the long elements to be copied to the newly allocated memory block.
@@ -270,7 +270,7 @@ public interface SegmentAllocator {
     }
 
     /**
-     * Allocates a memory segment with the given layout and initializes it with the given double array.
+     * Allocates a memory segment with the given layout and initializes it with the given double elements.
      * @implSpec the default implementation for this method calls {@code this.allocateArray(layout, array.length)}.
      * @param elementLayout the element layout of the array to be allocated.
      * @param elements the double elements to be copied to the newly allocated memory block.

--- a/src/java.base/share/classes/java/lang/foreign/SequenceLayout.java
+++ b/src/java.base/share/classes/java/lang/foreign/SequenceLayout.java
@@ -51,16 +51,8 @@ import jdk.internal.javac.PreviewFeature;
  *     ValueLayout.JAVA_INT.withOrder(ByteOrder.BIG_ENDIAN));
  * }
  *
- * <p>
- * This is a <a href="{@docRoot}/java.base/java/lang/doc-files/ValueBased.html">value-based</a>
- * class; programmers should treat instances that are
- * {@linkplain #equals(Object) equal} as interchangeable and should not
- * use instances for synchronization, or unpredictable behavior may
- * occur. For example, in a future release, synchronization may fail.
- * The {@code equals} method should be used for comparisons.
- *
  * @implSpec
- * This class is immutable and thread-safe and <a href="{@docRoot}/java.base/java/lang/doc-files/ValueBased.html">value-based</a>.
+ * This class is immutable, thread-safe and <a href="{@docRoot}/java.base/java/lang/doc-files/ValueBased.html">value-based</a>.
  *
  * @since 19
  */

--- a/src/java.base/share/classes/java/lang/foreign/ValueLayout.java
+++ b/src/java.base/share/classes/java/lang/foreign/ValueLayout.java
@@ -49,13 +49,6 @@ import sun.invoke.util.Wrapper;
  * The layout constants in this class make implicit alignment and byte-ordering assumption: all layout
  * constants in this class are byte-aligned, and their byte order is set to the {@linkplain ByteOrder#nativeOrder() platform default},
  * thus making it easy to work with other APIs, such as arrays and {@link java.nio.ByteBuffer}.
- * <p>
- * This is a <a href="{@docRoot}/java.base/java/lang/doc-files/ValueBased.html">value-based</a>
- * class; programmers should treat instances that are
- * {@linkplain #equals(Object) equal} as interchangeable and should not
- * use instances for synchronization, or unpredictable behavior may
- * occur. For example, in a future release, synchronization may fail.
- * The {@code equals} method should be used for comparisons.
  *
  * @implSpec
  * This class and its subclasses are immutable, thread-safe and <a href="{@docRoot}/java.base/java/lang/doc-files/ValueBased.html">value-based</a>.


### PR DESCRIPTION
I noticed more inconsistencies in the foreogn API javadoc. For instance, the text saying that a class is value-based was in some cases repeated twice, once inside the main javadoc, and another as an `@implSpec`. I've removed all duplicates, and opted for the `@implSpec` version, that is more succint and more separated from the main javadoc text.

I have also reworked the javadoc of `MemorySession` and `MemorySegment`. The `MemorySession` javadoc contained a big list of all the possible things that can be associated with a session and what happens to them once the session is closed. I found this to be redundant and I've decided to streamline the text a little.

As for `MemorySegment`, the javadoc has evolved into many different small subsections. I've consolidated the text, by quickly listing all types of memory segments at the top. I've also dropped the section on "views" (which is something that is far less important in this iteraton of the API) and created a new session on slicing, which covers both slices and stream support. The result makes, I think, a lot more sense.

Finally, I've tweaked some text in `SegmentAllocator` where we're still referring to `array` event though the signatures of the methods take a varargs.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [Julia Boes](https://openjdk.java.net/census#jboes) (@FrauBoes - Committer) ⚠️ Review applies to 011ca0a44557faf029c3274f0b877fa8675c6e40


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/670/head:pull/670` \
`$ git checkout pull/670`

Update a local copy of the PR: \
`$ git checkout pull/670` \
`$ git pull https://git.openjdk.java.net/panama-foreign pull/670/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 670`

View PR using the GUI difftool: \
`$ git pr show -t 670`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/panama-foreign/pull/670.diff">https://git.openjdk.java.net/panama-foreign/pull/670.diff</a>

</details>
