### PR TITLE
8293367: Enable native access for modules not in the boot layer

### DIFF
--- a/src/java.base/share/classes/java/lang/Module.java
+++ b/src/java.base/share/classes/java/lang/Module.java
@@ -269,9 +269,8 @@ public final class Module implements AnnotatedElement {
      * @return {@code true} if this module can access <em>restricted</em> methods.
      */
     @PreviewFeature(feature=PreviewFeature.Feature.FOREIGN)
-    public boolean isNativeAccessEnabled() {
-        return enableNativeAccess ||
-                (!isNamed() && ALL_UNNAMED_MODULE.enableNativeAccess);
+    public synchronized boolean isNativeAccessEnabled() {
+        return implIsEnableNativeAccess();
     }
 
     /**

--- a/src/java.base/share/classes/java/lang/Module.java
+++ b/src/java.base/share/classes/java/lang/Module.java
@@ -52,6 +52,7 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import jdk.internal.javac.PreviewFeature;
 import jdk.internal.loader.BuiltinClassLoader;
 import jdk.internal.loader.BootLoader;
 import jdk.internal.loader.ClassLoaders;
@@ -259,6 +260,18 @@ public final class Module implements AnnotatedElement {
     Module implAddEnableNativeAccess() {
         enableNativeAccess = true;
         return this;
+    }
+
+    /**
+     * Returns {@code true} if this module can access
+     * <a href="foreign/package-summary.html#restricted"><em>restricted</em></a> methods.
+     *
+     * @return {@code true} if this module can access <em>restricted</em> methods.
+     */
+    @PreviewFeature(feature=PreviewFeature.Feature.FOREIGN)
+    public boolean isNativeAccessEnabled() {
+        return enableNativeAccess ||
+                (!isNamed() && ALL_UNNAMED_MODULE.enableNativeAccess);
     }
 
     /**

--- a/src/java.base/share/classes/java/lang/Module.java
+++ b/src/java.base/share/classes/java/lang/Module.java
@@ -271,34 +271,35 @@ public final class Module implements AnnotatedElement {
      */
     @PreviewFeature(feature=PreviewFeature.Feature.FOREIGN)
     public boolean isNativeAccessEnabled() {
-        Module target = enableNativeAccessHolder();
+        Module target = moduleForNativeAccess();
         synchronized(target) {
             return target.enableNativeAccess;
         }
     }
 
-    // Returns the Module object holds the enableNativeAccess
+    // Returns the Module object that holds the enableNativeAccess
     // flag for this module.
-    private Module enableNativeAccessHolder() {
+    private Module moduleForNativeAccess() {
         return isNamed() ? this : ALL_UNNAMED_MODULE;
     }
 
     // This is invoked from Reflection.ensureNativeAccess
     void ensureNativeAccess(Class<?> owner, String methodName) {
         // The target module whose enableNativeAccess flag is ensured
-        Module target = enableNativeAccessHolder();
+        Module target = moduleForNativeAccess();
         // racy read of the enable native access flag
         boolean isNativeAccessEnabled = target.enableNativeAccess;
         if (!isNativeAccessEnabled) {
-            synchronized(target) {
+            synchronized (target) {
                 // safe read of the enableNativeAccess of the target module
                 isNativeAccessEnabled = target.enableNativeAccess;
+
                 // check again with the safely read flag
                 if (isNativeAccessEnabled) {
-                   // another thread beat us to it - nothing to do
-                   return;
+                    // another thread beat us to it - nothing to do
+                    return;
                 } else if (ModuleBootstrap.hasEnableNativeAccessFlag()) {
-                   throw new IllegalCallerException("Illegal native access from: " + this);
+                    throw new IllegalCallerException("Illegal native access from: " + this);
                 } else {
                     // warn and set flag, so that only one warning is reported per module
                     String cls = owner.getName();
@@ -322,7 +323,7 @@ public final class Module implements AnnotatedElement {
     /**
      * Update all unnamed modules to allow access to restricted methods.
      */
-    static void implAddEnableNativeAccessAllUnnamed() {
+    static void implAddEnableNativeAccessToAllUnnamed() {
         synchronized (ALL_UNNAMED_MODULE) {
             ALL_UNNAMED_MODULE.enableNativeAccess = true;
         }

--- a/src/java.base/share/classes/java/lang/Module.java
+++ b/src/java.base/share/classes/java/lang/Module.java
@@ -280,7 +280,7 @@ public final class Module implements AnnotatedElement {
     // Returns the Module object holds the enableNativeAccess
     // flag for this module.
     private Module enableNativeAccessHolder() {
-        return isNamed()? this : ALL_UNNAMED_MODULE;
+        return isNamed() ? this : ALL_UNNAMED_MODULE;
     }
 
     // This is invoked from Reflection.ensureNativeAccess
@@ -295,6 +295,7 @@ public final class Module implements AnnotatedElement {
                 isNativeAccessEnabled = target.enableNativeAccess;
                 // check again with the safely read flag
                 if (isNativeAccessEnabled) {
+                   // another thread beat us to it - nothing to do
                    return;
                 } else if (ModuleBootstrap.hasEnableNativeAccessFlag()) {
                    throw new IllegalCallerException("Illegal native access from: " + this);

--- a/src/java.base/share/classes/java/lang/Module.java
+++ b/src/java.base/share/classes/java/lang/Module.java
@@ -257,7 +257,7 @@ public final class Module implements AnnotatedElement {
     /**
      * Update this module to allow access to restricted methods.
      */
-    Module implAddEnableNativeAccess() {
+    synchronized Module implAddEnableNativeAccess() {
         enableNativeAccess = true;
         return this;
     }

--- a/src/java.base/share/classes/java/lang/ModuleLayer.java
+++ b/src/java.base/share/classes/java/lang/ModuleLayer.java
@@ -300,7 +300,7 @@ public final class ModuleLayer {
             return this;
         }
 
-        /***
+        /**
          * Enables native access for a module in the layer if the caller's module
          * has native access.
          *

--- a/src/java.base/share/classes/java/lang/ModuleLayer.java
+++ b/src/java.base/share/classes/java/lang/ModuleLayer.java
@@ -302,7 +302,7 @@ public final class ModuleLayer {
 
         /***
          * Enables native access for a module in the layer if the caller's module
-         * already has native access.
+         * has native access.
          *
          * <p> This method is <a href="foreign/package-summary.html#restricted"><em>restricted</em></a>.
          * Restricted methods are unsafe, and, if used incorrectly, their use might crash
@@ -310,14 +310,15 @@ public final class ModuleLayer {
          * from depending on restricted methods, and use safe and supported functionalities,
          * where possible.
          *
-         * @param target the module that's given native access
+         * @param  target
+         *         The module to update
          *
          * @return This controller
          *
          * @throws IllegalCallerException if access to this method occurs from a module {@code M}
-         * and the command line option {@code --enable-native-access} is specified, but does not
-         * mention the module name {@code M}, or {@code ALL-UNNAMED} in case {@code M} is an
-         * unnamed module.
+         *         and the command line option {@code --enable-native-access} is specified, but
+         *         does not mention the module name {@code M}, or {@code ALL-UNNAMED} in case
+         *         {@code M} is an unnamed module.
          */
          @PreviewFeature(feature=PreviewFeature.Feature.FOREIGN)
          @CallerSensitive

--- a/src/java.base/share/classes/java/lang/ModuleLayer.java
+++ b/src/java.base/share/classes/java/lang/ModuleLayer.java
@@ -315,10 +315,11 @@ public final class ModuleLayer {
          *
          * @return This controller
          *
-         * @throws IllegalCallerException if access to this method occurs from a module {@code M}
-         *         and the command line option {@code --enable-native-access} is specified, but
-         *         does not mention the module name {@code M}, or {@code ALL-UNNAMED} in case
-         *         {@code M} is an unnamed module.
+         * @throws IllegalArgumentException
+         *         If {@code target} is not in the module layer
+         *
+         * @throws IllegalCallerException
+         *         If the caller is in a module that does not have native access enabled
          */
          @PreviewFeature(feature=PreviewFeature.Feature.FOREIGN)
          @CallerSensitive

--- a/src/java.base/share/classes/java/lang/ModuleLayer.java
+++ b/src/java.base/share/classes/java/lang/ModuleLayer.java
@@ -303,11 +303,12 @@ public final class ModuleLayer {
         /***
          * Enables <a href="foreign/package-summary.html#restricted">native access</a>
          * for a module in the layer if the caller module already has native access.
-         * <p>
-         * This method is <a href="foreign/package-summary.html#restricted"><em>restricted</em></a>.
+         *
+         * <p> This method is <a href="foreign/package-summary.html#restricted"><em>restricted</em></a>.
          * Restricted methods are unsafe, and, if used incorrectly, their use might crash
-         * the JVM or, worse, silently result in memory corruption. Thus, clients should refrain from depending on
-         * restricted methods, and use safe and supported functionalities, where possible.
+         * the JVM or, worse, silently result in memory corruption. Thus, clients should refrain
+         * from depending on restricted methods, and use safe and supported functionalities,
+         * where possible.
          *
          * @param target the module that's given native access
          *

--- a/src/java.base/share/classes/java/lang/ModuleLayer.java
+++ b/src/java.base/share/classes/java/lang/ModuleLayer.java
@@ -301,8 +301,8 @@ public final class ModuleLayer {
         }
 
         /***
-         * Enables <a href="foreign/package-summary.html#restricted">native access</a>
-         * for a module in the layer if the caller module already has native access.
+         * Enables native access for a module in the layer if the caller's module
+         * already has native access.
          *
          * <p> This method is <a href="foreign/package-summary.html#restricted"><em>restricted</em></a>.
          * Restricted methods are unsafe, and, if used incorrectly, their use might crash
@@ -314,7 +314,10 @@ public final class ModuleLayer {
          *
          * @return This controller
          *
-         * @throws IllegalCallerException If the caller module doesn't have native access.
+         * @throws IllegalCallerException if access to this method occurs from a module {@code M}
+         * and the command line option {@code --enable-native-access} is specified, but does not
+         * mention the module name {@code M}, or {@code ALL-UNNAMED} in case {@code M} is an
+         * unnamed module.
          */
          @PreviewFeature(feature=PreviewFeature.Feature.FOREIGN)
          @CallerSensitive

--- a/src/java.base/share/classes/java/lang/ModuleLayer.java
+++ b/src/java.base/share/classes/java/lang/ModuleLayer.java
@@ -44,14 +44,16 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import jdk.internal.javac.PreviewFeature;
 import jdk.internal.loader.ClassLoaderValue;
 import jdk.internal.loader.Loader;
 import jdk.internal.loader.LoaderPool;
 import jdk.internal.module.ServicesCatalog;
 import jdk.internal.misc.CDS;
+import jdk.internal.reflect.CallerSensitive;
+import jdk.internal.reflect.Reflection;
 import jdk.internal.vm.annotation.Stable;
 import sun.security.util.SecurityConstants;
-
 
 /**
  * A layer of modules in the Java virtual machine.
@@ -297,6 +299,31 @@ public final class ModuleLayer {
             source.implAddOpens(pn, target);
             return this;
         }
+
+        /***
+         * Enables <a href="foreign/package-summary.html#restricted">native access</a>
+         * for a module in the layer if the caller module already has native access.
+         * <p>
+         * This method is <a href="foreign/package-summary.html#restricted"><em>restricted</em></a>.
+         * Restricted methods are unsafe, and, if used incorrectly, their use might crash
+         * the JVM or, worse, silently result in memory corruption. Thus, clients should refrain from depending on
+         * restricted methods, and use safe and supported functionalities, where possible.
+         *
+         * @param target the module that's given native access
+         *
+         * @return This controller
+         *
+         * @throws IllegalCallerException If the caller module doesn't have native access.
+         */
+         @PreviewFeature(feature=PreviewFeature.Feature.FOREIGN)
+         @CallerSensitive
+         public Controller enableNativeAccess(Module target) {
+             ensureInLayer(target);
+             Reflection.ensureNativeAccess(Reflection.getCallerClass(), Module.class,
+                 "enableNativeAccess");
+             target.implAddEnableNativeAccess();
+             return this;
+         }
     }
 
 

--- a/src/java.base/share/classes/java/lang/System.java
+++ b/src/java.base/share/classes/java/lang/System.java
@@ -2431,8 +2431,8 @@ public final class System {
             public Module addEnableNativeAccess(Module m) {
                 return m.implAddEnableNativeAccess();
             }
-            public void addEnableNativeAccessAllUnnamed() {
-                Module.implAddEnableNativeAccessAllUnnamed();
+            public void addEnableNativeAccessToAllUnnamed() {
+                Module.implAddEnableNativeAccessToAllUnnamed();
             }
             public void ensureNativeAccess(Module m, Class<?> owner, String methodName) {
                 m.ensureNativeAccess(owner, methodName);

--- a/src/java.base/share/classes/java/lang/System.java
+++ b/src/java.base/share/classes/java/lang/System.java
@@ -2431,11 +2431,11 @@ public final class System {
             public Module addEnableNativeAccess(Module m) {
                 return m.implAddEnableNativeAccess();
             }
-            public boolean isEnableNativeAccess(Module m) {
-                return m.implIsEnableNativeAccess();
-            }
             public void addEnableNativeAccessAllUnnamed() {
                 Module.implAddEnableNativeAccessAllUnnamed();
+            }
+            public void ensureNativeAccess(Module m, Class<?> owner, String methodName) {
+                m.ensureNativeAccess(owner, methodName);
             }
             public ServicesCatalog getServicesCatalog(ModuleLayer layer) {
                 return layer.getServicesCatalog();

--- a/src/java.base/share/classes/java/lang/System.java
+++ b/src/java.base/share/classes/java/lang/System.java
@@ -2434,9 +2434,6 @@ public final class System {
             public void addEnableNativeAccessAllUnnamed() {
                 Module.implAddEnableNativeAccessAllUnnamed();
             }
-            public boolean isEnableNativeAccess(Module m) {
-                return m.implIsEnableNativeAccess();
-            }
             public ServicesCatalog getServicesCatalog(ModuleLayer layer) {
                 return layer.getServicesCatalog();
             }

--- a/src/java.base/share/classes/java/lang/System.java
+++ b/src/java.base/share/classes/java/lang/System.java
@@ -2431,6 +2431,9 @@ public final class System {
             public Module addEnableNativeAccess(Module m) {
                 return m.implAddEnableNativeAccess();
             }
+            public boolean isEnableNativeAccess(Module m) {
+                return m.implIsEnableNativeAccess();
+            }
             public void addEnableNativeAccessAllUnnamed() {
                 Module.implAddEnableNativeAccessAllUnnamed();
             }

--- a/src/java.base/share/classes/jdk/internal/access/JavaLangAccess.java
+++ b/src/java.base/share/classes/jdk/internal/access/JavaLangAccess.java
@@ -270,7 +270,7 @@ public interface JavaLangAccess {
     /**
      * Updates all unnamed modules to allow access to restricted methods.
      */
-    void addEnableNativeAccessAllUnnamed();
+    void addEnableNativeAccessToAllUnnamed();
 
     /**
      * Ensure that the given module has native access. If not, warn or

--- a/src/java.base/share/classes/jdk/internal/access/JavaLangAccess.java
+++ b/src/java.base/share/classes/jdk/internal/access/JavaLangAccess.java
@@ -268,14 +268,15 @@ public interface JavaLangAccess {
     Module addEnableNativeAccess(Module m);
 
     /**
-     * Returns true if module m can access restricted methods.
-     */
-    boolean isEnableNativeAccess(Module m);
-
-    /**
      * Updates all unnamed modules to allow access to restricted methods.
      */
     void addEnableNativeAccessAllUnnamed();
+
+    /**
+     * Ensure that the given module has native access. If not, warn
+     * and set native access depending on the configuration.
+     */
+    void ensureNativeAccess(Module m, Class<?> owner, String methodName);
 
     /**
      * Returns the ServicesCatalog for the given Layer.

--- a/src/java.base/share/classes/jdk/internal/access/JavaLangAccess.java
+++ b/src/java.base/share/classes/jdk/internal/access/JavaLangAccess.java
@@ -273,8 +273,8 @@ public interface JavaLangAccess {
     void addEnableNativeAccessAllUnnamed();
 
     /**
-     * Ensure that the given module has native access. If not, warn
-     * and set native access depending on the configuration.
+     * Ensure that the given module has native access. If not, warn or
+     * throw exception depending on the configuration.
      */
     void ensureNativeAccess(Module m, Class<?> owner, String methodName);
 

--- a/src/java.base/share/classes/jdk/internal/access/JavaLangAccess.java
+++ b/src/java.base/share/classes/jdk/internal/access/JavaLangAccess.java
@@ -273,11 +273,6 @@ public interface JavaLangAccess {
     void addEnableNativeAccessAllUnnamed();
 
     /**
-     * Returns true if module m can access restricted methods.
-     */
-    boolean isEnableNativeAccess(Module m);
-
-    /**
      * Returns the ServicesCatalog for the given Layer.
      */
     ServicesCatalog getServicesCatalog(ModuleLayer layer);

--- a/src/java.base/share/classes/jdk/internal/access/JavaLangAccess.java
+++ b/src/java.base/share/classes/jdk/internal/access/JavaLangAccess.java
@@ -268,6 +268,11 @@ public interface JavaLangAccess {
     Module addEnableNativeAccess(Module m);
 
     /**
+     * Returns true if module m can access restricted methods.
+     */
+    boolean isEnableNativeAccess(Module m);
+
+    /**
      * Updates all unnamed modules to allow access to restricted methods.
      */
     void addEnableNativeAccessAllUnnamed();

--- a/src/java.base/share/classes/jdk/internal/module/ModuleBootstrap.java
+++ b/src/java.base/share/classes/jdk/internal/module/ModuleBootstrap.java
@@ -789,7 +789,7 @@ public final class ModuleBootstrap {
     private static void addEnableNativeAccess(ModuleLayer layer) {
         for (String name : NATIVE_ACCESS_MODULES) {
             if (name.equals("ALL-UNNAMED")) {
-                JLA.addEnableNativeAccessAllUnnamed();
+                JLA.addEnableNativeAccessToAllUnnamed();
             } else {
                 Optional<Module> module = layer.findModule(name);
                 if (module.isPresent()) {

--- a/src/java.base/share/classes/jdk/internal/reflect/Reflection.java
+++ b/src/java.base/share/classes/jdk/internal/reflect/Reflection.java
@@ -115,10 +115,10 @@ public class Reflection {
         Module module = currentClass != null ?
                 currentClass.getModule() :
                 ClassLoader.getSystemClassLoader().getUnnamedModule();
-        boolean isNativeAccessEnabled = module.isNativeAccessEnabled();
+        boolean isNativeAccessEnabled = SharedSecrets.getJavaLangAccess().isEnableNativeAccess(module);
         if (!isNativeAccessEnabled) {
             synchronized(module) {
-                isNativeAccessEnabled = module.isNativeAccessEnabled();
+                isNativeAccessEnabled = SharedSecrets.getJavaLangAccess().isEnableNativeAccess(module);
                 if (isNativeAccessEnabled) {
                     // some other thread got to it, do nothing
                 } else if (ModuleBootstrap.hasEnableNativeAccessFlag()) {

--- a/src/java.base/share/classes/jdk/internal/reflect/Reflection.java
+++ b/src/java.base/share/classes/jdk/internal/reflect/Reflection.java
@@ -115,33 +115,7 @@ public class Reflection {
         Module module = currentClass != null ?
                 currentClass.getModule() :
                 ClassLoader.getSystemClassLoader().getUnnamedModule();
-        boolean isNativeAccessEnabled = SharedSecrets.getJavaLangAccess().isEnableNativeAccess(module);
-        if (!isNativeAccessEnabled) {
-            synchronized(module) {
-                isNativeAccessEnabled = SharedSecrets.getJavaLangAccess().isEnableNativeAccess(module);
-                if (isNativeAccessEnabled) {
-                    // some other thread got to it, do nothing
-                } else if (ModuleBootstrap.hasEnableNativeAccessFlag()) {
-                    throw new IllegalCallerException("Illegal native access from: " + module);
-                } else {
-                    // warn and set flag, so that only one warning is reported per module
-                    String cls = owner.getName();
-                    String mtd = cls + "::" + methodName;
-                    String mod = module.isNamed() ? "module " + module.getName() : "the unnamed module";
-                    String modflag = module.isNamed() ? module.getName() : "ALL-UNNAMED";
-                    System.err.printf("""
-                            WARNING: A restricted method in %s has been called
-                            WARNING: %s has been called by %s
-                            WARNING: Use --enable-native-access=%s to avoid a warning for this module
-                            %n""", cls, mtd, mod, modflag);
-                    if (module.isNamed()) {
-                        SharedSecrets.getJavaLangAccess().addEnableNativeAccess(module);
-                    } else {
-                        SharedSecrets.getJavaLangAccess().addEnableNativeAccessAllUnnamed();
-                    }
-                }
-            }
-        }
+        SharedSecrets.getJavaLangAccess().ensureNativeAccess(module, owner, methodName);
     }
 
     /**

--- a/src/java.base/share/classes/jdk/internal/reflect/Reflection.java
+++ b/src/java.base/share/classes/jdk/internal/reflect/Reflection.java
@@ -115,10 +115,10 @@ public class Reflection {
         Module module = currentClass != null ?
                 currentClass.getModule() :
                 ClassLoader.getSystemClassLoader().getUnnamedModule();
-        boolean isNativeAccessEnabled = SharedSecrets.getJavaLangAccess().isEnableNativeAccess(module);
+        boolean isNativeAccessEnabled = module.isNativeAccessEnabled();
         if (!isNativeAccessEnabled) {
             synchronized(module) {
-                isNativeAccessEnabled = SharedSecrets.getJavaLangAccess().isEnableNativeAccess(module);
+                isNativeAccessEnabled = module.isNativeAccessEnabled();
                 if (isNativeAccessEnabled) {
                     // some other thread got to it, do nothing
                 } else if (ModuleBootstrap.hasEnableNativeAccessFlag()) {

--- a/test/jdk/java/foreign/enablenativeaccess/NativeAccessDynamicMain.java
+++ b/test/jdk/java/foreign/enablenativeaccess/NativeAccessDynamicMain.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.lang.Module;
+import java.lang.ModuleLayer;
+import java.lang.module.ModuleFinder;
+import java.lang.module.ModuleReference;
+import java.io.File;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Stream;
+import java.util.stream.Collectors;
+
+// This class creates a dynamic module layer and loads the
+// panama_module in it. enableNativeAccess on that dynamic
+// module is called depending on the command line option.
+//
+// Usage:
+//   java --enable-native-access=ALL-UNNAMED NativeAccessDynamicMain <module-path> <mod/class> <true|false> [main-args]
+public class NativeAccessDynamicMain {
+    public static void main(String[] args) throws Exception {
+        String modulePath = args[0];
+        String moduleAndClsName = args[1];
+        boolean enableNativeAccess = Boolean.parseBoolean(args[2]);
+        String[] mainArgs = args.length > 2? Arrays.copyOfRange(args, 3, args.length) : new String[0];
+
+        int idx = moduleAndClsName.indexOf('/');
+        String moduleName = moduleAndClsName.substring(0, idx);
+        String className = moduleAndClsName.substring(idx+1);
+
+        Path[] paths = Stream.of(modulePath.split(File.pathSeparator))
+            .map(Paths::get)
+            .toArray(Path[]::new);
+        ModuleFinder mf = ModuleFinder.of(paths);
+        var mrefs = mf.findAll();
+        if (mrefs.isEmpty()) {
+            throw new RuntimeException("No modules module path: " + modulePath);
+        }
+
+        var rootMods = mrefs.stream().
+            map(mr->mr.descriptor().name()).
+            collect(Collectors.toSet());
+
+        ModuleLayer boot = ModuleLayer.boot();
+        var conf = boot.configuration().
+            resolve(mf, ModuleFinder.of(), rootMods);
+        String firstMod = rootMods.iterator().next();
+        URLClassLoader cl = new URLClassLoader(new URL[] { paths[0].toFile().toURL() });
+        ModuleLayer.Controller controller = boot.defineModulesWithOneLoader(conf, List.of(boot), cl);
+        ModuleLayer layer = controller.layer();
+        Module mod = layer.findModule(firstMod).get();
+
+        // conditionally grant native access to the dynamic module created
+        if (enableNativeAccess) {
+            controller.enableNativeAccess(mod);
+        }
+        Class mainCls = Class.forName(mod, className);
+        var main = mainCls.getMethod("main", String[].class);
+        main.invoke(null, (Object)mainArgs);
+    }
+}

--- a/test/jdk/java/foreign/enablenativeaccess/TestEnableNativeAccessDynamic.java
+++ b/test/jdk/java/foreign/enablenativeaccess/TestEnableNativeAccessDynamic.java
@@ -158,6 +158,7 @@ public class TestEnableNativeAccessDynamic {
         list.add("--enable-preview");
         if (panamaModuleInBootLayer) {
             list.addAll(List.of("-p", MODULE_PATH));
+            list.add("--add-modules=panama_module");
             list.add("--enable-native-access=ALL-UNNAMED,panama_module");
         } else {
             list.add("--enable-native-access=ALL-UNNAMED");

--- a/test/jdk/java/foreign/enablenativeaccess/TestEnableNativeAccessDynamic.java
+++ b/test/jdk/java/foreign/enablenativeaccess/TestEnableNativeAccessDynamic.java
@@ -159,7 +159,7 @@ public class TestEnableNativeAccessDynamic {
         if (panamaModuleInBootLayer) {
             list.addAll(List.of("-p", MODULE_PATH));
             list.add("--add-modules=panama_module");
-            list.add("--enable-native-access=ALL-UNNAMED,panama_module");
+            list.add("--enable-native-access=panama_module");
         } else {
             list.add("--enable-native-access=ALL-UNNAMED");
         }

--- a/test/jdk/java/foreign/enablenativeaccess/TestEnableNativeAccessDynamic.java
+++ b/test/jdk/java/foreign/enablenativeaccess/TestEnableNativeAccessDynamic.java
@@ -1,0 +1,195 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @enablePreview
+ * @requires ((os.arch == "amd64" | os.arch == "x86_64") & sun.arch.data.model == "64") | os.arch == "aarch64"
+ * @requires !vm.musl
+ *
+ * @library /test/lib
+ * @build TestEnableNativeAccessDynamic
+ *        panama_module/*
+          NativeAccessDynamicMain
+ * @run testng/othervm/timeout=180 TestEnableNativeAccessDynamic
+ * @summary Test for dynamically setting --enable-native-access flag for a module
+ */
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Stream;
+
+import jdk.test.lib.process.ProcessTools;
+import jdk.test.lib.process.OutputAnalyzer;
+
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+import static org.testng.Assert.*;
+
+@Test
+public class TestEnableNativeAccessDynamic {
+
+    static final String MODULE_PATH = System.getProperty("jdk.module.path");
+
+    static final String PANAMA_MAIN = "panama_module/org.openjdk.foreigntest.PanamaMainDirect";
+    static final String PANAMA_REFLECTION = "panama_module/org.openjdk.foreigntest.PanamaMainReflection";
+    static final String PANAMA_INVOKE = "panama_module/org.openjdk.foreigntest.PanamaMainInvoke";
+    static final String PANAMA_JNI = "panama_module/org.openjdk.foreigntest.PanamaMainJNI";
+
+    /**
+     * Represents the expected result of a test.
+     */
+    static final class Result {
+        private final boolean success;
+        private final List<String> expectedOutput = new ArrayList<>();
+        private final List<String> notExpectedOutput = new ArrayList<>();
+
+        Result(boolean success) {
+            this.success = success;
+        }
+
+        Result expect(String msg) {
+            expectedOutput.add(msg);
+            return this;
+        }
+
+        Result doNotExpect(String msg) {
+            notExpectedOutput.add(msg);
+            return this;
+        }
+
+        boolean shouldSucceed() {
+            return success;
+        }
+
+        Stream<String> expectedOutput() {
+            return expectedOutput.stream();
+        }
+
+        Stream<String> notExpectedOutput() {
+            return notExpectedOutput.stream();
+        }
+
+        @Override
+        public String toString() {
+            String s = (success) ? "success" : "failure";
+            for (String msg : expectedOutput) {
+                s += "/" + msg;
+            }
+            return s;
+        }
+    }
+
+    static Result success() {
+        return new Result(true);
+    }
+
+    static Result successNoWarning() {
+        return success().doNotExpect("WARNING");
+    }
+
+    static Result failWithError(String expectedOutput) {
+        return new Result(false).expect(expectedOutput);
+    }
+
+    @DataProvider(name = "succeedCases")
+    public Object[][] succeedCases() {
+        return new Object[][] {
+                { "panama_enable_native_access", PANAMA_MAIN, successNoWarning() },
+                { "panama_enable_native_access_reflection", PANAMA_REFLECTION, successNoWarning() },
+                { "panama_enable_native_access_invoke", PANAMA_INVOKE, successNoWarning() },
+        };
+    }
+
+    @DataProvider(name = "failureCases")
+    public Object[][] failureCases() {
+        String errMsg = "Illegal native access from: module panama_module";
+        return new Object[][] {
+                { "panama_enable_native_access_fail", PANAMA_MAIN, failWithError(errMsg) },
+                { "panama_enable_native_access_fail_reflection", PANAMA_REFLECTION, failWithError(errMsg) },
+                { "panama_enable_native_access_fail_invoke", PANAMA_INVOKE, failWithError(errMsg) },
+        };
+    }
+
+    /**
+     * Checks an expected result with the output captured by the given
+     * OutputAnalyzer.
+     */
+    void checkResult(Result expectedResult, OutputAnalyzer outputAnalyzer) {
+        expectedResult.expectedOutput().forEach(outputAnalyzer::shouldContain);
+        expectedResult.notExpectedOutput().forEach(outputAnalyzer::shouldNotContain);
+        int exitValue = outputAnalyzer.getExitValue();
+        if (expectedResult.shouldSucceed()) {
+            assertTrue(exitValue == 0);
+        } else {
+            assertTrue(exitValue != 0);
+        }
+    }
+
+    /**
+     * Runs the test to execute the given test action. The VM is run with the
+     * given VM options and the output checked to see that it matches the
+     * expected result.
+     */
+    OutputAnalyzer run(String action, String moduleAndCls, boolean enableNativeAccess,
+            Result expectedResult, boolean panamaModuleInBootLayer) throws Exception
+    {
+        List<String> list = new ArrayList<>();
+        list.add("--enable-preview");
+        if (panamaModuleInBootLayer) {
+            list.addAll(List.of("-p", MODULE_PATH));
+            list.add("--enable-native-access=ALL-UNNAMED,panama_module");
+        } else {
+            list.add("--enable-native-access=ALL-UNNAMED");
+        }
+        list.addAll(List.of("NativeAccessDynamicMain", MODULE_PATH,
+                moduleAndCls, Boolean.toString(enableNativeAccess), action));
+        String[] opts = list.toArray(String[]::new);
+        OutputAnalyzer outputAnalyzer = ProcessTools
+                .executeTestJava(opts)
+                .outputTo(System.out)
+                .errorTo(System.out);
+        checkResult(expectedResult, outputAnalyzer);
+        return outputAnalyzer;
+    }
+
+    @Test(dataProvider = "succeedCases")
+    public void testSucceed(String action, String moduleAndCls,
+            Result expectedResult) throws Exception {
+        run(action, moduleAndCls, true, expectedResult, false);
+    }
+
+    @Test(dataProvider = "failureCases")
+    public void testFailures(String action, String moduleAndCls,
+            Result expectedResult) throws Exception {
+        run(action, moduleAndCls, false, expectedResult, false);
+    }
+
+    // make sure that having a same named module in boot layer with native access
+    // does not influence same named dynamic module.
+    @Test(dataProvider = "failureCases")
+    public void testFailuresWithPanamaModuleInBootLayer(String action, String moduleAndCls,
+            Result expectedResult) throws Exception {
+        run(action, moduleAndCls, false, expectedResult, true);
+    }
+}

--- a/test/micro/org/openjdk/bench/java/lang/foreign/LoopOverOfAddress.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/LoopOverOfAddress.java
@@ -51,7 +51,7 @@ public class LoopOverOfAddress extends JavaLayouts {
     public int segment_loop_addr() {
         int res = 0;
         for (int i = 0; i < ITERATIONS; i++) {
-            res += MemorySegment.ofAddress(i).hashCode();
+            res += MemorySegment.ofAddress(i % 100).address();
         }
         return res;
     }
@@ -60,7 +60,7 @@ public class LoopOverOfAddress extends JavaLayouts {
     public int segment_loop_addr_size() {
         int res = 0;
         for (int i = 0; i < ITERATIONS; i++) {
-            res += MemorySegment.ofAddress(i, 10).hashCode();
+            res += MemorySegment.ofAddress(i, i % 100).address();
         }
         return res;
     }
@@ -69,7 +69,7 @@ public class LoopOverOfAddress extends JavaLayouts {
     public int segment_loop_addr_size_session() {
         int res = 0;
         for (int i = 0; i < ITERATIONS; i++) {
-            res += MemorySegment.ofAddress(i, 10, MemorySession.global()).hashCode();
+            res += MemorySegment.ofAddress(i, i % 100, MemorySession.global()).address();
         }
         return res;
     }

--- a/test/micro/org/openjdk/bench/java/lang/foreign/LoopOverOfAddress.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/LoopOverOfAddress.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.bench.java.lang.foreign;
+
+import java.lang.foreign.MemorySegment;
+import java.lang.foreign.MemorySession;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Warmup;
+
+import java.util.concurrent.TimeUnit;
+
+@BenchmarkMode(Mode.AverageTime)
+@Warmup(iterations = 5, time = 500, timeUnit = TimeUnit.MILLISECONDS)
+@Measurement(iterations = 10, time = 500, timeUnit = TimeUnit.MILLISECONDS)
+@State(org.openjdk.jmh.annotations.Scope.Thread)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@Fork(value = 3, jvmArgsAppend = "--enable-preview")
+public class LoopOverOfAddress extends JavaLayouts {
+
+    static final int ITERATIONS = 1_000_000;
+
+    @Benchmark
+    public int segment_loop_addr() {
+        int res = 0;
+        for (int i = 0; i < ITERATIONS; i++) {
+            res += MemorySegment.ofAddress(i).hashCode();
+        }
+        return res;
+    }
+
+    @Benchmark
+    public int segment_loop_addr_size() {
+        int res = 0;
+        for (int i = 0; i < ITERATIONS; i++) {
+            res += MemorySegment.ofAddress(i, 10).hashCode();
+        }
+        return res;
+    }
+
+    @Benchmark
+    public int segment_loop_addr_size_session() {
+        int res = 0;
+        for (int i = 0; i < ITERATIONS; i++) {
+            res += MemorySegment.ofAddress(i, 10, MemorySession.global()).hashCode();
+        }
+        return res;
+    }
+}


### PR DESCRIPTION
Adding a new API ModuleLayer.Controller.enableNativeAccess(Module).
Reworked thread safety of enable native access flag reading and setting.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8293367](https://bugs.openjdk.org/browse/JDK-8293367): Enable native access for modules not in the boot layer


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.org/census#mcimadamore) (@mcimadamore - Committer) ⚠️ Review applies to [c98e661c](https://git.openjdk.org/panama-foreign/pull/729/files/c98e661c4e1e8391490d20b4ce12c6faacbacbd5)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/panama-foreign pull/729/head:pull/729` \
`$ git checkout pull/729`

Update a local copy of the PR: \
`$ git checkout pull/729` \
`$ git pull https://git.openjdk.org/panama-foreign pull/729/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 729`

View PR using the GUI difftool: \
`$ git pr show -t 729`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/panama-foreign/pull/729.diff">https://git.openjdk.org/panama-foreign/pull/729.diff</a>

</details>
