### PR TITLE
8290880: Add static MemorySegment::mismatch method

### DIFF
--- a/src/java.base/share/classes/java/lang/foreign/MemorySegment.java
+++ b/src/java.base/share/classes/java/lang/foreign/MemorySegment.java
@@ -1982,7 +1982,7 @@ public sealed interface MemorySegment extends Addressable permits AbstractMemory
     }
 
     /**
-     * Finds and returns the offset, in bytes, of the first mismatch between the source and the destination
+     * Finds and returns the relative offset, in bytes, of the first mismatch between the source and the destination
      * segments. More specifically, the bytes at offset {@code srcOffset} through {@code srcOffset + bytes - 1} in the
      * source segment are compared against the bytes at offset {@code dstOffset} through {@code dstOffset + bytes - 1}
      * in the destination segment.

--- a/src/java.base/share/classes/jdk/internal/foreign/AbstractMemorySegmentImpl.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/AbstractMemorySegmentImpl.java
@@ -153,12 +153,7 @@ public abstract non-sealed class AbstractMemorySegmentImpl implements MemorySegm
     @Override
     public long mismatch(MemorySegment other) {
         Objects.requireNonNull(other);
-        long thisSize = byteSize();
-        long thatSize = other.byteSize();
-        long length = Math.min(thisSize, thatSize);
-        long mismatch = MemorySegment.mismatch(this, 0, other, 0, length);
-        return (mismatch == -1 && thisSize != thatSize) ?
-            length : mismatch;
+        return MemorySegment.mismatch(this, 0, byteSize(), other, 0, other.byteSize());
     }
 
     /**

--- a/src/java.base/share/classes/jdk/internal/foreign/AbstractMemorySegmentImpl.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/AbstractMemorySegmentImpl.java
@@ -152,45 +152,19 @@ public abstract non-sealed class AbstractMemorySegmentImpl implements MemorySegm
 
     @Override
     public long mismatch(MemorySegment other) {
-        AbstractMemorySegmentImpl that = (AbstractMemorySegmentImpl)Objects.requireNonNull(other);
-        final long thisSize = this.byteSize();
-        final long thatSize = that.byteSize();
-        final long length = Math.min(thisSize, thatSize);
-        this.checkAccess(0, length, true);
-        that.checkAccess(0, length, true);
-        if (this == other) {
-            checkValidState();
-            return -1;
-        }
-
-        long i = 0;
-        if (length > 7) {
-            if (get(JAVA_BYTE, 0) != that.get(JAVA_BYTE, 0)) {
-                return 0;
-            }
-            i = vectorizedMismatchLargeForBytes(sessionImpl(), that.sessionImpl(),
-                    this.unsafeGetBase(), this.unsafeGetOffset(),
-                    that.unsafeGetBase(), that.unsafeGetOffset(),
-                    length);
-            if (i >= 0) {
-                return i;
-            }
-            long remaining = ~i;
-            assert remaining < 8 : "remaining greater than 7: " + remaining;
-            i = length - remaining;
-        }
-        for (; i < length; i++) {
-            if (get(JAVA_BYTE, i) != that.get(JAVA_BYTE, i)) {
-                return i;
-            }
-        }
-        return thisSize != thatSize ? length : -1;
+        Objects.requireNonNull(other);
+        long thisSize = byteSize();
+        long thatSize = other.byteSize();
+        long length = Math.min(thisSize, thatSize);
+        long mismatch = MemorySegment.mismatch(this, 0, other, 0, length);
+        return (mismatch == -1 && thisSize != thatSize) ?
+            length : mismatch;
     }
 
     /**
      * Mismatch over long lengths.
      */
