### PR TITLE
8292037: Consider moving Linker::methodType as FunctionDescriptor::toMethodType

### DIFF
--- a/src/java.base/share/classes/java/lang/foreign/FunctionDescriptor.java
+++ b/src/java.base/share/classes/java/lang/foreign/FunctionDescriptor.java
@@ -25,6 +25,7 @@
 package java.lang.foreign;
 
 import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodType;
 import java.util.*;
 
 import jdk.internal.foreign.FunctionDescriptorImpl;
@@ -93,6 +94,22 @@ public sealed interface FunctionDescriptor permits FunctionDescriptorImpl {
      * @return the new function descriptor.
      */
     FunctionDescriptor dropReturnLayout();
+
+    /**
+     * Returns the method type consisting of the carrier types of the layouts in this function descriptor.
+     * <p>
+     * The carrier type of a layout is determined as follows:
+     * <ul>
+     * <li>If the layout is a {@link ValueLayout} the carrier type is determined through {@link ValueLayout#carrier()}.</li>
+     * <li>If the layout is a {@link GroupLayout} the carrier type is {@link MemorySegment}.</li>
+     * <li>If the layout is a {@link PaddingLayout}, or {@link SequenceLayout} an {@link IllegalArgumentException} is thrown.</li>
+     * </ul>
+     *
+     * @return the method type consisting of the carrier types of the layouts in this function descriptor
+     * @throws IllegalArgumentException if one or more layouts in the function descriptor are not supported
+     * (e.g. if they are sequence layouts or padding layouts).
+     */
+    MethodType carrierMethodType();
 
     /**
      * Creates a specialized variadic function descriptor, by appending given variadic layouts to this

--- a/src/java.base/share/classes/java/lang/foreign/FunctionDescriptor.java
+++ b/src/java.base/share/classes/java/lang/foreign/FunctionDescriptor.java
@@ -101,15 +101,15 @@ public sealed interface FunctionDescriptor permits FunctionDescriptorImpl {
      * The carrier type of a layout is determined as follows:
      * <ul>
      * <li>If the layout is a {@link ValueLayout} the carrier type is determined through {@link ValueLayout#carrier()}.</li>
-     * <li>If the layout is a {@link GroupLayout}, or {@link SequenceLayout} the carrier type is {@link MemorySegment}.</li>
-     * <li>If the layout is a {@link PaddingLayout} an {@link IllegalArgumentException} is thrown.</li>
+     * <li>If the layout is a {@link GroupLayout} the carrier type is {@link MemorySegment}.</li>
+     * <li>If the layout is a {@link PaddingLayout}, or {@link SequenceLayout} an {@link IllegalArgumentException} is thrown.</li>
      * </ul>
      *
      * @return the method type consisting of the carrier types of the layouts in this function descriptor
-     * @throws IllegalArgumentException if one or more layouts in the function descriptor are not supported
-     * (e.g. if they are sequence layouts or padding layouts).
+     * @throws IllegalArgumentException if one or more layouts in the function descriptor can not be mapped to carrier
+     *                                  types (e.g. if they are sequence layouts or padding layouts).
      */
-    MethodType carrierMethodType();
+    MethodType toMethodType();
 
     /**
      * Creates a specialized variadic function descriptor, by appending given variadic layouts to this

--- a/src/java.base/share/classes/java/lang/foreign/FunctionDescriptor.java
+++ b/src/java.base/share/classes/java/lang/foreign/FunctionDescriptor.java
@@ -101,8 +101,8 @@ public sealed interface FunctionDescriptor permits FunctionDescriptorImpl {
      * The carrier type of a layout is determined as follows:
      * <ul>
      * <li>If the layout is a {@link ValueLayout} the carrier type is determined through {@link ValueLayout#carrier()}.</li>
-     * <li>If the layout is a {@link GroupLayout} the carrier type is {@link MemorySegment}.</li>
-     * <li>If the layout is a {@link PaddingLayout}, or {@link SequenceLayout} an {@link IllegalArgumentException} is thrown.</li>
+     * <li>If the layout is a {@link GroupLayout}, or {@link SequenceLayout} the carrier type is {@link MemorySegment}.</li>
+     * <li>If the layout is a {@link PaddingLayout} an {@link IllegalArgumentException} is thrown.</li>
      * </ul>
      *
      * @return the method type consisting of the carrier types of the layouts in this function descriptor

--- a/src/java.base/share/classes/java/lang/foreign/Linker.java
+++ b/src/java.base/share/classes/java/lang/foreign/Linker.java
@@ -32,7 +32,6 @@ import jdk.internal.reflect.CallerSensitive;
 import jdk.internal.reflect.Reflection;
 
 import java.lang.invoke.MethodHandle;
-import java.lang.invoke.MethodType;
 
 /**
  * A linker provides access to foreign functions from Java code, and access to Java code from foreign functions.
@@ -67,7 +66,7 @@ import java.lang.invoke.MethodType;
  * when complete, a downcall method handle, that is, a method handle that can be used to invoke the target foreign function.
  * <p>
  * The Java {@linkplain java.lang.invoke.MethodType method type} associated with the returned method handle is
- * {@linkplain FunctionDescriptor#carrierMethodType() derived} from the argument and return layouts in the function descriptor.
+ * {@linkplain FunctionDescriptor#toMethodType() derived} from the argument and return layouts in the function descriptor.
  * More specifically, given each layout {@code L} in the function descriptor, a corresponding carrier {@code C} is inferred,
  * as described below:
  * <ul>
@@ -92,7 +91,7 @@ import java.lang.invoke.MethodType;
  * handle and a function descriptor; in this case, the set of memory layouts in the function descriptor
  * specify the signature of the function pointer associated with the upcall stub.
  * <p>
- * The type of the provided method handle has to {@linkplain FunctionDescriptor#carrierMethodType() match} the Java
+ * The type of the provided method handle has to {@linkplain FunctionDescriptor#toMethodType() match} the Java
  * {@linkplain java.lang.invoke.MethodType method type} associated with the upcall stub, which is derived from the argument
  * and return layouts in the function descriptor. More specifically, given each layout {@code L} in the function descriptor,
  * a corresponding carrier {@code C} is inferred, as described below:

--- a/src/java.base/share/classes/java/lang/foreign/Linker.java
+++ b/src/java.base/share/classes/java/lang/foreign/Linker.java
@@ -67,7 +67,7 @@ import java.lang.invoke.MethodType;
  * when complete, a downcall method handle, that is, a method handle that can be used to invoke the target foreign function.
  * <p>
  * The Java {@linkplain java.lang.invoke.MethodType method type} associated with the returned method handle is
- * {@linkplain #methodType(FunctionDescriptor) derived} from the argument and return layouts in the function descriptor.
+ * {@linkplain FunctionDescriptor#carrierMethodType() derived} from the argument and return layouts in the function descriptor.
  * More specifically, given each layout {@code L} in the function descriptor, a corresponding carrier {@code C} is inferred,
  * as described below:
  * <ul>
@@ -92,7 +92,7 @@ import java.lang.invoke.MethodType;
  * handle and a function descriptor; in this case, the set of memory layouts in the function descriptor
  * specify the signature of the function pointer associated with the upcall stub.
  * <p>
- * The type of the provided method handle has to {@linkplain #methodType(FunctionDescriptor) match} the Java
+ * The type of the provided method handle has to {@linkplain FunctionDescriptor#carrierMethodType() match} the Java
  * {@linkplain java.lang.invoke.MethodType method type} associated with the upcall stub, which is derived from the argument
  * and return layouts in the function descriptor. More specifically, given each layout {@code L} in the function descriptor,
  * a corresponding carrier {@code C} is inferred, as described below:
@@ -283,14 +283,4 @@ public sealed interface Linker permits AbstractLinker {
      * @return a symbol lookup for symbols in a set of commonly used libraries.
      */
     SymbolLookup defaultLookup();
-
-    /**
-     * {@return the linker method handle {@linkplain MethodType type} associated with the given function descriptor}
-     * @param functionDescriptor a function descriptor.
-     * @throws IllegalArgumentException if one or more layouts in the function descriptor are not supported
-     * (e.g. if they are sequence layouts or padding layouts).
-     */
-    static MethodType methodType(FunctionDescriptor functionDescriptor) {
-        return SharedUtils.inferMethodType(functionDescriptor);
-    }
 }

