### PR TITLE
Add an internal MemoryInspection class

### DIFF
--- a/src/java.base/share/classes/jdk/internal/foreign/MemoryInspection.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/MemoryInspection.java
@@ -1,10 +1,12 @@
 /*
- *  Copyright (c) 2022, 2022, Oracle and/or its affiliates. All rights reserved.
+ *  Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
  *  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  *  This code is free software; you can redistribute it and/or modify it
  *  under the terms of the GNU General Public License version 2 only, as
- *  published by the Free Software Foundation.
+ *  published by the Free Software Foundation.  Oracle designates this
+ *  particular file as subject to the "Classpath" exception as provided
+ *  by Oracle in the LICENSE file that accompanied this code.
  *
  *  This code is distributed in the hope that it will be useful, but WITHOUT
  *  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
@@ -19,7 +21,6 @@
  *  Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
  *  or visit www.oracle.com if you need additional information or have any
  *  questions.
- *
  */
 package jdk.internal.foreign;
 
@@ -39,7 +40,6 @@ import static jdk.internal.foreign.MemoryInspectionUtil.*;
  * Memory abstractions such as ByteBuffers and byte arrays can be inspected via wrapping methods
  * such as {@link MemorySegment#ofArray(byte[])} and {@link MemorySegment#ofBuffer(Buffer)}.
  *
- * @author Per Minborg
  * @since 20
  */
 public final class MemoryInspection {

--- a/src/java.base/share/classes/jdk/internal/foreign/MemoryInspection.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/MemoryInspection.java
@@ -1,0 +1,243 @@
+/*
+ *  Copyright (c) 2022, 2022, Oracle and/or its affiliates. All rights reserved.
+ *  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ *  This code is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License version 2 only, as
+ *  published by the Free Software Foundation.
+ *
+ *  This code is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ *  version 2 for more details (a copy is included in the LICENSE file that
+ *  accompanied this code).
+ *
+ *  You should have received a copy of the GNU General Public License version
+ *  2 along with this work; if not, write to the Free Software Foundation,
+ *  Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ *  Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ *  or visit www.oracle.com if you need additional information or have any
+ *  questions.
+ *
+ */
+package jdk.internal.foreign;
+
+import java.lang.foreign.MemoryLayout;
+import java.lang.foreign.MemorySegment;
+import java.lang.foreign.ValueLayout;
+import java.nio.Buffer;
+import java.util.function.BiFunction;
+import java.util.stream.Stream;
+
+import static java.util.Objects.requireNonNull;
+import static jdk.internal.foreign.MemoryInspectionUtil.*;
+
+/**
+ * Class that supports inspection of MemorySegments through MemoryLayouts.
+ * <p>
+ * Memory abstractions such as ByteBuffers and byte arrays can be inspected via wrapping methods
+ * such as {@link MemorySegment#ofArray(byte[])} and {@link MemorySegment#ofBuffer(Buffer)}.
+ *
+ * @author Per Minborg
+ * @since 20
+ */
+public final class MemoryInspection {
+
+    // Suppresses default constructor, ensuring non-instantiability.
+    private MemoryInspection() {
+    }
+
+    /**
+     * Returns a human-readable view of the provided {@linkplain MemorySegment memory} viewed
+     * through the provided {@linkplain MemoryLayout layout} using the provided {@linkplain ValueLayoutRenderer renderer}.
+     * <p>
+     * The exact format of the returned view is unspecified and should not
+     * be acted upon programmatically.
+     * <p>
+     * As an example, a MemorySegment viewed though the following memory layout
+     * {@snippet lang = java:
+     * var layout = MemoryLayout.structLayout(
+     *         ValueLayout.JAVA_INT.withName("x"),
+     *         ValueLayout.JAVA_INT.withName("y")
+     * ).withName("Point");
+     *
+     * MemoryInspection.inspect(segment, layout, ValueLayoutRenderer.standard())
+     *     .forEach(System.out::println);
+     *
+     *}
+     * might be rendered to something like this:
+     * {@snippet lang = text:
+     * Point {
+     *   x=1,
+     *   y=2
+     * }
+     *}
+     * <p>
+     * This method is intended to view memory segments through small and medium-sized memory layouts.
+     *
+     * @param segment  to be viewed
+     * @param layout   to use as a layout when viewing the memory segment
+     * @param renderer to apply when rendering value layouts
+     * @return a view of the memory abstraction viewed through the memory layout
+     */
+    public static Stream<String> inspect(MemorySegment segment,
+                                         MemoryLayout layout,
+                                         ValueLayoutRenderer renderer) {
+        requireNonNull(segment);
+        requireNonNull(layout);
+        requireNonNull(renderer);
+        return MemoryInspectionUtil.inspect(segment, layout, renderer);
+    }
+
+    /**
+     * An interface that can be used to specify custom rendering of value
+     * layouts via the {@link MemoryInspection#inspect(MemorySegment, MemoryLayout, ValueLayoutRenderer)} method.
+     * <p>
+     * The render methods take two parameters:
+     * <ul>
+     *     <li>layout: This can be used to select different formatting for different paths</li>
+     *     <li>value: The actual value</li>
+     * </ul>
+     * <p>
+     * The {@linkplain ValueLayoutRenderer#standard() standard() } value layout renderer is path
+     * agnostic and will thus render all layouts of the same type the same way.
+     *
+     * @see MemoryInspection#inspect(MemorySegment, MemoryLayout, ValueLayoutRenderer)
+     */
+    public interface ValueLayoutRenderer {
+        /**
+         * Renders the provided {@code booleanLayout} and {@code value} to a String.
+         *
+         * @param booleanLayout the layout to render
+         * @param value         the value to render
+         * @return rendered String
+         */
+        default String render(ValueLayout.OfBoolean booleanLayout, boolean value) {
+            requireNonNull(booleanLayout);
+            return Boolean.toString(value);
+        }
+
+        /**
+         * Renders the provided {@code byteLayout} and {@code value} to a String.
+         *
+         * @param byteLayout the layout to render
+         * @param value         the value to render
+         * @return rendered String
+         */
+        default String render(ValueLayout.OfByte byteLayout, byte value) {
+            requireNonNull(byteLayout);
+            return Byte.toString(value);
+        }
+
+        /**
+         * Renders the provided {@code charLayout} and {@code value} to a String.
+         *
+         * @param charLayout the layout to render
+         * @param value      the value to render
+         * @return rendered String
+         */
+        default String render(ValueLayout.OfChar charLayout, char value) {
+            requireNonNull(charLayout);
+            return Character.toString(value);
+        }
+
+        /**
+         * Renders the provided {@code shortLayout} and {@code value} to a String.
+         *
+         * @param shortLayout the layout to render
+         * @param value       the value to render
+         * @return rendered String
+         */
+        default String render(ValueLayout.OfShort shortLayout, short value) {
+            requireNonNull(shortLayout);
+            return Short.toString(value);
+        }
+
+        /**
+         * Renders the provided {@code intLayout} and {@code value} to a String.
+         *
+         * @param intLayout the layout to render
+         * @param value     the value to render
+         * @return rendered String
+         */
+        default String render(ValueLayout.OfInt intLayout, int value) {
+            requireNonNull(intLayout);
+            return Integer.toString(value);
+        }
+
+        /**
+         * Renders the provided {@code longLayout} and {@code value} to a String.
+         *
+         * @param longLayout the layout to render
+         * @param value      the value to render
+         * @return rendered String
+         */
+        default String render(ValueLayout.OfLong longLayout, long value) {
+            requireNonNull(longLayout);
+            return Long.toString(value);
+        }
+
+        /**
+         * Renders the provided {@code floatLayout} and {@code value} to a String.
+         *
+         * @param floatLayout the layout to render
+         * @param value       the value to render
+         * @return rendered String
+         */
+        default String render(ValueLayout.OfFloat floatLayout, float value) {
+            requireNonNull(floatLayout);
+            return Float.toString(value);
+        }
+
+        /**
+         * Renders the provided {@code doubleLayout} and {@code value} to a String.
+         *
+         * @param doubleLayout the layout to render
+         * @param value        the value to render
+         * @return rendered String
+         */
+        default String render(ValueLayout.OfDouble doubleLayout, double value) {
+            requireNonNull(doubleLayout);
+            return Double.toString(value);
+        }
+
+        /**
+         * Renders the provided {@code addressLayout} and {@code value} to a String.
+         *
+         * @param addressLayout the layout to render
+         * @param value         the value to render
+         * @return rendered String
+         */
+        default String render(ValueLayout.OfAddress addressLayout, MemorySegment value) {
+            requireNonNull(addressLayout);
+            return String.format("0x%0" + (ValueLayout.ADDRESS.byteSize() * 2) + "X", value.address());
+        }
+
+        /**
+         * {@return a standard value layout renderer that will render numeric values into decimal form and where
+         * other value types are rendered to a reasonable "natural" form}
+         * <p>
+         * More specifically, values types are rendered as follows:
+         * <ul>
+         *     <li>Numeric values are rendered in decimal form (e.g 1 or 1.2).</li>
+         *     <li>Boolean values are rendered as {@code true} or {@code false}.</li>
+         *     <li>Character values are rendered as {@code char}.</li>
+         *     <li>Address values are rendered in hexadecimal form e.g. {@code 0x0000000000000000} (on 64-bit platforms) or
+         *     {@code 0x00000000} (on 32-bit platforms)</li>
+         * </ul>
+         */
+        static ValueLayoutRenderer standard() {
+            return STANDARD_VALUE_LAYOUT_RENDERER;
+        }
+
+        /**
+         * {@return a value layout renderer that will render all value layout types via the provided {@code renderer}}
+         */
+        static ValueLayoutRenderer of(BiFunction<ValueLayout, Object, String> renderer) {
+            requireNonNull(renderer);
+            return new SingleFunctionValueLayoutRenderer(renderer);
+        }
+
+    }
+}

--- a/src/java.base/share/classes/jdk/internal/foreign/MemoryInspectionUtil.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/MemoryInspectionUtil.java
@@ -1,10 +1,12 @@
 /*
- *  Copyright (c) 2022, 2022, Oracle and/or its affiliates. All rights reserved.
+ *  Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
  *  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  *  This code is free software; you can redistribute it and/or modify it
  *  under the terms of the GNU General Public License version 2 only, as
- *  published by the Free Software Foundation.
+ *  published by the Free Software Foundation.  Oracle designates this
+ *  particular file as subject to the "Classpath" exception as provided
+ *  by Oracle in the LICENSE file that accompanied this code.
  *
  *  This code is distributed in the hope that it will be useful, but WITHOUT
  *  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
@@ -19,7 +21,6 @@
  *  Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
  *  or visit www.oracle.com if you need additional information or have any
  *  questions.
- *
  */
 
 package jdk.internal.foreign;

--- a/src/java.base/share/classes/jdk/internal/foreign/MemoryInspectionUtil.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/MemoryInspectionUtil.java
@@ -1,0 +1,293 @@
+/*
+ *  Copyright (c) 2022, 2022, Oracle and/or its affiliates. All rights reserved.
+ *  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ *  This code is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License version 2 only, as
+ *  published by the Free Software Foundation.
+ *
+ *  This code is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ *  version 2 for more details (a copy is included in the LICENSE file that
+ *  accompanied this code).
+ *
+ *  You should have received a copy of the GNU General Public License version
+ *  2 along with this work; if not, write to the Free Software Foundation,
+ *  Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ *  Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ *  or visit www.oracle.com if you need additional information or have any
+ *  questions.
+ *
+ */
+
+package jdk.internal.foreign;
+
+import java.lang.foreign.GroupLayout;
+import java.lang.foreign.MemoryLayout;
+import java.lang.foreign.MemorySegment;
+import java.lang.foreign.PaddingLayout;
+import java.lang.foreign.SequenceLayout;
+import java.lang.foreign.StructLayout;
+import java.lang.foreign.ValueLayout;
+import java.lang.foreign.UnionLayout;
+import java.util.function.BiFunction;
+import java.util.function.Consumer;
+import java.util.stream.Stream;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Internal class to support inspection MemorySegments into various formats.
+ */
+final class MemoryInspectionUtil {
+
+    static final MemoryInspection.ValueLayoutRenderer STANDARD_VALUE_LAYOUT_RENDERER = new StandardValueLayoutRenderer();
+
+    // Suppresses default constructor, ensuring non-instantiability.
+    private MemoryInspectionUtil() {
+    }
+
+    static Stream<String> inspect(MemorySegment segment,
+                                  MemoryLayout layout,
+                                  MemoryInspection.ValueLayoutRenderer renderer) {
+        requireNonNull(segment);
+        requireNonNull(layout);
+        requireNonNull(renderer);
+
+        final var builder = Stream.<String>builder();
+        toString0(segment, layout, renderer, builder::add, new ViewState(), "");
+        return builder.build();
+    }
+
+    private static void toString0(MemorySegment segment,
+                                  MemoryLayout layout,
+                                  MemoryInspection.ValueLayoutRenderer renderer,
+                                  Consumer<String> action,
+                                  ViewState state,
+                                  String suffix) {
+
+        // TODO: Replace with "patterns in switch statement" once this becomes available.
+
+        if (layout instanceof ValueLayout.OfBoolean ofBoolean) {
+            action.accept(renderValueLayout(state, ofBoolean, renderer.render(ofBoolean, segment.get(ofBoolean, state.indexAndAdd(ofBoolean))), suffix));
+            return;
+        }
+        if (layout instanceof ValueLayout.OfByte ofByte) {
+            action.accept(renderValueLayout(state, ofByte, renderer.render(ofByte, segment.get(ofByte, state.indexAndAdd(ofByte))), suffix));
+            return;
+        }
+        if (layout instanceof ValueLayout.OfShort ofShort) {
+            action.accept(renderValueLayout(state, ofShort, renderer.render(ofShort, segment.get(ofShort, state.indexAndAdd(ofShort))), suffix));
+            return;
+        }
+        if (layout instanceof ValueLayout.OfInt ofInt) {
+            action.accept(renderValueLayout(state, ofInt, renderer.render(ofInt, segment.get(ofInt, state.indexAndAdd(ofInt))), suffix));
+            return;
+        }
+        if (layout instanceof ValueLayout.OfLong ofLong) {
+            action.accept(renderValueLayout(state, ofLong, renderer.render(ofLong, segment.get(ofLong, state.indexAndAdd(ofLong))), suffix));
+            return;
+        }
+        if (layout instanceof ValueLayout.OfFloat ofFloat) {
+            action.accept(renderValueLayout(state, ofFloat, renderer.render(ofFloat, segment.get(ofFloat, state.indexAndAdd(ofFloat))), suffix));
+            return;
+        }
+        if (layout instanceof ValueLayout.OfDouble ofDouble) {
+            action.accept(renderValueLayout(state, ofDouble, renderer.render(ofDouble, segment.get(ofDouble, state.indexAndAdd(ofDouble))), suffix));
+            return;
+        }
+        if (layout instanceof ValueLayout.OfChar ofChar) {
+            action.accept(renderValueLayout(state, ofChar, renderer.render(ofChar, segment.get(ofChar, state.indexAndAdd(ofChar))), suffix));
+            return;
+        }
+        if (layout instanceof ValueLayout.OfAddress ofAddress) {
+            action.accept(renderValueLayout(state, ofAddress, renderer.render(ofAddress, segment.get(ofAddress, state.indexAndAdd(ofAddress))), suffix));
+            return;
+        }
+        if (layout instanceof PaddingLayout paddingLayout) {
+            action.accept(state.indentSpaces() + paddingLayout.bitSize() + " padding bits");
+            state.indexAndAdd(paddingLayout);
+            return;
+        }
+        if (layout instanceof GroupLayout groupLayout) {
+
+            /* Strictly, we should provide all permutations of unions.
+             * So, if we have a union U =  (A|B),(C|D) then we should present:
+             * (A,C), (A,D), (B,C) and (B,D)
+             */
+
+            final var separator = groupLayout instanceof StructLayout
+                    ? ","  // Struct separator
+                    : "|"; // Union separator
+
+            action.accept(indentedLabel(state, groupLayout) + " {");
+            state.incrementIndent();
+            final var members = groupLayout.memberLayouts();
+            final long initialIndex = state.index();
+            long maxIndex = initialIndex;
+            for (int i = 0; i < members.size(); i++) {
+                if (groupLayout instanceof UnionLayout) {
+                    // If it is a union, we need to reset the index for each member
+                    state.index(initialIndex);
+                    // We record the max index used for any union member so we can leave off from there
+                    maxIndex = Math.max(maxIndex, state.index());
+                }
+                toString0(segment, members.get(i), renderer, action, state, (i != (members.size() - 1)) ? separator : "");
+                if (groupLayout instanceof UnionLayout) {
+                    // This is the best we can do.
+                    state.index(maxIndex);
+                }
+            }
+            state.decrementIndent();
+            action.accept(state.indentSpaces() + "}" + suffix);
+            return;
+        }
+        if (layout instanceof SequenceLayout sequenceLayout) {
+            action.accept(indentedLabel(state, sequenceLayout) + " [");
+            state.incrementIndent();
+            final long elementCount = sequenceLayout.elementCount();
+            for (long i = 0; i < elementCount; i++) {
+                toString0(segment, sequenceLayout.elementLayout(), renderer, action, state, (i != (elementCount - 1L)) ? "," : "");
+            }
+            state.decrementIndent();
+            action.accept(state.indentSpaces() + "]" + suffix);
+            return;
+        }
+        action.accept(state.indentSpaces() + "Unknown layout: " + layout + " at index " + state.index());
+        state.indexAndAdd(layout);
+    }
+
+    static String renderValueLayout(ViewState state,
+                                    ValueLayout layout,
+                                    String value,
+                                    String suffix) {
+        return indentedLabel(state, layout) + "=" + value + suffix;
+    }
+
+    static String indentedLabel(ViewState state,
+                                MemoryLayout layout) {
+        return state.indentSpaces() + layout.name()
+                .orElseGet(layout::toString);
+    }
+
+    static final class ViewState {
+
+        private static final int SPACES_PER_INDENT = 4;
+
+        // Holding a non-static indents allows simple thread-safe use
+        private final StringBuilder indents = new StringBuilder();
+
+        private int indent;
+        private long index;
+
+        void incrementIndent() {
+            indent++;
+        }
+
+        void decrementIndent() {
+            indent--;
+        }
+
+        String indentSpaces() {
+            final int spaces = indent * SPACES_PER_INDENT;
+            while (indents.length() < spaces) {
+                // Expand as needed
+                indents.append(" ");
+            }
+            return indents.substring(0, spaces);
+        }
+
+        long index() {
+            return index;
+        }
+
+        void index(long index) {
+            this.index = index;
+        }
+
+        long indexAndAdd(long delta) {
+            final long val = index;
+            index += delta;
+            return val;
+        }
+
+        long indexAndAdd(MemoryLayout layout) {
+            return indexAndAdd(layout.byteSize());
+        }
+    }
+
+    private static final class StandardValueLayoutRenderer implements MemoryInspection.ValueLayoutRenderer {
+        @Override
+        public String toString() {
+            return singletonToString(StandardValueLayoutRenderer.class);
+        }
+    }
+
+    private static String singletonToString(Class<?> implementingClass) {
+        return "The " + implementingClass.getName() + " singleton";
+    }
+
+    static final class SingleFunctionValueLayoutRenderer implements MemoryInspection.ValueLayoutRenderer {
+
+        private final BiFunction<ValueLayout, Object, String> renderer;
+
+        public SingleFunctionValueLayoutRenderer(BiFunction<ValueLayout, Object, String> renderer) {
+            this.renderer = renderer;
+        }
+
+        @Override
+        public String render(ValueLayout.OfBoolean booleanLayout, boolean value) {
+            return renderer.apply(booleanLayout, value);
+        }
+
+        @Override
+        public String render(ValueLayout.OfByte byteLayout, byte value) {
+            return renderer.apply(byteLayout, value);
+        }
+
+        @Override
+        public String render(ValueLayout.OfChar charLayout, char value) {
+            return renderer.apply(charLayout, value);
+        }
+
+        @Override
+        public String render(ValueLayout.OfShort shortLayout, short value) {
+            return renderer.apply(shortLayout, value);
+        }
+
+        @Override
+        public String render(ValueLayout.OfInt intLayout, int value) {
+            return renderer.apply(intLayout, value);
+        }
+
+        @Override
+        public String render(ValueLayout.OfLong longLayout, long value) {
+            return renderer.apply(longLayout, value);
+        }
+
+        @Override
+        public String render(ValueLayout.OfFloat floatLayout, float value) {
+            return renderer.apply(floatLayout, value);
+        }
+
+        @Override
+        public String render(ValueLayout.OfDouble doubleLayout, double value) {
+            return renderer.apply(doubleLayout, value);
+        }
+
+        @Override
+        public String render(ValueLayout.OfAddress addressLayout, MemorySegment value) {
+            return renderer.apply(addressLayout, value);
+        }
+
+        @Override
+        public String toString() {
+            return "SingleFunctionValueLayoutRenderer{" +
+                    "renderer=" + renderer +
+                    '}';
+        }
+    }
+
+}

--- a/test/jdk/java/foreign/TestMemoryInspection.java
+++ b/test/jdk/java/foreign/TestMemoryInspection.java
@@ -1,0 +1,288 @@
+
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @enablePreview
+ * @modules java.base/jdk.internal.foreign
+ * @run testng/othervm --enable-native-access=ALL-UNNAMED TestMemoryInspection
+ */
+
+import java.lang.foreign.*;
+import java.lang.invoke.VarHandle;
+import java.util.List;
+import java.util.function.Function;
+import java.util.stream.Stream;
+
+import jdk.internal.foreign.MemoryInspection;
+import org.testng.annotations.*;
+
+import static java.lang.foreign.ValueLayout.*;
+import static java.util.stream.Collectors.joining;
+import static org.testng.Assert.*;
+import static java.util.Objects.requireNonNull;
+
+@Test
+public class TestMemoryInspection {
+
+    private static final String EXPECT_ADDRESS = "0x" + "00".repeat((int) ValueLayout.ADDRESS.byteSize());
+
+    @Test
+    public void valueLayouts() {
+
+        record TestInput(ValueLayout layout, String stringValue) {
+        }
+
+        List.of(
+                new TestInput(ValueLayout.JAVA_BYTE, "0"),
+                new TestInput(ValueLayout.JAVA_SHORT, "0"),
+                new TestInput(ValueLayout.JAVA_INT, "0"),
+                new TestInput(ValueLayout.JAVA_LONG, "0"),
+                new TestInput(ValueLayout.JAVA_FLOAT, "0.0"),
+                new TestInput(ValueLayout.JAVA_DOUBLE, "0.0"),
+                new TestInput(ValueLayout.JAVA_CHAR, "" + (char) 0),
+                new TestInput(JAVA_BOOLEAN, "false"),
+                new TestInput(ValueLayout.ADDRESS, EXPECT_ADDRESS)
+        ).forEach(ti -> {
+            var expect = ti.layout() + "=" + ti.stringValue();
+            var actual = testWithFreshMemorySegment(ti.layout().byteSize(), s -> jdk.internal.foreign.MemoryInspection.inspect(s, ti.layout(), jdk.internal.foreign.MemoryInspection.ValueLayoutRenderer.standard()))
+                    .collect(joining(System.lineSeparator()));
+            assertEquals(actual, expect);
+        });
+    }
+
+    @Test
+    public void point() {
+
+        var expect = platformLineSeparated("""
+                Point {
+                    x=1,
+                    y=2
+                }""");
+
+        var actual = testWithFreshMemorySegment(Integer.BYTES * 2, segment -> {
+            final Point point = new Point(segment);
+            point.x(1);
+            point.y(2);
+            return jdk.internal.foreign.MemoryInspection.inspect(segment, Point.LAYOUT, jdk.internal.foreign.MemoryInspection.ValueLayoutRenderer.standard())
+                    .collect(joining(System.lineSeparator()));
+        });
+
+        assertEquals(actual, expect);
+    }
+
+    @Test
+    public void pointCustomRenderer() {
+
+        var expect = platformLineSeparated("""
+                Point {
+                    x=0x0001,
+                    y=0x0002
+                }""");
+
+        var actual = testWithFreshMemorySegment(Integer.BYTES * 2, segment -> {
+            final Point point = new Point(segment);
+            point.x(1);
+            point.y(2);
+            return MemoryInspection.inspect(segment, Point.LAYOUT, new jdk.internal.foreign.MemoryInspection.ValueLayoutRenderer() {
+                        @Override
+                        public String render(ValueLayout.OfInt intLayout, int value) {
+                            return String.format("0x%04x", value);
+                        }
+                    })
+                    .collect(joining(System.lineSeparator()));
+        });
+
+        assertEquals(actual, expect);
+    }
+
+    @Test
+    public void standardCustomRenderer() {
+
+        MemoryLayout layout = MemoryLayout.structLayout(
+                // These are in bit alignment order (descending) for all platforms
+                // in order for each element to be aligned to its type's bit alignment.
+                Stream.of(
+                                JAVA_LONG,
+                                JAVA_DOUBLE,
+                                ADDRESS,
+                                JAVA_INT,
+                                JAVA_FLOAT,
+                                JAVA_SHORT,
+                                JAVA_CHAR,
+                                JAVA_BOOLEAN,
+                                JAVA_BYTE
+                        )
+                        .map(vl -> vl.withName(vl.carrier().getSimpleName()))
+                        .toArray(MemoryLayout[]::new)
+        ).withName("struct");
+
+        System.out.println("layout = " + layout);
+        var expect = platformLineSeparated("""
+                struct {
+                    long=0,
+                    double=0.0,
+                    MemorySegment=$1,
+                    int=0,
+                    float=0.0,
+                    short=0,
+                    char=\u0000,
+                    boolean=false,
+                    byte=0
+                }""").replace("$1", EXPECT_ADDRESS);
+
+
+        var actual = testWithFreshMemorySegment(layout.byteSize(), segment ->
+                jdk.internal.foreign.MemoryInspection.inspect(segment, layout, jdk.internal.foreign.MemoryInspection.ValueLayoutRenderer.standard()))
+                .collect(joining(System.lineSeparator()));
+
+        assertEquals(actual, expect);
+    }
+
+
+    @Test
+    public void sequence() {
+        final int arraySize = 4;
+        var sequenceLayout = MemoryLayout.sequenceLayout(arraySize,
+                MemoryLayout.structLayout(
+                        ValueLayout.JAVA_INT.withName("x"),
+                        ValueLayout.JAVA_INT.withName("y")
+                ).withName("Point")
+        ).withName("PointArrayOfElements");
+
+        var expect = platformLineSeparated("""
+                PointArrayOfElements [
+                    Point {
+                        x=0,
+                        y=0
+                    },
+                    Point {
+                        x=0,
+                        y=0
+                    },
+                    Point {
+                        x=0,
+                        y=0
+                    },
+                    Point {
+                        x=0,
+                        y=0
+                    }
+                ]""");
+        var actual = testWithFreshMemorySegment(Integer.BYTES * 2 * arraySize, segment ->
+                jdk.internal.foreign.MemoryInspection.inspect(segment, sequenceLayout, jdk.internal.foreign.MemoryInspection.ValueLayoutRenderer.standard()))
+                .collect(joining(System.lineSeparator()));
+
+        assertEquals(actual, expect);
+    }
+
+
+    @Test
+    public void union() {
+        var u0 = MemoryLayout.structLayout(
+                ValueLayout.JAVA_INT.withName("x"),
+                ValueLayout.JAVA_INT.withName("y"),
+                MemoryLayout.paddingLayout(Integer.SIZE)
+        ).withName("Point");
+
+        var u1 = MemoryLayout.structLayout(
+                ValueLayout.JAVA_INT.withName("x"),
+                ValueLayout.JAVA_INT.withName("y"),
+                ValueLayout.JAVA_INT.withName("z")
+        ).withName("3D-Point");
+
+        var union = MemoryLayout.unionLayout(u0, u1).withName("Union");
+
+        var expect = platformLineSeparated("""
+                Union {
+                    Point {
+                        x=0,
+                        y=0,
+                        32 padding bits
+                    }|
+                    3D-Point {
+                        x=0,
+                        y=0,
+                        z=0
+                    }
+                }""");
+        var actual = testWithFreshMemorySegment(Integer.BYTES * 3, segment ->
+                MemoryInspection.inspect(segment, union, MemoryInspection.ValueLayoutRenderer.standard()))
+                .collect(joining(System.lineSeparator()));
+
+        assertEquals(actual, expect);
+    }
+
+    static final class Point {
+
+        static final MemoryLayout LAYOUT = MemoryLayout.structLayout(
+                ValueLayout.JAVA_INT.withName("x"),
+                ValueLayout.JAVA_INT.withName("y")
+        ).withName("Point");
+
+        static final VarHandle xVH = LAYOUT.varHandle(MemoryLayout.PathElement.groupElement("x"));
+        static final VarHandle yVH = LAYOUT.varHandle(MemoryLayout.PathElement.groupElement("y"));
+
+        private final MemorySegment memorySegment;
+
+        Point(MemorySegment memorySegment) {
+            this.memorySegment = requireNonNull(memorySegment);
+        }
+
+        int x() {
+            return (int) xVH.get(memorySegment);
+        }
+
+        int y() {
+            return (int) yVH.get(memorySegment);
+        }
+
+        void x(int x) {
+            xVH.set(memorySegment, x);
+        }
+
+        void y(int y) {
+            yVH.set(memorySegment, y);
+        }
+
+        @Override
+        public String toString() {
+            return "Point {x=" + x() + ", y=" + y() + "}";
+        }
+    }
+
+    private static String platformLineSeparated(String s) {
+        return s.lines()
+                .collect(joining(System.lineSeparator()));
+    }
+
+    private static <T> T testWithFreshMemorySegment(long size,
+                                                    Function<MemorySegment, T> mapper) {
+        try (final MemorySession session = MemorySession.openConfined()) {
+            var segment = session.allocate(size);
+            return mapper.apply(segment);
+        }
+    }
+
+}


### PR DESCRIPTION
This PR adds a way of inspecting a `MemoryLayout` through a `MemoryLayout`.

```
    /**
     * Returns a human-readable view of the provided {@linkplain MemorySegment memory} viewed
     * through the provided {@linkplain MemoryLayout layout} using the provided {@linkplain ValueLayoutRenderer renderer}.
     * <p>
     * The exact format of the returned view is unspecified and should not
     * be acted upon programmatically.
     * <p>
     * As an example, a MemorySegment viewed though the following memory layout
     * {@snippet lang = java:
     * var layout = MemoryLayout.structLayout(
     *         ValueLayout.JAVA_INT.withName("x"),
     *         ValueLayout.JAVA_INT.withName("y")
     * ).withName("Point");
     *
     * MemoryInspection.inspect(segment, layout, ValueLayoutRenderer.standard())
     *     .forEach(System.out::println);
     *
     *}
     * might be rendered to something like this:
     * {@snippet lang = text:
     * Point {
     *   x=1,
     *   y=2
     * }
     *}
     * <p>
     * This method is intended to view memory segments through small and medium-sized memory layouts.
     *
     * @param segment  to be viewed
     * @param layout   to use as a layout when viewing the memory segment
     * @param renderer to apply when rendering value layouts
     * @return a view of the memory abstraction viewed through the memory layout
     */
    public static Stream<String> inspect(MemorySegment segment,
                                         MemoryLayout layout,
                                         ValueLayoutRenderer renderer) {
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Reviewers
 * [Maurizio Cimadamore](https://openjdk.org/census#mcimadamore) (@mcimadamore - Committer) ⚠️ Review applies to [29dc714b](https://git.openjdk.org/panama-foreign/pull/715/files/29dc714ba19f0d24945b8233a803e3275c0994db)
 * [Athijegannathan Sundararajan](https://openjdk.org/census#sundar) (@sundararajana - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/panama-foreign pull/715/head:pull/715` \
`$ git checkout pull/715`

Update a local copy of the PR: \
`$ git checkout pull/715` \
`$ git pull https://git.openjdk.org/panama-foreign pull/715/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 715`

View PR using the GUI difftool: \
`$ git pr show -t 715`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/panama-foreign/pull/715.diff">https://git.openjdk.org/panama-foreign/pull/715.diff</a>

</details>
