### PR TITLE
Fix bug in hashCode after JDK-8291473

### DIFF
--- a/src/java.base/share/classes/jdk/internal/foreign/AbstractMemorySegmentImpl.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/AbstractMemorySegmentImpl.java
@@ -448,19 +448,15 @@ public abstract non-sealed class AbstractMemorySegmentImpl implements MemorySegm
     @Override
     public boolean equals(Object o) {
         return o instanceof AbstractMemorySegmentImpl that &&
-                array().equals(that.array()) &&
-                address() == that.address();
+                unsafeGetBase() == that.unsafeGetBase() &&
+                unsafeGetOffset() == that.unsafeGetOffset();
     }
 
     @Override
     public int hashCode() {
         return Objects.hash(
-                isNative(),
                 unsafeGetOffset(),
-                unsafeGetBase(),
-                length,
-                session
-        );
+                unsafeGetBase());
     }
 
     public static AbstractMemorySegmentImpl ofBuffer(Buffer bb) {

--- a/test/jdk/java/foreign/TestSegments.java
+++ b/test/jdk/java/foreign/TestSegments.java
@@ -139,6 +139,25 @@ public class TestSegments {
         assertNotEquals(segment, segment2);
     }
 
+    @Test
+    public void testHashCodeOffHeap() {
+        try (MemorySession session = MemorySession.openConfined()) {
+            MemorySegment segment = MemorySegment.allocateNative(100, session);
+            assertEquals(segment.hashCode(), segment.asReadOnly().hashCode());
+            assertEquals(segment.hashCode(), segment.asSlice(0, 100).hashCode());
+            assertEquals(segment.hashCode(), segment.asSlice(0, 90).hashCode());
+            assertEquals(segment.hashCode(), MemorySegment.ofAddress(segment.address(), 100, MemorySession.global()).hashCode());
+        }
+    }
+
+    @Test
+    public void testHashCodeOnHeap() {
+        MemorySegment segment = MemorySegment.ofArray(new byte[100]);
+        assertEquals(segment.hashCode(), segment.asReadOnly().hashCode());
+        assertEquals(segment.hashCode(), segment.asSlice(0, 100).hashCode());
+        assertEquals(segment.hashCode(), segment.asSlice(0, 90).hashCode());
+    }
+
     @Test(expectedExceptions = IndexOutOfBoundsException.class)
     public void testSmallSegmentMax() {
         long offset = (long)Integer.MAX_VALUE + (long)Integer.MAX_VALUE + 2L + 6L; // overflows to 6 when casted to int


### PR DESCRIPTION
There is an asymmetry between MemorySegment::equals and MemorySegment::hashCode after the unification of memory segment and memory address.

Both methods should only take into account unsafe offset and base (e.g. two segments are equals if they point to same memory location).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Reviewers
 * [Jorn Vernee](https://openjdk.org/census#jvernee) (@JornVernee - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/panama-foreign pull/701/head:pull/701` \
`$ git checkout pull/701`

Update a local copy of the PR: \
`$ git checkout pull/701` \
`$ git pull https://git.openjdk.org/panama-foreign pull/701/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 701`

View PR using the GUI difftool: \
`$ git pr show -t 701`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/panama-foreign/pull/701.diff">https://git.openjdk.org/panama-foreign/pull/701.diff</a>

</details>
