### PR TITLE
8289285: Use records for binding classes

### DIFF
--- a/src/java.base/share/classes/jdk/internal/foreign/abi/Binding.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/Binding.java
@@ -339,11 +339,7 @@ public interface Binding {
     }
 
     static UnboxAddress unboxAddress() {
-        return unboxAddress(MemoryAddress.class);
-    }
-
-    static UnboxAddress unboxAddress(Class<?> carrier) {
-        return UnboxAddress.INSTANCE.get(carrier);
+        return UnboxAddress.INSTANCE;
     }
 
     static ToSegment toSegment(MemoryLayout layout) {
@@ -406,11 +402,6 @@ public interface Binding {
 
         public Binding.Builder unboxAddress() {
             bindings.add(Binding.unboxAddress());
-            return this;
-        }
-
-        public Binding.Builder unboxAddress(Class<?> carrier) {
-            bindings.add(Binding.unboxAddress(carrier));
             return this;
         }
 
@@ -606,17 +597,12 @@ public interface Binding {
     }
 
     /**
-     * UNBOX_ADDRESS([carrier])
+     * UNBOX_ADDRESS()
      * Pops a 'MemoryAddress' from the operand stack, converts it to a 'long',
      *     and pushes that onto the operand stack.
      */
-    record UnboxAddress(Class<?> carrier) implements Binding {
-        static final ClassValue<UnboxAddress> INSTANCE = new ClassValue<>() {
-            @Override
-            protected UnboxAddress computeValue(Class<?> type) {
-                return new UnboxAddress(type);
-            }
-        };
+    record UnboxAddress() implements Binding {
+        static final UnboxAddress INSTANCE = new UnboxAddress();
 
         @Override
         public Tag tag() {
@@ -626,7 +612,7 @@ public interface Binding {
         @Override
         public void verify(Deque<Class<?>> stack) {
             Class<?> actualType = stack.pop();
-            SharedUtils.checkType(actualType, carrier);
+            SharedUtils.checkType(actualType, Addressable.class);
             stack.push(long.class);
         }
 

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/Binding.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/Binding.java
@@ -24,27 +24,17 @@
  */
 package jdk.internal.foreign.abi;
 
+import jdk.internal.foreign.MemoryAddressImpl;
+
 import java.lang.foreign.Addressable;
 import java.lang.foreign.MemoryAddress;
 import java.lang.foreign.MemoryLayout;
 import java.lang.foreign.MemorySegment;
 import java.lang.foreign.MemorySession;
 import java.lang.foreign.SegmentAllocator;
-import java.lang.foreign.ValueLayout;
-import jdk.internal.foreign.MemoryAddressImpl;
-
-import java.lang.invoke.MethodHandle;
-import java.lang.invoke.MethodHandles;
-import java.lang.invoke.MethodType;
 import java.util.ArrayList;
 import java.util.Deque;
 import java.util.List;
-import java.util.Objects;
-
-import java.lang.invoke.VarHandle;
-import java.nio.ByteOrder;
-
-import static java.lang.invoke.MethodType.methodType;
 
 /**
  * The binding operators defined in the Binding class can be combined into argument and return value processing 'recipes'.
@@ -199,7 +189,7 @@ import static java.lang.invoke.MethodType.methodType;
  *
  * --------------------
  */
-public abstract class Binding {
+public interface Binding {
 
     /**
      * A binding context is used as an helper to carry out evaluation of certain bindings; for instance,
@@ -207,7 +197,7 @@ public abstract class Binding {
      * the allocation operation, or {@link ToSegment} bindings, by providing the {@link MemorySession} that
      * should be used to create an unsafe struct from a memory address.
      */
-    public static class Context implements AutoCloseable {
+    class Context implements AutoCloseable {
         private final SegmentAllocator allocator;
         private final MemorySession session;
 
@@ -297,20 +287,12 @@ public abstract class Binding {
         DUP
     }
 
-    private final Tag tag;
+    Tag tag();
 
-    private Binding(Tag tag) {
-        this.tag = tag;
-    }
+    void verify(Deque<Class<?>> stack);
 
-    public Tag tag() {
-        return tag;
-    }
-
-    public abstract void verify(Deque<Class<?>> stack);
-
-    public abstract void interpret(Deque<Object> stack, BindingInterpreter.StoreFunc storeFunc,
-                                   BindingInterpreter.LoadFunc loadFunc, Context context);
+    void interpret(Deque<Object> stack, BindingInterpreter.StoreFunc storeFunc,
+                   BindingInterpreter.LoadFunc loadFunc, Context context);
 
     private static void checkType(Class<?> type) {
         if (!type.isPrimitive() || type == void.class)
@@ -322,82 +304,69 @@ public abstract class Binding {
             throw new IllegalArgumentException("Negative offset: " + offset);
     }
 
-    public static VMStore vmStore(VMStorage storage, Class<?> type) {
+    static VMStore vmStore(VMStorage storage, Class<?> type) {
         checkType(type);
         return new VMStore(storage, type);
     }
 
-    public static VMLoad vmLoad(VMStorage storage, Class<?> type) {
+    static VMLoad vmLoad(VMStorage storage, Class<?> type) {
         checkType(type);
         return new VMLoad(storage, type);
     }
 
-    public static BufferStore bufferStore(long offset, Class<?> type) {
+    static BufferStore bufferStore(long offset, Class<?> type) {
         checkType(type);
         checkOffset(offset);
         return new BufferStore(offset, type);
     }
 
-    public static BufferLoad bufferLoad(long offset, Class<?> type) {
+    static BufferLoad bufferLoad(long offset, Class<?> type) {
         checkType(type);
         checkOffset(offset);
         return new BufferLoad(offset, type);
     }
 
-    public static Copy copy(MemoryLayout layout) {
+    static Copy copy(MemoryLayout layout) {
         return new Copy(layout.byteSize(), layout.byteAlignment());
     }
 
-    public static Allocate allocate(MemoryLayout layout) {
+    static Allocate allocate(MemoryLayout layout) {
         return new Allocate(layout.byteSize(), layout.byteAlignment());
     }
 
-    public static BoxAddress boxAddress() {
+    static BoxAddress boxAddress() {
         return BoxAddress.INSTANCE;
     }
 
-    public static UnboxAddress unboxAddress() {
-        return UnboxAddress.INSTANCE.get(MemoryAddress.class);
+    static UnboxAddress unboxAddress() {
+        return unboxAddress(MemoryAddress.class);
     }
 
-    public static UnboxAddress unboxAddress(Class<?> carrier) {
+    static UnboxAddress unboxAddress(Class<?> carrier) {
         return UnboxAddress.INSTANCE.get(carrier);
     }
 
-    public static ToSegment toSegment(MemoryLayout layout) {
+    static ToSegment toSegment(MemoryLayout layout) {
         return new ToSegment(layout.byteSize());
     }
 
-    public static ToSegment toSegment(long byteSize) {
+    static ToSegment toSegment(long byteSize) {
         return new ToSegment(byteSize);
     }
 
-    public static Dup dup() {
+    static Dup dup() {
         return Dup.INSTANCE;
     }
 
 
-    public static Binding.Builder builder() {
+    static Binding.Builder builder() {
         return new Binding.Builder();
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        Binding binding = (Binding) o;
-        return tag == binding.tag;
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(tag);
     }
 
     /**
      * A builder helper class for generating lists of Bindings
      */
-    public static class Builder {
+    class Builder {
         private final List<Binding> bindings = new ArrayList<>();
 
         public Binding.Builder vmStore(VMStorage storage, Class<?> type) {
@@ -456,42 +425,13 @@ public abstract class Binding {
         }
 
         public List<Binding> build() {
-            return new ArrayList<>(bindings);
+            return List.copyOf(bindings);
         }
     }
 
-    abstract static class Move extends Binding {
-        private final VMStorage storage;
-        private final Class<?> type;
-
-        private Move(Tag tag, VMStorage storage, Class<?> type) {
-            super(tag);
-            this.storage = storage;
-            this.type = type;
-        }
-
-        public VMStorage storage() {
-            return storage;
-        }
-
-        public Class<?> type() {
-            return type;
-        }
-
-        @Override
-        public boolean equals(Object o) {
-            if (this == o) return true;
-            if (o == null || getClass() != o.getClass()) return false;
-            if (!super.equals(o)) return false;
-            Move move = (Move) o;
-            return Objects.equals(storage, move.storage) &&
-                    Objects.equals(type, move.type);
-        }
-
-        @Override
-        public int hashCode() {
-            return Objects.hash(super.hashCode(), storage, type);
-        }
+    interface Move extends Binding {
+        VMStorage storage();
+        Class<?> type();
     }
 
     /**
@@ -499,9 +439,10 @@ public abstract class Binding {
      * Pops a [type] from the operand stack, and moves it to [storage location]
      * The [type] must be one of byte, short, char, int, long, float, or double
      */
-    public static class VMStore extends Move {
-        private VMStore(VMStorage storage, Class<?> type) {
-            super(Tag.VM_STORE, storage, type);
+    record VMStore(VMStorage storage, Class<?> type) implements Move {
+        @Override
+        public Tag tag() {
+            return Tag.VM_STORE;
         }
 
         @Override
@@ -516,14 +457,6 @@ public abstract class Binding {
                               BindingInterpreter.LoadFunc loadFunc, Context context) {
             storeFunc.store(storage(), type(), stack.pop());
         }
-
-        @Override
-        public String toString() {
-            return "VMStore{" +
-                    "storage=" + storage() +
-                    ", type=" + type() +
-                    '}';
-        }
     }
 
     /**
@@ -531,9 +464,10 @@ public abstract class Binding {
      * Loads a [type] from [storage location], and pushes it onto the operand stack.
      * The [type] must be one of byte, short, char, int, long, float, or double
      */
-    public static class VMLoad extends Move {
-        private VMLoad(VMStorage storage, Class<?> type) {
-            super(Tag.VM_LOAD, storage, type);
+    record VMLoad(VMStorage storage, Class<?> type) implements Move {
+        @Override
+        public Tag tag() {
+            return Tag.VM_LOAD;
         }
 
         @Override
@@ -546,56 +480,11 @@ public abstract class Binding {
                               BindingInterpreter.LoadFunc loadFunc, Context context) {
             stack.push(loadFunc.load(storage(), type()));
         }
-
-        @Override
-        public String toString() {
-            return "VMLoad{" +
-                    "storage=" + storage() +
-                    ", type=" + type() +
-                    '}';
-        }
     }
 
-    private abstract static class Dereference extends Binding {
-        private final long offset;
-        private final Class<?> type;
-
-        private Dereference(Tag tag, long offset, Class<?> type) {
-            super(tag);
-            this.offset = offset;
-            this.type = type;
-        }
-
-        public long offset() {
-            return offset;
-        }
-
-        public Class<?> type() {
-            return type;
-        }
-
-        @Override
-        public boolean equals(Object o) {
-            if (this == o) return true;
-            if (o == null || getClass() != o.getClass()) return false;
-            if (!super.equals(o)) return false;
-            Dereference that = (Dereference) o;
-            return offset == that.offset &&
-                    Objects.equals(type, that.type);
-        }
-
-        @Override
-        public int hashCode() {
-            return Objects.hash(super.hashCode(), offset, type);
-        }
-
-        public VarHandle varHandle() {
-            // alignment is set to 1 byte here to avoid exceptions for cases where we do super word
-            // copies of e.g. 2 int fields of a struct as a single long, while the struct is only
-            // 4-byte-aligned (since it only contains ints)
-            ValueLayout layout = MemoryLayout.valueLayout(type(), ByteOrder.nativeOrder()).withBitAlignment(8);
-            return MethodHandles.insertCoordinates(MethodHandles.memorySegmentViewVarHandle(layout), 1, offset);
-        }
+    interface Dereference extends Binding {
+        long offset();
+        Class<?> type();
     }
 
     /**
@@ -604,9 +493,10 @@ public abstract class Binding {
      * Stores the [type] to [offset into memory region].
      * The [type] must be one of byte, short, char, int, long, float, or double
      */
-    public static class BufferStore extends Dereference {
-        private BufferStore(long offset, Class<?> type) {
-            super(Tag.BUFFER_STORE, offset, type);
+    record BufferStore(long offset, Class<?> type) implements Dereference {
+        @Override
+        public Tag tag() {
+            return Tag.BUFFER_STORE;
         }
 
         @Override
@@ -625,14 +515,6 @@ public abstract class Binding {
             MemorySegment writeAddress = operand.asSlice(offset());
             SharedUtils.write(writeAddress, type(), value);
         }
-
-        @Override
-        public String toString() {
-            return "BufferStore{" +
-                    "offset=" + offset() +
-                    ", type=" + type() +
-                    '}';
-        }
     }
 
     /**
@@ -641,9 +523,10 @@ public abstract class Binding {
      * and then stores [type] to [offset into memory region] of the MemorySegment.
      * The [type] must be one of byte, short, char, int, long, float, or double
      */
-    public static class BufferLoad extends Dereference {
-        private BufferLoad(long offset, Class<?> type) {
-            super(Tag.BUFFER_LOAD, offset, type);
+    record BufferLoad(long offset, Class<?> type) implements Dereference {
+        @Override
+        public Tag tag() {
+            return Tag.BUFFER_LOAD;
         }
 
         @Override
@@ -661,14 +544,6 @@ public abstract class Binding {
             MemorySegment readAddress = operand.asSlice(offset());
             stack.push(SharedUtils.read(readAddress, type()));
         }
-
-        @Override
-        public String toString() {
-            return "BufferLoad{" +
-                    "offset=" + offset() +
-                    ", type=" + type() +
-                    '}';
-        }
     }
 
     /**
@@ -677,36 +552,15 @@ public abstract class Binding {
      *     and copies contents from a MemorySegment popped from the top of the operand stack into this new buffer,
      *     and pushes the new buffer onto the operand stack
      */
-    public static class Copy extends Binding {
-        private final long size;
-        private final long alignment;
-
-        private Copy(long size, long alignment) {
-            super(Tag.COPY_BUFFER);
-            this.size = size;
-            this.alignment = alignment;
-        }
-
+    record Copy(long size, long alignment) implements Binding {
         private static MemorySegment copyBuffer(MemorySegment operand, long size, long alignment, Context context) {
             return context.allocator().allocate(size, alignment)
                             .copyFrom(operand.asSlice(0, size));
         }
 
-        public long size() {
-            return size;
-        }
-
-        public long alignment() {
-            return alignment;
-        }
-
         @Override
-        public String toString() {
-            return "Copy{" +
-                    "tag=" + tag() +
-                    ", size=" + size +
-                    ", alignment=" + alignment +
-                    '}';
+        public Tag tag() {
+            return Tag.COPY_BUFFER;
         }
 
         @Override
@@ -723,56 +577,20 @@ public abstract class Binding {
             MemorySegment copy = copyBuffer(operand, size, alignment, context);
             stack.push(copy);
         }
-
-        @Override
-        public boolean equals(Object o) {
-            if (this == o) return true;
-            if (o == null || getClass() != o.getClass()) return false;
-            if (!super.equals(o)) return false;
-            Copy copy = (Copy) o;
-            return size == copy.size &&
-                    alignment == copy.alignment;
-        }
-
-        @Override
-        public int hashCode() {
-            return Objects.hash(super.hashCode(), size, alignment);
-        }
     }
 
     /**
      * ALLOCATE([size], [alignment])
      *   Creates a new MemorySegment with the give [size] and [alignment], and pushes it onto the operand stack.
      */
-    public static class Allocate extends Binding {
-        private final long size;
-        private final long alignment;
-
-        private Allocate(long size, long alignment) {
-            super(Tag.ALLOC_BUFFER);
-            this.size = size;
-            this.alignment = alignment;
-        }
-
+    record Allocate(long size, long alignment) implements Binding {
         private static MemorySegment allocateBuffer(long size, long alignment, Context context) {
             return context.allocator().allocate(size, alignment);
         }
 
-        public long size() {
-            return size;
-        }
-
-        public long alignment() {
-            return alignment;
-        }
-
         @Override
-        public String toString() {
-            return "AllocateBuffer{" +
-                    "tag=" + tag() +
-                    "size=" + size +
-                    ", alignment=" + alignment +
-                    '}';
+        public Tag tag() {
+            return Tag.ALLOC_BUFFER;
         }
 
         @Override
@@ -785,30 +603,14 @@ public abstract class Binding {
                               BindingInterpreter.LoadFunc loadFunc, Context context) {
             stack.push(allocateBuffer(size, alignment, context));
         }
-
-        @Override
-        public boolean equals(Object o) {
-            if (this == o) return true;
-            if (o == null || getClass() != o.getClass()) return false;
-            if (!super.equals(o)) return false;
-            Allocate allocate = (Allocate) o;
-            return size == allocate.size &&
-                    alignment == allocate.alignment;
-        }
-
-        @Override
-        public int hashCode() {
-            return Objects.hash(super.hashCode(), size, alignment);
-        }
     }
 
     /**
-     * UNBOX_ADDRESS()
+     * UNBOX_ADDRESS([carrier])
      * Pops a 'MemoryAddress' from the operand stack, converts it to a 'long',
      *     and pushes that onto the operand stack.
      */
-    public static class UnboxAddress extends Binding {
-
+    record UnboxAddress(Class<?> carrier) implements Binding {
         static final ClassValue<UnboxAddress> INSTANCE = new ClassValue<>() {
             @Override
             protected UnboxAddress computeValue(Class<?> type) {
@@ -816,17 +618,9 @@ public abstract class Binding {
             }
         };
 
-        final Class<?> carrier;
-        final MethodHandle toAddress;
-
-        private UnboxAddress(Class<?> carrier) {
-            super(Tag.UNBOX_ADDRESS);
-            this.carrier = carrier;
-            try {
-                this.toAddress = MethodHandles.lookup().findVirtual(carrier, "address", MethodType.methodType(MemoryAddress.class));
-            } catch (Throwable ex) {
-                throw new IllegalArgumentException(ex);
-            }
+        @Override
+        public Tag tag() {
+            return Tag.UNBOX_ADDRESS;
         }
 
         @Override
@@ -841,11 +635,6 @@ public abstract class Binding {
                               BindingInterpreter.LoadFunc loadFunc, Context context) {
             stack.push(((Addressable)stack.pop()).address().toRawLongValue());
         }
-
-        @Override
-        public String toString() {
-            return "UnboxAddress{}";
-        }
     }
 
     /**
@@ -853,10 +642,12 @@ public abstract class Binding {
      * Pops a 'long' from the operand stack, converts it to a 'MemoryAddress',
      *     and pushes that onto the operand stack.
      */
-    public static class BoxAddress extends Binding {
-        private static final BoxAddress INSTANCE = new BoxAddress();
-        private BoxAddress() {
-            super(Tag.BOX_ADDRESS);
+    record BoxAddress() implements Binding {
+        static final BoxAddress INSTANCE = new BoxAddress();
+
+        @Override
+        public Tag tag() {
+            return Tag.BOX_ADDRESS;
         }
 
         @Override
@@ -871,11 +662,6 @@ public abstract class Binding {
                               BindingInterpreter.LoadFunc loadFunc, Context context) {
             stack.push(MemoryAddress.ofLong((long) stack.pop()));
         }
-
-        @Override
-        public String toString() {
-            return "BoxAddress{}";
-        }
     }
 
     /**
@@ -883,21 +669,14 @@ public abstract class Binding {
      *   Pops a MemoryAddress from the operand stack, and converts it to a MemorySegment
      *   with the given size, and pushes that onto the operand stack
      */
-    public static class ToSegment extends Binding {
-        private final long size;
-        // FIXME alignment?
-
-        public ToSegment(long size) {
-            super(Tag.TO_SEGMENT);
-            this.size = size;
-        }
-
-        public long size() {
-            return size;
-        }
-
+    record ToSegment(long size) implements Binding {
         private static MemorySegment toSegment(MemoryAddress operand, long size, Context context) {
             return MemoryAddressImpl.ofLongUnchecked(operand.toRawLongValue(), size, context.session);
+        }
+
+        @Override
+        public Tag tag() {
+            return Tag.TO_SEGMENT;
         }
 
         @Override
@@ -914,27 +693,6 @@ public abstract class Binding {
             MemorySegment segment = toSegment(operand, size, context);
             stack.push(segment);
         }
-
-        @Override
-        public String toString() {
-            return "ToSegemnt{" +
-                    "size=" + size +
-                    '}';
-        }
-
-        @Override
-        public boolean equals(Object o) {
-            if (this == o) return true;
-            if (o == null || getClass() != o.getClass()) return false;
-            if (!super.equals(o)) return false;
-            ToSegment toSegemnt = (ToSegment) o;
-            return size == toSegemnt.size;
-        }
-
-        @Override
-        public int hashCode() {
-            return Objects.hash(super.hashCode(), size);
-        }
     }
 
     /**
@@ -942,10 +700,12 @@ public abstract class Binding {
      *   Duplicates the value on the top of the operand stack (without popping it!),
      *   and pushes the duplicate onto the operand stack
      */
-    public static class Dup extends Binding {
-        private static final Dup INSTANCE = new Dup();
-        private Dup() {
-            super(Tag.DUP);
+    record Dup() implements Binding {
+        static final Dup INSTANCE = new Dup();
+
+        @Override
+        public Tag tag() {
+            return Tag.DUP;
         }
 
         @Override
@@ -957,17 +717,6 @@ public abstract class Binding {
         public void interpret(Deque<Object> stack, BindingInterpreter.StoreFunc storeFunc,
                               BindingInterpreter.LoadFunc loadFunc, Context context) {
             stack.push(stack.peekLast());
-        }
-
-        @Override
-        public boolean equals(Object o) {
-            if (this == o) return true;
-            return o != null && getClass() == o.getClass();
-        }
-
-        @Override
-        public String toString() {
-            return "Dup{}";
         }
     }
 }

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/CallingSequenceBuilder.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/CallingSequenceBuilder.java
@@ -97,11 +97,11 @@ public class CallingSequenceBuilder {
         MethodType calleeMethodType;
         if (!forUpcall) {
             addArgumentBinding(0, Addressable.class, ValueLayout.ADDRESS, List.of(
-                Binding.unboxAddress(Addressable.class),
+                Binding.unboxAddress(),
                 Binding.vmStore(abi.targetAddrStorage(), long.class)));
             if (needsReturnBuffer) {
                 addArgumentBinding(0, MemorySegment.class, ValueLayout.ADDRESS, List.of(
-                    Binding.unboxAddress(MemorySegment.class),
+                    Binding.unboxAddress(),
                     Binding.vmStore(abi.retBufAddrStorage(), long.class)));
             }
 

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/SharedUtils.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/SharedUtils.java
@@ -371,7 +371,7 @@ public class SharedUtils {
     }
 
     static void checkType(Class<?> actualType, Class<?> expectedType) {
-        if (expectedType != actualType) {
+        if (!expectedType.isAssignableFrom(actualType)) {
             throw new IllegalArgumentException(
                     String.format("Invalid operand type: %s. %s expected", actualType, expectedType));
         }

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/aarch64/CallArranger.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/aarch64/CallArranger.java
@@ -353,7 +353,7 @@ public abstract class CallArranger {
                 case STRUCT_REFERENCE: {
                     assert carrier == MemorySegment.class;
                     bindings.copy(layout)
-                            .unboxAddress(MemorySegment.class);
+                            .unboxAddress();
                     VMStorage storage = storageCalculator.nextStorage(
                         StorageClasses.INTEGER, AArch64.C_POINTER);
                     bindings.vmStore(storage, long.class);
@@ -384,7 +384,7 @@ public abstract class CallArranger {
                     break;
                 }
                 case POINTER: {
-                    bindings.unboxAddress(carrier);
+                    bindings.unboxAddress();
                     VMStorage storage =
                         storageCalculator.nextStorage(StorageClasses.INTEGER, layout);
                     bindings.vmStore(storage, long.class);

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/x64/sysv/CallArranger.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/x64/sysv/CallArranger.java
@@ -277,7 +277,7 @@ public class CallArranger {
                     break;
                 }
                 case POINTER: {
-                    bindings.unboxAddress(carrier);
+                    bindings.unboxAddress();
                     VMStorage storage = storageCalculator.nextStorage(StorageClasses.INTEGER);
                     bindings.vmStore(storage, long.class);
                     break;

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/x64/windows/CallArranger.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/x64/windows/CallArranger.java
@@ -210,13 +210,13 @@ public class CallArranger {
                 case STRUCT_REFERENCE: {
                     assert carrier == MemorySegment.class;
                     bindings.copy(layout)
-                            .unboxAddress(MemorySegment.class);
+                            .unboxAddress();
                     VMStorage storage = storageCalculator.nextStorage(StorageClasses.INTEGER, layout);
                     bindings.vmStore(storage, long.class);
                     break;
                 }
                 case POINTER: {
-                    bindings.unboxAddress(carrier);
+                    bindings.unboxAddress();
                     VMStorage storage = storageCalculator.nextStorage(StorageClasses.INTEGER, layout);
                     bindings.vmStore(storage, long.class);
                     break;

--- a/test/jdk/java/foreign/callarranger/TestAarch64CallArranger.java
+++ b/test/jdk/java/foreign/callarranger/TestAarch64CallArranger.java
@@ -67,7 +67,7 @@ public class TestAarch64CallArranger extends CallArrangerTestBase {
         assertEquals(callingSequence.functionDesc(), fd.insertArgumentLayouts(0, ADDRESS));
 
         checkArgumentBindings(callingSequence, new Binding[][]{
-            { unboxAddress(Addressable.class), vmStore(r9, long.class) }
+            { unboxAddress(), vmStore(r9, long.class) }
         });
 
         checkReturnBindings(callingSequence, new Binding[]{});
@@ -91,7 +91,7 @@ public class TestAarch64CallArranger extends CallArrangerTestBase {
         assertEquals(callingSequence.functionDesc(), fd.insertArgumentLayouts(0, ADDRESS));
 
         checkArgumentBindings(callingSequence, new Binding[][]{
-            { unboxAddress(Addressable.class), vmStore(r9, long.class) },
+            { unboxAddress(), vmStore(r9, long.class) },
             { vmStore(r0, int.class) },
             { vmStore(r1, int.class) },
             { vmStore(r2, int.class) },
@@ -121,7 +121,7 @@ public class TestAarch64CallArranger extends CallArrangerTestBase {
         assertEquals(callingSequence.functionDesc(), fd.insertArgumentLayouts(0, ADDRESS));
 
         checkArgumentBindings(callingSequence, new Binding[][]{
-            { unboxAddress(Addressable.class), vmStore(r9, long.class) },
+            { unboxAddress(), vmStore(r9, long.class) },
             { vmStore(r0, int.class) },
             { vmStore(r1, int.class) },
             { vmStore(v0, float.class) },
@@ -143,7 +143,7 @@ public class TestAarch64CallArranger extends CallArrangerTestBase {
         assertEquals(callingSequence.functionDesc(), fd.insertArgumentLayouts(0, ADDRESS));
 
         checkArgumentBindings(callingSequence, new Binding[][]{
-            { unboxAddress(Addressable.class), vmStore(r9, long.class) },
+            { unboxAddress(), vmStore(r9, long.class) },
             expectedBindings
         });
 
@@ -165,7 +165,7 @@ public class TestAarch64CallArranger extends CallArrangerTestBase {
             // struct s { int32_t a, b; double c; int32_t d };
             { struct2, new Binding[] {
                 copy(struct2),
-                unboxAddress(MemorySegment.class),
+                unboxAddress(),
                 vmStore(r0, long.class)
             }},
             // struct s { int32_t a[2]; float b[2] };
@@ -203,15 +203,15 @@ public class TestAarch64CallArranger extends CallArrangerTestBase {
         assertEquals(callingSequence.functionDesc(), fd.insertArgumentLayouts(0, ADDRESS));
 
         checkArgumentBindings(callingSequence, new Binding[][]{
-            { unboxAddress(Addressable.class), vmStore(r9, long.class) },
+            { unboxAddress(), vmStore(r9, long.class) },
             {
                 copy(struct1),
-                unboxAddress(MemorySegment.class),
+                unboxAddress(),
                 vmStore(r0, long.class)
             },
             {
                 copy(struct2),
-                unboxAddress(MemorySegment.class),
+                unboxAddress(),
                 vmStore(r1, long.class)
             },
             { vmStore(r2, int.class) }
@@ -234,7 +234,7 @@ public class TestAarch64CallArranger extends CallArrangerTestBase {
         assertEquals(callingSequence.functionDesc(), FunctionDescriptor.ofVoid(ADDRESS, C_POINTER));
 
         checkArgumentBindings(callingSequence, new Binding[][]{
-            { unboxAddress(Addressable.class), vmStore(r9, long.class) },
+            { unboxAddress(), vmStore(r9, long.class) },
             {
                 unboxAddress(),
                 vmStore(r8, long.class)
@@ -258,8 +258,8 @@ public class TestAarch64CallArranger extends CallArrangerTestBase {
         assertEquals(callingSequence.functionDesc(), fd.insertArgumentLayouts(0, ADDRESS, ADDRESS));
 
         checkArgumentBindings(callingSequence, new Binding[][]{
-            { unboxAddress(MemorySegment.class), vmStore(r10, long.class) },
-            { unboxAddress(Addressable.class), vmStore(r9, long.class) }
+            { unboxAddress(), vmStore(r10, long.class) },
+            { unboxAddress(), vmStore(r9, long.class) }
         });
 
         checkReturnBindings(callingSequence, new Binding[]{
@@ -287,8 +287,8 @@ public class TestAarch64CallArranger extends CallArrangerTestBase {
         assertEquals(callingSequence.functionDesc(), fd.insertArgumentLayouts(0, ADDRESS, ADDRESS));
 
         checkArgumentBindings(callingSequence, new Binding[][]{
-            { unboxAddress(MemorySegment.class), vmStore(r10, long.class) },
-            { unboxAddress(Addressable.class), vmStore(r9, long.class) },
+            { unboxAddress(), vmStore(r10, long.class) },
+            { unboxAddress(), vmStore(r9, long.class) },
             { vmStore(v0, float.class) },
             { vmStore(r0, int.class) },
             {
@@ -325,7 +325,7 @@ public class TestAarch64CallArranger extends CallArrangerTestBase {
         assertEquals(callingSequence.functionDesc(), fd.insertArgumentLayouts(0, ADDRESS));
 
         checkArgumentBindings(callingSequence, new Binding[][]{
-            { unboxAddress(Addressable.class), vmStore(r9, long.class) },
+            { unboxAddress(), vmStore(r9, long.class) },
             {
                 dup(),
                 bufferLoad(0, float.class),
@@ -379,16 +379,16 @@ public class TestAarch64CallArranger extends CallArrangerTestBase {
         assertEquals(callingSequence.functionDesc(), fd.insertArgumentLayouts(0, ADDRESS));
 
         checkArgumentBindings(callingSequence, new Binding[][]{
-            { unboxAddress(Addressable.class), vmStore(r9, long.class) },
-            { copy(struct), unboxAddress(MemorySegment.class), vmStore(r0, long.class) },
-            { copy(struct), unboxAddress(MemorySegment.class), vmStore(r1, long.class) },
+            { unboxAddress(), vmStore(r9, long.class) },
+            { copy(struct), unboxAddress(), vmStore(r0, long.class) },
+            { copy(struct), unboxAddress(), vmStore(r1, long.class) },
             { vmStore(r2, int.class) },
             { vmStore(r3, int.class) },
             { vmStore(r4, int.class) },
             { vmStore(r5, int.class) },
             { vmStore(r6, int.class) },
             { vmStore(r7, int.class) },
-            { copy(struct), unboxAddress(MemorySegment.class), vmStore(stackStorage(0), long.class) },
+            { copy(struct), unboxAddress(), vmStore(stackStorage(0), long.class) },
             { vmStore(stackStorage(1), int.class) },
         });
 
@@ -409,7 +409,7 @@ public class TestAarch64CallArranger extends CallArrangerTestBase {
 
         // This is identical to the non-variadic calling sequence
         checkArgumentBindings(callingSequence, new Binding[][]{
-            { unboxAddress(Addressable.class), vmStore(r9, long.class) },
+            { unboxAddress(), vmStore(r9, long.class) },
             { vmStore(r0, int.class) },
             { vmStore(r1, int.class) },
             { vmStore(v0, float.class) },
@@ -432,7 +432,7 @@ public class TestAarch64CallArranger extends CallArrangerTestBase {
 
         // The two variadic arguments should be allocated on the stack
         checkArgumentBindings(callingSequence, new Binding[][]{
-            { unboxAddress(Addressable.class), vmStore(r9, long.class) },
+            { unboxAddress(), vmStore(r9, long.class) },
             { vmStore(r0, int.class) },
             { vmStore(stackStorage(0), int.class) },
             { vmStore(stackStorage(1), float.class) },

--- a/test/jdk/java/foreign/callarranger/TestSysVCallArranger.java
+++ b/test/jdk/java/foreign/callarranger/TestSysVCallArranger.java
@@ -68,7 +68,7 @@ public class TestSysVCallArranger extends CallArrangerTestBase {
         assertEquals(callingSequence.functionDesc(), fd.appendArgumentLayouts(C_LONG).insertArgumentLayouts(0, ADDRESS));
 
         checkArgumentBindings(callingSequence, new Binding[][]{
-            { unboxAddress(Addressable.class), vmStore(r10, long.class) },
+            { unboxAddress(), vmStore(r10, long.class) },
             { vmStore(rax, long.class) }
         });
 
@@ -96,7 +96,7 @@ public class TestSysVCallArranger extends CallArrangerTestBase {
         assertEquals(callingSequence.functionDesc(), fd.appendArgumentLayouts(C_LONG).insertArgumentLayouts(0, ADDRESS));
 
         checkArgumentBindings(callingSequence, new Binding[][]{
-            { unboxAddress(Addressable.class), vmStore(r10, long.class) },
+            { unboxAddress(), vmStore(r10, long.class) },
             { dup(), bufferLoad(0, long.class), vmStore(rdi, long.class),
               bufferLoad(8, int.class), vmStore(rsi, int.class)},
             { vmStore(rax, long.class) },
@@ -127,7 +127,7 @@ public class TestSysVCallArranger extends CallArrangerTestBase {
         assertEquals(callingSequence.functionDesc(), fd.appendArgumentLayouts(C_LONG).insertArgumentLayouts(0, ADDRESS));
 
         checkArgumentBindings(callingSequence, new Binding[][]{
-            { unboxAddress(Addressable.class), vmStore(r10, long.class) },
+            { unboxAddress(), vmStore(r10, long.class) },
             { dup(), bufferLoad(0, long.class), vmStore(rdi, long.class),
                     bufferLoad(8, long.class), vmStore(rsi, long.class)},
             { vmStore(rax, long.class) },
@@ -157,7 +157,7 @@ public class TestSysVCallArranger extends CallArrangerTestBase {
         assertEquals(callingSequence.functionDesc(), fd.appendArgumentLayouts(C_LONG).insertArgumentLayouts(0, ADDRESS));
 
         checkArgumentBindings(callingSequence, new Binding[][]{
-            { unboxAddress(Addressable.class), vmStore(r10, long.class) },
+            { unboxAddress(), vmStore(r10, long.class) },
             { dup(), bufferLoad(0, long.class), vmStore(stackStorage(0), long.class),
                     bufferLoad(8, long.class), vmStore(stackStorage(1), long.class)},
             { vmStore(rax, long.class) },
@@ -187,7 +187,7 @@ public class TestSysVCallArranger extends CallArrangerTestBase {
         assertEquals(callingSequence.functionDesc(), fd.appendArgumentLayouts(C_LONG).insertArgumentLayouts(0, ADDRESS));
 
         checkArgumentBindings(callingSequence, new Binding[][]{
-            { unboxAddress(Addressable.class), vmStore(r10, long.class) },
+            { unboxAddress(), vmStore(r10, long.class) },
             { dup(), bufferLoad(0, long.class), vmStore(stackStorage(0), long.class),
                     bufferLoad(8, int.class), vmStore(stackStorage(1), int.class)},
             { vmStore(rax, long.class) },
@@ -212,7 +212,7 @@ public class TestSysVCallArranger extends CallArrangerTestBase {
         assertEquals(callingSequence.functionDesc(), fd.appendArgumentLayouts(C_LONG).insertArgumentLayouts(0, ADDRESS));
 
         checkArgumentBindings(callingSequence, new Binding[][]{
-            { unboxAddress(Addressable.class), vmStore(r10, long.class) },
+            { unboxAddress(), vmStore(r10, long.class) },
             { vmStore(rdi, int.class) },
             { vmStore(rsi, int.class) },
             { vmStore(rdx, int.class) },
@@ -243,7 +243,7 @@ public class TestSysVCallArranger extends CallArrangerTestBase {
         assertEquals(callingSequence.functionDesc(), fd.appendArgumentLayouts(C_LONG).insertArgumentLayouts(0, ADDRESS));
 
         checkArgumentBindings(callingSequence, new Binding[][]{
-            { unboxAddress(Addressable.class), vmStore(r10, long.class) },
+            { unboxAddress(), vmStore(r10, long.class) },
             { vmStore(xmm0, double.class) },
             { vmStore(xmm1, double.class) },
             { vmStore(xmm2, double.class) },
@@ -278,7 +278,7 @@ public class TestSysVCallArranger extends CallArrangerTestBase {
         assertEquals(callingSequence.functionDesc(), fd.appendArgumentLayouts(C_LONG).insertArgumentLayouts(0, ADDRESS));
 
         checkArgumentBindings(callingSequence, new Binding[][]{
-            { unboxAddress(Addressable.class), vmStore(r10, long.class) },
+            { unboxAddress(), vmStore(r10, long.class) },
             { vmStore(rdi, long.class) },
             { vmStore(rsi, long.class) },
             { vmStore(rdx, long.class) },
@@ -335,7 +335,7 @@ public class TestSysVCallArranger extends CallArrangerTestBase {
         assertEquals(callingSequence.functionDesc(), fd.appendArgumentLayouts(C_LONG).insertArgumentLayouts(0, ADDRESS));
 
         checkArgumentBindings(callingSequence, new Binding[][]{
-            { unboxAddress(Addressable.class), vmStore(r10, long.class) },
+            { unboxAddress(), vmStore(r10, long.class) },
             { vmStore(rdi, int.class) },
             { vmStore(rsi, int.class) },
             {
@@ -378,7 +378,7 @@ public class TestSysVCallArranger extends CallArrangerTestBase {
         assertEquals(callingSequence.functionDesc(), fd.appendArgumentLayouts(C_LONG).insertArgumentLayouts(0, ADDRESS));
 
         checkArgumentBindings(callingSequence, new Binding[][]{
-            { unboxAddress(Addressable.class), vmStore(r10, long.class) },
+            { unboxAddress(), vmStore(r10, long.class) },
             { unboxAddress(), vmStore(rdi, long.class) },
             { vmStore(rax, long.class) },
         });
@@ -400,7 +400,7 @@ public class TestSysVCallArranger extends CallArrangerTestBase {
         assertEquals(callingSequence.functionDesc(), fd.appendArgumentLayouts(C_LONG).insertArgumentLayouts(0, ADDRESS));
 
         checkArgumentBindings(callingSequence, new Binding[][]{
-            { unboxAddress(Addressable.class), vmStore(r10, long.class) },
+            { unboxAddress(), vmStore(r10, long.class) },
             expectedBindings,
             { vmStore(rax, long.class) },
         });
@@ -459,8 +459,8 @@ public class TestSysVCallArranger extends CallArrangerTestBase {
         assertEquals(callingSequence.functionDesc(), fd.appendArgumentLayouts(C_LONG).insertArgumentLayouts(0, ADDRESS, ADDRESS));
 
         checkArgumentBindings(callingSequence, new Binding[][]{
-            { unboxAddress(MemorySegment.class), vmStore(r11, long.class) },
-            { unboxAddress(Addressable.class), vmStore(r10, long.class) },
+            { unboxAddress(), vmStore(r11, long.class) },
+            { unboxAddress(), vmStore(r10, long.class) },
             { vmStore(rax, long.class) }
         });
 
@@ -491,7 +491,7 @@ public class TestSysVCallArranger extends CallArrangerTestBase {
         assertEquals(callingSequence.functionDesc(), FunctionDescriptor.ofVoid(ADDRESS, C_POINTER, C_LONG));
 
         checkArgumentBindings(callingSequence, new Binding[][]{
-            { unboxAddress(Addressable.class), vmStore(r10, long.class) },
+            { unboxAddress(), vmStore(r10, long.class) },
             { unboxAddress(), vmStore(rdi, long.class) },
             { vmStore(rax, long.class) }
         });

--- a/test/jdk/java/foreign/callarranger/TestWindowsCallArranger.java
+++ b/test/jdk/java/foreign/callarranger/TestWindowsCallArranger.java
@@ -66,7 +66,7 @@ public class TestWindowsCallArranger extends CallArrangerTestBase {
         assertEquals(callingSequence.functionDesc(), fd.insertArgumentLayouts(0, ADDRESS));
 
         checkArgumentBindings(callingSequence, new Binding[][]{
-            { unboxAddress(Addressable.class), vmStore(r10, long.class) }
+            { unboxAddress(), vmStore(r10, long.class) }
         });
         checkReturnBindings(callingSequence, new Binding[]{});
     }
@@ -83,7 +83,7 @@ public class TestWindowsCallArranger extends CallArrangerTestBase {
         assertEquals(callingSequence.functionDesc(), fd.insertArgumentLayouts(0, ADDRESS));
 
         checkArgumentBindings(callingSequence, new Binding[][]{
-            { unboxAddress(Addressable.class), vmStore(r10, long.class) },
+            { unboxAddress(), vmStore(r10, long.class) },
             { vmStore(rcx, int.class) },
             { vmStore(rdx, int.class) },
             { vmStore(r8, int.class) },
@@ -105,7 +105,7 @@ public class TestWindowsCallArranger extends CallArrangerTestBase {
         assertEquals(callingSequence.functionDesc(), fd.insertArgumentLayouts(0, ADDRESS));
 
         checkArgumentBindings(callingSequence, new Binding[][]{
-            { unboxAddress(Addressable.class), vmStore(r10, long.class) },
+            { unboxAddress(), vmStore(r10, long.class) },
             { vmStore(xmm0, double.class) },
             { vmStore(xmm1, double.class) },
             { vmStore(xmm2, double.class) },
@@ -129,7 +129,7 @@ public class TestWindowsCallArranger extends CallArrangerTestBase {
         assertEquals(callingSequence.functionDesc(), fd.insertArgumentLayouts(0, ADDRESS));
 
         checkArgumentBindings(callingSequence, new Binding[][]{
-            { unboxAddress(Addressable.class), vmStore(r10, long.class) },
+            { unboxAddress(), vmStore(r10, long.class) },
             { vmStore(rcx, long.class) },
             { vmStore(rdx, long.class) },
             { vmStore(xmm2, float.class) },
@@ -160,12 +160,12 @@ public class TestWindowsCallArranger extends CallArrangerTestBase {
         assertEquals(callingSequence.functionDesc(), fd.insertArgumentLayouts(0, ADDRESS));
 
         checkArgumentBindings(callingSequence, new Binding[][]{
-            { unboxAddress(Addressable.class), vmStore(r10, long.class) },
+            { unboxAddress(), vmStore(r10, long.class) },
             { vmStore(rcx, int.class) },
             { vmStore(rdx, int.class) },
             {
                 copy(structLayout),
-                unboxAddress(MemorySegment.class),
+                unboxAddress(),
                 vmStore(r8, long.class)
             },
             { vmStore(r9, int.class) },
@@ -197,7 +197,7 @@ public class TestWindowsCallArranger extends CallArrangerTestBase {
         assertEquals(callingSequence.functionDesc(), fdExpected);
 
         checkArgumentBindings(callingSequence, new Binding[][]{
-            { unboxAddress(Addressable.class), vmStore(r10, long.class) },
+            { unboxAddress(), vmStore(r10, long.class) },
             { vmStore(rcx, int.class) },
             { vmStore(xmm1, double.class) },
             { vmStore(r8, int.class) },
@@ -231,7 +231,7 @@ public class TestWindowsCallArranger extends CallArrangerTestBase {
         assertEquals(callingSequence.functionDesc(), fd.insertArgumentLayouts(0, ADDRESS));
 
         checkArgumentBindings(callingSequence, new Binding[][]{
-            { unboxAddress(Addressable.class), vmStore(r10, long.class) },
+            { unboxAddress(), vmStore(r10, long.class) },
             { bufferLoad(0, long.class), vmStore(rcx, long.class) }
         });
 
@@ -261,10 +261,10 @@ public class TestWindowsCallArranger extends CallArrangerTestBase {
         assertEquals(callingSequence.functionDesc(), fd.insertArgumentLayouts(0, ADDRESS));
 
         checkArgumentBindings(callingSequence, new Binding[][]{
-            { unboxAddress(Addressable.class), vmStore(r10, long.class) },
+            { unboxAddress(), vmStore(r10, long.class) },
             {
                 copy(struct),
-                unboxAddress(MemorySegment.class),
+                unboxAddress(),
                 vmStore(rcx, long.class)
             }
         });
@@ -292,7 +292,7 @@ public class TestWindowsCallArranger extends CallArrangerTestBase {
         assertEquals(callingSequence.functionDesc(), fd.insertArgumentLayouts(0, ADDRESS));
 
         checkArgumentBindings(callingSequence, new Binding[][]{
-            { unboxAddress(Addressable.class), vmStore(r10, long.class) },
+            { unboxAddress(), vmStore(r10, long.class) },
             { unboxAddress(), vmStore(rcx, long.class) }
         });
 
@@ -313,7 +313,7 @@ public class TestWindowsCallArranger extends CallArrangerTestBase {
         assertEquals(callingSequence.functionDesc(), fd.insertArgumentLayouts(0, ADDRESS));
 
         checkArgumentBindings(callingSequence, new Binding[][]{
-            { unboxAddress(Addressable.class), vmStore(r10, long.class) },
+            { unboxAddress(), vmStore(r10, long.class) },
         });
 
         checkReturnBindings(callingSequence,
@@ -337,7 +337,7 @@ public class TestWindowsCallArranger extends CallArrangerTestBase {
         assertEquals(callingSequence.functionDesc(), FunctionDescriptor.ofVoid(ADDRESS, C_POINTER));
 
         checkArgumentBindings(callingSequence, new Binding[][]{
-            { unboxAddress(Addressable.class), vmStore(r10, long.class) },
+            { unboxAddress(), vmStore(r10, long.class) },
             { unboxAddress(), vmStore(rcx, long.class) }
         });
 
@@ -366,20 +366,20 @@ public class TestWindowsCallArranger extends CallArrangerTestBase {
         assertEquals(callingSequence.functionDesc(), fd.insertArgumentLayouts(0, ADDRESS));
 
         checkArgumentBindings(callingSequence, new Binding[][]{
-            { unboxAddress(Addressable.class), vmStore(r10, long.class) },
-            { copy(struct), unboxAddress(MemorySegment.class), vmStore(rcx, long.class) },
+            { unboxAddress(), vmStore(r10, long.class) },
+            { copy(struct), unboxAddress(), vmStore(rcx, long.class) },
             { vmStore(rdx, int.class) },
             { vmStore(xmm2, double.class) },
             { unboxAddress(), vmStore(r9, long.class) },
-            { copy(struct), unboxAddress(MemorySegment.class), vmStore(stackStorage(0), long.class) },
+            { copy(struct), unboxAddress(), vmStore(stackStorage(0), long.class) },
             { vmStore(stackStorage(1), int.class) },
             { vmStore(stackStorage(2), double.class) },
             { unboxAddress(), vmStore(stackStorage(3), long.class) },
-            { copy(struct), unboxAddress(MemorySegment.class), vmStore(stackStorage(4), long.class) },
+            { copy(struct), unboxAddress(), vmStore(stackStorage(4), long.class) },
             { vmStore(stackStorage(5), int.class) },
             { vmStore(stackStorage(6), double.class) },
             { unboxAddress(), vmStore(stackStorage(7), long.class) },
-            { copy(struct), unboxAddress(MemorySegment.class), vmStore(stackStorage(8), long.class) },
+            { copy(struct), unboxAddress(), vmStore(stackStorage(8), long.class) },
             { vmStore(stackStorage(9), int.class) },
             { vmStore(stackStorage(10), double.class) },
             { unboxAddress(), vmStore(stackStorage(11), long.class) },


### PR DESCRIPTION
This PR switches the Binding classes to use records. This results in a clean simplification of the code due to the no longer having the need to implement equals/hashcode/toString as well. When we have type patterns for switch, we will also be able to remove the tag, and just switch on the type.

I also noticed that the UnboxAddress binding had 2 fields that were not being used. In practice this binding always operates on Addressable instances (both in the interpreter and specializer). So, I've cleaned up these 2 fields as well, and related factory method.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8289285](https://bugs.openjdk.org/browse/JDK-8289285): Use records for binding classes


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.org/census#mcimadamore) (@mcimadamore - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/panama-foreign pull/690/head:pull/690` \
`$ git checkout pull/690`

Update a local copy of the PR: \
`$ git checkout pull/690` \
`$ git pull https://git.openjdk.org/panama-foreign pull/690/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 690`

View PR using the GUI difftool: \
`$ git pr show -t 690`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/panama-foreign/pull/690.diff">https://git.openjdk.org/panama-foreign/pull/690.diff</a>

</details>
