### PR TITLE
8291913: Remove the TraceOptimizedUpcallStubs flag

### DIFF
--- a/src/hotspot/cpu/aarch64/upcallLinker_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/upcallLinker_aarch64.cpp
@@ -329,9 +329,13 @@ address UpcallLinker::make_upcall_stub(jobject receiver, Method* entry,
                          receiver,
                          in_ByteSize(frame_data_offset));
 
-  if (TraceOptimizedUpcallStubs) {
-    blob->print_on(tty);
+#ifndef PRODUCT
+  if (lt.is_enabled()) {
+    ResourceMark rm;
+    LogStream ls(lt);
+    blob->print_on(&ls);
   }
+#endif
 
   return blob->code_begin();
 }

--- a/src/hotspot/cpu/x86/upcallLinker_x86_64.cpp
+++ b/src/hotspot/cpu/x86/upcallLinker_x86_64.cpp
@@ -392,9 +392,13 @@ address UpcallLinker::make_upcall_stub(jobject receiver, Method* entry,
                          receiver,
                          in_ByteSize(frame_data_offset));
 
-  if (TraceOptimizedUpcallStubs) {
-    blob->print_on(tty);
+#ifndef PRODUCT
+  if (lt.is_enabled()) {
+    ResourceMark rm;
+    LogStream ls(lt);
+    blob->print_on(&ls);
   }
+#endif
 
   return blob->code_begin();
 }

--- a/src/hotspot/share/code/codeBlob.cpp
+++ b/src/hotspot/share/code/codeBlob.cpp
@@ -793,5 +793,6 @@ void UpcallStub::print_on(outputStream* st) const {
 }
 
 void UpcallStub::print_value_on(outputStream* st) const {
-  st->print_cr("UpcallStub (" INTPTR_FORMAT  ") used for %s", p2i(this), name());
+  st->print_cr("UpcallStub (" INTPTR_FORMAT  "): %s", p2i(this), name());
+  Disassembler::decode((RuntimeBlob*)this, st);
 }

--- a/src/hotspot/share/code/codeBlob.cpp
+++ b/src/hotspot/share/code/codeBlob.cpp
@@ -790,9 +790,9 @@ void UpcallStub::verify() {
 void UpcallStub::print_on(outputStream* st) const {
   RuntimeBlob::print_on(st);
   print_value_on(st);
+  Disassembler::decode((RuntimeBlob*)this, st);
 }
 
 void UpcallStub::print_value_on(outputStream* st) const {
-  st->print_cr("UpcallStub (" INTPTR_FORMAT  "): %s", p2i(this), name());
-  Disassembler::decode((RuntimeBlob*)this, st);
+  st->print_cr("UpcallStub (" INTPTR_FORMAT  ") used for %s", p2i(this), name());
 }

--- a/src/hotspot/share/runtime/globals.hpp
+++ b/src/hotspot/share/runtime/globals.hpp
@@ -2055,9 +2055,6 @@ const int ObjectAlignmentInBytes = 8;
           false AARCH64_ONLY(DEBUG_ONLY(||true)),                           \
              "Mark all threads after a safepoint, and clear on a modify "   \
              "fence. Add cleanliness checks.")                              \
-                                                                            \
-  develop(bool, TraceOptimizedUpcallStubs, false,                           \
-                "Trace optimized upcall stub generation")                   \
 
 // end of RUNTIME_FLAGS
 


### PR DESCRIPTION
Removes the `TraceOptimizedUpcallStubs` flag. This flag should have been replaced by unified logging, together with the downcall counterpart, but it seems that part of this was missed.

This patch fixes that, removing the flag, and also adding the disassembly to the logging output. The output is now similar to what we output for downcall stubs.

<details>
<summary>Sample output (click to unfold)</summary>

