### PR TITLE
Refactor compound layouts such as SequenceLayout and StructLayout

### DIFF
--- a/src/java.base/share/classes/java/lang/foreign/CompoundLayout.java
+++ b/src/java.base/share/classes/java/lang/foreign/CompoundLayout.java
@@ -1,0 +1,46 @@
+package java.lang.foreign;
+
+import java.util.NoSuchElementException;
+import java.util.stream.Stream;
+
+/**
+ * A compound layout aggregates multiple <em>memory layout</em> elements. There are two ways in which
+ * element layouts can be combined: if element layouts can be heterogeneous, the resulting compound
+ * layout is said to be a <em>group layout</em> (see {@link GroupLayout});
+ * conversely, if all element layouts are homogeneous, the resulting compound layout is said to be a
+ * <em>sequence layout</em> (see {@link SequenceLayout}).
+ *
+ * @implSpec
+ * Implementing classes are immutable, thread-safe and <a href="{@docRoot}/java.base/java/lang/doc-files/ValueBased.html">value-based</a>.
+ *
+ * @since 20
+ */
+public sealed interface CompoundLayout extends MemoryLayout, Iterable<MemoryLayout> permits GroupLayout, SequenceLayout {
+
+    /**
+     * {@return the size of this group layout (i.e. the number of elements in this group).}
+     */
+    long elementCount();
+
+    /**
+     * {@return the element at the provided {@code index}.}
+     *
+     * @apiNote the order in which member layouts are produced is the same order in which member layouts have
+     * been passed to one of the group layout factory methods (see {@link MemoryLayout#structLayout(MemoryLayout...)},
+     * {@link MemoryLayout#unionLayout(MemoryLayout...)}, {@link MemoryLayout#sequenceLayout(long, MemoryLayout)}).
+     *
+     * @param index the index for the MemoryLayout to retrieve
+     * @throws NoSuchElementException if the provided {@code index} is negative or if greater or equal to {@link #elementCount()}
+     */
+    MemoryLayout elementAt(long index);
+
+    /**
+     * {@return a stream of all elements in this group.}
+     *
+     * @apiNote the order in which element layouts are produced is the same order in which member layouts have
+     * been passed to one of the group layout factory methods (see {@link MemoryLayout#structLayout(MemoryLayout...)},
+     * {@link MemoryLayout#unionLayout(MemoryLayout...)}, {@link MemoryLayout#sequenceLayout(long, MemoryLayout)}).
+     */
+    Stream<MemoryLayout> stream();
+
+}

--- a/src/java.base/share/classes/java/lang/foreign/GroupLayout.java
+++ b/src/java.base/share/classes/java/lang/foreign/GroupLayout.java
@@ -25,7 +25,9 @@
  */
 package java.lang.foreign;
 
-import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.stream.Stream;
+
 import jdk.internal.javac.PreviewFeature;
 
 /**
@@ -40,18 +42,33 @@ import jdk.internal.javac.PreviewFeature;
  * @since 19
  */
 @PreviewFeature(feature=PreviewFeature.Feature.FOREIGN)
