### PR TITLE
Fix regression

### DIFF
--- a/test/hotspot/jtreg/runtime/ClassFile/ClassFileVersionTest.java
+++ b/test/hotspot/jtreg/runtime/ClassFile/ClassFileVersionTest.java
@@ -42,7 +42,7 @@ public class ClassFileVersionTest {
      * compilation. If a particular class becomes non-preview, any
      * currently preview class can be substituted in.
      */
-    private static final Class<?> PREVIEW_API = java.lang.foreign.MemoryAddress.class;
+    private static final Class<?> PREVIEW_API = java.lang.foreign.MemorySegment.class;
     static Method m;
 
     public static void testIt(String className, int expectedResult) throws Exception {


### PR DESCRIPTION
This PR fixes a regression that appeared when `MemoryAddress` was removed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Reviewers
 * [Paul Sandoz](https://openjdk.org/census#psandoz) (@PaulSandoz - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/panama-foreign pull/707/head:pull/707` \
`$ git checkout pull/707`

Update a local copy of the PR: \
`$ git checkout pull/707` \
`$ git pull https://git.openjdk.org/panama-foreign pull/707/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 707`

View PR using the GUI difftool: \
`$ git pr show -t 707`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/panama-foreign/pull/707.diff">https://git.openjdk.org/panama-foreign/pull/707.diff</a>

</details>
