### PR TITLE
8292078: Thread-safety issues in AbstractLinker implementations

### DIFF
--- a/src/java.base/share/classes/jdk/internal/foreign/abi/aarch64/linux/LinuxAArch64Linker.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/aarch64/linux/LinuxAArch64Linker.java
@@ -27,6 +27,7 @@ package jdk.internal.foreign.abi.aarch64.linux;
 
 import jdk.internal.foreign.abi.AbstractLinker;
 import jdk.internal.foreign.abi.aarch64.CallArranger;
+import jdk.internal.foreign.abi.aarch64.macos.MacOsAArch64Linker;
 
 import java.lang.foreign.MemorySession;
 import java.lang.foreign.FunctionDescriptor;
@@ -41,13 +42,16 @@ import java.util.function.Consumer;
  * the ARM 64-bit Architecture".
  */
 public final class LinuxAArch64Linker extends AbstractLinker {
-    private static LinuxAArch64Linker instance;
+    private static final class Holder {
+        private static final LinuxAArch64Linker INSTANCE = new LinuxAArch64Linker();
+    }
 
     public static LinuxAArch64Linker getInstance() {
-        if (instance == null) {
-            instance = new LinuxAArch64Linker();
-        }
-        return instance;
+        return Holder.INSTANCE;
+    }
+
+    private LinuxAArch64Linker() {
+        // Ensure there is only one instance
     }
 
     @Override

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/aarch64/linux/LinuxAArch64Linker.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/aarch64/linux/LinuxAArch64Linker.java
@@ -27,7 +27,6 @@ package jdk.internal.foreign.abi.aarch64.linux;
 
 import jdk.internal.foreign.abi.AbstractLinker;
 import jdk.internal.foreign.abi.aarch64.CallArranger;
-import jdk.internal.foreign.abi.aarch64.macos.MacOsAArch64Linker;
 
 import java.lang.foreign.MemorySession;
 import java.lang.foreign.FunctionDescriptor;

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/aarch64/linux/LinuxAArch64Linker.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/aarch64/linux/LinuxAArch64Linker.java
@@ -41,11 +41,12 @@ import java.util.function.Consumer;
  * the ARM 64-bit Architecture".
  */
 public final class LinuxAArch64Linker extends AbstractLinker {
-    private static final class Holder {
-        private static final LinuxAArch64Linker INSTANCE = new LinuxAArch64Linker();
-    }
 
     public static LinuxAArch64Linker getInstance() {
+        final class Holder {
+            private static final LinuxAArch64Linker INSTANCE = new LinuxAArch64Linker();
+        }
+
         return Holder.INSTANCE;
     }
 

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/aarch64/linux/LinuxAArch64VaList.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/aarch64/linux/LinuxAArch64VaList.java
@@ -64,24 +64,24 @@ public non-sealed class LinuxAArch64VaList implements VaList {
     // } va_list;
 
     static final GroupLayout LAYOUT = MemoryLayout.structLayout(
-            AArch64.C_POINTER.withName("__stack"),
-            AArch64.C_POINTER.withName("__gr_top"),
-            AArch64.C_POINTER.withName("__vr_top"),
-            AArch64.C_INT.withName("__gr_offs"),
-            AArch64.C_INT.withName("__vr_offs")
+        AArch64.C_POINTER.withName("__stack"),
+        AArch64.C_POINTER.withName("__gr_top"),
+        AArch64.C_POINTER.withName("__vr_top"),
+        AArch64.C_INT.withName("__gr_offs"),
+        AArch64.C_INT.withName("__vr_offs")
     ).withName("__va_list");
 
     private static final long STACK_SLOT_SIZE = 8;
 
     private static final MemoryLayout GP_REG
-            = MemoryLayout.paddingLayout(64).withBitAlignment(64);
+        = MemoryLayout.paddingLayout(64).withBitAlignment(64);
     private static final MemoryLayout FP_REG
-            = MemoryLayout.paddingLayout(128).withBitAlignment(128);
+        = MemoryLayout.paddingLayout(128).withBitAlignment(128);
 
     private static final MemoryLayout LAYOUT_GP_REGS
-            = MemoryLayout.sequenceLayout(MAX_REGISTER_ARGUMENTS, GP_REG);
+        = MemoryLayout.sequenceLayout(MAX_REGISTER_ARGUMENTS, GP_REG);
     private static final MemoryLayout LAYOUT_FP_REGS
-            = MemoryLayout.sequenceLayout(MAX_REGISTER_ARGUMENTS, FP_REG);
+        = MemoryLayout.sequenceLayout(MAX_REGISTER_ARGUMENTS, FP_REG);
 
     private static final int GP_SLOT_SIZE = (int) GP_REG.byteSize();
     private static final int FP_SLOT_SIZE = (int) FP_REG.byteSize();
@@ -93,12 +93,12 @@ public non-sealed class LinuxAArch64VaList implements VaList {
     private static final VarHandle VH_gr_top = LAYOUT.varHandle(groupElement("__gr_top"));
     private static final VarHandle VH_vr_top = LAYOUT.varHandle(groupElement("__vr_top"));
     private static final VarHandle VH_gr_offs
-            = LAYOUT.varHandle(groupElement("__gr_offs"));
+        = LAYOUT.varHandle(groupElement("__gr_offs"));
     private static final VarHandle VH_vr_offs
-            = LAYOUT.varHandle(groupElement("__vr_offs"));
+        = LAYOUT.varHandle(groupElement("__vr_offs"));
 
     private static final VaList EMPTY
-            = new SharedUtils.EmptyVaList(emptyListAddress());
+        = new SharedUtils.EmptyVaList(emptyListAddress());
 
     private final MemorySegment segment;
     private MemorySegment stack;

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/aarch64/linux/LinuxAArch64VaList.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/aarch64/linux/LinuxAArch64VaList.java
@@ -26,7 +26,6 @@
 package jdk.internal.foreign.abi.aarch64.linux;
 
 import java.lang.foreign.*;
-
 import jdk.internal.foreign.abi.aarch64.TypeClass;
 import jdk.internal.foreign.MemorySessionImpl;
 import jdk.internal.foreign.Utils;
@@ -248,7 +247,7 @@ public non-sealed class LinuxAArch64VaList implements VaList {
     @Override
     public MemorySegment nextVarg(GroupLayout layout, SegmentAllocator allocator) {
         Objects.requireNonNull(allocator);
-        return (MemorySegment) read(layout, allocator);
+        return (MemorySegment) read( layout, allocator);
     }
 
     private Object read(MemoryLayout layout) {
@@ -297,7 +296,7 @@ public non-sealed class LinuxAArch64VaList implements VaList {
                     // Struct is passed with each element in a separate floating
                     // point register.
                     MemorySegment value = allocator.allocate(layout);
-                    GroupLayout group = (GroupLayout) layout;
+                    GroupLayout group = (GroupLayout)layout;
                     long offset = 0;
                     for (MemoryLayout elem : group.memberLayouts()) {
                         assert elem.byteSize() <= 8;
@@ -313,7 +312,7 @@ public non-sealed class LinuxAArch64VaList implements VaList {
                     // Struct is passed indirectly via a pointer in an integer register.
                     VarHandle ptrReader = AArch64.C_POINTER.varHandle();
                     MemorySegment ptr = (MemorySegment) ptrReader.get(
-                            gpRegsArea.asSlice(currentGPOffset()));
+                        gpRegsArea.asSlice(currentGPOffset()));
                     consumeGPSlots(1);
 
                     MemorySegment slice = MemorySegment.ofAddress(ptr.address(), layout.byteSize(), segment.session());
@@ -421,12 +420,12 @@ public non-sealed class LinuxAArch64VaList implements VaList {
     @Override
     public String toString() {
         return "LinuxAArch64VaList{"
-                + "__stack=" + stackPtr()
-                + ", __gr_top=" + grTop()
-                + ", __vr_top=" + vrTop()
-                + ", __gr_offs=" + grOffs()
-                + ", __vr_offs=" + vrOffs()
-                + '}';
+            + "__stack=" + stackPtr()
+            + ", __gr_top=" + grTop()
+            + ", __vr_top=" + vrTop()
+            + ", __gr_offs=" + grOffs()
+            + ", __vr_offs=" + vrOffs()
+            + '}';
     }
 
     public static non-sealed class Builder implements VaList.Builder {
@@ -492,7 +491,7 @@ public non-sealed class LinuxAArch64VaList implements VaList {
                         // Struct is passed with each element in a separate floating
                         // point register.
                         MemorySegment valueSegment = (MemorySegment) value;
-                        GroupLayout group = (GroupLayout) layout;
+                        GroupLayout group = (GroupLayout)layout;
                         long offset = 0;
                         for (MemoryLayout elem : group.memberLayouts()) {
                             assert elem.byteSize() <= 8;
@@ -507,7 +506,7 @@ public non-sealed class LinuxAArch64VaList implements VaList {
                         MemorySegment valueSegment = (MemorySegment) value;
                         VarHandle writer = AArch64.C_POINTER.varHandle();
                         writer.set(gpRegs.asSlice(currentGPOffset),
-                                valueSegment);
+                                   valueSegment);
                         currentGPOffset += GP_SLOT_SIZE;
                     }
                     case POINTER, INTEGER -> {
@@ -538,7 +537,7 @@ public non-sealed class LinuxAArch64VaList implements VaList {
             MemorySegment stackArgsSegment;
             if (!stackArgs.isEmpty()) {
                 long stackArgsSize = stackArgs.stream()
-                        .reduce(0L, (acc, e) -> acc + Utils.alignUp(e.layout.byteSize(), STACK_SLOT_SIZE), Long::sum);
+                    .reduce(0L, (acc, e) -> acc + Utils.alignUp(e.layout.byteSize(), STACK_SLOT_SIZE), Long::sum);
                 stackArgsSegment = session.allocate(stackArgsSize, 16);
                 MemorySegment writeCursor = stackArgsSegment;
                 for (SimpleVaArg arg : stackArgs) {

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/aarch64/macos/MacOsAArch64Linker.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/aarch64/macos/MacOsAArch64Linker.java
@@ -41,11 +41,12 @@ import java.util.function.Consumer;
  * changes to va_list and passing arguments on the stack.
  */
 public final class MacOsAArch64Linker extends AbstractLinker {
-    private static final class Holder {
-        private static final MacOsAArch64Linker INSTANCE = new MacOsAArch64Linker();
-    }
 
     public static MacOsAArch64Linker getInstance() {
+        final class Holder {
+            private static final MacOsAArch64Linker INSTANCE = new MacOsAArch64Linker();
+        }
+
         return Holder.INSTANCE;
     }
 

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/aarch64/macos/MacOsAArch64Linker.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/aarch64/macos/MacOsAArch64Linker.java
@@ -27,6 +27,7 @@ package jdk.internal.foreign.abi.aarch64.macos;
 
 import jdk.internal.foreign.abi.AbstractLinker;
 import jdk.internal.foreign.abi.aarch64.CallArranger;
+import jdk.internal.foreign.abi.x64.windows.Windowsx64Linker;
 
 import java.lang.foreign.FunctionDescriptor;
 import java.lang.foreign.MemorySegment;
@@ -41,13 +42,16 @@ import java.util.function.Consumer;
  * changes to va_list and passing arguments on the stack.
  */
 public final class MacOsAArch64Linker extends AbstractLinker {
-    private static MacOsAArch64Linker instance;
+    private static final class Holder {
+        private static final MacOsAArch64Linker INSTANCE = new MacOsAArch64Linker();
+    }
 
     public static MacOsAArch64Linker getInstance() {
-        if (instance == null) {
-            instance = new MacOsAArch64Linker();
-        }
-        return instance;
+        return Holder.INSTANCE;
+    }
+
+    private MacOsAArch64Linker() {
+        // Ensure there is only one instance
     }
 
     @Override

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/aarch64/macos/MacOsAArch64Linker.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/aarch64/macos/MacOsAArch64Linker.java
@@ -27,7 +27,6 @@ package jdk.internal.foreign.abi.aarch64.macos;
 
 import jdk.internal.foreign.abi.AbstractLinker;
 import jdk.internal.foreign.abi.aarch64.CallArranger;
-import jdk.internal.foreign.abi.x64.windows.Windowsx64Linker;
 
 import java.lang.foreign.FunctionDescriptor;
 import java.lang.foreign.MemorySegment;

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/x64/sysv/SysVx64Linker.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/x64/sysv/SysVx64Linker.java
@@ -26,6 +26,7 @@ package jdk.internal.foreign.abi.x64.sysv;
 
 
 import jdk.internal.foreign.abi.AbstractLinker;
+import jdk.internal.foreign.abi.x64.windows.Windowsx64Linker;
 
 import java.lang.foreign.MemorySession;
 import java.lang.foreign.FunctionDescriptor;
@@ -39,15 +40,17 @@ import java.util.function.Consumer;
  * ABI implementation based on System V ABI AMD64 supplement v.0.99.6
  */
 public final class SysVx64Linker extends AbstractLinker {
-    private static SysVx64Linker instance;
-
-    public static SysVx64Linker getInstance() {
-        if (instance == null) {
-            instance = new SysVx64Linker();
-        }
-        return instance;
+    private static final class Holder {
+        private static final SysVx64Linker INSTANCE = new SysVx64Linker();
     }
 
+    public static SysVx64Linker getInstance() {
+        return SysVx64Linker.Holder.INSTANCE;
+    }
+
+    private SysVx64Linker() {
+        // Ensure there is only one instance
+    }
     @Override
     protected MethodHandle arrangeDowncall(MethodType inferredMethodType, FunctionDescriptor function) {
         return CallArranger.arrangeDowncall(inferredMethodType, function);

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/x64/sysv/SysVx64Linker.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/x64/sysv/SysVx64Linker.java
@@ -26,7 +26,6 @@ package jdk.internal.foreign.abi.x64.sysv;
 
 
 import jdk.internal.foreign.abi.AbstractLinker;
-import jdk.internal.foreign.abi.x64.windows.Windowsx64Linker;
 
 import java.lang.foreign.MemorySession;
 import java.lang.foreign.FunctionDescriptor;

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/x64/sysv/SysVx64Linker.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/x64/sysv/SysVx64Linker.java
@@ -39,12 +39,13 @@ import java.util.function.Consumer;
  * ABI implementation based on System V ABI AMD64 supplement v.0.99.6
  */
 public final class SysVx64Linker extends AbstractLinker {
-    private static final class Holder {
-        private static final SysVx64Linker INSTANCE = new SysVx64Linker();
-    }
 
     public static SysVx64Linker getInstance() {
-        return SysVx64Linker.Holder.INSTANCE;
+        final class Holder {
+            private static final SysVx64Linker INSTANCE = new SysVx64Linker();
+        }
+
+        return Holder.INSTANCE;
     }
 
     private SysVx64Linker() {

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/x64/windows/Windowsx64Linker.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/x64/windows/Windowsx64Linker.java
@@ -38,13 +38,17 @@ import java.util.function.Consumer;
  * ABI implementation based on Windows ABI AMD64 supplement v.0.99.6
  */
 public final class Windowsx64Linker extends AbstractLinker {
-    private static Windowsx64Linker instance;
+
+    private static final class Holder {
+        private static final Windowsx64Linker INSTANCE = new Windowsx64Linker();
+    }
 
     public static Windowsx64Linker getInstance() {
-        if (instance == null) {
-            instance = new Windowsx64Linker();
-        }
-        return instance;
+        return Holder.INSTANCE;
+    }
+
+    private Windowsx64Linker() {
+        // Ensure there is only one instance
     }
 
     @Override

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/x64/windows/Windowsx64Linker.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/x64/windows/Windowsx64Linker.java
@@ -39,11 +39,11 @@ import java.util.function.Consumer;
  */
 public final class Windowsx64Linker extends AbstractLinker {
 
-    private static final class Holder {
-        private static final Windowsx64Linker INSTANCE = new Windowsx64Linker();
-    }
-
     public static Windowsx64Linker getInstance() {
+        final class Holder {
+            private static final Windowsx64Linker INSTANCE = new Windowsx64Linker();
+        }
+
         return Holder.INSTANCE;
     }
 


### PR DESCRIPTION
Change to lazy static initializing for singletons and fix a bug in `LinuxAArch64VaList` that threw an `IndexOutOfBoundsException`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8292078](https://bugs.openjdk.org/browse/JDK-8292078): Thread-safety issues in AbstractLinker implementations


### Reviewers
 * [Jorn Vernee](https://openjdk.org/census#jvernee) (@JornVernee - Committer) ⚠️ Review applies to [02d4dcd0](https://git.openjdk.org/panama-foreign/pull/702/files/02d4dcd0bc1e25150c51cdc7dbc3d6c267b307f9)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/panama-foreign pull/702/head:pull/702` \
`$ git checkout pull/702`

Update a local copy of the PR: \
`$ git checkout pull/702` \
`$ git pull https://git.openjdk.org/panama-foreign pull/702/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 702`

View PR using the GUI difftool: \
`$ git pr show -t 702`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/panama-foreign/pull/702.diff">https://git.openjdk.org/panama-foreign/pull/702.diff</a>

</details>
