### PR TITLE
8292918: Split FunctionDescriptor into an interface and implementation(s)

### DIFF
--- a/src/java.base/share/classes/java/lang/foreign/FunctionDescriptor.java
+++ b/src/java.base/share/classes/java/lang/foreign/FunctionDescriptor.java
@@ -26,9 +26,8 @@ package java.lang.foreign;
 
 import java.lang.invoke.MethodHandle;
 import java.util.*;
-import java.util.stream.Collectors;
-import java.util.stream.IntStream;
-import java.util.stream.Stream;
+
+import jdk.internal.foreign.FunctionDescriptorImpl;
 import jdk.internal.javac.PreviewFeature;
 
 /**
@@ -38,57 +37,62 @@ import jdk.internal.javac.PreviewFeature;
  * {@linkplain Linker#upcallStub(MethodHandle, FunctionDescriptor, MemorySession) upcall stubs}.
  *
  * @implSpec
- * This class is immutable, thread-safe and <a href="{@docRoot}/java.base/java/lang/doc-files/ValueBased.html">value-based</a>.
+ * Implementing classes are immutable, thread-safe and <a href="{@docRoot}/java.base/java/lang/doc-files/ValueBased.html">value-based</a>.
  *
  * @see MemoryLayout
  * @since 19
  */
 @PreviewFeature(feature=PreviewFeature.Feature.FOREIGN)
