### PR TITLE
8294986: Possible mismatched acquire/release in binding specializer

### DIFF
--- a/src/java.base/share/classes/jdk/internal/foreign/ConfinedSession.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/ConfinedSession.java
@@ -81,12 +81,12 @@ final class ConfinedSession extends MemorySessionImpl {
 
     void justClose() {
         checkValidState();
-        if (state == 0 || state - ((int)ASYNC_RELEASE_COUNT.getVolatile(this)) == 0) {
-            assert state != 0 || ((int)ASYNC_RELEASE_COUNT.getVolatile(this)) == 0
-                    : "if state was 0, there should be no async releases";
+        int asyncCount = (int)ASYNC_RELEASE_COUNT.getVolatile(this);
+        if ((state == 0 && asyncCount == 0)
+                || ((state - asyncCount) == 0)) {
             state = CLOSED;
         } else {
-            throw alreadyAcquired(state);
+            throw alreadyAcquired(state - asyncCount);
         }
     }
 

--- a/src/java.base/share/classes/jdk/internal/foreign/ConfinedSession.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/ConfinedSession.java
@@ -82,6 +82,8 @@ final class ConfinedSession extends MemorySessionImpl {
     void justClose() {
         checkValidState();
         if (state == 0 || state - ((int)ASYNC_RELEASE_COUNT.getVolatile(this)) == 0) {
+            assert state != 0 || ((int)ASYNC_RELEASE_COUNT.getVolatile(this)) == 0
+                    : "if state was 0, there should be no async releases";
             state = CLOSED;
         } else {
             throw alreadyAcquired(state);

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/BindingSpecializer.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/BindingSpecializer.java
@@ -515,8 +515,9 @@ public class BindingSpecializer {
         // 1 scope to acquire on the stack
         emitDup(Object.class);
         int nextScopeLocal = scopeSlots[curScopeLocalIdx++];
-        emitStore(Object.class, nextScopeLocal); // store off one to release later
+        // call acquire first here. So that if it fails, we don't call release
         emitInvokeVirtual(MemorySessionImpl.class, "acquire0", ACQUIRE0_DESC); // call acquire on the other
+        emitStore(Object.class, nextScopeLocal); // store off one to release later
 
         if (hasOtherScopes) { // avoid ASM generating a bunch of nops for the dead code
             mv.visitJumpInsn(GOTO, end);

--- a/test/jdk/java/foreign/dontrelease/TestDontRelease.java
+++ b/test/jdk/java/foreign/dontrelease/TestDontRelease.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @enablePreview
+ * @library ../ /test/lib
+ * @requires ((os.arch == "amd64" | os.arch == "x86_64") & sun.arch.data.model == "64") | os.arch == "aarch64"
+ * @run testng/othervm --enable-native-access=ALL-UNNAMED TestDontRelease
+ */
+
+import org.testng.annotations.Test;
+
+import java.lang.foreign.FunctionDescriptor;
+import java.lang.foreign.MemorySegment;
+import java.lang.foreign.MemorySession;
+import java.lang.invoke.MethodHandle;
+
+import static java.lang.foreign.ValueLayout.ADDRESS;
+import static java.lang.foreign.ValueLayout.JAVA_INT;
+import static org.testng.Assert.assertTrue;
+
+public class TestDontRelease extends NativeTestHelper  {
+
+    static {
+        System.loadLibrary("DontRelease");
+    }
+
+    @Test
+    public void testDontRelease() {
+        MethodHandle handle = downcallHandle("test_ptr", FunctionDescriptor.ofVoid(ADDRESS));
+        try (MemorySession session = MemorySession.openConfined()) {
+            MemorySegment segment = session.allocate(JAVA_INT);
+            session.whileAlive(() -> {
+                Thread t = new Thread(() -> {
+                    try {
+                        // acquire of the segment should fail here,
+                        // due to wrong thread
+                        handle.invokeExact(segment);
+                    } catch (Throwable e) {
+                        // catch the exception.
+                        assertTrue(e instanceof WrongThreadException);
+                        assertTrue(e.getMessage().matches(".*Attempted access outside owning thread.*"));
+                    }
+                });
+                t.start();
+                try {
+                    t.join();
+                } catch (InterruptedException e) {
+                    throw new RuntimeException(e);
+                }
+
+                // the downcall above should not have called release on the session
+                // so doing it here should succeed without error
+            });
+        }
+    }
+}
+

--- a/test/jdk/java/foreign/dontrelease/libDontRelease.c
+++ b/test/jdk/java/foreign/dontrelease/libDontRelease.c
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+#ifdef _WIN64
+#define EXPORT __declspec(dllexport)
+#else
+#define EXPORT
+#endif
+
+EXPORT void test_ptr(void* ptr) {}


### PR DESCRIPTION
We acquire sessions of address parameters before a downcall, and release them afterwards. However, if acquire fails with an exception, we still call release in the finally block.

Fixing this is a simple case of switching 2 lines: when acquire fails, we don't store the session in a local, and so the cleanup in the finally block will not call release on it either.

For testing, I doesn't seem possible to make this bug result in an error with the current code. So, I've added an assert to the implementation that checks whether release was called too many times.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8294986](https://bugs.openjdk.org/browse/JDK-8294986): Possible mismatched acquire/release in binding specializer


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.org/census#mcimadamore) (@mcimadamore - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/panama-foreign pull/739/head:pull/739` \
`$ git checkout pull/739`

Update a local copy of the PR: \
`$ git checkout pull/739` \
`$ git pull https://git.openjdk.org/panama-foreign pull/739/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 739`

View PR using the GUI difftool: \
`$ git pr show -t 739`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/panama-foreign/pull/739.diff">https://git.openjdk.org/panama-foreign/pull/739.diff</a>

</details>