--- a/src/java.base/share/classes/java/lang/foreign/package-info.java
+++ b/src/java.base/share/classes/java/lang/foreign/package-info.java
@@ -211,7 +211,7 @@
  *
  * As before, we need to create a {@link java.lang.foreign.FunctionDescriptor} instance, this time describing the signature
  * of the function pointer we want to create. The descriptor can be used to
- * {@linkplain java.lang.foreign.Linker#methodType(java.lang.foreign.FunctionDescriptor) derive} a method type
+ * {@linkplain java.lang.foreign.FunctionDescriptor#carrierMethodType() derive} a method type
  * that can be used to look up the method handle for {@code IntComparator.intCompare}.
  * <p>
  * Now that we have a method handle instance, we can turn it into a fresh function pointer,

--- a/src/java.base/share/classes/java/lang/foreign/package-info.java
+++ b/src/java.base/share/classes/java/lang/foreign/package-info.java
@@ -211,7 +211,7 @@
  *
  * As before, we need to create a {@link java.lang.foreign.FunctionDescriptor} instance, this time describing the signature
  * of the function pointer we want to create. The descriptor can be used to
- * {@linkplain java.lang.foreign.FunctionDescriptor#carrierMethodType() derive} a method type
+ * {@linkplain java.lang.foreign.FunctionDescriptor#toMethodType() derive} a method type
  * that can be used to look up the method handle for {@code IntComparator.intCompare}.
  * <p>
  * Now that we have a method handle instance, we can turn it into a fresh function pointer,

--- a/src/java.base/share/classes/jdk/internal/foreign/FunctionDescriptorImpl.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/FunctionDescriptorImpl.java
@@ -25,6 +25,7 @@
 package jdk.internal.foreign;
 
 import java.lang.foreign.*;
+import java.lang.invoke.MethodType;
 import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -134,6 +135,26 @@ public sealed class FunctionDescriptorImpl implements FunctionDescriptor {
      */
     public FunctionDescriptorImpl dropReturnLayout() {
         return new FunctionDescriptorImpl(null, argLayouts);
+    }
+
+    private static Class<?> carrierTypeFor(MemoryLayout layout) {
+        if (layout instanceof ValueLayout valueLayout) {
+            return valueLayout.carrier();
+        } else if (layout instanceof GroupLayout) {
+            return MemorySegment.class;
+        } else {
+            throw new IllegalArgumentException("Unsupported layout: " + layout);
+        }
+    }
+
+    @Override
+    public MethodType carrierMethodType() {
+        Class<?> returnValue = resLayout != null ? carrierTypeFor(resLayout) : void.class;
+        Class<?>[] argCarriers = new Class<?>[argLayouts.size()];
+        for (int i = 0; i < argCarriers.length; i++) {
+            argCarriers[i] = carrierTypeFor(argLayouts.get(i));
+        }
+        return MethodType.methodType(returnValue, argCarriers);
     }
 
     /**

--- a/src/java.base/share/classes/jdk/internal/foreign/FunctionDescriptorImpl.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/FunctionDescriptorImpl.java
@@ -140,7 +140,7 @@ public sealed class FunctionDescriptorImpl implements FunctionDescriptor {
     private static Class<?> carrierTypeFor(MemoryLayout layout) {
         if (layout instanceof ValueLayout valueLayout) {
             return valueLayout.carrier();
-        } else if (layout instanceof GroupLayout || layout instanceof SequenceLayout) {
+        } else if (layout instanceof GroupLayout) {
             return MemorySegment.class;
         } else {
             throw new IllegalArgumentException("Unsupported layout: " + layout);
@@ -148,7 +148,7 @@ public sealed class FunctionDescriptorImpl implements FunctionDescriptor {
     }
 
     @Override
-    public MethodType carrierMethodType() {
+    public MethodType toMethodType() {
         Class<?> returnValue = resLayout != null ? carrierTypeFor(resLayout) : void.class;
         Class<?>[] argCarriers = new Class<?>[argLayouts.size()];
         for (int i = 0; i < argCarriers.length; i++) {

--- a/src/java.base/share/classes/jdk/internal/foreign/FunctionDescriptorImpl.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/FunctionDescriptorImpl.java
@@ -140,7 +140,7 @@ public sealed class FunctionDescriptorImpl implements FunctionDescriptor {
     private static Class<?> carrierTypeFor(MemoryLayout layout) {
         if (layout instanceof ValueLayout valueLayout) {
             return valueLayout.carrier();
-        } else if (layout instanceof GroupLayout) {
+        } else if (layout instanceof GroupLayout || layout instanceof SequenceLayout) {
             return MemorySegment.class;
         } else {
             throw new IllegalArgumentException("Unsupported layout: " + layout);

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/AbstractLinker.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/AbstractLinker.java
@@ -48,7 +48,7 @@ public abstract sealed class AbstractLinker implements Linker permits LinuxAArch
         Objects.requireNonNull(function);
 
         return DOWNCALL_CACHE.get(function, fd -> {
-            MethodType type = SharedUtils.inferMethodType(fd);
+            MethodType type = fd.carrierMethodType();
             MethodHandle handle = arrangeDowncall(type, fd);
             handle = SharedUtils.maybeInsertAllocator(fd, handle);
             return handle;
@@ -63,7 +63,7 @@ public abstract sealed class AbstractLinker implements Linker permits LinuxAArch
         Objects.requireNonNull(function);
         SharedUtils.checkExceptions(target);
 
-        MethodType type = SharedUtils.inferMethodType(function);
+        MethodType type = function.carrierMethodType();
         if (!type.equals(target.type())) {
             throw new IllegalArgumentException("Wrong method handle type: " + target.type());
         }

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/AbstractLinker.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/AbstractLinker.java
@@ -48,7 +48,7 @@ public abstract sealed class AbstractLinker implements Linker permits LinuxAArch
         Objects.requireNonNull(function);
 
         return DOWNCALL_CACHE.get(function, fd -> {
-            MethodType type = fd.carrierMethodType();
+            MethodType type = fd.toMethodType();
             MethodHandle handle = arrangeDowncall(type, fd);
             handle = SharedUtils.maybeInsertAllocator(fd, handle);
             return handle;
@@ -63,7 +63,7 @@ public abstract sealed class AbstractLinker implements Linker permits LinuxAArch
         Objects.requireNonNull(function);
         SharedUtils.checkExceptions(target);
 
-        MethodType type = function.carrierMethodType();
+        MethodType type = function.toMethodType();
         if (!type.equals(target.type())) {
             throw new IllegalArgumentException("Wrong method handle type: " + target.type());
         }

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/SharedUtils.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/SharedUtils.java
@@ -509,23 +509,4 @@ public final class SharedUtils {
             throw new IllegalArgumentException("Unsupported carrier: " + type);
         }
     }
-
-    public static MethodType inferMethodType(FunctionDescriptor descriptor) {
-        MethodType type = MethodType.methodType(descriptor.returnLayout().isPresent() ?
-                carrierFor(descriptor.returnLayout().get()) : void.class);
-        for (MemoryLayout argLayout : descriptor.argumentLayouts()) {
-            type = type.appendParameterTypes(carrierFor(argLayout));
-        }
-        return type;
-    }
-
-    static Class<?> carrierFor(MemoryLayout layout) {
-        if (layout instanceof ValueLayout valueLayout) {
-            return valueLayout.carrier();
-        } else if (layout instanceof GroupLayout) {
-            return MemorySegment.class;
-        } else {
-            throw new IllegalArgumentException("Unsupported layout: " + layout);
-        }
-    }
 }

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/aarch64/TypeClass.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/aarch64/TypeClass.java
@@ -105,10 +105,8 @@ public enum TypeClass {
             return classifyValueType((ValueLayout) type);
         } else if (type instanceof GroupLayout) {
             return classifyStructType(type);
-        } else if (type instanceof SequenceLayout) {
-            return TypeClass.INTEGER;
         } else {
-            throw new IllegalArgumentException("Unhandled type " + type);
+            throw new IllegalArgumentException("Unsupported layout: " + type);
         }
     }
 }

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/x64/sysv/TypeClass.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/x64/sysv/TypeClass.java
@@ -180,7 +180,7 @@ class TypeClass {
             } else if (type instanceof GroupLayout) {
                 return ofStruct((GroupLayout)type);
             } else {
-                throw new IllegalArgumentException("Unhandled type " + type);
+                throw new IllegalArgumentException("Unsupported layout: " + type);
             }
         } catch (UnsupportedOperationException e) {
             System.err.println("Failed to classify layout: " + type);

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/x64/windows/TypeClass.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/x64/windows/TypeClass.java
@@ -85,7 +85,7 @@ enum TypeClass {
         } else if (type instanceof GroupLayout) {
             return classifyStructType(type);
         } else {
-            throw new IllegalArgumentException("Unhandled type " + type);
+            throw new IllegalArgumentException("Unsupported layout: " + type);
         }
     }
 }

--- a/test/jdk/java/foreign/StdLibTest.java
+++ b/test/jdk/java/foreign/StdLibTest.java
@@ -188,7 +188,7 @@ public class StdLibTest extends NativeTestHelper {
             try {
                 //qsort upcall handle
                 qsortCompar = MethodHandles.lookup().findStatic(StdLibTest.StdLibHelper.class, "qsortCompare",
-                        Linker.methodType(qsortComparFunction));
+                        qsortComparFunction.carrierMethodType());
             } catch (ReflectiveOperationException ex) {
                 throw new IllegalStateException(ex);
             }

--- a/test/jdk/java/foreign/StdLibTest.java
+++ b/test/jdk/java/foreign/StdLibTest.java
@@ -188,7 +188,7 @@ public class StdLibTest extends NativeTestHelper {
             try {
                 //qsort upcall handle
                 qsortCompar = MethodHandles.lookup().findStatic(StdLibTest.StdLibHelper.class, "qsortCompare",
-                        qsortComparFunction.carrierMethodType());
+                        qsortComparFunction.toMethodType());
             } catch (ReflectiveOperationException ex) {
                 throw new IllegalStateException(ex);
             }

--- a/test/jdk/java/foreign/TestFunctionDescriptor.java
+++ b/test/jdk/java/foreign/TestFunctionDescriptor.java
@@ -111,10 +111,9 @@ public class TestFunctionDescriptor extends NativeTestHelper {
     public void testCarrierMethodType() {
         FunctionDescriptor fd = FunctionDescriptor.of(C_INT,
                 C_INT,
-                MemoryLayout.structLayout(C_INT, C_INT),
-                MemoryLayout.sequenceLayout(3, C_INT));
-        MethodType cmt = fd.carrierMethodType();
-        assertEquals(cmt, MethodType.methodType(int.class, int.class, MemorySegment.class, MemorySegment.class));
+                MemoryLayout.structLayout(C_INT, C_INT));
+        MethodType cmt = fd.toMethodType();
+        assertEquals(cmt, MethodType.methodType(int.class, int.class, MemorySegment.class));
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class)
@@ -124,6 +123,6 @@ public class TestFunctionDescriptor extends NativeTestHelper {
                 MemoryLayout.structLayout(C_INT, C_INT),
                 MemoryLayout.sequenceLayout(3, C_INT),
                 MemoryLayout.paddingLayout(32));
-        fd.carrierMethodType(); // should throw
+        fd.toMethodType(); // should throw
     }
 }

--- a/test/jdk/java/foreign/TestFunctionDescriptor.java
+++ b/test/jdk/java/foreign/TestFunctionDescriptor.java
@@ -31,6 +31,8 @@
 
 import java.lang.foreign.FunctionDescriptor;
 import java.lang.foreign.MemoryLayout;
+import java.lang.foreign.MemorySegment;
+import java.lang.invoke.MethodType;
 import java.util.List;
 import java.util.Optional;
 import org.testng.annotations.Test;
@@ -103,5 +105,25 @@ public class TestFunctionDescriptor extends NativeTestHelper {
         assertEquals(fd, fd);
         assertNotEquals(fd, fd_va1);
         assertNotEquals(fd, fd_va2);
+    }
+
+    @Test
+    public void testCarrierMethodType() {
+        FunctionDescriptor fd = FunctionDescriptor.of(C_INT,
+                C_INT,
+                MemoryLayout.structLayout(C_INT, C_INT),
+                MemoryLayout.sequenceLayout(3, C_INT));
+        MethodType cmt = fd.carrierMethodType();
+        assertEquals(cmt, MethodType.methodType(int.class, int.class, MemorySegment.class, MemorySegment.class));
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testBadCarrierMethodType() {
+        FunctionDescriptor fd = FunctionDescriptor.of(C_INT,
+                C_INT,
+                MemoryLayout.structLayout(C_INT, C_INT),
+                MemoryLayout.sequenceLayout(3, C_INT),
+                MemoryLayout.paddingLayout(32));
+        fd.carrierMethodType(); // should throw
     }
 }

--- a/test/jdk/java/foreign/TestIllegalLink.java
+++ b/test/jdk/java/foreign/TestIllegalLink.java
@@ -58,12 +58,12 @@ public class TestIllegalLink extends NativeTestHelper {
     public static Object[][] types() {
         return new Object[][]{
             {
-                FunctionDescriptor.of(MemoryLayout.paddingLayout(64)),
-                "Unsupported layout: x64"
+                    FunctionDescriptor.of(MemoryLayout.paddingLayout(64)),
+                    "Unsupported layout: x64"
             },
             {
-                FunctionDescriptor.ofVoid(MemoryLayout.paddingLayout(64)),
-                "Unsupported layout: x64"
+                    FunctionDescriptor.ofVoid(MemoryLayout.paddingLayout(64)),
+                    "Unsupported layout: x64"
             },
             {
                     FunctionDescriptor.of(MemoryLayout.sequenceLayout(2, C_INT)),


### PR DESCRIPTION
This patch moves `Linker::methodType` to `FunctionDescriptor` as `carrierMethodType`.

I went with the name `carrierMethodType` instead of `toMethodType` (as suggested by the JBS issue) since I think it's a bit more descriptive. Please let me know your thoughts.

This issue also suggest adding support for `SequenceLayout` in the linker implementation. I think adding support in FunctionDescriptor could be a good idea, but since passing arrays by value is not supported in C, I feel like we should reject it in the linker implementations we have (which are all C as well). Of course, we could make it work any way by interpreting such cases as a pointer layout instead, but it's a case of being able to do the same thing in multiple ways (which I think can be confusing), and might actually be surprising if someone passes the wrong layout to the linker by accident, but it doesn't get "caught".

I've added support for `SequenceLayout` to `FunctionDescriptor`, but it is still rejected in the type classification logic.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8292037](https://bugs.openjdk.org/browse/JDK-8292037): Consider moving Linker::methodType as FunctionDescriptor::toMethodType


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.org/census#mcimadamore) (@mcimadamore - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/panama-foreign pull/717/head:pull/717` \
`$ git checkout pull/717`

Update a local copy of the PR: \
`$ git checkout pull/717` \
`$ git pull https://git.openjdk.org/panama-foreign pull/717/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 717`

View PR using the GUI difftool: \
`$ git pr show -t 717`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/panama-foreign/pull/717.diff">https://git.openjdk.org/panama-foreign/pull/717.diff</a>

</details>