-public sealed interface GroupLayout extends MemoryLayout permits StructLayout, UnionLayout {
+public sealed interface GroupLayout extends MemoryLayout, Iterable<MemoryLayout> permits StructLayout, UnionLayout, SequenceLayout {
 
     /**
-     * Returns the member layouts associated with this group.
-     *
-     * @apiNote the order in which member layouts are returned is the same order in which member layouts have
-     * been passed to one of the group layout factory methods (see {@link MemoryLayout#structLayout(MemoryLayout...)},
-     * {@link MemoryLayout#unionLayout(MemoryLayout...)}).
-     *
-     * @return the member layouts associated with this group.
+     * {@return the size of this group layout (i.e. the number of elements in this group).}
      */
-    List<MemoryLayout> memberLayouts();
+    long elementCount();
+
+    /**
+     * {@return the element at the provided {@code index}.}
+     *
+     * @apiNote the order in which member layouts are produced is the same order in which member layouts have
+     * been passed to one of the group layout factory methods (see {@link MemoryLayout#structLayout(MemoryLayout...)},
+     * {@link MemoryLayout#unionLayout(MemoryLayout...)}, {@link MemoryLayout#sequenceLayout(long, MemoryLayout)}).
+     *
+     * @param index the index for the MemoryLayout to retrieve
+     * @throws NoSuchElementException if the provided {@code index} is negative or if greater or equal to {@link #elementCount()}
+     */
+    MemoryLayout elementAt(long index);
+
+    /**
+     * {@return a stream of all elements in this group.}
+     *
+     * @apiNote the order in which element layouts are produced is the same order in which member layouts have
+     * been passed to one of the group layout factory methods (see {@link MemoryLayout#structLayout(MemoryLayout...)},
+     * {@link MemoryLayout#unionLayout(MemoryLayout...)}, {@link MemoryLayout#sequenceLayout(long, MemoryLayout)}).
+     */
+    Stream<MemoryLayout> stream();
 
     @Override
     GroupLayout withName(String name);

--- a/src/java.base/share/classes/java/lang/foreign/GroupLayout.java
+++ b/src/java.base/share/classes/java/lang/foreign/GroupLayout.java
@@ -25,9 +25,6 @@
  */
 package java.lang.foreign;
 
-import java.util.NoSuchElementException;
-import java.util.stream.Stream;
-
 import jdk.internal.javac.PreviewFeature;
 
 /**
@@ -37,38 +34,12 @@ import jdk.internal.javac.PreviewFeature;
  * the resulting group layout is said to be a <em>union</em> (see {@link MemoryLayout#unionLayout(MemoryLayout...)}).
  *
  * @implSpec
- * This class is immutable, thread-safe and <a href="{@docRoot}/java.base/java/lang/doc-files/ValueBased.html">value-based</a>.
+ * Implementing classes are immutable, thread-safe and <a href="{@docRoot}/java.base/java/lang/doc-files/ValueBased.html">value-based</a>.
  *
  * @since 19
  */
 @PreviewFeature(feature=PreviewFeature.Feature.FOREIGN)
-public sealed interface GroupLayout extends MemoryLayout, Iterable<MemoryLayout> permits StructLayout, UnionLayout, SequenceLayout {
-
-    /**
-     * {@return the size of this group layout (i.e. the number of elements in this group).}
-     */
-    long elementCount();
-
-    /**
-     * {@return the element at the provided {@code index}.}
-     *
-     * @apiNote the order in which member layouts are produced is the same order in which member layouts have
-     * been passed to one of the group layout factory methods (see {@link MemoryLayout#structLayout(MemoryLayout...)},
-     * {@link MemoryLayout#unionLayout(MemoryLayout...)}, {@link MemoryLayout#sequenceLayout(long, MemoryLayout)}).
-     *
-     * @param index the index for the MemoryLayout to retrieve
-     * @throws NoSuchElementException if the provided {@code index} is negative or if greater or equal to {@link #elementCount()}
-     */
-    MemoryLayout elementAt(long index);
-
-    /**
-     * {@return a stream of all elements in this group.}
-     *
-     * @apiNote the order in which element layouts are produced is the same order in which member layouts have
-     * been passed to one of the group layout factory methods (see {@link MemoryLayout#structLayout(MemoryLayout...)},
-     * {@link MemoryLayout#unionLayout(MemoryLayout...)}, {@link MemoryLayout#sequenceLayout(long, MemoryLayout)}).
-     */
-    Stream<MemoryLayout> stream();
+public sealed interface GroupLayout extends CompoundLayout permits StructLayout, UnionLayout {
 
     @Override
     GroupLayout withName(String name);

--- a/src/java.base/share/classes/java/lang/foreign/MemoryLayout.java
+++ b/src/java.base/share/classes/java/lang/foreign/MemoryLayout.java
@@ -165,7 +165,7 @@ import jdk.internal.javac.PreviewFeature;
  * @since 19
  */
 @PreviewFeature(feature=PreviewFeature.Feature.FOREIGN)
-public sealed interface MemoryLayout permits SequenceLayout, GroupLayout, PaddingLayout, ValueLayout {
+public sealed interface MemoryLayout permits GroupLayout, PaddingLayout, ValueLayout {
 
     /**
      * {@return the layout size, in bits}
@@ -460,8 +460,8 @@ public sealed interface MemoryLayout permits SequenceLayout, GroupLayout, Paddin
     /**
      * An element in a <a href="MemoryLayout.html#layout-paths"><em>layout path</em></a>. There
      * are two kinds of path elements: <em>group path elements</em> and <em>sequence path elements</em>. Group
-     * path elements are used to select a named member layout within a {@link GroupLayout}. Sequence
-     * path elements are used to select a sequence element layout within a {@link SequenceLayout}; selection
+     * path elements are used to select a named member layout within a {@link StructLayout} or a {@link UnionLayout}.
+     * Sequence path elements are used to select a sequence element layout within a {@link SequenceLayout}; selection
      * of sequence element layout can be <em>explicit</em> (see {@link PathElement#sequenceElement(long)}) or
      * <em>implicit</em> (see {@link PathElement#sequenceElement()}). When a path uses one or more implicit
      * sequence path elements, it acquires additional <em>free dimensions</em>.
@@ -583,7 +583,7 @@ public sealed interface MemoryLayout permits SequenceLayout, GroupLayout, Paddin
      *     <li>two sequence layouts are considered equal if they have the same element count (see {@link SequenceLayout#elementCount()}), and
      *     if their element layouts (see {@link SequenceLayout#elementLayout()}) are also equal</li>
      *     <li>two group layouts are considered equal if they are of the same type (see {@link StructLayout},
-     *     {@link UnionLayout}) and if their member layouts (see {@link GroupLayout#memberLayouts()}) are also equal</li>
+     *     {@link UnionLayout}) and if their member layouts (see {@link GroupLayout#stream()} ()}) are also equal</li>
      * </ul>
      *
      * @param other the object to be compared for equality with this layout.

--- a/src/java.base/share/classes/java/lang/foreign/MemoryLayout.java
+++ b/src/java.base/share/classes/java/lang/foreign/MemoryLayout.java
@@ -165,7 +165,7 @@ import jdk.internal.javac.PreviewFeature;
  * @since 19
  */
 @PreviewFeature(feature=PreviewFeature.Feature.FOREIGN)
-public sealed interface MemoryLayout permits GroupLayout, PaddingLayout, ValueLayout {
+public sealed interface MemoryLayout permits CompoundLayout, PaddingLayout, ValueLayout {
 
     /**
      * {@return the layout size, in bits}

--- a/src/java.base/share/classes/java/lang/foreign/SequenceLayout.java
+++ b/src/java.base/share/classes/java/lang/foreign/SequenceLayout.java
@@ -48,12 +48,12 @@ import jdk.internal.javac.PreviewFeature;
  * }
  *
  * @implSpec
- * This class is immutable, thread-safe and <a href="{@docRoot}/java.base/java/lang/doc-files/ValueBased.html">value-based</a>.
+ * Implementing classes are immutable, thread-safe and <a href="{@docRoot}/java.base/java/lang/doc-files/ValueBased.html">value-based</a>.
  *
  * @since 19
  */
 @PreviewFeature(feature=PreviewFeature.Feature.FOREIGN)
-public sealed interface SequenceLayout extends GroupLayout permits SequenceLayoutImpl {
+public sealed interface SequenceLayout extends CompoundLayout permits SequenceLayoutImpl {
 
     /**
      * {@return the element layout associated with this sequence layout}

--- a/src/java.base/share/classes/java/lang/foreign/SequenceLayout.java
+++ b/src/java.base/share/classes/java/lang/foreign/SequenceLayout.java
@@ -53,18 +53,12 @@ import jdk.internal.javac.PreviewFeature;
  * @since 19
  */
 @PreviewFeature(feature=PreviewFeature.Feature.FOREIGN)
-public sealed interface SequenceLayout extends MemoryLayout permits SequenceLayoutImpl {
-
+public sealed interface SequenceLayout extends GroupLayout permits SequenceLayoutImpl {
 
     /**
      * {@return the element layout associated with this sequence layout}
      */
     MemoryLayout elementLayout();
-
-    /**
-     * {@return the element count of this sequence layout}
-     */
-    long elementCount();
 
     /**
      * Returns a sequence layout with the same element layout, alignment constraints and name as this sequence layout,

--- a/src/java.base/share/classes/jdk/internal/foreign/LayoutPath.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/LayoutPath.java
@@ -118,8 +118,8 @@ public class LayoutPath {
         GroupLayout g = (GroupLayout)layout;
         long offset = 0;
         MemoryLayout elem = null;
-        for (int i = 0; i < g.memberLayouts().size(); i++) {
-            MemoryLayout l = g.memberLayouts().get(i);
+        for (int i = 0; i < g.elementCount(); i++) {
+            MemoryLayout l = g.elementAt(i);
             if (l.name().isPresent() &&
                 l.name().get().equals(name)) {
                 elem = l;

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/SharedUtils.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/SharedUtils.java
@@ -145,7 +145,7 @@ public final class SharedUtils {
 
     private static long alignmentOfContainer(GroupLayout ct) {
         // Most strict member
-        return ct.memberLayouts().stream().mapToLong(t -> alignment(t, false)).max().orElse(1);
+        return ct.stream().mapToLong(t -> alignment(t, false)).max().orElse(1);
     }
 
     /**

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/aarch64/CallArranger.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/aarch64/CallArranger.java
@@ -362,15 +362,15 @@ public abstract class CallArranger {
                     assert carrier == MemorySegment.class;
                     GroupLayout group = (GroupLayout)layout;
                     VMStorage[] regs = storageCalculator.regAlloc(
-                        StorageClasses.VECTOR, group.memberLayouts().size());
+                        StorageClasses.VECTOR, Math.toIntExact(group.elementCount()));
                     if (regs != null) {
                         long offset = 0;
-                        for (int i = 0; i < group.memberLayouts().size(); i++) {
+                        for (int i = 0; i < Math.toIntExact(group.elementCount()); i++) {
                             VMStorage storage = regs[i];
-                            final long size = group.memberLayouts().get(i).byteSize();
+                            final long size = group.elementAt(i).byteSize();
                             boolean useFloat = storage.type() == StorageClasses.VECTOR;
                             Class<?> type = SharedUtils.primitiveCarrierForSize(size, useFloat);
-                            if (i + 1 < group.memberLayouts().size()) {
+                            if (i + 1 < Math.toIntExact(group.elementCount())) {
                                 bindings.dup();
                             }
                             bindings.bufferLoad(offset, type)
@@ -462,12 +462,12 @@ public abstract class CallArranger {
                     bindings.allocate(layout);
                     GroupLayout group = (GroupLayout)layout;
                     VMStorage[] regs = storageCalculator.regAlloc(
-                        StorageClasses.VECTOR, group.memberLayouts().size());
+                        StorageClasses.VECTOR, Math.toIntExact(group.elementCount()));
                     if (regs != null) {
                         long offset = 0;
-                        for (int i = 0; i < group.memberLayouts().size(); i++) {
+                        for (int i = 0; i < Math.toIntExact(group.elementCount()); i++) {
                             VMStorage storage = regs[i];
-                            final long size = group.memberLayouts().get(i).byteSize();
+                            final long size = group.elementAt(i).byteSize();
                             boolean useFloat = storage.type() == StorageClasses.VECTOR;
                             Class<?> type = SharedUtils.primitiveCarrierForSize(size, useFloat);
                             bindings.dup()

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/aarch64/TypeClass.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/aarch64/TypeClass.java
@@ -25,7 +25,7 @@
  */
 package jdk.internal.foreign.abi.aarch64;
 
-import jdk.internal.foreign.layout.AbstractStructOrUnionLayout;
+import jdk.internal.foreign.layout.AbstractGroupLayout;
 
 import java.lang.foreign.*;
 
@@ -58,14 +58,14 @@ public enum TypeClass {
     }
 
     static boolean isHomogeneousFloatAggregate(MemoryLayout type) {
-        if (!(type instanceof AbstractStructOrUnionLayout<?> structOrUnionLayout))
+        if (!(type instanceof GroupLayout groupLayout))
             return false;
 
-        final long numElements = structOrUnionLayout.elementCount();
+        final long numElements = groupLayout.elementCount();
         if (numElements > 4 || numElements == 0)
             return false;
 
-        MemoryLayout baseType = structOrUnionLayout.elementAt(0);
+        MemoryLayout baseType = groupLayout.elementAt(0);
 
         if (!(baseType instanceof ValueLayout))
             return false;
@@ -74,7 +74,7 @@ public enum TypeClass {
         if (baseArgClass != FLOAT)
            return false;
 
-        for (MemoryLayout elem : structOrUnionLayout) {
+        for (MemoryLayout elem : groupLayout) {
             if (!(elem instanceof ValueLayout))
                 return false;
 

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/aarch64/TypeClass.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/aarch64/TypeClass.java
@@ -25,11 +25,9 @@
  */
 package jdk.internal.foreign.abi.aarch64;
 
-import java.lang.foreign.GroupLayout;
-import java.lang.foreign.MemoryLayout;
-import java.lang.foreign.MemorySegment;
-import java.lang.foreign.SequenceLayout;
-import java.lang.foreign.ValueLayout;
+import jdk.internal.foreign.layout.AbstractStructOrUnionLayout;
+
+import java.lang.foreign.*;
 
 public enum TypeClass {
     STRUCT_REGISTER,
@@ -60,14 +58,14 @@ public enum TypeClass {
     }
 
     static boolean isHomogeneousFloatAggregate(MemoryLayout type) {
-        if (!(type instanceof GroupLayout groupLayout))
+        if (!(type instanceof AbstractStructOrUnionLayout<?> structOrUnionLayout))
             return false;
 
-        final int numElements = groupLayout.memberLayouts().size();
+        final long numElements = structOrUnionLayout.elementCount();
         if (numElements > 4 || numElements == 0)
             return false;
 
-        MemoryLayout baseType = groupLayout.memberLayouts().get(0);
+        MemoryLayout baseType = structOrUnionLayout.elementAt(0);
 
         if (!(baseType instanceof ValueLayout))
             return false;
@@ -76,7 +74,7 @@ public enum TypeClass {
         if (baseArgClass != FLOAT)
            return false;
 
-        for (MemoryLayout elem : groupLayout.memberLayouts()) {
+        for (MemoryLayout elem : structOrUnionLayout) {
             if (!(elem instanceof ValueLayout))
                 return false;
 
@@ -103,10 +101,10 @@ public enum TypeClass {
     public static TypeClass classifyLayout(MemoryLayout type) {
         if (type instanceof ValueLayout) {
             return classifyValueType((ValueLayout) type);
-        } else if (type instanceof GroupLayout) {
-            return classifyStructType(type);
         } else if (type instanceof SequenceLayout) {
             return TypeClass.INTEGER;
+        } else if (type instanceof GroupLayout) {
+            return classifyStructType(type);
         } else {
             throw new IllegalArgumentException("Unhandled type " + type);
         }

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/aarch64/linux/LinuxAArch64VaList.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/aarch64/linux/LinuxAArch64VaList.java
@@ -298,7 +298,7 @@ public non-sealed class LinuxAArch64VaList implements VaList {
                     MemorySegment value = allocator.allocate(layout);
                     GroupLayout group = (GroupLayout)layout;
                     long offset = 0;
-                    for (MemoryLayout elem : group.memberLayouts()) {
+                    for (MemoryLayout elem : group) {
                         assert elem.byteSize() <= 8;
                         final long copy = elem.byteSize();
                         MemorySegment.copy(fpRegsArea, currentFPOffset(), value, offset, copy);
@@ -493,7 +493,7 @@ public non-sealed class LinuxAArch64VaList implements VaList {
                         MemorySegment valueSegment = (MemorySegment) value;
                         GroupLayout group = (GroupLayout)layout;
                         long offset = 0;
-                        for (MemoryLayout elem : group.memberLayouts()) {
+                        for (MemoryLayout elem : group) {
                             assert elem.byteSize() <= 8;
                             final long copy = elem.byteSize();
                             MemorySegment.copy(valueSegment, offset, fpRegs, currentFPOffset, copy);

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/x64/sysv/TypeClass.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/x64/sysv/TypeClass.java
@@ -193,7 +193,7 @@ class TypeClass {
         int nEightbytes = (int) Utils.alignUp(group.byteSize(), 8) / 8;
         @SuppressWarnings({"unchecked", "rawtypes"})
         List<ArgumentClassImpl>[] groups = new List[nEightbytes];
-        for (MemoryLayout l : group.memberLayouts()) {
+        for (MemoryLayout l : group) {
             groupByEightBytes(l, offset, groups);
             if (group instanceof StructLayout) {
                 offset += l.byteSize();
@@ -204,7 +204,7 @@ class TypeClass {
 
     private static void groupByEightBytes(MemoryLayout l, long offset, List<ArgumentClassImpl>[] groups) {
         if (l instanceof GroupLayout group) {
-            for (MemoryLayout m : group.memberLayouts()) {
+            for (MemoryLayout m : group) {
                 groupByEightBytes(m, offset, groups);
                 if (group instanceof StructLayout) {
                     offset += m.byteSize();
@@ -214,7 +214,7 @@ class TypeClass {
             return;
         } else if (l instanceof SequenceLayout seq) {
             MemoryLayout elem = seq.elementLayout();
-            for (long i = 0 ; i < seq.elementCount() ; i++) {
+            for (long i = 0; i < seq.elementCount() ; i++) {
                 groupByEightBytes(elem, offset, groups);
                 offset += elem.byteSize();
             }

--- a/src/java.base/share/classes/jdk/internal/foreign/layout/AbstractGroupLayout.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/layout/AbstractGroupLayout.java
@@ -47,7 +47,7 @@ import static jdk.internal.foreign.layout.MemoryLayoutUtil.checkGetIndex;
  *
  * @since 19
  */
-public sealed abstract class AbstractStructOrUnionLayout<L extends AbstractStructOrUnionLayout<L> & MemoryLayout>
+public sealed abstract class AbstractGroupLayout<L extends AbstractGroupLayout<L> & MemoryLayout>
         extends AbstractLayout<L>
         implements Iterable<MemoryLayout>
         permits StructLayoutImpl, UnionLayoutImpl {
@@ -55,11 +55,11 @@ public sealed abstract class AbstractStructOrUnionLayout<L extends AbstractStruc
     private final Kind kind;
     final List<MemoryLayout> elements;
 
-    AbstractStructOrUnionLayout(Kind kind, List<MemoryLayout> elements) {
+    AbstractGroupLayout(Kind kind, List<MemoryLayout> elements) {
         this(kind, elements, kind.alignof(elements), Optional.empty());
     }
 
-    AbstractStructOrUnionLayout(Kind kind, List<MemoryLayout> elements, long bitAlignment, Optional<String> name) {
+    AbstractGroupLayout(Kind kind, List<MemoryLayout> elements, long bitAlignment, Optional<String> name) {
         super(kind.sizeof(elements), bitAlignment, name); // Subclassing creates toctou problems here
         this.kind = kind;
         this.elements = List.copyOf(elements);
@@ -98,7 +98,7 @@ public sealed abstract class AbstractStructOrUnionLayout<L extends AbstractStruc
         if (!super.equals(other)) {
             return false;
         }
-        return other instanceof AbstractStructOrUnionLayout<?> otherGroup &&
+        return other instanceof AbstractGroupLayout<?> otherGroup &&
                 kind == otherGroup.kind &&
                 elements.equals(otherGroup.elements);
     }

--- a/src/java.base/share/classes/jdk/internal/foreign/layout/AbstractLayout.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/layout/AbstractLayout.java
@@ -34,7 +34,7 @@ import java.util.Objects;
 import java.util.Optional;
 
 abstract sealed class AbstractLayout<L extends AbstractLayout<L> & MemoryLayout>
-        permits AbstractStructOrUnionLayout, PaddingLayoutImpl, SequenceLayoutImpl, ValueLayouts.AbstractValueLayout {
+        permits AbstractGroupLayout, PaddingLayoutImpl, SequenceLayoutImpl, ValueLayouts.AbstractValueLayout {
 
     private final long bitSize;
     private final long bitAlignment;

--- a/src/java.base/share/classes/jdk/internal/foreign/layout/AbstractLayout.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/layout/AbstractLayout.java
@@ -34,7 +34,7 @@ import java.util.Objects;
 import java.util.Optional;
 
 abstract sealed class AbstractLayout<L extends AbstractLayout<L> & MemoryLayout>
-        permits AbstractGroupLayout, PaddingLayoutImpl, SequenceLayoutImpl, ValueLayouts.AbstractValueLayout {
+        permits AbstractStructOrUnionLayout, PaddingLayoutImpl, SequenceLayoutImpl, ValueLayouts.AbstractValueLayout {
 
     private final long bitSize;
     private final long bitAlignment;
@@ -108,8 +108,8 @@ abstract sealed class AbstractLayout<L extends AbstractLayout<L> & MemoryLayout>
      *     and {@linkplain ValueLayout#carrier() carrier}</li>
      *     <li>two sequence layouts are considered equal if they have the same element count (see {@link SequenceLayout#elementCount()}), and
      *     if their element layouts (see {@link SequenceLayout#elementLayout()}) are also equal</li>
-     *     <li>two group layouts are considered equal if they are of the same kind (see {@link GroupLayout#isStruct()},
-     *     {@link GroupLayout#isUnion()}) and if their member layouts (see {@link GroupLayout#memberLayouts()}) are also equal</li>
+     *     <li>two group layouts are considered equal if they are of the same type (see {@link StructLayout},
+     *     {@link UnionLayout}, {@link SequenceLayout}) and if their member layouts (see {@link GroupLayout#stream()} ()}) are also equal</li>
      * </ul>
      *
      * @param other the object to be compared for equality with this layout.

--- a/src/java.base/share/classes/jdk/internal/foreign/layout/MemoryLayoutUtil.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/layout/MemoryLayoutUtil.java
@@ -25,6 +25,8 @@
  */
 package jdk.internal.foreign.layout;
 
+import java.util.NoSuchElementException;
+
 public final class MemoryLayoutUtil {
 
     private MemoryLayoutUtil() {
@@ -37,6 +39,12 @@ public final class MemoryLayoutUtil {
     public static void checkSize(long size, boolean includeZero) {
         if (size < 0 || (!includeZero && size == 0)) {
             throw new IllegalArgumentException("Invalid size for layout: " + size);
+        }
+    }
+
+    public static void checkGetIndex(long toExclusive, long index) {
+        if (index < 0 || index >= toExclusive) {
+            throw new NoSuchElementException("The index must be in range [0, " + toExclusive + ") but was " + index);
         }
     }
 

--- a/src/java.base/share/classes/jdk/internal/foreign/layout/SequenceLayoutImpl.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/layout/SequenceLayoutImpl.java
@@ -27,8 +27,13 @@ package jdk.internal.foreign.layout;
 
 import java.lang.foreign.MemoryLayout;
 import java.lang.foreign.SequenceLayout;
+import java.util.Iterator;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.stream.LongStream;
+import java.util.stream.Stream;
+
+import static jdk.internal.foreign.layout.MemoryLayoutUtil.checkGetIndex;
 
 public final class SequenceLayoutImpl extends AbstractLayout<SequenceLayoutImpl> implements SequenceLayout {
 
@@ -45,67 +50,36 @@ public final class SequenceLayoutImpl extends AbstractLayout<SequenceLayoutImpl>
         this.elementLayout = elementLayout;
     }
 
-    /**
-     * {@return the element layout associated with this sequence layout}
-     */
     public MemoryLayout elementLayout() {
         return elementLayout;
     }
 
-    /**
-     * {@return the element count of this sequence layout}
-     */
     public long elementCount() {
         return elemCount;
     }
 
-    /**
-     * Returns a sequence layout with the same element layout, alignment constraints and name as this sequence layout,
-     * but with the specified element count.
-     *
-     * @param elementCount the new element count.
-     * @return a sequence layout with the given element count.
-     * @throws IllegalArgumentException if {@code elementCount < 0}.
-     */
+    @Override
+    public MemoryLayout elementAt(long index) {
+        checkGetIndex(elemCount, index);
+        return elementLayout;
+    }
+
+    @Override
+    public Iterator<MemoryLayout> iterator() {
+        return stream().iterator();
+    }
+
+    @Override
+    public Stream<MemoryLayout> stream() {
+        return LongStream.range(0, elemCount)
+                .mapToObj(i -> elementLayout);
+    }
+
     public SequenceLayout withElementCount(long elementCount) {
         MemoryLayoutUtil.checkSize(elementCount, true);
         return new SequenceLayoutImpl(elementCount, elementLayout, bitAlignment(), name());
     }
 
-    /**
-     * Re-arrange the elements in this sequence layout into a multi-dimensional sequence layout.
-     * The resulting layout is a sequence layout where element layouts in the flattened projection of this
-     * sequence layout (see {@link #flatten()}) are re-arranged into one or more nested sequence layouts
-     * according to the provided element counts. This transformation preserves the layout size;
-     * that is, multiplying the provided element counts must yield the same element count
-     * as the flattened projection of this sequence layout.
-     * <p>
-     * For instance, given a sequence layout of the kind:
-     * {@snippet lang = java:
-     * var seq = MemoryLayout.sequenceLayout(4, MemoryLayout.sequenceLayout(3, ValueLayout.JAVA_INT));
-     *}
-     * calling {@code seq.reshape(2, 6)} will yield the following sequence layout:
-     * {@snippet lang = java:
-     * var reshapeSeq = MemoryLayout.sequenceLayout(2, MemoryLayout.sequenceLayout(6, ValueLayout.JAVA_INT));
-     *}
-     * <p>
-     * If one of the provided element count is the special value {@code -1}, then the element
-     * count in that position will be inferred from the remaining element counts and the
-     * element count of the flattened projection of this layout. For instance, a layout equivalent to
-     * the above {@code reshapeSeq} can also be computed in the following ways:
-     * {@snippet lang = java:
-     * var reshapeSeqImplicit1 = seq.reshape(-1, 6);
-     * var reshapeSeqImplicit2 = seq.reshape(2, -1);
-     *}
-     *
-     * @param elementCounts an array of element counts, of which at most one can be {@code -1}.
-     * @return a sequence layout where element layouts in the flattened projection of this
-     * sequence layout (see {@link #flatten()}) are re-arranged into one or more nested sequence layouts.
-     * @throws IllegalArgumentException if two or more element counts are set to {@code -1}, or if one
-     *                                  or more element count is {@code <= 0} (but other than {@code -1}) or, if, after any required inference,
-     *                                  multiplying the element counts does not yield the same element count as the flattened projection of this
-     *                                  sequence layout.
-     */
     public SequenceLayout reshape(long... elementCounts) {
         Objects.requireNonNull(elementCounts);
         if (elementCounts.length == 0) {
@@ -148,23 +122,6 @@ public final class SequenceLayoutImpl extends AbstractLayout<SequenceLayoutImpl>
         return (SequenceLayoutImpl) res;
     }
 
-    /**
-     * Returns a flattened sequence layout. The element layout of the returned sequence layout
-     * is the first non-sequence element layout found by recursively traversing the element layouts of this sequence layout.
-     * This transformation preserves the layout size; nested sequence layout in this sequence layout will
-     * be dropped and their element counts will be incorporated into that of the returned sequence layout.
-     * For instance, given a sequence layout of the kind:
-     * {@snippet lang = java:
-     * var seq = MemoryLayout.sequenceLayout(4, MemoryLayout.sequenceLayout(3, ValueLayout.JAVA_INT));
-     *}
-     * calling {@code seq.flatten()} will yield the following sequence layout:
-     * {@snippet lang = java:
-     * var flattenedSeq = MemoryLayout.sequenceLayout(12, ValueLayout.JAVA_INT);
-     *}
-     *
-     * @return a sequence layout with the same size as this layout (but, possibly, with different
-     * element count), whose element layout is not a sequence layout.
-     */
     public SequenceLayout flatten() {
         long count = elementCount();
         MemoryLayout elemLayout = elementLayout();

--- a/src/java.base/share/classes/jdk/internal/foreign/layout/StructLayoutImpl.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/layout/StructLayoutImpl.java
@@ -27,11 +27,10 @@ package jdk.internal.foreign.layout;
 
 import java.lang.foreign.MemoryLayout;
 import java.lang.foreign.StructLayout;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Optional;
 
-public final class StructLayoutImpl extends AbstractStructOrUnionLayout<StructLayoutImpl> implements StructLayout {
+public final class StructLayoutImpl extends AbstractGroupLayout<StructLayoutImpl> implements StructLayout {
 
     private StructLayoutImpl(List<MemoryLayout> elements) {
         super(Kind.STRUCT, elements);

--- a/src/java.base/share/classes/jdk/internal/foreign/layout/StructLayoutImpl.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/layout/StructLayoutImpl.java
@@ -27,10 +27,11 @@ package jdk.internal.foreign.layout;
 
 import java.lang.foreign.MemoryLayout;
 import java.lang.foreign.StructLayout;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Optional;
 
-public final class StructLayoutImpl extends AbstractGroupLayout<StructLayoutImpl> implements StructLayout {
+public final class StructLayoutImpl extends AbstractStructOrUnionLayout<StructLayoutImpl> implements StructLayout {
 
     private StructLayoutImpl(List<MemoryLayout> elements) {
         super(Kind.STRUCT, elements);
@@ -42,7 +43,7 @@ public final class StructLayoutImpl extends AbstractGroupLayout<StructLayoutImpl
 
     @Override
     StructLayoutImpl dup(long bitAlignment, Optional<String> name) {
-        return new StructLayoutImpl(memberLayouts(), bitAlignment, name);
+        return new StructLayoutImpl(elements, bitAlignment, name);
     }
 
     public static StructLayout of(List<MemoryLayout> elements) {

--- a/src/java.base/share/classes/jdk/internal/foreign/layout/UnionLayoutImpl.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/layout/UnionLayoutImpl.java
@@ -30,7 +30,7 @@ import java.lang.foreign.UnionLayout;
 import java.util.List;
 import java.util.Optional;
 
-public final class UnionLayoutImpl extends AbstractGroupLayout<UnionLayoutImpl> implements UnionLayout {
+public final class UnionLayoutImpl extends AbstractStructOrUnionLayout<UnionLayoutImpl> implements UnionLayout {
 
     private UnionLayoutImpl(List<MemoryLayout> elements) {
         super(Kind.UNION, elements);
@@ -42,7 +42,7 @@ public final class UnionLayoutImpl extends AbstractGroupLayout<UnionLayoutImpl> 
 
     @Override
     UnionLayoutImpl dup(long bitAlignment, Optional<String> name) {
-        return new UnionLayoutImpl(memberLayouts(), bitAlignment, name);
+        return new UnionLayoutImpl(elements, bitAlignment, name);
     }
 
     public static UnionLayout of(List<MemoryLayout> elements) {

--- a/src/java.base/share/classes/jdk/internal/foreign/layout/UnionLayoutImpl.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/layout/UnionLayoutImpl.java
@@ -30,7 +30,7 @@ import java.lang.foreign.UnionLayout;
 import java.util.List;
 import java.util.Optional;
 
-public final class UnionLayoutImpl extends AbstractStructOrUnionLayout<UnionLayoutImpl> implements UnionLayout {
+public final class UnionLayoutImpl extends AbstractGroupLayout<UnionLayoutImpl> implements UnionLayout {
 
     private UnionLayoutImpl(List<MemoryLayout> elements) {
         super(Kind.UNION, elements);

--- a/test/jdk/java/foreign/CallGeneratorHelper.java
+++ b/test/jdk/java/foreign/CallGeneratorHelper.java
@@ -58,7 +58,7 @@ public class CallGeneratorHelper extends NativeTestHelper {
     public static void assertStructEquals(MemorySegment actual, MemorySegment expected, MemoryLayout layout) {
         assertEquals(actual.byteSize(), expected.byteSize());
         GroupLayout g = (GroupLayout) layout;
-        for (MemoryLayout field : g.memberLayouts()) {
+        for (MemoryLayout field : (Iterable<MemoryLayout>) g.stream()::iterator) {
             if (field instanceof ValueLayout) {
                 VarHandle vh = g.varHandle(MemoryLayout.PathElement.groupElement(field.name().orElseThrow()));
                 assertEquals(vh.get(actual), vh.get(expected));
@@ -416,9 +416,9 @@ public class CallGeneratorHelper extends NativeTestHelper {
     }
 
     static void initStruct(MemorySegment str, GroupLayout g, List<Consumer<Object>> checks, boolean check) throws ReflectiveOperationException {
-        for (MemoryLayout l : g.memberLayouts()) {
+        for (MemoryLayout l : (Iterable<MemoryLayout>) g.stream()::iterator) {
             if (l instanceof PaddingLayout) continue;
-            VarHandle accessor = g.varHandle(MemoryLayout.PathElement.groupElement(l.name().get()));
+            VarHandle accessor = g.varHandle(MemoryLayout.PathElement.groupElement(l.name().orElseThrow()));
             List<Consumer<Object>> fieldsCheck = new ArrayList<>();
             Object value = makeArg(l, fieldsCheck, check);
             //set value

--- a/test/jdk/java/foreign/GraphSealedHierarchyTest.java
+++ b/test/jdk/java/foreign/GraphSealedHierarchyTest.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @enablePreview
+ * @run testng/othervm GraphSealedHierarchyTest
+ */
+
+import org.testng.annotations.*;
+
+import java.lang.foreign.MemoryLayout;
+import java.lang.reflect.Modifier;
+import java.util.*;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static java.lang.System.lineSeparator;
+import static org.testng.Assert.*;
+
+public class GraphSealedHierarchyTest {
+
+    @Test
+    public void graph() {
+        Stream.of(
+                        MemoryLayout.class
+                )
+                .map(GraphSealedHierarchyTest::graph)
+                .forEach(System.out::println);
+    }
+
+    // Generates a graph in DOT format
+    static String graph(Class<?> rootClass) {
+        final State state = new State(rootClass);
+        traverse(state, rootClass);
+        return state.render();
+    }
+
+    static void traverse(State state, Class<?> node) {
+        for (Class<?> subNode : permittedSubclasses(node)) {
+            state.addEdge(node, subNode);
+            traverse(state, subNode);
+        }
+    }
+
+    private static final class State {
+
+        private final StringBuilder builder;
+        private final Map<Class<?>, List<String>> labels;
+        private final Map<Class<?>, Map<String, String>> stylings;
+
+        public State(Class<?> rootNode) {
+            builder = new StringBuilder()
+                    .append("digraph G {")
+                    .append(lineSeparator())
+                    .append("  labelloc=\"b\";")
+                    .append(lineSeparator())
+                    .append("  label=\"The Sealed Hierarchy of ")
+                    .append(rootNode.getName())
+                    .append("\";")
+                    .append(lineSeparator())
+                    .append("  rankdir=\"BT\";")
+                    .append(lineSeparator());
+            labels = new HashMap<>();
+            stylings = new HashMap<>();
+        }
+
+        public void addEdge(Class<?> node, Class<?> subNode) {
+            builder.append("  ")
+                    .append(subNode.getSimpleName())
+                    .append(" -> ")
+                    .append(node.getSimpleName())
+                    .append(";")
+                    .append(lineSeparator());
+            var subNodeStyles = stylings.computeIfAbsent(subNode, k -> new HashMap<>());
+            var subNodeLabels = labels.computeIfAbsent(subNode, k -> new ArrayList<>());
+            if (subNode.getName().contains(".internal")) {
+                subNodeStyles.put("style", "filled");
+                subNodeStyles.put("fillcolor", "gray");
+                subNodeLabels.add("internal");
+            }
+            if (!subNode.isInterface()) {
+                if (Modifier.isPublic(subNode.getModifiers()) && !subNode.getName().contains(".internal")) {
+                    subNodeLabels.add("public impl");
+                    subNodeStyles.put("style", "filled");
+                    subNodeStyles.put("fillcolor", "#FFD0D0");
+                }
+                if (Modifier.isAbstract(subNode.getModifiers())) {
+                    subNodeLabels.add("abstract");
+                    subNodeStyles.put("style", "filled");
+                    subNodeStyles.put("fillcolor", "red");
+                }
+            }
+            if (!Modifier.isPublic(subNode.getModifiers())) {
+                subNodeLabels.add("non-public");
+                subNodeStyles.put("style", "filled");
+                subNodeStyles.put("fillcolor", "red");
+            }
+
+        }
+
+        public String render() {
+            final StringBuilder result = new StringBuilder(builder);
+
+            labels.forEach((node, l) -> {
+                final var label = Stream.concat(
+                        Stream.of(node.getSimpleName()),
+                        l.stream()).collect(Collectors.joining("\\n"));
+                stylings.computeIfAbsent(node, k -> new HashMap<>())
+                        .put("label", label);
+            });
+
+            stylings.forEach((node, styles) -> {
+                result.append("  ")
+                        .append(node.getSimpleName());
+
+                result.append("[");
+                result.append(styles.entrySet().stream()
+                        .map(e -> String.format("%s=\"%s\"", e.getKey(), e.getValue()))
+                        .collect(Collectors.joining(", ")));
+                result.append("];")
+                        .append(lineSeparator());
+            });
+
+            result.append("}");
+            return result.toString();
+        }
+
+    }
+
+    private static Class<?>[] permittedSubclasses(Class<?> node) {
+        return java.util.Optional.ofNullable(node.getPermittedSubclasses())
+                .orElse(new Class<?>[0]);
+    }
+
+}

--- a/test/jdk/java/foreign/MemoryLayoutPrincipalTotalityTest.java
+++ b/test/jdk/java/foreign/MemoryLayoutPrincipalTotalityTest.java
@@ -53,6 +53,7 @@ public class MemoryLayoutPrincipalTotalityTest extends NativeTestHelper {
         var v1 = switch (memoryLayout) {
             case GroupLayout gl -> 0;
             case PaddingLayout pl -> 0; // leaf
+            case SequenceLayout sl -> 0; // leaf
             case ValueLayout vl -> 1;
         };
         assertEquals(v1, 1);
@@ -98,6 +99,7 @@ public class MemoryLayoutPrincipalTotalityTest extends NativeTestHelper {
         var v4 = switch (memoryLayout) {
             case GroupLayout gl -> 0;
             case PaddingLayout pl -> 0; // leaf
+            case SequenceLayout sl -> 0; // leaf
             case OfAddress oa -> 0; // leaf
             case OfBoolean ob -> 0; // leaf
             case OfByte ob -> 0; // leaf

--- a/test/jdk/java/foreign/MemoryLayoutPrincipalTotalityTest.java
+++ b/test/jdk/java/foreign/MemoryLayoutPrincipalTotalityTest.java
@@ -53,7 +53,6 @@ public class MemoryLayoutPrincipalTotalityTest extends NativeTestHelper {
         var v1 = switch (memoryLayout) {
             case GroupLayout gl -> 0;
             case PaddingLayout pl -> 0; // leaf
-            case SequenceLayout sl -> 0; // leaf
             case ValueLayout vl -> 1;
         };
         assertEquals(v1, 1);
@@ -99,7 +98,6 @@ public class MemoryLayoutPrincipalTotalityTest extends NativeTestHelper {
         var v4 = switch (memoryLayout) {
             case GroupLayout gl -> 0;
             case PaddingLayout pl -> 0; // leaf
-            case SequenceLayout sl -> 0; // leaf
             case OfAddress oa -> 0; // leaf
             case OfBoolean ob -> 0; // leaf
             case OfByte ob -> 0; // leaf

--- a/test/jdk/java/foreign/TestIllegalLink.java
+++ b/test/jdk/java/foreign/TestIllegalLink.java
@@ -64,15 +64,7 @@ public class TestIllegalLink extends NativeTestHelper {
             {
                 FunctionDescriptor.ofVoid(MemoryLayout.paddingLayout(64)),
                 "Unsupported layout: x64"
-            },
-            {
-                    FunctionDescriptor.of(MemoryLayout.sequenceLayout(2, C_INT)),
-                    "Unsupported layout: [2:i32]"
-            },
-            {
-                    FunctionDescriptor.ofVoid(MemoryLayout.sequenceLayout(2, C_INT)),
-                    "Unsupported layout: [2:i32]"
-            },
+            }
         };
     }
 

--- a/test/jdk/java/foreign/TestLayoutPaths.java
+++ b/test/jdk/java/foreign/TestLayoutPaths.java
@@ -272,7 +272,7 @@ public class TestLayoutPaths {
 
         for (int i = 1 ; i <= 4 ; i++) {
             MemoryLayout selected = g.select(groupElement(String.valueOf(i)));
-            assertTrue(selected == g.memberLayouts().get(i - 1));
+            assertTrue(selected == g.elementAt(i - 1));
         }
 
         // test offset
@@ -299,7 +299,7 @@ public class TestLayoutPaths {
 
         for (int i = 1 ; i <= 4 ; i++) {
             MemoryLayout selected = g.select(groupElement(String.valueOf(i)));
-            assertTrue(selected == g.memberLayouts().get(i - 1));
+            assertTrue(selected == g.elementAt(i - 1));
         }
 
         // test offset

--- a/test/jdk/java/foreign/TestLayouts.java
+++ b/test/jdk/java/foreign/TestLayouts.java
@@ -138,8 +138,9 @@ public class TestLayouts {
 
     @Test(dataProvider = "basicLayouts")
     public void testSequenceInferredCount(MemoryLayout layout) {
-        assertEquals(MemoryLayout.sequenceLayout(layout),
-                     MemoryLayout.sequenceLayout(Long.MAX_VALUE / layout.bitSize(), layout));
+        // assertEquals() will take too long
+        assertTrue(MemoryLayout.sequenceLayout(layout).equals(
+                     MemoryLayout.sequenceLayout(Long.MAX_VALUE / layout.bitSize(), layout)));
     }
 
     public void testSequenceNegativeElementCount() {
@@ -243,35 +244,35 @@ public class TestLayouts {
 
     @DataProvider(name = "basicLayouts")
     public Object[][] basicLayouts() {
-        return Stream.of(basicLayouts)
+        return Stream.of(BASIC_LAYOUTS)
                 .map(l -> new Object[] { l })
                 .toArray(Object[][]::new);
     }
 
     @DataProvider(name = "layoutsAndAlignments")
     public Object[][] layoutsAndAlignments() {
-        Object[][] layoutsAndAlignments = new Object[basicLayouts.length * 4][];
+        Object[][] layoutsAndAlignments = new Object[BASIC_LAYOUTS.length * 4][];
         int i = 0;
         //add basic layouts
-        for (MemoryLayout l : basicLayouts) {
+        for (MemoryLayout l : BASIC_LAYOUTS) {
             layoutsAndAlignments[i++] = new Object[] { l, l.bitAlignment() };
         }
         //add basic layouts wrapped in a sequence with given size
-        for (MemoryLayout l : basicLayouts) {
+        for (MemoryLayout l : BASIC_LAYOUTS) {
             layoutsAndAlignments[i++] = new Object[] { MemoryLayout.sequenceLayout(4, l), l.bitAlignment() };
         }
         //add basic layouts wrapped in a struct
-        for (MemoryLayout l : basicLayouts) {
+        for (MemoryLayout l : BASIC_LAYOUTS) {
             layoutsAndAlignments[i++] = new Object[] { MemoryLayout.structLayout(l), l.bitAlignment() };
         }
         //add basic layouts wrapped in a union
-        for (MemoryLayout l : basicLayouts) {
+        for (MemoryLayout l : BASIC_LAYOUTS) {
             layoutsAndAlignments[i++] = new Object[] { MemoryLayout.unionLayout(l), l.bitAlignment() };
         }
         return layoutsAndAlignments;
     }
 
-    static MemoryLayout[] basicLayouts = {
+    static final MemoryLayout[] BASIC_LAYOUTS = {
             ValueLayout.JAVA_BYTE,
             ValueLayout.JAVA_CHAR,
             ValueLayout.JAVA_SHORT,

--- a/test/jdk/java/foreign/TestSharedAccess.java
+++ b/test/jdk/java/foreign/TestSharedAccess.java
@@ -50,7 +50,7 @@ public class TestSharedAccess {
         SequenceLayout layout = MemoryLayout.sequenceLayout(1024, ValueLayout.JAVA_INT);
         try (MemorySession session = MemorySession.openShared()) {
             MemorySegment s = MemorySegment.allocateNative(layout, session);
-            for (int i = 0 ; i < layout.elementCount() ; i++) {
+            for (int i = 0; i < layout.elementCount() ; i++) {
                 setInt(s.asSlice(i * 4), 42);
             }
             List<Thread> threads = new ArrayList<>();


### PR DESCRIPTION
This PR proposes harmonizations between `SequenceLayout` and `GroupLayout` as well as some improvements to the API exposing fewer details.

In this PR, there is an extra level that unifies and deduplicates the common methods in Sequence and Group Layouts. This level is visible in the sealed hierarchy. It would be possible to make it a separate interface that is not in the sealed hierarchy as an alternative.

![graphviz (23)](https://user-images.githubusercontent.com/7457876/189898114-b1fc8a44-7ce0-43ad-a82e-d62b3ce0e110.svg)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/panama-foreign pull/719/head:pull/719` \
`$ git checkout pull/719`

Update a local copy of the PR: \
`$ git checkout pull/719` \
`$ git pull https://git.openjdk.org/panama-foreign pull/719/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 719`

View PR using the GUI difftool: \
`$ git pr show -t 719`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/panama-foreign/pull/719.diff">https://git.openjdk.org/panama-foreign/pull/719.diff</a>

</details>
