### PR TITLE
8291873: Implement return value normalization in Java

### DIFF
--- a/src/hotspot/cpu/aarch64/downcallLinker_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/downcallLinker_aarch64.cpp
@@ -208,23 +208,7 @@ void DowncallStubGenerator::generate() {
   __ blr(_abi._target_addr_reg);
   // this call is assumed not to have killed rthread
 
-  if (!_needs_return_buffer) {
-    // Unpack native results.
-    switch (_ret_bt) {
-      case T_BOOLEAN: __ c2bool(r0);                     break;
-      case T_CHAR   : __ ubfx(r0, r0, 0, 16);            break;
-      case T_BYTE   : __ sbfx(r0, r0, 0, 8);             break;
-      case T_SHORT  : __ sbfx(r0, r0, 0, 16);            break;
-      case T_INT    : __ sbfx(r0, r0, 0, 32);            break;
-      case T_DOUBLE :
-      case T_FLOAT  :
-        // Result is in v0 we'll save as needed
-        break;
-      case T_VOID: break;
-      case T_LONG: break;
-      default       : ShouldNotReachHere();
-    }
-  } else {
+  if (_needs_return_buffer) {
     assert(ret_buf_addr_sp_offset != -1, "no return buffer addr spill");
     __ ldr(tmp1, Address(sp, ret_buf_addr_sp_offset));
     int offset = 0;

--- a/src/hotspot/cpu/x86/downcallLinker_x86_64.cpp
+++ b/src/hotspot/cpu/x86/downcallLinker_x86_64.cpp
@@ -209,24 +209,7 @@ void DowncallStubGenerator::generate() {
   __ call(_abi._target_addr_reg);
   // this call is assumed not to have killed r15_thread
 
-  if (!_needs_return_buffer) {
-    // FIXME: this assumes we return in rax/xmm0, which might not be the case
-    // Unpack native results.
-    switch (_ret_bt) {
-      case T_BOOLEAN: __ c2bool(rax);            break;
-      case T_CHAR   : __ movzwl(rax, rax);       break;
-      case T_BYTE   : __ sign_extend_byte (rax); break;
-      case T_SHORT  : __ sign_extend_short(rax); break;
-      case T_INT    : /* nothing to do */        break;
-      case T_DOUBLE :
-      case T_FLOAT  :
-        // Result is in xmm0 we'll save as needed
-        break;
-      case T_VOID: break;
-      case T_LONG: break;
-      default       : ShouldNotReachHere();
-    }
-  } else {
+  if (_needs_return_buffer) {
     assert(ret_buf_addr_rsp_offset != -1, "no return buffer addr spill");
     __ movptr(rscratch1, Address(rsp, ret_buf_addr_rsp_offset));
     int offset = 0;

--- a/src/java.base/share/classes/java/lang/invoke/NativeMethodHandle.java
+++ b/src/java.base/share/classes/java/lang/invoke/NativeMethodHandle.java
@@ -52,24 +52,32 @@ import static java.lang.invoke.MethodHandleStatics.newInternalError;
      */
     public static MethodHandle make(NativeEntryPoint nep) {
         MethodType type = nep.type();
-        if (!allTypesPrimitive(type))
-            throw new IllegalArgumentException("Type must only contain primitives: " + type);
+        if (hasIllegalType(type))
+            throw new IllegalArgumentException("Illegal type(s) found: " + type);
 
 
         LambdaForm lform = preparedLambdaForm(type);
         return new NativeMethodHandle(type, lform, nep);
     }
 
-    private static boolean allTypesPrimitive(MethodType type) {
-        if (!type.returnType().isPrimitive())
-            return false;
+    private static boolean hasIllegalType(MethodType type) {
+        if (isIllegalType(type.returnType()))
+            return true;
 
         for (Class<?> pType : type.parameterArray()) {
-            if (!pType.isPrimitive())
-                return false;
+            if (isIllegalType(pType))
+                return true;
         }
 
-        return true;
+        return false;
+    }
+
+    private static boolean isIllegalType(Class<?> pType) {
+        return !(pType == long.class
+              || pType == int.class
+              || pType == float.class
+              || pType == double.class
+              || pType == void.class);
     }
 
     private static final MemberName.Factory IMPL_NAMES = MemberName.getFactory();

--- a/src/java.base/share/classes/jdk/internal/foreign/Utils.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/Utils.java
@@ -128,7 +128,7 @@ public final class Utils {
         return VarHandleCache.put(layout, handle);
     }
 
-    private static boolean byteToBoolean(byte b) {
+    public static boolean byteToBoolean(byte b) {
         return b != 0;
     }
 

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/BindingSpecializer.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/BindingSpecializer.java
@@ -27,6 +27,7 @@ package jdk.internal.foreign.abi;
 import jdk.internal.foreign.MemorySessionImpl;
 import jdk.internal.foreign.NativeMemorySegmentImpl;
 import jdk.internal.foreign.Scoped;
+import jdk.internal.foreign.Utils;
 import jdk.internal.misc.VM;
 import jdk.internal.org.objectweb.asm.ClassReader;
 import jdk.internal.org.objectweb.asm.ClassWriter;
@@ -683,20 +684,13 @@ public class BindingSpecializer {
 
             if (toType == boolean.class) {
                 // implement least significant byte non-zero test
-                Label falseLabel = new Label();
-                Label endLabel = new Label();
 
                 // select first byte
                 emitConst(0xFF);
                 mv.visitInsn(IAND);
 
-                // check non-zero
-                mv.visitJumpInsn(IFEQ, falseLabel);
-                emitConst(1);
-                mv.visitJumpInsn(GOTO, endLabel);
-                mv.visitLabel(falseLabel);
-                emitConst(0);
-                mv.visitLabel(endLabel);
+                // convert to boolean
+                emitInvokeStatic(Utils.class, "byteToBoolean", "(B)Z");
             } else if (toType == byte.class) {
                 mv.visitInsn(I2B);
             } else if (toType == short.class) {

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/BindingSpecializer.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/BindingSpecializer.java
@@ -682,8 +682,21 @@ public class BindingSpecializer {
             popType(int.class);
 
             if (toType == boolean.class) {
-                emitConst(0b1);
+                // implement least significant byte non-zero test
+                Label falseLabel = new Label();
+                Label endLabel = new Label();
+
+                // select first byte
+                emitConst(0xFF);
                 mv.visitInsn(IAND);
+
+                // check non-zero
+                mv.visitJumpInsn(IFEQ, falseLabel);
+                emitConst(1);
+                mv.visitJumpInsn(GOTO, endLabel);
+                mv.visitLabel(falseLabel);
+                emitConst(0);
+                mv.visitLabel(endLabel);
             } else if (toType == byte.class) {
                 mv.visitInsn(I2B);
             } else if (toType == short.class) {

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/BindingSpecializer.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/BindingSpecializer.java
@@ -617,9 +617,7 @@ public class BindingSpecializer {
         emitInvokeInterface(MemorySegment.class, "set", descriptor);
     }
 
-
     // VM_STORE and VM_LOAD are emulated, which is different for down/upcalls
-
     private void emitVMStore(Binding.VMStore vmStore) {
         Class<?> storeType = vmStore.type();
         popType(storeType);
@@ -646,6 +644,7 @@ public class BindingSpecializer {
             }
         }
     }
+
     private void emitVMLoad(Binding.VMLoad vmLoad) {
         Class<?> loadType = vmLoad.type();
 

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/CallingSequenceBuilder.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/CallingSequenceBuilder.java
@@ -193,7 +193,8 @@ public class CallingSequenceBuilder {
         //ALLOC_BUFFER,
         //BOX_ADDRESS,
         UNBOX_ADDRESS,
-        DUP
+        DUP,
+        CAST
     );
 
     private static void verifyUnboxBindings(Class<?> inType, List<Binding> bindings) {
@@ -220,7 +221,8 @@ public class CallingSequenceBuilder {
         ALLOC_BUFFER,
         BOX_ADDRESS,
         //UNBOX_ADDRESS,
-        DUP
+        DUP,
+        CAST
     );
 
     private static void verifyBoxBindings(Class<?> expectedOutType, List<Binding> bindings) {

--- a/test/jdk/java/foreign/normalize/TestNormalize.java
+++ b/test/jdk/java/foreign/normalize/TestNormalize.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @enablePreview
+ * @library ../
+ * @requires ((os.arch == "amd64" | os.arch == "x86_64") & sun.arch.data.model == "64") | os.arch == "aarch64"
+ * @run testng/othervm --enable-native-access=ALL-UNNAMED TestNormalize
+ */
+
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.lang.foreign.FunctionDescriptor;
+import java.lang.foreign.Linker;
+import java.lang.foreign.MemorySegment;
+import java.lang.foreign.MemorySession;
+import java.lang.foreign.SymbolLookup;
+import java.lang.foreign.ValueLayout;
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+
+import static java.lang.foreign.ValueLayout.ADDRESS;
+import static java.lang.foreign.ValueLayout.JAVA_BOOLEAN;
+import static java.lang.foreign.ValueLayout.JAVA_BYTE;
+import static java.lang.foreign.ValueLayout.JAVA_CHAR;
+import static java.lang.foreign.ValueLayout.JAVA_SHORT;
+import static org.testng.Assert.assertEquals;
+
+// test normalization of smaller than int primitive types
+public class TestNormalize extends NativeTestHelper {
+
+    private static final Linker LINKER = Linker.nativeLinker();
+    private static final MethodHandle MH_BOOLEAN;
+    private static final MethodHandle MH_BYTE;
+    private static final MethodHandle MH_SHORT;
+    private static final MethodHandle MH_CHAR;
+
+    static {
+        System.loadLibrary("Normalize");
+
+        try {
+            MethodHandles.Lookup lookup = MethodHandles.lookup();
+            MH_BOOLEAN = lookup.findStatic(TestNormalize.class, "identity", MethodType.methodType(boolean.class, boolean.class));
+            MH_BYTE = lookup.findStatic(TestNormalize.class, "identity", MethodType.methodType(byte.class, byte.class));
+            MH_SHORT = lookup.findStatic(TestNormalize.class, "identity", MethodType.methodType(short.class, short.class));
+            MH_CHAR = lookup.findStatic(TestNormalize.class, "identity", MethodType.methodType(char.class, char.class));
+        } catch (ReflectiveOperationException e) {
+            throw new ExceptionInInitializerError(e);
+        }
+    }
+
+    @Test(dataProvider = "cases")
+    public void testNormalize(String targetName, ValueLayout layout, Object testValue, MethodHandle upcallTarget) throws Throwable {
+        FunctionDescriptor upcallDesc = FunctionDescriptor.of(layout, layout);
+        FunctionDescriptor downcallDesc = upcallDesc.insertArgumentLayouts(0, ADDRESS); // upcall stub
+
+        MemorySegment target = findNativeOrThrow(targetName);
+        MethodHandle downcallHandle = LINKER.downcallHandle(target, downcallDesc);
+        Object result;
+        try (MemorySession session = MemorySession.openConfined()) {
+            MemorySegment upcallStub = LINKER.upcallStub(upcallTarget, upcallDesc, session);
+
+            result = downcallHandle.invoke(upcallStub, testValue);
+        }
+        assertEquals(result, testValue);
+    }
+
+    // use explicit functions to avoid LambdaForm erasure
+    public static boolean identity(boolean b) {
+        return b;
+    }
+    public static byte identity(byte b) {
+        return b;
+    }
+    public static char identity(char c) {
+        return c;
+    }
+    public static short identity(short s) {
+        return s;
+    }
+
+    @DataProvider
+    public static Object[][] cases() {
+        return new Object[][] {
+                { "test_char", JAVA_BOOLEAN, true, MH_BOOLEAN },
+                { "test_char", JAVA_BYTE, (byte) 42, MH_BYTE },
+                { "test_short", JAVA_SHORT, (short) 42, MH_SHORT },
+                { "test_short", JAVA_CHAR, 'a', MH_CHAR }
+        };
+    }
+}

--- a/test/jdk/java/foreign/normalize/TestNormalize.java
+++ b/test/jdk/java/foreign/normalize/TestNormalize.java
@@ -26,7 +26,11 @@
  * @enablePreview
  * @library ../
  * @requires ((os.arch == "amd64" | os.arch == "x86_64") & sun.arch.data.model == "64") | os.arch == "aarch64"
- * @run testng/othervm --enable-native-access=ALL-UNNAMED TestNormalize
+ * @run testng/othervm
+ *   --enable-native-access=ALL-UNNAMED
+ *   -Xbatch
+ *   -XX:CompileCommand=dontinline,TestNormalize::doCall*
+ *   TestNormalize
  */
 
 import org.testng.annotations.DataProvider;
@@ -36,16 +40,17 @@ import java.lang.foreign.FunctionDescriptor;
 import java.lang.foreign.Linker;
 import java.lang.foreign.MemorySegment;
 import java.lang.foreign.MemorySession;
-import java.lang.foreign.SymbolLookup;
 import java.lang.foreign.ValueLayout;
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.MethodType;
+import java.util.function.IntConsumer;
 
 import static java.lang.foreign.ValueLayout.ADDRESS;
 import static java.lang.foreign.ValueLayout.JAVA_BOOLEAN;
 import static java.lang.foreign.ValueLayout.JAVA_BYTE;
 import static java.lang.foreign.ValueLayout.JAVA_CHAR;
+import static java.lang.foreign.ValueLayout.JAVA_INT;
 import static java.lang.foreign.ValueLayout.JAVA_SHORT;
 import static org.testng.Assert.assertEquals;
 
@@ -53,62 +58,117 @@ import static org.testng.Assert.assertEquals;
 public class TestNormalize extends NativeTestHelper {
 
     private static final Linker LINKER = Linker.nativeLinker();
-    private static final MethodHandle MH_BOOLEAN;
-    private static final MethodHandle MH_BYTE;
-    private static final MethodHandle MH_SHORT;
-    private static final MethodHandle MH_CHAR;
+    private static final MethodHandle SAVE_BOOLEAN;
+    private static final MethodHandle SAVE_BYTE;
+    private static final MethodHandle SAVE_SHORT;
+    private static final MethodHandle SAVE_CHAR;
+
+    private static final MethodHandle BOOLEAN_TO_INT;
+    private static final MethodHandle BYTE_TO_INT;
+    private static final MethodHandle SHORT_TO_INT;
+    private static final MethodHandle CHAR_TO_INT;
+
+    private static final MethodHandle NATIVE_BOOLEAN_TO_INT;
+
+    private static final int BOOLEAN_HOB_MASK = ~0b1;
+    private static final int BYTE_HOB_MASK    = ~0xFF;
+    private static final int SHORT_HOB_MASK   = ~0xFFFF;
+    private static final int CHAR_HOB_MASK    = ~0xFFFF;
 
     static {
         System.loadLibrary("Normalize");
 
         try {
             MethodHandles.Lookup lookup = MethodHandles.lookup();
-            MH_BOOLEAN = lookup.findStatic(TestNormalize.class, "identity", MethodType.methodType(boolean.class, boolean.class));
-            MH_BYTE = lookup.findStatic(TestNormalize.class, "identity", MethodType.methodType(byte.class, byte.class));
-            MH_SHORT = lookup.findStatic(TestNormalize.class, "identity", MethodType.methodType(short.class, short.class));
-            MH_CHAR = lookup.findStatic(TestNormalize.class, "identity", MethodType.methodType(char.class, char.class));
+            SAVE_BOOLEAN = lookup.findStatic(TestNormalize.class, "saveBoolean", MethodType.methodType(void.class, boolean.class, int[].class));
+            SAVE_BYTE = lookup.findStatic(TestNormalize.class, "saveByte", MethodType.methodType(void.class, byte.class, int[].class));
+            SAVE_SHORT = lookup.findStatic(TestNormalize.class, "saveShort", MethodType.methodType(void.class, short.class, int[].class));
+            SAVE_CHAR = lookup.findStatic(TestNormalize.class, "saveChar", MethodType.methodType(void.class, char.class, int[].class));
+
+            BOOLEAN_TO_INT = lookup.findStatic(TestNormalize.class, "booleanToInt", MethodType.methodType(int.class, boolean.class));
+            BYTE_TO_INT = lookup.findStatic(TestNormalize.class, "byteToInt", MethodType.methodType(int.class, byte.class));
+            SHORT_TO_INT = lookup.findStatic(TestNormalize.class, "shortToInt", MethodType.methodType(int.class, short.class));
+            CHAR_TO_INT = lookup.findStatic(TestNormalize.class, "charToInt", MethodType.methodType(int.class, char.class));
+
+            NATIVE_BOOLEAN_TO_INT = LINKER.downcallHandle(findNativeOrThrow("int_identity"), FunctionDescriptor.of(JAVA_INT, JAVA_BOOLEAN));
         } catch (ReflectiveOperationException e) {
             throw new ExceptionInInitializerError(e);
         }
     }
 
+    // The idea of this test is that we pass a 'dirty' int value down to native code, and then receive it back
+    // as the argument to an upcall, as well as the result of the downcall, but with a sub-int type (boolean, byte, short, char).
+    // When we do either of those, argument normalization should take place, so that the resulting value is sane (1).
+    // After that we convert the value back to int again, the JVM can/will skip value normalization here.
+    // We then check the high order bits of the resulting int. If argument normalization took place at (1), they should all be 0.
     @Test(dataProvider = "cases")
-    public void testNormalize(String targetName, ValueLayout layout, Object testValue, MethodHandle upcallTarget) throws Throwable {
-        FunctionDescriptor upcallDesc = FunctionDescriptor.of(layout, layout);
-        FunctionDescriptor downcallDesc = upcallDesc.insertArgumentLayouts(0, ADDRESS); // upcall stub
+    public void testNormalize(ValueLayout layout, int testValue, int hobMask, MethodHandle toInt, MethodHandle saver) throws Throwable {
+        // use actual type as parameter type to test upcall arg normalization
+        FunctionDescriptor upcallDesc = FunctionDescriptor.ofVoid(layout);
+        // use actual type as return type to test downcall return normalization
+        FunctionDescriptor downcallDesc = FunctionDescriptor.of(layout, ADDRESS, JAVA_INT);
 
-        MemorySegment target = findNativeOrThrow(targetName);
+        MemorySegment target = findNativeOrThrow("test");
         MethodHandle downcallHandle = LINKER.downcallHandle(target, downcallDesc);
-        Object result;
+        downcallHandle = MethodHandles.filterReturnValue(downcallHandle, toInt);
+
         try (MemorySession session = MemorySession.openConfined()) {
-            MemorySegment upcallStub = LINKER.upcallStub(upcallTarget, upcallDesc, session);
+            int[] box = new int[1];
+            saver = MethodHandles.insertArguments(saver, 1, box);
+            MemorySegment upcallStub = LINKER.upcallStub(saver, upcallDesc, session);
+            int dirtyValue = testValue | hobMask; // set all bits that should not be set
 
-            result = downcallHandle.invoke(upcallStub, testValue);
+            // test after JIT as well
+            for (int i = 0; i < 20_000; i++) {
+                doCall(downcallHandle, upcallStub, box, dirtyValue, hobMask);
+            }
         }
-        assertEquals(result, testValue);
     }
 
-    // use explicit functions to avoid LambdaForm erasure
-    public static boolean identity(boolean b) {
+    private static void doCall(MethodHandle downcallHandle, MemorySegment upcallStub,
+                               int[] box, int dirtyValue, int hobMask) throws Throwable {
+        int result = (int) downcallHandle.invokeExact(upcallStub, dirtyValue);
+        assertEquals(box[0] & hobMask, 0); // check normalized upcall arg
+        assertEquals(result & hobMask, 0); // check normalized downcall return value
+    }
+
+    public static void saveBoolean(boolean b, int[] box) {
+        box[0] = booleanToInt(b);
+    }
+    public static void saveByte(byte b, int[] box) {
+        box[0] = byteToInt(b);
+    }
+    public static void saveShort(short s, int[] box) {
+        box[0] = shortToInt(s);
+    }
+    public static void saveChar(char c, int[] box) {
+        box[0] = charToInt(c);
+    }
+
+    public static int booleanToInt(boolean b) {
+        try {
+            return (int) NATIVE_BOOLEAN_TO_INT.invokeExact(b); // FIXME do in pure Java?
+        } catch (Throwable e) {
+            throw new RuntimeException(e);
+        }
+    }
+    public static int byteToInt(byte b) {
         return b;
     }
-    public static byte identity(byte b) {
-        return b;
-    }
-    public static char identity(char c) {
+    public static int charToInt(char c) {
         return c;
     }
-    public static short identity(short s) {
+    public static int shortToInt(short s) {
         return s;
     }
 
     @DataProvider
     public static Object[][] cases() {
         return new Object[][] {
-                { "test_char", JAVA_BOOLEAN, true, MH_BOOLEAN },
-                { "test_char", JAVA_BYTE, (byte) 42, MH_BYTE },
-                { "test_short", JAVA_SHORT, (short) 42, MH_SHORT },
-                { "test_short", JAVA_CHAR, 'a', MH_CHAR }
+            { JAVA_BOOLEAN, booleanToInt(true),     BOOLEAN_HOB_MASK, BOOLEAN_TO_INT, SAVE_BOOLEAN },
+            { JAVA_BYTE,    byteToInt((byte) 42),   BYTE_HOB_MASK,    BYTE_TO_INT,    SAVE_BYTE    },
+            { JAVA_SHORT,   shortToInt((short) 42), SHORT_HOB_MASK,   SHORT_TO_INT,   SAVE_SHORT   },
+            { JAVA_CHAR,    charToInt('a'),         CHAR_HOB_MASK,    CHAR_TO_INT,    SAVE_CHAR    }
         };
     }
 }

--- a/test/jdk/java/foreign/normalize/TestNormalize.java
+++ b/test/jdk/java/foreign/normalize/TestNormalize.java
@@ -44,7 +44,6 @@ import java.lang.foreign.ValueLayout;
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.MethodType;
-import java.util.function.IntConsumer;
 
 import static java.lang.foreign.ValueLayout.ADDRESS;
 import static java.lang.foreign.ValueLayout.JAVA_BOOLEAN;

--- a/test/jdk/java/foreign/normalize/libNormalize.c
+++ b/test/jdk/java/foreign/normalize/libNormalize.c
@@ -27,11 +27,13 @@
 #define EXPORT
 #endif
 
-// re-use for boolean
-EXPORT char test_char(char (*cb)(char), char x) {
-    return cb(x);
+// we use 'int' here to make sure the native code doesn't touch any of the bits
+// the important part is that our Java code performs argument normalization
+EXPORT int test(void (*cb)(int), int x) {
+    cb(x); // check upcall arg normalization
+    return x; // check return value normalization
 }
 
-EXPORT short test_short(short (*cb)(short), short x) {
-    return cb(x);
+EXPORT int int_identity(int x) {
+    return x;
 }

--- a/test/jdk/java/foreign/normalize/libNormalize.c
+++ b/test/jdk/java/foreign/normalize/libNormalize.c
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+#ifdef _WIN64
+#define EXPORT __declspec(dllexport)
+#else
+#define EXPORT
+#endif
+
+// re-use for boolean
+EXPORT char test_char(char (*cb)(char), char x) {
+    return cb(x);
+}
+
+EXPORT short test_short(short (*cb)(short), short x) {
+    return cb(x);
+}


### PR DESCRIPTION
This patch moves value normalization code from the downcall stub (where it was hard coded) to Java, and also adds it for upcall arguments where it was missing.

~There is a slight change in behavior with this. The previous hard-coded conversion from a native value to Java `boolean` checked if the least significant byte was non-zero, i.e. `boolean result = value & 0xFF != 0`. While the new conversion only looks at the least significant bit, i.e. `boolean result = value & 0b1 != 0`. I think the new behavior is more correct. It means that the Linker will just do the "dumb" thing when mapping anything to `boolean`, and the native representation is really expected to be like a Java `boolean` i.e. only using the least significant bit. On the other hand I think it means that e.g. jextract will have to map the C `bool` as `byte` and then do a non-zero check to convert to `boolean`.~

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8291873](https://bugs.openjdk.org/browse/JDK-8291873): Implement return value normalization in Java


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.org/census#mcimadamore) (@mcimadamore - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/panama-foreign pull/720/head:pull/720` \
`$ git checkout pull/720`

Update a local copy of the PR: \
`$ git checkout pull/720` \
`$ git pull https://git.openjdk.org/panama-foreign pull/720/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 720`

View PR using the GUI difftool: \
`$ git pr show -t 720`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/panama-foreign/pull/720.diff">https://git.openjdk.org/panama-foreign/pull/720.diff</a>

</details>