-public sealed class FunctionDescriptor {
-
-    private final MemoryLayout resLayout;
-    private final List<MemoryLayout> argLayouts;
-
-    private FunctionDescriptor(MemoryLayout resLayout, List<MemoryLayout> argLayouts) {
-        this.resLayout = resLayout;
-        this.argLayouts = argLayouts;
-    }
+public sealed interface FunctionDescriptor permits FunctionDescriptorImpl {
 
     /**
      * {@return the return layout (if any) associated with this function descriptor}
      */
-    public Optional<MemoryLayout> returnLayout() {
-        return Optional.ofNullable(resLayout);
-    }
+    Optional<MemoryLayout> returnLayout();
 
     /**
      * {@return the argument layouts associated with this function descriptor (as an immutable list)}.
      */
-    public List<MemoryLayout> argumentLayouts() {
-        return Collections.unmodifiableList(argLayouts);
-    }
+    List<MemoryLayout> argumentLayouts();
 
     /**
-     * Creates a function descriptor with the given return and argument layouts.
-     * @param resLayout the return layout.
-     * @param argLayouts the argument layouts.
-     * @return the new function descriptor.
+     * The index of the first variadic argument layout (where defined).
+     * @return The index of the first variadic argument layout, or {@code -1} if this is not a
+     * {@linkplain #asVariadic(MemoryLayout...) variadic} layout.
      */
-    public static FunctionDescriptor of(MemoryLayout resLayout, MemoryLayout... argLayouts) {
-        Objects.requireNonNull(resLayout);
-        // Null checks are implicit in List.of(argLayouts)
-        return new FunctionDescriptor(resLayout, List.of(argLayouts));
-    }
+    int firstVariadicArgumentIndex();
 
     /**
-     * Creates a function descriptor with the given argument layouts and no return layout.
-     * @param argLayouts the argument layouts.
+     * Returns a function descriptor with the given argument layouts appended to the argument layout array
+     * of this function descriptor.
+     * @param addedLayouts the argument layouts to append.
      * @return the new function descriptor.
      */
-    public static FunctionDescriptor ofVoid(MemoryLayout... argLayouts) {
-        // Null checks are implicit in List.of(argLayouts)
-        return new FunctionDescriptor(null, List.of(argLayouts));
-    }
+    FunctionDescriptor appendArgumentLayouts(MemoryLayout... addedLayouts);
+
+    /**
+     * Returns a function descriptor with the given argument layouts inserted at the given index, into the argument
+     * layout array of this function descriptor.
+     * @param index the index at which to insert the arguments
+     * @param addedLayouts the argument layouts to insert at given index.
+     * @return the new function descriptor.
+     * @throws IllegalArgumentException if {@code index < 0 || index > argumentLayouts().size()}.
+     */
+    FunctionDescriptor insertArgumentLayouts(int index, MemoryLayout... addedLayouts);
+
+    /**
+     * Returns a function descriptor with the given memory layout as the new return layout.
+     * @param newReturn the new return layout.
+     * @return the new function descriptor.
+     */
+    FunctionDescriptor changeReturnLayout(MemoryLayout newReturn);
+
+    /**
+     * Returns a function descriptor with the return layout dropped. This is useful to model functions
+     * which return no values.
+     * @return the new function descriptor.
+     */
+    FunctionDescriptor dropReturnLayout();
 
     /**
      * Creates a specialized variadic function descriptor, by appending given variadic layouts to this
@@ -99,149 +103,28 @@ public sealed class FunctionDescriptor {
      * @param variadicLayouts the variadic argument layouts to be appended to this descriptor argument layouts.
      * @return a variadic function descriptor, or this descriptor if {@code variadicLayouts.length == 0}.
      */
-    public FunctionDescriptor asVariadic(MemoryLayout... variadicLayouts) {
-        // Null checks are implicit in the constructor of VariadicFunction
-        return variadicLayouts.length == 0 ? this : new VariadicFunction(this, variadicLayouts);
-    }
+    FunctionDescriptor asVariadic(MemoryLayout... variadicLayouts);
 
     /**
-     * The index of the first variadic argument layout (where defined).
-     * @return The index of the first variadic argument layout, or {@code -1} if this is not a
-     * {@linkplain #asVariadic(MemoryLayout...) variadic} layout.
-     */
-    public int firstVariadicArgumentIndex() {
-        return -1;
-    }
-
-    /**
-     * Returns a function descriptor with the given argument layouts appended to the argument layout array
-     * of this function descriptor.
-     * @param addedLayouts the argument layouts to append.
+     * Creates a function descriptor with the given return and argument layouts.
+     * @param resLayout the return layout.
+     * @param argLayouts the argument layouts.
      * @return the new function descriptor.
      */
-    public FunctionDescriptor appendArgumentLayouts(MemoryLayout... addedLayouts) {
-        return insertArgumentLayouts(argLayouts.size(), addedLayouts);
+    static FunctionDescriptor of(MemoryLayout resLayout, MemoryLayout... argLayouts) {
+        Objects.requireNonNull(resLayout);
+        // Null checks are implicit in List.of(argLayouts)
+        return FunctionDescriptorImpl.of(resLayout, List.of(argLayouts));
     }
 
     /**
-     * Returns a function descriptor with the given argument layouts inserted at the given index, into the argument
-     * layout array of this function descriptor.
-     * @param index the index at which to insert the arguments
-     * @param addedLayouts the argument layouts to insert at given index.
-     * @return the new function descriptor.
-     * @throws IllegalArgumentException if {@code index < 0 || index > argumentLayouts().size()}.
-     */
-    public FunctionDescriptor insertArgumentLayouts(int index, MemoryLayout... addedLayouts) {
-        if (index < 0 || index > argLayouts.size())
-            throw new IllegalArgumentException("Index out of bounds: " + index);
-        List<MemoryLayout> added = List.of(addedLayouts); // null check on array and its elements
-        List<MemoryLayout> newLayouts = new ArrayList<>(argLayouts.size() + addedLayouts.length);
-        newLayouts.addAll(argLayouts.subList(0, index));
-        newLayouts.addAll(added);
-        newLayouts.addAll(argLayouts.subList(index, argLayouts.size()));
-        return new FunctionDescriptor(resLayout, newLayouts);
-    }
-
-    /**
-     * Returns a function descriptor with the given memory layout as the new return layout.
-     * @param newReturn the new return layout.
+     * Creates a function descriptor with the given argument layouts and no return layout.
+     * @param argLayouts the argument layouts.
      * @return the new function descriptor.
      */
-    public FunctionDescriptor changeReturnLayout(MemoryLayout newReturn) {
-        Objects.requireNonNull(newReturn);
-        return new FunctionDescriptor(newReturn, argLayouts);
+    static FunctionDescriptor ofVoid(MemoryLayout... argLayouts) {
+        // Null checks are implicit in List.of(argLayouts)
+        return FunctionDescriptorImpl.ofVoid(List.of(argLayouts));
     }
 
-    /**
-     * Returns a function descriptor with the return layout dropped. This is useful to model functions
-     * which return no values.
-     * @return the new function descriptor.
-     */
-    public FunctionDescriptor dropReturnLayout() {
-        return new FunctionDescriptor(null, argLayouts);
-    }
-
-    /**
-     * {@return the string representation of this function descriptor}
-     */
-    @Override
-    public String toString() {
-        return String.format("(%s)%s",
-                IntStream.range(0, argLayouts.size())
-                        .mapToObj(i -> (i == firstVariadicArgumentIndex() ?
-                                "..." : "") + argLayouts.get(i))
-                        .collect(Collectors.joining()),
-                returnLayout().map(Object::toString).orElse("v"));
-    }
-
-    /**
-     * Compares the specified object with this function descriptor for equality. Returns {@code true} if and only if the specified
-     * object is also a function descriptor, and all the following conditions are met:
-     * <ul>
-     *     <li>the two function descriptors have equals return layouts (see {@link MemoryLayout#equals(Object)}), or both have no return layout;</li>
-     *     <li>the two function descriptors have argument layouts that are pair-wise {@linkplain MemoryLayout#equals(Object) equal}; and</li>
-     *     <li>the two function descriptors have the same leading {@linkplain #firstVariadicArgumentIndex() variadic argument index}</li>
-     * </ul>
-     *
-     * @param other the object to be compared for equality with this function descriptor.
-     * @return {@code true} if the specified object is equal to this function descriptor.
-     */
-    @Override
-    public boolean equals(Object other) {
-        return other instanceof FunctionDescriptor f &&
-                Objects.equals(resLayout, f.resLayout) &&
-                Objects.equals(argLayouts, f.argLayouts) &&
-                firstVariadicArgumentIndex() == f.firstVariadicArgumentIndex();
-    }
-
-    /**
-     * {@return the hash code value for this function descriptor}
-     */
-    @Override
-    public int hashCode() {
-        return Objects.hash(argLayouts, resLayout, firstVariadicArgumentIndex());
-    }
-
-    static final class VariadicFunction extends FunctionDescriptor {
-
-        private final int firstVariadicIndex;
-
-        /**
-         * Constructor.
-         *
-         * @param descriptor the original functional descriptor
-         * @param argLayouts the memory layouts to apply
-         * @throws NullPointerException if any of the provided parameters or array elements are {@code null}
-         */
-        VariadicFunction(FunctionDescriptor descriptor, MemoryLayout... argLayouts) {
-            super(descriptor.returnLayout().orElse(null),
-                    Stream.concat(descriptor.argumentLayouts().stream(), Arrays.stream(argLayouts).map(Objects::requireNonNull)).toList());
-            this.firstVariadicIndex = descriptor.argumentLayouts().size();
-        }
-
-        @Override
-        public int firstVariadicArgumentIndex() {
-            return firstVariadicIndex;
-        }
-
-        @Override
-        public FunctionDescriptor appendArgumentLayouts(MemoryLayout... addedLayouts) {
-            throw new UnsupportedOperationException();
-        }
-
-        @Override
-        public FunctionDescriptor insertArgumentLayouts(int index, MemoryLayout... addedLayouts) {
-            throw new UnsupportedOperationException();
-        }
-
-        @Override
-        public FunctionDescriptor changeReturnLayout(MemoryLayout newReturn) {
-            throw new UnsupportedOperationException();
-        }
-
-        @Override
-        public FunctionDescriptor dropReturnLayout() {
-            throw new UnsupportedOperationException();
-        }
-    }
 }

--- a/src/java.base/share/classes/jdk/internal/foreign/FunctionDescriptorImpl.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/FunctionDescriptorImpl.java
@@ -105,7 +105,8 @@ public sealed class FunctionDescriptorImpl implements FunctionDescriptor {
      * @throws IllegalArgumentException if {@code index < 0 || index > argumentLayouts().size()}.
      */
     public FunctionDescriptorImpl insertArgumentLayouts(int index, MemoryLayout... addedLayouts) {
-        checkIndex(index);
+        if (index < 0 || index > argLayouts.size())
+            throw new IllegalArgumentException("Index out of bounds: " + index);
         List<MemoryLayout> added = List.of(addedLayouts); // null check on array and its elements
         List<MemoryLayout> newLayouts = new ArrayList<>(argLayouts.size() + addedLayouts.length);
         newLayouts.addAll(argLayouts.subList(0, index));
@@ -176,11 +177,6 @@ public sealed class FunctionDescriptorImpl implements FunctionDescriptor {
         return Objects.hash(argLayouts, resLayout, firstVariadicArgumentIndex());
     }
 
-    final void checkIndex(int index) {
-        if (index < 0 || index > argLayouts.size())
-            throw new IllegalArgumentException("Index out of bounds: " + index);
-    }
-
     public static FunctionDescriptor of(MemoryLayout resLayout, List<MemoryLayout> argLayouts) {
         return new FunctionDescriptorImpl(resLayout, argLayouts);
     }
@@ -213,16 +209,11 @@ public sealed class FunctionDescriptorImpl implements FunctionDescriptor {
 
         @Override
         public FunctionDescriptorImpl insertArgumentLayouts(int index, MemoryLayout... addedLayouts) {
-            checkIndex(index);
-            for (MemoryLayout layout : addedLayouts) {
-                requireNonNull(layout);
-            }
             throw newUnsupportedOperationException();
         }
 
         @Override
         public FunctionDescriptorImpl changeReturnLayout(MemoryLayout newReturn) {
-            requireNonNull(newReturn);
             throw newUnsupportedOperationException();
         }
 

--- a/src/java.base/share/classes/jdk/internal/foreign/FunctionDescriptorImpl.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/FunctionDescriptorImpl.java
@@ -1,0 +1,238 @@
+/*
+ *  Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
+ *  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ *  This code is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License version 2 only, as
+ *  published by the Free Software Foundation.  Oracle designates this
+ *  particular file as subject to the "Classpath" exception as provided
+ *  by Oracle in the LICENSE file that accompanied this code.
+ *
+ *  This code is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ *  version 2 for more details (a copy is included in the LICENSE file that
+ *  accompanied this code).
+ *
+ *  You should have received a copy of the GNU General Public License version
+ *  2 along with this work; if not, write to the Free Software Foundation,
+ *  Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ *  Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ *  or visit www.oracle.com if you need additional information or have any
+ *  questions.
+ */
+package jdk.internal.foreign;
+
+import java.lang.foreign.*;
+import java.util.*;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * @implSpec This class and its subclasses are immutable, thread-safe and <a href="{@docRoot}/java.base/java/lang/doc-files/ValueBased.html">value-based</a>.
+ */
+public sealed class FunctionDescriptorImpl implements FunctionDescriptor {
+
+    private final MemoryLayout resLayout; // Nullable
+    private final List<MemoryLayout> argLayouts;
+
+    private FunctionDescriptorImpl(MemoryLayout resLayout, List<MemoryLayout> argLayouts) {
+        this.resLayout = resLayout;
+        this.argLayouts = List.copyOf(argLayouts);
+    }
+
+    /**
+     * {@return the return layout (if any) associated with this function descriptor}
+     */
+    public final Optional<MemoryLayout> returnLayout() {
+        return Optional.ofNullable(resLayout);
+    }
+
+    /**
+     * {@return the argument layouts associated with this function descriptor (as an immutable list)}.
+     */
+    public final List<MemoryLayout> argumentLayouts() {
+        return argLayouts;
+    }
+
+    /**
+     * Creates a specialized variadic function descriptor, by appending given variadic layouts to this
+     * function descriptor argument layouts. The resulting function descriptor can report the position
+     * of the {@linkplain #firstVariadicArgumentIndex() first variadic argument}, and cannot be altered
+     * in any way: for instance, calling {@link #changeReturnLayout(MemoryLayout)} on the resulting descriptor
+     * will throw an {@link UnsupportedOperationException}.
+     *
+     * @param variadicLayouts the variadic argument layouts to be appended to this descriptor argument layouts.
+     * @return a variadic function descriptor, or this descriptor if {@code variadicLayouts.length == 0}.
+     */
+    public final FunctionDescriptorImpl asVariadic(MemoryLayout... variadicLayouts) {
+        // Null checks are implicit in the constructor of VariadicFunction
+        return variadicLayouts.length == 0 ? this : new VariadicFunctionDescriptor(this, variadicLayouts);
+    }
+
+    /**
+     * The index of the first variadic argument layout (where defined).
+     *
+     * @return The index of the first variadic argument layout, or {@code -1} if this is not a
+     * {@linkplain #asVariadic(MemoryLayout...) variadic} layout.
+     */
+    public int firstVariadicArgumentIndex() {
+        return -1;
+    }
+
+    /**
+     * Returns a function descriptor with the given argument layouts appended to the argument layout array
+     * of this function descriptor.
+     *
+     * @param addedLayouts the argument layouts to append.
+     * @return the new function descriptor.
+     */
+    public final FunctionDescriptorImpl appendArgumentLayouts(MemoryLayout... addedLayouts) {
+        return insertArgumentLayouts(argLayouts.size(), addedLayouts);
+    }
+
+    /**
+     * Returns a function descriptor with the given argument layouts inserted at the given index, into the argument
+     * layout array of this function descriptor.
+     *
+     * @param index        the index at which to insert the arguments
+     * @param addedLayouts the argument layouts to insert at given index.
+     * @return the new function descriptor.
+     * @throws IllegalArgumentException if {@code index < 0 || index > argumentLayouts().size()}.
+     */
+    public FunctionDescriptorImpl insertArgumentLayouts(int index, MemoryLayout... addedLayouts) {
+        checkIndex(index);
+        List<MemoryLayout> added = List.of(addedLayouts); // null check on array and its elements
+        List<MemoryLayout> newLayouts = new ArrayList<>(argLayouts.size() + addedLayouts.length);
+        newLayouts.addAll(argLayouts.subList(0, index));
+        newLayouts.addAll(added);
+        newLayouts.addAll(argLayouts.subList(index, argLayouts.size()));
+        return new FunctionDescriptorImpl(resLayout, newLayouts);
+    }
+
+    /**
+     * Returns a function descriptor with the given memory layout as the new return layout.
+     *
+     * @param newReturn the new return layout.
+     * @return the new function descriptor.
+     */
+    public FunctionDescriptorImpl changeReturnLayout(MemoryLayout newReturn) {
+        requireNonNull(newReturn);
+        return new FunctionDescriptorImpl(newReturn, argLayouts);
+    }
+
+    /**
+     * Returns a function descriptor with the return layout dropped. This is useful to model functions
+     * which return no values.
+     *
+     * @return the new function descriptor.
+     */
+    public FunctionDescriptorImpl dropReturnLayout() {
+        return new FunctionDescriptorImpl(null, argLayouts);
+    }
+
+    /**
+     * {@return the string representation of this function descriptor}
+     */
+    @Override
+    public final String toString() {
+        return String.format("(%s)%s",
+                IntStream.range(0, argLayouts.size())
+                        .mapToObj(i -> (i == firstVariadicArgumentIndex() ?
+                                "..." : "") + argLayouts.get(i))
+                        .collect(Collectors.joining()),
+                returnLayout().map(Object::toString).orElse("v"));
+    }
+
+    /**
+     * Compares the specified object with this function descriptor for equality. Returns {@code true} if and only if the specified
+     * object is also a function descriptor, and all the following conditions are met:
+     * <ul>
+     *     <li>the two function descriptors have equals return layouts (see {@link MemoryLayout#equals(Object)}), or both have no return layout;</li>
+     *     <li>the two function descriptors have argument layouts that are pair-wise {@linkplain MemoryLayout#equals(Object) equal}; and</li>
+     *     <li>the two function descriptors have the same leading {@linkplain #firstVariadicArgumentIndex() variadic argument index}</li>
+     * </ul>
+     *
+     * @param other the object to be compared for equality with this function descriptor.
+     * @return {@code true} if the specified object is equal to this function descriptor.
+     */
+    @Override
+    public final boolean equals(Object other) {
+        return other instanceof FunctionDescriptorImpl f &&
+                Objects.equals(resLayout, f.resLayout) &&
+                Objects.equals(argLayouts, f.argLayouts) &&
+                firstVariadicArgumentIndex() == f.firstVariadicArgumentIndex();
+    }
+
+    /**
+     * {@return the hash code value for this function descriptor}
+     */
+    @Override
+    public final int hashCode() {
+        return Objects.hash(argLayouts, resLayout, firstVariadicArgumentIndex());
+    }
+
+    final void checkIndex(int index) {
+        if (index < 0 || index > argLayouts.size())
+            throw new IllegalArgumentException("Index out of bounds: " + index);
+    }
+
+    public static FunctionDescriptor of(MemoryLayout resLayout, List<MemoryLayout> argLayouts) {
+        return new FunctionDescriptorImpl(resLayout, argLayouts);
+    }
+
+    public static FunctionDescriptor ofVoid(List<MemoryLayout> argLayouts) {
+        return new FunctionDescriptorImpl(null, argLayouts);
+    }
+
+    static final class VariadicFunctionDescriptor extends FunctionDescriptorImpl {
+
+        private final int firstVariadicIndex;
+
+        /**
+         * Constructor.
+         *
+         * @param descriptor the original functional descriptor
+         * @param argLayouts the memory layouts to apply
+         * @throws NullPointerException if any of the provided parameters or array elements are {@code null}
+         */
+        VariadicFunctionDescriptor(FunctionDescriptorImpl descriptor, MemoryLayout... argLayouts) {
+            super(descriptor.returnLayout().orElse(null),
+                    Stream.concat(descriptor.argumentLayouts().stream(), Arrays.stream(argLayouts).map(Objects::requireNonNull)).toList());
+            this.firstVariadicIndex = descriptor.argumentLayouts().size();
+        }
+
+        @Override
+        public int firstVariadicArgumentIndex() {
+            return firstVariadicIndex;
+        }
+
+        @Override
+        public FunctionDescriptorImpl insertArgumentLayouts(int index, MemoryLayout... addedLayouts) {
+            checkIndex(index);
+            for (MemoryLayout layout : addedLayouts) {
+                requireNonNull(layout);
+            }
+            throw newUnsupportedOperationException();
+        }
+
+        @Override
+        public FunctionDescriptorImpl changeReturnLayout(MemoryLayout newReturn) {
+            requireNonNull(newReturn);
+            throw newUnsupportedOperationException();
+        }
+
+        @Override
+        public FunctionDescriptorImpl dropReturnLayout() {
+            throw newUnsupportedOperationException();
+        }
+
+        private UnsupportedOperationException newUnsupportedOperationException() {
+            return new UnsupportedOperationException("Method not supported by " + VariadicFunctionDescriptor.class.getSimpleName());
+        }
+    }
+}


### PR DESCRIPTION
This PR splits the current FunctionDescription class into an interface and two internal implementing classes.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8292918](https://bugs.openjdk.org/browse/JDK-8292918): Split FunctionDescriptor into an interface and implementation(s)


### Reviewers
 * [Athijegannathan Sundararajan](https://openjdk.org/census#sundar) (@sundararajana - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/panama-foreign pull/713/head:pull/713` \
`$ git checkout pull/713`

Update a local copy of the PR: \
`$ git checkout pull/713` \
`$ git pull https://git.openjdk.org/panama-foreign pull/713/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 713`

View PR using the GUI difftool: \
`$ git pr show -t 713`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/panama-foreign/pull/713.diff">https://git.openjdk.org/panama-foreign/pull/713.diff</a>

</details>