```
[0.250s][trace][foreign,upcall] Argument shuffle {
[0.250s][trace][foreign,upcall] Stack argument slots: 0
[0.250s][trace][foreign,upcall] }
[0.250s][trace][foreign,upcall] [CodeBlob (0x00000272554fa090)]
[0.250s][trace][foreign,upcall] Framesize: 0
[0.250s][trace][foreign,upcall] UpcallStub (0x00000272554fa090) used for upcall_stub_(Ljava/lang/Object;)V
[0.250s][trace][foreign,upcall] --------------------------------------------------------------------------------
[0.250s][trace][foreign,upcall] Decoding CodeBlob, name: upcall_stub_(Ljava/lang/Object;)V, at  [0x00000272554fa140, 0x00000272554fa4c8]  904 bytes
[0.264s][trace][foreign,upcall]   0x00000272554fa140:   pushq		%rbp
[0.264s][trace][foreign,upcall]   0x00000272554fa141:   movq		%rsp, %rbp
[0.264s][trace][foreign,upcall]   0x00000272554fa144:   subq		$0x1d0, %rsp
[0.264s][trace][foreign,upcall]  ;; { preserve_callee_saved_regs 
[0.264s][trace][foreign,upcall]   0x00000272554fa14b:   movq		%rbx, 0x20(%rsp)
[0.264s][trace][foreign,upcall]   0x00000272554fa150:   movq		%rsi, 0x28(%rsp)
[0.264s][trace][foreign,upcall]   0x00000272554fa155:   movq		%rdi, 0x30(%rsp)
[0.264s][trace][foreign,upcall]   0x00000272554fa15a:   movq		%r12, 0x38(%rsp)
[0.264s][trace][foreign,upcall]   0x00000272554fa15f:   movq		%r13, 0x40(%rsp)
[0.264s][trace][foreign,upcall]   0x00000272554fa164:   movq		%r14, 0x48(%rsp)
[0.264s][trace][foreign,upcall]   0x00000272554fa169:   movq		%r15, 0x50(%rsp)
[0.264s][trace][foreign,upcall]   0x00000272554fa16e:   vmovdqu		%ymm6, 0x58(%rsp)
[0.264s][trace][foreign,upcall]   0x00000272554fa174:   vmovdqu		%ymm7, 0x78(%rsp)
[0.264s][trace][foreign,upcall]   0x00000272554fa17a:   vmovdqu		%ymm8, 0x98(%rsp)
[0.264s][trace][foreign,upcall]   0x00000272554fa183:   vmovdqu		%ymm9, 0xb8(%rsp)
[0.264s][trace][foreign,upcall]   0x00000272554fa18c:   vmovdqu		%ymm10, 0xd8(%rsp)
[0.264s][trace][foreign,upcall]   0x00000272554fa195:   vmovdqu		%ymm11, 0xf8(%rsp)
[0.264s][trace][foreign,upcall]   0x00000272554fa19e:   vmovdqu		%ymm12, 0x118(%rsp)
[0.264s][trace][foreign,upcall]   0x00000272554fa1a7:   vmovdqu		%ymm13, 0x138(%rsp)
[0.264s][trace][foreign,upcall]   0x00000272554fa1b0:   vmovdqu		%ymm14, 0x158(%rsp)
[0.264s][trace][foreign,upcall]   0x00000272554fa1b9:   vmovdqu		%ymm15, 0x178(%rsp)
[0.264s][trace][foreign,upcall]  ;; } preserve_callee_saved_regs 
[0.264s][trace][foreign,upcall]  ;; { on_entry
[0.264s][trace][foreign,upcall]   0x00000272554fa1c2:   vzeroupper		
[0.264s][trace][foreign,upcall]   0x00000272554fa1c5:   leaq		0x198(%rsp), %rcx
[0.264s][trace][foreign,upcall]   0x00000272554fa1cd:   movabsq		$0x7ffa97a4c2b0, %r10
[0.264s][trace][foreign,upcall]   0x00000272554fa1d7:   callq		*%r10
[0.264s][trace][foreign,upcall]   0x00000272554fa1da:   movq		%rax, %r15
[0.264s][trace][foreign,upcall]   0x00000272554fa1dd:   xorq		%r12, %r12
[0.264s][trace][foreign,upcall]  ;; } on_entry
[0.264s][trace][foreign,upcall]  ;; { argument shuffle
[0.264s][trace][foreign,upcall]  ;; } argument shuffle
[0.264s][trace][foreign,upcall]  ;; { receiver 
[0.264s][trace][foreign,upcall]   0x00000272554fa1e0:   movabsq		$0x272665e6468, %r10
[0.264s][trace][foreign,upcall]   0x00000272554fa1ea:   testq		%r10, %r10
[0.264s][trace][foreign,upcall]   0x00000272554fa1ed:   je		0x272554fa3e4
[0.264s][trace][foreign,upcall]   0x00000272554fa1f3:   testb		$1, %r10b
[0.264s][trace][foreign,upcall]   0x00000272554fa1f7:   je		0x272554fa3e1
[0.264s][trace][foreign,upcall]   0x00000272554fa1fd:   movq		-1(%r10), %r10
[0.264s][trace][foreign,upcall]   0x00000272554fa201:   cmpb		$0, 0x40(%r15)
[0.264s][trace][foreign,upcall]   0x00000272554fa206:   je		0x272554fa3dc
[0.264s][trace][foreign,upcall]   0x00000272554fa20c:   cmpq		$0, %r10
[0.264s][trace][foreign,upcall]   0x00000272554fa210:   je		0x272554fa3dc
[0.264s][trace][foreign,upcall]   0x00000272554fa216:   movq		0x28(%r15), %r11
[0.264s][trace][foreign,upcall]   0x00000272554fa21a:   cmpq		$0, %r11
[0.264s][trace][foreign,upcall]   0x00000272554fa21e:   je		0x272554fa238
[0.264s][trace][foreign,upcall]   0x00000272554fa224:   subq		$8, %r11
[0.265s][trace][foreign,upcall]   0x00000272554fa228:   movq		%r11, 0x28(%r15)
[0.265s][trace][foreign,upcall]   0x00000272554fa22c:   addq		0x38(%r15), %r11
[0.265s][trace][foreign,upcall]   0x00000272554fa230:   movq		%r10, (%r11)
[0.265s][trace][foreign,upcall]   0x00000272554fa233:   jmp		0x272554fa3dc
[0.265s][trace][foreign,upcall]  ;; push_call_clobbered_registers start
[0.265s][trace][foreign,upcall]   0x00000272554fa238:   subq		$0xd0, %rsp
[0.265s][trace][foreign,upcall]   0x00000272554fa23f:   movq		%rax, (%rsp)
[0.265s][trace][foreign,upcall]   0x00000272554fa243:   movq		%rcx, 8(%rsp)
[0.265s][trace][foreign,upcall]   0x00000272554fa248:   movq		%rdx, 0x10(%rsp)
[0.265s][trace][foreign,upcall]   0x00000272554fa24d:   movq		%rsi, 0x18(%rsp)
[0.265s][trace][foreign,upcall]   0x00000272554fa252:   movq		%rdi, 0x20(%rsp)
[0.265s][trace][foreign,upcall]   0x00000272554fa257:   movq		%r8, 0x28(%rsp)
[0.265s][trace][foreign,upcall]   0x00000272554fa25c:   movq		%r9, 0x30(%rsp)
[0.265s][trace][foreign,upcall]   0x00000272554fa261:   movq		%r10, 0x38(%rsp)
[0.265s][trace][foreign,upcall]   0x00000272554fa266:   movq		%r11, 0x40(%rsp)
[0.265s][trace][foreign,upcall]   0x00000272554fa26b:   vmovsd		%xmm0, 0x50(%rsp)
[0.265s][trace][foreign,upcall]   0x00000272554fa271:   vmovsd		%xmm1, 0x58(%rsp)
[0.265s][trace][foreign,upcall]   0x00000272554fa277:   vmovsd		%xmm2, 0x60(%rsp)
[0.265s][trace][foreign,upcall]   0x00000272554fa27d:   vmovsd		%xmm3, 0x68(%rsp)
[0.265s][trace][foreign,upcall]   0x00000272554fa283:   vmovsd		%xmm4, 0x70(%rsp)
[0.265s][trace][foreign,upcall]   0x00000272554fa289:   vmovsd		%xmm5, 0x78(%rsp)
[0.265s][trace][foreign,upcall]   0x00000272554fa28f:   vmovsd		%xmm6, 0x80(%rsp)
[0.265s][trace][foreign,upcall]   0x00000272554fa298:   vmovsd		%xmm7, 0x88(%rsp)
[0.265s][trace][foreign,upcall]   0x00000272554fa2a1:   vmovsd		%xmm8, 0x90(%rsp)
[0.265s][trace][foreign,upcall]   0x00000272554fa2aa:   vmovsd		%xmm9, 0x98(%rsp)
[0.265s][trace][foreign,upcall]   0x00000272554fa2b3:   vmovsd		%xmm10, 0xa0(%rsp)
[0.265s][trace][foreign,upcall]   0x00000272554fa2bc:   vmovsd		%xmm11, 0xa8(%rsp)
[0.265s][trace][foreign,upcall]   0x00000272554fa2c5:   vmovsd		%xmm12, 0xb0(%rsp)
[0.265s][trace][foreign,upcall]   0x00000272554fa2ce:   vmovsd		%xmm13, 0xb8(%rsp)
[0.265s][trace][foreign,upcall]   0x00000272554fa2d7:   vmovsd		%xmm14, 0xc0(%rsp)
[0.265s][trace][foreign,upcall]   0x00000272554fa2e0:   vmovsd		%xmm15, 0xc8(%rsp)
[0.265s][trace][foreign,upcall]  ;; push_call_clobbered_registers end
[0.265s][trace][foreign,upcall]   0x00000272554fa2e9:   movq		%r15, %rdx
[0.265s][trace][foreign,upcall]   0x00000272554fa2ec:   movq		%r10, %rcx
[0.265s][trace][foreign,upcall]   0x00000272554fa2ef:   subq		$0x20, %rsp
[0.265s][trace][foreign,upcall]   0x00000272554fa2f3:   testb		$0xf, %spl
[0.265s][trace][foreign,upcall]   0x00000272554fa2f7:   je		0x272554fa317
[0.265s][trace][foreign,upcall]   0x00000272554fa2fd:   subq		$8, %rsp
[0.265s][trace][foreign,upcall]   0x00000272554fa301:   movabsq		$0x7ffa971d4860, %r10
[0.265s][trace][foreign,upcall]   0x00000272554fa30b:   callq		*%r10
[0.265s][trace][foreign,upcall]   0x00000272554fa30e:   addq		$8, %rsp
[0.265s][trace][foreign,upcall]   0x00000272554fa312:   jmp		0x272554fa324
[0.265s][trace][foreign,upcall]   0x00000272554fa317:   movabsq		$0x7ffa971d4860, %r10
[0.265s][trace][foreign,upcall]   0x00000272554fa321:   callq		*%r10
[0.265s][trace][foreign,upcall]   0x00000272554fa324:   addq		$0x20, %rsp
[0.265s][trace][foreign,upcall]  ;; pop_call_clobbered_registers start
[0.265s][trace][foreign,upcall]   0x00000272554fa328:   vmovsd		0xc8(%rsp), %xmm15
[0.265s][trace][foreign,upcall]   0x00000272554fa331:   vmovsd		0xc0(%rsp), %xmm14
[0.265s][trace][foreign,upcall]   0x00000272554fa33a:   vmovsd		0xb8(%rsp), %xmm13
[0.265s][trace][foreign,upcall]   0x00000272554fa343:   vmovsd		0xb0(%rsp), %xmm12
[0.265s][trace][foreign,upcall]   0x00000272554fa34c:   vmovsd		0xa8(%rsp), %xmm11
[0.265s][trace][foreign,upcall]   0x00000272554fa355:   vmovsd		0xa0(%rsp), %xmm10
[0.265s][trace][foreign,upcall]   0x00000272554fa35e:   vmovsd		0x98(%rsp), %xmm9
[0.265s][trace][foreign,upcall]   0x00000272554fa367:   vmovsd		0x90(%rsp), %xmm8
[0.265s][trace][foreign,upcall]   0x00000272554fa370:   vmovsd		0x88(%rsp), %xmm7
[0.265s][trace][foreign,upcall]   0x00000272554fa379:   vmovsd		0x80(%rsp), %xmm6
[0.265s][trace][foreign,upcall]   0x00000272554fa382:   vmovsd		0x78(%rsp), %xmm5
[0.265s][trace][foreign,upcall]   0x00000272554fa388:   vmovsd		0x70(%rsp), %xmm4
[0.265s][trace][foreign,upcall]   0x00000272554fa38e:   vmovsd		0x68(%rsp), %xmm3
[0.265s][trace][foreign,upcall]   0x00000272554fa394:   vmovsd		0x60(%rsp), %xmm2
[0.265s][trace][foreign,upcall]   0x00000272554fa39a:   vmovsd		0x58(%rsp), %xmm1
[0.265s][trace][foreign,upcall]   0x00000272554fa3a0:   vmovsd		0x50(%rsp), %xmm0
[0.265s][trace][foreign,upcall]   0x00000272554fa3a6:   movq		0x40(%rsp), %r11
[0.265s][trace][foreign,upcall]   0x00000272554fa3ab:   movq		0x38(%rsp), %r10
[0.265s][trace][foreign,upcall]   0x00000272554fa3b0:   movq		0x30(%rsp), %r9
[0.265s][trace][foreign,upcall]   0x00000272554fa3b5:   movq		0x28(%rsp), %r8
[0.265s][trace][foreign,upcall]   0x00000272554fa3ba:   movq		0x20(%rsp), %rdi
[0.265s][trace][foreign,upcall]   0x00000272554fa3bf:   movq		0x18(%rsp), %rsi
[0.265s][trace][foreign,upcall]   0x00000272554fa3c4:   movq		0x10(%rsp), %rdx
[0.265s][trace][foreign,upcall]   0x00000272554fa3c9:   movq		8(%rsp), %rcx
[0.265s][trace][foreign,upcall]   0x00000272554fa3ce:   movq		(%rsp), %rax
[0.265s][trace][foreign,upcall]   0x00000272554fa3d2:   addq		$0xd0, %rsp
[0.265s][trace][foreign,upcall]   0x00000272554fa3d9:   vzeroupper		
[0.265s][trace][foreign,upcall]  ;; pop_call_clobbered_registers end
[0.265s][trace][foreign,upcall]   0x00000272554fa3dc:   jmp		0x272554fa3e4
[0.265s][trace][foreign,upcall]   0x00000272554fa3e1:   movq		(%r10), %r10
[0.265s][trace][foreign,upcall]   0x00000272554fa3e4:   movq		%r10, %rdx
[0.265s][trace][foreign,upcall]  ;; } receiver 
[0.265s][trace][foreign,upcall]   0x00000272554fa3e7:   movabsq		$0x27267007f68, %rbx
[0.265s][trace][foreign,upcall]   0x00000272554fa3f1:   movq		%rbx, 0x360(%r15)
[0.265s][trace][foreign,upcall]   0x00000272554fa3f8:   callq		*0x58(%rbx)
[0.265s][trace][foreign,upcall]  ;; { on_exit
[0.265s][trace][foreign,upcall]   0x00000272554fa3fb:   vzeroupper		
[0.266s][trace][foreign,upcall]   0x00000272554fa3fe:   leaq		0x198(%rsp), %rcx
[0.266s][trace][foreign,upcall]   0x00000272554fa406:   movabsq		$0x7ffa97a4c490, %r10
[0.266s][trace][foreign,upcall]   0x00000272554fa410:   callq		*%r10
[0.266s][trace][foreign,upcall]   0x00000272554fa413:   xorq		%r12, %r12
[0.266s][trace][foreign,upcall]  ;; } on_exit
[0.266s][trace][foreign,upcall]  ;; { restore_callee_saved_regs 
[0.266s][trace][foreign,upcall]   0x00000272554fa416:   movq		0x20(%rsp), %rbx
[0.266s][trace][foreign,upcall]   0x00000272554fa41b:   movq		0x28(%rsp), %rsi
[0.266s][trace][foreign,upcall]   0x00000272554fa420:   movq		0x30(%rsp), %rdi
[0.266s][trace][foreign,upcall]   0x00000272554fa425:   movq		0x38(%rsp), %r12
[0.266s][trace][foreign,upcall]   0x00000272554fa42a:   movq		0x40(%rsp), %r13
[0.266s][trace][foreign,upcall]   0x00000272554fa42f:   movq		0x48(%rsp), %r14
[0.266s][trace][foreign,upcall]   0x00000272554fa434:   movq		0x50(%rsp), %r15
[0.266s][trace][foreign,upcall]   0x00000272554fa439:   vmovdqu		0x58(%rsp), %ymm6
[0.266s][trace][foreign,upcall]   0x00000272554fa43f:   vmovdqu		0x78(%rsp), %ymm7
[0.266s][trace][foreign,upcall]   0x00000272554fa445:   vmovdqu		0x98(%rsp), %ymm8
[0.266s][trace][foreign,upcall]   0x00000272554fa44e:   vmovdqu		0xb8(%rsp), %ymm9
[0.266s][trace][foreign,upcall]   0x00000272554fa457:   vmovdqu		0xd8(%rsp), %ymm10
[0.266s][trace][foreign,upcall]   0x00000272554fa460:   vmovdqu		0xf8(%rsp), %ymm11
[0.266s][trace][foreign,upcall]   0x00000272554fa469:   vmovdqu		0x118(%rsp), %ymm12
[0.266s][trace][foreign,upcall]   0x00000272554fa472:   vmovdqu		0x138(%rsp), %ymm13
[0.266s][trace][foreign,upcall]   0x00000272554fa47b:   vmovdqu		0x158(%rsp), %ymm14
[0.266s][trace][foreign,upcall]   0x00000272554fa484:   vmovdqu		0x178(%rsp), %ymm15
[0.266s][trace][foreign,upcall]  ;; } restore_callee_saved_regs 
[0.266s][trace][foreign,upcall]   0x00000272554fa48d:   leave		
[0.266s][trace][foreign,upcall]   0x00000272554fa48e:   retq		
[0.266s][trace][foreign,upcall]  ;; { exception handler
[0.266s][trace][foreign,upcall]   0x00000272554fa48f:   vzeroupper		
[0.266s][trace][foreign,upcall]   0x00000272554fa492:   movq		%rax, %rcx
[0.266s][trace][foreign,upcall]   0x00000272554fa495:   andq		$0xfffffffffffffff0, %rsp
[0.266s][trace][foreign,upcall]   0x00000272554fa499:   subq		$0x20, %rsp
[0.266s][trace][foreign,upcall]   0x00000272554fa49d:   movabsq		$0x7ffa97a4c200, %r10
[0.266s][trace][foreign,upcall]   0x00000272554fa4a7:   callq		*%r10
[0.266s][trace][foreign,upcall]   0x00000272554fa4aa:   movabsq		$0x7ffa97bfa818, %rcx
[0.266s][trace][foreign,upcall]   0x00000272554fa4b4:   andq		$0xfffffffffffffff0, %rsp
[0.266s][trace][foreign,upcall]   0x00000272554fa4b8:   movabsq		$0x7ffa9764b370, %r10
[0.266s][trace][foreign,upcall]   0x00000272554fa4c2:   callq		*%r10
[0.266s][trace][foreign,upcall]   0x00000272554fa4c5:   hlt		
[0.266s][trace][foreign,upcall]  ;; } exception handler
[0.266s][trace][foreign,upcall]   0x00000272554fa4c6:   hlt		
[0.266s][trace][foreign,upcall]   0x00000272554fa4c7:   hlt		
[0.266s][trace][foreign,upcall] --------------------------------------------------------------------------------
```
</details>

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8291913](https://bugs.openjdk.org/browse/JDK-8291913): Remove the TraceOptimizedUpcallStubs flag


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.org/census#mcimadamore) (@mcimadamore - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/panama-foreign pull/698/head:pull/698` \
`$ git checkout pull/698`

Update a local copy of the PR: \
`$ git checkout pull/698` \
`$ git pull https://git.openjdk.org/panama-foreign pull/698/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 698`

View PR using the GUI difftool: \
`$ git pr show -t 698`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/panama-foreign/pull/698.diff">https://git.openjdk.org/panama-foreign/pull/698.diff</a>

</details>
