### PR TITLE
Fix tests using stale `SymbolLookup::lookup`

### DIFF
--- a/test/hotspot/jtreg/gc/shenandoah/compiler/TestLinkToNativeRBP.java
+++ b/test/hotspot/jtreg/gc/shenandoah/compiler/TestLinkToNativeRBP.java
@@ -50,7 +50,7 @@ public class TestLinkToNativeRBP {
 
     final static Linker abi = Linker.nativeLinker();
     static final SymbolLookup lookup = SymbolLookup.loaderLookup();
-    final static MethodHandle foo = abi.downcallHandle(lookup.lookup("foo").get(),
+    final static MethodHandle foo = abi.downcallHandle(lookup.find("foo").get(),
             FunctionDescriptor.of(ValueLayout.JAVA_INT));
 
     static int foo() throws Throwable {

--- a/test/jdk/java/lang/Thread/jni/AttachCurrentThread/ImplicitAttach.java
+++ b/test/jdk/java/lang/Thread/jni/AttachCurrentThread/ImplicitAttach.java
@@ -62,7 +62,7 @@ public class ImplicitAttach {
 
         // void start_threads(int count, void *(*f)(void *))
         SymbolLookup symbolLookup = SymbolLookup.loaderLookup();
-        MemorySegment symbol = symbolLookup.lookup("start_threads").orElseThrow();
+        MemorySegment symbol = symbolLookup.find("start_threads").orElseThrow();
         FunctionDescriptor desc = FunctionDescriptor.ofVoid(C_INT, C_POINTER);
         MethodHandle start_threads = abi.downcallHandle(symbol, desc);
 


### PR DESCRIPTION
This simple patch fixes a couple of tests that were missed during https://git.openjdk.org/panama-foreign/pull/716

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Reviewers
 * [Athijegannathan Sundararajan](https://openjdk.org/census#sundar) (@sundararajana - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/panama-foreign pull/722/head:pull/722` \
`$ git checkout pull/722`

Update a local copy of the PR: \
`$ git checkout pull/722` \
`$ git pull https://git.openjdk.org/panama-foreign pull/722/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 722`

View PR using the GUI difftool: \
`$ git pr show -t 722`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/panama-foreign/pull/722.diff">https://git.openjdk.org/panama-foreign/pull/722.diff</a>

</details>