-    private static long vectorizedMismatchLargeForBytes(MemorySessionImpl aSession, MemorySessionImpl bSession,
+    public static long vectorizedMismatchLargeForBytes(MemorySessionImpl aSession, MemorySessionImpl bSession,
                                                         Object a, long aOffset,
                                                         Object b, long bOffset,
                                                         long length) {

--- a/test/jdk/java/foreign/TestMismatch.java
+++ b/test/jdk/java/foreign/TestMismatch.java
@@ -28,7 +28,6 @@
  */
 
 import java.lang.foreign.MemorySession;
-import java.lang.invoke.VarHandle;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
@@ -36,6 +35,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.lang.foreign.MemorySegment;
 import java.lang.foreign.ValueLayout;
 import java.util.function.IntFunction;
+import java.util.stream.Stream;
 
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -45,14 +45,27 @@ import static org.testng.Assert.assertThrows;
 
 public class TestMismatch {
 
-    final static VarHandle BYTE_HANDLE = ValueLayout.JAVA_BYTE.varHandle();
-
     // stores a increasing sequence of values into the memory of the given segment
     static MemorySegment initializeSegment(MemorySegment segment) {
         for (int i = 0 ; i < segment.byteSize() ; i++) {
-            BYTE_HANDLE.set(segment.asSlice(i), (byte)i);
+            segment.set(ValueLayout.JAVA_BYTE, i, (byte)i);
         }
         return segment;
+    }
+
+    @Test(dataProvider = "slices", expectedExceptions = IndexOutOfBoundsException.class)
+    public void testNegativeSrcOffset(MemorySegment s1, MemorySegment s2) {
+        MemorySegment.mismatch(s1, -1, s2, 0, 0);
+    }
+
+    @Test(dataProvider = "slices", expectedExceptions = IndexOutOfBoundsException.class)
+    public void testNegativeDstOffset(MemorySegment s1, MemorySegment s2) {
+        MemorySegment.mismatch(s1, 0, s2, -1, 0);
+    }
+
+    @Test(dataProvider = "slices", expectedExceptions = IndexOutOfBoundsException.class)
+    public void testNegativeLength(MemorySegment s1, MemorySegment s2) {
+        MemorySegment.mismatch(s1, 0, s2, 0, -1);
     }
 
     @Test(dataProvider = "slices")
@@ -74,6 +87,19 @@ public class TestMismatch {
         }
     }
 
+    @Test(dataProvider = "slicesStatic")
+    public void testSameValuesStatic(SliceOffsetAndSize ss1, SliceOffsetAndSize ss2) {
+        out.format("testSameValuesStatic s1:%s, s2:%s\n", ss1, ss2);
+        MemorySegment s1 = initializeSegment(ss1.toSlice());
+        MemorySegment s2 = initializeSegment(ss2.toSlice());
+        long length = Math.min(s1.byteSize(), s2.byteSize());
+
+        for (int i = 0 ; i < length ; i++) {
+            assertEquals(MemorySegment.mismatch(ss1.segment, ss1.offset, ss2.segment, ss2.offset, i), -1);
+            assertEquals(MemorySegment.mismatch(ss2.segment, ss2.offset, ss1.segment, ss1.offset, i), -1);
+        }
+    }
+
     @Test(dataProvider = "slices")
     public void testDifferentValues(MemorySegment s1, MemorySegment s2) {
         out.format("testDifferentValues s1:%s, s2:%s\n", s1, s2);
@@ -82,7 +108,7 @@ public class TestMismatch {
 
         for (long i = s2.byteSize() -1 ; i >= 0; i--) {
             long expectedMismatchOffset = i;
-            BYTE_HANDLE.set(s2.asSlice(i), (byte) 0xFF);
+            s2.set(ValueLayout.JAVA_BYTE, i, (byte) 0xFF);
 
             if (s1.byteSize() == s2.byteSize()) {
                 assertEquals(s1.mismatch(s2), expectedMismatchOffset);
@@ -95,6 +121,24 @@ public class TestMismatch {
                 var off = Math.min(s1.byteSize(), expectedMismatchOffset);
                 assertEquals(s1.mismatch(s2), off);  // proper prefix
                 assertEquals(s2.mismatch(s1), off);
+            }
+        }
+    }
+
+    @Test(dataProvider = "slicesStatic")
+    public void testDifferentValuesStatic(SliceOffsetAndSize ss1, SliceOffsetAndSize ss2) {
+        out.format("testDifferentValues s1:%s, s2:%s\n", ss1, ss2);
+        long length = Math.min(ss1.size(), ss2.size());
+
+        for (long i = ss2.size - 1 ; i >= 0; i--) {
+            initializeSegment(ss1.toSlice());
+            initializeSegment(ss2.toSlice());
+            long expectedMismatchOffset = i;
+            ss2.toSlice().set(ValueLayout.JAVA_BYTE, i, (byte) 0xFF);
+
+            for (long j = expectedMismatchOffset + 1 ; j < length ; j++) {
+                assertEquals(MemorySegment.mismatch(ss1.segment, ss1.offset, ss2.segment, ss2.offset, j), expectedMismatchOffset);
+                assertEquals(MemorySegment.mismatch(ss2.segment, ss2.offset, ss1.segment, ss1.offset, j), expectedMismatchOffset);
             }
         }
     }
@@ -133,15 +177,20 @@ public class TestMismatch {
         for (long i = s2.byteSize() -1 ; i >= Integer.MAX_VALUE - 10L; i--) {
             var s3 = s1.asSlice(0, i);
             var s4 = s2.asSlice(0, i);
+            // instance
             assertEquals(s3.mismatch(s3), -1);
             assertEquals(s3.mismatch(s4), -1);
             assertEquals(s4.mismatch(s3), -1);
+            // static
+            assertEquals(MemorySegment.mismatch(s1, 0, s1, 0, i), -1);
+            assertEquals(MemorySegment.mismatch(s2, 0, s1, 0, i), -1);
+            assertEquals(MemorySegment.mismatch(s1, 0, s2, 0, i), -1);
         }
     }
 
     private void testLargeMismatchAcrossMaxBoundary(MemorySegment s1, MemorySegment s2) {
         for (long i = s2.byteSize() -1 ; i >= Integer.MAX_VALUE - 10L; i--) {
-            BYTE_HANDLE.set(s2.asSlice(i), (byte) 0xFF);
+            s2.set(ValueLayout.JAVA_BYTE, i, (byte) 0xFF);
             long expectedMismatchOffset = i;
             assertEquals(s1.mismatch(s2), expectedMismatchOffset);
             assertEquals(s2.mismatch(s1), expectedMismatchOffset);
@@ -221,30 +270,45 @@ public class TestMismatch {
         }
     }
 
-    @DataProvider(name = "slices")
-    static Object[][] slices() {
+    record SliceOffsetAndSize(MemorySegment segment, long offset, long size) {
+        MemorySegment toSlice() {
+            return segment.asSlice(offset, size);
+        }
+    };
+
+    @DataProvider(name = "slicesStatic")
+    static Object[][] slicesStatic() {
         int[] sizes = { 16, 8, 1 };
-        List<MemorySegment> aSlices = new ArrayList<>();
-        List<MemorySegment> bSlices = new ArrayList<>();
-        for (List<MemorySegment> slices : List.of(aSlices, bSlices)) {
+        List<SliceOffsetAndSize> aSliceOffsetAndSizes = new ArrayList<>();
+        List<SliceOffsetAndSize> bSliceOffsetAndSizes = new ArrayList<>();
+        for (List<SliceOffsetAndSize> slices : List.of(aSliceOffsetAndSizes, bSliceOffsetAndSizes)) {
             for (SegmentKind kind : SegmentKind.values()) {
                 MemorySegment segment = kind.makeSegment(16);
                 //compute all slices
                 for (int size : sizes) {
                     for (int index = 0 ; index < 16 ; index += size) {
-                        MemorySegment slice = segment.asSlice(index, size);
-                        slices.add(slice);
+                        slices.add(new SliceOffsetAndSize(segment, index, size));
                     }
                 }
             }
         }
-        assert aSlices.size() == bSlices.size();
-        Object[][] sliceArray = new Object[aSlices.size() * bSlices.size()][];
-        for (int i = 0 ; i < aSlices.size() ; i++) {
-            for (int j = 0 ; j < bSlices.size() ; j++) {
-                sliceArray[i * aSlices.size() + j] = new Object[] { aSlices.get(i), bSlices.get(j) };
+        assert aSliceOffsetAndSizes.size() == bSliceOffsetAndSizes.size();
+        Object[][] sliceArray = new Object[aSliceOffsetAndSizes.size() * bSliceOffsetAndSizes.size()][];
+        for (int i = 0 ; i < aSliceOffsetAndSizes.size() ; i++) {
+            for (int j = 0 ; j < bSliceOffsetAndSizes.size() ; j++) {
+                sliceArray[i * aSliceOffsetAndSizes.size() + j] = new Object[] { aSliceOffsetAndSizes.get(i), bSliceOffsetAndSizes.get(j) };
             }
         }
         return sliceArray;
+    }
+
+    @DataProvider(name = "slices")
+    static Object[][] slices() {
+        Object[][] slicesStatic = slicesStatic();
+        return Stream.of(slicesStatic)
+                .map(arr -> new Object[]{
+                        ((SliceOffsetAndSize) arr[0]).toSlice(),
+                        ((SliceOffsetAndSize) arr[1]).toSlice()
+                }).toArray(Object[][]::new);
     }
 }


### PR DESCRIPTION
As discussed in [1], it would be useful if the `MemorySegment` class provided a static mismatch method, similarly to what we have provided for `copy`.

This patch adds that method, and rewrites the existing instance `mismatch` method to be based on that new static method.
It then adds new tests to cover the new static method.

[1] - https://mail.openjdk.org/pipermail/panama-dev/2022-June/017099.html

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8290880](https://bugs.openjdk.org/browse/JDK-8290880): Add static MemorySegment::mismatch method


### Reviewers
 * [Jorn Vernee](https://openjdk.org/census#jvernee) (@JornVernee - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/panama-foreign pull/691/head:pull/691` \
`$ git checkout pull/691`

Update a local copy of the PR: \
`$ git checkout pull/691` \
`$ git pull https://git.openjdk.org/panama-foreign pull/691/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 691`

View PR using the GUI difftool: \
`$ git pr show -t 691`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/panama-foreign/pull/691.diff">https://git.openjdk.org/panama-foreign/pull/691.diff</a>

</details>
