### PR TITLE
8292038: Split factories to create sequence layouts

### DIFF
--- a/src/java.base/share/classes/java/lang/foreign/AbstractLayout.java
+++ b/src/java.base/share/classes/java/lang/foreign/AbstractLayout.java
@@ -75,8 +75,8 @@ abstract non-sealed class AbstractLayout implements MemoryLayout {
         checkSize(size, false);
     }
 
-    static void checkSize(long size, boolean includeZero) {
-        if (size < 0 || (!includeZero && size == 0)) {
+    static void checkSize(long size, boolean allowZero) {
+        if (size < 0 || (!allowZero && size == 0)) {
             throw new IllegalArgumentException("Invalid size for layout: " + size);
         }
     }

--- a/src/java.base/share/classes/java/lang/foreign/MemoryLayout.java
+++ b/src/java.base/share/classes/java/lang/foreign/MemoryLayout.java
@@ -681,11 +681,12 @@ public sealed interface MemoryLayout permits AbstractLayout, SequenceLayout, Gro
 
     /**
      * Creates a sequence layout with the given element layout and the maximum element
-     * count such that it does not overflow a {@code long}, using the following formula:
+     * count such that it does not overflow a {@code long}.
      *
-     * <blockquote><pre>{@code
-     * maxElementCount = Long.MAX_VALUE / elementLayout.bitSize();
-     * }</pre></blockquote>
+     * This is equivalent to the following code:
+     * {@snippet lang = java:
+     * sequenceLayout(Long.MAX_VALUE / elementLayout.bitSize(), elementLayout);
+     * }
      *
      * @param elementLayout the sequence element layout.
      * @return a new sequence layout with the given element layout and maximum element count.

--- a/src/java.base/share/classes/java/lang/foreign/MemoryLayout.java
+++ b/src/java.base/share/classes/java/lang/foreign/MemoryLayout.java
@@ -665,31 +665,34 @@ public sealed interface MemoryLayout permits AbstractLayout, SequenceLayout, Gro
     }
 
     /**
-     * Creates a sequence layout with the given element layout and element count. If the element count has the
-     * special value {@code -1}, the element count is inferred to be the biggest possible count such that
-     * the sequence layout size does not overflow, using the following formula:
+     * Creates a sequence layout with the given element layout and element count.
      *
-     * <blockquote><pre>{@code
-     * inferredElementCount = Long.MAX_VALUE / elementLayout.bitSize();
-     * }</pre></blockquote>
-     *
-     * @param elementCount the sequence element count; if set to {@code -1}, the sequence element count is inferred.
+     * @param elementCount the sequence element count.
      * @param elementLayout the sequence element layout.
      * @return the new sequence layout with the given element layout and size.
-     * @throws IllegalArgumentException if {@code elementCount < -1}.
-     * @throws IllegalArgumentException if {@code elementCount != -1} and the computation {@code elementCount * elementLayout.bitSize()} overflows.
+     * @throws IllegalArgumentException if {@code elementCount } is negative.
      */
     static SequenceLayout sequenceLayout(long elementCount, MemoryLayout elementLayout) {
-        if (elementCount == -1) {
-            // inferred element count
-            long inferredElementCount = Long.MAX_VALUE / elementLayout.bitSize();
-            return new SequenceLayout(inferredElementCount, elementLayout);
-        } else {
-            // explicit element count
             AbstractLayout.checkSize(elementCount, true);
+            Objects.requireNonNull(elementLayout);
             return wrapOverflow(() ->
-                    new SequenceLayout(elementCount, Objects.requireNonNull(elementLayout)));
-        }
+                    new SequenceLayout(elementCount, elementLayout));
+    }
+
+    /**
+     * Creates a sequence layout with the given element layout and the maximum element
+     * count such that it does not overflow a {@code long}, using the following formula:
+     *
+     * <blockquote><pre>{@code
+     * maxElementCount = Long.MAX_VALUE / elementLayout.bitSize();
+     * }</pre></blockquote>
+     *
+     * @param elementLayout the sequence element layout.
+     * @return a new sequence layout with the given element layout and maximum element count.
+     */
+    static SequenceLayout sequenceLayout(MemoryLayout elementLayout) {
+        Objects.requireNonNull(elementLayout);
+        return sequenceLayout(Long.MAX_VALUE / elementLayout.bitSize(), elementLayout);
     }
 
     /**

--- a/src/java.base/share/classes/java/lang/foreign/ValueLayout.java
+++ b/src/java.base/share/classes/java/lang/foreign/ValueLayout.java
@@ -140,11 +140,11 @@ public sealed class ValueLayout extends AbstractLayout implements MemoryLayout {
      *
      * Can be used to access a multi-dimensional array whose layout is as follows:
      *
-     * {@snippet lang=java :
-     * SequenceLayout arrayLayout = MemoryLayout.sequenceLayout(-1,
+     * {@snippet lang = java:
+     * SequenceLayout arrayLayout = MemoryLayout.sequenceLayout(
      *                                      MemoryLayout.sequenceLayout(10,
      *                                                  MemoryLayout.sequenceLayout(20, ValueLayout.JAVA_INT)));
-     * }
+     *}
      *
      * The resulting var handle {@code arrayHandle} will feature 3 coordinates of type {@code long}; each coordinate
      * is interpreted as an index into the corresponding sequence layout. If we refer to the var handle coordinates, from left
@@ -190,7 +190,7 @@ public sealed class ValueLayout extends AbstractLayout implements MemoryLayout {
             layout = MemoryLayout.sequenceLayout(size, layout);
             path.add(PathElement.sequenceElement());
         }
-        layout = MemoryLayout.sequenceLayout(-1, layout);
+        layout = MemoryLayout.sequenceLayout(layout);
         path.add(PathElement.sequenceElement());
         return layout.varHandle(path.toArray(new PathElement[0]));
     }

--- a/test/jdk/java/foreign/TestLayouts.java
+++ b/test/jdk/java/foreign/TestLayouts.java
@@ -138,8 +138,13 @@ public class TestLayouts {
 
     @Test(dataProvider = "basicLayouts")
     public void testSequenceInferredCount(MemoryLayout layout) {
-        assertEquals(MemoryLayout.sequenceLayout(-1, layout),
+        assertEquals(MemoryLayout.sequenceLayout(layout),
                      MemoryLayout.sequenceLayout(Long.MAX_VALUE / layout.bitSize(), layout));
+    }
+
+    public void testSequenceNegativeElementCount() {
+        assertThrows(IllegalArgumentException.class, // negative
+                () -> MemoryLayout.sequenceLayout(-1, JAVA_SHORT));
     }
 
     @Test


### PR DESCRIPTION
This PR splits the `MemoryLayout::sequence` method into two separate overloads:

1. Explicit `elementCount`
2. Inferred `elementCount`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8292038](https://bugs.openjdk.org/browse/JDK-8292038): Split factories to create sequence layouts


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.org/census#mcimadamore) (@mcimadamore - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/panama-foreign pull/704/head:pull/704` \
`$ git checkout pull/704`

Update a local copy of the PR: \
`$ git checkout pull/704` \
`$ git pull https://git.openjdk.org/panama-foreign pull/704/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 704`

View PR using the GUI difftool: \
`$ git pr show -t 704`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/panama-foreign/pull/704.diff">https://git.openjdk.org/panama-foreign/pull/704.diff</a>

</details>
