### PR TITLE
8284072: foreign/StdLibTest.java randomly crashes on MacOS/AArch64

### DIFF
--- a/src/hotspot/share/prims/upcallLinker.cpp
+++ b/src/hotspot/share/prims/upcallLinker.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -71,6 +71,10 @@ JavaThread* UpcallLinker::on_entry(UpcallStub::FrameData* context) {
 
   // clear any pending exception in thread (native calls start with no exception pending)
   thread->clear_pending_exception();
+
+  // The call to transition_from_native below contains a safepoint check
+  // which needs the code cache to be writable.
+  MACOS_AARCH64_ONLY(ThreadWXEnable wx(WXWrite, thread));
 
   // After this, we are officially in Java Code. This needs to be done before we change any of the thread local
   // info, since we cannot find oops before the new information is set up completely.


### PR DESCRIPTION
This test fails intermittently on Apple silicon macOS with a JVM SIGBUS and the stack trace below:

```
  Stack: [0x0000000171758000,0x000000017195b000], sp=0x0000000171957ef0, free space=2047k
  Native frames: (J=compiled Java code, j=interpreted, Vv=VM code, C=native code)
  V [libjvm.dylib+0x984f70] MarkActivationClosure::do_code_blob(CodeBlob*)+0x3c
  V [libjvm.dylib+0x9bfb60] JavaThread::nmethods_do(CodeBlobClosure*)+0xac
  V [libjvm.dylib+0x4669a8] HandshakeState::process_by_self(bool)+0x31c
  V [libjvm.dylib+0x891230] SafepointMechanism::process(JavaThread*, bool)+0xac
  V [libjvm.dylib+0x9f4df0] UpcallLinker::on_entry(UpcallStub::FrameData*)+0xe0
  v blob 0x000000010e1ca4a8
  C [libsystem_c.dylib+0x5c284] _isort+0x88
  C 0x176d80010e0ca444
  j java.lang.invoke.LambdaForm$MH+0x0000000800c82000.invoke(Ljava/lang/Object;JJJJJ)V+16 java.base@19-internal
```

In `UpcallLinker::on_entry` we call `ThreadStateTransition::transition_from_native()` which needs the code cache to be writable if it suspends for a safepoint/handshake.

Use the ThreadWXEnable helper to temporarily set the W^X state to W while inside `on_entry()` and then toggle it back to X before returning to the upcall stub.

Tested `jdk_foreign` plus looped `java/foreign/StdLibTest.java` for several hours on an M1 Mac Mini which used to eventually fail.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [JDK-8284072](https://bugs.openjdk.java.net/browse/JDK-8284072): foreign/StdLibTest.java randomly crashes on MacOS/AArch64


### Reviewers
 * [Jorn Vernee](https://openjdk.java.net/census#jvernee) (@JornVernee - Committer)
 * [Maurizio Cimadamore](https://openjdk.java.net/census#mcimadamore) (@mcimadamore - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/674/head:pull/674` \
`$ git checkout pull/674`

Update a local copy of the PR: \
`$ git checkout pull/674` \
`$ git pull https://git.openjdk.java.net/panama-foreign pull/674/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 674`

View PR using the GUI difftool: \
`$ git pr show -t 674`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/panama-foreign/pull/674.diff">https://git.openjdk.java.net/panama-foreign/pull/674.diff</a>

</details>
