### PR TITLE
8293495: Revisit name of SymbolLookup::lookup

### DIFF
--- a/src/java.base/share/classes/java/lang/foreign/SymbolLookup.java
+++ b/src/java.base/share/classes/java/lang/foreign/SymbolLookup.java
@@ -45,7 +45,7 @@ import java.util.function.BiFunction;
  * A <em>symbol lookup</em> is an object that may be used to retrieve the address of a symbol in one or more libraries.
  * A symbol is a named entity, such as a function or a global variable.
  * <p>
- * A symbol lookup is created with respect to a particular library (or libraries). Subsequently, the {@link SymbolLookup#lookup(String)}
+ * A symbol lookup is created with respect to a particular library (or libraries). Subsequently, the {@link SymbolLookup#find(String)}
  * method takes the name of a symbol and returns the address of the symbol in that library.
  * <p>
  * The address of a symbol is modelled as a zero-length {@linkplain MemorySegment memory segment}. The segment can be used in different ways:
@@ -64,13 +64,13 @@ import java.util.function.BiFunction;
  * The library is loaded if not already loaded. The symbol lookup, which is known as a <em>library lookup</em>, is associated
  * with a {@linkplain  MemorySession memory session}; when the session is {@linkplain MemorySession#close() closed}, the library is unloaded:
  *
- * {@snippet lang=java :
+ * {@snippet lang = java:
  * try (MemorySession session = MemorySession.openConfined()) {
  *     SymbolLookup libGL = SymbolLookup.libraryLookup("libGL.so"); // libGL.so loaded here
- *     MemorySegment glGetString = libGL.lookup("glGetString").orElseThrow();
+ *     MemorySegment glGetString = libGL.find("glGetString").orElseThrow();
  *     ...
  * } //  libGL.so unloaded here
- * }
+ *}
  * <p>
  * If a library was previously loaded through JNI, i.e., by {@link System#load(String)}
  * or {@link System#loadLibrary(String)}, then the library was also associated with a particular class loader. The factory
@@ -80,7 +80,7 @@ import java.util.function.BiFunction;
  * System.loadLibrary("GL"); // libGL.so loaded here
  * ...
  * SymbolLookup libGL = SymbolLookup.loaderLookup();
- * MemorySegment glGetString = libGL.lookup("glGetString").orElseThrow();
+ * MemorySegment glGetString = libGL.find("glGetString").orElseThrow();
  * }
  *
  * This symbol lookup, which is known as a <em>loader lookup</em>, is dynamic with respect to the libraries associated
@@ -91,18 +91,18 @@ import java.util.function.BiFunction;
  * by {@link System#load(String)} or {@link System#loadLibrary(String)}. A loader lookup does not expose symbols in libraries
  * that were loaded in the course of creating a library lookup:
  *
- * {@snippet lang=java :
- * libraryLookup("libGL.so", session).lookup("glGetString").isPresent(); // true
- * loaderLookup().lookup("glGetString").isPresent(); // false
- * }
+ * {@snippet lang = java:
+ * libraryLookup("libGL.so", session).find("glGetString").isPresent(); // true
+ * loaderLookup().find("glGetString").isPresent(); // false
+ *}
  *
  * Note also that a library lookup for library {@code L} exposes symbols in {@code L} even if {@code L} was previously loaded
  * through JNI (the association with a class loader is immaterial to the library lookup):
  *
- * {@snippet lang=java :
+ * {@snippet lang = java:
  * System.loadLibrary("GL"); // libGL.so loaded here
- * libraryLookup("libGL.so", session).lookup("glGetString").isPresent(); // true
- * }
+ * libraryLookup("libGL.so", session).find("glGetString").isPresent(); // true
+ *}
  *
  * <p>
  * Finally, each {@link Linker} provides a symbol lookup for libraries that are commonly used on the OS and processor
@@ -110,11 +110,11 @@ import java.util.function.BiFunction;
  * helps clients to quickly find addresses of well-known symbols. For example, a {@link Linker} for Linux/x64 might choose to
  * expose symbols in {@code libc} through the default lookup:
  *
- * {@snippet lang=java :
+ * {@snippet lang = java:
  * Linker nativeLinker = Linker.nativeLinker();
  * SymbolLookup stdlib = nativeLinker.defaultLookup();
- * MemorySegment malloc = stdlib.lookup("malloc").orElseThrow();
- * }
+ * MemorySegment malloc = stdlib.find("malloc").orElseThrow();
+ *}
  */
 @PreviewFeature(feature=PreviewFeature.Feature.FOREIGN)
 @FunctionalInterface
@@ -125,7 +125,7 @@ public interface SymbolLookup {
      * @param name the symbol name.
      * @return a zero-length memory segment whose base address indicates the address of the symbol, if found.
      */
-    Optional<MemorySegment> lookup(String name);
+    Optional<MemorySegment> find(String name);
 
     /**
      * Returns a symbol lookup for symbols in the libraries associated with the caller's class loader.

--- a/src/java.base/share/classes/java/lang/foreign/package-info.java
+++ b/src/java.base/share/classes/java/lang/foreign/package-info.java
@@ -110,11 +110,11 @@
  * For example, to compute the length of a string using the C standard library function {@code strlen} on a Linux x64 platform,
  * we can use the following code:
  *
- * {@snippet lang=java :
+ * {@snippet lang = java:
  * Linker linker = Linker.nativeLinker();
  * SymbolLookup stdlib = linker.defaultLookup();
  * MethodHandle strlen = linker.downcallHandle(
- *     stdlib.lookup("strlen").get(),
+ *     stdlib.find("strlen").get(),
  *     FunctionDescriptor.of(ValueLayout.JAVA_LONG, ValueLayout.ADDRESS)
  * );
  *
@@ -123,10 +123,10 @@
  *     cString.setUtf8String(0, "Hello");
  *     long len = (long)strlen.invoke(cString); // 5
  * }
- * }
+ *}
  *
  * Here, we obtain a {@linkplain java.lang.foreign.Linker#nativeLinker() native linker} and we use it
- * to {@linkplain java.lang.foreign.SymbolLookup#lookup(java.lang.String) look up} the {@code strlen} symbol in the
+ * to {@linkplain java.lang.foreign.SymbolLookup#find(java.lang.String) look up} the {@code strlen} symbol in the
  * standard C library; a <em>downcall method handle</em> targeting said symbol is subsequently
  * {@linkplain java.lang.foreign.Linker#downcallHandle(java.lang.foreign.FunctionDescriptor) obtained}.
  * To complete the linking successfully, we must provide a {@link java.lang.foreign.FunctionDescriptor} instance,

--- a/src/java.base/share/classes/jdk/internal/foreign/SystemLookup.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/SystemLookup.java
@@ -85,14 +85,14 @@ public final class SystemLookup implements SymbolLookup {
                     libLookup(libs -> libs.load(jdkLibraryPath("syslookup")));
 
             int numSymbols = WindowsFallbackSymbols.values().length;
-            MemorySegment funcs = MemorySegment.ofAddress(fallbackLibLookup.lookup("funcs").orElseThrow().address(),
+            MemorySegment funcs = MemorySegment.ofAddress(fallbackLibLookup.find("funcs").orElseThrow().address(),
                 ADDRESS.byteSize() * numSymbols, MemorySession.global());
 
             Function<String, Optional<MemorySegment>> fallbackLookup = name -> Optional.ofNullable(WindowsFallbackSymbols.valueOfOrNull(name))
                 .map(symbol -> MemorySegment.ofAddress(funcs.getAtIndex(ADDRESS, symbol.ordinal()).address(), 0L, MemorySession.global()));
 
             final SymbolLookup finalLookup = lookup;
-            lookup = name -> finalLookup.lookup(name).or(() -> fallbackLookup.apply(name));
+            lookup = name -> finalLookup.find(name).or(() -> fallbackLookup.apply(name));
         }
 
         return lookup;
@@ -132,8 +132,8 @@ public final class SystemLookup implements SymbolLookup {
     }
 
     @Override
-    public Optional<MemorySegment> lookup(String name) {
-        return SYSTEM_LOOKUP.lookup(name);
+    public Optional<MemorySegment> find(String name) {
+        return SYSTEM_LOOKUP.find(name);
     }
 
     // fallback symbols missing from ucrtbase.dll

--- a/test/jdk/java/foreign/LibraryLookupTest.java
+++ b/test/jdk/java/foreign/LibraryLookupTest.java
@@ -72,7 +72,7 @@ public class LibraryLookupTest {
 
     private static MemorySegment loadLibrary(MemorySession session) {
         SymbolLookup lib = SymbolLookup.libraryLookup(LIB_PATH, session);
-        MemorySegment addr = lib.lookup("inc").get();
+        MemorySegment addr = lib.find("inc").get();
         assertEquals(addr.session(), session);
         return addr;
     }

--- a/test/jdk/java/foreign/NativeTestHelper.java
+++ b/test/jdk/java/foreign/NativeTestHelper.java
@@ -86,10 +86,10 @@ public class NativeTestHelper {
     private static Linker LINKER = Linker.nativeLinker();
 
     private static final MethodHandle FREE = LINKER.downcallHandle(
-            LINKER.defaultLookup().lookup("free").get(), FunctionDescriptor.ofVoid(C_POINTER));
+            LINKER.defaultLookup().find("free").get(), FunctionDescriptor.ofVoid(C_POINTER));
 
     private static final MethodHandle MALLOC = LINKER.downcallHandle(
-            LINKER.defaultLookup().lookup("malloc").get(), FunctionDescriptor.of(C_POINTER, C_LONG_LONG));
+            LINKER.defaultLookup().find("malloc").get(), FunctionDescriptor.of(C_POINTER, C_LONG_LONG));
 
     public static void freeMemory(MemorySegment address) {
         try {
@@ -108,6 +108,6 @@ public class NativeTestHelper {
     }
 
     public static MemorySegment findNativeOrThrow(String name) {
-        return SymbolLookup.loaderLookup().lookup(name).orElseThrow();
+        return SymbolLookup.loaderLookup().find(name).orElseThrow();
     }
 }

--- a/test/jdk/java/foreign/StdLibTest.java
+++ b/test/jdk/java/foreign/StdLibTest.java
@@ -152,35 +152,35 @@ public class StdLibTest extends NativeTestHelper {
 
     static class StdLibHelper {
 
-        final static MethodHandle strcat = abi.downcallHandle(abi.defaultLookup().lookup("strcat").get(),
+        final static MethodHandle strcat = abi.downcallHandle(abi.defaultLookup().find("strcat").get(),
                 FunctionDescriptor.of(C_POINTER, C_POINTER, C_POINTER));
 
-        final static MethodHandle strcmp = abi.downcallHandle(abi.defaultLookup().lookup("strcmp").get(),
+        final static MethodHandle strcmp = abi.downcallHandle(abi.defaultLookup().find("strcmp").get(),
                 FunctionDescriptor.of(C_INT, C_POINTER, C_POINTER));
 
-        final static MethodHandle puts = abi.downcallHandle(abi.defaultLookup().lookup("puts").get(),
+        final static MethodHandle puts = abi.downcallHandle(abi.defaultLookup().find("puts").get(),
                 FunctionDescriptor.of(C_INT, C_POINTER));
 
-        final static MethodHandle strlen = abi.downcallHandle(abi.defaultLookup().lookup("strlen").get(),
+        final static MethodHandle strlen = abi.downcallHandle(abi.defaultLookup().find("strlen").get(),
                 FunctionDescriptor.of(C_INT, C_POINTER));
 
-        final static MethodHandle gmtime = abi.downcallHandle(abi.defaultLookup().lookup("gmtime").get(),
+        final static MethodHandle gmtime = abi.downcallHandle(abi.defaultLookup().find("gmtime").get(),
                 FunctionDescriptor.of(C_POINTER, C_POINTER));
 
-        final static MethodHandle qsort = abi.downcallHandle(abi.defaultLookup().lookup("qsort").get(),
+        final static MethodHandle qsort = abi.downcallHandle(abi.defaultLookup().find("qsort").get(),
                 FunctionDescriptor.ofVoid(C_POINTER, C_LONG_LONG, C_LONG_LONG, C_POINTER));
 
         final static FunctionDescriptor qsortComparFunction = FunctionDescriptor.of(C_INT, C_POINTER, C_POINTER);
 
         final static MethodHandle qsortCompar;
 
-        final static MethodHandle rand = abi.downcallHandle(abi.defaultLookup().lookup("rand").get(),
+        final static MethodHandle rand = abi.downcallHandle(abi.defaultLookup().find("rand").get(),
                 FunctionDescriptor.of(C_INT));
 
-        final static MethodHandle vprintf = abi.downcallHandle(abi.defaultLookup().lookup("vprintf").get(),
+        final static MethodHandle vprintf = abi.downcallHandle(abi.defaultLookup().find("vprintf").get(),
                 FunctionDescriptor.of(C_INT, C_POINTER, C_POINTER));
 
-        final static MemorySegment printfAddr = abi.defaultLookup().lookup("printf").get();
+        final static MemorySegment printfAddr = abi.defaultLookup().find("printf").get();
 
         final static FunctionDescriptor printfBase = FunctionDescriptor.of(C_INT, C_POINTER);
 

--- a/test/jdk/java/foreign/TestClassLoaderFindNative.java
+++ b/test/jdk/java/foreign/TestClassLoaderFindNative.java
@@ -49,18 +49,18 @@ public class TestClassLoaderFindNative {
 
     @Test
     public void testSimpleLookup() {
-        assertFalse(SymbolLookup.loaderLookup().lookup("f").isEmpty());
+        assertFalse(SymbolLookup.loaderLookup().find("f").isEmpty());
     }
 
     @Test
     public void testInvalidSymbolLookup() {
-        assertTrue(SymbolLookup.loaderLookup().lookup("nonExistent").isEmpty());
+        assertTrue(SymbolLookup.loaderLookup().find("nonExistent").isEmpty());
     }
 
     @Test
     public void testVariableSymbolLookup() {
         MemorySegment segment = MemorySegment.ofAddress(
-                SymbolLookup.loaderLookup().lookup("c").get().address(),
+                SymbolLookup.loaderLookup().find("c").get().address(),
                 ValueLayout.JAVA_INT.byteSize(),
                 MemorySession.global());
         assertEquals(segment.get(JAVA_BYTE, 0), 42);

--- a/test/jdk/java/foreign/TestFallbackLookup.java
+++ b/test/jdk/java/foreign/TestFallbackLookup.java
@@ -38,6 +38,6 @@ public class TestFallbackLookup {
     void testBadSystemLookupRequest() {
         // we request a Linker, forcing OS name to be "Windows". This should trigger an exception when
         // attempting to load a non-existent ucrtbase.dll. Make sure that no error is generated at this stage.
-        assertTrue(Linker.nativeLinker().defaultLookup().lookup("nonExistentSymbol").isEmpty());
+        assertTrue(Linker.nativeLinker().defaultLookup().find("nonExistentSymbol").isEmpty());
     }
 }

--- a/test/jdk/java/foreign/TestNULLAddress.java
+++ b/test/jdk/java/foreign/TestNULLAddress.java
@@ -65,7 +65,7 @@ public class TestNULLAddress {
 
     @Test
     public void testNULLReturn_unbounded() throws Throwable {
-        MethodHandle mh = LINKER.downcallHandle(SymbolLookup.loaderLookup().lookup("get_null").get(),
+        MethodHandle mh = LINKER.downcallHandle(SymbolLookup.loaderLookup().find("get_null").get(),
                 FunctionDescriptor.of(ValueLayout.ADDRESS.asUnbounded()));
         MemorySegment ret = (MemorySegment)mh.invokeExact();
         assertTrue(ret.equals(MemorySegment.NULL));
@@ -73,7 +73,7 @@ public class TestNULLAddress {
 
     @Test
     public void testNULLReturn_plain() throws Throwable {
-        MethodHandle mh = LINKER.downcallHandle(SymbolLookup.loaderLookup().lookup("get_null").get(),
+        MethodHandle mh = LINKER.downcallHandle(SymbolLookup.loaderLookup().find("get_null").get(),
                 FunctionDescriptor.of(ValueLayout.ADDRESS));
         MemorySegment ret = (MemorySegment)mh.invokeExact();
         assertTrue(ret.equals(MemorySegment.NULL));

--- a/test/jdk/java/foreign/loaderLookup/TestLoaderLookupJNI.java
+++ b/test/jdk/java/foreign/loaderLookup/TestLoaderLookupJNI.java
@@ -42,10 +42,10 @@ public class TestLoaderLookupJNI {
     @Test
     void testLoaderLookupJNI() {
         SymbolLookup loaderLookup = SymbolLookup.loaderLookup();
-        assertTrue(loaderLookup.lookup("Java_TestLoaderLookupJNI_loaderLookup0").isPresent());
+        assertTrue(loaderLookup.find("Java_TestLoaderLookupJNI_loaderLookup0").isPresent());
         // now try calling via JNI
         loaderLookup = loaderLookup0(); // lookup backed by application loader, so can see same symbols
-        assertTrue(loaderLookup.lookup("Java_TestLoaderLookupJNI_loaderLookup0").isPresent());
+        assertTrue(loaderLookup.find("Java_TestLoaderLookupJNI_loaderLookup0").isPresent());
     }
 
     static native SymbolLookup loaderLookup0();

--- a/test/jdk/java/foreign/loaderLookup/lookup/Lookup.java
+++ b/test/jdk/java/foreign/loaderLookup/lookup/Lookup.java
@@ -32,6 +32,6 @@ public class Lookup {
     }
 
     public static MemorySegment fooSymbol() {
-        return SymbolLookup.loaderLookup().lookup("foo").get();
+        return SymbolLookup.loaderLookup().find("foo").get();
     }
 }

--- a/test/micro/org/openjdk/bench/java/lang/foreign/CLayouts.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/CLayouts.java
@@ -71,10 +71,10 @@ public class CLayouts {
     private static Linker LINKER = Linker.nativeLinker();
 
     private static final MethodHandle FREE = LINKER.downcallHandle(
-            LINKER.defaultLookup().lookup("free").get(), FunctionDescriptor.ofVoid(ValueLayout.ADDRESS));
+            LINKER.defaultLookup().find("free").get(), FunctionDescriptor.ofVoid(ValueLayout.ADDRESS));
 
     private static final MethodHandle MALLOC = LINKER.downcallHandle(
-            LINKER.defaultLookup().lookup("malloc").get(), FunctionDescriptor.of(ValueLayout.ADDRESS.asUnbounded(), ValueLayout.JAVA_LONG));
+            LINKER.defaultLookup().find("malloc").get(), FunctionDescriptor.of(ValueLayout.ADDRESS.asUnbounded(), ValueLayout.JAVA_LONG));
 
     public static void freeMemory(MemorySegment address) {
         try {

--- a/test/micro/org/openjdk/bench/java/lang/foreign/CallOverheadHelper.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/CallOverheadHelper.java
@@ -93,64 +93,64 @@ public class CallOverheadHelper extends CLayouts {
         System.loadLibrary("CallOverhead");
         SymbolLookup loaderLibs = SymbolLookup.loaderLookup();
         {
-            func_addr = loaderLibs.lookup("func").orElseThrow();
+            func_addr = loaderLibs.find("func").orElseThrow();
             MethodType mt = MethodType.methodType(void.class);
             FunctionDescriptor fd = FunctionDescriptor.ofVoid();
             func_v = abi.downcallHandle(fd);
             func = insertArguments(func_v, 0, func_addr);
         }
         {
-            identity_addr = loaderLibs.lookup("identity").orElseThrow();
+            identity_addr = loaderLibs.find("identity").orElseThrow();
             FunctionDescriptor fd = FunctionDescriptor.of(C_INT, C_INT);
             identity_v = abi.downcallHandle(fd);
             identity = insertArguments(identity_v, 0, identity_addr);
         }
-        identity_struct_addr = loaderLibs.lookup("identity_struct").orElseThrow();
+        identity_struct_addr = loaderLibs.find("identity_struct").orElseThrow();
         identity_struct_v = abi.downcallHandle(
                 FunctionDescriptor.of(POINT_LAYOUT, POINT_LAYOUT));
         identity_struct = insertArguments(identity_struct_v, 0, identity_struct_addr);
 
-        identity_struct_3_addr = loaderLibs.lookup("identity_struct_3").orElseThrow();
+        identity_struct_3_addr = loaderLibs.find("identity_struct_3").orElseThrow();
         identity_struct_3_v = abi.downcallHandle(
                 FunctionDescriptor.of(POINT_LAYOUT, POINT_LAYOUT, POINT_LAYOUT, POINT_LAYOUT));
         identity_struct_3 = insertArguments(identity_struct_3_v, 0, identity_struct_3_addr);
 
-        identity_memory_address_addr = loaderLibs.lookup("identity_memory_address").orElseThrow();
+        identity_memory_address_addr = loaderLibs.find("identity_memory_address").orElseThrow();
         identity_memory_address_v = abi.downcallHandle(
                 FunctionDescriptor.of(C_POINTER, C_POINTER));
         identity_memory_address = insertArguments(identity_memory_address_v, 0, identity_memory_address_addr);
 
-        identity_memory_address_3_addr = loaderLibs.lookup("identity_memory_address_3").orElseThrow();
+        identity_memory_address_3_addr = loaderLibs.find("identity_memory_address_3").orElseThrow();
         identity_memory_address_3_v = abi.downcallHandle(
                 FunctionDescriptor.of(C_POINTER, C_POINTER, C_POINTER, C_POINTER));
         identity_memory_address_3 = insertArguments(identity_memory_address_3_v, 0, identity_memory_address_3_addr);
 
-        args1_addr = loaderLibs.lookup("args1").orElseThrow();
+        args1_addr = loaderLibs.find("args1").orElseThrow();
         args1_v = abi.downcallHandle(
                 FunctionDescriptor.ofVoid(C_LONG_LONG));
         args1 = insertArguments(args1_v, 0, args1_addr);
 
-        args2_addr = loaderLibs.lookup("args2").orElseThrow();
+        args2_addr = loaderLibs.find("args2").orElseThrow();
         args2_v = abi.downcallHandle(
                 FunctionDescriptor.ofVoid(C_LONG_LONG, C_DOUBLE));
         args2 = insertArguments(args2_v, 0, args2_addr);
 
-        args3_addr = loaderLibs.lookup("args3").orElseThrow();
+        args3_addr = loaderLibs.find("args3").orElseThrow();
         args3_v = abi.downcallHandle(
                 FunctionDescriptor.ofVoid(C_LONG_LONG, C_DOUBLE, C_LONG_LONG));
         args3 = insertArguments(args3_v, 0, args3_addr);
 
-        args4_addr = loaderLibs.lookup("args4").orElseThrow();
+        args4_addr = loaderLibs.find("args4").orElseThrow();
         args4_v = abi.downcallHandle(
                 FunctionDescriptor.ofVoid(C_LONG_LONG, C_DOUBLE, C_LONG_LONG, C_DOUBLE));
         args4 = insertArguments(args4_v, 0, args4_addr);
 
-        args5_addr = loaderLibs.lookup("args5").orElseThrow();
+        args5_addr = loaderLibs.find("args5").orElseThrow();
         args5_v = abi.downcallHandle(
                 FunctionDescriptor.ofVoid(C_LONG_LONG, C_DOUBLE, C_LONG_LONG, C_DOUBLE, C_LONG_LONG));
         args5 = insertArguments(args5_v, 0, args5_addr);
 
-        args10_addr = loaderLibs.lookup("args10").orElseThrow();
+        args10_addr = loaderLibs.find("args10").orElseThrow();
         args10_v = abi.downcallHandle(
                 FunctionDescriptor.ofVoid(C_LONG_LONG, C_DOUBLE, C_LONG_LONG, C_DOUBLE, C_LONG_LONG,
                                           C_DOUBLE, C_LONG_LONG, C_DOUBLE, C_LONG_LONG, C_DOUBLE));

--- a/test/micro/org/openjdk/bench/java/lang/foreign/PointerInvoke.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/PointerInvoke.java
@@ -66,9 +66,9 @@ public class PointerInvoke extends CLayouts {
     static {
         Linker abi = Linker.nativeLinker();
         SymbolLookup loaderLibs = SymbolLookup.loaderLookup();
-        F_LONG = abi.downcallHandle(loaderLibs.lookup("func_as_long").get(),
+        F_LONG = abi.downcallHandle(loaderLibs.find("func_as_long").get(),
                 FunctionDescriptor.of(C_INT, C_LONG_LONG));
-        F_PTR = abi.downcallHandle(loaderLibs.lookup("func_as_ptr").get(),
+        F_PTR = abi.downcallHandle(loaderLibs.find("func_as_ptr").get(),
                 FunctionDescriptor.of(C_INT, C_POINTER));
     }
 

--- a/test/micro/org/openjdk/bench/java/lang/foreign/QSort.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/QSort.java
@@ -61,7 +61,7 @@ public class QSort extends CLayouts {
     static final int[] INPUT = { 5, 3, 2, 7, 8, 12, 1, 7 };
     static final MemorySegment INPUT_SEGMENT;
 
-    static MemorySegment qsort_addr = abi.defaultLookup().lookup("qsort").get();
+    static MemorySegment qsort_addr = abi.defaultLookup().find("qsort").get();
 
     static {
         INPUT_SEGMENT = MemorySegment.allocateNative(MemoryLayout.sequenceLayout(INPUT.length, JAVA_INT), MemorySession.global());
@@ -76,7 +76,7 @@ public class QSort extends CLayouts {
                     FunctionDescriptor.ofVoid(C_POINTER, C_LONG_LONG, C_LONG_LONG, C_POINTER)
             );
             System.loadLibrary("QSort");
-            native_compar = SymbolLookup.loaderLookup().lookup("compar").orElseThrow();
+            native_compar = SymbolLookup.loaderLookup().find("compar").orElseThrow();
             panama_upcall_compar = abi.upcallStub(
                     lookup().findStatic(QSort.class,
                             "panama_upcall_compar",

--- a/test/micro/org/openjdk/bench/java/lang/foreign/StrLenTest.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/StrLenTest.java
@@ -73,7 +73,7 @@ public class StrLenTest extends CLayouts {
 
     static {
         Linker abi = Linker.nativeLinker();
-        STRLEN = abi.downcallHandle(abi.defaultLookup().lookup("strlen").get(),
+        STRLEN = abi.downcallHandle(abi.defaultLookup().find("strlen").get(),
                 FunctionDescriptor.of(C_INT, C_POINTER));
     }
 

--- a/test/micro/org/openjdk/bench/java/lang/foreign/Upcalls.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/Upcalls.java
@@ -122,7 +122,7 @@ public class Upcalls extends CLayouts {
 
     static MethodHandle linkFunc(String name, FunctionDescriptor baseDesc) {
         return abi.downcallHandle(
-                SymbolLookup.loaderLookup().lookup(name).orElseThrow(),
+                SymbolLookup.loaderLookup().find(name).orElseThrow(),
                 baseDesc.appendArgumentLayouts(C_POINTER)
         );
     }

--- a/test/micro/org/openjdk/bench/java/lang/foreign/VaList.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/VaList.java
@@ -57,9 +57,9 @@ public class VaList extends CLayouts {
 
     static {
         SymbolLookup loaderLibs = SymbolLookup.loaderLookup();
-        MH_ellipsis = linker.downcallHandle(loaderLibs.lookup("ellipsis").get(),
+        MH_ellipsis = linker.downcallHandle(loaderLibs.find("ellipsis").get(),
                 FunctionDescriptor.ofVoid(C_INT).asVariadic(C_INT, C_DOUBLE, C_LONG_LONG));
-        MH_vaList = linker.downcallHandle(loaderLibs.lookup("vaList").get(),
+        MH_vaList = linker.downcallHandle(loaderLibs.find("vaList").get(),
                 FunctionDescriptor.ofVoid(C_INT, C_POINTER));
     }
 

--- a/test/micro/org/openjdk/bench/java/lang/foreign/points/support/PanamaPoint.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/points/support/PanamaPoint.java
@@ -52,11 +52,11 @@ public class PanamaPoint extends CLayouts implements AutoCloseable {
         System.loadLibrary("Point");
         SymbolLookup loaderLibs = SymbolLookup.loaderLookup();
         MH_distance = abi.downcallHandle(
-                loaderLibs.lookup("distance").get(),
+                loaderLibs.find("distance").get(),
                 FunctionDescriptor.of(C_DOUBLE, LAYOUT, LAYOUT)
         );
         MH_distance_ptrs = abi.downcallHandle(
-                loaderLibs.lookup("distance_ptrs").get(),
+                loaderLibs.find("distance_ptrs").get(),
                 FunctionDescriptor.of(C_DOUBLE, C_POINTER, C_POINTER)
         );
     }


### PR DESCRIPTION
This simple patch changes the name of SymbolLookup::lookup to SymbolLookup::find.

This change was suggested during many rounds of API reviews, as the term "lookup" can refer to both a noun and a verb and, sadly, the API is using both forms.

Since we already have a precedent in the JDK for using Lookup in the noun form (e.g. method handle lookup), I have decided to rename the method to something more neutral like "find", which, coincidentally is also the term we settled on in the javadoc in order to avoid confusion.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8293495](https://bugs.openjdk.org/browse/JDK-8293495): Revisit name of SymbolLookup::lookup


### Reviewers
 * [Athijegannathan Sundararajan](https://openjdk.org/census#sundar) (@sundararajana - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/panama-foreign pull/716/head:pull/716` \
`$ git checkout pull/716`

Update a local copy of the PR: \
`$ git checkout pull/716` \
`$ git pull https://git.openjdk.org/panama-foreign pull/716/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 716`

View PR using the GUI difftool: \
`$ git pr show -t 716`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/panama-foreign/pull/716.diff">https://git.openjdk.org/panama-foreign/pull/716.diff</a>

</details>
