### PR TITLE
Add @sealedGraph tag to MemoryLayout

### DIFF
--- a/src/java.base/share/classes/java/lang/foreign/MemoryLayout.java
+++ b/src/java.base/share/classes/java/lang/foreign/MemoryLayout.java
@@ -167,6 +167,7 @@ import jdk.internal.javac.PreviewFeature;
  * @implSpec
  * Implementations of this interface are immutable, thread-safe and <a href="{@docRoot}/java.base/java/lang/doc-files/ValueBased.html">value-based</a>.
  *
+ * @sealedGraph
  * @since 19
  */
 @PreviewFeature(feature=PreviewFeature.Feature.FOREIGN)


### PR DESCRIPTION
This PR adds a `@sealedGraph` JavaDoc tag, opting in for rendering a graphical version of the sealed hierarchy of `MemoryLayout`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Reviewers
 * [Maurizio Cimadamore](https://openjdk.org/census#mcimadamore) (@mcimadamore - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/panama-foreign pull/735/head:pull/735` \
`$ git checkout pull/735`

Update a local copy of the PR: \
`$ git checkout pull/735` \
`$ git pull https://git.openjdk.org/panama-foreign pull/735/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 735`

View PR using the GUI difftool: \
`$ git pr show -t 735`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/panama-foreign/pull/735.diff">https://git.openjdk.org/panama-foreign/pull/735.diff</a>

</details>
