### PR TITLE
8292851: MemorySegment arithmetics performed with int accuracy where long is required

### DIFF
--- a/src/java.base/share/classes/java/lang/foreign/MemorySegment.java
+++ b/src/java.base/share/classes/java/lang/foreign/MemorySegment.java
@@ -1938,7 +1938,7 @@ public sealed interface MemorySegment permits AbstractMemorySegmentImpl {
             throw new IllegalArgumentException("Incompatible value layout: " + srcLayout);
         }
         int dstBase = (int)baseAndScale;
-        long dstWidth = (int)(baseAndScale >> 32); // Use long arithmetics, JDK-8292851
+        long dstWidth = (int)(baseAndScale >> 32); // Use long arithmetics below
         AbstractMemorySegmentImpl srcImpl = (AbstractMemorySegmentImpl)srcSegment;
         Utils.checkElementAlignment(srcLayout, "Source layout alignment greater than its size");
         if (!srcImpl.isAlignedForElement(srcOffset, srcLayout)) {
@@ -1990,7 +1990,7 @@ public sealed interface MemorySegment permits AbstractMemorySegmentImpl {
             throw new IllegalArgumentException("Incompatible value layout: " + dstLayout);
         }
         int srcBase = (int)baseAndScale;
-        long srcWidth = (int)(baseAndScale >> 32); // Use long arithmetics, JDK-8292851
+        long srcWidth = (int)(baseAndScale >> 32); // Use long arithmetics below
         Objects.checkFromIndexSize(srcIndex, elementCount, Array.getLength(srcArray));
         AbstractMemorySegmentImpl destImpl = (AbstractMemorySegmentImpl)dstSegment;
         Utils.checkElementAlignment(dstLayout, "Destination layout alignment greater than its size");

--- a/src/java.base/share/classes/java/lang/foreign/MemorySegment.java
+++ b/src/java.base/share/classes/java/lang/foreign/MemorySegment.java
@@ -1938,7 +1938,7 @@ public sealed interface MemorySegment permits AbstractMemorySegmentImpl {
             throw new IllegalArgumentException("Incompatible value layout: " + srcLayout);
         }
         int dstBase = (int)baseAndScale;
-        int dstWidth = (int)(baseAndScale >> 32);
+        long dstWidth = (int)(baseAndScale >> 32); // Use long arithmetics, JDK-8292851
         AbstractMemorySegmentImpl srcImpl = (AbstractMemorySegmentImpl)srcSegment;
         Utils.checkElementAlignment(srcLayout, "Source layout alignment greater than its size");
         if (!srcImpl.isAlignedForElement(srcOffset, srcLayout)) {
@@ -1990,7 +1990,7 @@ public sealed interface MemorySegment permits AbstractMemorySegmentImpl {
             throw new IllegalArgumentException("Incompatible value layout: " + dstLayout);
         }
         int srcBase = (int)baseAndScale;
-        int srcWidth = (int)(baseAndScale >> 32);
+        long srcWidth = (int)(baseAndScale >> 32); // Use long arithmetics, JDK-8292851
         Objects.checkFromIndexSize(srcIndex, elementCount, Array.getLength(srcArray));
         AbstractMemorySegmentImpl destImpl = (AbstractMemorySegmentImpl)dstSegment;
         Utils.checkElementAlignment(dstLayout, "Destination layout alignment greater than its size");

--- a/test/jdk/java/foreign/TestLargeSegmentCopy.java
+++ b/test/jdk/java/foreign/TestLargeSegmentCopy.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ *  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ *  This code is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License version 2 only, as
+ *  published by the Free Software Foundation.
+ *
+ *  This code is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ *  version 2 for more details (a copy is included in the LICENSE file that
+ *  accompanied this code).
+ *
+ *  You should have received a copy of the GNU General Public License version
+ *  2 along with this work; if not, write to the Free Software Foundation,
+ *  Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ *   Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ *  or visit www.oracle.com if you need additional information or have any
+ *  questions.
+ *
+ */
+
+/*
+ * @test
+ * @enablePreview
+ * @bug 8292851
+ * @run testng/othervm -Xmx4G TestLargeSegmentCopy
+ */
+
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.lang.foreign.MemorySegment;
+import java.lang.foreign.MemorySession;
+
+import static java.lang.foreign.ValueLayout.JAVA_LONG;
+import static org.testng.Assert.*;
+
+public class TestLargeSegmentCopy {
+
+    @Test
+    public void testLargeSegmentCopy() {
+        // Make sure the byte size is bigger than Integer.MAX_VALUE
+        final int longArrayLength = Integer.MAX_VALUE / Long.BYTES + 100;
+        final long[] array = new long[longArrayLength];
+
+        try (var session = MemorySession.openConfined()) {
+            var segment = session.allocate((long) longArrayLength * Long.BYTES, Long.SIZE);
+            // Should not throw an exception or error
+            MemorySegment.copy(segment, JAVA_LONG, 0, array, 0, longArrayLength);
+            // Should not throw an exception or error
+            MemorySegment.copy(array,0, segment, JAVA_LONG, 0, longArrayLength);
+        }
+
+    }
+
+}


### PR DESCRIPTION
This PR fixes a potentially severe `int` overflow issue.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8292851](https://bugs.openjdk.org/browse/JDK-8292851): MemorySegment arithmetics performed with int accuracy where long is required


### Reviewers
 * [Athijegannathan Sundararajan](https://openjdk.org/census#sundar) (@sundararajana - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/panama-foreign pull/712/head:pull/712` \
`$ git checkout pull/712`

Update a local copy of the PR: \
`$ git checkout pull/712` \
`$ git pull https://git.openjdk.org/panama-foreign pull/712/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 712`

View PR using the GUI difftool: \
`$ git pr show -t 712`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/panama-foreign/pull/712.diff">https://git.openjdk.org/panama-foreign/pull/712.diff</a>

</details>
