### PR TITLE
8283175: Add equals/hashcode to MemorySegment

### DIFF
--- a/src/java.base/share/classes/java/lang/foreign/FunctionDescriptor.java
+++ b/src/java.base/share/classes/java/lang/foreign/FunctionDescriptor.java
@@ -186,8 +186,9 @@ public sealed class FunctionDescriptor implements Constable permits FunctionDesc
      * Compares the specified object with this function descriptor for equality. Returns {@code true} if and only if the specified
      * object is also a function descriptor, and all the following conditions are met:
      * <ul>
-     *     <li>the two function descriptors have equals return layouts (see {@link MemoryLayout#equals(Object)}), or both have no return layout</li>
-     *     <li>the two function descriptors have argument layouts that are pair-wise equal (see {@link MemoryLayout#equals(Object)})
+     *     <li>the two function descriptors have equals return layouts (see {@link MemoryLayout#equals(Object)}), or both have no return layout;</li>
+     *     <li>the two function descriptors have argument layouts that are pair-wise {@linkplain MemoryLayout#equals(Object) equal}; and
+     *     <li>the two function descriptors have the same leading {@linkplain #firstVariadicArgumentIndex() variadic argument index}</li>
      * </ul>
      *
      * @param other the object to be compared for equality with this function descriptor.
@@ -195,13 +196,10 @@ public sealed class FunctionDescriptor implements Constable permits FunctionDesc
      */
     @Override
     public boolean equals(Object other) {
-        if (this == other) {
-            return true;
-        }
-        if (!(other instanceof FunctionDescriptor f)) {
-            return false;
-        }
-        return Objects.equals(resLayout, f.resLayout) && Objects.equals(argLayouts, f.argLayouts);
+        return other instanceof FunctionDescriptor f &&
+                Objects.equals(resLayout, f.resLayout) &&
+                Objects.equals(argLayouts, f.argLayouts) &&
+                firstVariadicArgumentIndex() == f.firstVariadicArgumentIndex();
     }
 
     /**
@@ -209,8 +207,7 @@ public sealed class FunctionDescriptor implements Constable permits FunctionDesc
      */
     @Override
     public int hashCode() {
-        int hashCode = Objects.hashCode(argLayouts);
-        return resLayout == null ? hashCode : resLayout.hashCode() ^ hashCode;
+        return Objects.hash(argLayouts, resLayout, firstVariadicArgumentIndex());
     }
 
      /**

--- a/src/java.base/share/classes/java/lang/foreign/FunctionDescriptor.java
+++ b/src/java.base/share/classes/java/lang/foreign/FunctionDescriptor.java
@@ -190,7 +190,7 @@ public sealed class FunctionDescriptor implements Constable permits FunctionDesc
      * object is also a function descriptor, and all the following conditions are met:
      * <ul>
      *     <li>the two function descriptors have equals return layouts (see {@link MemoryLayout#equals(Object)}), or both have no return layout;</li>
-     *     <li>the two function descriptors have argument layouts that are pair-wise {@linkplain MemoryLayout#equals(Object) equal}; and
+     *     <li>the two function descriptors have argument layouts that are pair-wise {@linkplain MemoryLayout#equals(Object) equal}; and</li>
      *     <li>the two function descriptors have the same leading {@linkplain #firstVariadicArgumentIndex() variadic argument index}</li>
      * </ul>
      *

--- a/src/java.base/share/classes/java/lang/foreign/FunctionDescriptor.java
+++ b/src/java.base/share/classes/java/lang/foreign/FunctionDescriptor.java
@@ -35,6 +35,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 import java.util.stream.Stream;
 import jdk.internal.javac.PreviewFeature;
 
@@ -177,8 +178,9 @@ public sealed class FunctionDescriptor implements Constable permits FunctionDesc
     @Override
     public String toString() {
         return String.format("(%s)%s",
-                Stream.of(argLayouts)
-                        .map(Object::toString)
+                IntStream.range(0, argLayouts.size())
+                        .mapToObj(i -> (i == firstVariadicArgumentIndex() ?
+                                "..." : "") + argLayouts.get(i))
                         .collect(Collectors.joining()),
                 returnLayout().map(Object::toString).orElse("v"));
     }

--- a/src/java.base/share/classes/java/lang/foreign/MemorySegment.java
+++ b/src/java.base/share/classes/java/lang/foreign/MemorySegment.java
@@ -1721,6 +1721,36 @@ public sealed interface MemorySegment extends Addressable permits AbstractMemory
         layout.accessHandle().set(this, index * layout.byteSize(), value.address());
     }
 
+    /**
+     * Compares the specified object with this memory segment for equality. Returns {@code true} if and only if the specified
+     * object is also a memory segment, and if that segment refers to the same memory region as this segment. More specifically,
+     * for two segments to be considered equals, all the following must be true:
+     * <ul>
+     *     <li>the two segments must be of the same kind; either both are {@linkplain #isNative() native segments},
+     *     backed by off-heap memory, or both are backed by on-heap memory;
+     *     <li>if the two segments are {@linkplain #isNative() native segments}, their {@link #address() base address}
+     *     must be {@linkplain MemoryAddress#equals(Object) equal}. Otherwise, the two segments must wrap the
+     *     same Java array instance, at the same starting offset;</li>
+     *     <li>the two segments must have the same {@linkplain #byteSize() size}; and</li>
+     *     <li>the two segments must have the {@linkplain MemorySession#equals(Object) same} {@linkplain #session() temporal bounds}.
+     * </ul>
+     * @apiNote This method does not perform a structural comparison of the contents of the two memory segments. Clients can
+     * compare memory segments structurally by using the {@link #mismatch(MemorySegment)} method instead.
+     *
+     * @param that the object to be compared for equality with this memory segment.
+     * @return {@code true} if the specified object is equal to this memory segment.
+     * @see #mismatch(MemorySegment)
+     * @see #asOverlappingSlice(MemorySegment)
+     */
+    @Override
+    boolean equals(Object that);
+
+    /**
+     * {@return the hash code value for this memory segment}
+     */
+    @Override
+    int hashCode();
+
 
     /**
      * Copies a number of elements from a source memory segment to a destination array. The elements, whose size and alignment

--- a/src/java.base/share/classes/jdk/internal/foreign/AbstractMemorySegmentImpl.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/AbstractMemorySegmentImpl.java
@@ -495,6 +495,27 @@ public abstract non-sealed class AbstractMemorySegmentImpl implements MemorySegm
         return "MemorySegment{ id=0x" + Long.toHexString(id()) + " limit: " + length + " }";
     }
 
+    @Override
+    public boolean equals(Object o) {
+        return o instanceof AbstractMemorySegmentImpl that &&
+                isNative() == that.isNative() &&
+                unsafeGetOffset() == that.unsafeGetOffset() &&
+                unsafeGetBase() == that.unsafeGetBase() &&
+                length == that.length &&
+                session.equals(that.session);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(
+                isNative(),
+                unsafeGetOffset(),
+                unsafeGetBase(),
+                length,
+                session
+        );
+    }
+
     public static AbstractMemorySegmentImpl ofBuffer(ByteBuffer bb) {
         Objects.requireNonNull(bb);
         long bbAddress = nioAccess.getBufferAddress(bb);

--- a/test/jdk/java/foreign/TestFunctionDescriptor.java
+++ b/test/jdk/java/foreign/TestFunctionDescriptor.java
@@ -37,6 +37,7 @@ import org.testng.annotations.Test;
 
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotEquals;
 import static org.testng.Assert.assertTrue;
 
 public class TestFunctionDescriptor extends NativeTestHelper {
@@ -92,5 +93,15 @@ public class TestFunctionDescriptor extends NativeTestHelper {
         assertEquals(fd.argumentLayouts(), List.of(C_DOUBLE, C_LONG_LONG));
         Optional<MemoryLayout> returnLayoutOp = fd.returnLayout();
         assertFalse(returnLayoutOp.isPresent());
+    }
+
+    @Test
+    public void testEquals() {
+        FunctionDescriptor fd = FunctionDescriptor.of(C_INT, C_INT, C_INT);
+        FunctionDescriptor fd_va1 = FunctionDescriptor.of(C_INT).asVariadic(C_INT, C_INT);
+        FunctionDescriptor fd_va2 = FunctionDescriptor.of(C_INT, C_INT).asVariadic(C_INT);
+        assertEquals(fd, fd);
+        assertNotEquals(fd, fd_va1);
+        assertNotEquals(fd, fd_va2);
     }
 }

--- a/test/jdk/java/foreign/TestSegments.java
+++ b/test/jdk/java/foreign/TestSegments.java
@@ -114,6 +114,32 @@ public class TestSegments {
         }
     }
 
+    @Test
+    public void testEqualsOffHeap() {
+        try (MemorySession session = MemorySession.openConfined()) {
+            MemorySegment segment = MemorySegment.allocateNative(100, session);
+            assertEquals(segment, segment.asReadOnly());
+            assertEquals(segment, segment.asSlice(0, 100));
+            assertNotEquals(segment, segment.asSlice(10, 90));
+            assertNotEquals(segment, segment.asSlice(0, 90));
+            assertEquals(segment, MemorySegment.ofAddress(segment.address(), 100, session.asNonCloseable()));
+            assertNotEquals(segment, MemorySegment.ofAddress(segment.address(), 100, MemorySession.global()));
+            MemorySegment segment2 = MemorySegment.allocateNative(100, session);
+            assertNotEquals(segment, segment2);
+        }
+    }
+
+    @Test
+    public void testEqualsOnHeap() {
+        MemorySegment segment = MemorySegment.ofArray(new byte[100]);
+        assertEquals(segment, segment.asReadOnly());
+        assertEquals(segment, segment.asSlice(0, 100));
+        assertNotEquals(segment, segment.asSlice(10, 90));
+        assertNotEquals(segment, segment.asSlice(0, 90));
+        MemorySegment segment2 = MemorySegment.ofArray(new byte[100]);
+        assertNotEquals(segment, segment2);
+    }
+
     @Test(expectedExceptions = IndexOutOfBoundsException.class)
     public void testSmallSegmentMax() {
         long offset = (long)Integer.MAX_VALUE + (long)Integer.MAX_VALUE + 2L + 6L; // overflows to 6 when casted to int

--- a/test/jdk/java/foreign/callarranger/TestAarch64CallArranger.java
+++ b/test/jdk/java/foreign/callarranger/TestAarch64CallArranger.java
@@ -399,7 +399,7 @@ public class TestAarch64CallArranger extends CallArrangerTestBase {
     public void testVarArgsInRegs() {
         MethodType mt = MethodType.methodType(void.class, int.class, int.class, float.class);
         FunctionDescriptor fd = FunctionDescriptor.ofVoid(C_INT).asVariadic(C_INT, C_FLOAT);
-        FunctionDescriptor fdExpected = FunctionDescriptor.ofVoid(ADDRESS, C_INT).asVariadic(C_INT, C_FLOAT);
+        FunctionDescriptor fdExpected = FunctionDescriptor.ofVoid(ADDRESS, C_INT, C_INT, C_FLOAT);
         CallArranger.Bindings bindings = CallArranger.LINUX.getBindings(mt, fd, false);
 
         assertFalse(bindings.isInMemoryReturn);
@@ -422,7 +422,7 @@ public class TestAarch64CallArranger extends CallArrangerTestBase {
     public void testVarArgsOnStack() {
         MethodType mt = MethodType.methodType(void.class, int.class, int.class, float.class);
         FunctionDescriptor fd = FunctionDescriptor.ofVoid(C_INT).asVariadic(C_INT, C_FLOAT);
-        FunctionDescriptor fdExpected = FunctionDescriptor.ofVoid(ADDRESS, C_INT).asVariadic(C_INT, C_FLOAT);
+        FunctionDescriptor fdExpected = FunctionDescriptor.ofVoid(ADDRESS, C_INT, C_INT, C_FLOAT);
         CallArranger.Bindings bindings = CallArranger.MACOS.getBindings(mt, fd, false);
 
         assertFalse(bindings.isInMemoryReturn);

--- a/test/jdk/java/foreign/callarranger/TestWindowsCallArranger.java
+++ b/test/jdk/java/foreign/callarranger/TestWindowsCallArranger.java
@@ -188,7 +188,7 @@ public class TestWindowsCallArranger extends CallArrangerTestBase {
         FunctionDescriptor fd = FunctionDescriptor.ofVoid(
                 C_INT, C_DOUBLE).asVariadic(C_INT, C_DOUBLE, C_DOUBLE);
         FunctionDescriptor fdExpected = FunctionDescriptor.ofVoid(
-                ADDRESS, C_INT, C_DOUBLE).asVariadic(C_INT, C_DOUBLE, C_DOUBLE);
+                ADDRESS, C_INT, C_DOUBLE, C_INT, C_DOUBLE, C_DOUBLE);
         CallArranger.Bindings bindings = CallArranger.getBindings(mt, fd, false);
 
         assertFalse(bindings.isInMemoryReturn);


### PR DESCRIPTION
When looking at the API, we realized that `MemorySegment` is the only class not to expose equals/hashcode (`MemoryLayout`, `MemoryAddress` and `MemorySession` do). This makes it difficult to e.g. use a `MemorySegment` as a map key.

This patch adds equals/hashcode; the behavior is that of a shallow comparison - e.g. equals makes sure that the two segments point to the same memory region and have same spatial and temporal bounds. Read-only status is ignored by the comparison (on the basis that the segment is still pointing to the same memory region). And, since comparing memory session uses `MemorySession::equals`, segments backed by different "views" of the same session will also turn out to be equal (which also makes sense).

To perform a deeper comparison, clients can go through the `MemorySegment::mismatch` path, but I don't think that's a useful implementation for equals/hashCode (even though that's how byte buffers behave - but then, byte buffers do not provide a mismatch method).

When fixing this I realized that the equals method for `FunctionDescriptor` did not take into account the variable arity index, so I've fixed that too (and also tweaked the toString method to take that into account as well). Doing this revealed an issue in some of the calling convention tests, where we passed a variable arity descriptor as the expected descriptor, where in reality the calling convention "flattens" the variable arity descriptor into a specialized, fixed-arity one.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [JDK-8283175](https://bugs.openjdk.java.net/browse/JDK-8283175): Add equals/hashcode to MemorySegment


### Reviewers
 * [Athijegannathan Sundararajan](https://openjdk.java.net/census#sundar) (@sundararajana - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/671/head:pull/671` \
`$ git checkout pull/671`

Update a local copy of the PR: \
`$ git checkout pull/671` \
`$ git pull https://git.openjdk.java.net/panama-foreign pull/671/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 671`

View PR using the GUI difftool: \
`$ git pr show -t 671`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/panama-foreign/pull/671.diff">https://git.openjdk.java.net/panama-foreign/pull/671.diff</a>

</details>
