### PR TITLE
8294365: LoopOverOfAddress.java benchmark fails to compile

### DIFF
--- a/test/micro/org/openjdk/bench/java/lang/foreign/LoopOverOfAddress.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/LoopOverOfAddress.java
@@ -48,8 +48,8 @@ public class LoopOverOfAddress extends JavaLayouts {
     static final int ITERATIONS = 1_000_000;
 
     @Benchmark
-    public int segment_loop_addr() {
-        int res = 0;
+    public long segment_loop_addr() {
+        long res = 0;
         for (int i = 0; i < ITERATIONS; i++) {
             res += MemorySegment.ofAddress(i % 100).address();
         }
@@ -57,8 +57,8 @@ public class LoopOverOfAddress extends JavaLayouts {
     }
 
     @Benchmark
-    public int segment_loop_addr_size() {
-        int res = 0;
+    public long segment_loop_addr_size() {
+        long res = 0;
         for (int i = 0; i < ITERATIONS; i++) {
             res += MemorySegment.ofAddress(i, i % 100).address();
         }
@@ -66,8 +66,8 @@ public class LoopOverOfAddress extends JavaLayouts {
     }
 
     @Benchmark
-    public int segment_loop_addr_size_session() {
-        int res = 0;
+    public long segment_loop_addr_size_session() {
+        long res = 0;
         for (int i = 0; i < ITERATIONS; i++) {
             res += MemorySegment.ofAddress(i, i % 100, MemorySession.global()).address();
         }


### PR DESCRIPTION
using long instead of int

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8294365](https://bugs.openjdk.org/browse/JDK-8294365): LoopOverOfAddress.java benchmark fails to compile


### Reviewers
 * [Jorn Vernee](https://openjdk.org/census#jvernee) (@JornVernee - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/panama-foreign pull/736/head:pull/736` \
`$ git checkout pull/736`

Update a local copy of the PR: \
`$ git checkout pull/736` \
`$ git pull https://git.openjdk.org/panama-foreign pull/736/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 736`

View PR using the GUI difftool: \
`$ git pr show -t 736`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/panama-foreign/pull/736.diff">https://git.openjdk.org/panama-foreign/pull/736.diff</a>

</details>
