### PR TITLE
Switch to daemon threads for async upcalls

### DIFF
--- a/src/hotspot/share/prims/universalUpcallHandler.cpp
+++ b/src/hotspot/share/prims/universalUpcallHandler.cpp
@@ -63,7 +63,7 @@ JavaThread* ProgrammableUpcallHandler::maybe_attach_and_get_thread() {
   if (thread == nullptr) {
     JavaVM_ *vm = (JavaVM *)(&main_vm);
     JNIEnv* p_env = nullptr; // unused
-    jint result = vm->functions->AttachCurrentThread(vm, (void**) &p_env, nullptr);
+    jint result = vm->functions->AttachCurrentThreadAsDaemon(vm, (void**) &p_env, nullptr);
     guarantee(result == JNI_OK, "Could not attach thread for upcall. JNI error code: %d", result);
     thread = JavaThread::current();
     threadContext.attachedThread = thread;


### PR DESCRIPTION
In a previous PR (https://git.openjdk.java.net/panama-foreign/pull/570), when merging code I forgot to re-apply the change to attach the thread as daemon thread instead of as ordinary thread.
As described previously, the daemon thread semantics is the preferred one: if the JVM waits for all background threads to stop in order to shutdown, there are cases where native libraries might not cleanup their background threads, and rely on process termination instead - which leads to a circularity (and the process never terminates).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [Jorn Vernee](https://openjdk.java.net/census#jvernee) (@JornVernee - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/673/head:pull/673` \
`$ git checkout pull/673`

Update a local copy of the PR: \
`$ git checkout pull/673` \
`$ git pull https://git.openjdk.java.net/panama-foreign pull/673/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 673`

View PR using the GUI difftool: \
`$ git pr show -t 673`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/panama-foreign/pull/673.diff">https://git.openjdk.java.net/panama-foreign/pull/673.diff</a>

</details>
