### PR TITLE
8294309: Downcall and Upcall unboxing code should reject heap segments

### DIFF
--- a/src/java.base/share/classes/jdk/internal/foreign/abi/BindingSpecializer.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/BindingSpecializer.java
@@ -85,7 +85,7 @@ public class BindingSpecializer {
     private static final String SESSION_DESC = methodType(MemorySession.class).descriptorString();
     private static final String SESSION_IMPL_DESC = methodType(MemorySessionImpl.class).descriptorString();
     private static final String CLOSE_DESC = VOID_DESC;
-    private static final String ADDRESS_DESC = methodType(long.class).descriptorString();
+    private static final String UNBOX_SEGMENT_DESC = methodType(long.class, MemorySegment.class).descriptorString();
     private static final String COPY_DESC = methodType(void.class, MemorySegment.class, long.class, MemorySegment.class, long.class, long.class).descriptorString();
     private static final String OF_LONG_DESC = methodType(MemorySegment.class, long.class, long.class).descriptorString();
     private static final String OF_LONG_UNCHECKED_DESC = methodType(MemorySegment.class, long.class, long.class, MemorySession.class).descriptorString();
@@ -575,10 +575,6 @@ public class BindingSpecializer {
         emitInvokeVirtual(Binding.Context.class, "close", CLOSE_DESC);
     }
 
-    private void emitAddress() {
-        emitInvokeInterface(MemorySegment.class, "address", ADDRESS_DESC);
-    }
-
     private void emitBoxAddress(Binding.BoxAddress boxAddress) {
         popType(long.class);
         emitConst(boxAddress.size());
@@ -717,7 +713,7 @@ public class BindingSpecializer {
 
     private void emitUnboxAddress() {
         popType(MemorySegment.class);
-        emitAddress();
+        emitInvokeStatic(SharedUtils.class, "unboxSegment", UNBOX_SEGMENT_DESC);
         pushType(long.class);
     }
 

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/SharedUtils.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/SharedUtils.java
@@ -28,6 +28,7 @@ import jdk.internal.access.JavaLangAccess;
 import jdk.internal.access.JavaLangInvokeAccess;
 import jdk.internal.access.SharedSecrets;
 import jdk.internal.foreign.CABI;
+import jdk.internal.foreign.HeapMemorySegmentImpl;
 import jdk.internal.foreign.abi.aarch64.linux.LinuxAArch64Linker;
 import jdk.internal.foreign.abi.aarch64.macos.MacOsAArch64Linker;
 import jdk.internal.foreign.abi.x64.sysv.SysVx64Linker;
@@ -258,6 +259,13 @@ public final class SharedUtils {
             t.printStackTrace();
             JLA.exit(1);
         }
+    }
+
+    static long unboxSegment(MemorySegment segment) {
+        if (segment instanceof HeapMemorySegmentImpl) {
+            throw new IllegalArgumentException("Heap segment not allowed: " + segment);
+        }
+        return segment.address();
     }
 
     public static void checkExceptions(MethodHandle target) {

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/SharedUtils.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/SharedUtils.java
@@ -262,7 +262,7 @@ public final class SharedUtils {
     }
 
     static long unboxSegment(MemorySegment segment) {
-        if (segment instanceof HeapMemorySegmentImpl) {
+        if (!segment.isNative()) {
             throw new IllegalArgumentException("Heap segment not allowed: " + segment);
         }
         return segment.address();

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/SharedUtils.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/SharedUtils.java
@@ -28,7 +28,6 @@ import jdk.internal.access.JavaLangAccess;
 import jdk.internal.access.JavaLangInvokeAccess;
 import jdk.internal.access.SharedSecrets;
 import jdk.internal.foreign.CABI;
-import jdk.internal.foreign.HeapMemorySegmentImpl;
 import jdk.internal.foreign.abi.aarch64.linux.LinuxAArch64Linker;
 import jdk.internal.foreign.abi.aarch64.macos.MacOsAArch64Linker;
 import jdk.internal.foreign.abi.x64.sysv.SysVx64Linker;

--- a/test/jdk/java/foreign/TestUpcallException.java
+++ b/test/jdk/java/foreign/TestUpcallException.java
@@ -33,71 +33,26 @@
  *   TestUpcallException
  */
 
-import jdk.test.lib.Utils;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
-import java.io.BufferedReader;
 import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.nio.file.Paths;
-import java.util.List;
 
-import static org.testng.Assert.assertFalse;
-import static org.testng.Assert.assertNotEquals;
-import static org.testng.Assert.assertTrue;
+public class TestUpcallException extends UpcallTestHelper {
 
-public class TestUpcallException {
-
-    @Test
-    public void testExceptionInterpreted() throws InterruptedException, IOException {
-        run(/* useSpec = */ false, /* isVoid = */ true);
-        run(/* useSpec = */ false, /* isVoid = */ false);
+    @Test(dataProvider = "cases")
+    public void testException(boolean useSpec, boolean isVoid) throws InterruptedException, IOException {
+        runInNewProcess(ThrowingUpcall.class, useSpec, isVoid ? "void" : "")
+                .assertStdErrContains("Testing upcall exceptions");
     }
 
-    @Test
-    public void testExceptionSpecialized() throws IOException, InterruptedException {
-        run(/* useSpec = */ true, /* isVoid = */ true);
-        run(/* useSpec = */ true, /* isVoid = */ false);
-    }
-
-    private void run(boolean useSpec, boolean isVoid) throws IOException, InterruptedException {
-        Process process = new ProcessBuilder()
-            .command(
-                Paths.get(Utils.TEST_JDK)
-                     .resolve("bin")
-                     .resolve("java")
-                     .toAbsolutePath()
-                     .toString(),
-                "--enable-preview",
-                "--enable-native-access=ALL-UNNAMED",
-                "-Djava.library.path=" + System.getProperty("java.library.path"),
-                "-Djdk.internal.foreign.ProgrammableUpcallHandler.USE_SPEC=" + useSpec,
-                "-cp", Utils.TEST_CLASS_PATH,
-                "ThrowingUpcall",
-                isVoid ? "void" : "non-void")
-            .start();
-
-        int result = process.waitFor();
-        assertNotEquals(result, 0);
-
-        List<String> outLines = linesFromStream(process.getInputStream());
-        outLines.forEach(System.out::println);
-        List<String> errLines = linesFromStream(process.getErrorStream());
-        errLines.forEach(System.err::println);
-
-        // Exception message would be found in stack trace
-        String shouldInclude = "Testing upcall exceptions";
-        assertTrue(linesContain(errLines, shouldInclude), "Did not find '" + shouldInclude + "' in stderr");
-    }
-
-    private boolean linesContain(List<String> errLines, String shouldInclude) {
-        return errLines.stream().anyMatch(line -> line.contains(shouldInclude));
-    }
-
-    private static List<String> linesFromStream(InputStream stream) throws IOException {
-        try (BufferedReader reader = new BufferedReader(new InputStreamReader(stream))) {
-            return reader.lines().toList();
-        }
+    @DataProvider
+    public static Object[][] cases() {
+        return new Object[][]{
+            { false, true,  },
+            { false, false, },
+            { true,  true,  },
+            { true,  false, }
+        };
     }
 }

--- a/test/jdk/java/foreign/UpcallTestHelper.java
+++ b/test/jdk/java/foreign/UpcallTestHelper.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import jdk.test.lib.Utils;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.testng.Assert.assertNotEquals;
+import static org.testng.Assert.assertTrue;
+
+public class UpcallTestHelper extends NativeTestHelper {
+    public record Output(List<String> stdout, List<String> stderr) {
+        private static void assertContains(List<String> lines, String shouldInclude) {
+            assertTrue(lines.stream().anyMatch(line -> line.contains(shouldInclude)),
+                "Did not find '" + shouldInclude + "' in stderr");
+        }
+
+        public void assertStdErrContains(String shouldInclude) {
+            assertContains(stderr, shouldInclude);
+        }
+    }
+
+    public Output runInNewProcess(Class<?> target, boolean useSpec, String... programArgs) throws IOException, InterruptedException {
+        assert !target.isArray();
+
+        List<String> command = new ArrayList<>(List.of(
+            Paths.get(Utils.TEST_JDK)
+                    .resolve("bin")
+                    .resolve("java")
+                    .toAbsolutePath()
+                    .toString(),
+            "--enable-preview",
+            "--enable-native-access=ALL-UNNAMED",
+            "-Djava.library.path=" + System.getProperty("java.library.path"),
+            "-Djdk.internal.foreign.ProgrammableUpcallHandler.USE_SPEC=" + useSpec,
+            "-cp", Utils.TEST_CLASS_PATH,
+            target.getName()
+        ));
+        command.addAll(Arrays.asList(programArgs));
+        Process process = new ProcessBuilder()
+            .command(command)
+            .start();
+
+        int result = process.waitFor();
+        assertNotEquals(result, 0);
+
+        List<String> outLines = linesFromStream(process.getInputStream());
+        outLines.forEach(System.out::println);
+        List<String> errLines = linesFromStream(process.getErrorStream());
+        errLines.forEach(System.err::println);
+
+        return new Output(outLines, errLines);
+    }
+
+    private static List<String> linesFromStream(InputStream stream) throws IOException {
+        try (BufferedReader reader = new BufferedReader(new InputStreamReader(stream))) {
+            return reader.lines().toList();
+        }
+    }
+}

--- a/test/jdk/java/foreign/passheapsegment/TestPassHeapSegment.java
+++ b/test/jdk/java/foreign/passheapsegment/TestPassHeapSegment.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @enablePreview
+ * @library ../ /test/lib
+ * @requires ((os.arch == "amd64" | os.arch == "x86_64") & sun.arch.data.model == "64") | os.arch == "aarch64"
+ * @run testng/othervm --enable-native-access=ALL-UNNAMED TestPassHeapSegment
+ */
+
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+import java.lang.foreign.FunctionDescriptor;
+import java.lang.foreign.MemorySegment;
+import java.lang.invoke.MethodHandle;
+
+import static java.lang.foreign.ValueLayout.ADDRESS;
+
+public class TestPassHeapSegment extends UpcallTestHelper  {
+
+    static {
+        System.loadLibrary("PassHeapSegment");
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class,
+        expectedExceptionsMessageRegExp = ".*Heap segment not allowed.*")
+    public void testNoHeapArgs() throws Throwable {
+        MethodHandle handle = downcallHandle("test_args", FunctionDescriptor.ofVoid(ADDRESS));
+        MemorySegment segment = MemorySegment.ofArray(new byte[]{ 0, 1, 2 });
+        handle.invoke(segment); // should throw
+    }
+
+    @Test(dataProvider = "specs")
+    public void testNoHeapReturns(boolean spec) throws IOException, InterruptedException {
+        runInNewProcess(Runner.class, spec).assertStdErrContains("Heap segment not allowed");
+    }
+
+    public static class Runner {
+
+        static {
+            System.loadLibrary("PassHeapSegment");
+        }
+
+        public static void main(String[] args) throws Throwable {
+            MethodHandle handle = downcallHandle("test_return", FunctionDescriptor.ofVoid(ADDRESS));
+            MemorySegment upcallStub = upcallStub(Runner.class, "target", FunctionDescriptor.of(ADDRESS));
+            handle.invoke(upcallStub);
+        }
+
+        public static MemorySegment target() {
+            return MemorySegment.ofArray(new byte[]{ 0, 1, 2 }); // should throw
+        }
+    }
+
+    @DataProvider
+    public static Object[][] specs() {
+        return new Object[][]{
+            { true },
+            { false }
+        };
+    }
+}
+

--- a/test/jdk/java/foreign/passheapsegment/libPassHeapSegment.c
+++ b/test/jdk/java/foreign/passheapsegment/libPassHeapSegment.c
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+#ifdef _WIN64
+#define EXPORT __declspec(dllexport)
+#else
+#define EXPORT
+#endif
+
+EXPORT void test_args(void* ptr) {}
+
+EXPORT void test_return(void* (*cb)(void)) {
+    cb();
+}


### PR DESCRIPTION
Recently I noticed that we don't check for heap segments anymore when unboxing memory segments to be passed to native code as addresses. This allows someone to pass a heap segment, which will be unboxed simply by calling `MemorySegment::address` which for heap segments returns the byte offset into the array. This is of course not a valid pointer.

This patch changes the unboxing logic to reject heap segments with an `IllegalArgumentException`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8294309](https://bugs.openjdk.org/browse/JDK-8294309): Downcall and Upcall unboxing code should reject heap segments


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.org/census#mcimadamore) (@mcimadamore - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/panama-foreign pull/737/head:pull/737` \
`$ git checkout pull/737`

Update a local copy of the PR: \
`$ git checkout pull/737` \
`$ git pull https://git.openjdk.org/panama-foreign pull/737/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 737`

View PR using the GUI difftool: \
`$ git pr show -t 737`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/panama-foreign/pull/737.diff">https://git.openjdk.org/panama-foreign/pull/737.diff</a>

</details>
