### PR TITLE
8284306: TestVarArgs silently passes

### DIFF
--- a/test/jdk/java/foreign/TestVarArgs.java
+++ b/test/jdk/java/foreign/TestVarArgs.java
@@ -26,7 +26,7 @@
  * @test
  * @enablePreview
  * @requires ((os.arch == "amd64" | os.arch == "x86_64") & sun.arch.data.model == "64") | os.arch == "aarch64"
- * @run testng/othervm --enable-native-access=ALL-UNNAMED -Dgenerator.sample.factor=17 TestVarArgs
+ * @run testng/othervm --enable-native-access=ALL-UNNAMED -Dgenerator.sample.factor=-1 TestVarArgs
  */
 
 import java.lang.foreign.Addressable;
@@ -59,7 +59,7 @@ public class TestVarArgs extends CallGeneratorHelper {
         System.loadLibrary("VarArgs");
         try {
             MH_CHECK = MethodHandles.lookup().findStatic(TestVarArgs.class, "check",
-                    MethodType.methodType(void.class, int.class, MemoryAddress.class, List.class, List.class));
+                    MethodType.methodType(void.class, int.class, MemoryAddress.class, List.class));
         } catch (ReflectiveOperationException e) {
             throw new ExceptionInInitializerError(e);
         }
@@ -70,11 +70,10 @@ public class TestVarArgs extends CallGeneratorHelper {
     @Test(dataProvider = "functions")
     public void testVarArgs(int count, String fName, Ret ret, // ignore this stuff
                             List<ParamType> paramTypes, List<StructFieldType> fields) throws Throwable {
-        List<Consumer<Object>> checks = new ArrayList<>();
-        List<Arg> args = makeArgs(paramTypes, fields, checks);
+        List<Arg> args = makeArgs(paramTypes, fields);
 
         try (MemorySession session = MemorySession.openConfined()) {
-            MethodHandle checker = MethodHandles.insertArguments(MH_CHECK, 2, checks, args);
+            MethodHandle checker = MethodHandles.insertArguments(MH_CHECK, 2, args);
             MemorySegment writeBack = LINKER.upcallStub(checker, FunctionDescriptor.ofVoid(C_INT, C_POINTER), session);
             MemorySegment callInfo = MemorySegment.allocateNative(CallInfo.LAYOUT, session);
             MemorySegment argIDs = MemorySegment.allocateNative(MemoryLayout.sequenceLayout(args.size(), C_INT), session);
@@ -82,7 +81,7 @@ public class TestVarArgs extends CallGeneratorHelper {
             MemoryAddress callInfoPtr = callInfo.address();
 
             CallInfo.writeback(callInfo, writeBack);
-            CallInfo.argIDs(callInfo, writeBack);
+            CallInfo.argIDs(callInfo, argIDs);
 
             for (int i = 0; i < args.size(); i++) {
                 VH_IntArray.set(argIDs, (long) i, args.get(i).id.ordinal());
@@ -108,29 +107,29 @@ public class TestVarArgs extends CallGeneratorHelper {
         }
     }
 
-    private static List<Arg> makeArgs(List<ParamType> paramTypes, List<StructFieldType> fields, List<Consumer<Object>> checks) throws ReflectiveOperationException {
+    private static List<Arg> makeArgs(List<ParamType> paramTypes, List<StructFieldType> fields) throws ReflectiveOperationException {
         List<Arg> args = new ArrayList<>();
         for (ParamType pType : paramTypes) {
             MemoryLayout layout = pType.layout(fields);
+            List<Consumer<Object>> checks = new ArrayList<>();
             Object arg = makeArg(layout, checks, true);
             Arg.NativeType type = Arg.NativeType.of(pType.type(fields));
             args.add(pType == ParamType.STRUCT
-                ? Arg.structArg(type, layout, arg)
-                : Arg.primitiveArg(type, layout, arg));
+                ? Arg.structArg(type, layout, arg, checks)
+                : Arg.primitiveArg(type, layout, arg, checks));
         }
         return args;
     }
 
-    private static void check(int index, MemoryAddress ptr, List<Consumer<Object>> checks, List<Arg> args) {
-        Consumer<Object> check = checks.get(index);
+    private static void check(int index, MemoryAddress ptr, List<Arg> args) {
         Arg varArg = args.get(index);
-
         MemoryLayout layout = varArg.layout;
         MethodHandle getter = varArg.getter;
+        List<Consumer<Object>> checks = varArg.checks;
         try (MemorySession session = MemorySession.openConfined()) {
             MemorySegment seg = MemorySegment.ofAddress(ptr, layout.byteSize(), session);
             Object obj = getter.invoke(seg);
-            check.accept(obj);
+            checks.forEach(check -> check.accept(obj));
         } catch (Throwable e) {
             throw new RuntimeException(e);
         }
@@ -157,20 +156,22 @@ public class TestVarArgs extends CallGeneratorHelper {
         final MemoryLayout layout;
         final Object value;
         final MethodHandle getter;
+        final List<Consumer<Object>> checks;
 
-        private Arg(NativeType id, MemoryLayout layout, Object value, MethodHandle getter) {
+        private Arg(NativeType id, MemoryLayout layout, Object value, MethodHandle getter, List<Consumer<Object>> checks) {
             this.id = id;
             this.layout = layout;
             this.value = value;
             this.getter = getter;
+            this.checks = checks;
         }
 
-        private static Arg primitiveArg(NativeType id, MemoryLayout layout, Object value) {
-            return new Arg(id, layout, value, layout.varHandle().toMethodHandle(VarHandle.AccessMode.GET));
+        private static Arg primitiveArg(NativeType id, MemoryLayout layout, Object value, List<Consumer<Object>> checks) {
+            return new Arg(id, layout, value, layout.varHandle().toMethodHandle(VarHandle.AccessMode.GET), checks);
         }
 
-        private static Arg structArg(NativeType id, MemoryLayout layout, Object value) {
-            return new Arg(id, layout, value, MethodHandles.identity(MemorySegment.class));
+        private static Arg structArg(NativeType id, MemoryLayout layout, Object value, List<Consumer<Object>> checks) {
+            return new Arg(id, layout, value, MethodHandles.identity(MemorySegment.class), checks);
         }
 
         enum NativeType {

--- a/test/jdk/java/foreign/TestVarArgs.java
+++ b/test/jdk/java/foreign/TestVarArgs.java
@@ -26,7 +26,7 @@
  * @test
  * @enablePreview
  * @requires ((os.arch == "amd64" | os.arch == "x86_64") & sun.arch.data.model == "64") | os.arch == "aarch64"
- * @run testng/othervm --enable-native-access=ALL-UNNAMED -Dgenerator.sample.factor=-1 TestVarArgs
+ * @run testng/othervm --enable-native-access=ALL-UNNAMED -Dgenerator.sample.factor=17 TestVarArgs
  */
 
 import java.lang.foreign.Addressable;

--- a/test/jdk/java/foreign/libVarArgs.c
+++ b/test/jdk/java/foreign/libVarArgs.c
@@ -23,6 +23,7 @@
  */
 
 #include <stdarg.h>
+#include <stdlib.h>
 
 #include "shared.h"
 
@@ -226,6 +227,7 @@ EXPORT void varargs(call_info* info, int num, ...) {
             CASE(T_S_PPF, struct S_PPF)
             CASE(T_S_PPD, struct S_PPD)
             CASE(T_S_PPP, struct S_PPP)
+            default: exit(-1); // invalid id
         }
     }
 


### PR DESCRIPTION
There was a copy paste error in the updated TestVarArgs that made it pass silently.

I've fixed the test, and verified that it fails when the `check` method throws an exception. I've re-ran it on Windows, Linux/x64, Linux/AArch64, and Macos/AArch64. Luckily it still passes on all platforms.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [JDK-8284306](https://bugs.openjdk.java.net/browse/JDK-8284306): TestVarArgs silently passes


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.java.net/census#mcimadamore) (@mcimadamore - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/panama-foreign pull/677/head:pull/677` \
`$ git checkout pull/677`

Update a local copy of the PR: \
`$ git checkout pull/677` \
`$ git pull https://git.openjdk.java.net/panama-foreign pull/677/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 677`

View PR using the GUI difftool: \
`$ git pr show -t 677`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/panama-foreign/pull/677.diff">https://git.openjdk.java.net/panama-foreign/pull/677.diff</a>

</details>
