### PR TITLE
Revert changes to ValueLayout.OfAddress::toString

### DIFF
--- a/src/java.base/share/classes/java/lang/foreign/ValueLayout.java
+++ b/src/java.base/share/classes/java/lang/foreign/ValueLayout.java
@@ -100,17 +100,9 @@ public sealed class ValueLayout extends AbstractLayout implements MemoryLayout {
      */
     @Override
     public String toString() {
-        String descriptor;
-        if (this instanceof ValueLayout.OfAddress addressLayout) {
-            descriptor = "A";
-            if (addressLayout.isUnbounded) {
-                descriptor += "!";
-            }
-        } else {
-            descriptor = carrier.descriptorString().substring(0, 1);
-        }
+        char descriptor = carrier == MemorySegment.class ? 'A' : carrier.descriptorString().charAt(0);
         if (order == ByteOrder.LITTLE_ENDIAN) {
-            descriptor = descriptor.toLowerCase();
+            descriptor = Character.toLowerCase(descriptor);
         }
         return decorateLayoutString(String.format("%s%d", descriptor, bitSize()));
     }

--- a/test/jdk/java/foreign/TestUnsupportedLinker.java
+++ b/test/jdk/java/foreign/TestUnsupportedLinker.java
@@ -29,7 +29,6 @@
  */
 
 import java.lang.foreign.Linker;
-import java.lang.foreign.MemoryAddress;
 import java.lang.foreign.MemorySession;
 import java.lang.foreign.VaList;
 import java.lang.foreign.ValueLayout;
@@ -55,6 +54,6 @@ public class TestUnsupportedLinker {
 
     @Test(expectedExceptions = UnsupportedOperationException.class)
     public void testUnsafeVaList() {
-        VaList.ofAddress(MemoryAddress.NULL, MemorySession.openImplicit());
+        VaList.ofAddress(0L, MemorySession.openImplicit());
     }
 }


### PR DESCRIPTION
The patch for unifying memory segment and memory address contained some changes to tweak address layout toString method, so that the layout would show whether dereference was safe or not. I think that went too far - an address layout is still 32/64 bits, and capturing dereference properties in toString representation is not helpful (and can actually be confusing, attra>

This patch also fixes a failure in a test that was imported from jdk/jdk during last week's automatic merge.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Reviewers
 * [Jorn Vernee](https://openjdk.org/census#jvernee) (@JornVernee - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/panama-foreign pull/697/head:pull/697` \
`$ git checkout pull/697`

Update a local copy of the PR: \
`$ git checkout pull/697` \
`$ git pull https://git.openjdk.org/panama-foreign pull/697/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 697`

View PR using the GUI difftool: \
`$ git pr show -t 697`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/panama-foreign/pull/697.diff">https://git.openjdk.org/panama-foreign/pull/697.diff</a>

</details>
