### PR TITLE
8293400: Modify static constructors in MemorySegment

### DIFF
--- a/src/java.base/share/classes/java/lang/foreign/MemorySegment.java
+++ b/src/java.base/share/classes/java/lang/foreign/MemorySegment.java
@@ -994,7 +994,7 @@ public sealed interface MemorySegment permits AbstractMemorySegmentImpl {
      * @return a new native memory segment.
      * @throws IllegalArgumentException if {@code bytesSize < 0}.
      * @see ByteBuffer#allocateDirect(int)
-     * @see MemorySession#allocate(long) 
+     * @see MemorySession#allocate(long)
      */
     static MemorySegment allocateNative(long bytesSize) {
         return allocateNative(bytesSize, 1L);
@@ -1020,7 +1020,7 @@ public sealed interface MemorySegment permits AbstractMemorySegmentImpl {
      * @return a new native memory segment.
      * @throws IllegalArgumentException if {@code bytesSize < 0}, {@code alignmentBytes <= 0}, or if {@code alignmentBytes}
      * is not a power of 2.
-     * @see MemorySession#allocate(long, long) 
+     * @see MemorySession#allocate(long, long)
      */
     static MemorySegment allocateNative(long bytesSize, long byteAlignment) {
         Utils.checkAllocationSizeAndAlign(bytesSize, byteAlignment);

--- a/src/java.base/share/classes/java/lang/foreign/MemorySegment.java
+++ b/src/java.base/share/classes/java/lang/foreign/MemorySegment.java
@@ -952,9 +952,10 @@ public sealed interface MemorySegment permits AbstractMemorySegmentImpl {
     /**
      * Creates a native memory segment with the given layout.
      * <p>
-     * The memory segment is automatically freed some unspecified time after it is no longer referenced.
-     * If a memory segment needs to be deterministically freed, use an appropriate memory session from which
-     * {@linkplain MemorySession#allocate(MemoryLayout) allocation} can be made instead.
+     * The returned memory segment is associated with a new {@linkplain MemorySession#openImplicit implicit}
+     * memory session. As such, the native memory region associated with the returned segment is
+     * freed <em>automatically</em>, some unspecified time after it is no longer referenced.
+     * Native segments featuring deterministic deallocation can be obtained using the {@link MemorySession#allocate} method.
      * <p>
      * This is equivalent to the following code:
      * {@snippet lang=java :

--- a/src/java.base/share/classes/java/lang/foreign/MemorySegment.java
+++ b/src/java.base/share/classes/java/lang/foreign/MemorySegment.java
@@ -928,7 +928,6 @@ public sealed interface MemorySegment permits AbstractMemorySegmentImpl {
      * the JVM or, worse, silently result in memory corruption. Thus, clients should refrain from depending on
      * restricted methods, and use safe and supported functionalities, where possible.
      *
-     *
      * @param address the returned segment's base address.
      * @param bytesSize the desired size.
      * @param session the native segment memory session.
@@ -955,7 +954,9 @@ public sealed interface MemorySegment permits AbstractMemorySegmentImpl {
      * The returned memory segment is associated with a new {@linkplain MemorySession#openImplicit implicit}
      * memory session. As such, the native memory region associated with the returned segment is
      * freed <em>automatically</em>, some unspecified time after it is no longer referenced.
-     * Native segments featuring deterministic deallocation can be obtained using the {@link MemorySession#allocate} method.
+     * <p>
+     * Native segments featuring deterministic deallocation can be obtained using the
+     * {@link MemorySession#allocate(MemoryLayout)} method.
      * <p>
      * This is equivalent to the following code:
      * {@snippet lang=java :
@@ -977,9 +978,12 @@ public sealed interface MemorySegment permits AbstractMemorySegmentImpl {
     /**
      * Creates a native memory segment with the given size (in bytes).
      * <p>
-     * The memory segment is automatically freed some unspecified time after it is no longer referenced.
-     * If a memory segment needs to be deterministically freed, use an appropriate memory session from which
-     * {@linkplain MemorySession#allocate(long) allocation } can be made instead.
+     * The returned memory segment is associated with a new {@linkplain MemorySession#openImplicit implicit}
+     * memory session. As such, the native memory region associated with the returned segment is
+     * freed <em>automatically</em>, some unspecified time after it is no longer referenced.
+     * <p>
+     * Native segments featuring deterministic deallocation can be obtained using the
+     * {@link MemorySession#allocate(long)}} method.
      * <p>
      * This is equivalent to the following code:
      * {@snippet lang=java :
@@ -1004,9 +1008,12 @@ public sealed interface MemorySegment permits AbstractMemorySegmentImpl {
     /**
      * Creates a native memory segment with the given size (in bytes) and alignment (in bytes).
      * <p>
-     * The memory segment is automatically freed some unspecified time after it is no longer referenced.
-     * If a memory segment needs to be deterministically freed, use an appropriate memory session from which
-     * {@linkplain MemorySession#allocate(long, long) allocation} can be made instead.
+     * The returned memory segment is associated with a new {@linkplain MemorySession#openImplicit implicit}
+     * memory session. As such, the native memory region associated with the returned segment is
+     * freed <em>automatically</em>, some unspecified time after it is no longer referenced.
+     * <p>
+     * Native segments featuring deterministic deallocation can be obtained using the
+     * {@link MemorySession#allocate(long, long)} method.
      * <p>
      * This is equivalent to the following code:
      * {@snippet lang=java :

--- a/src/java.base/share/classes/java/lang/foreign/MemorySession.java
+++ b/src/java.base/share/classes/java/lang/foreign/MemorySession.java
@@ -219,7 +219,7 @@ public sealed interface MemorySession extends AutoCloseable, SegmentAllocator pe
      * A client is responsible for ensuring that this memory session is closed when the
      * segment is no longer in use. Failure to do so will result in off-heap memory leaks.
      * <p>
-     * The block of off-heap memory associated with the returned native memory segment is initialized to zero.
+     * The off-heap memory associated with the returned native memory segment is initialized to zero.
      *
      * @param bytesSize the size (in bytes) of the off-heap memory block backing the native memory segment.
      * @param bytesAlignment the alignment constraint (in bytes) of the off-heap memory block backing the native memory segment.
@@ -229,6 +229,7 @@ public sealed interface MemorySession extends AutoCloseable, SegmentAllocator pe
      * @throws IllegalStateException if this session is not {@linkplain MemorySession#isAlive() alive}.
      * @throws WrongThreadException if this method is called from a thread other than the thread
      * {@linkplain MemorySession#ownerThread() owning} this session.
+     * @see MemorySegment#allocateNative(long, long)
      */
     @Override
     default MemorySegment allocate(long bytesSize, long bytesAlignment) {

--- a/src/java.base/share/classes/java/lang/foreign/SegmentAllocator.java
+++ b/src/java.base/share/classes/java/lang/foreign/SegmentAllocator.java
@@ -462,8 +462,7 @@ public interface SegmentAllocator {
      */
     static SegmentAllocator implicitAllocator() {
         final class Holder {
-            static final SegmentAllocator IMPLICIT_ALLOCATOR = (size, align) ->
-                    MemorySession.openImplicit().allocate(size, align);
+            static final SegmentAllocator IMPLICIT_ALLOCATOR = MemorySegment::allocateNative;
         }
         return Holder.IMPLICIT_ALLOCATOR;
     }

--- a/src/java.base/share/classes/java/lang/foreign/SegmentAllocator.java
+++ b/src/java.base/share/classes/java/lang/foreign/SegmentAllocator.java
@@ -387,7 +387,7 @@ public interface SegmentAllocator {
      * the given block size {@code B} and the given arena size {@code A}, and the native segments
      * it allocates are associated with the provided memory session.
      * <p>
-     * The allocator arena is first initialized by {@linkplain MemorySegment#allocateNative(long, MemorySession) allocating} a
+     * The allocator arena is first initialized by {@linkplain MemorySession#allocate(long) allocating} a
      * native memory segment {@code S} of size {@code B}. The allocator then responds to allocation requests in one of the following ways:
      * <ul>
      *     <li>if the size of the allocation requests is smaller than the size of {@code S}, and {@code S} has a <em>free</em>
@@ -454,7 +454,8 @@ public interface SegmentAllocator {
      * Returns an allocator which allocates native segments in independent {@linkplain MemorySession#openImplicit() implicit memory sessions}.
      * Equivalent to (but likely more efficient than) the following code:
      * {@snippet lang=java :
-     * SegmentAllocator implicitAllocator = (size, align) -> MemorySegment.allocateNative(size, align, MemorySession.openImplicit());
+     * SegmentAllocator implicitAllocator = (size, align) ->
+     *     MemorySession.openImplicit().allocate(size, align);
      * }
      *
      * @return an allocator which allocates native segments in independent {@linkplain MemorySession#openImplicit() implicit memory sessions}.
@@ -462,7 +463,7 @@ public interface SegmentAllocator {
     static SegmentAllocator implicitAllocator() {
         final class Holder {
             static final SegmentAllocator IMPLICIT_ALLOCATOR = (size, align) ->
-                    MemorySegment.allocateNative(size, align, MemorySession.openImplicit());
+                    MemorySession.openImplicit().allocate(size, align);
         }
         return Holder.IMPLICIT_ALLOCATOR;
     }

--- a/src/java.base/share/classes/java/lang/foreign/package-info.java
+++ b/src/java.base/share/classes/java/lang/foreign/package-info.java
@@ -42,7 +42,7 @@
  * ranging from {@code 0} to {@code 9}, we can use the following code:
  *
  * {@snippet lang=java :
- * MemorySegment segment = MemorySegment.allocateNative(10 * 4, MemorySession.openImplicit());
+ * MemorySegment segment = MemorySegment.allocateNative(10 * 4);
  * for (int i = 0 ; i < 10 ; i++) {
  *     segment.setAtIndex(ValueLayout.JAVA_INT, i, i);
  * }
@@ -74,7 +74,7 @@
  *
  * {@snippet lang=java :
  * try (MemorySession session = MemorySession.openConfined()) {
- *     MemorySegment segment = MemorySegment.allocateNative(10 * 4, session);
+ *     MemorySegment segment = session.allocate(10 * 4);
  *     for (int i = 0 ; i < 10 ; i++) {
  *         segment.setAtIndex(ValueLayout.JAVA_INT, i, i);
  *     }
@@ -119,7 +119,7 @@
  * );
  *
  * try (MemorySession session = MemorySession.openConfined()) {
- *     MemorySegment cString = MemorySegment.allocateNative(5 + 1, session);
+ *     MemorySegment cString = session.allocate(5 + 1);
  *     cString.setUtf8String(0, "Hello");
  *     long len = (long)strlen.invoke(cString); // 5
  * }

--- a/src/java.base/share/classes/jdk/internal/foreign/ArenaAllocator.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/ArenaAllocator.java
@@ -66,7 +66,7 @@ public final class ArenaAllocator implements SegmentAllocator {
             throw new OutOfMemoryError();
         }
         size += allocatedSize;
-        return MemorySegment.allocateNative(bytesSize, bytesAlignment, session);
+        return session.allocate(bytesSize, bytesAlignment);
     }
 
     @Override

--- a/src/java.base/share/classes/jdk/internal/foreign/MemorySessionImpl.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/MemorySessionImpl.java
@@ -134,7 +134,8 @@ public abstract sealed class MemorySessionImpl
 
     @Override
     public MemorySegment allocate(long bytesSize, long bytesAlignment) {
-        return MemorySegment.allocateNative(bytesSize, bytesAlignment, this);
+        Utils.checkAllocationSizeAndAlign(bytesSize, bytesAlignment);
+        return NativeMemorySegmentImpl.makeNativeSegment(bytesSize, bytesAlignment, this);
     }
 
     public abstract void release0();

--- a/test/jdk/java/foreign/CallGeneratorHelper.java
+++ b/test/jdk/java/foreign/CallGeneratorHelper.java
@@ -378,11 +378,11 @@ public class CallGeneratorHelper extends NativeTestHelper {
     @SuppressWarnings("unchecked")
     static Object makeArg(MemoryLayout layout, List<Consumer<Object>> checks, boolean check) throws ReflectiveOperationException {
         if (layout instanceof GroupLayout) {
-            MemorySegment segment = MemorySession.openImplicit().allocate(layout);
+            MemorySegment segment = MemorySegment.allocateNative(layout);
             initStruct(segment, (GroupLayout)layout, checks, check);
             return segment;
         } else if (isPointer(layout)) {
-            MemorySegment segment = MemorySession.openImplicit().allocate(1);
+            MemorySegment segment = MemorySegment.allocateNative(1L);
             if (check) {
                 checks.add(o -> {
                     try {

--- a/test/jdk/java/foreign/CallGeneratorHelper.java
+++ b/test/jdk/java/foreign/CallGeneratorHelper.java
@@ -378,11 +378,11 @@ public class CallGeneratorHelper extends NativeTestHelper {
     @SuppressWarnings("unchecked")
     static Object makeArg(MemoryLayout layout, List<Consumer<Object>> checks, boolean check) throws ReflectiveOperationException {
         if (layout instanceof GroupLayout) {
-            MemorySegment segment = MemorySegment.allocateNative(layout, MemorySession.openImplicit());
+            MemorySegment segment = MemorySession.openImplicit().allocate(layout);
             initStruct(segment, (GroupLayout)layout, checks, check);
             return segment;
         } else if (isPointer(layout)) {
-            MemorySegment segment = MemorySegment.allocateNative(1, MemorySession.openImplicit());
+            MemorySegment segment = MemorySession.openImplicit().allocate(1);
             if (check) {
                 checks.add(o -> {
                     try {

--- a/test/jdk/java/foreign/SafeFunctionAccessTest.java
+++ b/test/jdk/java/foreign/SafeFunctionAccessTest.java
@@ -56,7 +56,7 @@ public class SafeFunctionAccessTest extends NativeTestHelper {
     public void testClosedStruct() throws Throwable {
         MemorySegment segment;
         try (MemorySession session = MemorySession.openConfined()) {
-            segment = MemorySegment.allocateNative(POINT, session);
+            segment = session.allocate(POINT);
         }
         assertFalse(segment.session().isAlive());
         MethodHandle handle = Linker.nativeLinker().downcallHandle(
@@ -73,12 +73,12 @@ public class SafeFunctionAccessTest extends NativeTestHelper {
                 FunctionDescriptor.ofVoid(C_POINTER, C_POINTER, C_POINTER, C_POINTER, C_POINTER, C_POINTER));
         for (int i = 0 ; i < 6 ; i++) {
             MemorySegment[] segments = new MemorySegment[]{
-                    MemorySegment.allocateNative(POINT, MemorySession.openShared()),
-                    MemorySegment.allocateNative(POINT, MemorySession.openShared()),
-                    MemorySegment.allocateNative(POINT, MemorySession.openShared()),
-                    MemorySegment.allocateNative(POINT, MemorySession.openShared()),
-                    MemorySegment.allocateNative(POINT, MemorySession.openShared()),
-                    MemorySegment.allocateNative(POINT, MemorySession.openShared())
+                    MemorySession.openShared().allocate(POINT),
+                    MemorySession.openShared().allocate(POINT),
+                    MemorySession.openShared().allocate(POINT),
+                    MemorySession.openShared().allocate(POINT),
+                    MemorySession.openShared().allocate(POINT),
+                    MemorySession.openShared().allocate(POINT)
             };
             // check liveness
             segments[i].session().close();
@@ -153,7 +153,7 @@ public class SafeFunctionAccessTest extends NativeTestHelper {
                 FunctionDescriptor.ofVoid(C_POINTER, C_POINTER));
 
         try (MemorySession session = MemorySession.openConfined()) {
-            MemorySegment segment = MemorySegment.allocateNative(POINT, session);
+            MemorySegment segment = session.allocate(POINT);
             handle.invokeExact(segment, sessionChecker(session));
         }
     }

--- a/test/jdk/java/foreign/TestAdaptVarHandles.java
+++ b/test/jdk/java/foreign/TestAdaptVarHandles.java
@@ -93,7 +93,7 @@ public class TestAdaptVarHandles {
     @Test
     public void testFilterValue() throws Throwable {
         ValueLayout layout = ValueLayout.JAVA_INT;
-        MemorySegment segment = MemorySession.openImplicit().allocate(layout);
+        MemorySegment segment = MemorySegment.allocateNative(layout);
         VarHandle intHandle = layout.varHandle();
         VarHandle i2SHandle = MethodHandles.filterValue(intHandle, S2I, I2S);
         i2SHandle.set(segment, "1");
@@ -112,7 +112,7 @@ public class TestAdaptVarHandles {
     @Test
     public void testFilterValueComposite() throws Throwable {
         ValueLayout layout = ValueLayout.JAVA_INT;
-        MemorySegment segment = MemorySession.openImplicit().allocate(layout);
+        MemorySegment segment = MemorySegment.allocateNative(layout);
         VarHandle intHandle = layout.varHandle();
         MethodHandle CTX_S2I = MethodHandles.dropArguments(S2I, 0, String.class, String.class);
         VarHandle i2SHandle = MethodHandles.filterValue(intHandle, CTX_S2I, CTX_I2S);
@@ -133,7 +133,7 @@ public class TestAdaptVarHandles {
     @Test
     public void testFilterValueLoose() throws Throwable {
         ValueLayout layout = ValueLayout.JAVA_INT;
-        MemorySegment segment = MemorySession.openImplicit().allocate(layout);
+        MemorySegment segment = MemorySegment.allocateNative(layout);
         VarHandle intHandle = layout.varHandle();
         VarHandle i2SHandle = MethodHandles.filterValue(intHandle, O2I, I2O);
         i2SHandle.set(segment, "1");
@@ -210,7 +210,7 @@ public class TestAdaptVarHandles {
     @Test
     public void testFilterCoordinates() throws Throwable {
         ValueLayout layout = ValueLayout.JAVA_INT;
-        MemorySegment segment = MemorySession.openImplicit().allocate(layout);
+        MemorySegment segment = MemorySegment.allocateNative(layout);
         VarHandle intHandle_longIndex = MethodHandles.filterCoordinates(intHandleIndexed, 0, BASE_ADDR, S2L);
         intHandle_longIndex.set(segment, "0", 1);
         int oldValue = (int)intHandle_longIndex.getAndAdd(segment, "0", 42);
@@ -253,7 +253,7 @@ public class TestAdaptVarHandles {
     @Test
     public void testInsertCoordinates() throws Throwable {
         ValueLayout layout = ValueLayout.JAVA_INT;
-        MemorySegment segment = MemorySession.openImplicit().allocate(layout);
+        MemorySegment segment = MemorySegment.allocateNative(layout);
         VarHandle intHandle_longIndex = MethodHandles.insertCoordinates(intHandleIndexed, 0, segment, 0L);
         intHandle_longIndex.set(1);
         int oldValue = (int)intHandle_longIndex.getAndAdd(42);
@@ -291,7 +291,7 @@ public class TestAdaptVarHandles {
     @Test
     public void testPermuteCoordinates() throws Throwable {
         ValueLayout layout = ValueLayout.JAVA_INT;
-        MemorySegment segment = MemorySession.openImplicit().allocate(layout);
+        MemorySegment segment = MemorySegment.allocateNative(layout);
         VarHandle intHandle_swap = MethodHandles.permuteCoordinates(intHandleIndexed,
                 List.of(long.class, MemorySegment.class), 1, 0);
         intHandle_swap.set(0L, segment, 1);
@@ -330,7 +330,7 @@ public class TestAdaptVarHandles {
     @Test
     public void testCollectCoordinates() throws Throwable {
         ValueLayout layout = ValueLayout.JAVA_INT;
-        MemorySegment segment = MemorySession.openImplicit().allocate(layout);
+        MemorySegment segment = MemorySegment.allocateNative(layout);
         VarHandle intHandle_sum = MethodHandles.collectCoordinates(intHandleIndexed, 1, SUM_OFFSETS);
         intHandle_sum.set(segment, -2L, 2L, 1);
         int oldValue = (int)intHandle_sum.getAndAdd(segment, -2L, 2L, 42);
@@ -373,7 +373,7 @@ public class TestAdaptVarHandles {
     @Test
     public void testDropCoordinates() throws Throwable {
         ValueLayout layout = ValueLayout.JAVA_INT;
-        MemorySegment segment = MemorySession.openImplicit().allocate(layout);
+        MemorySegment segment = MemorySegment.allocateNative(layout);
         VarHandle intHandle_dummy = MethodHandles.dropCoordinates(intHandleIndexed, 1, float.class, String.class);
         intHandle_dummy.set(segment, 1f, "hello", 0L, 1);
         int oldValue = (int)intHandle_dummy.getAndAdd(segment, 1f, "hello", 0L, 42);

--- a/test/jdk/java/foreign/TestAdaptVarHandles.java
+++ b/test/jdk/java/foreign/TestAdaptVarHandles.java
@@ -93,7 +93,7 @@ public class TestAdaptVarHandles {
     @Test
     public void testFilterValue() throws Throwable {
         ValueLayout layout = ValueLayout.JAVA_INT;
-        MemorySegment segment = MemorySegment.allocateNative(layout, MemorySession.openImplicit());
+        MemorySegment segment = MemorySession.openImplicit().allocate(layout);
         VarHandle intHandle = layout.varHandle();
         VarHandle i2SHandle = MethodHandles.filterValue(intHandle, S2I, I2S);
         i2SHandle.set(segment, "1");
@@ -112,7 +112,7 @@ public class TestAdaptVarHandles {
     @Test
     public void testFilterValueComposite() throws Throwable {
         ValueLayout layout = ValueLayout.JAVA_INT;
-        MemorySegment segment = MemorySegment.allocateNative(layout, MemorySession.openImplicit());
+        MemorySegment segment = MemorySession.openImplicit().allocate(layout);
         VarHandle intHandle = layout.varHandle();
         MethodHandle CTX_S2I = MethodHandles.dropArguments(S2I, 0, String.class, String.class);
         VarHandle i2SHandle = MethodHandles.filterValue(intHandle, CTX_S2I, CTX_I2S);
@@ -133,7 +133,7 @@ public class TestAdaptVarHandles {
     @Test
     public void testFilterValueLoose() throws Throwable {
         ValueLayout layout = ValueLayout.JAVA_INT;
-        MemorySegment segment = MemorySegment.allocateNative(layout, MemorySession.openImplicit());
+        MemorySegment segment = MemorySession.openImplicit().allocate(layout);
         VarHandle intHandle = layout.varHandle();
         VarHandle i2SHandle = MethodHandles.filterValue(intHandle, O2I, I2O);
         i2SHandle.set(segment, "1");
@@ -191,7 +191,7 @@ public class TestAdaptVarHandles {
         VarHandle intHandle = ValueLayout.JAVA_INT.varHandle();
         VarHandle vh = MethodHandles.filterValue(intHandle, S2I, I2S_EX);
         try (MemorySession session = MemorySession.openConfined()) {
-            MemorySegment seg = MemorySegment.allocateNative(ValueLayout.JAVA_INT, session);
+            MemorySegment seg = session.allocate(ValueLayout.JAVA_INT);
             vh.set(seg, "42");
             String x = (String) vh.get(seg); // should throw
         }
@@ -202,7 +202,7 @@ public class TestAdaptVarHandles {
         VarHandle intHandle = ValueLayout.JAVA_INT.varHandle();
         VarHandle vh = MethodHandles.filterValue(intHandle, S2I_EX, I2S);
         try (MemorySession session = MemorySession.openConfined()) {
-            MemorySegment seg = MemorySegment.allocateNative(ValueLayout.JAVA_INT, session);
+            MemorySegment seg = session.allocate(ValueLayout.JAVA_INT);
             vh.set(seg, "42"); // should throw
         }
     }
@@ -210,7 +210,7 @@ public class TestAdaptVarHandles {
     @Test
     public void testFilterCoordinates() throws Throwable {
         ValueLayout layout = ValueLayout.JAVA_INT;
-        MemorySegment segment = MemorySegment.allocateNative(layout, MemorySession.openImplicit());
+        MemorySegment segment = MemorySession.openImplicit().allocate(layout);
         VarHandle intHandle_longIndex = MethodHandles.filterCoordinates(intHandleIndexed, 0, BASE_ADDR, S2L);
         intHandle_longIndex.set(segment, "0", 1);
         int oldValue = (int)intHandle_longIndex.getAndAdd(segment, "0", 42);
@@ -253,7 +253,7 @@ public class TestAdaptVarHandles {
     @Test
     public void testInsertCoordinates() throws Throwable {
         ValueLayout layout = ValueLayout.JAVA_INT;
-        MemorySegment segment = MemorySegment.allocateNative(layout, MemorySession.openImplicit());
+        MemorySegment segment = MemorySession.openImplicit().allocate(layout);
         VarHandle intHandle_longIndex = MethodHandles.insertCoordinates(intHandleIndexed, 0, segment, 0L);
         intHandle_longIndex.set(1);
         int oldValue = (int)intHandle_longIndex.getAndAdd(42);
@@ -291,7 +291,7 @@ public class TestAdaptVarHandles {
     @Test
     public void testPermuteCoordinates() throws Throwable {
         ValueLayout layout = ValueLayout.JAVA_INT;
-        MemorySegment segment = MemorySegment.allocateNative(layout, MemorySession.openImplicit());
+        MemorySegment segment = MemorySession.openImplicit().allocate(layout);
         VarHandle intHandle_swap = MethodHandles.permuteCoordinates(intHandleIndexed,
                 List.of(long.class, MemorySegment.class), 1, 0);
         intHandle_swap.set(0L, segment, 1);
@@ -330,7 +330,7 @@ public class TestAdaptVarHandles {
     @Test
     public void testCollectCoordinates() throws Throwable {
         ValueLayout layout = ValueLayout.JAVA_INT;
-        MemorySegment segment = MemorySegment.allocateNative(layout, MemorySession.openImplicit());
+        MemorySegment segment = MemorySession.openImplicit().allocate(layout);
         VarHandle intHandle_sum = MethodHandles.collectCoordinates(intHandleIndexed, 1, SUM_OFFSETS);
         intHandle_sum.set(segment, -2L, 2L, 1);
         int oldValue = (int)intHandle_sum.getAndAdd(segment, -2L, 2L, 42);
@@ -373,7 +373,7 @@ public class TestAdaptVarHandles {
     @Test
     public void testDropCoordinates() throws Throwable {
         ValueLayout layout = ValueLayout.JAVA_INT;
-        MemorySegment segment = MemorySegment.allocateNative(layout, MemorySession.openImplicit());
+        MemorySegment segment = MemorySession.openImplicit().allocate(layout);
         VarHandle intHandle_dummy = MethodHandles.dropCoordinates(intHandleIndexed, 1, float.class, String.class);
         intHandle_dummy.set(segment, 1f, "hello", 0L, 1);
         int oldValue = (int)intHandle_dummy.getAndAdd(segment, 1f, "hello", 0L, 42);

--- a/test/jdk/java/foreign/TestArrays.java
+++ b/test/jdk/java/foreign/TestArrays.java
@@ -107,7 +107,7 @@ public class TestArrays {
 
     @Test(dataProvider = "arrays")
     public void testArrays(Consumer<MemorySegment> init, Consumer<MemorySegment> checker, MemoryLayout layout) {
-        MemorySegment segment = MemorySegment.allocateNative(layout, MemorySession.openImplicit());
+        MemorySegment segment = MemorySession.openImplicit().allocate(layout);
         init.accept(segment);
         assertFalse(segment.isReadOnly());
         checker.accept(segment);
@@ -127,7 +127,7 @@ public class TestArrays {
     public void testBadSize(MemoryLayout layout, Function<MemorySegment, Object> arrayFactory) {
         if (layout.byteSize() == 1) throw new IllegalStateException(); //make it fail
         try (MemorySession session = MemorySession.openConfined()) {
-            MemorySegment segment = MemorySegment.allocateNative(layout.byteSize() + 1, layout.byteSize(), session);
+            MemorySegment segment = session.allocate(layout.byteSize() + 1, layout.byteSize());
             arrayFactory.apply(segment);
         }
     }
@@ -135,7 +135,7 @@ public class TestArrays {
     @Test(dataProvider = "elemLayouts",
             expectedExceptions = IllegalStateException.class)
     public void testArrayFromClosedSegment(MemoryLayout layout, Function<MemorySegment, Object> arrayFactory) {
-        MemorySegment segment = MemorySegment.allocateNative(layout, MemorySession.openConfined());
+        MemorySegment segment = MemorySession.openConfined().allocate(layout);
         segment.session().close();
         arrayFactory.apply(segment);
     }

--- a/test/jdk/java/foreign/TestArrays.java
+++ b/test/jdk/java/foreign/TestArrays.java
@@ -107,7 +107,7 @@ public class TestArrays {
 
     @Test(dataProvider = "arrays")
     public void testArrays(Consumer<MemorySegment> init, Consumer<MemorySegment> checker, MemoryLayout layout) {
-        MemorySegment segment = MemorySession.openImplicit().allocate(layout);
+        MemorySegment segment = MemorySegment.allocateNative(layout);
         init.accept(segment);
         assertFalse(segment.isReadOnly());
         checker.accept(segment);

--- a/test/jdk/java/foreign/TestByteBuffer.java
+++ b/test/jdk/java/foreign/TestByteBuffer.java
@@ -186,7 +186,7 @@ public class TestByteBuffer {
     @Test
     public void testOffheap() {
         try (MemorySession session = MemorySession.openConfined()) {
-            MemorySegment segment = MemorySegment.allocateNative(tuples, session);
+            MemorySegment segment = session.allocate(tuples);
             initTuples(segment, tuples.elementCount());
 
             ByteBuffer bb = segment.asByteBuffer();
@@ -361,7 +361,7 @@ public class TestByteBuffer {
     public void testScopedBuffer(Function<ByteBuffer, Buffer> bufferFactory, @NoInjection Method method, Object[] args) {
         Buffer bb;
         try (MemorySession session = MemorySession.openConfined()) {
-            MemorySegment segment = MemorySegment.allocateNative(bytes, session);
+            MemorySegment segment = session.allocate(bytes);
             bb = bufferFactory.apply(segment.asByteBuffer());
         }
         //outside of session!!
@@ -387,7 +387,7 @@ public class TestByteBuffer {
     public void testScopedBufferAndVarHandle(VarHandle bufferHandle) {
         ByteBuffer bb;
         try (MemorySession session = MemorySession.openConfined()) {
-            MemorySegment segment = MemorySegment.allocateNative(bytes, session);
+            MemorySegment segment = session.allocate(bytes);
             bb = segment.asByteBuffer();
             for (Map.Entry<MethodHandle, Object[]> e : varHandleMembers(bb, bufferHandle).entrySet()) {
                 MethodHandle handle = e.getKey().bindTo(bufferHandle)
@@ -421,7 +421,7 @@ public class TestByteBuffer {
     @Test(dataProvider = "bufferOps")
     public void testDirectBuffer(Function<ByteBuffer, Buffer> bufferFactory, @NoInjection Method method, Object[] args) {
         try (MemorySession session = MemorySession.openConfined()) {
-            MemorySegment segment = MemorySegment.allocateNative(bytes, session);
+            MemorySegment segment = session.allocate(bytes);
             Buffer bb = bufferFactory.apply(segment.asByteBuffer());
             assertTrue(bb.isDirect());
             DirectBuffer directBuffer = ((DirectBuffer)bb);
@@ -434,7 +434,7 @@ public class TestByteBuffer {
     @Test(dataProvider="resizeOps")
     public void testResizeOffheap(Consumer<MemorySegment> checker, Consumer<MemorySegment> initializer, SequenceLayout seq) {
         try (MemorySession session = MemorySession.openConfined()) {
-            MemorySegment segment = MemorySegment.allocateNative(seq, session);
+            MemorySegment segment = session.allocate(seq);
             initializer.accept(segment);
             checker.accept(segment);
         }
@@ -472,7 +472,7 @@ public class TestByteBuffer {
     @Test(dataProvider="resizeOps")
     public void testResizeRoundtripNative(Consumer<MemorySegment> checker, Consumer<MemorySegment> initializer, SequenceLayout seq) {
         try (MemorySession session = MemorySession.openConfined()) {
-            MemorySegment segment = MemorySegment.allocateNative(seq, session);
+            MemorySegment segment = session.allocate(seq);
             initializer.accept(segment);
             MemorySegment second = MemorySegment.ofBuffer(segment.asByteBuffer());
             checker.accept(second);
@@ -483,7 +483,7 @@ public class TestByteBuffer {
     public void testBufferOnClosedSession() {
         MemorySegment leaked;
         try (MemorySession session = MemorySession.openConfined()) {
-            leaked = MemorySegment.allocateNative(bytes, session);
+            leaked = session.allocate(bytes);
         }
         ByteBuffer byteBuffer = leaked.asByteBuffer(); // ok
         byteBuffer.get(); // should throw
@@ -585,7 +585,7 @@ public class TestByteBuffer {
         checkByteArrayAlignment(seq.elementLayout());
         int bytes = (int)seq.byteSize();
         try (MemorySession session = MemorySession.openConfined()) {
-            MemorySegment nativeArray = MemorySegment.allocateNative(bytes, 1, session);
+            MemorySegment nativeArray = session.allocate(bytes, 1);
             MemorySegment heapArray = MemorySegment.ofArray(new byte[bytes]);
             initializer.accept(heapArray);
             nativeArray.copyFrom(heapArray);
@@ -598,7 +598,7 @@ public class TestByteBuffer {
         checkByteArrayAlignment(seq.elementLayout());
         int bytes = (int)seq.byteSize();
         try (MemorySession session = MemorySession.openConfined()) {
-            MemorySegment nativeArray = MemorySegment.allocateNative(seq, session);
+            MemorySegment nativeArray = session.allocate(seq);
             MemorySegment heapArray = MemorySegment.ofArray(new byte[bytes]);
             initializer.accept(nativeArray);
             heapArray.copyFrom(nativeArray);
@@ -670,7 +670,7 @@ public class TestByteBuffer {
     @Test
     public void testRoundTripAccess() {
         try (MemorySession session = MemorySession.openConfined()) {
-            MemorySegment ms = MemorySegment.allocateNative(4, 1, session);
+            MemorySegment ms = session.allocate(4, 1);
             MemorySegment msNoAccess = ms.asReadOnly();
             MemorySegment msRoundTrip = MemorySegment.ofBuffer(msNoAccess.asByteBuffer());
             assertEquals(msNoAccess.isReadOnly(), msRoundTrip.isReadOnly());
@@ -679,7 +679,7 @@ public class TestByteBuffer {
 
     @Test(expectedExceptions = IllegalStateException.class)
     public void testDeadAccessOnClosedBufferSegment() {
-        MemorySegment s1 = MemorySegment.allocateNative(JAVA_INT, MemorySession.openConfined());
+        MemorySegment s1 = MemorySession.openConfined().allocate(JAVA_INT);
         MemorySegment s2 = MemorySegment.ofBuffer(s1.asByteBuffer());
 
         // memory freed
@@ -695,7 +695,7 @@ public class TestByteBuffer {
         MemorySession session;
         try (FileChannel channel = FileChannel.open(tmp.toPath(), StandardOpenOption.READ, StandardOpenOption.WRITE) ;
             MemorySession scp = closeableSessionOrNull(session = sessionSupplier.get())) {
-            MemorySegment segment = MemorySegment.allocateNative(10, 1, session);
+            MemorySegment segment = session.allocate(10, 1);
             for (int i = 0; i < 10; i++) {
                 segment.set(JAVA_BYTE, i, (byte) i);
             }
@@ -715,7 +715,7 @@ public class TestByteBuffer {
         File tmp = File.createTempFile("tmp", "txt");
         tmp.deleteOnExit();
         try (FileChannel channel = FileChannel.open(tmp.toPath(), StandardOpenOption.READ, StandardOpenOption.WRITE)) {
-            MemorySegment segment = MemorySegment.allocateNative(10, sessionSupplier.get());
+            MemorySegment segment = sessionSupplier.get().allocate(10);
             for (int i = 0; i < 10; i++) {
                 segment.set(JAVA_BYTE, i, (byte) i);
             }
@@ -733,7 +733,7 @@ public class TestByteBuffer {
     @Test
     public void buffersAndArraysFromSlices() {
         try (MemorySession session = MemorySession.openShared()) {
-            MemorySegment segment = MemorySegment.allocateNative(16, session);
+            MemorySegment segment = session.allocate(16);
             int newSize = 8;
             var slice = segment.asSlice(4, newSize);
 
@@ -751,7 +751,7 @@ public class TestByteBuffer {
     @Test
     public void viewsFromSharedSegment() {
         try (MemorySession session = MemorySession.openShared()) {
-            MemorySegment segment = MemorySegment.allocateNative(16, session);
+            MemorySegment segment = session.allocate(16);
             var byteBuffer = segment.asByteBuffer();
             byteBuffer.asReadOnlyBuffer();
             byteBuffer.slice(0, 8);
@@ -761,8 +761,8 @@ public class TestByteBuffer {
     @DataProvider(name = "segments")
     public static Object[][] segments() throws Throwable {
         return new Object[][] {
-                { (Supplier<MemorySegment>) () -> MemorySegment.allocateNative(16, MemorySession.openImplicit()) },
-                { (Supplier<MemorySegment>) () -> MemorySegment.allocateNative(16, MemorySession.openConfined()) },
+                { (Supplier<MemorySegment>) () -> MemorySession.openImplicit().allocate(16) },
+                { (Supplier<MemorySegment>) () -> MemorySession.openConfined().allocate(16) },
                 { (Supplier<MemorySegment>) () -> MemorySegment.ofArray(new byte[16]) }
         };
     }
@@ -770,8 +770,8 @@ public class TestByteBuffer {
     @DataProvider(name = "closeableSessions")
     public static Object[][] closeableSessions() {
         return new Object[][] {
-                { (Supplier<MemorySession>) () -> MemorySession.openShared()   },
-                { (Supplier<MemorySession>) () -> MemorySession.openConfined() },
+                { (Supplier<MemorySession>) MemorySession::openShared},
+                { (Supplier<MemorySession>) MemorySession::openConfined},
                 { (Supplier<MemorySession>) () -> MemorySession.openShared(Cleaner.create())   },
                 { (Supplier<MemorySession>) () -> MemorySession.openConfined(Cleaner.create()) },
         };

--- a/test/jdk/java/foreign/TestHandshake.java
+++ b/test/jdk/java/foreign/TestHandshake.java
@@ -68,7 +68,7 @@ public class TestHandshake {
     public void testHandshake(String testName, AccessorFactory accessorFactory) throws InterruptedException {
         for (int it = 0 ; it < ITERATIONS ; it++) {
             MemorySession session = MemorySession.openShared();
-            MemorySegment segment = MemorySegment.allocateNative(SEGMENT_SIZE, 1, session);
+            MemorySegment segment = session.allocate(SEGMENT_SIZE, 1);
             System.out.println("ITERATION " + it);
             ExecutorService accessExecutor = Executors.newCachedThreadPool();
             start.set(System.currentTimeMillis());
@@ -193,7 +193,7 @@ public class TestHandshake {
 
         SegmentMismatchAccessor(int id, MemorySegment segment) {
             super(id, segment);
-            this.copy = MemorySegment.allocateNative(SEGMENT_SIZE, 1, segment.session());
+            this.copy = segment.session().allocate(SEGMENT_SIZE, 1);
             copy.copyFrom(segment);
             copy.set(JAVA_BYTE, ThreadLocalRandom.current().nextInt(SEGMENT_SIZE), (byte)42);
         }

--- a/test/jdk/java/foreign/TestHeapAlignment.java
+++ b/test/jdk/java/foreign/TestHeapAlignment.java
@@ -100,7 +100,7 @@ public class TestHeapAlignment {
         HEAP_FLOAT(MemorySegment.ofArray(new float[2]), 4),
         HEAP_LONG(MemorySegment.ofArray(new long[1]), 8),
         HEAP_DOUBLE(MemorySegment.ofArray(new double[1]), 8),
-        NATIVE(MemorySegment.allocateNative(8, MemorySession.openImplicit()), -1);
+        NATIVE(MemorySession.openImplicit().allocate(8), -1);
 
         final MemorySegment segment;
         final int align;

--- a/test/jdk/java/foreign/TestHeapAlignment.java
+++ b/test/jdk/java/foreign/TestHeapAlignment.java
@@ -100,7 +100,7 @@ public class TestHeapAlignment {
         HEAP_FLOAT(MemorySegment.ofArray(new float[2]), 4),
         HEAP_LONG(MemorySegment.ofArray(new long[1]), 8),
         HEAP_DOUBLE(MemorySegment.ofArray(new double[1]), 8),
-        NATIVE(MemorySession.openImplicit().allocate(8), -1);
+        NATIVE(MemorySegment.allocateNative(8), -1);
 
         final MemorySegment segment;
         final int align;

--- a/test/jdk/java/foreign/TestLayoutPaths.java
+++ b/test/jdk/java/foreign/TestLayoutPaths.java
@@ -434,7 +434,7 @@ public class TestLayoutPaths {
         sliceHandle = sliceHandle.asSpreader(long[].class, indexes.length);
 
         try (MemorySession session = MemorySession.openConfined()) {
-            MemorySegment segment = MemorySegment.allocateNative(layout, session);
+            MemorySegment segment = session.allocate(layout);
             MemorySegment slice = (MemorySegment) sliceHandle.invokeExact(segment, indexes);
             assertEquals(slice.address() - segment.address(), expectedBitOffset / 8);
             assertEquals(slice.byteSize(), selected.byteSize());
@@ -469,7 +469,7 @@ public class TestLayoutPaths {
         }
 
         try (MemorySession session = MemorySession.openConfined()) {
-            MemorySegment segment = MemorySegment.allocateNative(layout, session);
+            MemorySegment segment = session.allocate(layout);
 
             try {
                 sliceHandle.invokeExact(segment, 1); // should work

--- a/test/jdk/java/foreign/TestLayouts.java
+++ b/test/jdk/java/foreign/TestLayouts.java
@@ -53,7 +53,7 @@ public class TestLayouts {
     public void testIndexedSequencePath() {
         MemoryLayout seq = MemoryLayout.sequenceLayout(10, ValueLayout.JAVA_INT);
         try (MemorySession session = MemorySession.openConfined()) {
-            MemorySegment segment = MemorySegment.allocateNative(seq, session);
+            MemorySegment segment = session.allocate(seq);
             VarHandle indexHandle = seq.varHandle(MemoryLayout.PathElement.sequenceElement());
             // init segment
             for (int i = 0 ; i < 10 ; i++) {

--- a/test/jdk/java/foreign/TestMemoryAccess.java
+++ b/test/jdk/java/foreign/TestMemoryAccess.java
@@ -92,7 +92,7 @@ public class TestMemoryAccess {
     private void testAccessInternal(Function<MemorySegment, MemorySegment> viewFactory, MemoryLayout layout, VarHandle handle, Checker checker) {
         MemorySegment outer_segment;
         try (MemorySession session = MemorySession.openConfined()) {
-            MemorySegment segment = viewFactory.apply(MemorySegment.allocateNative(layout, session));
+            MemorySegment segment = viewFactory.apply(session.allocate(layout));
             boolean isRO = segment.isReadOnly();
             try {
                 checker.check(handle, segment);
@@ -124,7 +124,7 @@ public class TestMemoryAccess {
     private void testArrayAccessInternal(Function<MemorySegment, MemorySegment> viewFactory, SequenceLayout seq, VarHandle handle, ArrayChecker checker) {
         MemorySegment outer_segment;
         try (MemorySession session = MemorySession.openConfined()) {
-            MemorySegment segment = viewFactory.apply(MemorySegment.allocateNative(seq, session));
+            MemorySegment segment = viewFactory.apply(session.allocate(seq));
             boolean isRO = segment.isReadOnly();
             try {
                 for (int i = 0; i < seq.elementCount(); i++) {
@@ -193,7 +193,7 @@ public class TestMemoryAccess {
     private void testMatrixAccessInternal(Function<MemorySegment, MemorySegment> viewFactory, SequenceLayout seq, VarHandle handle, MatrixChecker checker) {
         MemorySegment outer_segment;
         try (MemorySession session = MemorySession.openConfined()) {
-            MemorySegment segment = viewFactory.apply(MemorySegment.allocateNative(seq, session));
+            MemorySegment segment = viewFactory.apply(session.allocate(seq));
             boolean isRO = segment.isReadOnly();
             try {
                 for (int i = 0; i < seq.elementCount(); i++) {

--- a/test/jdk/java/foreign/TestMemoryAccessInstance.java
+++ b/test/jdk/java/foreign/TestMemoryAccessInstance.java
@@ -80,7 +80,7 @@ public class TestMemoryAccessInstance {
 
         void test() {
             try (MemorySession session = MemorySession.openConfined()) {
-                MemorySegment segment = MemorySegment.allocateNative(128, session);
+                MemorySegment segment = session.allocate(128);
                 ByteBuffer buffer = segment.asByteBuffer();
                 T t = transform.apply(segment);
                 segmentSetter.set(t, layout, 8, value);
@@ -93,7 +93,7 @@ public class TestMemoryAccessInstance {
         @SuppressWarnings("unchecked")
         void testHyperAligned() {
             try (MemorySession session = MemorySession.openConfined()) {
-                MemorySegment segment = MemorySegment.allocateNative(64, session);
+                MemorySegment segment = session.allocate(64);
                 T t = transform.apply(segment);
                 L alignedLayout = (L)layout.withBitAlignment(layout.byteSize() * 8 * 2);
                 try {

--- a/test/jdk/java/foreign/TestMemoryAlignment.java
+++ b/test/jdk/java/foreign/TestMemoryAlignment.java
@@ -53,7 +53,7 @@ public class TestMemoryAlignment {
         assertEquals(aligned.bitAlignment(), align); //unreasonable alignment here, to make sure access throws
         VarHandle vh = aligned.varHandle();
         try (MemorySession session = MemorySession.openConfined()) {
-            MemorySegment segment = MemorySegment.allocateNative(aligned, session);
+            MemorySegment segment = session.allocate(aligned);
             vh.set(segment, -42);
             int val = (int)vh.get(segment);
             assertEquals(val, -42);
@@ -71,7 +71,7 @@ public class TestMemoryAlignment {
         assertEquals(alignedGroup.bitAlignment(), align);
         VarHandle vh = aligned.varHandle();
         try (MemorySession session = MemorySession.openConfined()) {
-            MemorySegment segment = MemorySegment.allocateNative(alignedGroup, session);
+            MemorySegment segment = session.allocate(alignedGroup);
             vh.set(segment.asSlice(1L), -42);
             assertEquals(align, 8); //this is the only case where access is aligned
         } catch (IllegalArgumentException ex) {
@@ -98,7 +98,7 @@ public class TestMemoryAlignment {
         try {
             VarHandle vh = layout.varHandle(PathElement.sequenceElement());
             try (MemorySession session = MemorySession.openConfined()) {
-                MemorySegment segment = MemorySegment.allocateNative(layout, session);
+                MemorySegment segment = session.allocate(layout);
                 for (long i = 0 ; i < 5 ; i++) {
                     vh.set(segment, i, -42);
                 }
@@ -122,7 +122,7 @@ public class TestMemoryAlignment {
         VarHandle vh_s = g.varHandle(PathElement.groupElement("b"));
         VarHandle vh_i = g.varHandle(PathElement.groupElement("c"));
         try (MemorySession session = MemorySession.openConfined()) {
-            MemorySegment segment = MemorySegment.allocateNative(g, session);
+            MemorySegment segment = session.allocate(g);
             vh_c.set(segment, Byte.MIN_VALUE);
             assertEquals(vh_c.get(segment), Byte.MIN_VALUE);
             vh_s.set(segment, Short.MIN_VALUE);

--- a/test/jdk/java/foreign/TestMismatch.java
+++ b/test/jdk/java/foreign/TestMismatch.java
@@ -280,7 +280,7 @@ public class TestMismatch {
     }
 
     enum SegmentKind {
-        NATIVE(i -> MemorySession.openImplicit().allocate(i)),
+        NATIVE(i -> MemorySegment.allocateNative(i)),
         ARRAY(i -> MemorySegment.ofArray(new byte[i]));
 
         final IntFunction<MemorySegment> segmentFactory;

--- a/test/jdk/java/foreign/TestMismatch.java
+++ b/test/jdk/java/foreign/TestMismatch.java
@@ -172,7 +172,7 @@ public class TestMismatch {
         var s1 = MemorySegment.ofArray(new byte[0]);
         assertEquals(s1.mismatch(s1), -1);
         try (MemorySession session = MemorySession.openConfined()) {
-            var nativeSegment = MemorySegment.allocateNative(4, 4, session);
+            var nativeSegment = session.allocate(4, 4);
             var s2 = nativeSegment.asSlice(0, 0);
             assertEquals(s1.mismatch(s2), -1);
             assertEquals(s2.mismatch(s1), -1);
@@ -184,8 +184,8 @@ public class TestMismatch {
         // skip if not on 64 bits
         if (ValueLayout.ADDRESS.byteSize() > 32) {
             try (MemorySession session = MemorySession.openConfined()) {
-                var s1 = MemorySegment.allocateNative((long) Integer.MAX_VALUE + 10L, 8, session);
-                var s2 = MemorySegment.allocateNative((long) Integer.MAX_VALUE + 10L, 8, session);
+                var s1 = session.allocate((long) Integer.MAX_VALUE + 10L, 8);
+                var s2 = session.allocate((long) Integer.MAX_VALUE + 10L, 8);
                 assertEquals(s1.mismatch(s1), -1);
                 assertEquals(s1.mismatch(s2), -1);
                 assertEquals(s2.mismatch(s1), -1);
@@ -228,8 +228,8 @@ public class TestMismatch {
     public void testClosed() {
         MemorySegment s1, s2;
         try (MemorySession session = MemorySession.openConfined()) {
-            s1 = MemorySegment.allocateNative(4, 1, session);
-            s2 = MemorySegment.allocateNative(4, 1, session);
+            s1 = session.allocate(4, 1);
+            s2 = session.allocate(4, 1);
         }
         assertThrows(ISE, () -> s1.mismatch(s1));
         assertThrows(ISE, () -> s1.mismatch(s2));
@@ -239,7 +239,7 @@ public class TestMismatch {
     @Test
     public void testThreadAccess() throws Exception {
         try (MemorySession session = MemorySession.openConfined()) {
-            var segment = MemorySegment.allocateNative(4, 1, session);
+            var segment = session.allocate(4, 1);
             {
                 AtomicReference<RuntimeException> exception = new AtomicReference<>();
                 Runnable action = () -> {
@@ -280,7 +280,7 @@ public class TestMismatch {
     }
 
     enum SegmentKind {
-        NATIVE(i -> MemorySegment.allocateNative(i, MemorySession.openImplicit())),
+        NATIVE(i -> MemorySession.openImplicit().allocate(i)),
         ARRAY(i -> MemorySegment.ofArray(new byte[i]));
 
         final IntFunction<MemorySegment> segmentFactory;

--- a/test/jdk/java/foreign/TestNative.java
+++ b/test/jdk/java/foreign/TestNative.java
@@ -145,7 +145,7 @@ public class TestNative extends NativeTestHelper {
     @Test(dataProvider="nativeAccessOps")
     public void testNativeAccess(Consumer<MemorySegment> checker, Consumer<MemorySegment> initializer, SequenceLayout seq) {
         try (MemorySession session = MemorySession.openConfined()) {
-            MemorySegment segment = MemorySegment.allocateNative(seq, session);
+            MemorySegment segment = session.allocate(seq);
             initializer.accept(segment);
             checker.accept(segment);
         }
@@ -155,7 +155,7 @@ public class TestNative extends NativeTestHelper {
     public void testNativeCapacity(Function<ByteBuffer, Buffer> bufferFunction, int elemSize) {
         int capacity = (int)doubles.byteSize();
         try (MemorySession session = MemorySession.openConfined()) {
-            MemorySegment segment = MemorySegment.allocateNative(doubles, session);
+            MemorySegment segment = session.allocate(doubles);
             ByteBuffer bb = segment.asByteBuffer();
             Buffer buf = bufferFunction.apply(bb);
             int expected = capacity / elemSize;
@@ -198,7 +198,7 @@ public class TestNative extends NativeTestHelper {
     @Test(expectedExceptions = IllegalArgumentException.class)
     public void testBadResize() {
         try (MemorySession session = MemorySession.openConfined()) {
-            MemorySegment segment = MemorySegment.allocateNative(4, 1, session);
+            MemorySegment segment = session.allocate(4, 1);
             MemorySegment.ofAddress(segment.address(), -1, MemorySession.global());
         }
     }

--- a/test/jdk/java/foreign/TestScopedOperations.java
+++ b/test/jdk/java/foreign/TestScopedOperations.java
@@ -111,7 +111,7 @@ public class TestScopedOperations {
         // session operations
         ScopedOperation.ofScope(session -> session.addCloseAction(() -> {
         }), "MemorySession::addCloseAction");
-        ScopedOperation.ofScope(session -> MemorySegment.allocateNative(100, session), "MemorySegment::allocateNative");
+        ScopedOperation.ofScope(session -> session.allocate(100), "MemorySession::allocate");
         ScopedOperation.ofScope(session -> {
             try (FileChannel fileChannel = FileChannel.open(tempPath, StandardOpenOption.READ, StandardOpenOption.WRITE)) {
                 fileChannel.map(FileChannel.MapMode.READ_WRITE, 0L, 10L, session);
@@ -217,7 +217,7 @@ public class TestScopedOperations {
 
         enum SegmentFactory {
 
-            NATIVE(session -> MemorySegment.allocateNative(10, session)),
+            NATIVE(session -> session.allocate(10)),
             MAPPED(session -> {
                 try (FileChannel fileChannel = FileChannel.open(Path.of("foo.txt"), StandardOpenOption.READ, StandardOpenOption.WRITE)) {
                     return fileChannel.map(FileChannel.MapMode.READ_WRITE, 0L, 10L, session);

--- a/test/jdk/java/foreign/TestSegmentAllocators.java
+++ b/test/jdk/java/foreign/TestSegmentAllocators.java
@@ -202,7 +202,7 @@ public class TestSegmentAllocators {
         SegmentAllocator allocator = new SegmentAllocator() {
             @Override
             public MemorySegment allocate(long bytesSize, long bytesAlignment) {
-                return MemorySession.openImplicit().allocate(bytesSize, bytesAlignment);
+                return MemorySegment.allocateNative(bytesSize, bytesAlignment);
             }
 
             @Override

--- a/test/jdk/java/foreign/TestSegmentAllocators.java
+++ b/test/jdk/java/foreign/TestSegmentAllocators.java
@@ -202,7 +202,7 @@ public class TestSegmentAllocators {
         SegmentAllocator allocator = new SegmentAllocator() {
             @Override
             public MemorySegment allocate(long bytesSize, long bytesAlignment) {
-                return MemorySegment.allocateNative(bytesSize, bytesAlignment, MemorySession.openImplicit());
+                return MemorySession.openImplicit().allocate(bytesSize, bytesAlignment);
             }
 
             @Override
@@ -499,7 +499,7 @@ public class TestSegmentAllocators {
         return new Object[][] {
                 { SegmentAllocator.implicitAllocator() },
                 { SegmentAllocator.newNativeArena(MemorySession.global()) },
-                { SegmentAllocator.prefixAllocator(MemorySegment.allocateNative(10, MemorySession.global())) },
+                { SegmentAllocator.prefixAllocator(MemorySession.global().allocate(10)) },
         };
     }
 }

--- a/test/jdk/java/foreign/TestSegmentCopy.java
+++ b/test/jdk/java/foreign/TestSegmentCopy.java
@@ -144,7 +144,7 @@ public class TestSegmentCopy {
     static class SegmentSlice {
 
         enum Kind {
-            NATIVE(i -> MemorySegment.allocateNative(i, MemorySession.openImplicit())),
+            NATIVE(i -> MemorySession.openImplicit().allocate(i)),
             ARRAY(i -> MemorySegment.ofArray(new byte[i]));
 
             final IntFunction<MemorySegment> segmentFactory;

--- a/test/jdk/java/foreign/TestSegmentCopy.java
+++ b/test/jdk/java/foreign/TestSegmentCopy.java
@@ -144,7 +144,7 @@ public class TestSegmentCopy {
     static class SegmentSlice {
 
         enum Kind {
-            NATIVE(i -> MemorySession.openImplicit().allocate(i)),
+            NATIVE(i -> MemorySegment.allocateNative(i)),
             ARRAY(i -> MemorySegment.ofArray(new byte[i]));
 
             final IntFunction<MemorySegment> segmentFactory;

--- a/test/jdk/java/foreign/TestSegmentOffset.java
+++ b/test/jdk/java/foreign/TestSegmentOffset.java
@@ -79,7 +79,7 @@ public class TestSegmentOffset {
     static class SegmentSlice {
 
         enum Kind {
-            NATIVE(i -> MemorySegment.allocateNative(i, MemorySession.openConfined())),
+            NATIVE(i -> MemorySession.openConfined().allocate(i)),
             ARRAY(i -> MemorySegment.ofArray(new byte[i]));
 
             final IntFunction<MemorySegment> segmentFactory;

--- a/test/jdk/java/foreign/TestSegmentOverlap.java
+++ b/test/jdk/java/foreign/TestSegmentOverlap.java
@@ -61,7 +61,7 @@ public class TestSegmentOverlap {
     @DataProvider(name = "segmentFactories")
     public Object[][] segmentFactories() {
         List<Supplier<MemorySegment>> l = List.of(
-                () -> MemorySegment.allocateNative(16, MemorySession.openConfined()),
+                () -> MemorySession.openConfined().allocate(16),
                 () -> {
                     try (FileChannel fileChannel = FileChannel.open(tempPath, StandardOpenOption.READ, StandardOpenOption.WRITE)) {
                         return fileChannel.map(FileChannel.MapMode.READ_WRITE, 0L, 16L, MemorySession.openConfined());
@@ -131,7 +131,7 @@ public class TestSegmentOverlap {
     }
 
     enum OtherSegmentFactory {
-        NATIVE(() -> MemorySegment.allocateNative(16, MemorySession.openConfined())),
+        NATIVE(() -> MemorySession.openConfined().allocate(16)),
         HEAP(() -> MemorySegment.ofArray(new byte[]{16}));
 
         final Supplier<MemorySegment> factory;

--- a/test/jdk/java/foreign/TestSegments.java
+++ b/test/jdk/java/foreign/TestSegments.java
@@ -50,19 +50,19 @@ public class TestSegments {
 
     @Test(dataProvider = "badSizeAndAlignments", expectedExceptions = IllegalArgumentException.class)
     public void testBadAllocateAlign(long size, long align) {
-        MemorySegment.allocateNative(size, align, MemorySession.openImplicit());
+        MemorySession.openImplicit().allocate(size, align);
     }
 
     @Test
     public void testZeroLengthNativeSegment() {
         try (MemorySession session = MemorySession.openConfined()) {
-            var segment = MemorySegment.allocateNative(0, session);
+            var segment = session.allocate(0);
             assertEquals(segment.byteSize(), 0);
             MemoryLayout seq = MemoryLayout.sequenceLayout(0, JAVA_INT);
-            segment = MemorySegment.allocateNative(seq, session);
+            segment = session.allocate(seq);
             assertEquals(segment.byteSize(), 0);
             assertEquals(segment.address() % seq.byteAlignment(), 0);
-            segment = MemorySegment.allocateNative(0, 4, session);
+            segment = session.allocate(0, 4);
             assertEquals(segment.byteSize(), 0);
             assertEquals(segment.address() % 4, 0);
             MemorySegment rawAddress = MemorySegment.ofAddress(segment.address(), 0, session);
@@ -74,19 +74,19 @@ public class TestSegments {
     @Test(expectedExceptions = { OutOfMemoryError.class,
                                  IllegalArgumentException.class })
     public void testAllocateTooBig() {
-        MemorySegment.allocateNative(Long.MAX_VALUE, MemorySession.openImplicit());
+        MemorySession.openImplicit().allocate(Long.MAX_VALUE);
     }
 
     @Test(expectedExceptions = OutOfMemoryError.class)
     public void testNativeAllocationTooBig() {
-        MemorySegment segment = MemorySegment.allocateNative(1024 * 1024 * 8 * 2, MemorySession.openImplicit()); // 2M
+        MemorySegment segment = MemorySession.openImplicit().allocate(1024 * 1024 * 8 * 2); // 2M
     }
 
     @Test
     public void testNativeSegmentIsZeroed() {
         VarHandle byteHandle = ValueLayout.JAVA_BYTE.arrayElementVarHandle();
         try (MemorySession session = MemorySession.openConfined()) {
-            MemorySegment segment = MemorySegment.allocateNative(1000, 1, session);
+            MemorySegment segment = session.allocate(1000, 1);
             for (long i = 0 ; i < segment.byteSize() ; i++) {
                 assertEquals(0, (byte)byteHandle.get(segment, i));
             }
@@ -97,7 +97,7 @@ public class TestSegments {
     public void testSlices() {
         VarHandle byteHandle = ValueLayout.JAVA_BYTE.arrayElementVarHandle();
         try (MemorySession session = MemorySession.openConfined()) {
-            MemorySegment segment = MemorySegment.allocateNative(10, 1, session);
+            MemorySegment segment = session.allocate(10, 1);
             //init
             for (byte i = 0 ; i < segment.byteSize() ; i++) {
                 byteHandle.set(segment, (long)i, i);
@@ -117,13 +117,13 @@ public class TestSegments {
     @Test
     public void testEqualsOffHeap() {
         try (MemorySession session = MemorySession.openConfined()) {
-            MemorySegment segment = MemorySegment.allocateNative(100, session);
+            MemorySegment segment = session.allocate(100);
             assertEquals(segment, segment.asReadOnly());
             assertEquals(segment, segment.asSlice(0, 100));
             assertNotEquals(segment, segment.asSlice(10, 90));
             assertEquals(segment, segment.asSlice(0, 90));
             assertEquals(segment, MemorySegment.ofAddress(segment.address(), 100, MemorySession.global()));
-            MemorySegment segment2 = MemorySegment.allocateNative(100, session);
+            MemorySegment segment2 = session.allocate(100);
             assertNotEquals(segment, segment2);
         }
     }
@@ -142,7 +142,7 @@ public class TestSegments {
     @Test
     public void testHashCodeOffHeap() {
         try (MemorySession session = MemorySession.openConfined()) {
-            MemorySegment segment = MemorySegment.allocateNative(100, session);
+            MemorySegment segment = session.allocate(100);
             assertEquals(segment.hashCode(), segment.asReadOnly().hashCode());
             assertEquals(segment.hashCode(), segment.asSlice(0, 100).hashCode());
             assertEquals(segment.hashCode(), segment.asSlice(0, 90).hashCode());
@@ -160,22 +160,22 @@ public class TestSegments {
 
     @Test(expectedExceptions = IndexOutOfBoundsException.class)
     public void testSmallSegmentMax() {
-        long offset = (long)Integer.MAX_VALUE + (long)Integer.MAX_VALUE + 2L + 6L; // overflows to 6 when casted to int
-        MemorySegment memorySegment = MemorySegment.allocateNative(10, MemorySession.openImplicit());
+        long offset = (long)Integer.MAX_VALUE + (long)Integer.MAX_VALUE + 2L + 6L; // overflows to 6 when cast to int
+        MemorySegment memorySegment = MemorySession.openImplicit().allocate(10);
         memorySegment.get(JAVA_INT, offset);
     }
 
     @Test(expectedExceptions = IndexOutOfBoundsException.class)
     public void testSmallSegmentMin() {
-        long offset = ((long)Integer.MIN_VALUE * 2L) + 6L; // underflows to 6 when casted to int
-        MemorySegment memorySegment = MemorySegment.allocateNative(10, MemorySession.openImplicit());
+        long offset = ((long)Integer.MIN_VALUE * 2L) + 6L; // underflows to 6 when cast to int
+        MemorySegment memorySegment = MemorySession.openImplicit().allocate(10);
         memorySegment.get(JAVA_INT, offset);
     }
 
     @Test
     public void testSegmentOOBMessage() {
         try {
-            var segment = MemorySegment.allocateNative(10, MemorySession.global());
+            var segment = MemorySession.global().allocate(10);
             segment.getAtIndex(ValueLayout.JAVA_INT, 2);
         } catch (IndexOutOfBoundsException ex) {
             assertTrue(ex.getMessage().contains("Out of bound access"));
@@ -207,12 +207,12 @@ public class TestSegments {
                 () -> MemorySegment.ofArray(new int[] { 1, 2, 3, 4 }),
                 () -> MemorySegment.ofArray(new long[] { 1l, 2l, 3l, 4l } ),
                 () -> MemorySegment.ofArray(new short[] { 1, 2, 3, 4 } ),
-                () -> MemorySegment.allocateNative(4, MemorySession.openImplicit()),
-                () -> MemorySegment.allocateNative(4, 8, MemorySession.openImplicit()),
-                () -> MemorySegment.allocateNative(JAVA_INT, MemorySession.openImplicit()),
-                () -> MemorySegment.allocateNative(4, MemorySession.openImplicit()),
-                () -> MemorySegment.allocateNative(4, 8, MemorySession.openImplicit()),
-                () -> MemorySegment.allocateNative(JAVA_INT, MemorySession.openImplicit())
+                () -> MemorySession.openImplicit().allocate(4),
+                () -> MemorySession.openImplicit().allocate(4, 8),
+                () -> MemorySession.openImplicit().allocate(JAVA_INT),
+                () -> MemorySession.openImplicit().allocate(4),
+                () -> MemorySession.openImplicit().allocate(4, 8),
+                () -> MemorySession.openImplicit().allocate(JAVA_INT)
 
         );
         return l.stream().map(s -> new Object[] { s }).toArray(Object[][]::new);

--- a/test/jdk/java/foreign/TestSegments.java
+++ b/test/jdk/java/foreign/TestSegments.java
@@ -50,7 +50,7 @@ public class TestSegments {
 
     @Test(dataProvider = "badSizeAndAlignments", expectedExceptions = IllegalArgumentException.class)
     public void testBadAllocateAlign(long size, long align) {
-        MemorySession.openImplicit().allocate(size, align);
+        MemorySegment.allocateNative(size, align);
     }
 
     @Test
@@ -74,12 +74,12 @@ public class TestSegments {
     @Test(expectedExceptions = { OutOfMemoryError.class,
                                  IllegalArgumentException.class })
     public void testAllocateTooBig() {
-        MemorySession.openImplicit().allocate(Long.MAX_VALUE);
+        MemorySegment.allocateNative(Long.MAX_VALUE);
     }
 
     @Test(expectedExceptions = OutOfMemoryError.class)
     public void testNativeAllocationTooBig() {
-        MemorySegment segment = MemorySession.openImplicit().allocate(1024 * 1024 * 8 * 2); // 2M
+        MemorySegment segment = MemorySegment.allocateNative(1024L * 1024 * 8 * 2); // 2M
     }
 
     @Test
@@ -161,14 +161,14 @@ public class TestSegments {
     @Test(expectedExceptions = IndexOutOfBoundsException.class)
     public void testSmallSegmentMax() {
         long offset = (long)Integer.MAX_VALUE + (long)Integer.MAX_VALUE + 2L + 6L; // overflows to 6 when cast to int
-        MemorySegment memorySegment = MemorySession.openImplicit().allocate(10);
+        MemorySegment memorySegment = MemorySegment.allocateNative(10);
         memorySegment.get(JAVA_INT, offset);
     }
 
     @Test(expectedExceptions = IndexOutOfBoundsException.class)
     public void testSmallSegmentMin() {
         long offset = ((long)Integer.MIN_VALUE * 2L) + 6L; // underflows to 6 when cast to int
-        MemorySegment memorySegment = MemorySession.openImplicit().allocate(10);
+        MemorySegment memorySegment = MemorySegment.allocateNative(10L);
         memorySegment.get(JAVA_INT, offset);
     }
 
@@ -207,12 +207,12 @@ public class TestSegments {
                 () -> MemorySegment.ofArray(new int[] { 1, 2, 3, 4 }),
                 () -> MemorySegment.ofArray(new long[] { 1l, 2l, 3l, 4l } ),
                 () -> MemorySegment.ofArray(new short[] { 1, 2, 3, 4 } ),
-                () -> MemorySession.openImplicit().allocate(4),
-                () -> MemorySession.openImplicit().allocate(4, 8),
-                () -> MemorySession.openImplicit().allocate(JAVA_INT),
-                () -> MemorySession.openImplicit().allocate(4),
-                () -> MemorySession.openImplicit().allocate(4, 8),
-                () -> MemorySession.openImplicit().allocate(JAVA_INT)
+                () -> MemorySegment.allocateNative(4L),
+                () -> MemorySegment.allocateNative(4L, 8),
+                () -> MemorySegment.allocateNative(JAVA_INT),
+                () -> MemorySegment.allocateNative(4L),
+                () -> MemorySegment.allocateNative(4L, 8),
+                () -> MemorySegment.allocateNative(JAVA_INT)
 
         );
         return l.stream().map(s -> new Object[] { s }).toArray(Object[][]::new);

--- a/test/jdk/java/foreign/TestSharedAccess.java
+++ b/test/jdk/java/foreign/TestSharedAccess.java
@@ -49,7 +49,7 @@ public class TestSharedAccess {
     public void testShared() throws Throwable {
         SequenceLayout layout = MemoryLayout.sequenceLayout(1024, ValueLayout.JAVA_INT);
         try (MemorySession session = MemorySession.openShared()) {
-            MemorySegment s = MemorySegment.allocateNative(layout, session);
+            MemorySegment s = session.allocate(layout);
             for (int i = 0 ; i < layout.elementCount() ; i++) {
                 setInt(s.asSlice(i * 4), 42);
             }
@@ -94,7 +94,7 @@ public class TestSharedAccess {
     @Test
     public void testSharedUnsafe() throws Throwable {
         try (MemorySession session = MemorySession.openShared()) {
-            MemorySegment s = MemorySegment.allocateNative(4, 1, session);
+            MemorySegment s = session.allocate(4, 1);
             setInt(s, 42);
             assertEquals(getInt(s), 42);
             List<Thread> threads = new ArrayList<>();
@@ -121,7 +121,7 @@ public class TestSharedAccess {
         CountDownLatch b = new CountDownLatch(1);
         CompletableFuture<?> r;
         try (MemorySession session = MemorySession.openConfined()) {
-            MemorySegment s1 = MemorySegment.allocateNative(MemoryLayout.sequenceLayout(2, ValueLayout.JAVA_INT), session);
+            MemorySegment s1 = session.allocate(MemoryLayout.sequenceLayout(2, ValueLayout.JAVA_INT));
             r = CompletableFuture.runAsync(() -> {
                 try {
                     ByteBuffer bb = s1.asByteBuffer();

--- a/test/jdk/java/foreign/TestSlices.java
+++ b/test/jdk/java/foreign/TestSlices.java
@@ -47,7 +47,7 @@ public class TestSlices {
     @Test(dataProvider = "slices")
     public void testSlices(VarHandle handle, int lo, int hi, int[] values) {
         try (MemorySession session = MemorySession.openConfined()) {
-            MemorySegment segment = MemorySegment.allocateNative(LAYOUT, session);
+            MemorySegment segment = session.allocate(LAYOUT);
             //init
             for (long i = 0 ; i < 2 ; i++) {
                 for (long j = 0 ; j < 5 ; j++) {
@@ -62,7 +62,7 @@ public class TestSlices {
     @Test(dataProvider = "slices")
     public void testSliceBadIndex(VarHandle handle, int lo, int hi, int[] values) {
         try (MemorySession session = MemorySession.openConfined()) {
-            MemorySegment segment = MemorySegment.allocateNative(LAYOUT, session);
+            MemorySegment segment = session.allocate(LAYOUT);
             assertThrows(() -> handle.get(segment, lo, 0));
             assertThrows(() -> handle.get(segment, 0, hi));
         }

--- a/test/jdk/java/foreign/TestSpliterator.java
+++ b/test/jdk/java/foreign/TestSpliterator.java
@@ -84,7 +84,7 @@ public class TestSpliterator {
         SequenceLayout layout = MemoryLayout.sequenceLayout(1024, ValueLayout.JAVA_INT);
 
         //setup
-        MemorySegment segment = MemorySession.openImplicit().allocate(layout);
+        MemorySegment segment = MemorySegment.allocateNative(layout);
         for (int i = 0; i < layout.elementCount(); i++) {
             INT_HANDLE.set(segment, (long) i, i);
         }

--- a/test/jdk/java/foreign/TestSpliterator.java
+++ b/test/jdk/java/foreign/TestSpliterator.java
@@ -58,7 +58,7 @@ public class TestSpliterator {
 
         //setup
         try (MemorySession session = MemorySession.openShared()) {
-            MemorySegment segment = MemorySegment.allocateNative(layout, session);
+            MemorySegment segment = session.allocate(layout);
             for (int i = 0; i < layout.elementCount(); i++) {
                 INT_HANDLE.set(segment, (long) i, i);
             }
@@ -84,7 +84,7 @@ public class TestSpliterator {
         SequenceLayout layout = MemoryLayout.sequenceLayout(1024, ValueLayout.JAVA_INT);
 
         //setup
-        MemorySegment segment = MemorySegment.allocateNative(layout, MemorySession.openImplicit());
+        MemorySegment segment = MemorySession.openImplicit().allocate(layout);
         for (int i = 0; i < layout.elementCount(); i++) {
             INT_HANDLE.set(segment, (long) i, i);
         }

--- a/test/jdk/java/foreign/TestTypeAccess.java
+++ b/test/jdk/java/foreign/TestTypeAccess.java
@@ -54,7 +54,7 @@ public class TestTypeAccess {
     @Test(expectedExceptions=ClassCastException.class)
     public void testMemoryAddressValueGetAsString() {
         try (MemorySession session = MemorySession.openConfined()) {
-            MemorySegment s = MemorySegment.allocateNative(8, 8, session);
+            MemorySegment s = session.allocate(8, 8);
             String address = (String)ADDR_HANDLE.get(s);
         }
     }
@@ -62,7 +62,7 @@ public class TestTypeAccess {
     @Test(expectedExceptions=ClassCastException.class)
     public void testMemoryAddressValueSetAsString() {
         try (MemorySession session = MemorySession.openConfined()) {
-            MemorySegment s = MemorySegment.allocateNative(8, 8, session);
+            MemorySegment s = session.allocate(8, 8);
             ADDR_HANDLE.set(s, "string");
         }
     }
@@ -70,7 +70,7 @@ public class TestTypeAccess {
     @Test(expectedExceptions=WrongMethodTypeException.class)
     public void testMemoryAddressValueGetAsPrimitive() {
         try (MemorySession session = MemorySession.openConfined()) {
-            MemorySegment s = MemorySegment.allocateNative(8, 8, session);
+            MemorySegment s = session.allocate(8, 8);
             int address = (int)ADDR_HANDLE.get(s);
         }
     }
@@ -78,7 +78,7 @@ public class TestTypeAccess {
     @Test(expectedExceptions=WrongMethodTypeException.class)
     public void testMemoryAddressValueSetAsPrimitive() {
         try (MemorySession session = MemorySession.openConfined()) {
-            MemorySegment s = MemorySegment.allocateNative(8, 8, session);
+            MemorySegment s = session.allocate(8, 8);
             ADDR_HANDLE.set(s, 1);
         }
     }

--- a/test/jdk/java/foreign/TestUpcallBase.java
+++ b/test/jdk/java/foreign/TestUpcallBase.java
@@ -152,7 +152,7 @@ public abstract class TestUpcallBase extends CallGeneratorHelper {
         for (int i = 0; i < o.length; i++) {
             if (layouts.get(i) instanceof GroupLayout) {
                 MemorySegment ms = (MemorySegment) o[i];
-                MemorySegment copy = MemorySession.openImplicit().allocate(ms.byteSize());
+                MemorySegment copy = MemorySegment.allocateNative(ms.byteSize());
                 copy.copyFrom(ms);
                 o[i] = copy;
             }

--- a/test/jdk/java/foreign/TestUpcallBase.java
+++ b/test/jdk/java/foreign/TestUpcallBase.java
@@ -152,7 +152,7 @@ public abstract class TestUpcallBase extends CallGeneratorHelper {
         for (int i = 0; i < o.length; i++) {
             if (layouts.get(i) instanceof GroupLayout) {
                 MemorySegment ms = (MemorySegment) o[i];
-                MemorySegment copy = MemorySegment.allocateNative(ms.byteSize(), MemorySession.openImplicit());
+                MemorySegment copy = MemorySession.openImplicit().allocate(ms.byteSize());
                 copy.copyFrom(ms);
                 o[i] = copy;
             }

--- a/test/jdk/java/foreign/TestUpcallHighArity.java
+++ b/test/jdk/java/foreign/TestUpcallHighArity.java
@@ -86,7 +86,7 @@ public class TestUpcallHighArity extends CallGeneratorHelper {
         for (int i = 0; i < o.length; i++) {
             if (layouts.get(i) instanceof GroupLayout) {
                 MemorySegment ms = (MemorySegment) o[i];
-                MemorySegment copy = MemorySegment.allocateNative(ms.byteSize(), MemorySession.openImplicit());
+                MemorySegment copy = MemorySession.openImplicit().allocate(ms.byteSize());
                 copy.copyFrom(ms);
                 o[i] = copy;
             }

--- a/test/jdk/java/foreign/TestUpcallHighArity.java
+++ b/test/jdk/java/foreign/TestUpcallHighArity.java
@@ -86,7 +86,7 @@ public class TestUpcallHighArity extends CallGeneratorHelper {
         for (int i = 0; i < o.length; i++) {
             if (layouts.get(i) instanceof GroupLayout) {
                 MemorySegment ms = (MemorySegment) o[i];
-                MemorySegment copy = MemorySession.openImplicit().allocate(ms.byteSize());
+                MemorySegment copy = MemorySegment.allocateNative(ms.byteSize());
                 copy.copyFrom(ms);
                 o[i] = copy;
             }

--- a/test/jdk/java/foreign/TestUpcallStructScope.java
+++ b/test/jdk/java/foreign/TestUpcallStructScope.java
@@ -91,7 +91,7 @@ public class TestUpcallStructScope extends NativeTestHelper {
         FunctionDescriptor upcallDesc = FunctionDescriptor.ofVoid(S_PDI_LAYOUT);
         try (MemorySession session = MemorySession.openConfined()) {
             MemorySegment upcallStub = LINKER.upcallStub(target, upcallDesc, session);
-            MemorySegment argSegment = MemorySegment.allocateNative(S_PDI_LAYOUT, session);
+            MemorySegment argSegment = session.allocate(S_PDI_LAYOUT);
             MH_do_upcall.invoke(upcallStub, argSegment);
         }
 

--- a/test/jdk/java/foreign/TestVarArgs.java
+++ b/test/jdk/java/foreign/TestVarArgs.java
@@ -73,8 +73,8 @@ public class TestVarArgs extends CallGeneratorHelper {
         try (MemorySession session = MemorySession.openConfined()) {
             MethodHandle checker = MethodHandles.insertArguments(MH_CHECK, 2, args);
             MemorySegment writeBack = LINKER.upcallStub(checker, FunctionDescriptor.ofVoid(C_INT, C_POINTER), session);
-            MemorySegment callInfo = MemorySegment.allocateNative(CallInfo.LAYOUT, session);
-            MemorySegment argIDs = MemorySegment.allocateNative(MemoryLayout.sequenceLayout(args.size(), C_INT), session);
+            MemorySegment callInfo = session.allocate(CallInfo.LAYOUT);
+            MemorySegment argIDs = session.allocate(MemoryLayout.sequenceLayout(args.size(), C_INT));
 
             MemorySegment callInfoPtr = callInfo;
 

--- a/test/jdk/java/foreign/TestVarHandleCombinators.java
+++ b/test/jdk/java/foreign/TestVarHandleCombinators.java
@@ -65,7 +65,7 @@ public class TestVarHandleCombinators {
     public void testAlign() {
         VarHandle vh = MethodHandles.memorySegmentViewVarHandle(ValueLayout.JAVA_BYTE.withBitAlignment(16));
 
-        MemorySegment segment = MemorySegment.allocateNative(1, 2, MemorySession.openImplicit());
+        MemorySegment segment = MemorySession.openImplicit().allocate(1, 2);
         vh.set(segment, 0L, (byte) 10); // fine, memory region is aligned
         assertEquals((byte) vh.get(segment, 0L), (byte) 10);
     }
@@ -102,7 +102,7 @@ public class TestVarHandleCombinators {
         VarHandle vh = MethodHandles.memorySegmentViewVarHandle(ValueLayout.JAVA_INT.withBitAlignment(32));
         int count = 0;
         try (MemorySession session = MemorySession.openConfined()) {
-            MemorySegment segment = MemorySegment.allocateNative(inner_size * outer_size * 8, 4, session);
+            MemorySegment segment = session.allocate(inner_size * outer_size * 8, 4);
             for (long i = 0; i < outer_size; i++) {
                 for (long j = 0; j < inner_size; j++) {
                     vh.set(segment, i * 40 + j * 8, count);

--- a/test/jdk/java/foreign/TestVarHandleCombinators.java
+++ b/test/jdk/java/foreign/TestVarHandleCombinators.java
@@ -65,7 +65,7 @@ public class TestVarHandleCombinators {
     public void testAlign() {
         VarHandle vh = MethodHandles.memorySegmentViewVarHandle(ValueLayout.JAVA_BYTE.withBitAlignment(16));
 
-        MemorySegment segment = MemorySession.openImplicit().allocate(1, 2);
+        MemorySegment segment = MemorySegment.allocateNative(1L, 2);
         vh.set(segment, 0L, (byte) 10); // fine, memory region is aligned
         assertEquals((byte) vh.get(segment, 0L), (byte) 10);
     }

--- a/test/jdk/java/foreign/channels/AbstractChannelsTest.java
+++ b/test/jdk/java/foreign/channels/AbstractChannelsTest.java
@@ -73,7 +73,7 @@ public class AbstractChannelsTest {
     static final Random RANDOM = RandomFactory.getRandom();
 
     static ByteBuffer segmentBufferOfSize(MemorySession session, int size) {
-        var segment = MemorySegment.allocateNative(size, 1, session);
+        var segment = session.allocate(size, 1);
         for (int i = 0; i < size; i++) {
             segment.set(JAVA_BYTE, i, ((byte)RANDOM.nextInt()));
         }

--- a/test/jdk/java/foreign/channels/TestAsyncSocketChannels.java
+++ b/test/jdk/java/foreign/channels/TestAsyncSocketChannels.java
@@ -75,7 +75,7 @@ public class TestAsyncSocketChannels extends AbstractChannelsTest {
              var server = AsynchronousServerSocketChannel.open();
              var connectedChannel = connectChannels(server, channel);
              var session = closeableSessionOrNull(sessionSupplier.get())) {
-            var segment = MemorySegment.allocateNative(10, 1, session);
+            var segment = session.allocate(10, 1);
             var bb = segment.asByteBuffer();
             var bba = new ByteBuffer[] { bb };
             List<ThrowingConsumer<TestHandler,?>> ioOps = List.of(
@@ -160,8 +160,8 @@ public class TestAsyncSocketChannels extends AbstractChannelsTest {
              var assc = AsynchronousServerSocketChannel.open();
              var asc2 = connectChannels(assc, asc1);
              var scp = closeableSessionOrNull(session = sessionSupplier.get())) {
-            MemorySegment segment1 = MemorySegment.allocateNative(10, 1, session);
-            MemorySegment segment2 = MemorySegment.allocateNative(10, 1, session);
+            MemorySegment segment1 = session.allocate(10, 1);
+            MemorySegment segment2 = session.allocate(10, 1);
             for (int i = 0; i < 10; i++) {
                 segment1.set(JAVA_BYTE, i, (byte) i);
             }
@@ -207,7 +207,7 @@ public class TestAsyncSocketChannels extends AbstractChannelsTest {
              var assc = AsynchronousServerSocketChannel.open();
              var asc2 = connectChannels(assc, asc1);
              var session = closeableSessionOrNull(sessionSupplier.get())) {
-            var segment = MemorySegment.allocateNative(10, 1, session);
+            var segment = session.allocate(10, 1);
             var bb = segment.asByteBuffer();
             var bba = new ByteBuffer[] { bb };
             List<ThrowingConsumer<TestHandler,?>> readOps = List.of(

--- a/test/jdk/java/foreign/channels/TestSocketChannels.java
+++ b/test/jdk/java/foreign/channels/TestSocketChannels.java
@@ -101,8 +101,8 @@ public class TestSocketChannels extends AbstractChannelsTest {
              var ssc = ServerSocketChannel.open();
              var sc2 = connectChannels(ssc, sc1);
              var scp = closeableSessionOrNull(session = sessionSupplier.get())) {
-            MemorySegment segment1 = MemorySegment.allocateNative(10, 1, session);
-            MemorySegment segment2 = MemorySegment.allocateNative(10, 1, session);
+            MemorySegment segment1 = session.allocate(10, 1);
+            MemorySegment segment2 = session.allocate(10, 1);
             for (int i = 0; i < 10; i++) {
                 segment1.set(JAVA_BYTE, i, (byte) i);
             }
@@ -140,7 +140,7 @@ public class TestSocketChannels extends AbstractChannelsTest {
              var server = ServerSocketChannel.open();
              var connected = connectChannels(server, channel);
              var session = closeableSessionOrNull(sessionSupplier.get())) {
-            var segment = MemorySegment.allocateNative(10, 1, session);
+            var segment = session.allocate(10, 1);
             ByteBuffer bb = segment.asByteBuffer();
             List<ThrowingRunnable> ioOps = List.of(
                     () -> channel.write(bb),

--- a/test/jdk/java/foreign/valist/VaListTest.java
+++ b/test/jdk/java/foreign/valist/VaListTest.java
@@ -301,7 +301,7 @@ public class VaListTest extends NativeTestHelper {
         TriFunction<GroupLayout, VarHandle, VarHandle, Function<VaList, Long>> sumStructJavaFact
                 = (BigPoint_LAYOUT, VH_BigPoint_x, VH_BigPoint_y) ->
                 list -> {
-                    MemorySegment struct = MemorySegment.allocateNative(BigPoint_LAYOUT, MemorySession.openImplicit());
+                    MemorySegment struct = MemorySession.openImplicit().allocate(BigPoint_LAYOUT);
                     list.nextVarg(BigPoint_LAYOUT, SegmentAllocator.prefixAllocator(struct));
                     long x = (long) VH_BigPoint_x.get(struct);
                     long y = (long) VH_BigPoint_y.get(struct);
@@ -338,7 +338,7 @@ public class VaListTest extends NativeTestHelper {
                               Function<VaList, Long> sumBigStruct,
                               GroupLayout BigPoint_LAYOUT, VarHandle VH_BigPoint_x, VarHandle VH_BigPoint_y) {
         try (MemorySession session = MemorySession.openConfined()) {
-            MemorySegment struct = MemorySegment.allocateNative(BigPoint_LAYOUT, session);
+            MemorySegment struct = session.allocate(BigPoint_LAYOUT);
             VH_BigPoint_x.set(struct, 5);
             VH_BigPoint_y.set(struct, 10);
 
@@ -354,7 +354,7 @@ public class VaListTest extends NativeTestHelper {
         TriFunction<GroupLayout, VarHandle, VarHandle, Function<VaList, Float>> sumStructJavaFact
                 = (FloatPoint_LAYOUT, VH_FloatPoint_x, VH_FloatPoint_y) ->
                 list -> {
-                    MemorySegment struct = MemorySegment.allocateNative(FloatPoint_LAYOUT, MemorySession.openImplicit());
+                    MemorySegment struct = MemorySession.openImplicit().allocate(FloatPoint_LAYOUT);
                     list.nextVarg(FloatPoint_LAYOUT, SegmentAllocator.prefixAllocator(struct));
                     float x = (float) VH_FloatPoint_x.get(struct);
                     float y = (float) VH_FloatPoint_y.get(struct);
@@ -392,7 +392,7 @@ public class VaListTest extends NativeTestHelper {
                                 GroupLayout FloatPoint_LAYOUT,
                                 VarHandle VH_FloatPoint_x, VarHandle VH_FloatPoint_y) {
         try (MemorySession session = MemorySession.openConfined()) {
-            MemorySegment struct = MemorySegment.allocateNative(FloatPoint_LAYOUT, session);
+            MemorySegment struct = session.allocate(FloatPoint_LAYOUT);
             VH_FloatPoint_x.set(struct, 1.234f);
             VH_FloatPoint_y.set(struct, 3.142f);
 
@@ -412,7 +412,7 @@ public class VaListTest extends NativeTestHelper {
         QuadFunc<GroupLayout, VarHandle, VarHandle, VarHandle, Function<VaList, Long>> sumStructJavaFact
                 = (HugePoint_LAYOUT, VH_HugePoint_x, VH_HugePoint_y, VH_HugePoint_z) ->
                 list -> {
-                    MemorySegment struct = MemorySegment.allocateNative(HugePoint_LAYOUT, MemorySession.openImplicit());
+                    MemorySegment struct = MemorySession.openImplicit().allocate(HugePoint_LAYOUT);
                     list.nextVarg(HugePoint_LAYOUT, SegmentAllocator.prefixAllocator(struct));
                     long x = (long) VH_HugePoint_x.get(struct);
                     long y = (long) VH_HugePoint_y.get(struct);
@@ -456,7 +456,7 @@ public class VaListTest extends NativeTestHelper {
         // On AArch64 a struct needs to be larger than 16 bytes to be
         // passed by reference.
         try (MemorySession session = MemorySession.openConfined()) {
-            MemorySegment struct = MemorySegment.allocateNative(HugePoint_LAYOUT, session);
+            MemorySegment struct = session.allocate(HugePoint_LAYOUT);
             VH_HugePoint_x.set(struct, 1);
             VH_HugePoint_y.set(struct, 2);
             VH_HugePoint_z.set(struct, 3);
@@ -508,8 +508,8 @@ public class VaListTest extends NativeTestHelper {
                           ValueLayout.OfLong longLayout,
                           ValueLayout.OfDouble doubleLayout) {
         try (MemorySession session = MemorySession.openConfined()) {
-            MemorySegment longSum = MemorySegment.allocateNative(longLayout, session);
-            MemorySegment doubleSum = MemorySegment.allocateNative(doubleLayout, session);
+            MemorySegment longSum = session.allocate(longLayout);
+            MemorySegment doubleSum = session.allocate(doubleLayout);
             longSum.set(JAVA_LONG, 0, 0L);
             doubleSum.set(JAVA_DOUBLE, 0, 0D);
 
@@ -593,11 +593,11 @@ public class VaListTest extends NativeTestHelper {
         MemorySegment pointOut;
         try (MemorySession session = MemorySession.openConfined()) {
             try (MemorySession innerSession = MemorySession.openConfined()) {
-                MemorySegment pointIn = MemorySegment.allocateNative(Point_LAYOUT, innerSession);
+                MemorySegment pointIn = innerSession.allocate(Point_LAYOUT);
                 VH_Point_x.set(pointIn, 3);
                 VH_Point_y.set(pointIn, 6);
                 VaList list = vaListFactory.apply(b -> b.addVarg(Point_LAYOUT, pointIn));
-                pointOut = MemorySegment.allocateNative(Point_LAYOUT, session);
+                pointOut = session.allocate(Point_LAYOUT);
                 list.nextVarg(Point_LAYOUT, SegmentAllocator.prefixAllocator(pointOut));
                 assertEquals((int) VH_Point_x.get(pointOut), 3);
                 assertEquals((int) VH_Point_y.get(pointOut), 6);
@@ -684,14 +684,14 @@ public class VaListTest extends NativeTestHelper {
 
         return new Object[][]{
                 { linkVaListCB("upcallBigStruct"), VaListConsumer.mh(vaList -> {
-                    MemorySegment struct = MemorySegment.allocateNative(BigPoint_LAYOUT, MemorySession.openImplicit());
+                    MemorySegment struct = MemorySession.openImplicit().allocate(BigPoint_LAYOUT);
                     vaList.nextVarg(BigPoint_LAYOUT, SegmentAllocator.prefixAllocator(struct));
                     assertEquals((long) VH_BigPoint_x.get(struct), 8);
                     assertEquals((long) VH_BigPoint_y.get(struct), 16);
                 })},
                 { linkVaListCB("upcallBigStruct"), VaListConsumer.mh(vaList -> {
                     VaList copy = vaList.copy();
-                    MemorySegment struct = MemorySegment.allocateNative(BigPoint_LAYOUT, MemorySession.openImplicit());
+                    MemorySegment struct =  MemorySession.openImplicit().allocate(BigPoint_LAYOUT);
                     vaList.nextVarg(BigPoint_LAYOUT, SegmentAllocator.prefixAllocator(struct));
                     assertEquals((long) VH_BigPoint_x.get(struct), 8);
                     assertEquals((long) VH_BigPoint_y.get(struct), 16);
@@ -705,7 +705,7 @@ public class VaListTest extends NativeTestHelper {
                     assertEquals((long) VH_BigPoint_y.get(struct), 16);
                 })},
                 { linkVaListCB("upcallBigStructPlusScalar"), VaListConsumer.mh(vaList -> {
-                    MemorySegment struct = MemorySegment.allocateNative(BigPoint_LAYOUT, MemorySession.openImplicit());
+                    MemorySegment struct = MemorySession.openImplicit().allocate(BigPoint_LAYOUT);
                     vaList.nextVarg(BigPoint_LAYOUT, SegmentAllocator.prefixAllocator(struct));
                     assertEquals((long) VH_BigPoint_x.get(struct), 8);
                     assertEquals((long) VH_BigPoint_y.get(struct), 16);
@@ -717,20 +717,20 @@ public class VaListTest extends NativeTestHelper {
                     assertEquals(vaList.nextVarg(C_LONG_LONG), 42);
                 })},
                 { linkVaListCB("upcallStruct"), VaListConsumer.mh(vaList -> {
-                    MemorySegment struct = MemorySegment.allocateNative(Point_LAYOUT, MemorySession.openImplicit());
+                    MemorySegment struct = MemorySession.openImplicit().allocate(Point_LAYOUT);
                     vaList.nextVarg(Point_LAYOUT, SegmentAllocator.prefixAllocator(struct));
                     assertEquals((int) VH_Point_x.get(struct), 5);
                     assertEquals((int) VH_Point_y.get(struct), 10);
                 })},
                 { linkVaListCB("upcallHugeStruct"), VaListConsumer.mh(vaList -> {
-                    MemorySegment struct = MemorySegment.allocateNative(HugePoint_LAYOUT, MemorySession.openImplicit());
+                    MemorySegment struct = MemorySession.openImplicit().allocate(HugePoint_LAYOUT);
                     vaList.nextVarg(HugePoint_LAYOUT, SegmentAllocator.prefixAllocator(struct));
                     assertEquals((long) VH_HugePoint_x.get(struct), 1);
                     assertEquals((long) VH_HugePoint_y.get(struct), 2);
                     assertEquals((long) VH_HugePoint_z.get(struct), 3);
                 })},
                 { linkVaListCB("upcallFloatStruct"), VaListConsumer.mh(vaList -> {
-                    MemorySegment struct = MemorySegment.allocateNative(FloatPoint_LAYOUT, MemorySession.openImplicit());
+                    MemorySegment struct = MemorySession.openImplicit().allocate(FloatPoint_LAYOUT);
                     vaList.nextVarg(FloatPoint_LAYOUT, SegmentAllocator.prefixAllocator(struct));
                     assertEquals((float) VH_FloatPoint_x.get(struct), 1.0f);
                     assertEquals((float) VH_FloatPoint_y.get(struct), 2.0f);
@@ -775,7 +775,7 @@ public class VaListTest extends NativeTestHelper {
                     assertEquals((float) vaList.nextVarg(C_DOUBLE), 13.0F);
                     assertEquals(vaList.nextVarg(C_DOUBLE), 14.0D);
 
-                    MemorySegment buffer = MemorySegment.allocateNative(BigPoint_LAYOUT, MemorySession.openImplicit());
+                    MemorySegment buffer = MemorySession.openImplicit().allocate(BigPoint_LAYOUT);
                     SegmentAllocator bufferAllocator = SegmentAllocator.prefixAllocator(buffer);
 
                     MemorySegment point = vaList.nextVarg(Point_LAYOUT, bufferAllocator);

--- a/test/jdk/java/foreign/valist/VaListTest.java
+++ b/test/jdk/java/foreign/valist/VaListTest.java
@@ -248,7 +248,7 @@ public class VaListTest extends NativeTestHelper {
         TriFunction<GroupLayout, VarHandle, VarHandle, Function<VaList, Integer>> sumStructJavaFact
                 = (pointLayout, VH_Point_x, VH_Point_y) ->
                 list -> {
-                    MemorySegment struct = MemorySession.openImplicit().allocate(pointLayout);
+                    MemorySegment struct = MemorySegment.allocateNative(pointLayout);
                     list.nextVarg(pointLayout, SegmentAllocator.prefixAllocator(struct));
                     int x = (int) VH_Point_x.get(struct);
                     int y = (int) VH_Point_y.get(struct);
@@ -301,7 +301,7 @@ public class VaListTest extends NativeTestHelper {
         TriFunction<GroupLayout, VarHandle, VarHandle, Function<VaList, Long>> sumStructJavaFact
                 = (BigPoint_LAYOUT, VH_BigPoint_x, VH_BigPoint_y) ->
                 list -> {
-                    MemorySegment struct = MemorySession.openImplicit().allocate(BigPoint_LAYOUT);
+                    MemorySegment struct = MemorySegment.allocateNative(BigPoint_LAYOUT);
                     list.nextVarg(BigPoint_LAYOUT, SegmentAllocator.prefixAllocator(struct));
                     long x = (long) VH_BigPoint_x.get(struct);
                     long y = (long) VH_BigPoint_y.get(struct);
@@ -354,7 +354,7 @@ public class VaListTest extends NativeTestHelper {
         TriFunction<GroupLayout, VarHandle, VarHandle, Function<VaList, Float>> sumStructJavaFact
                 = (FloatPoint_LAYOUT, VH_FloatPoint_x, VH_FloatPoint_y) ->
                 list -> {
-                    MemorySegment struct = MemorySession.openImplicit().allocate(FloatPoint_LAYOUT);
+                    MemorySegment struct = MemorySegment.allocateNative(FloatPoint_LAYOUT);
                     list.nextVarg(FloatPoint_LAYOUT, SegmentAllocator.prefixAllocator(struct));
                     float x = (float) VH_FloatPoint_x.get(struct);
                     float y = (float) VH_FloatPoint_y.get(struct);
@@ -412,7 +412,7 @@ public class VaListTest extends NativeTestHelper {
         QuadFunc<GroupLayout, VarHandle, VarHandle, VarHandle, Function<VaList, Long>> sumStructJavaFact
                 = (HugePoint_LAYOUT, VH_HugePoint_x, VH_HugePoint_y, VH_HugePoint_z) ->
                 list -> {
-                    MemorySegment struct = MemorySession.openImplicit().allocate(HugePoint_LAYOUT);
+                    MemorySegment struct = MemorySegment.allocateNative(HugePoint_LAYOUT);
                     list.nextVarg(HugePoint_LAYOUT, SegmentAllocator.prefixAllocator(struct));
                     long x = (long) VH_HugePoint_x.get(struct);
                     long y = (long) VH_HugePoint_y.get(struct);
@@ -684,14 +684,14 @@ public class VaListTest extends NativeTestHelper {
 
         return new Object[][]{
                 { linkVaListCB("upcallBigStruct"), VaListConsumer.mh(vaList -> {
-                    MemorySegment struct = MemorySession.openImplicit().allocate(BigPoint_LAYOUT);
+                    MemorySegment struct = MemorySegment.allocateNative(BigPoint_LAYOUT);
                     vaList.nextVarg(BigPoint_LAYOUT, SegmentAllocator.prefixAllocator(struct));
                     assertEquals((long) VH_BigPoint_x.get(struct), 8);
                     assertEquals((long) VH_BigPoint_y.get(struct), 16);
                 })},
                 { linkVaListCB("upcallBigStruct"), VaListConsumer.mh(vaList -> {
                     VaList copy = vaList.copy();
-                    MemorySegment struct =  MemorySession.openImplicit().allocate(BigPoint_LAYOUT);
+                    MemorySegment struct =  MemorySegment.allocateNative(BigPoint_LAYOUT);
                     vaList.nextVarg(BigPoint_LAYOUT, SegmentAllocator.prefixAllocator(struct));
                     assertEquals((long) VH_BigPoint_x.get(struct), 8);
                     assertEquals((long) VH_BigPoint_y.get(struct), 16);
@@ -705,7 +705,7 @@ public class VaListTest extends NativeTestHelper {
                     assertEquals((long) VH_BigPoint_y.get(struct), 16);
                 })},
                 { linkVaListCB("upcallBigStructPlusScalar"), VaListConsumer.mh(vaList -> {
-                    MemorySegment struct = MemorySession.openImplicit().allocate(BigPoint_LAYOUT);
+                    MemorySegment struct = MemorySegment.allocateNative(BigPoint_LAYOUT);
                     vaList.nextVarg(BigPoint_LAYOUT, SegmentAllocator.prefixAllocator(struct));
                     assertEquals((long) VH_BigPoint_x.get(struct), 8);
                     assertEquals((long) VH_BigPoint_y.get(struct), 16);
@@ -717,20 +717,20 @@ public class VaListTest extends NativeTestHelper {
                     assertEquals(vaList.nextVarg(C_LONG_LONG), 42);
                 })},
                 { linkVaListCB("upcallStruct"), VaListConsumer.mh(vaList -> {
-                    MemorySegment struct = MemorySession.openImplicit().allocate(Point_LAYOUT);
+                    MemorySegment struct = MemorySegment.allocateNative(Point_LAYOUT);
                     vaList.nextVarg(Point_LAYOUT, SegmentAllocator.prefixAllocator(struct));
                     assertEquals((int) VH_Point_x.get(struct), 5);
                     assertEquals((int) VH_Point_y.get(struct), 10);
                 })},
                 { linkVaListCB("upcallHugeStruct"), VaListConsumer.mh(vaList -> {
-                    MemorySegment struct = MemorySession.openImplicit().allocate(HugePoint_LAYOUT);
+                    MemorySegment struct = MemorySegment.allocateNative(HugePoint_LAYOUT);
                     vaList.nextVarg(HugePoint_LAYOUT, SegmentAllocator.prefixAllocator(struct));
                     assertEquals((long) VH_HugePoint_x.get(struct), 1);
                     assertEquals((long) VH_HugePoint_y.get(struct), 2);
                     assertEquals((long) VH_HugePoint_z.get(struct), 3);
                 })},
                 { linkVaListCB("upcallFloatStruct"), VaListConsumer.mh(vaList -> {
-                    MemorySegment struct = MemorySession.openImplicit().allocate(FloatPoint_LAYOUT);
+                    MemorySegment struct = MemorySegment.allocateNative(FloatPoint_LAYOUT);
                     vaList.nextVarg(FloatPoint_LAYOUT, SegmentAllocator.prefixAllocator(struct));
                     assertEquals((float) VH_FloatPoint_x.get(struct), 1.0f);
                     assertEquals((float) VH_FloatPoint_y.get(struct), 2.0f);
@@ -775,7 +775,7 @@ public class VaListTest extends NativeTestHelper {
                     assertEquals((float) vaList.nextVarg(C_DOUBLE), 13.0F);
                     assertEquals(vaList.nextVarg(C_DOUBLE), 14.0D);
 
-                    MemorySegment buffer = MemorySession.openImplicit().allocate(BigPoint_LAYOUT);
+                    MemorySegment buffer = MemorySegment.allocateNative(BigPoint_LAYOUT);
                     SegmentAllocator bufferAllocator = SegmentAllocator.prefixAllocator(buffer);
 
                     MemorySegment point = vaList.nextVarg(Point_LAYOUT, bufferAllocator);

--- a/test/jdk/java/lang/invoke/VarHandles/VarHandleTestExact.java
+++ b/test/jdk/java/lang/invoke/VarHandles/VarHandleTestExact.java
@@ -171,7 +171,7 @@ public class VarHandleTestExact {
     public void testExactSegmentSet(Class<?> carrier, Object testValue, SetSegmentX setter) {
         VarHandle vh = MethodHandles.memorySegmentViewVarHandle(MemoryLayout.valueLayout(carrier, ByteOrder.nativeOrder()));
         try (MemorySession session = MemorySession.openConfined()) {
-            MemorySegment seg = MemorySegment.allocateNative(8, session);
+            MemorySegment seg = session.allocate(8);
             doTest(vh,
                 tvh -> tvh.set(seg, 0L, testValue),
                 tvh -> setter.set(tvh, seg, 0L, testValue),

--- a/test/jdk/java/util/stream/test/org/openjdk/tests/java/util/stream/SpliteratorTest.java
+++ b/test/jdk/java/util/stream/test/org/openjdk/tests/java/util/stream/SpliteratorTest.java
@@ -66,7 +66,7 @@ public class SpliteratorTest {
     @Test(dataProvider = "SegmentSpliterator", dataProviderClass = SegmentTestDataProvider.class )
     public void testSegmentSpliterator(String name, SequenceLayout layout, SpliteratorTestHelper.ContentAsserter<MemorySegment> contentAsserter) {
         try (MemorySession session = MemorySession.openConfined()) {
-            MemorySegment segment = MemorySegment.allocateNative(layout, session);
+            MemorySegment segment = session.allocate(layout);
             SegmentTestDataProvider.initSegment(segment);
             SpliteratorTestHelper.testSpliterator(() -> segment.spliterator(layout),
                     SegmentTestDataProvider::segmentCopier, contentAsserter);

--- a/test/jdk/jdk/incubator/vector/AbstractVectorLoadStoreTest.java
+++ b/test/jdk/jdk/incubator/vector/AbstractVectorLoadStoreTest.java
@@ -43,7 +43,7 @@ public class AbstractVectorLoadStoreTest extends AbstractVectorTest {
                     ByteBuffer.allocateDirect(s)
                         .order(ByteOrder.nativeOrder())),
             withToString("MS:RW:NE", (int s) ->
-                    MemorySession.openImplicit().allocate(s)
+                    MemorySegment.allocateNative(s)
                         .asByteBuffer()
                         .order(ByteOrder.nativeOrder())
             )
@@ -51,7 +51,7 @@ public class AbstractVectorLoadStoreTest extends AbstractVectorTest {
 
     static final List<IntFunction<MemorySegment>> MEMORY_SEGMENT_GENERATORS = List.of(
             withToString("HMS", (int s) ->
-                    MemorySession.openImplicit().allocate(s)
+                    MemorySegment.allocateNative(s)
             ),
             withToString("DMS", (int s) -> {
                 byte[] b = new byte[s];

--- a/test/jdk/jdk/incubator/vector/AbstractVectorLoadStoreTest.java
+++ b/test/jdk/jdk/incubator/vector/AbstractVectorLoadStoreTest.java
@@ -36,25 +36,23 @@ public class AbstractVectorLoadStoreTest extends AbstractVectorTest {
             ByteOrder.BIG_ENDIAN, ByteOrder.LITTLE_ENDIAN);
 
     static final List<IntFunction<ByteBuffer>> BYTE_BUFFER_GENERATORS = List.of(
-            withToString("HB:RW:NE", (int s) -> {
-                return ByteBuffer.allocate(s)
-                        .order(ByteOrder.nativeOrder());
-            }),
-            withToString("DB:RW:NE", (int s) -> {
-                return ByteBuffer.allocateDirect(s)
-                        .order(ByteOrder.nativeOrder());
-            }),
-            withToString("MS:RW:NE", (int s) -> {
-                return MemorySegment.allocateNative(s, MemorySession.openImplicit())
+            withToString("HB:RW:NE", (int s) ->
+                    ByteBuffer.allocate(s)
+                        .order(ByteOrder.nativeOrder())),
+            withToString("DB:RW:NE", (int s) ->
+                    ByteBuffer.allocateDirect(s)
+                        .order(ByteOrder.nativeOrder())),
+            withToString("MS:RW:NE", (int s) ->
+                    MemorySession.openImplicit().allocate(s)
                         .asByteBuffer()
-                        .order(ByteOrder.nativeOrder());
-            })
+                        .order(ByteOrder.nativeOrder())
+            )
     );
 
     static final List<IntFunction<MemorySegment>> MEMORY_SEGMENT_GENERATORS = List.of(
-            withToString("HMS", (int s) -> {
-                return MemorySegment.allocateNative(s, MemorySession.openImplicit());
-            }),
+            withToString("HMS", (int s) ->
+                    MemorySession.openImplicit().allocate(s)
+            ),
             withToString("DMS", (int s) -> {
                 byte[] b = new byte[s];
                 return MemorySegment.ofArray(b);

--- a/test/jdk/jdk/incubator/vector/Byte128VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Byte128VectorLoadStoreTests.java
@@ -479,8 +479,8 @@ public class Byte128VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @Test(dataProvider = "byteByteProviderForIOOBE")
     static void loadMemorySegmentIOOBE(IntFunction<byte[]> fa, IntFunction<Integer> fi) {
-        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySession.openImplicit().allocate(i, Byte.SIZE));
-        MemorySegment r = MemorySession.openImplicit().allocate(a.byteSize(), Byte.SIZE);
+        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySegment.allocateNative(i, Byte.SIZE));
+        MemorySegment r = MemorySegment.allocateNative(a.byteSize(), Byte.SIZE);
 
         int l = (int) a.byteSize();
         int s = SPECIES.vectorByteSize();
@@ -508,8 +508,8 @@ public class Byte128VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @Test(dataProvider = "byteByteProviderForIOOBE")
     static void storeMemorySegmentIOOBE(IntFunction<byte[]> fa, IntFunction<Integer> fi) {
-        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySession.openImplicit().allocate(i, Byte.SIZE));
-        MemorySegment r = MemorySession.openImplicit().allocate(a.byteSize(), Byte.SIZE);
+        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySegment.allocateNative(i, Byte.SIZE));
+        MemorySegment r = MemorySegment.allocateNative(a.byteSize(), Byte.SIZE);
 
         int l = (int) a.byteSize();
         int s = SPECIES.vectorByteSize();
@@ -572,8 +572,8 @@ public class Byte128VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @Test(dataProvider = "byteByteMaskProviderForIOOBE")
     static void loadMemorySegmentMaskIOOBE(IntFunction<byte[]> fa, IntFunction<Integer> fi, IntFunction<boolean[]> fm) {
-        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySession.openImplicit().allocate(i, Byte.SIZE));
-        MemorySegment r = MemorySession.openImplicit().allocate(a.byteSize(), Byte.SIZE);
+        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySegment.allocateNative(i, Byte.SIZE));
+        MemorySegment r = MemorySegment.allocateNative(a.byteSize(), Byte.SIZE);
         boolean[] mask = fm.apply(SPECIES.length());
         VectorMask<Byte> vmask = VectorMask.fromValues(SPECIES, mask);
 
@@ -603,8 +603,8 @@ public class Byte128VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @Test(dataProvider = "byteByteMaskProviderForIOOBE")
     static void storeMemorySegmentMaskIOOBE(IntFunction<byte[]> fa, IntFunction<Integer> fi, IntFunction<boolean[]> fm) {
-        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySession.openImplicit().allocate(i, Byte.SIZE));
-        MemorySegment r = MemorySession.openImplicit().allocate(a.byteSize(), Byte.SIZE);
+        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySegment.allocateNative(i, Byte.SIZE));
+        MemorySegment r = MemorySegment.allocateNative(a.byteSize(), Byte.SIZE);
         boolean[] mask = fm.apply(SPECIES.length());
         VectorMask<Byte> vmask = VectorMask.fromValues(SPECIES, mask);
 

--- a/test/jdk/jdk/incubator/vector/Byte128VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Byte128VectorLoadStoreTests.java
@@ -479,8 +479,8 @@ public class Byte128VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @Test(dataProvider = "byteByteProviderForIOOBE")
     static void loadMemorySegmentIOOBE(IntFunction<byte[]> fa, IntFunction<Integer> fi) {
-        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySegment.allocateNative(i, Byte.SIZE, MemorySession.openImplicit()));
-        MemorySegment r = MemorySegment.allocateNative(a.byteSize(), Byte.SIZE, MemorySession.openImplicit());
+        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySession.openImplicit().allocate(i, Byte.SIZE));
+        MemorySegment r = MemorySession.openImplicit().allocate(a.byteSize(), Byte.SIZE);
 
         int l = (int) a.byteSize();
         int s = SPECIES.vectorByteSize();
@@ -508,8 +508,8 @@ public class Byte128VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @Test(dataProvider = "byteByteProviderForIOOBE")
     static void storeMemorySegmentIOOBE(IntFunction<byte[]> fa, IntFunction<Integer> fi) {
-        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySegment.allocateNative(i, Byte.SIZE, MemorySession.openImplicit()));
-        MemorySegment r = MemorySegment.allocateNative(a.byteSize(), Byte.SIZE, MemorySession.openImplicit());
+        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySession.openImplicit().allocate(i, Byte.SIZE));
+        MemorySegment r = MemorySession.openImplicit().allocate(a.byteSize(), Byte.SIZE);
 
         int l = (int) a.byteSize();
         int s = SPECIES.vectorByteSize();
@@ -572,8 +572,8 @@ public class Byte128VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @Test(dataProvider = "byteByteMaskProviderForIOOBE")
     static void loadMemorySegmentMaskIOOBE(IntFunction<byte[]> fa, IntFunction<Integer> fi, IntFunction<boolean[]> fm) {
-        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySegment.allocateNative(i, Byte.SIZE, MemorySession.openImplicit()));
-        MemorySegment r = MemorySegment.allocateNative(a.byteSize(), Byte.SIZE, MemorySession.openImplicit());
+        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySession.openImplicit().allocate(i, Byte.SIZE));
+        MemorySegment r = MemorySession.openImplicit().allocate(a.byteSize(), Byte.SIZE);
         boolean[] mask = fm.apply(SPECIES.length());
         VectorMask<Byte> vmask = VectorMask.fromValues(SPECIES, mask);
 
@@ -603,8 +603,8 @@ public class Byte128VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @Test(dataProvider = "byteByteMaskProviderForIOOBE")
     static void storeMemorySegmentMaskIOOBE(IntFunction<byte[]> fa, IntFunction<Integer> fi, IntFunction<boolean[]> fm) {
-        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySegment.allocateNative(i, Byte.SIZE, MemorySession.openImplicit()));
-        MemorySegment r = MemorySegment.allocateNative(a.byteSize(), Byte.SIZE, MemorySession.openImplicit());
+        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySession.openImplicit().allocate(i, Byte.SIZE));
+        MemorySegment r = MemorySession.openImplicit().allocate(a.byteSize(), Byte.SIZE);
         boolean[] mask = fm.apply(SPECIES.length());
         VectorMask<Byte> vmask = VectorMask.fromValues(SPECIES, mask);
 

--- a/test/jdk/jdk/incubator/vector/Byte256VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Byte256VectorLoadStoreTests.java
@@ -479,8 +479,8 @@ public class Byte256VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @Test(dataProvider = "byteByteProviderForIOOBE")
     static void loadMemorySegmentIOOBE(IntFunction<byte[]> fa, IntFunction<Integer> fi) {
-        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySegment.allocateNative(i, Byte.SIZE, MemorySession.openImplicit()));
-        MemorySegment r = MemorySegment.allocateNative(a.byteSize(), Byte.SIZE, MemorySession.openImplicit());
+        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySession.openImplicit().allocate(i, Byte.SIZE));
+        MemorySegment r = MemorySession.openImplicit().allocate(a.byteSize(), Byte.SIZE);
 
         int l = (int) a.byteSize();
         int s = SPECIES.vectorByteSize();
@@ -508,8 +508,8 @@ public class Byte256VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @Test(dataProvider = "byteByteProviderForIOOBE")
     static void storeMemorySegmentIOOBE(IntFunction<byte[]> fa, IntFunction<Integer> fi) {
-        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySegment.allocateNative(i, Byte.SIZE, MemorySession.openImplicit()));
-        MemorySegment r = MemorySegment.allocateNative(a.byteSize(), Byte.SIZE, MemorySession.openImplicit());
+        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySession.openImplicit().allocate(i, Byte.SIZE));
+        MemorySegment r = MemorySession.openImplicit().allocate(a.byteSize(), Byte.SIZE);
 
         int l = (int) a.byteSize();
         int s = SPECIES.vectorByteSize();
@@ -572,8 +572,8 @@ public class Byte256VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @Test(dataProvider = "byteByteMaskProviderForIOOBE")
     static void loadMemorySegmentMaskIOOBE(IntFunction<byte[]> fa, IntFunction<Integer> fi, IntFunction<boolean[]> fm) {
-        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySegment.allocateNative(i, Byte.SIZE, MemorySession.openImplicit()));
-        MemorySegment r = MemorySegment.allocateNative(a.byteSize(), Byte.SIZE, MemorySession.openImplicit());
+        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySession.openImplicit().allocate(i, Byte.SIZE));
+        MemorySegment r = MemorySession.openImplicit().allocate(a.byteSize(), Byte.SIZE);
         boolean[] mask = fm.apply(SPECIES.length());
         VectorMask<Byte> vmask = VectorMask.fromValues(SPECIES, mask);
 
@@ -603,8 +603,8 @@ public class Byte256VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @Test(dataProvider = "byteByteMaskProviderForIOOBE")
     static void storeMemorySegmentMaskIOOBE(IntFunction<byte[]> fa, IntFunction<Integer> fi, IntFunction<boolean[]> fm) {
-        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySegment.allocateNative(i, Byte.SIZE, MemorySession.openImplicit()));
-        MemorySegment r = MemorySegment.allocateNative(a.byteSize(), Byte.SIZE, MemorySession.openImplicit());
+        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySession.openImplicit().allocate(i, Byte.SIZE));
+        MemorySegment r = MemorySession.openImplicit().allocate(a.byteSize(), Byte.SIZE);
         boolean[] mask = fm.apply(SPECIES.length());
         VectorMask<Byte> vmask = VectorMask.fromValues(SPECIES, mask);
 

--- a/test/jdk/jdk/incubator/vector/Byte256VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Byte256VectorLoadStoreTests.java
@@ -479,8 +479,8 @@ public class Byte256VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @Test(dataProvider = "byteByteProviderForIOOBE")
     static void loadMemorySegmentIOOBE(IntFunction<byte[]> fa, IntFunction<Integer> fi) {
-        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySession.openImplicit().allocate(i, Byte.SIZE));
-        MemorySegment r = MemorySession.openImplicit().allocate(a.byteSize(), Byte.SIZE);
+        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySegment.allocateNative(i, Byte.SIZE));
+        MemorySegment r = MemorySegment.allocateNative(a.byteSize(), Byte.SIZE);
 
         int l = (int) a.byteSize();
         int s = SPECIES.vectorByteSize();
@@ -508,8 +508,8 @@ public class Byte256VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @Test(dataProvider = "byteByteProviderForIOOBE")
     static void storeMemorySegmentIOOBE(IntFunction<byte[]> fa, IntFunction<Integer> fi) {
-        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySession.openImplicit().allocate(i, Byte.SIZE));
-        MemorySegment r = MemorySession.openImplicit().allocate(a.byteSize(), Byte.SIZE);
+        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySegment.allocateNative(i, Byte.SIZE));
+        MemorySegment r = MemorySegment.allocateNative(a.byteSize(), Byte.SIZE);
 
         int l = (int) a.byteSize();
         int s = SPECIES.vectorByteSize();
@@ -572,8 +572,8 @@ public class Byte256VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @Test(dataProvider = "byteByteMaskProviderForIOOBE")
     static void loadMemorySegmentMaskIOOBE(IntFunction<byte[]> fa, IntFunction<Integer> fi, IntFunction<boolean[]> fm) {
-        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySession.openImplicit().allocate(i, Byte.SIZE));
-        MemorySegment r = MemorySession.openImplicit().allocate(a.byteSize(), Byte.SIZE);
+        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySegment.allocateNative(i, Byte.SIZE));
+        MemorySegment r = MemorySegment.allocateNative(a.byteSize(), Byte.SIZE);
         boolean[] mask = fm.apply(SPECIES.length());
         VectorMask<Byte> vmask = VectorMask.fromValues(SPECIES, mask);
 
@@ -603,8 +603,8 @@ public class Byte256VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @Test(dataProvider = "byteByteMaskProviderForIOOBE")
     static void storeMemorySegmentMaskIOOBE(IntFunction<byte[]> fa, IntFunction<Integer> fi, IntFunction<boolean[]> fm) {
-        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySession.openImplicit().allocate(i, Byte.SIZE));
-        MemorySegment r = MemorySession.openImplicit().allocate(a.byteSize(), Byte.SIZE);
+        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySegment.allocateNative(i, Byte.SIZE));
+        MemorySegment r = MemorySegment.allocateNative(a.byteSize(), Byte.SIZE);
         boolean[] mask = fm.apply(SPECIES.length());
         VectorMask<Byte> vmask = VectorMask.fromValues(SPECIES, mask);
 

--- a/test/jdk/jdk/incubator/vector/Byte512VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Byte512VectorLoadStoreTests.java
@@ -479,8 +479,8 @@ public class Byte512VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @Test(dataProvider = "byteByteProviderForIOOBE")
     static void loadMemorySegmentIOOBE(IntFunction<byte[]> fa, IntFunction<Integer> fi) {
-        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySession.openImplicit().allocate(i, Byte.SIZE));
-        MemorySegment r = MemorySession.openImplicit().allocate(a.byteSize(), Byte.SIZE);
+        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySegment.allocateNative(i, Byte.SIZE));
+        MemorySegment r = MemorySegment.allocateNative(a.byteSize(), Byte.SIZE);
 
         int l = (int) a.byteSize();
         int s = SPECIES.vectorByteSize();
@@ -508,8 +508,8 @@ public class Byte512VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @Test(dataProvider = "byteByteProviderForIOOBE")
     static void storeMemorySegmentIOOBE(IntFunction<byte[]> fa, IntFunction<Integer> fi) {
-        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySession.openImplicit().allocate(i, Byte.SIZE));
-        MemorySegment r = MemorySession.openImplicit().allocate(a.byteSize(), Byte.SIZE);
+        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySegment.allocateNative(i, Byte.SIZE));
+        MemorySegment r = MemorySegment.allocateNative(a.byteSize(), Byte.SIZE);
 
         int l = (int) a.byteSize();
         int s = SPECIES.vectorByteSize();
@@ -572,8 +572,8 @@ public class Byte512VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @Test(dataProvider = "byteByteMaskProviderForIOOBE")
     static void loadMemorySegmentMaskIOOBE(IntFunction<byte[]> fa, IntFunction<Integer> fi, IntFunction<boolean[]> fm) {
-        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySession.openImplicit().allocate(i, Byte.SIZE));
-        MemorySegment r = MemorySession.openImplicit().allocate(a.byteSize(), Byte.SIZE);
+        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySegment.allocateNative(i, Byte.SIZE));
+        MemorySegment r = MemorySegment.allocateNative(a.byteSize(), Byte.SIZE);
         boolean[] mask = fm.apply(SPECIES.length());
         VectorMask<Byte> vmask = VectorMask.fromValues(SPECIES, mask);
 
@@ -603,8 +603,8 @@ public class Byte512VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @Test(dataProvider = "byteByteMaskProviderForIOOBE")
     static void storeMemorySegmentMaskIOOBE(IntFunction<byte[]> fa, IntFunction<Integer> fi, IntFunction<boolean[]> fm) {
-        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySession.openImplicit().allocate(i, Byte.SIZE));
-        MemorySegment r = MemorySession.openImplicit().allocate(a.byteSize(), Byte.SIZE);
+        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySegment.allocateNative(i, Byte.SIZE));
+        MemorySegment r = MemorySegment.allocateNative(a.byteSize(), Byte.SIZE);
         boolean[] mask = fm.apply(SPECIES.length());
         VectorMask<Byte> vmask = VectorMask.fromValues(SPECIES, mask);
 

--- a/test/jdk/jdk/incubator/vector/Byte512VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Byte512VectorLoadStoreTests.java
@@ -479,8 +479,8 @@ public class Byte512VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @Test(dataProvider = "byteByteProviderForIOOBE")
     static void loadMemorySegmentIOOBE(IntFunction<byte[]> fa, IntFunction<Integer> fi) {
-        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySegment.allocateNative(i, Byte.SIZE, MemorySession.openImplicit()));
-        MemorySegment r = MemorySegment.allocateNative(a.byteSize(), Byte.SIZE, MemorySession.openImplicit());
+        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySession.openImplicit().allocate(i, Byte.SIZE));
+        MemorySegment r = MemorySession.openImplicit().allocate(a.byteSize(), Byte.SIZE);
 
         int l = (int) a.byteSize();
         int s = SPECIES.vectorByteSize();
@@ -508,8 +508,8 @@ public class Byte512VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @Test(dataProvider = "byteByteProviderForIOOBE")
     static void storeMemorySegmentIOOBE(IntFunction<byte[]> fa, IntFunction<Integer> fi) {
-        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySegment.allocateNative(i, Byte.SIZE, MemorySession.openImplicit()));
-        MemorySegment r = MemorySegment.allocateNative(a.byteSize(), Byte.SIZE, MemorySession.openImplicit());
+        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySession.openImplicit().allocate(i, Byte.SIZE));
+        MemorySegment r = MemorySession.openImplicit().allocate(a.byteSize(), Byte.SIZE);
 
         int l = (int) a.byteSize();
         int s = SPECIES.vectorByteSize();
@@ -572,8 +572,8 @@ public class Byte512VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @Test(dataProvider = "byteByteMaskProviderForIOOBE")
     static void loadMemorySegmentMaskIOOBE(IntFunction<byte[]> fa, IntFunction<Integer> fi, IntFunction<boolean[]> fm) {
-        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySegment.allocateNative(i, Byte.SIZE, MemorySession.openImplicit()));
-        MemorySegment r = MemorySegment.allocateNative(a.byteSize(), Byte.SIZE, MemorySession.openImplicit());
+        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySession.openImplicit().allocate(i, Byte.SIZE));
+        MemorySegment r = MemorySession.openImplicit().allocate(a.byteSize(), Byte.SIZE);
         boolean[] mask = fm.apply(SPECIES.length());
         VectorMask<Byte> vmask = VectorMask.fromValues(SPECIES, mask);
 
@@ -603,8 +603,8 @@ public class Byte512VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @Test(dataProvider = "byteByteMaskProviderForIOOBE")
     static void storeMemorySegmentMaskIOOBE(IntFunction<byte[]> fa, IntFunction<Integer> fi, IntFunction<boolean[]> fm) {
-        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySegment.allocateNative(i, Byte.SIZE, MemorySession.openImplicit()));
-        MemorySegment r = MemorySegment.allocateNative(a.byteSize(), Byte.SIZE, MemorySession.openImplicit());
+        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySession.openImplicit().allocate(i, Byte.SIZE));
+        MemorySegment r = MemorySession.openImplicit().allocate(a.byteSize(), Byte.SIZE);
         boolean[] mask = fm.apply(SPECIES.length());
         VectorMask<Byte> vmask = VectorMask.fromValues(SPECIES, mask);
 

--- a/test/jdk/jdk/incubator/vector/Byte64VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Byte64VectorLoadStoreTests.java
@@ -479,8 +479,8 @@ public class Byte64VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @Test(dataProvider = "byteByteProviderForIOOBE")
     static void loadMemorySegmentIOOBE(IntFunction<byte[]> fa, IntFunction<Integer> fi) {
-        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySegment.allocateNative(i, Byte.SIZE, MemorySession.openImplicit()));
-        MemorySegment r = MemorySegment.allocateNative(a.byteSize(), Byte.SIZE, MemorySession.openImplicit());
+        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySession.openImplicit().allocate(i, Byte.SIZE));
+        MemorySegment r = MemorySession.openImplicit().allocate(a.byteSize(), Byte.SIZE);
 
         int l = (int) a.byteSize();
         int s = SPECIES.vectorByteSize();
@@ -508,8 +508,8 @@ public class Byte64VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @Test(dataProvider = "byteByteProviderForIOOBE")
     static void storeMemorySegmentIOOBE(IntFunction<byte[]> fa, IntFunction<Integer> fi) {
-        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySegment.allocateNative(i, Byte.SIZE, MemorySession.openImplicit()));
-        MemorySegment r = MemorySegment.allocateNative(a.byteSize(), Byte.SIZE, MemorySession.openImplicit());
+        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySession.openImplicit().allocate(i, Byte.SIZE));
+        MemorySegment r = MemorySession.openImplicit().allocate(a.byteSize(), Byte.SIZE);
 
         int l = (int) a.byteSize();
         int s = SPECIES.vectorByteSize();
@@ -572,8 +572,8 @@ public class Byte64VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @Test(dataProvider = "byteByteMaskProviderForIOOBE")
     static void loadMemorySegmentMaskIOOBE(IntFunction<byte[]> fa, IntFunction<Integer> fi, IntFunction<boolean[]> fm) {
-        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySegment.allocateNative(i, Byte.SIZE, MemorySession.openImplicit()));
-        MemorySegment r = MemorySegment.allocateNative(a.byteSize(), Byte.SIZE, MemorySession.openImplicit());
+        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySession.openImplicit().allocate(i, Byte.SIZE));
+        MemorySegment r = MemorySession.openImplicit().allocate(a.byteSize(), Byte.SIZE);
         boolean[] mask = fm.apply(SPECIES.length());
         VectorMask<Byte> vmask = VectorMask.fromValues(SPECIES, mask);
 
@@ -603,8 +603,8 @@ public class Byte64VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @Test(dataProvider = "byteByteMaskProviderForIOOBE")
     static void storeMemorySegmentMaskIOOBE(IntFunction<byte[]> fa, IntFunction<Integer> fi, IntFunction<boolean[]> fm) {
-        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySegment.allocateNative(i, Byte.SIZE, MemorySession.openImplicit()));
-        MemorySegment r = MemorySegment.allocateNative(a.byteSize(), Byte.SIZE, MemorySession.openImplicit());
+        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySession.openImplicit().allocate(i, Byte.SIZE));
+        MemorySegment r = MemorySession.openImplicit().allocate(a.byteSize(), Byte.SIZE);
         boolean[] mask = fm.apply(SPECIES.length());
         VectorMask<Byte> vmask = VectorMask.fromValues(SPECIES, mask);
 

--- a/test/jdk/jdk/incubator/vector/Byte64VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Byte64VectorLoadStoreTests.java
@@ -479,8 +479,8 @@ public class Byte64VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @Test(dataProvider = "byteByteProviderForIOOBE")
     static void loadMemorySegmentIOOBE(IntFunction<byte[]> fa, IntFunction<Integer> fi) {
-        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySession.openImplicit().allocate(i, Byte.SIZE));
-        MemorySegment r = MemorySession.openImplicit().allocate(a.byteSize(), Byte.SIZE);
+        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySegment.allocateNative(i, Byte.SIZE));
+        MemorySegment r = MemorySegment.allocateNative(a.byteSize(), Byte.SIZE);
 
         int l = (int) a.byteSize();
         int s = SPECIES.vectorByteSize();
@@ -508,8 +508,8 @@ public class Byte64VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @Test(dataProvider = "byteByteProviderForIOOBE")
     static void storeMemorySegmentIOOBE(IntFunction<byte[]> fa, IntFunction<Integer> fi) {
-        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySession.openImplicit().allocate(i, Byte.SIZE));
-        MemorySegment r = MemorySession.openImplicit().allocate(a.byteSize(), Byte.SIZE);
+        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySegment.allocateNative(i, Byte.SIZE));
+        MemorySegment r = MemorySegment.allocateNative(a.byteSize(), Byte.SIZE);
 
         int l = (int) a.byteSize();
         int s = SPECIES.vectorByteSize();
@@ -572,8 +572,8 @@ public class Byte64VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @Test(dataProvider = "byteByteMaskProviderForIOOBE")
     static void loadMemorySegmentMaskIOOBE(IntFunction<byte[]> fa, IntFunction<Integer> fi, IntFunction<boolean[]> fm) {
-        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySession.openImplicit().allocate(i, Byte.SIZE));
-        MemorySegment r = MemorySession.openImplicit().allocate(a.byteSize(), Byte.SIZE);
+        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySegment.allocateNative(i, Byte.SIZE));
+        MemorySegment r = MemorySegment.allocateNative(a.byteSize(), Byte.SIZE);
         boolean[] mask = fm.apply(SPECIES.length());
         VectorMask<Byte> vmask = VectorMask.fromValues(SPECIES, mask);
 
@@ -603,8 +603,8 @@ public class Byte64VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @Test(dataProvider = "byteByteMaskProviderForIOOBE")
     static void storeMemorySegmentMaskIOOBE(IntFunction<byte[]> fa, IntFunction<Integer> fi, IntFunction<boolean[]> fm) {
-        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySession.openImplicit().allocate(i, Byte.SIZE));
-        MemorySegment r = MemorySession.openImplicit().allocate(a.byteSize(), Byte.SIZE);
+        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySegment.allocateNative(i, Byte.SIZE));
+        MemorySegment r = MemorySegment.allocateNative(a.byteSize(), Byte.SIZE);
         boolean[] mask = fm.apply(SPECIES.length());
         VectorMask<Byte> vmask = VectorMask.fromValues(SPECIES, mask);
 

--- a/test/jdk/jdk/incubator/vector/ByteMaxVectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/ByteMaxVectorLoadStoreTests.java
@@ -486,8 +486,8 @@ public class ByteMaxVectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @Test(dataProvider = "byteByteProviderForIOOBE")
     static void loadMemorySegmentIOOBE(IntFunction<byte[]> fa, IntFunction<Integer> fi) {
-        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySegment.allocateNative(i, Byte.SIZE, MemorySession.openImplicit()));
-        MemorySegment r = MemorySegment.allocateNative(a.byteSize(), Byte.SIZE, MemorySession.openImplicit());
+        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySession.openImplicit().allocate(i, Byte.SIZE));
+        MemorySegment r = MemorySession.openImplicit().allocate(a.byteSize(), Byte.SIZE);
 
         int l = (int) a.byteSize();
         int s = SPECIES.vectorByteSize();
@@ -515,8 +515,8 @@ public class ByteMaxVectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @Test(dataProvider = "byteByteProviderForIOOBE")
     static void storeMemorySegmentIOOBE(IntFunction<byte[]> fa, IntFunction<Integer> fi) {
-        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySegment.allocateNative(i, Byte.SIZE, MemorySession.openImplicit()));
-        MemorySegment r = MemorySegment.allocateNative(a.byteSize(), Byte.SIZE, MemorySession.openImplicit());
+        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySession.openImplicit().allocate(i, Byte.SIZE));
+        MemorySegment r = MemorySession.openImplicit().allocate(a.byteSize(), Byte.SIZE);
 
         int l = (int) a.byteSize();
         int s = SPECIES.vectorByteSize();
@@ -579,8 +579,8 @@ public class ByteMaxVectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @Test(dataProvider = "byteByteMaskProviderForIOOBE")
     static void loadMemorySegmentMaskIOOBE(IntFunction<byte[]> fa, IntFunction<Integer> fi, IntFunction<boolean[]> fm) {
-        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySegment.allocateNative(i, Byte.SIZE, MemorySession.openImplicit()));
-        MemorySegment r = MemorySegment.allocateNative(a.byteSize(), Byte.SIZE, MemorySession.openImplicit());
+        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySession.openImplicit().allocate(i, Byte.SIZE));
+        MemorySegment r = MemorySession.openImplicit().allocate(a.byteSize(), Byte.SIZE);
         boolean[] mask = fm.apply(SPECIES.length());
         VectorMask<Byte> vmask = VectorMask.fromValues(SPECIES, mask);
 
@@ -610,8 +610,8 @@ public class ByteMaxVectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @Test(dataProvider = "byteByteMaskProviderForIOOBE")
     static void storeMemorySegmentMaskIOOBE(IntFunction<byte[]> fa, IntFunction<Integer> fi, IntFunction<boolean[]> fm) {
-        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySegment.allocateNative(i, Byte.SIZE, MemorySession.openImplicit()));
-        MemorySegment r = MemorySegment.allocateNative(a.byteSize(), Byte.SIZE, MemorySession.openImplicit());
+        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySession.openImplicit().allocate(i, Byte.SIZE));
+        MemorySegment r = MemorySession.openImplicit().allocate(a.byteSize(), Byte.SIZE);
         boolean[] mask = fm.apply(SPECIES.length());
         VectorMask<Byte> vmask = VectorMask.fromValues(SPECIES, mask);
 

--- a/test/jdk/jdk/incubator/vector/ByteMaxVectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/ByteMaxVectorLoadStoreTests.java
@@ -486,8 +486,8 @@ public class ByteMaxVectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @Test(dataProvider = "byteByteProviderForIOOBE")
     static void loadMemorySegmentIOOBE(IntFunction<byte[]> fa, IntFunction<Integer> fi) {
-        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySession.openImplicit().allocate(i, Byte.SIZE));
-        MemorySegment r = MemorySession.openImplicit().allocate(a.byteSize(), Byte.SIZE);
+        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySegment.allocateNative(i, Byte.SIZE));
+        MemorySegment r = MemorySegment.allocateNative(a.byteSize(), Byte.SIZE);
 
         int l = (int) a.byteSize();
         int s = SPECIES.vectorByteSize();
@@ -515,8 +515,8 @@ public class ByteMaxVectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @Test(dataProvider = "byteByteProviderForIOOBE")
     static void storeMemorySegmentIOOBE(IntFunction<byte[]> fa, IntFunction<Integer> fi) {
-        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySession.openImplicit().allocate(i, Byte.SIZE));
-        MemorySegment r = MemorySession.openImplicit().allocate(a.byteSize(), Byte.SIZE);
+        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySegment.allocateNative(i, Byte.SIZE));
+        MemorySegment r = MemorySegment.allocateNative(a.byteSize(), Byte.SIZE);
 
         int l = (int) a.byteSize();
         int s = SPECIES.vectorByteSize();
@@ -579,8 +579,8 @@ public class ByteMaxVectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @Test(dataProvider = "byteByteMaskProviderForIOOBE")
     static void loadMemorySegmentMaskIOOBE(IntFunction<byte[]> fa, IntFunction<Integer> fi, IntFunction<boolean[]> fm) {
-        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySession.openImplicit().allocate(i, Byte.SIZE));
-        MemorySegment r = MemorySession.openImplicit().allocate(a.byteSize(), Byte.SIZE);
+        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySegment.allocateNative(i, Byte.SIZE));
+        MemorySegment r = MemorySegment.allocateNative(a.byteSize(), Byte.SIZE);
         boolean[] mask = fm.apply(SPECIES.length());
         VectorMask<Byte> vmask = VectorMask.fromValues(SPECIES, mask);
 
@@ -610,8 +610,8 @@ public class ByteMaxVectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @Test(dataProvider = "byteByteMaskProviderForIOOBE")
     static void storeMemorySegmentMaskIOOBE(IntFunction<byte[]> fa, IntFunction<Integer> fi, IntFunction<boolean[]> fm) {
-        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySession.openImplicit().allocate(i, Byte.SIZE));
-        MemorySegment r = MemorySession.openImplicit().allocate(a.byteSize(), Byte.SIZE);
+        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySegment.allocateNative(i, Byte.SIZE));
+        MemorySegment r = MemorySegment.allocateNative(a.byteSize(), Byte.SIZE);
         boolean[] mask = fm.apply(SPECIES.length());
         VectorMask<Byte> vmask = VectorMask.fromValues(SPECIES, mask);
 

--- a/test/jdk/jdk/incubator/vector/Double128VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Double128VectorLoadStoreTests.java
@@ -479,8 +479,8 @@ public class Double128VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @Test(dataProvider = "doubleByteProviderForIOOBE")
     static void loadMemorySegmentIOOBE(IntFunction<double[]> fa, IntFunction<Integer> fi) {
-        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySession.openImplicit().allocate(i, Double.SIZE));
-        MemorySegment r = MemorySession.openImplicit().allocate(a.byteSize(), Double.SIZE);
+        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySegment.allocateNative(i, Double.SIZE));
+        MemorySegment r = MemorySegment.allocateNative(a.byteSize(), Double.SIZE);
 
         int l = (int) a.byteSize();
         int s = SPECIES.vectorByteSize();
@@ -508,8 +508,8 @@ public class Double128VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @Test(dataProvider = "doubleByteProviderForIOOBE")
     static void storeMemorySegmentIOOBE(IntFunction<double[]> fa, IntFunction<Integer> fi) {
-        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySession.openImplicit().allocate(i, Double.SIZE));
-        MemorySegment r = MemorySession.openImplicit().allocate(a.byteSize(), Double.SIZE);
+        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySegment.allocateNative(i, Double.SIZE));
+        MemorySegment r = MemorySegment.allocateNative(a.byteSize(), Double.SIZE);
 
         int l = (int) a.byteSize();
         int s = SPECIES.vectorByteSize();
@@ -572,8 +572,8 @@ public class Double128VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @Test(dataProvider = "doubleByteMaskProviderForIOOBE")
     static void loadMemorySegmentMaskIOOBE(IntFunction<double[]> fa, IntFunction<Integer> fi, IntFunction<boolean[]> fm) {
-        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySession.openImplicit().allocate(i, Double.SIZE));
-        MemorySegment r = MemorySession.openImplicit().allocate(a.byteSize(), Double.SIZE);
+        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySegment.allocateNative(i, Double.SIZE));
+        MemorySegment r = MemorySegment.allocateNative(a.byteSize(), Double.SIZE);
         boolean[] mask = fm.apply(SPECIES.length());
         VectorMask<Double> vmask = VectorMask.fromValues(SPECIES, mask);
 
@@ -603,8 +603,8 @@ public class Double128VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @Test(dataProvider = "doubleByteMaskProviderForIOOBE")
     static void storeMemorySegmentMaskIOOBE(IntFunction<double[]> fa, IntFunction<Integer> fi, IntFunction<boolean[]> fm) {
-        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySession.openImplicit().allocate(i, Double.SIZE));
-        MemorySegment r = MemorySession.openImplicit().allocate(a.byteSize(), Double.SIZE);
+        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySegment.allocateNative(i, Double.SIZE));
+        MemorySegment r = MemorySegment.allocateNative(a.byteSize(), Double.SIZE);
         boolean[] mask = fm.apply(SPECIES.length());
         VectorMask<Double> vmask = VectorMask.fromValues(SPECIES, mask);
 

--- a/test/jdk/jdk/incubator/vector/Double128VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Double128VectorLoadStoreTests.java
@@ -479,8 +479,8 @@ public class Double128VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @Test(dataProvider = "doubleByteProviderForIOOBE")
     static void loadMemorySegmentIOOBE(IntFunction<double[]> fa, IntFunction<Integer> fi) {
-        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySegment.allocateNative(i, Double.SIZE, MemorySession.openImplicit()));
-        MemorySegment r = MemorySegment.allocateNative(a.byteSize(), Double.SIZE, MemorySession.openImplicit());
+        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySession.openImplicit().allocate(i, Double.SIZE));
+        MemorySegment r = MemorySession.openImplicit().allocate(a.byteSize(), Double.SIZE);
 
         int l = (int) a.byteSize();
         int s = SPECIES.vectorByteSize();
@@ -508,8 +508,8 @@ public class Double128VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @Test(dataProvider = "doubleByteProviderForIOOBE")
     static void storeMemorySegmentIOOBE(IntFunction<double[]> fa, IntFunction<Integer> fi) {
-        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySegment.allocateNative(i, Double.SIZE, MemorySession.openImplicit()));
-        MemorySegment r = MemorySegment.allocateNative(a.byteSize(), Double.SIZE, MemorySession.openImplicit());
+        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySession.openImplicit().allocate(i, Double.SIZE));
+        MemorySegment r = MemorySession.openImplicit().allocate(a.byteSize(), Double.SIZE);
 
         int l = (int) a.byteSize();
         int s = SPECIES.vectorByteSize();
@@ -572,8 +572,8 @@ public class Double128VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @Test(dataProvider = "doubleByteMaskProviderForIOOBE")
     static void loadMemorySegmentMaskIOOBE(IntFunction<double[]> fa, IntFunction<Integer> fi, IntFunction<boolean[]> fm) {
-        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySegment.allocateNative(i, Double.SIZE, MemorySession.openImplicit()));
-        MemorySegment r = MemorySegment.allocateNative(a.byteSize(), Double.SIZE, MemorySession.openImplicit());
+        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySession.openImplicit().allocate(i, Double.SIZE));
+        MemorySegment r = MemorySession.openImplicit().allocate(a.byteSize(), Double.SIZE);
         boolean[] mask = fm.apply(SPECIES.length());
         VectorMask<Double> vmask = VectorMask.fromValues(SPECIES, mask);
 
@@ -603,8 +603,8 @@ public class Double128VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @Test(dataProvider = "doubleByteMaskProviderForIOOBE")
     static void storeMemorySegmentMaskIOOBE(IntFunction<double[]> fa, IntFunction<Integer> fi, IntFunction<boolean[]> fm) {
-        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySegment.allocateNative(i, Double.SIZE, MemorySession.openImplicit()));
-        MemorySegment r = MemorySegment.allocateNative(a.byteSize(), Double.SIZE, MemorySession.openImplicit());
+        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySession.openImplicit().allocate(i, Double.SIZE));
+        MemorySegment r = MemorySession.openImplicit().allocate(a.byteSize(), Double.SIZE);
         boolean[] mask = fm.apply(SPECIES.length());
         VectorMask<Double> vmask = VectorMask.fromValues(SPECIES, mask);
 

--- a/test/jdk/jdk/incubator/vector/Double256VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Double256VectorLoadStoreTests.java
@@ -479,8 +479,8 @@ public class Double256VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @Test(dataProvider = "doubleByteProviderForIOOBE")
     static void loadMemorySegmentIOOBE(IntFunction<double[]> fa, IntFunction<Integer> fi) {
-        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySession.openImplicit().allocate(i, Double.SIZE));
-        MemorySegment r = MemorySession.openImplicit().allocate(a.byteSize(), Double.SIZE);
+        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySegment.allocateNative(i, Double.SIZE));
+        MemorySegment r = MemorySegment.allocateNative(a.byteSize(), Double.SIZE);
 
         int l = (int) a.byteSize();
         int s = SPECIES.vectorByteSize();
@@ -508,8 +508,8 @@ public class Double256VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @Test(dataProvider = "doubleByteProviderForIOOBE")
     static void storeMemorySegmentIOOBE(IntFunction<double[]> fa, IntFunction<Integer> fi) {
-        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySession.openImplicit().allocate(i, Double.SIZE));
-        MemorySegment r = MemorySession.openImplicit().allocate(a.byteSize(), Double.SIZE);
+        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySegment.allocateNative(i, Double.SIZE));
+        MemorySegment r = MemorySegment.allocateNative(a.byteSize(), Double.SIZE);
 
         int l = (int) a.byteSize();
         int s = SPECIES.vectorByteSize();
@@ -572,8 +572,8 @@ public class Double256VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @Test(dataProvider = "doubleByteMaskProviderForIOOBE")
     static void loadMemorySegmentMaskIOOBE(IntFunction<double[]> fa, IntFunction<Integer> fi, IntFunction<boolean[]> fm) {
-        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySession.openImplicit().allocate(i, Double.SIZE));
-        MemorySegment r = MemorySession.openImplicit().allocate(a.byteSize(), Double.SIZE);
+        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySegment.allocateNative(i, Double.SIZE));
+        MemorySegment r = MemorySegment.allocateNative(a.byteSize(), Double.SIZE);
         boolean[] mask = fm.apply(SPECIES.length());
         VectorMask<Double> vmask = VectorMask.fromValues(SPECIES, mask);
 
@@ -603,8 +603,8 @@ public class Double256VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @Test(dataProvider = "doubleByteMaskProviderForIOOBE")
     static void storeMemorySegmentMaskIOOBE(IntFunction<double[]> fa, IntFunction<Integer> fi, IntFunction<boolean[]> fm) {
-        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySession.openImplicit().allocate(i, Double.SIZE));
-        MemorySegment r = MemorySession.openImplicit().allocate(a.byteSize(), Double.SIZE);
+        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySegment.allocateNative(i, Double.SIZE));
+        MemorySegment r = MemorySegment.allocateNative(a.byteSize(), Double.SIZE);
         boolean[] mask = fm.apply(SPECIES.length());
         VectorMask<Double> vmask = VectorMask.fromValues(SPECIES, mask);
 

--- a/test/jdk/jdk/incubator/vector/Double256VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Double256VectorLoadStoreTests.java
@@ -479,8 +479,8 @@ public class Double256VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @Test(dataProvider = "doubleByteProviderForIOOBE")
     static void loadMemorySegmentIOOBE(IntFunction<double[]> fa, IntFunction<Integer> fi) {
-        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySegment.allocateNative(i, Double.SIZE, MemorySession.openImplicit()));
-        MemorySegment r = MemorySegment.allocateNative(a.byteSize(), Double.SIZE, MemorySession.openImplicit());
+        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySession.openImplicit().allocate(i, Double.SIZE));
+        MemorySegment r = MemorySession.openImplicit().allocate(a.byteSize(), Double.SIZE);
 
         int l = (int) a.byteSize();
         int s = SPECIES.vectorByteSize();
@@ -508,8 +508,8 @@ public class Double256VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @Test(dataProvider = "doubleByteProviderForIOOBE")
     static void storeMemorySegmentIOOBE(IntFunction<double[]> fa, IntFunction<Integer> fi) {
-        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySegment.allocateNative(i, Double.SIZE, MemorySession.openImplicit()));
-        MemorySegment r = MemorySegment.allocateNative(a.byteSize(), Double.SIZE, MemorySession.openImplicit());
+        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySession.openImplicit().allocate(i, Double.SIZE));
+        MemorySegment r = MemorySession.openImplicit().allocate(a.byteSize(), Double.SIZE);
 
         int l = (int) a.byteSize();
         int s = SPECIES.vectorByteSize();
@@ -572,8 +572,8 @@ public class Double256VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @Test(dataProvider = "doubleByteMaskProviderForIOOBE")
     static void loadMemorySegmentMaskIOOBE(IntFunction<double[]> fa, IntFunction<Integer> fi, IntFunction<boolean[]> fm) {
-        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySegment.allocateNative(i, Double.SIZE, MemorySession.openImplicit()));
-        MemorySegment r = MemorySegment.allocateNative(a.byteSize(), Double.SIZE, MemorySession.openImplicit());
+        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySession.openImplicit().allocate(i, Double.SIZE));
+        MemorySegment r = MemorySession.openImplicit().allocate(a.byteSize(), Double.SIZE);
         boolean[] mask = fm.apply(SPECIES.length());
         VectorMask<Double> vmask = VectorMask.fromValues(SPECIES, mask);
 
@@ -603,8 +603,8 @@ public class Double256VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @Test(dataProvider = "doubleByteMaskProviderForIOOBE")
     static void storeMemorySegmentMaskIOOBE(IntFunction<double[]> fa, IntFunction<Integer> fi, IntFunction<boolean[]> fm) {
-        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySegment.allocateNative(i, Double.SIZE, MemorySession.openImplicit()));
-        MemorySegment r = MemorySegment.allocateNative(a.byteSize(), Double.SIZE, MemorySession.openImplicit());
+        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySession.openImplicit().allocate(i, Double.SIZE));
+        MemorySegment r = MemorySession.openImplicit().allocate(a.byteSize(), Double.SIZE);
         boolean[] mask = fm.apply(SPECIES.length());
         VectorMask<Double> vmask = VectorMask.fromValues(SPECIES, mask);
 

--- a/test/jdk/jdk/incubator/vector/Double512VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Double512VectorLoadStoreTests.java
@@ -479,8 +479,8 @@ public class Double512VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @Test(dataProvider = "doubleByteProviderForIOOBE")
     static void loadMemorySegmentIOOBE(IntFunction<double[]> fa, IntFunction<Integer> fi) {
-        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySegment.allocateNative(i, Double.SIZE, MemorySession.openImplicit()));
-        MemorySegment r = MemorySegment.allocateNative(a.byteSize(), Double.SIZE, MemorySession.openImplicit());
+        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySession.openImplicit().allocate(i, Double.SIZE));
+        MemorySegment r = MemorySession.openImplicit().allocate(a.byteSize(), Double.SIZE);
 
         int l = (int) a.byteSize();
         int s = SPECIES.vectorByteSize();
@@ -508,8 +508,8 @@ public class Double512VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @Test(dataProvider = "doubleByteProviderForIOOBE")
     static void storeMemorySegmentIOOBE(IntFunction<double[]> fa, IntFunction<Integer> fi) {
-        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySegment.allocateNative(i, Double.SIZE, MemorySession.openImplicit()));
-        MemorySegment r = MemorySegment.allocateNative(a.byteSize(), Double.SIZE, MemorySession.openImplicit());
+        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySession.openImplicit().allocate(i, Double.SIZE));
+        MemorySegment r = MemorySession.openImplicit().allocate(a.byteSize(), Double.SIZE);
 
         int l = (int) a.byteSize();
         int s = SPECIES.vectorByteSize();
@@ -572,8 +572,8 @@ public class Double512VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @Test(dataProvider = "doubleByteMaskProviderForIOOBE")
     static void loadMemorySegmentMaskIOOBE(IntFunction<double[]> fa, IntFunction<Integer> fi, IntFunction<boolean[]> fm) {
-        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySegment.allocateNative(i, Double.SIZE, MemorySession.openImplicit()));
-        MemorySegment r = MemorySegment.allocateNative(a.byteSize(), Double.SIZE, MemorySession.openImplicit());
+        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySession.openImplicit().allocate(i, Double.SIZE));
+        MemorySegment r = MemorySession.openImplicit().allocate(a.byteSize(), Double.SIZE);
         boolean[] mask = fm.apply(SPECIES.length());
         VectorMask<Double> vmask = VectorMask.fromValues(SPECIES, mask);
 
@@ -603,8 +603,8 @@ public class Double512VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @Test(dataProvider = "doubleByteMaskProviderForIOOBE")
     static void storeMemorySegmentMaskIOOBE(IntFunction<double[]> fa, IntFunction<Integer> fi, IntFunction<boolean[]> fm) {
-        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySegment.allocateNative(i, Double.SIZE, MemorySession.openImplicit()));
-        MemorySegment r = MemorySegment.allocateNative(a.byteSize(), Double.SIZE, MemorySession.openImplicit());
+        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySession.openImplicit().allocate(i, Double.SIZE));
+        MemorySegment r = MemorySession.openImplicit().allocate(a.byteSize(), Double.SIZE);
         boolean[] mask = fm.apply(SPECIES.length());
         VectorMask<Double> vmask = VectorMask.fromValues(SPECIES, mask);
 

--- a/test/jdk/jdk/incubator/vector/Double512VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Double512VectorLoadStoreTests.java
@@ -479,8 +479,8 @@ public class Double512VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @Test(dataProvider = "doubleByteProviderForIOOBE")
     static void loadMemorySegmentIOOBE(IntFunction<double[]> fa, IntFunction<Integer> fi) {
-        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySession.openImplicit().allocate(i, Double.SIZE));
-        MemorySegment r = MemorySession.openImplicit().allocate(a.byteSize(), Double.SIZE);
+        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySegment.allocateNative(i, Double.SIZE));
+        MemorySegment r = MemorySegment.allocateNative(a.byteSize(), Double.SIZE);
 
         int l = (int) a.byteSize();
         int s = SPECIES.vectorByteSize();
@@ -508,8 +508,8 @@ public class Double512VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @Test(dataProvider = "doubleByteProviderForIOOBE")
     static void storeMemorySegmentIOOBE(IntFunction<double[]> fa, IntFunction<Integer> fi) {
-        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySession.openImplicit().allocate(i, Double.SIZE));
-        MemorySegment r = MemorySession.openImplicit().allocate(a.byteSize(), Double.SIZE);
+        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySegment.allocateNative(i, Double.SIZE));
+        MemorySegment r = MemorySegment.allocateNative(a.byteSize(), Double.SIZE);
 
         int l = (int) a.byteSize();
         int s = SPECIES.vectorByteSize();
@@ -572,8 +572,8 @@ public class Double512VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @Test(dataProvider = "doubleByteMaskProviderForIOOBE")
     static void loadMemorySegmentMaskIOOBE(IntFunction<double[]> fa, IntFunction<Integer> fi, IntFunction<boolean[]> fm) {
-        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySession.openImplicit().allocate(i, Double.SIZE));
-        MemorySegment r = MemorySession.openImplicit().allocate(a.byteSize(), Double.SIZE);
+        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySegment.allocateNative(i, Double.SIZE));
+        MemorySegment r = MemorySegment.allocateNative(a.byteSize(), Double.SIZE);
         boolean[] mask = fm.apply(SPECIES.length());
         VectorMask<Double> vmask = VectorMask.fromValues(SPECIES, mask);
 
@@ -603,8 +603,8 @@ public class Double512VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @Test(dataProvider = "doubleByteMaskProviderForIOOBE")
     static void storeMemorySegmentMaskIOOBE(IntFunction<double[]> fa, IntFunction<Integer> fi, IntFunction<boolean[]> fm) {
-        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySession.openImplicit().allocate(i, Double.SIZE));
-        MemorySegment r = MemorySession.openImplicit().allocate(a.byteSize(), Double.SIZE);
+        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySegment.allocateNative(i, Double.SIZE));
+        MemorySegment r = MemorySegment.allocateNative(a.byteSize(), Double.SIZE);
         boolean[] mask = fm.apply(SPECIES.length());
         VectorMask<Double> vmask = VectorMask.fromValues(SPECIES, mask);
 

--- a/test/jdk/jdk/incubator/vector/Double64VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Double64VectorLoadStoreTests.java
@@ -479,8 +479,8 @@ public class Double64VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @Test(dataProvider = "doubleByteProviderForIOOBE")
     static void loadMemorySegmentIOOBE(IntFunction<double[]> fa, IntFunction<Integer> fi) {
-        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySession.openImplicit().allocate(i, Double.SIZE));
-        MemorySegment r = MemorySession.openImplicit().allocate(a.byteSize(), Double.SIZE);
+        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySegment.allocateNative(i, Double.SIZE));
+        MemorySegment r = MemorySegment.allocateNative(a.byteSize(), Double.SIZE);
 
         int l = (int) a.byteSize();
         int s = SPECIES.vectorByteSize();
@@ -508,8 +508,8 @@ public class Double64VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @Test(dataProvider = "doubleByteProviderForIOOBE")
     static void storeMemorySegmentIOOBE(IntFunction<double[]> fa, IntFunction<Integer> fi) {
-        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySession.openImplicit().allocate(i, Double.SIZE));
-        MemorySegment r = MemorySession.openImplicit().allocate(a.byteSize(), Double.SIZE);
+        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySegment.allocateNative(i, Double.SIZE));
+        MemorySegment r = MemorySegment.allocateNative(a.byteSize(), Double.SIZE);
 
         int l = (int) a.byteSize();
         int s = SPECIES.vectorByteSize();
@@ -572,8 +572,8 @@ public class Double64VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @Test(dataProvider = "doubleByteMaskProviderForIOOBE")
     static void loadMemorySegmentMaskIOOBE(IntFunction<double[]> fa, IntFunction<Integer> fi, IntFunction<boolean[]> fm) {
-        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySession.openImplicit().allocate(i, Double.SIZE));
-        MemorySegment r = MemorySession.openImplicit().allocate(a.byteSize(), Double.SIZE);
+        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySegment.allocateNative(i, Double.SIZE));
+        MemorySegment r = MemorySegment.allocateNative(a.byteSize(), Double.SIZE);
         boolean[] mask = fm.apply(SPECIES.length());
         VectorMask<Double> vmask = VectorMask.fromValues(SPECIES, mask);
 
@@ -603,8 +603,8 @@ public class Double64VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @Test(dataProvider = "doubleByteMaskProviderForIOOBE")
     static void storeMemorySegmentMaskIOOBE(IntFunction<double[]> fa, IntFunction<Integer> fi, IntFunction<boolean[]> fm) {
-        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySession.openImplicit().allocate(i, Double.SIZE));
-        MemorySegment r = MemorySession.openImplicit().allocate(a.byteSize(), Double.SIZE);
+        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySegment.allocateNative(i, Double.SIZE));
+        MemorySegment r = MemorySegment.allocateNative(a.byteSize(), Double.SIZE);
         boolean[] mask = fm.apply(SPECIES.length());
         VectorMask<Double> vmask = VectorMask.fromValues(SPECIES, mask);
 

--- a/test/jdk/jdk/incubator/vector/Double64VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Double64VectorLoadStoreTests.java
@@ -479,8 +479,8 @@ public class Double64VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @Test(dataProvider = "doubleByteProviderForIOOBE")
     static void loadMemorySegmentIOOBE(IntFunction<double[]> fa, IntFunction<Integer> fi) {
-        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySegment.allocateNative(i, Double.SIZE, MemorySession.openImplicit()));
-        MemorySegment r = MemorySegment.allocateNative(a.byteSize(), Double.SIZE, MemorySession.openImplicit());
+        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySession.openImplicit().allocate(i, Double.SIZE));
+        MemorySegment r = MemorySession.openImplicit().allocate(a.byteSize(), Double.SIZE);
 
         int l = (int) a.byteSize();
         int s = SPECIES.vectorByteSize();
@@ -508,8 +508,8 @@ public class Double64VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @Test(dataProvider = "doubleByteProviderForIOOBE")
     static void storeMemorySegmentIOOBE(IntFunction<double[]> fa, IntFunction<Integer> fi) {
-        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySegment.allocateNative(i, Double.SIZE, MemorySession.openImplicit()));
-        MemorySegment r = MemorySegment.allocateNative(a.byteSize(), Double.SIZE, MemorySession.openImplicit());
+        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySession.openImplicit().allocate(i, Double.SIZE));
+        MemorySegment r = MemorySession.openImplicit().allocate(a.byteSize(), Double.SIZE);
 
         int l = (int) a.byteSize();
         int s = SPECIES.vectorByteSize();
@@ -572,8 +572,8 @@ public class Double64VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @Test(dataProvider = "doubleByteMaskProviderForIOOBE")
     static void loadMemorySegmentMaskIOOBE(IntFunction<double[]> fa, IntFunction<Integer> fi, IntFunction<boolean[]> fm) {
-        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySegment.allocateNative(i, Double.SIZE, MemorySession.openImplicit()));
-        MemorySegment r = MemorySegment.allocateNative(a.byteSize(), Double.SIZE, MemorySession.openImplicit());
+        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySession.openImplicit().allocate(i, Double.SIZE));
+        MemorySegment r = MemorySession.openImplicit().allocate(a.byteSize(), Double.SIZE);
         boolean[] mask = fm.apply(SPECIES.length());
         VectorMask<Double> vmask = VectorMask.fromValues(SPECIES, mask);
 
@@ -603,8 +603,8 @@ public class Double64VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @Test(dataProvider = "doubleByteMaskProviderForIOOBE")
     static void storeMemorySegmentMaskIOOBE(IntFunction<double[]> fa, IntFunction<Integer> fi, IntFunction<boolean[]> fm) {
-        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySegment.allocateNative(i, Double.SIZE, MemorySession.openImplicit()));
-        MemorySegment r = MemorySegment.allocateNative(a.byteSize(), Double.SIZE, MemorySession.openImplicit());
+        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySession.openImplicit().allocate(i, Double.SIZE));
+        MemorySegment r = MemorySession.openImplicit().allocate(a.byteSize(), Double.SIZE);
         boolean[] mask = fm.apply(SPECIES.length());
         VectorMask<Double> vmask = VectorMask.fromValues(SPECIES, mask);
 

--- a/test/jdk/jdk/incubator/vector/DoubleMaxVectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/DoubleMaxVectorLoadStoreTests.java
@@ -486,8 +486,8 @@ public class DoubleMaxVectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @Test(dataProvider = "doubleByteProviderForIOOBE")
     static void loadMemorySegmentIOOBE(IntFunction<double[]> fa, IntFunction<Integer> fi) {
-        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySegment.allocateNative(i, Double.SIZE, MemorySession.openImplicit()));
-        MemorySegment r = MemorySegment.allocateNative(a.byteSize(), Double.SIZE, MemorySession.openImplicit());
+        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySession.openImplicit().allocate(i, Double.SIZE));
+        MemorySegment r = MemorySession.openImplicit().allocate(a.byteSize(), Double.SIZE);
 
         int l = (int) a.byteSize();
         int s = SPECIES.vectorByteSize();
@@ -515,8 +515,8 @@ public class DoubleMaxVectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @Test(dataProvider = "doubleByteProviderForIOOBE")
     static void storeMemorySegmentIOOBE(IntFunction<double[]> fa, IntFunction<Integer> fi) {
-        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySegment.allocateNative(i, Double.SIZE, MemorySession.openImplicit()));
-        MemorySegment r = MemorySegment.allocateNative(a.byteSize(), Double.SIZE, MemorySession.openImplicit());
+        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySession.openImplicit().allocate(i, Double.SIZE));
+        MemorySegment r = MemorySession.openImplicit().allocate(a.byteSize(), Double.SIZE);
 
         int l = (int) a.byteSize();
         int s = SPECIES.vectorByteSize();
@@ -579,8 +579,8 @@ public class DoubleMaxVectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @Test(dataProvider = "doubleByteMaskProviderForIOOBE")
     static void loadMemorySegmentMaskIOOBE(IntFunction<double[]> fa, IntFunction<Integer> fi, IntFunction<boolean[]> fm) {
-        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySegment.allocateNative(i, Double.SIZE, MemorySession.openImplicit()));
-        MemorySegment r = MemorySegment.allocateNative(a.byteSize(), Double.SIZE, MemorySession.openImplicit());
+        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySession.openImplicit().allocate(i, Double.SIZE));
+        MemorySegment r = MemorySession.openImplicit().allocate(a.byteSize(), Double.SIZE);
         boolean[] mask = fm.apply(SPECIES.length());
         VectorMask<Double> vmask = VectorMask.fromValues(SPECIES, mask);
 
@@ -610,8 +610,8 @@ public class DoubleMaxVectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @Test(dataProvider = "doubleByteMaskProviderForIOOBE")
     static void storeMemorySegmentMaskIOOBE(IntFunction<double[]> fa, IntFunction<Integer> fi, IntFunction<boolean[]> fm) {
-        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySegment.allocateNative(i, Double.SIZE, MemorySession.openImplicit()));
-        MemorySegment r = MemorySegment.allocateNative(a.byteSize(), Double.SIZE, MemorySession.openImplicit());
+        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySession.openImplicit().allocate(i, Double.SIZE));
+        MemorySegment r = MemorySession.openImplicit().allocate(a.byteSize(), Double.SIZE);
         boolean[] mask = fm.apply(SPECIES.length());
         VectorMask<Double> vmask = VectorMask.fromValues(SPECIES, mask);
 

--- a/test/jdk/jdk/incubator/vector/DoubleMaxVectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/DoubleMaxVectorLoadStoreTests.java
@@ -486,8 +486,8 @@ public class DoubleMaxVectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @Test(dataProvider = "doubleByteProviderForIOOBE")
     static void loadMemorySegmentIOOBE(IntFunction<double[]> fa, IntFunction<Integer> fi) {
-        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySession.openImplicit().allocate(i, Double.SIZE));
-        MemorySegment r = MemorySession.openImplicit().allocate(a.byteSize(), Double.SIZE);
+        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySegment.allocateNative(i, Double.SIZE));
+        MemorySegment r = MemorySegment.allocateNative(a.byteSize(), Double.SIZE);
 
         int l = (int) a.byteSize();
         int s = SPECIES.vectorByteSize();
@@ -515,8 +515,8 @@ public class DoubleMaxVectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @Test(dataProvider = "doubleByteProviderForIOOBE")
     static void storeMemorySegmentIOOBE(IntFunction<double[]> fa, IntFunction<Integer> fi) {
-        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySession.openImplicit().allocate(i, Double.SIZE));
-        MemorySegment r = MemorySession.openImplicit().allocate(a.byteSize(), Double.SIZE);
+        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySegment.allocateNative(i, Double.SIZE));
+        MemorySegment r = MemorySegment.allocateNative(a.byteSize(), Double.SIZE);
 
         int l = (int) a.byteSize();
         int s = SPECIES.vectorByteSize();
@@ -579,8 +579,8 @@ public class DoubleMaxVectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @Test(dataProvider = "doubleByteMaskProviderForIOOBE")
     static void loadMemorySegmentMaskIOOBE(IntFunction<double[]> fa, IntFunction<Integer> fi, IntFunction<boolean[]> fm) {
-        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySession.openImplicit().allocate(i, Double.SIZE));
-        MemorySegment r = MemorySession.openImplicit().allocate(a.byteSize(), Double.SIZE);
+        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySegment.allocateNative(i, Double.SIZE));
+        MemorySegment r = MemorySegment.allocateNative(a.byteSize(), Double.SIZE);
         boolean[] mask = fm.apply(SPECIES.length());
         VectorMask<Double> vmask = VectorMask.fromValues(SPECIES, mask);
 
@@ -610,8 +610,8 @@ public class DoubleMaxVectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @Test(dataProvider = "doubleByteMaskProviderForIOOBE")
     static void storeMemorySegmentMaskIOOBE(IntFunction<double[]> fa, IntFunction<Integer> fi, IntFunction<boolean[]> fm) {
-        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySession.openImplicit().allocate(i, Double.SIZE));
-        MemorySegment r = MemorySession.openImplicit().allocate(a.byteSize(), Double.SIZE);
+        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySegment.allocateNative(i, Double.SIZE));
+        MemorySegment r = MemorySegment.allocateNative(a.byteSize(), Double.SIZE);
         boolean[] mask = fm.apply(SPECIES.length());
         VectorMask<Double> vmask = VectorMask.fromValues(SPECIES, mask);
 

--- a/test/jdk/jdk/incubator/vector/Float128VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Float128VectorLoadStoreTests.java
@@ -479,8 +479,8 @@ public class Float128VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @Test(dataProvider = "floatByteProviderForIOOBE")
     static void loadMemorySegmentIOOBE(IntFunction<float[]> fa, IntFunction<Integer> fi) {
-        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySegment.allocateNative(i, Float.SIZE, MemorySession.openImplicit()));
-        MemorySegment r = MemorySegment.allocateNative(a.byteSize(), Float.SIZE, MemorySession.openImplicit());
+        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySession.openImplicit().allocate(i, Float.SIZE));
+        MemorySegment r = MemorySession.openImplicit().allocate(a.byteSize(), Float.SIZE);
 
         int l = (int) a.byteSize();
         int s = SPECIES.vectorByteSize();
@@ -508,8 +508,8 @@ public class Float128VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @Test(dataProvider = "floatByteProviderForIOOBE")
     static void storeMemorySegmentIOOBE(IntFunction<float[]> fa, IntFunction<Integer> fi) {
-        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySegment.allocateNative(i, Float.SIZE, MemorySession.openImplicit()));
-        MemorySegment r = MemorySegment.allocateNative(a.byteSize(), Float.SIZE, MemorySession.openImplicit());
+        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySession.openImplicit().allocate(i, Float.SIZE));
+        MemorySegment r = MemorySession.openImplicit().allocate(a.byteSize(), Float.SIZE);
 
         int l = (int) a.byteSize();
         int s = SPECIES.vectorByteSize();
@@ -572,8 +572,8 @@ public class Float128VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @Test(dataProvider = "floatByteMaskProviderForIOOBE")
     static void loadMemorySegmentMaskIOOBE(IntFunction<float[]> fa, IntFunction<Integer> fi, IntFunction<boolean[]> fm) {
-        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySegment.allocateNative(i, Float.SIZE, MemorySession.openImplicit()));
-        MemorySegment r = MemorySegment.allocateNative(a.byteSize(), Float.SIZE, MemorySession.openImplicit());
+        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySession.openImplicit().allocate(i, Float.SIZE));
+        MemorySegment r = MemorySession.openImplicit().allocate(a.byteSize(), Float.SIZE);
         boolean[] mask = fm.apply(SPECIES.length());
         VectorMask<Float> vmask = VectorMask.fromValues(SPECIES, mask);
 
@@ -603,8 +603,8 @@ public class Float128VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @Test(dataProvider = "floatByteMaskProviderForIOOBE")
     static void storeMemorySegmentMaskIOOBE(IntFunction<float[]> fa, IntFunction<Integer> fi, IntFunction<boolean[]> fm) {
-        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySegment.allocateNative(i, Float.SIZE, MemorySession.openImplicit()));
-        MemorySegment r = MemorySegment.allocateNative(a.byteSize(), Float.SIZE, MemorySession.openImplicit());
+        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySession.openImplicit().allocate(i, Float.SIZE));
+        MemorySegment r = MemorySession.openImplicit().allocate(a.byteSize(), Float.SIZE);
         boolean[] mask = fm.apply(SPECIES.length());
         VectorMask<Float> vmask = VectorMask.fromValues(SPECIES, mask);
 

--- a/test/jdk/jdk/incubator/vector/Float128VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Float128VectorLoadStoreTests.java
@@ -479,8 +479,8 @@ public class Float128VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @Test(dataProvider = "floatByteProviderForIOOBE")
     static void loadMemorySegmentIOOBE(IntFunction<float[]> fa, IntFunction<Integer> fi) {
-        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySession.openImplicit().allocate(i, Float.SIZE));
-        MemorySegment r = MemorySession.openImplicit().allocate(a.byteSize(), Float.SIZE);
+        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySegment.allocateNative(i, Float.SIZE));
+        MemorySegment r = MemorySegment.allocateNative(a.byteSize(), Float.SIZE);
 
         int l = (int) a.byteSize();
         int s = SPECIES.vectorByteSize();
@@ -508,8 +508,8 @@ public class Float128VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @Test(dataProvider = "floatByteProviderForIOOBE")
     static void storeMemorySegmentIOOBE(IntFunction<float[]> fa, IntFunction<Integer> fi) {
-        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySession.openImplicit().allocate(i, Float.SIZE));
-        MemorySegment r = MemorySession.openImplicit().allocate(a.byteSize(), Float.SIZE);
+        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySegment.allocateNative(i, Float.SIZE));
+        MemorySegment r = MemorySegment.allocateNative(a.byteSize(), Float.SIZE);
 
         int l = (int) a.byteSize();
         int s = SPECIES.vectorByteSize();
@@ -572,8 +572,8 @@ public class Float128VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @Test(dataProvider = "floatByteMaskProviderForIOOBE")
     static void loadMemorySegmentMaskIOOBE(IntFunction<float[]> fa, IntFunction<Integer> fi, IntFunction<boolean[]> fm) {
-        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySession.openImplicit().allocate(i, Float.SIZE));
-        MemorySegment r = MemorySession.openImplicit().allocate(a.byteSize(), Float.SIZE);
+        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySegment.allocateNative(i, Float.SIZE));
+        MemorySegment r = MemorySegment.allocateNative(a.byteSize(), Float.SIZE);
         boolean[] mask = fm.apply(SPECIES.length());
         VectorMask<Float> vmask = VectorMask.fromValues(SPECIES, mask);
 
@@ -603,8 +603,8 @@ public class Float128VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @Test(dataProvider = "floatByteMaskProviderForIOOBE")
     static void storeMemorySegmentMaskIOOBE(IntFunction<float[]> fa, IntFunction<Integer> fi, IntFunction<boolean[]> fm) {
-        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySession.openImplicit().allocate(i, Float.SIZE));
-        MemorySegment r = MemorySession.openImplicit().allocate(a.byteSize(), Float.SIZE);
+        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySegment.allocateNative(i, Float.SIZE));
+        MemorySegment r = MemorySegment.allocateNative(a.byteSize(), Float.SIZE);
         boolean[] mask = fm.apply(SPECIES.length());
         VectorMask<Float> vmask = VectorMask.fromValues(SPECIES, mask);
 

--- a/test/jdk/jdk/incubator/vector/Float256VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Float256VectorLoadStoreTests.java
@@ -479,8 +479,8 @@ public class Float256VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @Test(dataProvider = "floatByteProviderForIOOBE")
     static void loadMemorySegmentIOOBE(IntFunction<float[]> fa, IntFunction<Integer> fi) {
-        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySegment.allocateNative(i, Float.SIZE, MemorySession.openImplicit()));
-        MemorySegment r = MemorySegment.allocateNative(a.byteSize(), Float.SIZE, MemorySession.openImplicit());
+        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySession.openImplicit().allocate(i, Float.SIZE));
+        MemorySegment r = MemorySession.openImplicit().allocate(a.byteSize(), Float.SIZE);
 
         int l = (int) a.byteSize();
         int s = SPECIES.vectorByteSize();
@@ -508,8 +508,8 @@ public class Float256VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @Test(dataProvider = "floatByteProviderForIOOBE")
     static void storeMemorySegmentIOOBE(IntFunction<float[]> fa, IntFunction<Integer> fi) {
-        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySegment.allocateNative(i, Float.SIZE, MemorySession.openImplicit()));
-        MemorySegment r = MemorySegment.allocateNative(a.byteSize(), Float.SIZE, MemorySession.openImplicit());
+        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySession.openImplicit().allocate(i, Float.SIZE));
+        MemorySegment r = MemorySession.openImplicit().allocate(a.byteSize(), Float.SIZE);
 
         int l = (int) a.byteSize();
         int s = SPECIES.vectorByteSize();
@@ -572,8 +572,8 @@ public class Float256VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @Test(dataProvider = "floatByteMaskProviderForIOOBE")
     static void loadMemorySegmentMaskIOOBE(IntFunction<float[]> fa, IntFunction<Integer> fi, IntFunction<boolean[]> fm) {
-        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySegment.allocateNative(i, Float.SIZE, MemorySession.openImplicit()));
-        MemorySegment r = MemorySegment.allocateNative(a.byteSize(), Float.SIZE, MemorySession.openImplicit());
+        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySession.openImplicit().allocate(i, Float.SIZE));
+        MemorySegment r = MemorySession.openImplicit().allocate(a.byteSize(), Float.SIZE);
         boolean[] mask = fm.apply(SPECIES.length());
         VectorMask<Float> vmask = VectorMask.fromValues(SPECIES, mask);
 
@@ -603,8 +603,8 @@ public class Float256VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @Test(dataProvider = "floatByteMaskProviderForIOOBE")
     static void storeMemorySegmentMaskIOOBE(IntFunction<float[]> fa, IntFunction<Integer> fi, IntFunction<boolean[]> fm) {
-        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySegment.allocateNative(i, Float.SIZE, MemorySession.openImplicit()));
-        MemorySegment r = MemorySegment.allocateNative(a.byteSize(), Float.SIZE, MemorySession.openImplicit());
+        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySession.openImplicit().allocate(i, Float.SIZE));
+        MemorySegment r = MemorySession.openImplicit().allocate(a.byteSize(), Float.SIZE);
         boolean[] mask = fm.apply(SPECIES.length());
         VectorMask<Float> vmask = VectorMask.fromValues(SPECIES, mask);
 

--- a/test/jdk/jdk/incubator/vector/Float256VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Float256VectorLoadStoreTests.java
@@ -479,8 +479,8 @@ public class Float256VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @Test(dataProvider = "floatByteProviderForIOOBE")
     static void loadMemorySegmentIOOBE(IntFunction<float[]> fa, IntFunction<Integer> fi) {
-        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySession.openImplicit().allocate(i, Float.SIZE));
-        MemorySegment r = MemorySession.openImplicit().allocate(a.byteSize(), Float.SIZE);
+        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySegment.allocateNative(i, Float.SIZE));
+        MemorySegment r = MemorySegment.allocateNative(a.byteSize(), Float.SIZE);
 
         int l = (int) a.byteSize();
         int s = SPECIES.vectorByteSize();
@@ -508,8 +508,8 @@ public class Float256VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @Test(dataProvider = "floatByteProviderForIOOBE")
     static void storeMemorySegmentIOOBE(IntFunction<float[]> fa, IntFunction<Integer> fi) {
-        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySession.openImplicit().allocate(i, Float.SIZE));
-        MemorySegment r = MemorySession.openImplicit().allocate(a.byteSize(), Float.SIZE);
+        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySegment.allocateNative(i, Float.SIZE));
+        MemorySegment r = MemorySegment.allocateNative(a.byteSize(), Float.SIZE);
 
         int l = (int) a.byteSize();
         int s = SPECIES.vectorByteSize();
@@ -572,8 +572,8 @@ public class Float256VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @Test(dataProvider = "floatByteMaskProviderForIOOBE")
     static void loadMemorySegmentMaskIOOBE(IntFunction<float[]> fa, IntFunction<Integer> fi, IntFunction<boolean[]> fm) {
-        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySession.openImplicit().allocate(i, Float.SIZE));
-        MemorySegment r = MemorySession.openImplicit().allocate(a.byteSize(), Float.SIZE);
+        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySegment.allocateNative(i, Float.SIZE));
+        MemorySegment r = MemorySegment.allocateNative(a.byteSize(), Float.SIZE);
         boolean[] mask = fm.apply(SPECIES.length());
         VectorMask<Float> vmask = VectorMask.fromValues(SPECIES, mask);
 
@@ -603,8 +603,8 @@ public class Float256VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @Test(dataProvider = "floatByteMaskProviderForIOOBE")
     static void storeMemorySegmentMaskIOOBE(IntFunction<float[]> fa, IntFunction<Integer> fi, IntFunction<boolean[]> fm) {
-        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySession.openImplicit().allocate(i, Float.SIZE));
-        MemorySegment r = MemorySession.openImplicit().allocate(a.byteSize(), Float.SIZE);
+        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySegment.allocateNative(i, Float.SIZE));
+        MemorySegment r = MemorySegment.allocateNative(a.byteSize(), Float.SIZE);
         boolean[] mask = fm.apply(SPECIES.length());
         VectorMask<Float> vmask = VectorMask.fromValues(SPECIES, mask);
 

--- a/test/jdk/jdk/incubator/vector/Float512VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Float512VectorLoadStoreTests.java
@@ -479,8 +479,8 @@ public class Float512VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @Test(dataProvider = "floatByteProviderForIOOBE")
     static void loadMemorySegmentIOOBE(IntFunction<float[]> fa, IntFunction<Integer> fi) {
-        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySegment.allocateNative(i, Float.SIZE, MemorySession.openImplicit()));
-        MemorySegment r = MemorySegment.allocateNative(a.byteSize(), Float.SIZE, MemorySession.openImplicit());
+        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySession.openImplicit().allocate(i, Float.SIZE));
+        MemorySegment r = MemorySession.openImplicit().allocate(a.byteSize(), Float.SIZE);
 
         int l = (int) a.byteSize();
         int s = SPECIES.vectorByteSize();
@@ -508,8 +508,8 @@ public class Float512VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @Test(dataProvider = "floatByteProviderForIOOBE")
     static void storeMemorySegmentIOOBE(IntFunction<float[]> fa, IntFunction<Integer> fi) {
-        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySegment.allocateNative(i, Float.SIZE, MemorySession.openImplicit()));
-        MemorySegment r = MemorySegment.allocateNative(a.byteSize(), Float.SIZE, MemorySession.openImplicit());
+        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySession.openImplicit().allocate(i, Float.SIZE));
+        MemorySegment r = MemorySession.openImplicit().allocate(a.byteSize(), Float.SIZE);
 
         int l = (int) a.byteSize();
         int s = SPECIES.vectorByteSize();
@@ -572,8 +572,8 @@ public class Float512VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @Test(dataProvider = "floatByteMaskProviderForIOOBE")
     static void loadMemorySegmentMaskIOOBE(IntFunction<float[]> fa, IntFunction<Integer> fi, IntFunction<boolean[]> fm) {
-        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySegment.allocateNative(i, Float.SIZE, MemorySession.openImplicit()));
-        MemorySegment r = MemorySegment.allocateNative(a.byteSize(), Float.SIZE, MemorySession.openImplicit());
+        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySession.openImplicit().allocate(i, Float.SIZE));
+        MemorySegment r = MemorySession.openImplicit().allocate(a.byteSize(), Float.SIZE);
         boolean[] mask = fm.apply(SPECIES.length());
         VectorMask<Float> vmask = VectorMask.fromValues(SPECIES, mask);
 
@@ -603,8 +603,8 @@ public class Float512VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @Test(dataProvider = "floatByteMaskProviderForIOOBE")
     static void storeMemorySegmentMaskIOOBE(IntFunction<float[]> fa, IntFunction<Integer> fi, IntFunction<boolean[]> fm) {
-        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySegment.allocateNative(i, Float.SIZE, MemorySession.openImplicit()));
-        MemorySegment r = MemorySegment.allocateNative(a.byteSize(), Float.SIZE, MemorySession.openImplicit());
+        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySession.openImplicit().allocate(i, Float.SIZE));
+        MemorySegment r = MemorySession.openImplicit().allocate(a.byteSize(), Float.SIZE);
         boolean[] mask = fm.apply(SPECIES.length());
         VectorMask<Float> vmask = VectorMask.fromValues(SPECIES, mask);
 

--- a/test/jdk/jdk/incubator/vector/Float512VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Float512VectorLoadStoreTests.java
@@ -479,8 +479,8 @@ public class Float512VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @Test(dataProvider = "floatByteProviderForIOOBE")
     static void loadMemorySegmentIOOBE(IntFunction<float[]> fa, IntFunction<Integer> fi) {
-        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySession.openImplicit().allocate(i, Float.SIZE));
-        MemorySegment r = MemorySession.openImplicit().allocate(a.byteSize(), Float.SIZE);
+        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySegment.allocateNative(i, Float.SIZE));
+        MemorySegment r = MemorySegment.allocateNative(a.byteSize(), Float.SIZE);
 
         int l = (int) a.byteSize();
         int s = SPECIES.vectorByteSize();
@@ -508,8 +508,8 @@ public class Float512VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @Test(dataProvider = "floatByteProviderForIOOBE")
     static void storeMemorySegmentIOOBE(IntFunction<float[]> fa, IntFunction<Integer> fi) {
-        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySession.openImplicit().allocate(i, Float.SIZE));
-        MemorySegment r = MemorySession.openImplicit().allocate(a.byteSize(), Float.SIZE);
+        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySegment.allocateNative(i, Float.SIZE));
+        MemorySegment r = MemorySegment.allocateNative(a.byteSize(), Float.SIZE);
 
         int l = (int) a.byteSize();
         int s = SPECIES.vectorByteSize();
@@ -572,8 +572,8 @@ public class Float512VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @Test(dataProvider = "floatByteMaskProviderForIOOBE")
     static void loadMemorySegmentMaskIOOBE(IntFunction<float[]> fa, IntFunction<Integer> fi, IntFunction<boolean[]> fm) {
-        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySession.openImplicit().allocate(i, Float.SIZE));
-        MemorySegment r = MemorySession.openImplicit().allocate(a.byteSize(), Float.SIZE);
+        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySegment.allocateNative(i, Float.SIZE));
+        MemorySegment r = MemorySegment.allocateNative(a.byteSize(), Float.SIZE);
         boolean[] mask = fm.apply(SPECIES.length());
         VectorMask<Float> vmask = VectorMask.fromValues(SPECIES, mask);
 
@@ -603,8 +603,8 @@ public class Float512VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @Test(dataProvider = "floatByteMaskProviderForIOOBE")
     static void storeMemorySegmentMaskIOOBE(IntFunction<float[]> fa, IntFunction<Integer> fi, IntFunction<boolean[]> fm) {
-        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySession.openImplicit().allocate(i, Float.SIZE));
-        MemorySegment r = MemorySession.openImplicit().allocate(a.byteSize(), Float.SIZE);
+        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySegment.allocateNative(i, Float.SIZE));
+        MemorySegment r = MemorySegment.allocateNative(a.byteSize(), Float.SIZE);
         boolean[] mask = fm.apply(SPECIES.length());
         VectorMask<Float> vmask = VectorMask.fromValues(SPECIES, mask);
 

--- a/test/jdk/jdk/incubator/vector/Float64VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Float64VectorLoadStoreTests.java
@@ -479,8 +479,8 @@ public class Float64VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @Test(dataProvider = "floatByteProviderForIOOBE")
     static void loadMemorySegmentIOOBE(IntFunction<float[]> fa, IntFunction<Integer> fi) {
-        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySegment.allocateNative(i, Float.SIZE, MemorySession.openImplicit()));
-        MemorySegment r = MemorySegment.allocateNative(a.byteSize(), Float.SIZE, MemorySession.openImplicit());
+        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySession.openImplicit().allocate(i, Float.SIZE));
+        MemorySegment r = MemorySession.openImplicit().allocate(a.byteSize(), Float.SIZE);
 
         int l = (int) a.byteSize();
         int s = SPECIES.vectorByteSize();
@@ -508,8 +508,8 @@ public class Float64VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @Test(dataProvider = "floatByteProviderForIOOBE")
     static void storeMemorySegmentIOOBE(IntFunction<float[]> fa, IntFunction<Integer> fi) {
-        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySegment.allocateNative(i, Float.SIZE, MemorySession.openImplicit()));
-        MemorySegment r = MemorySegment.allocateNative(a.byteSize(), Float.SIZE, MemorySession.openImplicit());
+        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySession.openImplicit().allocate(i, Float.SIZE));
+        MemorySegment r = MemorySession.openImplicit().allocate(a.byteSize(), Float.SIZE);
 
         int l = (int) a.byteSize();
         int s = SPECIES.vectorByteSize();
@@ -572,8 +572,8 @@ public class Float64VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @Test(dataProvider = "floatByteMaskProviderForIOOBE")
     static void loadMemorySegmentMaskIOOBE(IntFunction<float[]> fa, IntFunction<Integer> fi, IntFunction<boolean[]> fm) {
-        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySegment.allocateNative(i, Float.SIZE, MemorySession.openImplicit()));
-        MemorySegment r = MemorySegment.allocateNative(a.byteSize(), Float.SIZE, MemorySession.openImplicit());
+        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySession.openImplicit().allocate(i, Float.SIZE));
+        MemorySegment r = MemorySession.openImplicit().allocate(a.byteSize(), Float.SIZE);
         boolean[] mask = fm.apply(SPECIES.length());
         VectorMask<Float> vmask = VectorMask.fromValues(SPECIES, mask);
 
@@ -603,8 +603,8 @@ public class Float64VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @Test(dataProvider = "floatByteMaskProviderForIOOBE")
     static void storeMemorySegmentMaskIOOBE(IntFunction<float[]> fa, IntFunction<Integer> fi, IntFunction<boolean[]> fm) {
-        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySegment.allocateNative(i, Float.SIZE, MemorySession.openImplicit()));
-        MemorySegment r = MemorySegment.allocateNative(a.byteSize(), Float.SIZE, MemorySession.openImplicit());
+        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySession.openImplicit().allocate(i, Float.SIZE));
+        MemorySegment r = MemorySession.openImplicit().allocate(a.byteSize(), Float.SIZE);
         boolean[] mask = fm.apply(SPECIES.length());
         VectorMask<Float> vmask = VectorMask.fromValues(SPECIES, mask);
 

--- a/test/jdk/jdk/incubator/vector/Float64VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Float64VectorLoadStoreTests.java
@@ -479,8 +479,8 @@ public class Float64VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @Test(dataProvider = "floatByteProviderForIOOBE")
     static void loadMemorySegmentIOOBE(IntFunction<float[]> fa, IntFunction<Integer> fi) {
-        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySession.openImplicit().allocate(i, Float.SIZE));
-        MemorySegment r = MemorySession.openImplicit().allocate(a.byteSize(), Float.SIZE);
+        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySegment.allocateNative(i, Float.SIZE));
+        MemorySegment r = MemorySegment.allocateNative(a.byteSize(), Float.SIZE);
 
         int l = (int) a.byteSize();
         int s = SPECIES.vectorByteSize();
@@ -508,8 +508,8 @@ public class Float64VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @Test(dataProvider = "floatByteProviderForIOOBE")
     static void storeMemorySegmentIOOBE(IntFunction<float[]> fa, IntFunction<Integer> fi) {
-        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySession.openImplicit().allocate(i, Float.SIZE));
-        MemorySegment r = MemorySession.openImplicit().allocate(a.byteSize(), Float.SIZE);
+        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySegment.allocateNative(i, Float.SIZE));
+        MemorySegment r = MemorySegment.allocateNative(a.byteSize(), Float.SIZE);
 
         int l = (int) a.byteSize();
         int s = SPECIES.vectorByteSize();
@@ -572,8 +572,8 @@ public class Float64VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @Test(dataProvider = "floatByteMaskProviderForIOOBE")
     static void loadMemorySegmentMaskIOOBE(IntFunction<float[]> fa, IntFunction<Integer> fi, IntFunction<boolean[]> fm) {
-        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySession.openImplicit().allocate(i, Float.SIZE));
-        MemorySegment r = MemorySession.openImplicit().allocate(a.byteSize(), Float.SIZE);
+        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySegment.allocateNative(i, Float.SIZE));
+        MemorySegment r = MemorySegment.allocateNative(a.byteSize(), Float.SIZE);
         boolean[] mask = fm.apply(SPECIES.length());
         VectorMask<Float> vmask = VectorMask.fromValues(SPECIES, mask);
 
@@ -603,8 +603,8 @@ public class Float64VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @Test(dataProvider = "floatByteMaskProviderForIOOBE")
     static void storeMemorySegmentMaskIOOBE(IntFunction<float[]> fa, IntFunction<Integer> fi, IntFunction<boolean[]> fm) {
-        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySession.openImplicit().allocate(i, Float.SIZE));
-        MemorySegment r = MemorySession.openImplicit().allocate(a.byteSize(), Float.SIZE);
+        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySegment.allocateNative(i, Float.SIZE));
+        MemorySegment r = MemorySegment.allocateNative(a.byteSize(), Float.SIZE);
         boolean[] mask = fm.apply(SPECIES.length());
         VectorMask<Float> vmask = VectorMask.fromValues(SPECIES, mask);
 

--- a/test/jdk/jdk/incubator/vector/FloatMaxVectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/FloatMaxVectorLoadStoreTests.java
@@ -486,8 +486,8 @@ public class FloatMaxVectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @Test(dataProvider = "floatByteProviderForIOOBE")
     static void loadMemorySegmentIOOBE(IntFunction<float[]> fa, IntFunction<Integer> fi) {
-        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySegment.allocateNative(i, Float.SIZE, MemorySession.openImplicit()));
-        MemorySegment r = MemorySegment.allocateNative(a.byteSize(), Float.SIZE, MemorySession.openImplicit());
+        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySession.openImplicit().allocate(i, Float.SIZE));
+        MemorySegment r = MemorySession.openImplicit().allocate(a.byteSize(), Float.SIZE);
 
         int l = (int) a.byteSize();
         int s = SPECIES.vectorByteSize();
@@ -515,8 +515,8 @@ public class FloatMaxVectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @Test(dataProvider = "floatByteProviderForIOOBE")
     static void storeMemorySegmentIOOBE(IntFunction<float[]> fa, IntFunction<Integer> fi) {
-        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySegment.allocateNative(i, Float.SIZE, MemorySession.openImplicit()));
-        MemorySegment r = MemorySegment.allocateNative(a.byteSize(), Float.SIZE, MemorySession.openImplicit());
+        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySession.openImplicit().allocate(i, Float.SIZE));
+        MemorySegment r = MemorySession.openImplicit().allocate(a.byteSize(), Float.SIZE);
 
         int l = (int) a.byteSize();
         int s = SPECIES.vectorByteSize();
@@ -579,8 +579,8 @@ public class FloatMaxVectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @Test(dataProvider = "floatByteMaskProviderForIOOBE")
     static void loadMemorySegmentMaskIOOBE(IntFunction<float[]> fa, IntFunction<Integer> fi, IntFunction<boolean[]> fm) {
-        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySegment.allocateNative(i, Float.SIZE, MemorySession.openImplicit()));
-        MemorySegment r = MemorySegment.allocateNative(a.byteSize(), Float.SIZE, MemorySession.openImplicit());
+        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySession.openImplicit().allocate(i, Float.SIZE));
+        MemorySegment r = MemorySession.openImplicit().allocate(a.byteSize(), Float.SIZE);
         boolean[] mask = fm.apply(SPECIES.length());
         VectorMask<Float> vmask = VectorMask.fromValues(SPECIES, mask);
 
@@ -610,8 +610,8 @@ public class FloatMaxVectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @Test(dataProvider = "floatByteMaskProviderForIOOBE")
     static void storeMemorySegmentMaskIOOBE(IntFunction<float[]> fa, IntFunction<Integer> fi, IntFunction<boolean[]> fm) {
-        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySegment.allocateNative(i, Float.SIZE, MemorySession.openImplicit()));
-        MemorySegment r = MemorySegment.allocateNative(a.byteSize(), Float.SIZE, MemorySession.openImplicit());
+        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySession.openImplicit().allocate(i, Float.SIZE));
+        MemorySegment r = MemorySession.openImplicit().allocate(a.byteSize(), Float.SIZE);
         boolean[] mask = fm.apply(SPECIES.length());
         VectorMask<Float> vmask = VectorMask.fromValues(SPECIES, mask);
 

--- a/test/jdk/jdk/incubator/vector/FloatMaxVectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/FloatMaxVectorLoadStoreTests.java
@@ -486,8 +486,8 @@ public class FloatMaxVectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @Test(dataProvider = "floatByteProviderForIOOBE")
     static void loadMemorySegmentIOOBE(IntFunction<float[]> fa, IntFunction<Integer> fi) {
-        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySession.openImplicit().allocate(i, Float.SIZE));
-        MemorySegment r = MemorySession.openImplicit().allocate(a.byteSize(), Float.SIZE);
+        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySegment.allocateNative(i, Float.SIZE));
+        MemorySegment r = MemorySegment.allocateNative(a.byteSize(), Float.SIZE);
 
         int l = (int) a.byteSize();
         int s = SPECIES.vectorByteSize();
@@ -515,8 +515,8 @@ public class FloatMaxVectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @Test(dataProvider = "floatByteProviderForIOOBE")
     static void storeMemorySegmentIOOBE(IntFunction<float[]> fa, IntFunction<Integer> fi) {
-        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySession.openImplicit().allocate(i, Float.SIZE));
-        MemorySegment r = MemorySession.openImplicit().allocate(a.byteSize(), Float.SIZE);
+        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySegment.allocateNative(i, Float.SIZE));
+        MemorySegment r = MemorySegment.allocateNative(a.byteSize(), Float.SIZE);
 
         int l = (int) a.byteSize();
         int s = SPECIES.vectorByteSize();
@@ -579,8 +579,8 @@ public class FloatMaxVectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @Test(dataProvider = "floatByteMaskProviderForIOOBE")
     static void loadMemorySegmentMaskIOOBE(IntFunction<float[]> fa, IntFunction<Integer> fi, IntFunction<boolean[]> fm) {
-        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySession.openImplicit().allocate(i, Float.SIZE));
-        MemorySegment r = MemorySession.openImplicit().allocate(a.byteSize(), Float.SIZE);
+        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySegment.allocateNative(i, Float.SIZE));
+        MemorySegment r = MemorySegment.allocateNative(a.byteSize(), Float.SIZE);
         boolean[] mask = fm.apply(SPECIES.length());
         VectorMask<Float> vmask = VectorMask.fromValues(SPECIES, mask);
 
@@ -610,8 +610,8 @@ public class FloatMaxVectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @Test(dataProvider = "floatByteMaskProviderForIOOBE")
     static void storeMemorySegmentMaskIOOBE(IntFunction<float[]> fa, IntFunction<Integer> fi, IntFunction<boolean[]> fm) {
-        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySession.openImplicit().allocate(i, Float.SIZE));
-        MemorySegment r = MemorySession.openImplicit().allocate(a.byteSize(), Float.SIZE);
+        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySegment.allocateNative(i, Float.SIZE));
+        MemorySegment r = MemorySegment.allocateNative(a.byteSize(), Float.SIZE);
         boolean[] mask = fm.apply(SPECIES.length());
         VectorMask<Float> vmask = VectorMask.fromValues(SPECIES, mask);
 

--- a/test/jdk/jdk/incubator/vector/Int128VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Int128VectorLoadStoreTests.java
@@ -479,8 +479,8 @@ public class Int128VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @Test(dataProvider = "intByteProviderForIOOBE")
     static void loadMemorySegmentIOOBE(IntFunction<int[]> fa, IntFunction<Integer> fi) {
-        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySession.openImplicit().allocate(i, Integer.SIZE));
-        MemorySegment r = MemorySession.openImplicit().allocate(a.byteSize(), Integer.SIZE);
+        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySegment.allocateNative(i, Integer.SIZE));
+        MemorySegment r = MemorySegment.allocateNative(a.byteSize(), Integer.SIZE);
 
         int l = (int) a.byteSize();
         int s = SPECIES.vectorByteSize();
@@ -508,8 +508,8 @@ public class Int128VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @Test(dataProvider = "intByteProviderForIOOBE")
     static void storeMemorySegmentIOOBE(IntFunction<int[]> fa, IntFunction<Integer> fi) {
-        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySession.openImplicit().allocate(i, Integer.SIZE));
-        MemorySegment r = MemorySession.openImplicit().allocate(a.byteSize(), Integer.SIZE);
+        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySegment.allocateNative(i, Integer.SIZE));
+        MemorySegment r = MemorySegment.allocateNative(a.byteSize(), Integer.SIZE);
 
         int l = (int) a.byteSize();
         int s = SPECIES.vectorByteSize();
@@ -572,8 +572,8 @@ public class Int128VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @Test(dataProvider = "intByteMaskProviderForIOOBE")
     static void loadMemorySegmentMaskIOOBE(IntFunction<int[]> fa, IntFunction<Integer> fi, IntFunction<boolean[]> fm) {
-        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySession.openImplicit().allocate(i, Integer.SIZE));
-        MemorySegment r = MemorySession.openImplicit().allocate(a.byteSize(), Integer.SIZE);
+        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySegment.allocateNative(i, Integer.SIZE));
+        MemorySegment r = MemorySegment.allocateNative(a.byteSize(), Integer.SIZE);
         boolean[] mask = fm.apply(SPECIES.length());
         VectorMask<Integer> vmask = VectorMask.fromValues(SPECIES, mask);
 
@@ -603,8 +603,8 @@ public class Int128VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @Test(dataProvider = "intByteMaskProviderForIOOBE")
     static void storeMemorySegmentMaskIOOBE(IntFunction<int[]> fa, IntFunction<Integer> fi, IntFunction<boolean[]> fm) {
-        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySession.openImplicit().allocate(i, Integer.SIZE));
-        MemorySegment r = MemorySession.openImplicit().allocate(a.byteSize(), Integer.SIZE);
+        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySegment.allocateNative(i, Integer.SIZE));
+        MemorySegment r = MemorySegment.allocateNative(a.byteSize(), Integer.SIZE);
         boolean[] mask = fm.apply(SPECIES.length());
         VectorMask<Integer> vmask = VectorMask.fromValues(SPECIES, mask);
 

--- a/test/jdk/jdk/incubator/vector/Int128VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Int128VectorLoadStoreTests.java
@@ -479,8 +479,8 @@ public class Int128VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @Test(dataProvider = "intByteProviderForIOOBE")
     static void loadMemorySegmentIOOBE(IntFunction<int[]> fa, IntFunction<Integer> fi) {
-        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySegment.allocateNative(i, Integer.SIZE, MemorySession.openImplicit()));
-        MemorySegment r = MemorySegment.allocateNative(a.byteSize(), Integer.SIZE, MemorySession.openImplicit());
+        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySession.openImplicit().allocate(i, Integer.SIZE));
+        MemorySegment r = MemorySession.openImplicit().allocate(a.byteSize(), Integer.SIZE);
 
         int l = (int) a.byteSize();
         int s = SPECIES.vectorByteSize();
@@ -508,8 +508,8 @@ public class Int128VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @Test(dataProvider = "intByteProviderForIOOBE")
     static void storeMemorySegmentIOOBE(IntFunction<int[]> fa, IntFunction<Integer> fi) {
-        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySegment.allocateNative(i, Integer.SIZE, MemorySession.openImplicit()));
-        MemorySegment r = MemorySegment.allocateNative(a.byteSize(), Integer.SIZE, MemorySession.openImplicit());
+        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySession.openImplicit().allocate(i, Integer.SIZE));
+        MemorySegment r = MemorySession.openImplicit().allocate(a.byteSize(), Integer.SIZE);
 
         int l = (int) a.byteSize();
         int s = SPECIES.vectorByteSize();
@@ -572,8 +572,8 @@ public class Int128VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @Test(dataProvider = "intByteMaskProviderForIOOBE")
     static void loadMemorySegmentMaskIOOBE(IntFunction<int[]> fa, IntFunction<Integer> fi, IntFunction<boolean[]> fm) {
-        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySegment.allocateNative(i, Integer.SIZE, MemorySession.openImplicit()));
-        MemorySegment r = MemorySegment.allocateNative(a.byteSize(), Integer.SIZE, MemorySession.openImplicit());
+        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySession.openImplicit().allocate(i, Integer.SIZE));
+        MemorySegment r = MemorySession.openImplicit().allocate(a.byteSize(), Integer.SIZE);
         boolean[] mask = fm.apply(SPECIES.length());
         VectorMask<Integer> vmask = VectorMask.fromValues(SPECIES, mask);
 
@@ -603,8 +603,8 @@ public class Int128VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @Test(dataProvider = "intByteMaskProviderForIOOBE")
     static void storeMemorySegmentMaskIOOBE(IntFunction<int[]> fa, IntFunction<Integer> fi, IntFunction<boolean[]> fm) {
-        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySegment.allocateNative(i, Integer.SIZE, MemorySession.openImplicit()));
-        MemorySegment r = MemorySegment.allocateNative(a.byteSize(), Integer.SIZE, MemorySession.openImplicit());
+        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySession.openImplicit().allocate(i, Integer.SIZE));
+        MemorySegment r = MemorySession.openImplicit().allocate(a.byteSize(), Integer.SIZE);
         boolean[] mask = fm.apply(SPECIES.length());
         VectorMask<Integer> vmask = VectorMask.fromValues(SPECIES, mask);
 

--- a/test/jdk/jdk/incubator/vector/Int256VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Int256VectorLoadStoreTests.java
@@ -479,8 +479,8 @@ public class Int256VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @Test(dataProvider = "intByteProviderForIOOBE")
     static void loadMemorySegmentIOOBE(IntFunction<int[]> fa, IntFunction<Integer> fi) {
-        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySession.openImplicit().allocate(i, Integer.SIZE));
-        MemorySegment r = MemorySession.openImplicit().allocate(a.byteSize(), Integer.SIZE);
+        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySegment.allocateNative(i, Integer.SIZE));
+        MemorySegment r = MemorySegment.allocateNative(a.byteSize(), Integer.SIZE);
 
         int l = (int) a.byteSize();
         int s = SPECIES.vectorByteSize();
@@ -508,8 +508,8 @@ public class Int256VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @Test(dataProvider = "intByteProviderForIOOBE")
     static void storeMemorySegmentIOOBE(IntFunction<int[]> fa, IntFunction<Integer> fi) {
-        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySession.openImplicit().allocate(i, Integer.SIZE));
-        MemorySegment r = MemorySession.openImplicit().allocate(a.byteSize(), Integer.SIZE);
+        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySegment.allocateNative(i, Integer.SIZE));
+        MemorySegment r = MemorySegment.allocateNative(a.byteSize(), Integer.SIZE);
 
         int l = (int) a.byteSize();
         int s = SPECIES.vectorByteSize();
@@ -572,8 +572,8 @@ public class Int256VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @Test(dataProvider = "intByteMaskProviderForIOOBE")
     static void loadMemorySegmentMaskIOOBE(IntFunction<int[]> fa, IntFunction<Integer> fi, IntFunction<boolean[]> fm) {
-        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySession.openImplicit().allocate(i, Integer.SIZE));
-        MemorySegment r = MemorySession.openImplicit().allocate(a.byteSize(), Integer.SIZE);
+        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySegment.allocateNative(i, Integer.SIZE));
+        MemorySegment r = MemorySegment.allocateNative(a.byteSize(), Integer.SIZE);
         boolean[] mask = fm.apply(SPECIES.length());
         VectorMask<Integer> vmask = VectorMask.fromValues(SPECIES, mask);
 
@@ -603,8 +603,8 @@ public class Int256VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @Test(dataProvider = "intByteMaskProviderForIOOBE")
     static void storeMemorySegmentMaskIOOBE(IntFunction<int[]> fa, IntFunction<Integer> fi, IntFunction<boolean[]> fm) {
-        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySession.openImplicit().allocate(i, Integer.SIZE));
-        MemorySegment r = MemorySession.openImplicit().allocate(a.byteSize(), Integer.SIZE);
+        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySegment.allocateNative(i, Integer.SIZE));
+        MemorySegment r = MemorySegment.allocateNative(a.byteSize(), Integer.SIZE);
         boolean[] mask = fm.apply(SPECIES.length());
         VectorMask<Integer> vmask = VectorMask.fromValues(SPECIES, mask);
 

--- a/test/jdk/jdk/incubator/vector/Int256VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Int256VectorLoadStoreTests.java
@@ -479,8 +479,8 @@ public class Int256VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @Test(dataProvider = "intByteProviderForIOOBE")
     static void loadMemorySegmentIOOBE(IntFunction<int[]> fa, IntFunction<Integer> fi) {
-        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySegment.allocateNative(i, Integer.SIZE, MemorySession.openImplicit()));
-        MemorySegment r = MemorySegment.allocateNative(a.byteSize(), Integer.SIZE, MemorySession.openImplicit());
+        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySession.openImplicit().allocate(i, Integer.SIZE));
+        MemorySegment r = MemorySession.openImplicit().allocate(a.byteSize(), Integer.SIZE);
 
         int l = (int) a.byteSize();
         int s = SPECIES.vectorByteSize();
@@ -508,8 +508,8 @@ public class Int256VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @Test(dataProvider = "intByteProviderForIOOBE")
     static void storeMemorySegmentIOOBE(IntFunction<int[]> fa, IntFunction<Integer> fi) {
-        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySegment.allocateNative(i, Integer.SIZE, MemorySession.openImplicit()));
-        MemorySegment r = MemorySegment.allocateNative(a.byteSize(), Integer.SIZE, MemorySession.openImplicit());
+        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySession.openImplicit().allocate(i, Integer.SIZE));
+        MemorySegment r = MemorySession.openImplicit().allocate(a.byteSize(), Integer.SIZE);
 
         int l = (int) a.byteSize();
         int s = SPECIES.vectorByteSize();
@@ -572,8 +572,8 @@ public class Int256VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @Test(dataProvider = "intByteMaskProviderForIOOBE")
     static void loadMemorySegmentMaskIOOBE(IntFunction<int[]> fa, IntFunction<Integer> fi, IntFunction<boolean[]> fm) {
-        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySegment.allocateNative(i, Integer.SIZE, MemorySession.openImplicit()));
-        MemorySegment r = MemorySegment.allocateNative(a.byteSize(), Integer.SIZE, MemorySession.openImplicit());
+        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySession.openImplicit().allocate(i, Integer.SIZE));
+        MemorySegment r = MemorySession.openImplicit().allocate(a.byteSize(), Integer.SIZE);
         boolean[] mask = fm.apply(SPECIES.length());
         VectorMask<Integer> vmask = VectorMask.fromValues(SPECIES, mask);
 
@@ -603,8 +603,8 @@ public class Int256VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @Test(dataProvider = "intByteMaskProviderForIOOBE")
     static void storeMemorySegmentMaskIOOBE(IntFunction<int[]> fa, IntFunction<Integer> fi, IntFunction<boolean[]> fm) {
-        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySegment.allocateNative(i, Integer.SIZE, MemorySession.openImplicit()));
-        MemorySegment r = MemorySegment.allocateNative(a.byteSize(), Integer.SIZE, MemorySession.openImplicit());
+        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySession.openImplicit().allocate(i, Integer.SIZE));
+        MemorySegment r = MemorySession.openImplicit().allocate(a.byteSize(), Integer.SIZE);
         boolean[] mask = fm.apply(SPECIES.length());
         VectorMask<Integer> vmask = VectorMask.fromValues(SPECIES, mask);
 

--- a/test/jdk/jdk/incubator/vector/Int512VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Int512VectorLoadStoreTests.java
@@ -479,8 +479,8 @@ public class Int512VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @Test(dataProvider = "intByteProviderForIOOBE")
     static void loadMemorySegmentIOOBE(IntFunction<int[]> fa, IntFunction<Integer> fi) {
-        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySession.openImplicit().allocate(i, Integer.SIZE));
-        MemorySegment r = MemorySession.openImplicit().allocate(a.byteSize(), Integer.SIZE);
+        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySegment.allocateNative(i, Integer.SIZE));
+        MemorySegment r = MemorySegment.allocateNative(a.byteSize(), Integer.SIZE);
 
         int l = (int) a.byteSize();
         int s = SPECIES.vectorByteSize();
@@ -508,8 +508,8 @@ public class Int512VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @Test(dataProvider = "intByteProviderForIOOBE")
     static void storeMemorySegmentIOOBE(IntFunction<int[]> fa, IntFunction<Integer> fi) {
-        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySession.openImplicit().allocate(i, Integer.SIZE));
-        MemorySegment r = MemorySession.openImplicit().allocate(a.byteSize(), Integer.SIZE);
+        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySegment.allocateNative(i, Integer.SIZE));
+        MemorySegment r = MemorySegment.allocateNative(a.byteSize(), Integer.SIZE);
 
         int l = (int) a.byteSize();
         int s = SPECIES.vectorByteSize();
@@ -572,8 +572,8 @@ public class Int512VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @Test(dataProvider = "intByteMaskProviderForIOOBE")
     static void loadMemorySegmentMaskIOOBE(IntFunction<int[]> fa, IntFunction<Integer> fi, IntFunction<boolean[]> fm) {
-        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySession.openImplicit().allocate(i, Integer.SIZE));
-        MemorySegment r = MemorySession.openImplicit().allocate(a.byteSize(), Integer.SIZE);
+        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySegment.allocateNative(i, Integer.SIZE));
+        MemorySegment r = MemorySegment.allocateNative(a.byteSize(), Integer.SIZE);
         boolean[] mask = fm.apply(SPECIES.length());
         VectorMask<Integer> vmask = VectorMask.fromValues(SPECIES, mask);
 
@@ -603,8 +603,8 @@ public class Int512VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @Test(dataProvider = "intByteMaskProviderForIOOBE")
     static void storeMemorySegmentMaskIOOBE(IntFunction<int[]> fa, IntFunction<Integer> fi, IntFunction<boolean[]> fm) {
-        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySession.openImplicit().allocate(i, Integer.SIZE));
-        MemorySegment r = MemorySession.openImplicit().allocate(a.byteSize(), Integer.SIZE);
+        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySegment.allocateNative(i, Integer.SIZE));
+        MemorySegment r = MemorySegment.allocateNative(a.byteSize(), Integer.SIZE);
         boolean[] mask = fm.apply(SPECIES.length());
         VectorMask<Integer> vmask = VectorMask.fromValues(SPECIES, mask);
 

--- a/test/jdk/jdk/incubator/vector/Int512VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Int512VectorLoadStoreTests.java
@@ -479,8 +479,8 @@ public class Int512VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @Test(dataProvider = "intByteProviderForIOOBE")
     static void loadMemorySegmentIOOBE(IntFunction<int[]> fa, IntFunction<Integer> fi) {
-        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySegment.allocateNative(i, Integer.SIZE, MemorySession.openImplicit()));
-        MemorySegment r = MemorySegment.allocateNative(a.byteSize(), Integer.SIZE, MemorySession.openImplicit());
+        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySession.openImplicit().allocate(i, Integer.SIZE));
+        MemorySegment r = MemorySession.openImplicit().allocate(a.byteSize(), Integer.SIZE);
 
         int l = (int) a.byteSize();
         int s = SPECIES.vectorByteSize();
@@ -508,8 +508,8 @@ public class Int512VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @Test(dataProvider = "intByteProviderForIOOBE")
     static void storeMemorySegmentIOOBE(IntFunction<int[]> fa, IntFunction<Integer> fi) {
-        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySegment.allocateNative(i, Integer.SIZE, MemorySession.openImplicit()));
-        MemorySegment r = MemorySegment.allocateNative(a.byteSize(), Integer.SIZE, MemorySession.openImplicit());
+        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySession.openImplicit().allocate(i, Integer.SIZE));
+        MemorySegment r = MemorySession.openImplicit().allocate(a.byteSize(), Integer.SIZE);
 
         int l = (int) a.byteSize();
         int s = SPECIES.vectorByteSize();
@@ -572,8 +572,8 @@ public class Int512VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @Test(dataProvider = "intByteMaskProviderForIOOBE")
     static void loadMemorySegmentMaskIOOBE(IntFunction<int[]> fa, IntFunction<Integer> fi, IntFunction<boolean[]> fm) {
-        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySegment.allocateNative(i, Integer.SIZE, MemorySession.openImplicit()));
-        MemorySegment r = MemorySegment.allocateNative(a.byteSize(), Integer.SIZE, MemorySession.openImplicit());
+        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySession.openImplicit().allocate(i, Integer.SIZE));
+        MemorySegment r = MemorySession.openImplicit().allocate(a.byteSize(), Integer.SIZE);
         boolean[] mask = fm.apply(SPECIES.length());
         VectorMask<Integer> vmask = VectorMask.fromValues(SPECIES, mask);
 
@@ -603,8 +603,8 @@ public class Int512VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @Test(dataProvider = "intByteMaskProviderForIOOBE")
     static void storeMemorySegmentMaskIOOBE(IntFunction<int[]> fa, IntFunction<Integer> fi, IntFunction<boolean[]> fm) {
-        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySegment.allocateNative(i, Integer.SIZE, MemorySession.openImplicit()));
-        MemorySegment r = MemorySegment.allocateNative(a.byteSize(), Integer.SIZE, MemorySession.openImplicit());
+        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySession.openImplicit().allocate(i, Integer.SIZE));
+        MemorySegment r = MemorySession.openImplicit().allocate(a.byteSize(), Integer.SIZE);
         boolean[] mask = fm.apply(SPECIES.length());
         VectorMask<Integer> vmask = VectorMask.fromValues(SPECIES, mask);
 

--- a/test/jdk/jdk/incubator/vector/Int64VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Int64VectorLoadStoreTests.java
@@ -479,8 +479,8 @@ public class Int64VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @Test(dataProvider = "intByteProviderForIOOBE")
     static void loadMemorySegmentIOOBE(IntFunction<int[]> fa, IntFunction<Integer> fi) {
-        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySegment.allocateNative(i, Integer.SIZE, MemorySession.openImplicit()));
-        MemorySegment r = MemorySegment.allocateNative(a.byteSize(), Integer.SIZE, MemorySession.openImplicit());
+        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySession.openImplicit().allocate(i, Integer.SIZE));
+        MemorySegment r = MemorySession.openImplicit().allocate(a.byteSize(), Integer.SIZE);
 
         int l = (int) a.byteSize();
         int s = SPECIES.vectorByteSize();
@@ -508,8 +508,8 @@ public class Int64VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @Test(dataProvider = "intByteProviderForIOOBE")
     static void storeMemorySegmentIOOBE(IntFunction<int[]> fa, IntFunction<Integer> fi) {
-        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySegment.allocateNative(i, Integer.SIZE, MemorySession.openImplicit()));
-        MemorySegment r = MemorySegment.allocateNative(a.byteSize(), Integer.SIZE, MemorySession.openImplicit());
+        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySession.openImplicit().allocate(i, Integer.SIZE));
+        MemorySegment r = MemorySession.openImplicit().allocate(a.byteSize(), Integer.SIZE);
 
         int l = (int) a.byteSize();
         int s = SPECIES.vectorByteSize();
@@ -572,8 +572,8 @@ public class Int64VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @Test(dataProvider = "intByteMaskProviderForIOOBE")
     static void loadMemorySegmentMaskIOOBE(IntFunction<int[]> fa, IntFunction<Integer> fi, IntFunction<boolean[]> fm) {
-        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySegment.allocateNative(i, Integer.SIZE, MemorySession.openImplicit()));
-        MemorySegment r = MemorySegment.allocateNative(a.byteSize(), Integer.SIZE, MemorySession.openImplicit());
+        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySession.openImplicit().allocate(i, Integer.SIZE));
+        MemorySegment r = MemorySession.openImplicit().allocate(a.byteSize(), Integer.SIZE);
         boolean[] mask = fm.apply(SPECIES.length());
         VectorMask<Integer> vmask = VectorMask.fromValues(SPECIES, mask);
 
@@ -603,8 +603,8 @@ public class Int64VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @Test(dataProvider = "intByteMaskProviderForIOOBE")
     static void storeMemorySegmentMaskIOOBE(IntFunction<int[]> fa, IntFunction<Integer> fi, IntFunction<boolean[]> fm) {
-        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySegment.allocateNative(i, Integer.SIZE, MemorySession.openImplicit()));
-        MemorySegment r = MemorySegment.allocateNative(a.byteSize(), Integer.SIZE, MemorySession.openImplicit());
+        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySession.openImplicit().allocate(i, Integer.SIZE));
+        MemorySegment r = MemorySession.openImplicit().allocate(a.byteSize(), Integer.SIZE);
         boolean[] mask = fm.apply(SPECIES.length());
         VectorMask<Integer> vmask = VectorMask.fromValues(SPECIES, mask);
 

--- a/test/jdk/jdk/incubator/vector/Int64VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Int64VectorLoadStoreTests.java
@@ -479,8 +479,8 @@ public class Int64VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @Test(dataProvider = "intByteProviderForIOOBE")
     static void loadMemorySegmentIOOBE(IntFunction<int[]> fa, IntFunction<Integer> fi) {
-        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySession.openImplicit().allocate(i, Integer.SIZE));
-        MemorySegment r = MemorySession.openImplicit().allocate(a.byteSize(), Integer.SIZE);
+        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySegment.allocateNative(i, Integer.SIZE));
+        MemorySegment r = MemorySegment.allocateNative(a.byteSize(), Integer.SIZE);
 
         int l = (int) a.byteSize();
         int s = SPECIES.vectorByteSize();
@@ -508,8 +508,8 @@ public class Int64VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @Test(dataProvider = "intByteProviderForIOOBE")
     static void storeMemorySegmentIOOBE(IntFunction<int[]> fa, IntFunction<Integer> fi) {
-        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySession.openImplicit().allocate(i, Integer.SIZE));
-        MemorySegment r = MemorySession.openImplicit().allocate(a.byteSize(), Integer.SIZE);
+        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySegment.allocateNative(i, Integer.SIZE));
+        MemorySegment r = MemorySegment.allocateNative(a.byteSize(), Integer.SIZE);
 
         int l = (int) a.byteSize();
         int s = SPECIES.vectorByteSize();
@@ -572,8 +572,8 @@ public class Int64VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @Test(dataProvider = "intByteMaskProviderForIOOBE")
     static void loadMemorySegmentMaskIOOBE(IntFunction<int[]> fa, IntFunction<Integer> fi, IntFunction<boolean[]> fm) {
-        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySession.openImplicit().allocate(i, Integer.SIZE));
-        MemorySegment r = MemorySession.openImplicit().allocate(a.byteSize(), Integer.SIZE);
+        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySegment.allocateNative(i, Integer.SIZE));
+        MemorySegment r = MemorySegment.allocateNative(a.byteSize(), Integer.SIZE);
         boolean[] mask = fm.apply(SPECIES.length());
         VectorMask<Integer> vmask = VectorMask.fromValues(SPECIES, mask);
 
@@ -603,8 +603,8 @@ public class Int64VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @Test(dataProvider = "intByteMaskProviderForIOOBE")
     static void storeMemorySegmentMaskIOOBE(IntFunction<int[]> fa, IntFunction<Integer> fi, IntFunction<boolean[]> fm) {
-        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySession.openImplicit().allocate(i, Integer.SIZE));
-        MemorySegment r = MemorySession.openImplicit().allocate(a.byteSize(), Integer.SIZE);
+        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySegment.allocateNative(i, Integer.SIZE));
+        MemorySegment r = MemorySegment.allocateNative(a.byteSize(), Integer.SIZE);
         boolean[] mask = fm.apply(SPECIES.length());
         VectorMask<Integer> vmask = VectorMask.fromValues(SPECIES, mask);
 

--- a/test/jdk/jdk/incubator/vector/IntMaxVectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/IntMaxVectorLoadStoreTests.java
@@ -486,8 +486,8 @@ public class IntMaxVectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @Test(dataProvider = "intByteProviderForIOOBE")
     static void loadMemorySegmentIOOBE(IntFunction<int[]> fa, IntFunction<Integer> fi) {
-        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySegment.allocateNative(i, Integer.SIZE, MemorySession.openImplicit()));
-        MemorySegment r = MemorySegment.allocateNative(a.byteSize(), Integer.SIZE, MemorySession.openImplicit());
+        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySession.openImplicit().allocate(i, Integer.SIZE));
+        MemorySegment r = MemorySession.openImplicit().allocate(a.byteSize(), Integer.SIZE);
 
         int l = (int) a.byteSize();
         int s = SPECIES.vectorByteSize();
@@ -515,8 +515,8 @@ public class IntMaxVectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @Test(dataProvider = "intByteProviderForIOOBE")
     static void storeMemorySegmentIOOBE(IntFunction<int[]> fa, IntFunction<Integer> fi) {
-        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySegment.allocateNative(i, Integer.SIZE, MemorySession.openImplicit()));
-        MemorySegment r = MemorySegment.allocateNative(a.byteSize(), Integer.SIZE, MemorySession.openImplicit());
+        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySession.openImplicit().allocate(i, Integer.SIZE));
+        MemorySegment r = MemorySession.openImplicit().allocate(a.byteSize(), Integer.SIZE);
 
         int l = (int) a.byteSize();
         int s = SPECIES.vectorByteSize();
@@ -579,8 +579,8 @@ public class IntMaxVectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @Test(dataProvider = "intByteMaskProviderForIOOBE")
     static void loadMemorySegmentMaskIOOBE(IntFunction<int[]> fa, IntFunction<Integer> fi, IntFunction<boolean[]> fm) {
-        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySegment.allocateNative(i, Integer.SIZE, MemorySession.openImplicit()));
-        MemorySegment r = MemorySegment.allocateNative(a.byteSize(), Integer.SIZE, MemorySession.openImplicit());
+        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySession.openImplicit().allocate(i, Integer.SIZE));
+        MemorySegment r = MemorySession.openImplicit().allocate(a.byteSize(), Integer.SIZE);
         boolean[] mask = fm.apply(SPECIES.length());
         VectorMask<Integer> vmask = VectorMask.fromValues(SPECIES, mask);
 
@@ -610,8 +610,8 @@ public class IntMaxVectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @Test(dataProvider = "intByteMaskProviderForIOOBE")
     static void storeMemorySegmentMaskIOOBE(IntFunction<int[]> fa, IntFunction<Integer> fi, IntFunction<boolean[]> fm) {
-        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySegment.allocateNative(i, Integer.SIZE, MemorySession.openImplicit()));
-        MemorySegment r = MemorySegment.allocateNative(a.byteSize(), Integer.SIZE, MemorySession.openImplicit());
+        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySession.openImplicit().allocate(i, Integer.SIZE));
+        MemorySegment r = MemorySession.openImplicit().allocate(a.byteSize(), Integer.SIZE);
         boolean[] mask = fm.apply(SPECIES.length());
         VectorMask<Integer> vmask = VectorMask.fromValues(SPECIES, mask);
 

--- a/test/jdk/jdk/incubator/vector/IntMaxVectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/IntMaxVectorLoadStoreTests.java
@@ -486,8 +486,8 @@ public class IntMaxVectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @Test(dataProvider = "intByteProviderForIOOBE")
     static void loadMemorySegmentIOOBE(IntFunction<int[]> fa, IntFunction<Integer> fi) {
-        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySession.openImplicit().allocate(i, Integer.SIZE));
-        MemorySegment r = MemorySession.openImplicit().allocate(a.byteSize(), Integer.SIZE);
+        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySegment.allocateNative(i, Integer.SIZE));
+        MemorySegment r = MemorySegment.allocateNative(a.byteSize(), Integer.SIZE);
 
         int l = (int) a.byteSize();
         int s = SPECIES.vectorByteSize();
@@ -515,8 +515,8 @@ public class IntMaxVectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @Test(dataProvider = "intByteProviderForIOOBE")
     static void storeMemorySegmentIOOBE(IntFunction<int[]> fa, IntFunction<Integer> fi) {
-        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySession.openImplicit().allocate(i, Integer.SIZE));
-        MemorySegment r = MemorySession.openImplicit().allocate(a.byteSize(), Integer.SIZE);
+        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySegment.allocateNative(i, Integer.SIZE));
+        MemorySegment r = MemorySegment.allocateNative(a.byteSize(), Integer.SIZE);
 
         int l = (int) a.byteSize();
         int s = SPECIES.vectorByteSize();
@@ -579,8 +579,8 @@ public class IntMaxVectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @Test(dataProvider = "intByteMaskProviderForIOOBE")
     static void loadMemorySegmentMaskIOOBE(IntFunction<int[]> fa, IntFunction<Integer> fi, IntFunction<boolean[]> fm) {
-        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySession.openImplicit().allocate(i, Integer.SIZE));
-        MemorySegment r = MemorySession.openImplicit().allocate(a.byteSize(), Integer.SIZE);
+        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySegment.allocateNative(i, Integer.SIZE));
+        MemorySegment r = MemorySegment.allocateNative(a.byteSize(), Integer.SIZE);
         boolean[] mask = fm.apply(SPECIES.length());
         VectorMask<Integer> vmask = VectorMask.fromValues(SPECIES, mask);
 
@@ -610,8 +610,8 @@ public class IntMaxVectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @Test(dataProvider = "intByteMaskProviderForIOOBE")
     static void storeMemorySegmentMaskIOOBE(IntFunction<int[]> fa, IntFunction<Integer> fi, IntFunction<boolean[]> fm) {
-        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySession.openImplicit().allocate(i, Integer.SIZE));
-        MemorySegment r = MemorySession.openImplicit().allocate(a.byteSize(), Integer.SIZE);
+        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySegment.allocateNative(i, Integer.SIZE));
+        MemorySegment r = MemorySegment.allocateNative(a.byteSize(), Integer.SIZE);
         boolean[] mask = fm.apply(SPECIES.length());
         VectorMask<Integer> vmask = VectorMask.fromValues(SPECIES, mask);
 

--- a/test/jdk/jdk/incubator/vector/Long128VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Long128VectorLoadStoreTests.java
@@ -479,8 +479,8 @@ public class Long128VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @Test(dataProvider = "longByteProviderForIOOBE")
     static void loadMemorySegmentIOOBE(IntFunction<long[]> fa, IntFunction<Integer> fi) {
-        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySession.openImplicit().allocate(i, Long.SIZE));
-        MemorySegment r = MemorySession.openImplicit().allocate(a.byteSize(), Long.SIZE);
+        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySegment.allocateNative(i, Long.SIZE));
+        MemorySegment r = MemorySegment.allocateNative(a.byteSize(), Long.SIZE);
 
         int l = (int) a.byteSize();
         int s = SPECIES.vectorByteSize();
@@ -508,8 +508,8 @@ public class Long128VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @Test(dataProvider = "longByteProviderForIOOBE")
     static void storeMemorySegmentIOOBE(IntFunction<long[]> fa, IntFunction<Integer> fi) {
-        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySession.openImplicit().allocate(i, Long.SIZE));
-        MemorySegment r = MemorySession.openImplicit().allocate(a.byteSize(), Long.SIZE);
+        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySegment.allocateNative(i, Long.SIZE));
+        MemorySegment r = MemorySegment.allocateNative(a.byteSize(), Long.SIZE);
 
         int l = (int) a.byteSize();
         int s = SPECIES.vectorByteSize();
@@ -572,8 +572,8 @@ public class Long128VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @Test(dataProvider = "longByteMaskProviderForIOOBE")
     static void loadMemorySegmentMaskIOOBE(IntFunction<long[]> fa, IntFunction<Integer> fi, IntFunction<boolean[]> fm) {
-        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySession.openImplicit().allocate(i, Long.SIZE));
-        MemorySegment r = MemorySession.openImplicit().allocate(a.byteSize(), Long.SIZE);
+        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySegment.allocateNative(i, Long.SIZE));
+        MemorySegment r = MemorySegment.allocateNative(a.byteSize(), Long.SIZE);
         boolean[] mask = fm.apply(SPECIES.length());
         VectorMask<Long> vmask = VectorMask.fromValues(SPECIES, mask);
 
@@ -603,8 +603,8 @@ public class Long128VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @Test(dataProvider = "longByteMaskProviderForIOOBE")
     static void storeMemorySegmentMaskIOOBE(IntFunction<long[]> fa, IntFunction<Integer> fi, IntFunction<boolean[]> fm) {
-        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySession.openImplicit().allocate(i, Long.SIZE));
-        MemorySegment r = MemorySession.openImplicit().allocate(a.byteSize(), Long.SIZE);
+        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySegment.allocateNative(i, Long.SIZE));
+        MemorySegment r = MemorySegment.allocateNative(a.byteSize(), Long.SIZE);
         boolean[] mask = fm.apply(SPECIES.length());
         VectorMask<Long> vmask = VectorMask.fromValues(SPECIES, mask);
 

--- a/test/jdk/jdk/incubator/vector/Long128VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Long128VectorLoadStoreTests.java
@@ -479,8 +479,8 @@ public class Long128VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @Test(dataProvider = "longByteProviderForIOOBE")
     static void loadMemorySegmentIOOBE(IntFunction<long[]> fa, IntFunction<Integer> fi) {
-        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySegment.allocateNative(i, Long.SIZE, MemorySession.openImplicit()));
-        MemorySegment r = MemorySegment.allocateNative(a.byteSize(), Long.SIZE, MemorySession.openImplicit());
+        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySession.openImplicit().allocate(i, Long.SIZE));
+        MemorySegment r = MemorySession.openImplicit().allocate(a.byteSize(), Long.SIZE);
 
         int l = (int) a.byteSize();
         int s = SPECIES.vectorByteSize();
@@ -508,8 +508,8 @@ public class Long128VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @Test(dataProvider = "longByteProviderForIOOBE")
     static void storeMemorySegmentIOOBE(IntFunction<long[]> fa, IntFunction<Integer> fi) {
-        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySegment.allocateNative(i, Long.SIZE, MemorySession.openImplicit()));
-        MemorySegment r = MemorySegment.allocateNative(a.byteSize(), Long.SIZE, MemorySession.openImplicit());
+        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySession.openImplicit().allocate(i, Long.SIZE));
+        MemorySegment r = MemorySession.openImplicit().allocate(a.byteSize(), Long.SIZE);
 
         int l = (int) a.byteSize();
         int s = SPECIES.vectorByteSize();
@@ -572,8 +572,8 @@ public class Long128VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @Test(dataProvider = "longByteMaskProviderForIOOBE")
     static void loadMemorySegmentMaskIOOBE(IntFunction<long[]> fa, IntFunction<Integer> fi, IntFunction<boolean[]> fm) {
-        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySegment.allocateNative(i, Long.SIZE, MemorySession.openImplicit()));
-        MemorySegment r = MemorySegment.allocateNative(a.byteSize(), Long.SIZE, MemorySession.openImplicit());
+        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySession.openImplicit().allocate(i, Long.SIZE));
+        MemorySegment r = MemorySession.openImplicit().allocate(a.byteSize(), Long.SIZE);
         boolean[] mask = fm.apply(SPECIES.length());
         VectorMask<Long> vmask = VectorMask.fromValues(SPECIES, mask);
 
@@ -603,8 +603,8 @@ public class Long128VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @Test(dataProvider = "longByteMaskProviderForIOOBE")
     static void storeMemorySegmentMaskIOOBE(IntFunction<long[]> fa, IntFunction<Integer> fi, IntFunction<boolean[]> fm) {
-        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySegment.allocateNative(i, Long.SIZE, MemorySession.openImplicit()));
-        MemorySegment r = MemorySegment.allocateNative(a.byteSize(), Long.SIZE, MemorySession.openImplicit());
+        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySession.openImplicit().allocate(i, Long.SIZE));
+        MemorySegment r = MemorySession.openImplicit().allocate(a.byteSize(), Long.SIZE);
         boolean[] mask = fm.apply(SPECIES.length());
         VectorMask<Long> vmask = VectorMask.fromValues(SPECIES, mask);
 

--- a/test/jdk/jdk/incubator/vector/Long256VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Long256VectorLoadStoreTests.java
@@ -479,8 +479,8 @@ public class Long256VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @Test(dataProvider = "longByteProviderForIOOBE")
     static void loadMemorySegmentIOOBE(IntFunction<long[]> fa, IntFunction<Integer> fi) {
-        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySession.openImplicit().allocate(i, Long.SIZE));
-        MemorySegment r = MemorySession.openImplicit().allocate(a.byteSize(), Long.SIZE);
+        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySegment.allocateNative(i, Long.SIZE));
+        MemorySegment r = MemorySegment.allocateNative(a.byteSize(), Long.SIZE);
 
         int l = (int) a.byteSize();
         int s = SPECIES.vectorByteSize();
@@ -508,8 +508,8 @@ public class Long256VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @Test(dataProvider = "longByteProviderForIOOBE")
     static void storeMemorySegmentIOOBE(IntFunction<long[]> fa, IntFunction<Integer> fi) {
-        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySession.openImplicit().allocate(i, Long.SIZE));
-        MemorySegment r = MemorySession.openImplicit().allocate(a.byteSize(), Long.SIZE);
+        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySegment.allocateNative(i, Long.SIZE));
+        MemorySegment r = MemorySegment.allocateNative(a.byteSize(), Long.SIZE);
 
         int l = (int) a.byteSize();
         int s = SPECIES.vectorByteSize();
@@ -572,8 +572,8 @@ public class Long256VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @Test(dataProvider = "longByteMaskProviderForIOOBE")
     static void loadMemorySegmentMaskIOOBE(IntFunction<long[]> fa, IntFunction<Integer> fi, IntFunction<boolean[]> fm) {
-        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySession.openImplicit().allocate(i, Long.SIZE));
-        MemorySegment r = MemorySession.openImplicit().allocate(a.byteSize(), Long.SIZE);
+        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySegment.allocateNative(i, Long.SIZE));
+        MemorySegment r = MemorySegment.allocateNative(a.byteSize(), Long.SIZE);
         boolean[] mask = fm.apply(SPECIES.length());
         VectorMask<Long> vmask = VectorMask.fromValues(SPECIES, mask);
 
@@ -603,8 +603,8 @@ public class Long256VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @Test(dataProvider = "longByteMaskProviderForIOOBE")
     static void storeMemorySegmentMaskIOOBE(IntFunction<long[]> fa, IntFunction<Integer> fi, IntFunction<boolean[]> fm) {
-        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySession.openImplicit().allocate(i, Long.SIZE));
-        MemorySegment r = MemorySession.openImplicit().allocate(a.byteSize(), Long.SIZE);
+        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySegment.allocateNative(i, Long.SIZE));
+        MemorySegment r = MemorySegment.allocateNative(a.byteSize(), Long.SIZE);
         boolean[] mask = fm.apply(SPECIES.length());
         VectorMask<Long> vmask = VectorMask.fromValues(SPECIES, mask);
 

--- a/test/jdk/jdk/incubator/vector/Long256VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Long256VectorLoadStoreTests.java
@@ -479,8 +479,8 @@ public class Long256VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @Test(dataProvider = "longByteProviderForIOOBE")
     static void loadMemorySegmentIOOBE(IntFunction<long[]> fa, IntFunction<Integer> fi) {
-        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySegment.allocateNative(i, Long.SIZE, MemorySession.openImplicit()));
-        MemorySegment r = MemorySegment.allocateNative(a.byteSize(), Long.SIZE, MemorySession.openImplicit());
+        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySession.openImplicit().allocate(i, Long.SIZE));
+        MemorySegment r = MemorySession.openImplicit().allocate(a.byteSize(), Long.SIZE);
 
         int l = (int) a.byteSize();
         int s = SPECIES.vectorByteSize();
@@ -508,8 +508,8 @@ public class Long256VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @Test(dataProvider = "longByteProviderForIOOBE")
     static void storeMemorySegmentIOOBE(IntFunction<long[]> fa, IntFunction<Integer> fi) {
-        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySegment.allocateNative(i, Long.SIZE, MemorySession.openImplicit()));
-        MemorySegment r = MemorySegment.allocateNative(a.byteSize(), Long.SIZE, MemorySession.openImplicit());
+        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySession.openImplicit().allocate(i, Long.SIZE));
+        MemorySegment r = MemorySession.openImplicit().allocate(a.byteSize(), Long.SIZE);
 
         int l = (int) a.byteSize();
         int s = SPECIES.vectorByteSize();
@@ -572,8 +572,8 @@ public class Long256VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @Test(dataProvider = "longByteMaskProviderForIOOBE")
     static void loadMemorySegmentMaskIOOBE(IntFunction<long[]> fa, IntFunction<Integer> fi, IntFunction<boolean[]> fm) {
-        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySegment.allocateNative(i, Long.SIZE, MemorySession.openImplicit()));
-        MemorySegment r = MemorySegment.allocateNative(a.byteSize(), Long.SIZE, MemorySession.openImplicit());
+        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySession.openImplicit().allocate(i, Long.SIZE));
+        MemorySegment r = MemorySession.openImplicit().allocate(a.byteSize(), Long.SIZE);
         boolean[] mask = fm.apply(SPECIES.length());
         VectorMask<Long> vmask = VectorMask.fromValues(SPECIES, mask);
 
@@ -603,8 +603,8 @@ public class Long256VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @Test(dataProvider = "longByteMaskProviderForIOOBE")
     static void storeMemorySegmentMaskIOOBE(IntFunction<long[]> fa, IntFunction<Integer> fi, IntFunction<boolean[]> fm) {
-        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySegment.allocateNative(i, Long.SIZE, MemorySession.openImplicit()));
-        MemorySegment r = MemorySegment.allocateNative(a.byteSize(), Long.SIZE, MemorySession.openImplicit());
+        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySession.openImplicit().allocate(i, Long.SIZE));
+        MemorySegment r = MemorySession.openImplicit().allocate(a.byteSize(), Long.SIZE);
         boolean[] mask = fm.apply(SPECIES.length());
         VectorMask<Long> vmask = VectorMask.fromValues(SPECIES, mask);
 

--- a/test/jdk/jdk/incubator/vector/Long512VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Long512VectorLoadStoreTests.java
@@ -479,8 +479,8 @@ public class Long512VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @Test(dataProvider = "longByteProviderForIOOBE")
     static void loadMemorySegmentIOOBE(IntFunction<long[]> fa, IntFunction<Integer> fi) {
-        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySession.openImplicit().allocate(i, Long.SIZE));
-        MemorySegment r = MemorySession.openImplicit().allocate(a.byteSize(), Long.SIZE);
+        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySegment.allocateNative(i, Long.SIZE));
+        MemorySegment r = MemorySegment.allocateNative(a.byteSize(), Long.SIZE);
 
         int l = (int) a.byteSize();
         int s = SPECIES.vectorByteSize();
@@ -508,8 +508,8 @@ public class Long512VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @Test(dataProvider = "longByteProviderForIOOBE")
     static void storeMemorySegmentIOOBE(IntFunction<long[]> fa, IntFunction<Integer> fi) {
-        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySession.openImplicit().allocate(i, Long.SIZE));
-        MemorySegment r = MemorySession.openImplicit().allocate(a.byteSize(), Long.SIZE);
+        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySegment.allocateNative(i, Long.SIZE));
+        MemorySegment r = MemorySegment.allocateNative(a.byteSize(), Long.SIZE);
 
         int l = (int) a.byteSize();
         int s = SPECIES.vectorByteSize();
@@ -572,8 +572,8 @@ public class Long512VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @Test(dataProvider = "longByteMaskProviderForIOOBE")
     static void loadMemorySegmentMaskIOOBE(IntFunction<long[]> fa, IntFunction<Integer> fi, IntFunction<boolean[]> fm) {
-        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySession.openImplicit().allocate(i, Long.SIZE));
-        MemorySegment r = MemorySession.openImplicit().allocate(a.byteSize(), Long.SIZE);
+        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySegment.allocateNative(i, Long.SIZE));
+        MemorySegment r = MemorySegment.allocateNative(a.byteSize(), Long.SIZE);
         boolean[] mask = fm.apply(SPECIES.length());
         VectorMask<Long> vmask = VectorMask.fromValues(SPECIES, mask);
 
@@ -603,8 +603,8 @@ public class Long512VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @Test(dataProvider = "longByteMaskProviderForIOOBE")
     static void storeMemorySegmentMaskIOOBE(IntFunction<long[]> fa, IntFunction<Integer> fi, IntFunction<boolean[]> fm) {
-        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySession.openImplicit().allocate(i, Long.SIZE));
-        MemorySegment r = MemorySession.openImplicit().allocate(a.byteSize(), Long.SIZE);
+        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySegment.allocateNative(i, Long.SIZE));
+        MemorySegment r = MemorySegment.allocateNative(a.byteSize(), Long.SIZE);
         boolean[] mask = fm.apply(SPECIES.length());
         VectorMask<Long> vmask = VectorMask.fromValues(SPECIES, mask);
 

--- a/test/jdk/jdk/incubator/vector/Long512VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Long512VectorLoadStoreTests.java
@@ -479,8 +479,8 @@ public class Long512VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @Test(dataProvider = "longByteProviderForIOOBE")
     static void loadMemorySegmentIOOBE(IntFunction<long[]> fa, IntFunction<Integer> fi) {
-        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySegment.allocateNative(i, Long.SIZE, MemorySession.openImplicit()));
-        MemorySegment r = MemorySegment.allocateNative(a.byteSize(), Long.SIZE, MemorySession.openImplicit());
+        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySession.openImplicit().allocate(i, Long.SIZE));
+        MemorySegment r = MemorySession.openImplicit().allocate(a.byteSize(), Long.SIZE);
 
         int l = (int) a.byteSize();
         int s = SPECIES.vectorByteSize();
@@ -508,8 +508,8 @@ public class Long512VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @Test(dataProvider = "longByteProviderForIOOBE")
     static void storeMemorySegmentIOOBE(IntFunction<long[]> fa, IntFunction<Integer> fi) {
-        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySegment.allocateNative(i, Long.SIZE, MemorySession.openImplicit()));
-        MemorySegment r = MemorySegment.allocateNative(a.byteSize(), Long.SIZE, MemorySession.openImplicit());
+        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySession.openImplicit().allocate(i, Long.SIZE));
+        MemorySegment r = MemorySession.openImplicit().allocate(a.byteSize(), Long.SIZE);
 
         int l = (int) a.byteSize();
         int s = SPECIES.vectorByteSize();
@@ -572,8 +572,8 @@ public class Long512VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @Test(dataProvider = "longByteMaskProviderForIOOBE")
     static void loadMemorySegmentMaskIOOBE(IntFunction<long[]> fa, IntFunction<Integer> fi, IntFunction<boolean[]> fm) {
-        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySegment.allocateNative(i, Long.SIZE, MemorySession.openImplicit()));
-        MemorySegment r = MemorySegment.allocateNative(a.byteSize(), Long.SIZE, MemorySession.openImplicit());
+        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySession.openImplicit().allocate(i, Long.SIZE));
+        MemorySegment r = MemorySession.openImplicit().allocate(a.byteSize(), Long.SIZE);
         boolean[] mask = fm.apply(SPECIES.length());
         VectorMask<Long> vmask = VectorMask.fromValues(SPECIES, mask);
 
@@ -603,8 +603,8 @@ public class Long512VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @Test(dataProvider = "longByteMaskProviderForIOOBE")
     static void storeMemorySegmentMaskIOOBE(IntFunction<long[]> fa, IntFunction<Integer> fi, IntFunction<boolean[]> fm) {
-        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySegment.allocateNative(i, Long.SIZE, MemorySession.openImplicit()));
-        MemorySegment r = MemorySegment.allocateNative(a.byteSize(), Long.SIZE, MemorySession.openImplicit());
+        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySession.openImplicit().allocate(i, Long.SIZE));
+        MemorySegment r = MemorySession.openImplicit().allocate(a.byteSize(), Long.SIZE);
         boolean[] mask = fm.apply(SPECIES.length());
         VectorMask<Long> vmask = VectorMask.fromValues(SPECIES, mask);
 

--- a/test/jdk/jdk/incubator/vector/Long64VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Long64VectorLoadStoreTests.java
@@ -479,8 +479,8 @@ public class Long64VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @Test(dataProvider = "longByteProviderForIOOBE")
     static void loadMemorySegmentIOOBE(IntFunction<long[]> fa, IntFunction<Integer> fi) {
-        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySession.openImplicit().allocate(i, Long.SIZE));
-        MemorySegment r = MemorySession.openImplicit().allocate(a.byteSize(), Long.SIZE);
+        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySegment.allocateNative(i, Long.SIZE));
+        MemorySegment r = MemorySegment.allocateNative(a.byteSize(), Long.SIZE);
 
         int l = (int) a.byteSize();
         int s = SPECIES.vectorByteSize();
@@ -508,8 +508,8 @@ public class Long64VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @Test(dataProvider = "longByteProviderForIOOBE")
     static void storeMemorySegmentIOOBE(IntFunction<long[]> fa, IntFunction<Integer> fi) {
-        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySession.openImplicit().allocate(i, Long.SIZE));
-        MemorySegment r = MemorySession.openImplicit().allocate(a.byteSize(), Long.SIZE);
+        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySegment.allocateNative(i, Long.SIZE));
+        MemorySegment r = MemorySegment.allocateNative(a.byteSize(), Long.SIZE);
 
         int l = (int) a.byteSize();
         int s = SPECIES.vectorByteSize();
@@ -572,8 +572,8 @@ public class Long64VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @Test(dataProvider = "longByteMaskProviderForIOOBE")
     static void loadMemorySegmentMaskIOOBE(IntFunction<long[]> fa, IntFunction<Integer> fi, IntFunction<boolean[]> fm) {
-        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySession.openImplicit().allocate(i, Long.SIZE));
-        MemorySegment r = MemorySession.openImplicit().allocate(a.byteSize(), Long.SIZE);
+        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySegment.allocateNative(i, Long.SIZE));
+        MemorySegment r = MemorySegment.allocateNative(a.byteSize(), Long.SIZE);
         boolean[] mask = fm.apply(SPECIES.length());
         VectorMask<Long> vmask = VectorMask.fromValues(SPECIES, mask);
 
@@ -603,8 +603,8 @@ public class Long64VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @Test(dataProvider = "longByteMaskProviderForIOOBE")
     static void storeMemorySegmentMaskIOOBE(IntFunction<long[]> fa, IntFunction<Integer> fi, IntFunction<boolean[]> fm) {
-        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySession.openImplicit().allocate(i, Long.SIZE));
-        MemorySegment r = MemorySession.openImplicit().allocate(a.byteSize(), Long.SIZE);
+        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySegment.allocateNative(i, Long.SIZE));
+        MemorySegment r = MemorySegment.allocateNative(a.byteSize(), Long.SIZE);
         boolean[] mask = fm.apply(SPECIES.length());
         VectorMask<Long> vmask = VectorMask.fromValues(SPECIES, mask);
 

--- a/test/jdk/jdk/incubator/vector/Long64VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Long64VectorLoadStoreTests.java
@@ -479,8 +479,8 @@ public class Long64VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @Test(dataProvider = "longByteProviderForIOOBE")
     static void loadMemorySegmentIOOBE(IntFunction<long[]> fa, IntFunction<Integer> fi) {
-        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySegment.allocateNative(i, Long.SIZE, MemorySession.openImplicit()));
-        MemorySegment r = MemorySegment.allocateNative(a.byteSize(), Long.SIZE, MemorySession.openImplicit());
+        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySession.openImplicit().allocate(i, Long.SIZE));
+        MemorySegment r = MemorySession.openImplicit().allocate(a.byteSize(), Long.SIZE);
 
         int l = (int) a.byteSize();
         int s = SPECIES.vectorByteSize();
@@ -508,8 +508,8 @@ public class Long64VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @Test(dataProvider = "longByteProviderForIOOBE")
     static void storeMemorySegmentIOOBE(IntFunction<long[]> fa, IntFunction<Integer> fi) {
-        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySegment.allocateNative(i, Long.SIZE, MemorySession.openImplicit()));
-        MemorySegment r = MemorySegment.allocateNative(a.byteSize(), Long.SIZE, MemorySession.openImplicit());
+        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySession.openImplicit().allocate(i, Long.SIZE));
+        MemorySegment r = MemorySession.openImplicit().allocate(a.byteSize(), Long.SIZE);
 
         int l = (int) a.byteSize();
         int s = SPECIES.vectorByteSize();
@@ -572,8 +572,8 @@ public class Long64VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @Test(dataProvider = "longByteMaskProviderForIOOBE")
     static void loadMemorySegmentMaskIOOBE(IntFunction<long[]> fa, IntFunction<Integer> fi, IntFunction<boolean[]> fm) {
-        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySegment.allocateNative(i, Long.SIZE, MemorySession.openImplicit()));
-        MemorySegment r = MemorySegment.allocateNative(a.byteSize(), Long.SIZE, MemorySession.openImplicit());
+        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySession.openImplicit().allocate(i, Long.SIZE));
+        MemorySegment r = MemorySession.openImplicit().allocate(a.byteSize(), Long.SIZE);
         boolean[] mask = fm.apply(SPECIES.length());
         VectorMask<Long> vmask = VectorMask.fromValues(SPECIES, mask);
 
@@ -603,8 +603,8 @@ public class Long64VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @Test(dataProvider = "longByteMaskProviderForIOOBE")
     static void storeMemorySegmentMaskIOOBE(IntFunction<long[]> fa, IntFunction<Integer> fi, IntFunction<boolean[]> fm) {
-        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySegment.allocateNative(i, Long.SIZE, MemorySession.openImplicit()));
-        MemorySegment r = MemorySegment.allocateNative(a.byteSize(), Long.SIZE, MemorySession.openImplicit());
+        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySession.openImplicit().allocate(i, Long.SIZE));
+        MemorySegment r = MemorySession.openImplicit().allocate(a.byteSize(), Long.SIZE);
         boolean[] mask = fm.apply(SPECIES.length());
         VectorMask<Long> vmask = VectorMask.fromValues(SPECIES, mask);
 

--- a/test/jdk/jdk/incubator/vector/LongMaxVectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/LongMaxVectorLoadStoreTests.java
@@ -486,8 +486,8 @@ public class LongMaxVectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @Test(dataProvider = "longByteProviderForIOOBE")
     static void loadMemorySegmentIOOBE(IntFunction<long[]> fa, IntFunction<Integer> fi) {
-        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySession.openImplicit().allocate(i, Long.SIZE));
-        MemorySegment r = MemorySession.openImplicit().allocate(a.byteSize(), Long.SIZE);
+        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySegment.allocateNative(i, Long.SIZE));
+        MemorySegment r = MemorySegment.allocateNative(a.byteSize(), Long.SIZE);
 
         int l = (int) a.byteSize();
         int s = SPECIES.vectorByteSize();
@@ -515,8 +515,8 @@ public class LongMaxVectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @Test(dataProvider = "longByteProviderForIOOBE")
     static void storeMemorySegmentIOOBE(IntFunction<long[]> fa, IntFunction<Integer> fi) {
-        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySession.openImplicit().allocate(i, Long.SIZE));
-        MemorySegment r = MemorySession.openImplicit().allocate(a.byteSize(), Long.SIZE);
+        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySegment.allocateNative(i, Long.SIZE));
+        MemorySegment r = MemorySegment.allocateNative(a.byteSize(), Long.SIZE);
 
         int l = (int) a.byteSize();
         int s = SPECIES.vectorByteSize();
@@ -579,8 +579,8 @@ public class LongMaxVectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @Test(dataProvider = "longByteMaskProviderForIOOBE")
     static void loadMemorySegmentMaskIOOBE(IntFunction<long[]> fa, IntFunction<Integer> fi, IntFunction<boolean[]> fm) {
-        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySession.openImplicit().allocate(i, Long.SIZE));
-        MemorySegment r = MemorySession.openImplicit().allocate(a.byteSize(), Long.SIZE);
+        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySegment.allocateNative(i, Long.SIZE));
+        MemorySegment r = MemorySegment.allocateNative(a.byteSize(), Long.SIZE);
         boolean[] mask = fm.apply(SPECIES.length());
         VectorMask<Long> vmask = VectorMask.fromValues(SPECIES, mask);
 
@@ -610,8 +610,8 @@ public class LongMaxVectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @Test(dataProvider = "longByteMaskProviderForIOOBE")
     static void storeMemorySegmentMaskIOOBE(IntFunction<long[]> fa, IntFunction<Integer> fi, IntFunction<boolean[]> fm) {
-        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySession.openImplicit().allocate(i, Long.SIZE));
-        MemorySegment r = MemorySession.openImplicit().allocate(a.byteSize(), Long.SIZE);
+        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySegment.allocateNative(i, Long.SIZE));
+        MemorySegment r = MemorySegment.allocateNative(a.byteSize(), Long.SIZE);
         boolean[] mask = fm.apply(SPECIES.length());
         VectorMask<Long> vmask = VectorMask.fromValues(SPECIES, mask);
 

--- a/test/jdk/jdk/incubator/vector/LongMaxVectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/LongMaxVectorLoadStoreTests.java
@@ -486,8 +486,8 @@ public class LongMaxVectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @Test(dataProvider = "longByteProviderForIOOBE")
     static void loadMemorySegmentIOOBE(IntFunction<long[]> fa, IntFunction<Integer> fi) {
-        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySegment.allocateNative(i, Long.SIZE, MemorySession.openImplicit()));
-        MemorySegment r = MemorySegment.allocateNative(a.byteSize(), Long.SIZE, MemorySession.openImplicit());
+        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySession.openImplicit().allocate(i, Long.SIZE));
+        MemorySegment r = MemorySession.openImplicit().allocate(a.byteSize(), Long.SIZE);
 
         int l = (int) a.byteSize();
         int s = SPECIES.vectorByteSize();
@@ -515,8 +515,8 @@ public class LongMaxVectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @Test(dataProvider = "longByteProviderForIOOBE")
     static void storeMemorySegmentIOOBE(IntFunction<long[]> fa, IntFunction<Integer> fi) {
-        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySegment.allocateNative(i, Long.SIZE, MemorySession.openImplicit()));
-        MemorySegment r = MemorySegment.allocateNative(a.byteSize(), Long.SIZE, MemorySession.openImplicit());
+        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySession.openImplicit().allocate(i, Long.SIZE));
+        MemorySegment r = MemorySession.openImplicit().allocate(a.byteSize(), Long.SIZE);
 
         int l = (int) a.byteSize();
         int s = SPECIES.vectorByteSize();
@@ -579,8 +579,8 @@ public class LongMaxVectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @Test(dataProvider = "longByteMaskProviderForIOOBE")
     static void loadMemorySegmentMaskIOOBE(IntFunction<long[]> fa, IntFunction<Integer> fi, IntFunction<boolean[]> fm) {
-        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySegment.allocateNative(i, Long.SIZE, MemorySession.openImplicit()));
-        MemorySegment r = MemorySegment.allocateNative(a.byteSize(), Long.SIZE, MemorySession.openImplicit());
+        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySession.openImplicit().allocate(i, Long.SIZE));
+        MemorySegment r = MemorySession.openImplicit().allocate(a.byteSize(), Long.SIZE);
         boolean[] mask = fm.apply(SPECIES.length());
         VectorMask<Long> vmask = VectorMask.fromValues(SPECIES, mask);
 
@@ -610,8 +610,8 @@ public class LongMaxVectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @Test(dataProvider = "longByteMaskProviderForIOOBE")
     static void storeMemorySegmentMaskIOOBE(IntFunction<long[]> fa, IntFunction<Integer> fi, IntFunction<boolean[]> fm) {
-        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySegment.allocateNative(i, Long.SIZE, MemorySession.openImplicit()));
-        MemorySegment r = MemorySegment.allocateNative(a.byteSize(), Long.SIZE, MemorySession.openImplicit());
+        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySession.openImplicit().allocate(i, Long.SIZE));
+        MemorySegment r = MemorySession.openImplicit().allocate(a.byteSize(), Long.SIZE);
         boolean[] mask = fm.apply(SPECIES.length());
         VectorMask<Long> vmask = VectorMask.fromValues(SPECIES, mask);
 

--- a/test/jdk/jdk/incubator/vector/Short128VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Short128VectorLoadStoreTests.java
@@ -479,8 +479,8 @@ public class Short128VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @Test(dataProvider = "shortByteProviderForIOOBE")
     static void loadMemorySegmentIOOBE(IntFunction<short[]> fa, IntFunction<Integer> fi) {
-        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySegment.allocateNative(i, Short.SIZE, MemorySession.openImplicit()));
-        MemorySegment r = MemorySegment.allocateNative(a.byteSize(), Short.SIZE, MemorySession.openImplicit());
+        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySession.openImplicit().allocate(i, Short.SIZE));
+        MemorySegment r = MemorySession.openImplicit().allocate(a.byteSize(), Short.SIZE);
 
         int l = (int) a.byteSize();
         int s = SPECIES.vectorByteSize();
@@ -508,8 +508,8 @@ public class Short128VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @Test(dataProvider = "shortByteProviderForIOOBE")
     static void storeMemorySegmentIOOBE(IntFunction<short[]> fa, IntFunction<Integer> fi) {
-        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySegment.allocateNative(i, Short.SIZE, MemorySession.openImplicit()));
-        MemorySegment r = MemorySegment.allocateNative(a.byteSize(), Short.SIZE, MemorySession.openImplicit());
+        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySession.openImplicit().allocate(i, Short.SIZE));
+        MemorySegment r = MemorySession.openImplicit().allocate(a.byteSize(), Short.SIZE);
 
         int l = (int) a.byteSize();
         int s = SPECIES.vectorByteSize();
@@ -572,8 +572,8 @@ public class Short128VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @Test(dataProvider = "shortByteMaskProviderForIOOBE")
     static void loadMemorySegmentMaskIOOBE(IntFunction<short[]> fa, IntFunction<Integer> fi, IntFunction<boolean[]> fm) {
-        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySegment.allocateNative(i, Short.SIZE, MemorySession.openImplicit()));
-        MemorySegment r = MemorySegment.allocateNative(a.byteSize(), Short.SIZE, MemorySession.openImplicit());
+        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySession.openImplicit().allocate(i, Short.SIZE));
+        MemorySegment r = MemorySession.openImplicit().allocate(a.byteSize(), Short.SIZE);
         boolean[] mask = fm.apply(SPECIES.length());
         VectorMask<Short> vmask = VectorMask.fromValues(SPECIES, mask);
 
@@ -603,8 +603,8 @@ public class Short128VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @Test(dataProvider = "shortByteMaskProviderForIOOBE")
     static void storeMemorySegmentMaskIOOBE(IntFunction<short[]> fa, IntFunction<Integer> fi, IntFunction<boolean[]> fm) {
-        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySegment.allocateNative(i, Short.SIZE, MemorySession.openImplicit()));
-        MemorySegment r = MemorySegment.allocateNative(a.byteSize(), Short.SIZE, MemorySession.openImplicit());
+        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySession.openImplicit().allocate(i, Short.SIZE));
+        MemorySegment r = MemorySession.openImplicit().allocate(a.byteSize(), Short.SIZE);
         boolean[] mask = fm.apply(SPECIES.length());
         VectorMask<Short> vmask = VectorMask.fromValues(SPECIES, mask);
 

--- a/test/jdk/jdk/incubator/vector/Short128VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Short128VectorLoadStoreTests.java
@@ -479,8 +479,8 @@ public class Short128VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @Test(dataProvider = "shortByteProviderForIOOBE")
     static void loadMemorySegmentIOOBE(IntFunction<short[]> fa, IntFunction<Integer> fi) {
-        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySession.openImplicit().allocate(i, Short.SIZE));
-        MemorySegment r = MemorySession.openImplicit().allocate(a.byteSize(), Short.SIZE);
+        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySegment.allocateNative(i, Short.SIZE));
+        MemorySegment r = MemorySegment.allocateNative(a.byteSize(), Short.SIZE);
 
         int l = (int) a.byteSize();
         int s = SPECIES.vectorByteSize();
@@ -508,8 +508,8 @@ public class Short128VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @Test(dataProvider = "shortByteProviderForIOOBE")
     static void storeMemorySegmentIOOBE(IntFunction<short[]> fa, IntFunction<Integer> fi) {
-        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySession.openImplicit().allocate(i, Short.SIZE));
-        MemorySegment r = MemorySession.openImplicit().allocate(a.byteSize(), Short.SIZE);
+        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySegment.allocateNative(i, Short.SIZE));
+        MemorySegment r = MemorySegment.allocateNative(a.byteSize(), Short.SIZE);
 
         int l = (int) a.byteSize();
         int s = SPECIES.vectorByteSize();
@@ -572,8 +572,8 @@ public class Short128VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @Test(dataProvider = "shortByteMaskProviderForIOOBE")
     static void loadMemorySegmentMaskIOOBE(IntFunction<short[]> fa, IntFunction<Integer> fi, IntFunction<boolean[]> fm) {
-        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySession.openImplicit().allocate(i, Short.SIZE));
-        MemorySegment r = MemorySession.openImplicit().allocate(a.byteSize(), Short.SIZE);
+        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySegment.allocateNative(i, Short.SIZE));
+        MemorySegment r = MemorySegment.allocateNative(a.byteSize(), Short.SIZE);
         boolean[] mask = fm.apply(SPECIES.length());
         VectorMask<Short> vmask = VectorMask.fromValues(SPECIES, mask);
 
@@ -603,8 +603,8 @@ public class Short128VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @Test(dataProvider = "shortByteMaskProviderForIOOBE")
     static void storeMemorySegmentMaskIOOBE(IntFunction<short[]> fa, IntFunction<Integer> fi, IntFunction<boolean[]> fm) {
-        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySession.openImplicit().allocate(i, Short.SIZE));
-        MemorySegment r = MemorySession.openImplicit().allocate(a.byteSize(), Short.SIZE);
+        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySegment.allocateNative(i, Short.SIZE));
+        MemorySegment r = MemorySegment.allocateNative(a.byteSize(), Short.SIZE);
         boolean[] mask = fm.apply(SPECIES.length());
         VectorMask<Short> vmask = VectorMask.fromValues(SPECIES, mask);
 

--- a/test/jdk/jdk/incubator/vector/Short256VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Short256VectorLoadStoreTests.java
@@ -479,8 +479,8 @@ public class Short256VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @Test(dataProvider = "shortByteProviderForIOOBE")
     static void loadMemorySegmentIOOBE(IntFunction<short[]> fa, IntFunction<Integer> fi) {
-        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySegment.allocateNative(i, Short.SIZE, MemorySession.openImplicit()));
-        MemorySegment r = MemorySegment.allocateNative(a.byteSize(), Short.SIZE, MemorySession.openImplicit());
+        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySession.openImplicit().allocate(i, Short.SIZE));
+        MemorySegment r = MemorySession.openImplicit().allocate(a.byteSize(), Short.SIZE);
 
         int l = (int) a.byteSize();
         int s = SPECIES.vectorByteSize();
@@ -508,8 +508,8 @@ public class Short256VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @Test(dataProvider = "shortByteProviderForIOOBE")
     static void storeMemorySegmentIOOBE(IntFunction<short[]> fa, IntFunction<Integer> fi) {
-        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySegment.allocateNative(i, Short.SIZE, MemorySession.openImplicit()));
-        MemorySegment r = MemorySegment.allocateNative(a.byteSize(), Short.SIZE, MemorySession.openImplicit());
+        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySession.openImplicit().allocate(i, Short.SIZE));
+        MemorySegment r = MemorySession.openImplicit().allocate(a.byteSize(), Short.SIZE);
 
         int l = (int) a.byteSize();
         int s = SPECIES.vectorByteSize();
@@ -572,8 +572,8 @@ public class Short256VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @Test(dataProvider = "shortByteMaskProviderForIOOBE")
     static void loadMemorySegmentMaskIOOBE(IntFunction<short[]> fa, IntFunction<Integer> fi, IntFunction<boolean[]> fm) {
-        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySegment.allocateNative(i, Short.SIZE, MemorySession.openImplicit()));
-        MemorySegment r = MemorySegment.allocateNative(a.byteSize(), Short.SIZE, MemorySession.openImplicit());
+        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySession.openImplicit().allocate(i, Short.SIZE));
+        MemorySegment r = MemorySession.openImplicit().allocate(a.byteSize(), Short.SIZE);
         boolean[] mask = fm.apply(SPECIES.length());
         VectorMask<Short> vmask = VectorMask.fromValues(SPECIES, mask);
 
@@ -603,8 +603,8 @@ public class Short256VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @Test(dataProvider = "shortByteMaskProviderForIOOBE")
     static void storeMemorySegmentMaskIOOBE(IntFunction<short[]> fa, IntFunction<Integer> fi, IntFunction<boolean[]> fm) {
-        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySegment.allocateNative(i, Short.SIZE, MemorySession.openImplicit()));
-        MemorySegment r = MemorySegment.allocateNative(a.byteSize(), Short.SIZE, MemorySession.openImplicit());
+        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySession.openImplicit().allocate(i, Short.SIZE));
+        MemorySegment r = MemorySession.openImplicit().allocate(a.byteSize(), Short.SIZE);
         boolean[] mask = fm.apply(SPECIES.length());
         VectorMask<Short> vmask = VectorMask.fromValues(SPECIES, mask);
 

--- a/test/jdk/jdk/incubator/vector/Short256VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Short256VectorLoadStoreTests.java
@@ -479,8 +479,8 @@ public class Short256VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @Test(dataProvider = "shortByteProviderForIOOBE")
     static void loadMemorySegmentIOOBE(IntFunction<short[]> fa, IntFunction<Integer> fi) {
-        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySession.openImplicit().allocate(i, Short.SIZE));
-        MemorySegment r = MemorySession.openImplicit().allocate(a.byteSize(), Short.SIZE);
+        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySegment.allocateNative(i, Short.SIZE));
+        MemorySegment r = MemorySegment.allocateNative(a.byteSize(), Short.SIZE);
 
         int l = (int) a.byteSize();
         int s = SPECIES.vectorByteSize();
@@ -508,8 +508,8 @@ public class Short256VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @Test(dataProvider = "shortByteProviderForIOOBE")
     static void storeMemorySegmentIOOBE(IntFunction<short[]> fa, IntFunction<Integer> fi) {
-        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySession.openImplicit().allocate(i, Short.SIZE));
-        MemorySegment r = MemorySession.openImplicit().allocate(a.byteSize(), Short.SIZE);
+        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySegment.allocateNative(i, Short.SIZE));
+        MemorySegment r = MemorySegment.allocateNative(a.byteSize(), Short.SIZE);
 
         int l = (int) a.byteSize();
         int s = SPECIES.vectorByteSize();
@@ -572,8 +572,8 @@ public class Short256VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @Test(dataProvider = "shortByteMaskProviderForIOOBE")
     static void loadMemorySegmentMaskIOOBE(IntFunction<short[]> fa, IntFunction<Integer> fi, IntFunction<boolean[]> fm) {
-        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySession.openImplicit().allocate(i, Short.SIZE));
-        MemorySegment r = MemorySession.openImplicit().allocate(a.byteSize(), Short.SIZE);
+        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySegment.allocateNative(i, Short.SIZE));
+        MemorySegment r = MemorySegment.allocateNative(a.byteSize(), Short.SIZE);
         boolean[] mask = fm.apply(SPECIES.length());
         VectorMask<Short> vmask = VectorMask.fromValues(SPECIES, mask);
 
@@ -603,8 +603,8 @@ public class Short256VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @Test(dataProvider = "shortByteMaskProviderForIOOBE")
     static void storeMemorySegmentMaskIOOBE(IntFunction<short[]> fa, IntFunction<Integer> fi, IntFunction<boolean[]> fm) {
-        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySession.openImplicit().allocate(i, Short.SIZE));
-        MemorySegment r = MemorySession.openImplicit().allocate(a.byteSize(), Short.SIZE);
+        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySegment.allocateNative(i, Short.SIZE));
+        MemorySegment r = MemorySegment.allocateNative(a.byteSize(), Short.SIZE);
         boolean[] mask = fm.apply(SPECIES.length());
         VectorMask<Short> vmask = VectorMask.fromValues(SPECIES, mask);
 

--- a/test/jdk/jdk/incubator/vector/Short512VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Short512VectorLoadStoreTests.java
@@ -479,8 +479,8 @@ public class Short512VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @Test(dataProvider = "shortByteProviderForIOOBE")
     static void loadMemorySegmentIOOBE(IntFunction<short[]> fa, IntFunction<Integer> fi) {
-        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySegment.allocateNative(i, Short.SIZE, MemorySession.openImplicit()));
-        MemorySegment r = MemorySegment.allocateNative(a.byteSize(), Short.SIZE, MemorySession.openImplicit());
+        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySession.openImplicit().allocate(i, Short.SIZE));
+        MemorySegment r = MemorySession.openImplicit().allocate(a.byteSize(), Short.SIZE);
 
         int l = (int) a.byteSize();
         int s = SPECIES.vectorByteSize();
@@ -508,8 +508,8 @@ public class Short512VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @Test(dataProvider = "shortByteProviderForIOOBE")
     static void storeMemorySegmentIOOBE(IntFunction<short[]> fa, IntFunction<Integer> fi) {
-        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySegment.allocateNative(i, Short.SIZE, MemorySession.openImplicit()));
-        MemorySegment r = MemorySegment.allocateNative(a.byteSize(), Short.SIZE, MemorySession.openImplicit());
+        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySession.openImplicit().allocate(i, Short.SIZE));
+        MemorySegment r = MemorySession.openImplicit().allocate(a.byteSize(), Short.SIZE);
 
         int l = (int) a.byteSize();
         int s = SPECIES.vectorByteSize();
@@ -572,8 +572,8 @@ public class Short512VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @Test(dataProvider = "shortByteMaskProviderForIOOBE")
     static void loadMemorySegmentMaskIOOBE(IntFunction<short[]> fa, IntFunction<Integer> fi, IntFunction<boolean[]> fm) {
-        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySegment.allocateNative(i, Short.SIZE, MemorySession.openImplicit()));
-        MemorySegment r = MemorySegment.allocateNative(a.byteSize(), Short.SIZE, MemorySession.openImplicit());
+        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySession.openImplicit().allocate(i, Short.SIZE));
+        MemorySegment r = MemorySession.openImplicit().allocate(a.byteSize(), Short.SIZE);
         boolean[] mask = fm.apply(SPECIES.length());
         VectorMask<Short> vmask = VectorMask.fromValues(SPECIES, mask);
 
@@ -603,8 +603,8 @@ public class Short512VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @Test(dataProvider = "shortByteMaskProviderForIOOBE")
     static void storeMemorySegmentMaskIOOBE(IntFunction<short[]> fa, IntFunction<Integer> fi, IntFunction<boolean[]> fm) {
-        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySegment.allocateNative(i, Short.SIZE, MemorySession.openImplicit()));
-        MemorySegment r = MemorySegment.allocateNative(a.byteSize(), Short.SIZE, MemorySession.openImplicit());
+        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySession.openImplicit().allocate(i, Short.SIZE));
+        MemorySegment r = MemorySession.openImplicit().allocate(a.byteSize(), Short.SIZE);
         boolean[] mask = fm.apply(SPECIES.length());
         VectorMask<Short> vmask = VectorMask.fromValues(SPECIES, mask);
 

--- a/test/jdk/jdk/incubator/vector/Short512VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Short512VectorLoadStoreTests.java
@@ -479,8 +479,8 @@ public class Short512VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @Test(dataProvider = "shortByteProviderForIOOBE")
     static void loadMemorySegmentIOOBE(IntFunction<short[]> fa, IntFunction<Integer> fi) {
-        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySession.openImplicit().allocate(i, Short.SIZE));
-        MemorySegment r = MemorySession.openImplicit().allocate(a.byteSize(), Short.SIZE);
+        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySegment.allocateNative(i, Short.SIZE));
+        MemorySegment r = MemorySegment.allocateNative(a.byteSize(), Short.SIZE);
 
         int l = (int) a.byteSize();
         int s = SPECIES.vectorByteSize();
@@ -508,8 +508,8 @@ public class Short512VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @Test(dataProvider = "shortByteProviderForIOOBE")
     static void storeMemorySegmentIOOBE(IntFunction<short[]> fa, IntFunction<Integer> fi) {
-        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySession.openImplicit().allocate(i, Short.SIZE));
-        MemorySegment r = MemorySession.openImplicit().allocate(a.byteSize(), Short.SIZE);
+        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySegment.allocateNative(i, Short.SIZE));
+        MemorySegment r = MemorySegment.allocateNative(a.byteSize(), Short.SIZE);
 
         int l = (int) a.byteSize();
         int s = SPECIES.vectorByteSize();
@@ -572,8 +572,8 @@ public class Short512VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @Test(dataProvider = "shortByteMaskProviderForIOOBE")
     static void loadMemorySegmentMaskIOOBE(IntFunction<short[]> fa, IntFunction<Integer> fi, IntFunction<boolean[]> fm) {
-        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySession.openImplicit().allocate(i, Short.SIZE));
-        MemorySegment r = MemorySession.openImplicit().allocate(a.byteSize(), Short.SIZE);
+        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySegment.allocateNative(i, Short.SIZE));
+        MemorySegment r = MemorySegment.allocateNative(a.byteSize(), Short.SIZE);
         boolean[] mask = fm.apply(SPECIES.length());
         VectorMask<Short> vmask = VectorMask.fromValues(SPECIES, mask);
 
@@ -603,8 +603,8 @@ public class Short512VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @Test(dataProvider = "shortByteMaskProviderForIOOBE")
     static void storeMemorySegmentMaskIOOBE(IntFunction<short[]> fa, IntFunction<Integer> fi, IntFunction<boolean[]> fm) {
-        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySession.openImplicit().allocate(i, Short.SIZE));
-        MemorySegment r = MemorySession.openImplicit().allocate(a.byteSize(), Short.SIZE);
+        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySegment.allocateNative(i, Short.SIZE));
+        MemorySegment r = MemorySegment.allocateNative(a.byteSize(), Short.SIZE);
         boolean[] mask = fm.apply(SPECIES.length());
         VectorMask<Short> vmask = VectorMask.fromValues(SPECIES, mask);
 

--- a/test/jdk/jdk/incubator/vector/Short64VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Short64VectorLoadStoreTests.java
@@ -479,8 +479,8 @@ public class Short64VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @Test(dataProvider = "shortByteProviderForIOOBE")
     static void loadMemorySegmentIOOBE(IntFunction<short[]> fa, IntFunction<Integer> fi) {
-        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySegment.allocateNative(i, Short.SIZE, MemorySession.openImplicit()));
-        MemorySegment r = MemorySegment.allocateNative(a.byteSize(), Short.SIZE, MemorySession.openImplicit());
+        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySession.openImplicit().allocate(i, Short.SIZE));
+        MemorySegment r = MemorySession.openImplicit().allocate(a.byteSize(), Short.SIZE);
 
         int l = (int) a.byteSize();
         int s = SPECIES.vectorByteSize();
@@ -508,8 +508,8 @@ public class Short64VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @Test(dataProvider = "shortByteProviderForIOOBE")
     static void storeMemorySegmentIOOBE(IntFunction<short[]> fa, IntFunction<Integer> fi) {
-        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySegment.allocateNative(i, Short.SIZE, MemorySession.openImplicit()));
-        MemorySegment r = MemorySegment.allocateNative(a.byteSize(), Short.SIZE, MemorySession.openImplicit());
+        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySession.openImplicit().allocate(i, Short.SIZE));
+        MemorySegment r = MemorySession.openImplicit().allocate(a.byteSize(), Short.SIZE);
 
         int l = (int) a.byteSize();
         int s = SPECIES.vectorByteSize();
@@ -572,8 +572,8 @@ public class Short64VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @Test(dataProvider = "shortByteMaskProviderForIOOBE")
     static void loadMemorySegmentMaskIOOBE(IntFunction<short[]> fa, IntFunction<Integer> fi, IntFunction<boolean[]> fm) {
-        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySegment.allocateNative(i, Short.SIZE, MemorySession.openImplicit()));
-        MemorySegment r = MemorySegment.allocateNative(a.byteSize(), Short.SIZE, MemorySession.openImplicit());
+        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySession.openImplicit().allocate(i, Short.SIZE));
+        MemorySegment r = MemorySession.openImplicit().allocate(a.byteSize(), Short.SIZE);
         boolean[] mask = fm.apply(SPECIES.length());
         VectorMask<Short> vmask = VectorMask.fromValues(SPECIES, mask);
 
@@ -603,8 +603,8 @@ public class Short64VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @Test(dataProvider = "shortByteMaskProviderForIOOBE")
     static void storeMemorySegmentMaskIOOBE(IntFunction<short[]> fa, IntFunction<Integer> fi, IntFunction<boolean[]> fm) {
-        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySegment.allocateNative(i, Short.SIZE, MemorySession.openImplicit()));
-        MemorySegment r = MemorySegment.allocateNative(a.byteSize(), Short.SIZE, MemorySession.openImplicit());
+        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySession.openImplicit().allocate(i, Short.SIZE));
+        MemorySegment r = MemorySession.openImplicit().allocate(a.byteSize(), Short.SIZE);
         boolean[] mask = fm.apply(SPECIES.length());
         VectorMask<Short> vmask = VectorMask.fromValues(SPECIES, mask);
 

--- a/test/jdk/jdk/incubator/vector/Short64VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Short64VectorLoadStoreTests.java
@@ -479,8 +479,8 @@ public class Short64VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @Test(dataProvider = "shortByteProviderForIOOBE")
     static void loadMemorySegmentIOOBE(IntFunction<short[]> fa, IntFunction<Integer> fi) {
-        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySession.openImplicit().allocate(i, Short.SIZE));
-        MemorySegment r = MemorySession.openImplicit().allocate(a.byteSize(), Short.SIZE);
+        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySegment.allocateNative(i, Short.SIZE));
+        MemorySegment r = MemorySegment.allocateNative(a.byteSize(), Short.SIZE);
 
         int l = (int) a.byteSize();
         int s = SPECIES.vectorByteSize();
@@ -508,8 +508,8 @@ public class Short64VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @Test(dataProvider = "shortByteProviderForIOOBE")
     static void storeMemorySegmentIOOBE(IntFunction<short[]> fa, IntFunction<Integer> fi) {
-        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySession.openImplicit().allocate(i, Short.SIZE));
-        MemorySegment r = MemorySession.openImplicit().allocate(a.byteSize(), Short.SIZE);
+        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySegment.allocateNative(i, Short.SIZE));
+        MemorySegment r = MemorySegment.allocateNative(a.byteSize(), Short.SIZE);
 
         int l = (int) a.byteSize();
         int s = SPECIES.vectorByteSize();
@@ -572,8 +572,8 @@ public class Short64VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @Test(dataProvider = "shortByteMaskProviderForIOOBE")
     static void loadMemorySegmentMaskIOOBE(IntFunction<short[]> fa, IntFunction<Integer> fi, IntFunction<boolean[]> fm) {
-        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySession.openImplicit().allocate(i, Short.SIZE));
-        MemorySegment r = MemorySession.openImplicit().allocate(a.byteSize(), Short.SIZE);
+        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySegment.allocateNative(i, Short.SIZE));
+        MemorySegment r = MemorySegment.allocateNative(a.byteSize(), Short.SIZE);
         boolean[] mask = fm.apply(SPECIES.length());
         VectorMask<Short> vmask = VectorMask.fromValues(SPECIES, mask);
 
@@ -603,8 +603,8 @@ public class Short64VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @Test(dataProvider = "shortByteMaskProviderForIOOBE")
     static void storeMemorySegmentMaskIOOBE(IntFunction<short[]> fa, IntFunction<Integer> fi, IntFunction<boolean[]> fm) {
-        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySession.openImplicit().allocate(i, Short.SIZE));
-        MemorySegment r = MemorySession.openImplicit().allocate(a.byteSize(), Short.SIZE);
+        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySegment.allocateNative(i, Short.SIZE));
+        MemorySegment r = MemorySegment.allocateNative(a.byteSize(), Short.SIZE);
         boolean[] mask = fm.apply(SPECIES.length());
         VectorMask<Short> vmask = VectorMask.fromValues(SPECIES, mask);
 

--- a/test/jdk/jdk/incubator/vector/ShortMaxVectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/ShortMaxVectorLoadStoreTests.java
@@ -486,8 +486,8 @@ public class ShortMaxVectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @Test(dataProvider = "shortByteProviderForIOOBE")
     static void loadMemorySegmentIOOBE(IntFunction<short[]> fa, IntFunction<Integer> fi) {
-        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySegment.allocateNative(i, Short.SIZE, MemorySession.openImplicit()));
-        MemorySegment r = MemorySegment.allocateNative(a.byteSize(), Short.SIZE, MemorySession.openImplicit());
+        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySession.openImplicit().allocate(i, Short.SIZE));
+        MemorySegment r = MemorySession.openImplicit().allocate(a.byteSize(), Short.SIZE);
 
         int l = (int) a.byteSize();
         int s = SPECIES.vectorByteSize();
@@ -515,8 +515,8 @@ public class ShortMaxVectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @Test(dataProvider = "shortByteProviderForIOOBE")
     static void storeMemorySegmentIOOBE(IntFunction<short[]> fa, IntFunction<Integer> fi) {
-        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySegment.allocateNative(i, Short.SIZE, MemorySession.openImplicit()));
-        MemorySegment r = MemorySegment.allocateNative(a.byteSize(), Short.SIZE, MemorySession.openImplicit());
+        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySession.openImplicit().allocate(i, Short.SIZE));
+        MemorySegment r = MemorySession.openImplicit().allocate(a.byteSize(), Short.SIZE);
 
         int l = (int) a.byteSize();
         int s = SPECIES.vectorByteSize();
@@ -579,8 +579,8 @@ public class ShortMaxVectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @Test(dataProvider = "shortByteMaskProviderForIOOBE")
     static void loadMemorySegmentMaskIOOBE(IntFunction<short[]> fa, IntFunction<Integer> fi, IntFunction<boolean[]> fm) {
-        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySegment.allocateNative(i, Short.SIZE, MemorySession.openImplicit()));
-        MemorySegment r = MemorySegment.allocateNative(a.byteSize(), Short.SIZE, MemorySession.openImplicit());
+        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySession.openImplicit().allocate(i, Short.SIZE));
+        MemorySegment r = MemorySession.openImplicit().allocate(a.byteSize(), Short.SIZE);
         boolean[] mask = fm.apply(SPECIES.length());
         VectorMask<Short> vmask = VectorMask.fromValues(SPECIES, mask);
 
@@ -610,8 +610,8 @@ public class ShortMaxVectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @Test(dataProvider = "shortByteMaskProviderForIOOBE")
     static void storeMemorySegmentMaskIOOBE(IntFunction<short[]> fa, IntFunction<Integer> fi, IntFunction<boolean[]> fm) {
-        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySegment.allocateNative(i, Short.SIZE, MemorySession.openImplicit()));
-        MemorySegment r = MemorySegment.allocateNative(a.byteSize(), Short.SIZE, MemorySession.openImplicit());
+        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySession.openImplicit().allocate(i, Short.SIZE));
+        MemorySegment r = MemorySession.openImplicit().allocate(a.byteSize(), Short.SIZE);
         boolean[] mask = fm.apply(SPECIES.length());
         VectorMask<Short> vmask = VectorMask.fromValues(SPECIES, mask);
 

--- a/test/jdk/jdk/incubator/vector/ShortMaxVectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/ShortMaxVectorLoadStoreTests.java
@@ -486,8 +486,8 @@ public class ShortMaxVectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @Test(dataProvider = "shortByteProviderForIOOBE")
     static void loadMemorySegmentIOOBE(IntFunction<short[]> fa, IntFunction<Integer> fi) {
-        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySession.openImplicit().allocate(i, Short.SIZE));
-        MemorySegment r = MemorySession.openImplicit().allocate(a.byteSize(), Short.SIZE);
+        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySegment.allocateNative(i, Short.SIZE));
+        MemorySegment r = MemorySegment.allocateNative(a.byteSize(), Short.SIZE);
 
         int l = (int) a.byteSize();
         int s = SPECIES.vectorByteSize();
@@ -515,8 +515,8 @@ public class ShortMaxVectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @Test(dataProvider = "shortByteProviderForIOOBE")
     static void storeMemorySegmentIOOBE(IntFunction<short[]> fa, IntFunction<Integer> fi) {
-        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySession.openImplicit().allocate(i, Short.SIZE));
-        MemorySegment r = MemorySession.openImplicit().allocate(a.byteSize(), Short.SIZE);
+        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySegment.allocateNative(i, Short.SIZE));
+        MemorySegment r = MemorySegment.allocateNative(a.byteSize(), Short.SIZE);
 
         int l = (int) a.byteSize();
         int s = SPECIES.vectorByteSize();
@@ -579,8 +579,8 @@ public class ShortMaxVectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @Test(dataProvider = "shortByteMaskProviderForIOOBE")
     static void loadMemorySegmentMaskIOOBE(IntFunction<short[]> fa, IntFunction<Integer> fi, IntFunction<boolean[]> fm) {
-        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySession.openImplicit().allocate(i, Short.SIZE));
-        MemorySegment r = MemorySession.openImplicit().allocate(a.byteSize(), Short.SIZE);
+        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySegment.allocateNative(i, Short.SIZE));
+        MemorySegment r = MemorySegment.allocateNative(a.byteSize(), Short.SIZE);
         boolean[] mask = fm.apply(SPECIES.length());
         VectorMask<Short> vmask = VectorMask.fromValues(SPECIES, mask);
 
@@ -610,8 +610,8 @@ public class ShortMaxVectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @Test(dataProvider = "shortByteMaskProviderForIOOBE")
     static void storeMemorySegmentMaskIOOBE(IntFunction<short[]> fa, IntFunction<Integer> fi, IntFunction<boolean[]> fm) {
-        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySession.openImplicit().allocate(i, Short.SIZE));
-        MemorySegment r = MemorySession.openImplicit().allocate(a.byteSize(), Short.SIZE);
+        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySegment.allocateNative(i, Short.SIZE));
+        MemorySegment r = MemorySegment.allocateNative(a.byteSize(), Short.SIZE);
         boolean[] mask = fm.apply(SPECIES.length());
         VectorMask<Short> vmask = VectorMask.fromValues(SPECIES, mask);
 

--- a/test/jdk/jdk/incubator/vector/gen-template.sh
+++ b/test/jdk/jdk/incubator/vector/gen-template.sh
@@ -223,6 +223,7 @@ function gen_op_tmpl {
   replace_variables $unit_filename $unit_output "$kernel" "$test" "$op" "$init" "$guard" "$masked" "$op_name" "$kernel_smoke"
 
   local gen_perf_tests=$generate_perf_tests
+  gen_perf_tests=true
   if [[ $template == *"-Broadcast-"* ]] || [[ $template == "Miscellaneous" ]] ||
      [[ $template == *"Compare-Masked"* ]] || [[ $template == *"Compare-Broadcast"* ]]; then
     gen_perf_tests=false

--- a/test/jdk/jdk/incubator/vector/templates/X-LoadStoreTest.java.template
+++ b/test/jdk/jdk/incubator/vector/templates/X-LoadStoreTest.java.template
@@ -499,8 +499,8 @@ public class $vectorteststype$ extends AbstractVectorLoadStoreTest {
 
     @Test(dataProvider = "$type$ByteProviderForIOOBE")
     static void loadMemorySegmentIOOBE(IntFunction<$type$[]> fa, IntFunction<Integer> fi) {
-        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySession.openImplicit().allocate(i, $Boxtype$.SIZE));
-        MemorySegment r = MemorySession.openImplicit().allocate(a.byteSize(), $Boxtype$.SIZE);
+        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySegment.allocateNative(i, $Boxtype$.SIZE));
+        MemorySegment r = MemorySegment.allocateNative(a.byteSize(), $Boxtype$.SIZE);
 
         int l = (int) a.byteSize();
         int s = SPECIES.vectorByteSize();
@@ -528,8 +528,8 @@ public class $vectorteststype$ extends AbstractVectorLoadStoreTest {
 
     @Test(dataProvider = "$type$ByteProviderForIOOBE")
     static void storeMemorySegmentIOOBE(IntFunction<$type$[]> fa, IntFunction<Integer> fi) {
-        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySession.openImplicit().allocate(i, $Boxtype$.SIZE));
-        MemorySegment r = MemorySession.openImplicit().allocate(a.byteSize(), $Boxtype$.SIZE);
+        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySegment.allocateNative(i, $Boxtype$.SIZE));
+        MemorySegment r = MemorySegment.allocateNative(a.byteSize(), $Boxtype$.SIZE);
 
         int l = (int) a.byteSize();
         int s = SPECIES.vectorByteSize();
@@ -592,8 +592,8 @@ public class $vectorteststype$ extends AbstractVectorLoadStoreTest {
 
     @Test(dataProvider = "$type$ByteMaskProviderForIOOBE")
     static void loadMemorySegmentMaskIOOBE(IntFunction<$type$[]> fa, IntFunction<Integer> fi, IntFunction<boolean[]> fm) {
-        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySession.openImplicit().allocate(i, $Boxtype$.SIZE));
-        MemorySegment r = MemorySession.openImplicit().allocate(a.byteSize(), $Boxtype$.SIZE);
+        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySegment.allocateNative(i, $Boxtype$.SIZE));
+        MemorySegment r = MemorySegment.allocateNative(a.byteSize(), $Boxtype$.SIZE);
         boolean[] mask = fm.apply(SPECIES.length());
         VectorMask<$Boxtype$> vmask = VectorMask.fromValues(SPECIES, mask);
 
@@ -623,8 +623,8 @@ public class $vectorteststype$ extends AbstractVectorLoadStoreTest {
 
     @Test(dataProvider = "$type$ByteMaskProviderForIOOBE")
     static void storeMemorySegmentMaskIOOBE(IntFunction<$type$[]> fa, IntFunction<Integer> fi, IntFunction<boolean[]> fm) {
-        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySession.openImplicit().allocate(i, $Boxtype$.SIZE));
-        MemorySegment r = MemorySession.openImplicit().allocate(a.byteSize(), $Boxtype$.SIZE);
+        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySegment.allocateNative(i, $Boxtype$.SIZE));
+        MemorySegment r = MemorySegment.allocateNative(a.byteSize(), $Boxtype$.SIZE);
         boolean[] mask = fm.apply(SPECIES.length());
         VectorMask<$Boxtype$> vmask = VectorMask.fromValues(SPECIES, mask);
 

--- a/test/jdk/jdk/incubator/vector/templates/X-LoadStoreTest.java.template
+++ b/test/jdk/jdk/incubator/vector/templates/X-LoadStoreTest.java.template
@@ -499,8 +499,8 @@ public class $vectorteststype$ extends AbstractVectorLoadStoreTest {
 
     @Test(dataProvider = "$type$ByteProviderForIOOBE")
     static void loadMemorySegmentIOOBE(IntFunction<$type$[]> fa, IntFunction<Integer> fi) {
-        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySegment.allocateNative(i, $Boxtype$.SIZE, MemorySession.openImplicit()));
-        MemorySegment r = MemorySegment.allocateNative(a.byteSize(), $Boxtype$.SIZE, MemorySession.openImplicit());
+        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySession.openImplicit().allocate(i, $Boxtype$.SIZE));
+        MemorySegment r = MemorySession.openImplicit().allocate(a.byteSize(), $Boxtype$.SIZE);
 
         int l = (int) a.byteSize();
         int s = SPECIES.vectorByteSize();
@@ -528,8 +528,8 @@ public class $vectorteststype$ extends AbstractVectorLoadStoreTest {
 
     @Test(dataProvider = "$type$ByteProviderForIOOBE")
     static void storeMemorySegmentIOOBE(IntFunction<$type$[]> fa, IntFunction<Integer> fi) {
-        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySegment.allocateNative(i, $Boxtype$.SIZE, MemorySession.openImplicit()));
-        MemorySegment r = MemorySegment.allocateNative(a.byteSize(), $Boxtype$.SIZE, MemorySession.openImplicit());
+        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySession.openImplicit().allocate(i, $Boxtype$.SIZE));
+        MemorySegment r = MemorySession.openImplicit().allocate(a.byteSize(), $Boxtype$.SIZE);
 
         int l = (int) a.byteSize();
         int s = SPECIES.vectorByteSize();
@@ -592,8 +592,8 @@ public class $vectorteststype$ extends AbstractVectorLoadStoreTest {
 
     @Test(dataProvider = "$type$ByteMaskProviderForIOOBE")
     static void loadMemorySegmentMaskIOOBE(IntFunction<$type$[]> fa, IntFunction<Integer> fi, IntFunction<boolean[]> fm) {
-        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySegment.allocateNative(i, $Boxtype$.SIZE, MemorySession.openImplicit()));
-        MemorySegment r = MemorySegment.allocateNative(a.byteSize(), $Boxtype$.SIZE, MemorySession.openImplicit());
+        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySession.openImplicit().allocate(i, $Boxtype$.SIZE));
+        MemorySegment r = MemorySession.openImplicit().allocate(a.byteSize(), $Boxtype$.SIZE);
         boolean[] mask = fm.apply(SPECIES.length());
         VectorMask<$Boxtype$> vmask = VectorMask.fromValues(SPECIES, mask);
 
@@ -623,8 +623,8 @@ public class $vectorteststype$ extends AbstractVectorLoadStoreTest {
 
     @Test(dataProvider = "$type$ByteMaskProviderForIOOBE")
     static void storeMemorySegmentMaskIOOBE(IntFunction<$type$[]> fa, IntFunction<Integer> fi, IntFunction<boolean[]> fm) {
-        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySegment.allocateNative(i, $Boxtype$.SIZE, MemorySession.openImplicit()));
-        MemorySegment r = MemorySegment.allocateNative(a.byteSize(), $Boxtype$.SIZE, MemorySession.openImplicit());
+        MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> MemorySession.openImplicit().allocate(i, $Boxtype$.SIZE));
+        MemorySegment r = MemorySession.openImplicit().allocate(a.byteSize(), $Boxtype$.SIZE);
         boolean[] mask = fm.apply(SPECIES.length());
         VectorMask<$Boxtype$> vmask = VectorMask.fromValues(SPECIES, mask);
 

--- a/test/micro/org/openjdk/bench/java/lang/foreign/BulkMismatchAcquire.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/BulkMismatchAcquire.java
@@ -86,14 +86,14 @@ public class BulkMismatchAcquire {
     @Setup
     public void setup() {
         session = sessionKind.makeSession();
-        mismatchSegmentLarge1 = MemorySegment.allocateNative(SIZE_WITH_TAIL, session);
-        mismatchSegmentLarge2 = MemorySegment.allocateNative(SIZE_WITH_TAIL, session);
+        mismatchSegmentLarge1 = session.allocate(SIZE_WITH_TAIL);
+        mismatchSegmentLarge2 = session.allocate(SIZE_WITH_TAIL);
         mismatchBufferLarge1 = ByteBuffer.allocateDirect(SIZE_WITH_TAIL);
         mismatchBufferLarge2 = ByteBuffer.allocateDirect(SIZE_WITH_TAIL);
 
         // mismatch at first byte
-        mismatchSegmentSmall1 = MemorySegment.allocateNative(7, session);
-        mismatchSegmentSmall2 = MemorySegment.allocateNative(7, session);
+        mismatchSegmentSmall1 = session.allocate(7);
+        mismatchSegmentSmall2 = session.allocate(7);
         mismatchBufferSmall1 = ByteBuffer.allocateDirect(7);
         mismatchBufferSmall2 = ByteBuffer.allocateDirect(7);
         {

--- a/test/micro/org/openjdk/bench/java/lang/foreign/BulkOps.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/BulkOps.java
@@ -63,7 +63,7 @@ public class BulkOps {
     final MemorySession session = MemorySession.openConfined();
 
     final long unsafe_addr = unsafe.allocateMemory(ALLOC_SIZE);
-    final MemorySegment segment = MemorySegment.allocateNative(ALLOC_SIZE, MemorySession.openConfined());
+    final MemorySegment segment = MemorySession.openConfined().allocate(ALLOC_SIZE);
     final IntBuffer buffer = IntBuffer.allocate(ELEM_SIZE);
 
     final int[] ints = new int[ELEM_SIZE];
@@ -72,14 +72,14 @@ public class BulkOps {
 
     // large(ish) segments/buffers with same content, 0, for mismatch, non-multiple-of-8 sized
     static final int SIZE_WITH_TAIL = (1024 * 1024) + 7;
-    final MemorySegment mismatchSegmentLarge1 = MemorySegment.allocateNative(SIZE_WITH_TAIL, session);
-    final MemorySegment mismatchSegmentLarge2 = MemorySegment.allocateNative(SIZE_WITH_TAIL, session);
+    final MemorySegment mismatchSegmentLarge1 = session.allocate(SIZE_WITH_TAIL);
+    final MemorySegment mismatchSegmentLarge2 = session.allocate(SIZE_WITH_TAIL);
     final ByteBuffer mismatchBufferLarge1 = ByteBuffer.allocateDirect(SIZE_WITH_TAIL);
     final ByteBuffer mismatchBufferLarge2 = ByteBuffer.allocateDirect(SIZE_WITH_TAIL);
 
     // mismatch at first byte
-    final MemorySegment mismatchSegmentSmall1 = MemorySegment.allocateNative(7, session);
-    final MemorySegment mismatchSegmentSmall2 = MemorySegment.allocateNative(7, session);
+    final MemorySegment mismatchSegmentSmall1 = session.allocate(7);
+    final MemorySegment mismatchSegmentSmall2 = session.allocate(7);
     final ByteBuffer mismatchBufferSmall1 = ByteBuffer.allocateDirect(7);
     final ByteBuffer mismatchBufferSmall2 = ByteBuffer.allocateDirect(7);
 

--- a/test/micro/org/openjdk/bench/java/lang/foreign/CallOverheadHelper.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/CallOverheadHelper.java
@@ -80,12 +80,12 @@ public class CallOverheadHelper extends CLayouts {
             C_INT, C_INT
     );
 
-    static final MemorySegment sharedPoint = MemorySegment.allocateNative(POINT_LAYOUT, MemorySession.openShared());
-    static final MemorySegment confinedPoint = MemorySegment.allocateNative(POINT_LAYOUT, MemorySession.openConfined());
+    static final MemorySegment sharedPoint = MemorySession.openShared().allocate(POINT_LAYOUT);
+    static final MemorySegment confinedPoint = MemorySession.openConfined().allocate(POINT_LAYOUT);
 
-    static final MemorySegment point = MemorySegment.allocateNative(POINT_LAYOUT, MemorySession.openImplicit());
+    static final MemorySegment point = MemorySession.openImplicit().allocate(POINT_LAYOUT);
 
-    static final SegmentAllocator recycling_allocator = SegmentAllocator.prefixAllocator(MemorySegment.allocateNative(POINT_LAYOUT, MemorySession.openImplicit()));
+    static final SegmentAllocator recycling_allocator = SegmentAllocator.prefixAllocator(MemorySession.openImplicit().allocate(POINT_LAYOUT));
 
     static {
         System.loadLibrary("CallOverheadJNI");

--- a/test/micro/org/openjdk/bench/java/lang/foreign/CallOverheadHelper.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/CallOverheadHelper.java
@@ -83,9 +83,9 @@ public class CallOverheadHelper extends CLayouts {
     static final MemorySegment sharedPoint = MemorySession.openShared().allocate(POINT_LAYOUT);
     static final MemorySegment confinedPoint = MemorySession.openConfined().allocate(POINT_LAYOUT);
 
-    static final MemorySegment point = MemorySession.openImplicit().allocate(POINT_LAYOUT);
+    static final MemorySegment point = MemorySegment.allocateNative(POINT_LAYOUT);
 
-    static final SegmentAllocator recycling_allocator = SegmentAllocator.prefixAllocator(MemorySession.openImplicit().allocate(POINT_LAYOUT));
+    static final SegmentAllocator recycling_allocator = SegmentAllocator.prefixAllocator(MemorySegment.allocateNative(POINT_LAYOUT));
 
     static {
         System.loadLibrary("CallOverheadJNI");

--- a/test/micro/org/openjdk/bench/java/lang/foreign/LoopOverConstant.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/LoopOverConstant.java
@@ -69,7 +69,7 @@ public class LoopOverConstant extends JavaLayouts {
 
     //setup native memory segment
 
-    static final MemorySegment segment = MemorySession.openImplicit().allocate(ALLOC_SIZE);
+    static final MemorySegment segment = MemorySegment.allocateNative(ALLOC_SIZE);
 
     static {
         for (int i = 0; i < ELEM_SIZE; i++) {

--- a/test/micro/org/openjdk/bench/java/lang/foreign/LoopOverConstant.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/LoopOverConstant.java
@@ -69,7 +69,7 @@ public class LoopOverConstant extends JavaLayouts {
 
     //setup native memory segment
 
-    static final MemorySegment segment = MemorySegment.allocateNative(ALLOC_SIZE, MemorySession.openImplicit());
+    static final MemorySegment segment = MemorySession.openImplicit().allocate(ALLOC_SIZE);
 
     static {
         for (int i = 0; i < ELEM_SIZE; i++) {

--- a/test/micro/org/openjdk/bench/java/lang/foreign/LoopOverNew.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/LoopOverNew.java
@@ -59,7 +59,7 @@ public class LoopOverNew extends JavaLayouts {
     static final int ALLOC_SIZE = ELEM_SIZE * CARRIER_SIZE;
     static final MemoryLayout ALLOC_LAYOUT = MemoryLayout.sequenceLayout(ELEM_SIZE, JAVA_INT);
     final MemorySession session = MemorySession.openConfined();
-    final SegmentAllocator recyclingAlloc = SegmentAllocator.prefixAllocator(MemorySegment.allocateNative(ALLOC_LAYOUT, session));
+    final SegmentAllocator recyclingAlloc = SegmentAllocator.prefixAllocator(session.allocate(ALLOC_LAYOUT));
 
     @TearDown
     public void tearDown() throws Throwable {
@@ -78,7 +78,7 @@ public class LoopOverNew extends JavaLayouts {
     @Benchmark
     public void segment_loop_confined() {
         try (MemorySession session = MemorySession.openConfined()) {
-            MemorySegment segment = MemorySegment.allocateNative(ALLOC_SIZE, 4, session);
+            MemorySegment segment = session.allocate(ALLOC_SIZE, 4);
             for (int i = 0; i < ELEM_SIZE; i++) {
                 VH_INT.set(segment, (long) i, i);
             }
@@ -88,7 +88,7 @@ public class LoopOverNew extends JavaLayouts {
     @Benchmark
     public void segment_loop_shared() {
         try (MemorySession session = MemorySession.openShared()) {
-            MemorySegment segment = MemorySegment.allocateNative(ALLOC_SIZE, 4, session);
+            MemorySegment segment = session.allocate(ALLOC_SIZE, 4);
             for (int i = 0; i < ELEM_SIZE; i++) {
                 VH_INT.set(segment, (long) i, i);
             }
@@ -133,7 +133,7 @@ public class LoopOverNew extends JavaLayouts {
     @Benchmark
     public void segment_loop_implicit() {
         if (gcCount++ == 0) System.gc(); // GC when we overflow
-        MemorySegment segment = MemorySegment.allocateNative(ALLOC_SIZE, 4, MemorySession.openImplicit());
+        MemorySegment segment = MemorySession.openImplicit().allocate(ALLOC_SIZE, 4);
         for (int i = 0; i < ELEM_SIZE; i++) {
             VH_INT.set(segment, (long) i, i);
         }

--- a/test/micro/org/openjdk/bench/java/lang/foreign/LoopOverNew.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/LoopOverNew.java
@@ -133,7 +133,7 @@ public class LoopOverNew extends JavaLayouts {
     @Benchmark
     public void segment_loop_implicit() {
         if (gcCount++ == 0) System.gc(); // GC when we overflow
-        MemorySegment segment = MemorySession.openImplicit().allocate(ALLOC_SIZE, 4);
+        MemorySegment segment = MemorySegment.allocateNative(ALLOC_SIZE, 4);
         for (int i = 0; i < ELEM_SIZE; i++) {
             VH_INT.set(segment, (long) i, i);
         }

--- a/test/micro/org/openjdk/bench/java/lang/foreign/LoopOverNonConstant.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/LoopOverNonConstant.java
@@ -66,7 +66,7 @@ public class LoopOverNonConstant extends JavaLayouts {
         for (int i = 0; i < ELEM_SIZE; i++) {
             unsafe.putInt(unsafe_addr + (i * CARRIER_SIZE) , i);
         }
-        segment = MemorySegment.allocateNative(ALLOC_SIZE, MemorySession.openConfined());
+        segment = MemorySession.openConfined().allocate(ALLOC_SIZE);
         for (int i = 0; i < ELEM_SIZE; i++) {
             VH_INT.set(segment, (long) i, i);
         }

--- a/test/micro/org/openjdk/bench/java/lang/foreign/LoopOverNonConstantFP.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/LoopOverNonConstantFP.java
@@ -72,8 +72,8 @@ public class LoopOverNonConstantFP {
             unsafe.putDouble(unsafe_addrOut + (i * CARRIER_SIZE), i);
         }
         session = MemorySession.openConfined();
-        segmentIn = MemorySegment.allocateNative(ALLOC_SIZE, session);
-        segmentOut = MemorySegment.allocateNative(ALLOC_SIZE, session);
+        segmentIn = session.allocate(ALLOC_SIZE);
+        segmentOut = session.allocate(ALLOC_SIZE);
         for (int i = 0; i < ELEM_SIZE; i++) {
             segmentIn.setAtIndex(JAVA_DOUBLE, i, i);
         }

--- a/test/micro/org/openjdk/bench/java/lang/foreign/LoopOverNonConstantHeap.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/LoopOverNonConstantHeap.java
@@ -75,7 +75,7 @@ public class LoopOverNonConstantHeap extends JavaLayouts {
             MemorySegment intI = MemorySegment.ofArray(new int[ALLOC_SIZE]);
             MemorySegment intD = MemorySegment.ofArray(new double[ALLOC_SIZE]);
             MemorySegment intF = MemorySegment.ofArray(new float[ALLOC_SIZE]);
-            MemorySegment s = MemorySegment.allocateNative(ALLOC_SIZE, 1, MemorySession.openConfined());
+            MemorySegment s = MemorySession.openConfined().allocate(ALLOC_SIZE, 1);
             for (int i = 0; i < ALLOC_SIZE; i++) {
                 intB.set(JAVA_BYTE, i, (byte)i);
                 intI.setAtIndex(JAVA_INT, i, i);

--- a/test/micro/org/openjdk/bench/java/lang/foreign/LoopOverNonConstantShared.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/LoopOverNonConstantShared.java
@@ -66,7 +66,7 @@ public class LoopOverNonConstantShared extends JavaLayouts {
         for (int i = 0; i < ELEM_SIZE; i++) {
             unsafe.putInt(unsafe_addr + (i * CARRIER_SIZE) , i);
         }
-        segment = MemorySegment.allocateNative(ALLOC_SIZE, CARRIER_SIZE, MemorySession.openConfined());
+        segment = MemorySession.openConfined().allocate(ALLOC_SIZE, CARRIER_SIZE);
         for (int i = 0; i < ELEM_SIZE; i++) {
             VH_INT.set(segment, (long) i, i);
         }

--- a/test/micro/org/openjdk/bench/java/lang/foreign/LoopOverPollutedSegments.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/LoopOverPollutedSegments.java
@@ -67,8 +67,9 @@ public class LoopOverPollutedSegments extends JavaLayouts {
             unsafe.putInt(addr + (i * 4), i);
         }
         arr = new byte[ALLOC_SIZE];
-        nativeSegment = MemorySegment.allocateNative(ALLOC_SIZE, 4, session = MemorySession.openConfined());
-        nativeSharedSegment = MemorySegment.allocateNative(ALLOC_SIZE, 4, session);
+        session = MemorySession.openConfined();
+        nativeSegment = session.allocate(ALLOC_SIZE, 4);
+        nativeSharedSegment = session.allocate(ALLOC_SIZE, 4); // <- This segment is not shared!
         heapSegmentBytes = MemorySegment.ofArray(new byte[ALLOC_SIZE]);
         heapSegmentFloats = MemorySegment.ofArray(new float[ELEM_SIZE]);
 

--- a/test/micro/org/openjdk/bench/java/lang/foreign/LoopOverSlice.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/LoopOverSlice.java
@@ -61,7 +61,7 @@ public class LoopOverSlice {
 
     @Setup
     public void setup() {
-        nativeSegment = MemorySegment.allocateNative(ALLOC_SIZE, MemorySession.openConfined());
+        nativeSegment = MemorySession.openConfined().allocate(ALLOC_SIZE);
         heapSegment = MemorySegment.ofArray(new int[ELEM_SIZE]);
         nativeBuffer = ByteBuffer.allocateDirect(ALLOC_SIZE).order(ByteOrder.LITTLE_ENDIAN).asIntBuffer();
         heapBuffer = IntBuffer.wrap(new int[ELEM_SIZE]);

--- a/test/micro/org/openjdk/bench/java/lang/foreign/MemorySessionClose.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/MemorySessionClose.java
@@ -118,13 +118,13 @@ public class MemorySessionClose {
 
     @Benchmark
     public MemorySegment implicit_close() {
-        return MemorySession.openImplicit().allocate(ALLOC_SIZE, 4);
+        return MemorySegment.allocateNative(ALLOC_SIZE, 4);
     }
 
     @Benchmark
     public MemorySegment implicit_close_systemgc() {
         if (gcCount++ == 0) System.gc(); // GC when we overflow
-        return MemorySession.openImplicit().allocate(ALLOC_SIZE, 4);
+        return MemorySegment.allocateNative(ALLOC_SIZE, 4);
     }
 
     // keep

--- a/test/micro/org/openjdk/bench/java/lang/foreign/MemorySessionClose.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/MemorySessionClose.java
@@ -105,26 +105,26 @@ public class MemorySessionClose {
     @Benchmark
     public MemorySegment confined_close() {
         try (MemorySession session = MemorySession.openConfined()) {
-            return MemorySegment.allocateNative(ALLOC_SIZE, 4, session);
+            return session.allocate(ALLOC_SIZE, 4);
         }
     }
 
     @Benchmark
     public MemorySegment shared_close() {
         try (MemorySession session = MemorySession.openShared()) {
-            return MemorySegment.allocateNative(ALLOC_SIZE, 4, session);
+            return session.allocate(ALLOC_SIZE, 4);
         }
     }
 
     @Benchmark
     public MemorySegment implicit_close() {
-        return MemorySegment.allocateNative(ALLOC_SIZE, 4, MemorySession.openImplicit());
+        return MemorySession.openImplicit().allocate(ALLOC_SIZE, 4);
     }
 
     @Benchmark
     public MemorySegment implicit_close_systemgc() {
         if (gcCount++ == 0) System.gc(); // GC when we overflow
-        return MemorySegment.allocateNative(ALLOC_SIZE, 4, MemorySession.openImplicit());
+        return MemorySession.openImplicit().allocate(ALLOC_SIZE, 4);
     }
 
     // keep

--- a/test/micro/org/openjdk/bench/java/lang/foreign/ParallelSum.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/ParallelSum.java
@@ -77,7 +77,7 @@ public class ParallelSum extends JavaLayouts {
         for (int i = 0; i < ELEM_SIZE; i++) {
             unsafe.putInt(address + (i * CARRIER_SIZE), i);
         }
-        segment = MemorySegment.allocateNative(ALLOC_SIZE, CARRIER_SIZE, MemorySession.openShared());
+        segment = MemorySession.openShared().allocate(ALLOC_SIZE, CARRIER_SIZE);
         for (int i = 0; i < ELEM_SIZE; i++) {
             VH_INT.set(segment, (long) i, i);
         }

--- a/test/micro/org/openjdk/bench/java/lang/foreign/PointerInvoke.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/PointerInvoke.java
@@ -55,7 +55,7 @@ import java.util.concurrent.TimeUnit;
 public class PointerInvoke extends CLayouts {
 
     MemorySession session = MemorySession.openConfined();
-    MemorySegment segment = MemorySegment.allocateNative(100, session);
+    MemorySegment segment = session.allocate(100);
 
     static {
         System.loadLibrary("Ptr");

--- a/test/micro/org/openjdk/bench/java/lang/foreign/QSort.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/QSort.java
@@ -64,7 +64,7 @@ public class QSort extends CLayouts {
     static MemorySegment qsort_addr = abi.defaultLookup().lookup("qsort").get();
 
     static {
-        INPUT_SEGMENT = MemorySegment.allocateNative(MemoryLayout.sequenceLayout(INPUT.length, JAVA_INT), MemorySession.global());
+        INPUT_SEGMENT = MemorySession.global().allocate(MemoryLayout.sequenceLayout(INPUT.length, JAVA_INT));
         INPUT_SEGMENT.copyFrom(MemorySegment.ofArray(INPUT));
 
         System.loadLibrary("QSortJNI");

--- a/test/micro/org/openjdk/bench/java/lang/foreign/StrLenTest.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/StrLenTest.java
@@ -80,7 +80,7 @@ public class StrLenTest extends CLayouts {
     @Setup
     public void setup() {
         str = makeString(size);
-        segmentAllocator = SegmentAllocator.prefixAllocator(MemorySegment.allocateNative(size + 1, MemorySession.openConfined()));
+        segmentAllocator = SegmentAllocator.prefixAllocator(MemorySession.openConfined().allocate(size + 1));
     }
 
     @TearDown
@@ -96,7 +96,7 @@ public class StrLenTest extends CLayouts {
     @Benchmark
     public int panama_strlen() throws Throwable {
         try (MemorySession session = MemorySession.openConfined()) {
-            MemorySegment segment = MemorySegment.allocateNative(str.length() + 1, session);
+            MemorySegment segment = session.allocate(str.length() + 1);
             segment.setUtf8String(0, str);
             return (int)STRLEN.invokeExact(segment);
         }

--- a/test/micro/org/openjdk/bench/java/lang/foreign/TestLoadBytes.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/TestLoadBytes.java
@@ -67,7 +67,7 @@ public class TestLoadBytes {
         }
 
         srcBufferNative = ByteBuffer.allocateDirect(size);
-        srcSegmentImplicit = MemorySession.openImplicit().allocate(size);
+        srcSegmentImplicit = MemorySegment.allocateNative(size);
     }
 
     @Benchmark

--- a/test/micro/org/openjdk/bench/java/lang/foreign/TestLoadBytes.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/TestLoadBytes.java
@@ -67,7 +67,7 @@ public class TestLoadBytes {
         }
 
         srcBufferNative = ByteBuffer.allocateDirect(size);
-        srcSegmentImplicit = MemorySegment.allocateNative(size, MemorySession.openImplicit());
+        srcSegmentImplicit = MemorySession.openImplicit().allocate(size);
     }
 
     @Benchmark

--- a/test/micro/org/openjdk/bench/java/lang/foreign/VarHandleExact.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/VarHandleExact.java
@@ -61,7 +61,7 @@ public class VarHandleExact {
 
     @Setup
     public void setup() {
-        data = MemorySegment.allocateNative(JAVA_INT, MemorySession.openConfined());
+        data = MemorySession.openConfined().allocate(JAVA_INT);
     }
 
     @TearDown

--- a/test/micro/org/openjdk/bench/java/lang/foreign/points/support/PanamaPoint.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/points/support/PanamaPoint.java
@@ -64,7 +64,7 @@ public class PanamaPoint extends CLayouts implements AutoCloseable {
     private final MemorySegment segment;
 
     public PanamaPoint(int x, int y) {
-        this.segment = MemorySegment.allocateNative(LAYOUT, MemorySession.openConfined());
+        this.segment = MemorySession.openConfined().allocate(LAYOUT);
         setX(x);
         setY(y);
     }

--- a/test/micro/org/openjdk/bench/jdk/incubator/vector/MemorySegmentVectorAccess.java
+++ b/test/micro/org/openjdk/bench/jdk/incubator/vector/MemorySegmentVectorAccess.java
@@ -69,8 +69,8 @@ public class MemorySegmentVectorAccess {
 
   @Setup
   public void setup() {
-    nativeIn = MemorySegment.allocateNative(size, MemorySession.openImplicit());
-    nativeOut = MemorySegment.allocateNative(size, MemorySession.openImplicit());
+    nativeIn = MemorySession.openImplicit().allocate(size);
+    nativeOut = MemorySession.openImplicit().allocate(size);
 
     byteIn = new byte[size];
     byteOut = new byte[size];

--- a/test/micro/org/openjdk/bench/jdk/incubator/vector/MemorySegmentVectorAccess.java
+++ b/test/micro/org/openjdk/bench/jdk/incubator/vector/MemorySegmentVectorAccess.java
@@ -69,8 +69,8 @@ public class MemorySegmentVectorAccess {
 
   @Setup
   public void setup() {
-    nativeIn = MemorySession.openImplicit().allocate(size);
-    nativeOut = MemorySession.openImplicit().allocate(size);
+    nativeIn = MemorySegment.allocateNative(size);
+    nativeOut = MemorySegment.allocateNative(size);
 
     byteIn = new byte[size];
     byteOut = new byte[size];

--- a/test/micro/org/openjdk/bench/jdk/incubator/vector/TestLoadStoreBytes.java
+++ b/test/micro/org/openjdk/bench/jdk/incubator/vector/TestLoadStoreBytes.java
@@ -84,8 +84,8 @@ public class TestLoadStoreBytes {
     srcSegmentHeap = MemorySegment.ofArray(new byte[size]);
     dstSegmentHeap = MemorySegment.ofArray(new byte[size]);
 
-    srcSegment = MemorySegment.allocateNative(size, SPECIES.vectorByteSize(), MemorySession.openImplicit());
-    dstSegment = MemorySegment.allocateNative(size, SPECIES.vectorByteSize(), MemorySession.openImplicit());
+    srcSegment = MemorySession.openImplicit().allocate(size, SPECIES.vectorByteSize());
+    dstSegment = MemorySession.openImplicit().allocate(size, SPECIES.vectorByteSize());
 
     a = new byte[size];
     b = new byte[size];

--- a/test/micro/org/openjdk/bench/jdk/incubator/vector/TestLoadStoreBytes.java
+++ b/test/micro/org/openjdk/bench/jdk/incubator/vector/TestLoadStoreBytes.java
@@ -84,8 +84,8 @@ public class TestLoadStoreBytes {
     srcSegmentHeap = MemorySegment.ofArray(new byte[size]);
     dstSegmentHeap = MemorySegment.ofArray(new byte[size]);
 
-    srcSegment = MemorySession.openImplicit().allocate(size, SPECIES.vectorByteSize());
-    dstSegment = MemorySession.openImplicit().allocate(size, SPECIES.vectorByteSize());
+    srcSegment = MemorySegment.allocateNative(size, SPECIES.vectorByteSize());
+    dstSegment = MemorySegment.allocateNative(size, SPECIES.vectorByteSize());
 
     a = new byte[size];
     b = new byte[size];

--- a/test/micro/org/openjdk/bench/jdk/incubator/vector/TestLoadStoreShorts.java
+++ b/test/micro/org/openjdk/bench/jdk/incubator/vector/TestLoadStoreShorts.java
@@ -89,8 +89,8 @@ public class TestLoadStoreShorts {
     srcSegmentHeap = MemorySegment.ofArray(new byte[size]);
     dstSegmentHeap = MemorySegment.ofArray(new byte[size]);
 
-    srcSegment = MemorySegment.allocateNative(size, SPECIES.vectorByteSize(), MemorySession.openImplicit());
-    dstSegment = MemorySegment.allocateNative(size, SPECIES.vectorByteSize(), MemorySession.openImplicit());
+    srcSegment = MemorySession.openImplicit().allocate(size, SPECIES.vectorByteSize());
+    dstSegment = MemorySession.openImplicit().allocate(size, SPECIES.vectorByteSize());
 
     this.longSize = longSize;
 

--- a/test/micro/org/openjdk/bench/jdk/incubator/vector/TestLoadStoreShorts.java
+++ b/test/micro/org/openjdk/bench/jdk/incubator/vector/TestLoadStoreShorts.java
@@ -89,8 +89,8 @@ public class TestLoadStoreShorts {
     srcSegmentHeap = MemorySegment.ofArray(new byte[size]);
     dstSegmentHeap = MemorySegment.ofArray(new byte[size]);
 
-    srcSegment = MemorySession.openImplicit().allocate(size, SPECIES.vectorByteSize());
-    dstSegment = MemorySession.openImplicit().allocate(size, SPECIES.vectorByteSize());
+    srcSegment = MemorySegment.allocateNative(size, SPECIES.vectorByteSize());
+    dstSegment = MemorySegment.allocateNative(size, SPECIES.vectorByteSize());
 
     this.longSize = longSize;
 


### PR DESCRIPTION
This PR changes the `MemorySegment` static constructors to be more like the one of `ByteBuffer`.

<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8293400](https://bugs.openjdk.org/browse/JDK-8293400): Modify static constructors in MemorySegment


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.org/census#mcimadamore) (@mcimadamore - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/panama-foreign pull/718/head:pull/718` \
`$ git checkout pull/718`

Update a local copy of the PR: \
`$ git checkout pull/718` \
`$ git pull https://git.openjdk.org/panama-foreign pull/718/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 718`

View PR using the GUI difftool: \
`$ git pr show -t 718`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/panama-foreign/pull/718.diff">https://git.openjdk.org/panama-foreign/pull/718.diff</a>

</details>
