### PR TITLE
8295265: Refactor handling of special values passed to stubs

### DIFF
--- a/src/hotspot/cpu/aarch64/downcallLinker_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/downcallLinker_aarch64.cpp
@@ -215,10 +215,10 @@ void DowncallStubGenerator::generate() {
     int offset = 0;
     for (int i = 0; i < _output_registers.length(); i++) {
       VMStorage reg = _output_registers.at(i);
-      if (reg.type() == RegType::INTEGER) {
+      if (reg.type() == StorageType::INTEGER) {
         __ str(as_Register(reg), Address(tmp1, offset));
         offset += 8;
-      } else if(reg.type() == RegType::VECTOR) {
+      } else if(reg.type() == StorageType::VECTOR) {
         __ strd(as_FloatRegister(reg), Address(tmp1, offset));
         offset += 16;
       } else {

--- a/src/hotspot/cpu/aarch64/downcallLinker_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/downcallLinker_aarch64.cpp
@@ -96,11 +96,9 @@ RuntimeStub* DowncallLinker::make_downcall_stub(BasicType* signature,
                                                 const GrowableArray<VMStorage>& input_registers,
                                                 const GrowableArray<VMStorage>& output_registers,
                                                 bool needs_return_buffer) {
-  int locs_size = 64;
+  int locs_size  = 64;
   CodeBuffer code("nep_invoker_blob", native_invoker_code_size, locs_size);
-  DowncallStubGenerator g(&code, signature, num_args, ret_bt, abi,
-                          input_registers, output_registers,
-                          needs_return_buffer);
+  DowncallStubGenerator g(&code, signature, num_args, ret_bt, abi, input_registers, output_registers, needs_return_buffer);
   g.generate();
   code.log_section_sizes("nep_invoker_blob");
 

--- a/src/hotspot/cpu/aarch64/foreignGlobals_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/foreignGlobals_aarch64.cpp
@@ -48,16 +48,16 @@ const ABIDescriptor ForeignGlobals::parse_abi_descriptor(jobject jabi) {
   ABIDescriptor abi;
 
   objArrayOop inputStorage = jdk_internal_foreign_abi_ABIDescriptor::inputStorage(abi_oop);
-  parse_register_array(inputStorage, (int) RegType::INTEGER, abi._integer_argument_registers, as_Register);
-  parse_register_array(inputStorage, (int) RegType::VECTOR, abi._vector_argument_registers, as_FloatRegister);
+  parse_register_array(inputStorage, (int) StorageType::INTEGER, abi._integer_argument_registers, as_Register);
+  parse_register_array(inputStorage, (int) StorageType::VECTOR, abi._vector_argument_registers, as_FloatRegister);
 
   objArrayOop outputStorage = jdk_internal_foreign_abi_ABIDescriptor::outputStorage(abi_oop);
-  parse_register_array(outputStorage, (int) RegType::INTEGER, abi._integer_return_registers, as_Register);
-  parse_register_array(outputStorage, (int) RegType::VECTOR, abi._vector_return_registers, as_FloatRegister);
+  parse_register_array(outputStorage, (int) StorageType::INTEGER, abi._integer_return_registers, as_Register);
+  parse_register_array(outputStorage, (int) StorageType::VECTOR, abi._vector_return_registers, as_FloatRegister);
 
   objArrayOop volatileStorage = jdk_internal_foreign_abi_ABIDescriptor::volatileStorage(abi_oop);
-  parse_register_array(volatileStorage, (int) RegType::INTEGER, abi._integer_additional_volatile_registers, as_Register);
-  parse_register_array(volatileStorage, (int) RegType::VECTOR, abi._vector_additional_volatile_registers, as_FloatRegister);
+  parse_register_array(volatileStorage, (int) StorageType::INTEGER, abi._integer_additional_volatile_registers, as_Register);
+  parse_register_array(volatileStorage, (int) StorageType::VECTOR, abi._vector_additional_volatile_registers, as_FloatRegister);
 
   abi._stack_alignment_bytes = jdk_internal_foreign_abi_ABIDescriptor::stackAlignment(abi_oop);
   abi._shadow_space_bytes = jdk_internal_foreign_abi_ABIDescriptor::shadowSpace(abi_oop);
@@ -69,18 +69,18 @@ const ABIDescriptor ForeignGlobals::parse_abi_descriptor(jobject jabi) {
 }
 
 int RegSpiller::pd_reg_size(VMStorage reg) {
-  if (reg.type() == RegType::INTEGER) {
+  if (reg.type() == StorageType::INTEGER) {
     return 8;
-  } else if (reg.type() == RegType::VECTOR) {
+  } else if (reg.type() == StorageType::VECTOR) {
     return 16;   // Always spill/unspill Q registers
   }
   return 0; // stack and BAD
 }
 
 void RegSpiller::pd_store_reg(MacroAssembler* masm, int offset, VMStorage reg) {
-  if (reg.type() == RegType::INTEGER) {
+  if (reg.type() == StorageType::INTEGER) {
     masm->spill(as_Register(reg), true, offset);
-  } else if (reg.type() == RegType::VECTOR) {
+  } else if (reg.type() == StorageType::VECTOR) {
     masm->spill(as_FloatRegister(reg), masm->Q, offset);
   } else {
     // stack and BAD
@@ -88,9 +88,9 @@ void RegSpiller::pd_store_reg(MacroAssembler* masm, int offset, VMStorage reg) {
 }
 
 void RegSpiller::pd_load_reg(MacroAssembler* masm, int offset, VMStorage reg) {
-  if (reg.type() == RegType::INTEGER) {
+  if (reg.type() == StorageType::INTEGER) {
     masm->unspill(as_Register(reg), true, offset);
-  } else if (reg.type() == RegType::VECTOR) {
+  } else if (reg.type() == StorageType::VECTOR) {
     masm->unspill(as_FloatRegister(reg), masm->Q, offset);
   } else {
     // stack and BAD
@@ -102,11 +102,11 @@ static constexpr int RFP_BIAS = 16; // skip old rfp and lr
 static void move_reg64(MacroAssembler* masm, int out_stk_bias,
                        Register from_reg, VMStorage to_reg) {
   switch (to_reg.type()) {
-    case RegType::INTEGER:
+    case StorageType::INTEGER:
       assert(to_reg.segment_mask() == REG64_MASK, "only moves to 64-bit registers supported");
       masm->mov(as_Register(to_reg), from_reg);
       break;
-    case RegType::STACK:
+    case StorageType::STACK:
       switch (to_reg.stack_size()) {
         // FIXME use correctly sized stores
         case 8: case 4: case 2: case 1:
@@ -122,7 +122,7 @@ static void move_reg64(MacroAssembler* masm, int out_stk_bias,
 static void move_stack(MacroAssembler* masm, Register tmp_reg, int in_stk_bias, int out_stk_bias,
                        VMStorage from_reg, VMStorage to_reg) {
   switch (to_reg.type()) {
-    case RegType::INTEGER:
+    case StorageType::INTEGER:
       assert(to_reg.segment_mask() == REG64_MASK, "only moves to 64-bit registers supported");
       switch (from_reg.stack_size()) {
         // FIXME use correctly sized loads
@@ -132,7 +132,7 @@ static void move_stack(MacroAssembler* masm, Register tmp_reg, int in_stk_bias, 
         default: ShouldNotReachHere();
       }
       break;
-    case RegType::VECTOR:
+    case StorageType::VECTOR:
       assert(to_reg.segment_mask() == V128_MASK, "only moves to v128 registers supported");
       switch (from_reg.stack_size()) {
         case 8:
@@ -144,7 +144,7 @@ static void move_stack(MacroAssembler* masm, Register tmp_reg, int in_stk_bias, 
         default: ShouldNotReachHere();
       }
       break;
-    case RegType::STACK:
+    case StorageType::STACK:
       // We assume 8 bytes stack size when converting from VMReg (Java CC)
       //assert(from_reg.stack_size() == to_reg.stack_size(), "must be same");
       switch (from_reg.stack_size()) {
@@ -163,11 +163,11 @@ static void move_stack(MacroAssembler* masm, Register tmp_reg, int in_stk_bias, 
 static void move_v128(MacroAssembler* masm, int out_stk_bias,
                       FloatRegister from_reg, VMStorage to_reg) {
   switch (to_reg.type()) {
-    case RegType::VECTOR:
+    case StorageType::VECTOR:
       assert(to_reg.segment_mask() == V128_MASK, "only moves to v128 registers supported");
       masm->fmovd(as_FloatRegister(to_reg), from_reg);
       break;
-    case RegType::STACK:
+    case StorageType::STACK:
       switch(to_reg.stack_size()) {
         case 8:
           masm->strd(from_reg, Address(sp, to_reg.offset() + out_stk_bias));
@@ -190,15 +190,15 @@ void ArgumentShuffle::pd_generate(MacroAssembler* masm, VMStorage tmp, int in_st
     VMStorage to_reg   = move.to;
 
     switch (from_reg.type()) {
-      case RegType::INTEGER:
+      case StorageType::INTEGER:
         assert(from_reg.segment_mask() == REG64_MASK, "only 64-bit register supported");
         move_reg64(masm, out_stk_bias, as_Register(from_reg), to_reg);
         break;
-      case RegType::VECTOR:
+      case StorageType::VECTOR:
         assert(from_reg.segment_mask() == V128_MASK, "only v128 register supported");
         move_v128(masm, out_stk_bias, as_FloatRegister(from_reg), to_reg);
         break;
-      case RegType::STACK:
+      case StorageType::STACK:
         move_stack(masm, tmp_reg, in_stk_bias, out_stk_bias, from_reg, to_reg);
         break;
       default: ShouldNotReachHere();

--- a/src/hotspot/cpu/aarch64/foreignGlobals_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/foreignGlobals_aarch64.cpp
@@ -116,13 +116,8 @@ static void move_reg64(MacroAssembler* masm, int out_stk_bias,
       }
       break;
     case StorageType::FRAME_DATA:
-      switch (to_reg.stack_size()) {
-        // FIXME use correctly sized stores
-        case 8: case 4: case 2: case 1:
-          masm->str(from_reg, Address(sp, to_reg.offset()));
-        break;
-        default: ShouldNotReachHere();
-      }
+      assert(to_reg.stack_size() == 8, "only moves with 64-bit targets supported");
+      masm->str(from_reg, Address(sp, to_reg.offset()));
       break;
     default: ShouldNotReachHere();
   }
@@ -167,14 +162,9 @@ static void move_stack(MacroAssembler* masm, Register tmp_reg, int in_stk_bias, 
       }
       break;
     case StorageType::FRAME_DATA:
-      switch (to_reg.stack_size()) {
-        // FIXME use correctly sized stores
-        case 8: case 4: case 2: case 1:
-          masm->ldr(tmp_reg, from_addr);
-          masm->str(tmp_reg, Address(sp, to_reg.offset()));
-        break;
-        default: ShouldNotReachHere();
-      }
+      assert(to_reg.stack_size() == 8, "only moves with 64-bit targets supported");
+      masm->ldr(tmp_reg, from_addr);
+      masm->str(tmp_reg, Address(sp, to_reg.offset()));
       break;
     default: ShouldNotReachHere();
   }

--- a/src/hotspot/cpu/aarch64/foreignGlobals_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/foreignGlobals_aarch64.hpp
@@ -42,8 +42,8 @@ struct ABIDescriptor {
   int32_t _stack_alignment_bytes;
   int32_t _shadow_space_bytes;
 
-  Register _target_addr_reg;
-  Register _ret_buf_addr_reg;
+  VMStorage _scratch1;
+  VMStorage _scratch2;
 
   bool is_volatile_reg(Register reg) const;
   bool is_volatile_reg(FloatRegister reg) const;

--- a/src/hotspot/cpu/aarch64/upcallLinker_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/upcallLinker_aarch64.cpp
@@ -159,10 +159,14 @@ address UpcallLinker::make_upcall_stub(jobject receiver, Method* entry,
   int frame_data_offset      = reg_save_area_offset   + reg_save_area_size;
   int frame_bottom_offset    = frame_data_offset      + sizeof(UpcallStub::FrameData);
 
+  StubLocations locs;
   int ret_buf_offset = -1;
   if (needs_return_buffer) {
     ret_buf_offset = frame_bottom_offset;
     frame_bottom_offset += ret_buf_size;
+    // use a free register for shuffling code to pick up return
+    // buffer address from
+    locs.set(StubLocations::RETURN_BUFFER, abi._scratch1);
   }
 
   int frame_size = frame_bottom_offset;
@@ -219,9 +223,9 @@ address UpcallLinker::make_upcall_stub(jobject receiver, Method* entry,
   arg_spilller.generate_fill(_masm, arg_save_area_offset);
   if (needs_return_buffer) {
     assert(ret_buf_offset != -1, "no return buffer allocated");
-    __ lea(abi._ret_buf_addr_reg, Address(sp, ret_buf_offset));
+    __ lea(as_Register(locs.get(StubLocations::RETURN_BUFFER)), Address(sp, ret_buf_offset));
   }
-  arg_shuffle.generate(_masm, as_VMStorage(shuffle_reg), abi._shadow_space_bytes, 0);
+  arg_shuffle.generate(_masm, as_VMStorage(shuffle_reg), abi._shadow_space_bytes, 0, locs);
   __ block_comment("} argument shuffle");
 
   __ block_comment("{ receiver ");

--- a/src/hotspot/cpu/aarch64/upcallLinker_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/upcallLinker_aarch64.cpp
@@ -268,10 +268,10 @@ address UpcallLinker::make_upcall_stub(jobject receiver, Method* entry,
     int offset = 0;
     for (int i = 0; i < call_regs._ret_regs.length(); i++) {
       VMStorage reg = call_regs._ret_regs.at(i);
-      if (reg.type() == RegType::INTEGER) {
+      if (reg.type() == StorageType::INTEGER) {
         __ ldr(as_Register(reg), Address(rscratch1, offset));
         offset += 8;
-      } else if (reg.type() == RegType::VECTOR) {
+      } else if (reg.type() == StorageType::VECTOR) {
         __ ldrd(as_FloatRegister(reg), Address(rscratch1, offset));
         offset += 16; // needs to match VECTOR_REG_SIZE in AArch64Architecture (Java)
       } else {

--- a/src/hotspot/cpu/aarch64/vmstorage_aarch64.inline.hpp
+++ b/src/hotspot/cpu/aarch64/vmstorage_aarch64.inline.hpp
@@ -34,11 +34,19 @@ enum class StorageType : int8_t {
   INTEGER = 0,
   VECTOR = 1,
   STACK = 2,
+  PLACEHOLDER = 3,
+// special locations used only by native code
+  FRAME_DATA = PLACEHOLDER + 1,
+  INVALID = -1
 };
 
-constexpr inline StorageType VMStorage::stack_type() {
-  return StorageType::STACK;
+// need to define this before constructing VMStorage (below)
+constexpr inline bool VMStorage::is_reg(StorageType type) {
+   return type == StorageType::INTEGER || type == StorageType::VECTOR;
 }
+constexpr inline StorageType VMStorage::stack_type() { return StorageType::STACK; }
+constexpr inline StorageType VMStorage::placeholder_type() { return StorageType::PLACEHOLDER; }
+constexpr inline StorageType VMStorage::frame_data_type() { return StorageType::FRAME_DATA; }
 
 constexpr uint16_t REG64_MASK = 0b0000000000000001;
 constexpr uint16_t V128_MASK  = 0b0000000000000001;

--- a/src/hotspot/cpu/aarch64/vmstorage_aarch64.inline.hpp
+++ b/src/hotspot/cpu/aarch64/vmstorage_aarch64.inline.hpp
@@ -30,39 +30,39 @@
 #include "prims/vmstorageBase.inline.hpp"
 
 // keep in sync with jdk/internal/foreign/abi/aarch64/AArch64Architecture
-enum class RegType : int8_t {
+enum class StorageType : int8_t {
   INTEGER = 0,
   VECTOR = 1,
   STACK = 2,
 };
 
-constexpr inline RegType VMStorage::stack_type() {
-  return RegType::STACK;
+constexpr inline StorageType VMStorage::stack_type() {
+  return StorageType::STACK;
 }
 
 constexpr uint16_t REG64_MASK = 0b0000000000000001;
 constexpr uint16_t V128_MASK  = 0b0000000000000001;
 
-constexpr VMStorage VMS_R0 = VMStorage::reg_storage(RegType::INTEGER, REG64_MASK, 0);
-constexpr VMStorage VMS_R19 = VMStorage::reg_storage(RegType::INTEGER, REG64_MASK, 19);
-constexpr VMStorage VMS_V0 = VMStorage::reg_storage(RegType::VECTOR, V128_MASK, 0);
+constexpr VMStorage VMS_R0 = VMStorage::reg_storage(StorageType::INTEGER, REG64_MASK, 0);
+constexpr VMStorage VMS_R19 = VMStorage::reg_storage(StorageType::INTEGER, REG64_MASK, 19);
+constexpr VMStorage VMS_V0 = VMStorage::reg_storage(StorageType::VECTOR, V128_MASK, 0);
 
 inline Register as_Register(VMStorage vms) {
-  assert(vms.type() == RegType::INTEGER, "not the right type");
+  assert(vms.type() == StorageType::INTEGER, "not the right type");
   return ::as_Register(vms.index());
 }
 
 inline FloatRegister as_FloatRegister(VMStorage vms) {
-  assert(vms.type() == RegType::VECTOR, "not the right type");
+  assert(vms.type() == StorageType::VECTOR, "not the right type");
   return ::as_FloatRegister(vms.index());
 }
 
 inline VMStorage as_VMStorage(Register reg) {
-  return VMStorage::reg_storage(RegType::INTEGER, REG64_MASK, reg->encoding());
+  return VMStorage::reg_storage(StorageType::INTEGER, REG64_MASK, reg->encoding());
 }
 
 inline VMStorage as_VMStorage(FloatRegister reg) {
-  return VMStorage::reg_storage(RegType::VECTOR, V128_MASK, reg->encoding());
+  return VMStorage::reg_storage(StorageType::VECTOR, V128_MASK, reg->encoding());
 }
 
 inline VMStorage as_VMStorage(VMReg reg) {

--- a/src/hotspot/cpu/arm/foreignGlobals_arm.cpp
+++ b/src/hotspot/cpu/arm/foreignGlobals_arm.cpp
@@ -46,6 +46,6 @@ void RegSpiller::pd_load_reg(MacroAssembler* masm, int offset, VMStorage reg) {
   Unimplemented();
 }
 
-void ArgumentShuffle::pd_generate(MacroAssembler* masm, VMStorage tmp, int in_stk_bias, int out_stk_bias) const {
+void ArgumentShuffle::pd_generate(MacroAssembler* masm, VMStorage tmp, int in_stk_bias, int out_stk_bias, const StubLocations& locs) const {
   Unimplemented();
 }

--- a/src/hotspot/cpu/arm/vmstorage_arm.inline.hpp
+++ b/src/hotspot/cpu/arm/vmstorage_arm.inline.hpp
@@ -29,12 +29,12 @@
 #include "asm/register.hpp"
 #include "prims/vmstorageBase.inline.hpp"
 
-enum class RegType : int8_t {
+enum class StorageType : int8_t {
   STACK = 0
 };
 
-constexpr inline RegType VMStorage::stack_type() {
-  return RegType::STACK;
+constexpr inline StorageType VMStorage::stack_type() {
+  return StorageType::STACK;
 }
 
 inline VMStorage as_VMStorage(VMReg reg) {

--- a/src/hotspot/cpu/arm/vmstorage_arm.inline.hpp
+++ b/src/hotspot/cpu/arm/vmstorage_arm.inline.hpp
@@ -30,12 +30,20 @@
 #include "prims/vmstorageBase.inline.hpp"
 
 enum class StorageType : int8_t {
-  STACK = 0
+  STACK = 0,
+  PLACEHOLDER = 1,
+// special locations used only by native code
+  FRAME_DATA = PLACEHOLDER + 1,
+  INVALID = -1
 };
 
-constexpr inline StorageType VMStorage::stack_type() {
-  return StorageType::STACK;
+// need to define this before constructing VMStorage (below)
+constexpr inline bool VMStorage::is_reg(StorageType type) {
+   return false;
 }
+constexpr inline StorageType VMStorage::stack_type() { return StorageType::STACK; }
+constexpr inline StorageType VMStorage::placeholder_type() { return StorageType::PLACEHOLDER; }
+constexpr inline StorageType VMStorage::frame_data_type() { return StorageType::FRAME_DATA; }
 
 inline VMStorage as_VMStorage(VMReg reg) {
   ShouldNotReachHere();

--- a/src/hotspot/cpu/ppc/foreignGlobals_ppc.cpp
+++ b/src/hotspot/cpu/ppc/foreignGlobals_ppc.cpp
@@ -48,6 +48,6 @@ void RegSpiller::pd_load_reg(MacroAssembler* masm, int offset, VMStorage reg) {
   Unimplemented();
 }
 
-void ArgumentShuffle::pd_generate(MacroAssembler* masm, VMStorage tmp, int in_stk_bias, int out_stk_bias) const {
+void ArgumentShuffle::pd_generate(MacroAssembler* masm, VMStorage tmp, int in_stk_bias, int out_stk_bias, const StubLocations& locs) const {
   Unimplemented();
 }

--- a/src/hotspot/cpu/ppc/vmstorage_ppc.inline.hpp
+++ b/src/hotspot/cpu/ppc/vmstorage_ppc.inline.hpp
@@ -29,12 +29,12 @@
 #include "asm/register.hpp"
 #include "prims/vmstorageBase.inline.hpp"
 
-enum class RegType : int8_t {
+enum class StorageType : int8_t {
   STACK = 0
 };
 
-constexpr inline RegType VMStorage::stack_type() {
-  return RegType::STACK;
+constexpr inline StorageType VMStorage::stack_type() {
+  return StorageType::STACK;
 }
 
 inline VMStorage as_VMStorage(VMReg reg) {

--- a/src/hotspot/cpu/ppc/vmstorage_ppc.inline.hpp
+++ b/src/hotspot/cpu/ppc/vmstorage_ppc.inline.hpp
@@ -30,12 +30,20 @@
 #include "prims/vmstorageBase.inline.hpp"
 
 enum class StorageType : int8_t {
-  STACK = 0
+  STACK = 0,
+  PLACEHOLDER = 1,
+// special locations used only by native code
+  FRAME_DATA = PLACEHOLDER + 1,
+  INVALID = -1
 };
 
-constexpr inline StorageType VMStorage::stack_type() {
-  return StorageType::STACK;
+// need to define this before constructing VMStorage (below)
+constexpr inline bool VMStorage::is_reg(StorageType type) {
+   return false;
 }
+constexpr inline StorageType VMStorage::stack_type() { return StorageType::STACK; }
+constexpr inline StorageType VMStorage::placeholder_type() { return StorageType::PLACEHOLDER; }
+constexpr inline StorageType VMStorage::frame_data_type() { return StorageType::FRAME_DATA; }
 
 inline VMStorage as_VMStorage(VMReg reg) {
   ShouldNotReachHere();

--- a/src/hotspot/cpu/riscv/foreignGlobals_riscv.cpp
+++ b/src/hotspot/cpu/riscv/foreignGlobals_riscv.cpp
@@ -48,6 +48,6 @@ void RegSpiller::pd_load_reg(MacroAssembler* masm, int offset, VMStorage reg) {
   Unimplemented();
 }
 
-void ArgumentShuffle::pd_generate(MacroAssembler* masm, VMStorage tmp, int in_stk_bias, int out_stk_bias) const {
+void ArgumentShuffle::pd_generate(MacroAssembler* masm, VMStorage tmp, int in_stk_bias, int out_stk_bias, const StubLocations& locs) const {
   Unimplemented();
 }

--- a/src/hotspot/cpu/riscv/vmstorage_riscv.inline.hpp
+++ b/src/hotspot/cpu/riscv/vmstorage_riscv.inline.hpp
@@ -30,12 +30,20 @@
 #include "prims/vmstorageBase.inline.hpp"
 
 enum class StorageType : int8_t {
-  STACK = 0
+  STACK = 0,
+  PLACEHOLDER = 1,
+// special locations used only by native code
+  FRAME_DATA = PLACEHOLDER + 1,
+  INVALID = -1
 };
 
-constexpr inline StorageType VMStorage::stack_type() {
-  return StorageType::STACK;
+// need to define this before constructing VMStorage (below)
+constexpr inline bool VMStorage::is_reg(StorageType type) {
+   return false;
 }
+constexpr inline StorageType VMStorage::stack_type() { return StorageType::STACK; }
+constexpr inline StorageType VMStorage::placeholder_type() { return StorageType::PLACEHOLDER; }
+constexpr inline StorageType VMStorage::frame_data_type() { return StorageType::FRAME_DATA; }
 
 inline VMStorage as_VMStorage(VMReg reg) {
   ShouldNotReachHere();

--- a/src/hotspot/cpu/s390/foreignGlobals_s390.cpp
+++ b/src/hotspot/cpu/s390/foreignGlobals_s390.cpp
@@ -46,6 +46,6 @@ void RegSpiller::pd_load_reg(MacroAssembler* masm, int offset, VMStorage reg) {
   Unimplemented();
 }
 
-void ArgumentShuffle::pd_generate(MacroAssembler* masm, VMStorage tmp, int in_stk_bias, int out_stk_bias) const {
+void ArgumentShuffle::pd_generate(MacroAssembler* masm, VMStorage tmp, int in_stk_bias, int out_stk_bias, const StubLocations& locs) const {
   Unimplemented();
 }

--- a/src/hotspot/cpu/s390/vmstorage_s390.inline.hpp
+++ b/src/hotspot/cpu/s390/vmstorage_s390.inline.hpp
@@ -29,12 +29,12 @@
 #include "asm/register.hpp"
 #include "prims/vmstorageBase.inline.hpp"
 
-enum class RegType : int8_t {
+enum class StorageType : int8_t {
   STACK = 0
 };
 
-constexpr inline RegType VMStorage::stack_type() {
-  return RegType::STACK;
+constexpr inline StorageType VMStorage::stack_type() {
+  return StorageType::STACK;
 }
 
 inline VMStorage as_VMStorage(VMReg reg) {

--- a/src/hotspot/cpu/s390/vmstorage_s390.inline.hpp
+++ b/src/hotspot/cpu/s390/vmstorage_s390.inline.hpp
@@ -30,12 +30,20 @@
 #include "prims/vmstorageBase.inline.hpp"
 
 enum class StorageType : int8_t {
-  STACK = 0
+  STACK = 0,
+  PLACEHOLDER = 1,
+// special locations used only by native code
+  FRAME_DATA = PLACEHOLDER + 1,
+  INVALID = -1
 };
 
-constexpr inline StorageType VMStorage::stack_type() {
-  return StorageType::STACK;
+// need to define this before constructing VMStorage (below)
+constexpr inline bool VMStorage::is_reg(StorageType type) {
+   return false;
 }
+constexpr inline StorageType VMStorage::stack_type() { return StorageType::STACK; }
+constexpr inline StorageType VMStorage::placeholder_type() { return StorageType::PLACEHOLDER; }
+constexpr inline StorageType VMStorage::frame_data_type() { return StorageType::FRAME_DATA; }
 
 inline VMStorage as_VMStorage(VMReg reg) {
   ShouldNotReachHere();

--- a/src/hotspot/cpu/x86/downcallLinker_x86_64.cpp
+++ b/src/hotspot/cpu/x86/downcallLinker_x86_64.cpp
@@ -222,8 +222,6 @@ void DowncallStubGenerator::generate() {
     }
   }
 
-  //////////////////////////////////////////////////////////////////////////////
-
   __ block_comment("{ thread native2java");
   __ restore_cpu_control_state_after_jni(rscratch1);
 

--- a/src/hotspot/cpu/x86/downcallLinker_x86_64.cpp
+++ b/src/hotspot/cpu/x86/downcallLinker_x86_64.cpp
@@ -95,9 +95,11 @@ RuntimeStub* DowncallLinker::make_downcall_stub(BasicType* signature,
                                                 const GrowableArray<VMStorage>& input_registers,
                                                 const GrowableArray<VMStorage>& output_registers,
                                                 bool needs_return_buffer) {
-  int locs_size  = 64;
+  int locs_size = 64;
   CodeBuffer code("nep_invoker_blob", native_invoker_code_size, locs_size);
-  DowncallStubGenerator g(&code, signature, num_args, ret_bt, abi, input_registers, output_registers, needs_return_buffer);
+  DowncallStubGenerator g(&code, signature, num_args, ret_bt, abi,
+                          input_registers, output_registers,
+                          needs_return_buffer);
   g.generate();
   code.log_section_sizes("nep_invoker_blob");
 
@@ -149,24 +151,22 @@ void DowncallStubGenerator::generate() {
 
   // in bytes
   int allocated_frame_size = 0;
-  if (_needs_return_buffer) {
-    allocated_frame_size += 8; // store address
-  }
-  allocated_frame_size += arg_shuffle.out_arg_bytes();
   allocated_frame_size += _abi._shadow_space_bytes;
+  allocated_frame_size += arg_shuffle.out_arg_bytes();
 
-  int ret_buf_addr_rsp_offset = -1;
+  StubLocations locs;
+  locs.set(StubLocations::TARGET_ADDRESS, _abi._scratch1);
   if (_needs_return_buffer) {
-    // the above
-    ret_buf_addr_rsp_offset = allocated_frame_size - 8;
+    locs.set_frame_data(StubLocations::RETURN_BUFFER, allocated_frame_size);
+    allocated_frame_size += 8;
   }
 
-  // when we don't use a return buffer we need to spill the return value around our slowpath calls
-  // when we use a return buffer case this SHOULD be unused.
+  // when we don't use a return buffer we need to spill the return value around our slow path calls
+  bool should_save_return_value = !_needs_return_buffer;
   RegSpiller out_reg_spiller(_output_registers);
   int spill_rsp_offset = -1;
 
-  if (!_needs_return_buffer) {
+  if (should_save_return_value) {
     spill_rsp_offset = 0;
     // spill area can be shared with the above, so we take the max of the 2
     allocated_frame_size = out_reg_spiller.spill_size_bytes() > allocated_frame_size
@@ -199,27 +199,21 @@ void DowncallStubGenerator::generate() {
   __ block_comment("} thread java2native");
 
   __ block_comment("{ argument shuffle");
-  arg_shuffle.generate(_masm, shuffle_reg, 0, _abi._shadow_space_bytes);
-  if (_needs_return_buffer) {
-    // spill our return buffer address
-    assert(ret_buf_addr_rsp_offset != -1, "no return buffer addr spill");
-    __ movptr(Address(rsp, ret_buf_addr_rsp_offset), _abi._ret_buf_addr_reg);
-  }
+  arg_shuffle.generate(_masm, shuffle_reg, 0, _abi._shadow_space_bytes, locs);
   __ block_comment("} argument shuffle");
 
-  __ call(_abi._target_addr_reg);
+  __ call(as_Register(locs.get(StubLocations::TARGET_ADDRESS)));
   // this call is assumed not to have killed r15_thread
 
   if (_needs_return_buffer) {
-    assert(ret_buf_addr_rsp_offset != -1, "no return buffer addr spill");
-    __ movptr(rscratch1, Address(rsp, ret_buf_addr_rsp_offset));
+    __ movptr(rscratch1, Address(rsp, locs.data_offset(StubLocations::RETURN_BUFFER)));
     int offset = 0;
     for (int i = 0; i < _output_registers.length(); i++) {
       VMStorage reg = _output_registers.at(i);
-      if (reg.type() == RegType::INTEGER) {
+      if (reg.type() == StorageType::INTEGER) {
         __ movptr(Address(rscratch1, offset), as_Register(reg));
         offset += 8;
-      } else if (reg.type() == RegType::VECTOR) {
+      } else if (reg.type() == StorageType::VECTOR) {
         __ movdqu(Address(rscratch1, offset), as_XMMRegister(reg));
         offset += 16;
       } else {
@@ -227,6 +221,8 @@ void DowncallStubGenerator::generate() {
       }
     }
   }
+
+  //////////////////////////////////////////////////////////////////////////////
 
   __ block_comment("{ thread native2java");
   __ restore_cpu_control_state_after_jni(rscratch1);
@@ -271,7 +267,7 @@ void DowncallStubGenerator::generate() {
   __ bind(L_safepoint_poll_slow_path);
   __ vzeroupper();
 
-  if(!_needs_return_buffer) {
+  if(should_save_return_value) {
     out_reg_spiller.generate_spill(_masm, spill_rsp_offset);
   }
 
@@ -283,7 +279,7 @@ void DowncallStubGenerator::generate() {
   __ mov(rsp, r12); // restore sp
   __ reinit_heapbase();
 
-  if(!_needs_return_buffer) {
+  if(should_save_return_value) {
     out_reg_spiller.generate_fill(_masm, spill_rsp_offset);
   }
 
@@ -296,7 +292,7 @@ void DowncallStubGenerator::generate() {
   __ bind(L_reguard);
   __ vzeroupper();
 
-  if(!_needs_return_buffer) {
+  if(should_save_return_value) {
     out_reg_spiller.generate_spill(_masm, spill_rsp_offset);
   }
 
@@ -307,7 +303,7 @@ void DowncallStubGenerator::generate() {
   __ mov(rsp, r12); // restore sp
   __ reinit_heapbase();
 
-  if(!_needs_return_buffer) {
+  if(should_save_return_value) {
     out_reg_spiller.generate_fill(_masm, spill_rsp_offset);
   }
 

--- a/src/hotspot/cpu/x86/downcallLinker_x86_64.cpp
+++ b/src/hotspot/cpu/x86/downcallLinker_x86_64.cpp
@@ -95,11 +95,9 @@ RuntimeStub* DowncallLinker::make_downcall_stub(BasicType* signature,
                                                 const GrowableArray<VMStorage>& input_registers,
                                                 const GrowableArray<VMStorage>& output_registers,
                                                 bool needs_return_buffer) {
-  int locs_size = 64;
+  int locs_size  = 64;
   CodeBuffer code("nep_invoker_blob", native_invoker_code_size, locs_size);
-  DowncallStubGenerator g(&code, signature, num_args, ret_bt, abi,
-                          input_registers, output_registers,
-                          needs_return_buffer);
+  DowncallStubGenerator g(&code, signature, num_args, ret_bt, abi, input_registers, output_registers, needs_return_buffer);
   g.generate();
   code.log_section_sizes("nep_invoker_blob");
 

--- a/src/hotspot/cpu/x86/foreignGlobals_x86.hpp
+++ b/src/hotspot/cpu/x86/foreignGlobals_x86.hpp
@@ -40,8 +40,8 @@ struct ABIDescriptor {
   int32_t _stack_alignment_bytes;
   int32_t _shadow_space_bytes;
 
-  Register _target_addr_reg;
-  Register _ret_buf_addr_reg;
+  VMStorage _scratch1;
+  VMStorage _scratch2;
 
   bool is_volatile_reg(Register reg) const;
   bool is_volatile_reg(XMMRegister reg) const;

--- a/src/hotspot/cpu/x86/foreignGlobals_x86_32.cpp
+++ b/src/hotspot/cpu/x86/foreignGlobals_x86_32.cpp
@@ -46,6 +46,6 @@ void RegSpiller::pd_load_reg(MacroAssembler* masm, int offset, VMStorage reg) {
   Unimplemented();
 }
 
-void ArgumentShuffle::pd_generate(MacroAssembler* masm, VMStorage tmp, int in_stk_bias, int out_stk_bias) const {
+void ArgumentShuffle::pd_generate(MacroAssembler* masm, VMStorage tmp, int in_stk_bias, int out_stk_bias, const StubLocations& locs) const {
   Unimplemented();
 }

--- a/src/hotspot/cpu/x86/foreignGlobals_x86_64.cpp
+++ b/src/hotspot/cpu/x86/foreignGlobals_x86_64.cpp
@@ -45,41 +45,41 @@ const ABIDescriptor ForeignGlobals::parse_abi_descriptor(jobject jabi) {
   ABIDescriptor abi;
 
   objArrayOop inputStorage = jdk_internal_foreign_abi_ABIDescriptor::inputStorage(abi_oop);
-  parse_register_array(inputStorage, (int) RegType::INTEGER, abi._integer_argument_registers, as_Register);
-  parse_register_array(inputStorage, (int) RegType::VECTOR, abi._vector_argument_registers, as_XMMRegister);
+  parse_register_array(inputStorage, (int) StorageType::INTEGER, abi._integer_argument_registers, as_Register);
+  parse_register_array(inputStorage, (int) StorageType::VECTOR, abi._vector_argument_registers, as_XMMRegister);
 
   objArrayOop outputStorage = jdk_internal_foreign_abi_ABIDescriptor::outputStorage(abi_oop);
-  parse_register_array(outputStorage, (int) RegType::INTEGER, abi._integer_return_registers, as_Register);
-  parse_register_array(outputStorage, (int) RegType::VECTOR, abi._vector_return_registers, as_XMMRegister);
-  objArrayOop subarray = oop_cast<objArrayOop>(outputStorage->obj_at(((int) RegType::X87)));
+  parse_register_array(outputStorage, (int) StorageType::INTEGER, abi._integer_return_registers, as_Register);
+  parse_register_array(outputStorage, (int) StorageType::VECTOR, abi._vector_return_registers, as_XMMRegister);
+  objArrayOop subarray = oop_cast<objArrayOop>(outputStorage->obj_at(((int) StorageType::X87)));
   abi._X87_return_registers_noof = subarray->length();
 
   objArrayOop volatileStorage = jdk_internal_foreign_abi_ABIDescriptor::volatileStorage(abi_oop);
-  parse_register_array(volatileStorage, (int) RegType::INTEGER, abi._integer_additional_volatile_registers, as_Register);
-  parse_register_array(volatileStorage, (int) RegType::VECTOR, abi._vector_additional_volatile_registers, as_XMMRegister);
+  parse_register_array(volatileStorage, (int) StorageType::INTEGER, abi._integer_additional_volatile_registers, as_Register);
+  parse_register_array(volatileStorage, (int) StorageType::VECTOR, abi._vector_additional_volatile_registers, as_XMMRegister);
 
   abi._stack_alignment_bytes = jdk_internal_foreign_abi_ABIDescriptor::stackAlignment(abi_oop);
   abi._shadow_space_bytes = jdk_internal_foreign_abi_ABIDescriptor::shadowSpace(abi_oop);
 
-  abi._target_addr_reg = as_Register(parse_vmstorage(jdk_internal_foreign_abi_ABIDescriptor::targetAddrStorage(abi_oop)));
-  abi._ret_buf_addr_reg = as_Register(parse_vmstorage(jdk_internal_foreign_abi_ABIDescriptor::retBufAddrStorage(abi_oop)));
+  abi._scratch1 = parse_vmstorage(jdk_internal_foreign_abi_ABIDescriptor::scratch1(abi_oop));
+  abi._scratch2 = parse_vmstorage(jdk_internal_foreign_abi_ABIDescriptor::scratch2(abi_oop));
 
   return abi;
 }
 
 int RegSpiller::pd_reg_size(VMStorage reg) {
-  if (reg.type() == RegType::INTEGER) {
+  if (reg.type() == StorageType::INTEGER) {
     return 8;
-  } else if (reg.type() == RegType::VECTOR) {
+  } else if (reg.type() == StorageType::VECTOR) {
     return 16;
   }
   return 0; // stack and BAD
 }
 
 void RegSpiller::pd_store_reg(MacroAssembler* masm, int offset, VMStorage reg) {
-  if (reg.type() == RegType::INTEGER) {
+  if (reg.type() == StorageType::INTEGER) {
     masm->movptr(Address(rsp, offset), as_Register(reg));
-  } else if (reg.type() == RegType::VECTOR) {
+  } else if (reg.type() == StorageType::VECTOR) {
     masm->movdqu(Address(rsp, offset), as_XMMRegister(reg));
   } else {
     // stack and BAD
@@ -87,9 +87,9 @@ void RegSpiller::pd_store_reg(MacroAssembler* masm, int offset, VMStorage reg) {
 }
 
 void RegSpiller::pd_load_reg(MacroAssembler* masm, int offset, VMStorage reg) {
-  if (reg.type() == RegType::INTEGER) {
+  if (reg.type() == StorageType::INTEGER) {
     masm->movptr(as_Register(reg), Address(rsp, offset));
-  } else if (reg.type() == RegType::VECTOR) {
+  } else if (reg.type() == StorageType::VECTOR) {
     masm->movdqu(as_XMMRegister(reg), Address(rsp, offset));
   } else {
     // stack and BAD
@@ -101,33 +101,42 @@ static constexpr int RBP_BIAS = 16; // skip old rbp and return address
 static void move_reg64(MacroAssembler* masm, int out_stk_bias,
                        Register from_reg, VMStorage to_reg) {
   switch (to_reg.type()) {
-    case RegType::INTEGER:
+    case StorageType::INTEGER:
       assert(to_reg.segment_mask() == REG64_MASK, "only moves to 64-bit registers supported");
       masm->movq(as_Register(to_reg), from_reg);
       break;
-    case RegType::STACK:
+    case StorageType::STACK:
       assert(to_reg.stack_size() == 8, "only moves with 64-bit targets supported");
       masm->movq(Address(rsp, to_reg.offset() + out_stk_bias), from_reg);
+      break;
+    case StorageType::FRAME_DATA:
+      assert(to_reg.stack_size() == 8, "only moves with 64-bit targets supported");
+      masm->movq(Address(rsp, to_reg.offset()), from_reg);
       break;
     default: ShouldNotReachHere();
   }
 }
 
-static void move_stack64(MacroAssembler* masm, Register tmp_reg, int in_stk_bias, int out_stk_bias,
-                         int from_offset, VMStorage to_reg) {
+static void move_stack64(MacroAssembler* masm, Register tmp_reg, int out_stk_bias,
+                         Address from_address, VMStorage to_reg) {
   switch (to_reg.type()) {
-    case RegType::INTEGER:
+    case StorageType::INTEGER:
       assert(to_reg.segment_mask() == REG64_MASK, "only moves to 64-bit registers supported");
-      masm->movq(as_Register(to_reg), Address(rbp, RBP_BIAS + from_offset + in_stk_bias));
+      masm->movq(as_Register(to_reg), from_address);
       break;
-    case RegType::VECTOR:
+    case StorageType::VECTOR:
       assert(to_reg.segment_mask() == XMM_MASK, "only moves to xmm registers supported");
-      masm->movdqu(as_XMMRegister(to_reg), Address(rbp, RBP_BIAS + from_offset + in_stk_bias));
+      masm->movdqu(as_XMMRegister(to_reg), from_address);
       break;
-    case RegType::STACK:
+    case StorageType::STACK:
       assert(to_reg.stack_size() == 8, "only moves with 64-bit targets supported");
-      masm->movq(tmp_reg, Address(rbp, RBP_BIAS + from_offset + in_stk_bias));
+      masm->movq(tmp_reg, from_address);
       masm->movq(Address(rsp, to_reg.offset() + out_stk_bias), tmp_reg);
+      break;
+    case StorageType::FRAME_DATA:
+      assert(to_reg.stack_size() == 8, "only moves with 64-bit targets supported");
+      masm->movq(tmp_reg, from_address);
+      masm->movq(Address(rsp, to_reg.offset()), tmp_reg);
       break;
     default: ShouldNotReachHere();
   }
@@ -136,15 +145,15 @@ static void move_stack64(MacroAssembler* masm, Register tmp_reg, int in_stk_bias
 static void move_xmm(MacroAssembler* masm, int out_stk_bias,
                      XMMRegister from_reg, VMStorage to_reg) {
   switch (to_reg.type()) {
-    case RegType::INTEGER: // windows vargarg floats
+    case StorageType::INTEGER: // windows vargarg floats
       assert(to_reg.segment_mask() == REG64_MASK, "only moves to 64-bit registers supported");
       masm->movq(as_Register(to_reg), from_reg);
       break;
-    case RegType::VECTOR:
+    case StorageType::VECTOR:
       assert(to_reg.segment_mask() == XMM_MASK, "only moves to xmm registers supported");
       masm->movdqu(as_XMMRegister(to_reg), from_reg);
       break;
-    case RegType::STACK:
+    case StorageType::STACK:
       assert(to_reg.stack_size() == 8, "only moves with 64-bit targets supported");
       masm->movq(Address(rsp, to_reg.offset() + out_stk_bias), from_reg);
       break;
@@ -152,26 +161,35 @@ static void move_xmm(MacroAssembler* masm, int out_stk_bias,
   }
 }
 
-void ArgumentShuffle::pd_generate(MacroAssembler* masm, VMStorage tmp, int in_stk_bias, int out_stk_bias) const {
+void ArgumentShuffle::pd_generate(MacroAssembler* masm, VMStorage tmp, int in_stk_bias, int out_stk_bias, const StubLocations& locs) const {
   Register tmp_reg = as_Register(tmp);
   for (int i = 0; i < _moves.length(); i++) {
     Move move = _moves.at(i);
     VMStorage from_reg = move.from;
     VMStorage to_reg   = move.to;
 
+    // replace any placeholders
+    if (from_reg.type() == StorageType::PLACEHOLDER) {
+      from_reg = locs.get(from_reg);
+    }
+    if (to_reg.type() == StorageType::PLACEHOLDER) {
+      to_reg = locs.get(to_reg);
+    }
+
     switch (from_reg.type()) {
-      case RegType::INTEGER:
+      case StorageType::INTEGER:
         assert(from_reg.segment_mask() == REG64_MASK, "only 64-bit register supported");
         move_reg64(masm, out_stk_bias, as_Register(from_reg), to_reg);
         break;
-      case RegType::VECTOR:
+      case StorageType::VECTOR:
         assert(from_reg.segment_mask() == XMM_MASK, "only xmm register supported");
         move_xmm(masm, out_stk_bias, as_XMMRegister(from_reg), to_reg);
         break;
-      case RegType::STACK:
+      case StorageType::STACK: {
         assert(from_reg.stack_size() == 8, "only stack_size 8 supported");
-        move_stack64(masm, tmp_reg, in_stk_bias, out_stk_bias, from_reg.offset(), to_reg);
-        break;
+        Address from_addr(rbp, RBP_BIAS + from_reg.offset() + in_stk_bias);
+        move_stack64(masm, tmp_reg, out_stk_bias, from_addr, to_reg);
+      } break;
       default: ShouldNotReachHere();
     }
   }

--- a/src/hotspot/cpu/x86/upcallLinker_x86_64.cpp
+++ b/src/hotspot/cpu/x86/upcallLinker_x86_64.cpp
@@ -209,10 +209,14 @@ address UpcallLinker::make_upcall_stub(jobject receiver, Method* entry,
   int frame_data_offset      = reg_save_area_offset   + reg_save_area_size;
   int frame_bottom_offset    = frame_data_offset      + sizeof(UpcallStub::FrameData);
 
+  StubLocations locs;
   int ret_buf_offset = -1;
   if (needs_return_buffer) {
     ret_buf_offset = frame_bottom_offset;
     frame_bottom_offset += ret_buf_size;
+    // use a free register for shuffling code to pick up return
+    // buffer address from
+    locs.set(StubLocations::RETURN_BUFFER, abi._scratch1);
   }
 
   int frame_size = frame_bottom_offset;
@@ -274,9 +278,9 @@ address UpcallLinker::make_upcall_stub(jobject receiver, Method* entry,
   arg_spilller.generate_fill(_masm, arg_save_area_offset);
   if (needs_return_buffer) {
     assert(ret_buf_offset != -1, "no return buffer allocated");
-    __ lea(abi._ret_buf_addr_reg, Address(rsp, ret_buf_offset));
+    __ lea(as_Register(locs.get(StubLocations::RETURN_BUFFER)), Address(rsp, ret_buf_offset));
   }
-  arg_shuffle.generate(_masm, shuffle_reg, abi._shadow_space_bytes, 0);
+  arg_shuffle.generate(_masm, shuffle_reg, abi._shadow_space_bytes, 0, locs);
   __ block_comment("} argument shuffle");
 
   __ block_comment("{ receiver ");
@@ -322,10 +326,10 @@ address UpcallLinker::make_upcall_stub(jobject receiver, Method* entry,
     int offset = 0;
     for (int i = 0; i < call_regs._ret_regs.length(); i++) {
       VMStorage reg = call_regs._ret_regs.at(i);
-      if (reg.type() == RegType::INTEGER) {
+      if (reg.type() == StorageType::INTEGER) {
         __ movptr(as_Register(reg), Address(rscratch1, offset));
         offset += 8;
-      } else if (reg.type() == RegType::VECTOR) {
+      } else if (reg.type() == StorageType::VECTOR) {
         __ movdqu(as_XMMRegister(reg), Address(rscratch1, offset));
         offset += 16;
       } else {

--- a/src/hotspot/cpu/zero/foreignGlobals_zero.cpp
+++ b/src/hotspot/cpu/zero/foreignGlobals_zero.cpp
@@ -46,6 +46,6 @@ void RegSpiller::pd_load_reg(MacroAssembler* masm, int offset, VMStorage reg) {
   Unimplemented();
 }
 
-void ArgumentShuffle::pd_generate(MacroAssembler* masm, VMStorage tmp, int in_stk_bias, int out_stk_bias) const {
+void ArgumentShuffle::pd_generate(MacroAssembler* masm, VMStorage tmp, int in_stk_bias, int out_stk_bias, const StubLocations& locs) const {
   Unimplemented();
 }

--- a/src/hotspot/cpu/zero/vmstorage_zero.inline.hpp
+++ b/src/hotspot/cpu/zero/vmstorage_zero.inline.hpp
@@ -29,12 +29,12 @@
 #include "asm/register.hpp"
 #include "prims/vmstorageBase.inline.hpp"
 
-enum class RegType : int8_t {
+enum class StorageType : int8_t {
   STACK = 0
 };
 
-constexpr inline RegType VMStorage::stack_type() {
-  return RegType::STACK;
+constexpr inline StorageType VMStorage::stack_type() {
+  return StorageType::STACK;
 }
 
 inline VMStorage as_VMStorage(VMReg reg) {

--- a/src/hotspot/cpu/zero/vmstorage_zero.inline.hpp
+++ b/src/hotspot/cpu/zero/vmstorage_zero.inline.hpp
@@ -30,12 +30,20 @@
 #include "prims/vmstorageBase.inline.hpp"
 
 enum class StorageType : int8_t {
-  STACK = 0
+  STACK = 0,
+  PLACEHOLDER = 1,
+// special locations used only by native code
+  FRAME_DATA = PLACEHOLDER + 1,
+  INVALID = -1
 };
 
-constexpr inline StorageType VMStorage::stack_type() {
-  return StorageType::STACK;
+// need to define this before constructing VMStorage (below)
+constexpr inline bool VMStorage::is_reg(StorageType type) {
+   return false;
 }
+constexpr inline StorageType VMStorage::stack_type() { return StorageType::STACK; }
+constexpr inline StorageType VMStorage::placeholder_type() { return StorageType::PLACEHOLDER; }
+constexpr inline StorageType VMStorage::frame_data_type() { return StorageType::FRAME_DATA; }
 
 inline VMStorage as_VMStorage(VMReg reg) {
   ShouldNotReachHere();

--- a/src/hotspot/share/classfile/javaClasses.cpp
+++ b/src/hotspot/share/classfile/javaClasses.cpp
@@ -4216,17 +4216,17 @@ int jdk_internal_foreign_abi_ABIDescriptor::_outputStorage_offset;
 int jdk_internal_foreign_abi_ABIDescriptor::_volatileStorage_offset;
 int jdk_internal_foreign_abi_ABIDescriptor::_stackAlignment_offset;
 int jdk_internal_foreign_abi_ABIDescriptor::_shadowSpace_offset;
-int jdk_internal_foreign_abi_ABIDescriptor::_targetAddrStorage_offset;
-int jdk_internal_foreign_abi_ABIDescriptor::_retBufAddrStorage_offset;
+int jdk_internal_foreign_abi_ABIDescriptor::_scratch1_offset;
+int jdk_internal_foreign_abi_ABIDescriptor::_scratch2_offset;
 
 #define ABIDescriptor_FIELDS_DO(macro) \
-  macro(_inputStorage_offset,      k, "inputStorage",      jdk_internal_foreign_abi_VMStorage_array_array_signature, false); \
-  macro(_outputStorage_offset,     k, "outputStorage",     jdk_internal_foreign_abi_VMStorage_array_array_signature, false); \
-  macro(_volatileStorage_offset,   k, "volatileStorage",   jdk_internal_foreign_abi_VMStorage_array_array_signature, false); \
-  macro(_stackAlignment_offset,    k, "stackAlignment",    int_signature, false); \
-  macro(_shadowSpace_offset,       k, "shadowSpace",       int_signature, false); \
-  macro(_targetAddrStorage_offset, k, "targetAddrStorage", jdk_internal_foreign_abi_VMStorage_signature, false); \
-  macro(_retBufAddrStorage_offset, k, "retBufAddrStorage", jdk_internal_foreign_abi_VMStorage_signature, false);
+  macro(_inputStorage_offset,    k, "inputStorage",    jdk_internal_foreign_abi_VMStorage_array_array_signature, false); \
+  macro(_outputStorage_offset,   k, "outputStorage",   jdk_internal_foreign_abi_VMStorage_array_array_signature, false); \
+  macro(_volatileStorage_offset, k, "volatileStorage", jdk_internal_foreign_abi_VMStorage_array_array_signature, false); \
+  macro(_stackAlignment_offset,  k, "stackAlignment",  int_signature, false); \
+  macro(_shadowSpace_offset,     k, "shadowSpace",     int_signature, false); \
+  macro(_scratch1_offset,        k, "scratch1",        jdk_internal_foreign_abi_VMStorage_signature, false); \
+  macro(_scratch2_offset,        k, "scratch2",        jdk_internal_foreign_abi_VMStorage_signature, false);
 
 bool jdk_internal_foreign_abi_ABIDescriptor::is_instance(oop obj) {
   return obj != NULL && is_subclass(obj->klass());
@@ -4263,12 +4263,12 @@ jint jdk_internal_foreign_abi_ABIDescriptor::shadowSpace(oop entry) {
   return entry->int_field(_shadowSpace_offset);
 }
 
-oop jdk_internal_foreign_abi_ABIDescriptor::targetAddrStorage(oop entry) {
-  return entry->obj_field(_targetAddrStorage_offset);
+oop jdk_internal_foreign_abi_ABIDescriptor::scratch1(oop entry) {
+  return entry->obj_field(_scratch1_offset);
 }
 
-oop jdk_internal_foreign_abi_ABIDescriptor::retBufAddrStorage(oop entry) {
-  return entry->obj_field(_retBufAddrStorage_offset);
+oop jdk_internal_foreign_abi_ABIDescriptor::scratch2(oop entry) {
+  return entry->obj_field(_scratch2_offset);
 }
 
 int jdk_internal_foreign_abi_VMStorage::_type_offset;

--- a/src/hotspot/share/classfile/javaClasses.hpp
+++ b/src/hotspot/share/classfile/javaClasses.hpp
@@ -1138,8 +1138,8 @@ class jdk_internal_foreign_abi_ABIDescriptor: AllStatic {
   static int _volatileStorage_offset;
   static int _stackAlignment_offset;
   static int _shadowSpace_offset;
-  static int _targetAddrStorage_offset;
-  static int _retBufAddrStorage_offset;
+  static int _scratch1_offset;
+  static int _scratch2_offset;
 
   static void compute_offsets();
 
@@ -1152,8 +1152,8 @@ class jdk_internal_foreign_abi_ABIDescriptor: AllStatic {
   static objArrayOop volatileStorage(oop entry);
   static jint        stackAlignment(oop entry);
   static jint        shadowSpace(oop entry);
-  static oop         targetAddrStorage(oop entry);
-  static oop         retBufAddrStorage(oop entry);
+  static oop         scratch1(oop entry);
+  static oop         scratch2(oop entry);
 
   // Testers
   static bool is_subclass(Klass* klass) {

--- a/src/hotspot/share/prims/foreignGlobals.hpp
+++ b/src/hotspot/share/prims/foreignGlobals.hpp
@@ -33,6 +33,28 @@
 
 #include CPU_HEADER(foreignGlobals)
 
+// needs to match StubLocations in Java code.
+// placeholder locations to be filled in by
+// the code gen code
+class StubLocations {
+public:
+  enum Location : uint32_t {
+    TARGET_ADDRESS,
+    RETURN_BUFFER,
+    MAX
+  };
+private:
+  VMStorage _locs[MAX];
+public:
+  StubLocations();
+
+  void set(uint32_t loc, VMStorage storage);
+  void set_frame_data(uint32_t loc, int offset);
+  VMStorage get(uint32_t loc) const;
+  VMStorage get(VMStorage placeholder) const;
+  int data_offset(uint32_t loc) const;
+};
+
 class CallingConventionClosure {
 public:
   virtual int calling_convention(const BasicType* sig_bt, VMStorage* regs, int num_args) const = 0;
@@ -110,13 +132,13 @@ public:
     VMStorage shuffle_temp);
 
   int out_arg_bytes() const { return _out_arg_bytes; }
-  void generate(MacroAssembler* masm, VMStorage tmp, int in_stk_bias, int out_stk_bias) const {
-    pd_generate(masm, tmp, in_stk_bias, out_stk_bias);
+  void generate(MacroAssembler* masm, VMStorage tmp, int in_stk_bias, int out_stk_bias, const StubLocations& locs) const {
+    pd_generate(masm, tmp, in_stk_bias, out_stk_bias, locs);
   }
 
   void print_on(outputStream* os) const;
 private:
-  void pd_generate(MacroAssembler* masm, VMStorage tmp, int in_stk_bias, int out_stk_bias) const;
+  void pd_generate(MacroAssembler* masm, VMStorage tmp, int in_stk_bias, int out_stk_bias, const StubLocations& locs) const;
 };
 
 #endif // SHARE_PRIMS_FOREIGN_GLOBALS

--- a/src/hotspot/share/prims/nativeEntryPoint.cpp
+++ b/src/hotspot/share/prims/nativeEntryPoint.cpp
@@ -36,7 +36,8 @@
 #include "runtime/jniHandles.inline.hpp"
 
 JNI_ENTRY(jlong, NEP_makeDowncallStub(JNIEnv* env, jclass _unused, jobject method_type, jobject jabi,
-                                      jobjectArray arg_moves, jobjectArray ret_moves, jboolean needs_return_buffer))
+                                      jobjectArray arg_moves, jobjectArray ret_moves,
+                                      jboolean needs_return_buffer))
   ResourceMark rm;
   const ABIDescriptor abi = ForeignGlobals::parse_abi_descriptor(jabi);
 
@@ -73,7 +74,6 @@ JNI_ENTRY(jlong, NEP_makeDowncallStub(JNIEnv* env, jclass _unused, jobject metho
     // we are NOT moving Java values, we are moving register-sized values
     output_regs.push(ForeignGlobals::parse_vmstorage(ret_moves_oop->obj_at(i)));
   }
-
   return (jlong) DowncallLinker::make_downcall_stub(
     basic_type, pslots, ret_bt, abi, input_regs, output_regs, needs_return_buffer)->code_begin();
 JNI_END

--- a/src/hotspot/share/prims/nativeEntryPoint.cpp
+++ b/src/hotspot/share/prims/nativeEntryPoint.cpp
@@ -74,6 +74,7 @@ JNI_ENTRY(jlong, NEP_makeDowncallStub(JNIEnv* env, jclass _unused, jobject metho
     // we are NOT moving Java values, we are moving register-sized values
     output_regs.push(ForeignGlobals::parse_vmstorage(ret_moves_oop->obj_at(i)));
   }
+
   return (jlong) DowncallLinker::make_downcall_stub(
     basic_type, pslots, ret_bt, abi, input_regs, output_regs, needs_return_buffer)->code_begin();
 JNI_END

--- a/src/hotspot/share/prims/nativeEntryPoint.cpp
+++ b/src/hotspot/share/prims/nativeEntryPoint.cpp
@@ -36,8 +36,7 @@
 #include "runtime/jniHandles.inline.hpp"
 
 JNI_ENTRY(jlong, NEP_makeDowncallStub(JNIEnv* env, jclass _unused, jobject method_type, jobject jabi,
-                                      jobjectArray arg_moves, jobjectArray ret_moves,
-                                      jboolean needs_return_buffer))
+                                      jobjectArray arg_moves, jobjectArray ret_moves, jboolean needs_return_buffer))
   ResourceMark rm;
   const ABIDescriptor abi = ForeignGlobals::parse_abi_descriptor(jabi);
 

--- a/src/hotspot/share/prims/vmstorageBase.inline.hpp
+++ b/src/hotspot/share/prims/vmstorageBase.inline.hpp
@@ -32,26 +32,30 @@
 #include "utilities/debug.hpp"
 #include "utilities/ostream.hpp"
 
-enum class RegType : int8_t; // defined in arch specific headers
+enum class StorageType : int8_t; // defined in arch specific headers
 
 class VMStorage {
 public:
-  constexpr static RegType INVALID_TYPE = static_cast<RegType>(-1);
+  constexpr static StorageType INVALID_TYPE = static_cast<StorageType>(-1);
 private:
-  RegType _type;
+  StorageType _type;
   // 1 byte of padding
   uint16_t _segment_mask_or_size;
   uint32_t _index_or_offset; // stack offset in bytes for stack storage
 
   friend bool operator==(const VMStorage& a, const VMStorage& b);
-  constexpr VMStorage(RegType type, uint16_t segment_mask_or_size, uint32_t index_or_offset)
-    : _type(type), _segment_mask_or_size(segment_mask_or_size), _index_or_offset(index_or_offset) {};
+
+  constexpr inline static bool is_reg(StorageType type);
+  constexpr inline static StorageType stack_type();
+  constexpr inline static StorageType placeholder_type();
+  constexpr inline static StorageType frame_data_type();
 public:
   constexpr VMStorage() : _type(INVALID_TYPE), _segment_mask_or_size(0), _index_or_offset(0) {};
+  constexpr VMStorage(StorageType type, uint16_t segment_mask_or_size, uint32_t index_or_offset)
+    : _type(type), _segment_mask_or_size(segment_mask_or_size), _index_or_offset(index_or_offset) {};
 
-  constexpr static VMStorage reg_storage(RegType type, uint16_t segment_mask, uint32_t index) {
-    assert(type != stack_type(), "can not be stack type");
-    assert(type != INVALID_TYPE, "can not be invalid type");
+  constexpr static VMStorage reg_storage(StorageType type, uint16_t segment_mask, uint32_t index) {
+    assert(is_reg(type), "must be reg");
     return VMStorage(type, segment_mask, index);
   }
 
@@ -69,19 +73,20 @@ public:
     return result;
   }
 
-  constexpr inline static RegType stack_type();
+  StorageType type() const { return _type; }
 
-  RegType type()              const { return _type; }
   // type specific accessors to make calling code more readable
-  uint16_t segment_mask()     const { assert(is_reg(), "must be reg");     return _segment_mask_or_size; }
-  uint16_t stack_size()       const { assert(is_stack(), "must be stack"); return _segment_mask_or_size; }
-  uint32_t index()            const { assert(is_reg(), "must be reg");     return _index_or_offset; }
-  uint32_t offset()           const { assert(is_stack(), "must be stack"); return _index_or_offset; }
-  uint32_t index_or_offset()  const { assert(is_valid(), "must be valid"); return _index_or_offset; }
+  uint16_t segment_mask()    const { assert(is_reg(), "must be reg");                  return _segment_mask_or_size; }
+  uint16_t stack_size()      const { assert(is_stack() || is_frame_data(), "must be"); return _segment_mask_or_size; }
+  uint32_t index()           const { assert(is_reg() || is_placeholder(), "must be");  return _index_or_offset; }
+  uint32_t offset()          const { assert(is_stack() || is_frame_data(), "must be"); return _index_or_offset; }
+  uint32_t index_or_offset() const { assert(is_valid(), "must be valid");              return _index_or_offset; }
 
-  bool is_valid() const { return _type != INVALID_TYPE; }
-  bool is_reg() const { return is_valid() && !is_stack(); }
-  bool is_stack() const { return _type == stack_type(); }
+  bool is_valid()       const { return _type != INVALID_TYPE; }
+  bool is_reg()         const { return is_reg(_type); }
+  bool is_stack()       const { return _type == stack_type(); }
+  bool is_placeholder() const { return _type == placeholder_type(); }
+  bool is_frame_data()  const { return _type == frame_data_type(); }
 
   void print_on(outputStream* os) const;
 };

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/ABIDescriptor.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/ABIDescriptor.java
@@ -40,11 +40,15 @@ public class ABIDescriptor {
     final int stackAlignment;
     final int shadowSpace;
 
+    final VMStorage scratch1;
+    final VMStorage scratch2;
+
     final VMStorage targetAddrStorage;
     final VMStorage retBufAddrStorage;
 
     public ABIDescriptor(Architecture arch, VMStorage[][] inputStorage, VMStorage[][] outputStorage,
                          VMStorage[][] volatileStorage, int stackAlignment, int shadowSpace,
+                         VMStorage scratch1, VMStorage scratch2,
                          VMStorage targetAddrStorage, VMStorage retBufAddrStorage) {
         this.arch = arch;
         this.inputStorage = inputStorage;
@@ -52,6 +56,8 @@ public class ABIDescriptor {
         this.volatileStorage = volatileStorage;
         this.stackAlignment = stackAlignment;
         this.shadowSpace = shadowSpace;
+        this.scratch1 = scratch1;
+        this.scratch2 = scratch2;
         this.targetAddrStorage = targetAddrStorage;
         this.retBufAddrStorage = retBufAddrStorage;
     }

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/LinkerOptions.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/LinkerOptions.java
@@ -24,10 +24,16 @@
  */
 package jdk.internal.foreign.abi;
 
+import java.lang.foreign.FunctionDescriptor;
 import java.lang.foreign.Linker;
+import java.lang.foreign.MemoryLayout;
+import java.lang.foreign.StructLayout;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 public class LinkerOptions {
 

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/LinkerOptions.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/LinkerOptions.java
@@ -24,16 +24,10 @@
  */
 package jdk.internal.foreign.abi;
 
-import java.lang.foreign.FunctionDescriptor;
 import java.lang.foreign.Linker;
-import java.lang.foreign.MemoryLayout;
-import java.lang.foreign.StructLayout;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 public class LinkerOptions {
 

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/NativeEntryPoint.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/NativeEntryPoint.java
@@ -56,8 +56,7 @@ public class NativeEntryPoint {
 
     public static NativeEntryPoint make(ABIDescriptor abi,
                                         VMStorage[] argMoves, VMStorage[] returnMoves,
-                                        MethodType methodType,
-                                        boolean needsReturnBuffer) {
+                                        MethodType methodType, boolean needsReturnBuffer) {
         if (returnMoves.length > 1 != needsReturnBuffer) {
             throw new IllegalArgumentException("Multiple register return, but needsReturnBuffer was false");
         }

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/NativeEntryPoint.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/NativeEntryPoint.java
@@ -56,7 +56,8 @@ public class NativeEntryPoint {
 
     public static NativeEntryPoint make(ABIDescriptor abi,
                                         VMStorage[] argMoves, VMStorage[] returnMoves,
-                                        MethodType methodType, boolean needsReturnBuffer) {
+                                        MethodType methodType,
+                                        boolean needsReturnBuffer) {
         if (returnMoves.length > 1 != needsReturnBuffer) {
             throw new IllegalArgumentException("Multiple register return, but needsReturnBuffer was false");
         }

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/StubLocations.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/StubLocations.java
@@ -4,7 +4,9 @@
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 only, as
- * published by the Free Software Foundation.
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
  *
  * This code is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
@@ -20,26 +22,14 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+package jdk.internal.foreign.abi;
 
-#ifndef CPU_RISCV_VMSTORAGE_RISCV_INLINE_HPP
-#define CPU_RISCV_VMSTORAGE_RISCV_INLINE_HPP
+// must keep in sync with StubLocations in VM code
+public enum StubLocations {
+    TARGET_ADDRESS,
+    RETURN_BUFFER;
 
-#include <cstdint>
-
-#include "asm/register.hpp"
-#include "prims/vmstorageBase.inline.hpp"
-
-enum class StorageType : int8_t {
-  STACK = 0
-};
-
-constexpr inline StorageType VMStorage::stack_type() {
-  return StorageType::STACK;
+    public VMStorage storage(byte type) {
+        return new VMStorage(type, (short) 8, ordinal());
+    }
 }
-
-inline VMStorage as_VMStorage(VMReg reg) {
-  ShouldNotReachHere();
-  return VMStorage::invalid();
-}
-
-#endif // CPU_RISCV_VMSTORAGE_RISCV_INLINE_HPP

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/x64/X86_64Architecture.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/x64/X86_64Architecture.java
@@ -26,6 +26,7 @@ package jdk.internal.foreign.abi.x64;
 
 import jdk.internal.foreign.abi.ABIDescriptor;
 import jdk.internal.foreign.abi.Architecture;
+import jdk.internal.foreign.abi.StubLocations;
 import jdk.internal.foreign.abi.VMStorage;
 
 import java.util.stream.IntStream;
@@ -49,26 +50,28 @@ public class X86_64Architecture implements Architecture {
 
     @Override
     public boolean isStackType(int cls) {
-        return cls == StorageClasses.STACK;
+        return cls == StorageType.STACK;
     }
 
     @Override
     public int typeSize(int cls) {
         switch (cls) {
-            case StorageClasses.INTEGER: return INTEGER_REG_SIZE;
-            case StorageClasses.VECTOR: return VECTOR_REG_SIZE;
-            case StorageClasses.X87: return X87_REG_SIZE;
+            case StorageType.INTEGER: return INTEGER_REG_SIZE;
+            case StorageType.VECTOR: return VECTOR_REG_SIZE;
+            case StorageType.X87: return X87_REG_SIZE;
             // STACK is deliberately omitted
         }
 
         throw new IllegalArgumentException("Invalid Storage Class: " +cls);
     }
 
-    public interface StorageClasses {
+    // must keep in sync with StorageType in VM code
+    public interface StorageType {
         byte INTEGER = 0;
         byte VECTOR = 1;
         byte X87 = 2;
         byte STACK = 3;
+        byte PLACEHOLDER = 4;
     }
 
     public static class Regs { // break circular dependency
@@ -124,25 +127,25 @@ public class X86_64Architecture implements Architecture {
     }
 
     private static VMStorage integerRegister(int index, String debugName) {
-        return new VMStorage(StorageClasses.INTEGER, REG64_MASK, index, debugName);
+        return new VMStorage(StorageType.INTEGER, REG64_MASK, index, debugName);
     }
 
     private static VMStorage vectorRegister(int index, String debugName) {
-        return new VMStorage(StorageClasses.VECTOR, XMM_MASK, index, debugName);
+        return new VMStorage(StorageType.VECTOR, XMM_MASK, index, debugName);
     }
 
     public static VMStorage stackStorage(short size, int byteOffset) {
-        return new VMStorage(StorageClasses.STACK, size, byteOffset);
+        return new VMStorage(StorageType.STACK, size, byteOffset);
     }
 
     public static VMStorage x87Storage(int index) {
-        return new VMStorage(StorageClasses.X87, STP_MASK, index, "X87(" + index + ")");
+        return new VMStorage(StorageType.X87, STP_MASK, index, "X87(" + index + ")");
     }
 
     public static ABIDescriptor abiFor(VMStorage[] inputIntRegs, VMStorage[] inputVectorRegs, VMStorage[] outputIntRegs,
                                        VMStorage[] outputVectorRegs, int numX87Outputs, VMStorage[] volatileIntRegs,
                                        VMStorage[] volatileVectorRegs, int stackAlignment, int shadowSpace,
-                                       VMStorage targetAddrStorage, VMStorage retBufAddrStorage) {
+                                       VMStorage scratch1, VMStorage scratch2) {
         return new ABIDescriptor(
             INSTANCE,
             new VMStorage[][] {
@@ -162,7 +165,9 @@ public class X86_64Architecture implements Architecture {
             },
             stackAlignment,
             shadowSpace,
-            targetAddrStorage, retBufAddrStorage);
+            scratch1, scratch2,
+            StubLocations.TARGET_ADDRESS.storage(StorageType.PLACEHOLDER),
+            StubLocations.RETURN_BUFFER.storage(StorageType.PLACEHOLDER));
     }
 
 }

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/x64/windows/CallArranger.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/x64/windows/CallArranger.java
@@ -70,8 +70,7 @@ public class CallArranger {
         new VMStorage[] { xmm4, xmm5 },
         16,
         32,
-        r10, // target addr reg
-        r11  // ret buf addr reg
+        r10, r11 // scratch 1 & 2
     );
 
     public record Bindings(
@@ -177,7 +176,7 @@ public class CallArranger {
 
         public VMStorage extraVarargsStorage() {
             assert forArguments;
-            return CWindows.inputStorage[StorageClasses.INTEGER][nRegs - 1];
+            return CWindows.inputStorage[StorageType.INTEGER][nRegs - 1];
         }
     }
 
@@ -199,7 +198,7 @@ public class CallArranger {
             switch (argumentClass) {
                 case STRUCT_REGISTER: {
                     assert carrier == MemorySegment.class;
-                    VMStorage storage = storageCalculator.nextStorage(StorageClasses.INTEGER);
+                    VMStorage storage = storageCalculator.nextStorage(StorageType.INTEGER);
                     Class<?> type = SharedUtils.primitiveCarrierForSize(layout.byteSize(), false);
                     bindings.bufferLoad(0, type)
                             .vmStore(storage, type);
@@ -209,28 +208,28 @@ public class CallArranger {
                     assert carrier == MemorySegment.class;
                     bindings.copy(layout)
                             .unboxAddress();
-                    VMStorage storage = storageCalculator.nextStorage(StorageClasses.INTEGER);
+                    VMStorage storage = storageCalculator.nextStorage(StorageType.INTEGER);
                     bindings.vmStore(storage, long.class);
                     break;
                 }
                 case POINTER: {
                     bindings.unboxAddress();
-                    VMStorage storage = storageCalculator.nextStorage(StorageClasses.INTEGER);
+                    VMStorage storage = storageCalculator.nextStorage(StorageType.INTEGER);
                     bindings.vmStore(storage, long.class);
                     break;
                 }
                 case INTEGER: {
-                    VMStorage storage = storageCalculator.nextStorage(StorageClasses.INTEGER);
+                    VMStorage storage = storageCalculator.nextStorage(StorageType.INTEGER);
                     bindings.vmStore(storage, carrier);
                     break;
                 }
                 case FLOAT: {
-                    VMStorage storage = storageCalculator.nextStorage(StorageClasses.VECTOR);
+                    VMStorage storage = storageCalculator.nextStorage(StorageType.VECTOR);
                     bindings.vmStore(storage, carrier);
                     break;
                 }
                 case VARARG_FLOAT: {
-                    VMStorage storage = storageCalculator.nextStorage(StorageClasses.VECTOR);
+                    VMStorage storage = storageCalculator.nextStorage(StorageType.VECTOR);
                     if (!INSTANCE.isStackType(storage.type())) { // need extra for register arg
                         VMStorage extraStorage = storageCalculator.extraVarargsStorage();
                         bindings.dup()
@@ -263,7 +262,7 @@ public class CallArranger {
                     assert carrier == MemorySegment.class;
                     bindings.allocate(layout)
                             .dup();
-                    VMStorage storage = storageCalculator.nextStorage(StorageClasses.INTEGER);
+                    VMStorage storage = storageCalculator.nextStorage(StorageType.INTEGER);
                     Class<?> type = SharedUtils.primitiveCarrierForSize(layout.byteSize(), false);
                     bindings.vmLoad(storage, type)
                             .bufferStore(0, type);
@@ -271,24 +270,24 @@ public class CallArranger {
                 }
                 case STRUCT_REFERENCE: {
                     assert carrier == MemorySegment.class;
-                    VMStorage storage = storageCalculator.nextStorage(StorageClasses.INTEGER);
+                    VMStorage storage = storageCalculator.nextStorage(StorageType.INTEGER);
                     bindings.vmLoad(storage, long.class)
                             .boxAddress(layout);
                     break;
                 }
                 case POINTER: {
-                    VMStorage storage = storageCalculator.nextStorage(StorageClasses.INTEGER);
+                    VMStorage storage = storageCalculator.nextStorage(StorageType.INTEGER);
                     bindings.vmLoad(storage, long.class)
                             .boxAddressRaw(Utils.pointeeSize(layout));
                     break;
                 }
                 case INTEGER: {
-                    VMStorage storage = storageCalculator.nextStorage(StorageClasses.INTEGER);
+                    VMStorage storage = storageCalculator.nextStorage(StorageType.INTEGER);
                     bindings.vmLoad(storage, carrier);
                     break;
                 }
                 case FLOAT: {
-                    VMStorage storage = storageCalculator.nextStorage(StorageClasses.VECTOR);
+                    VMStorage storage = storageCalculator.nextStorage(StorageType.VECTOR);
                     bindings.vmLoad(storage, carrier);
                     break;
                 }

--- a/test/jdk/java/foreign/callarranger/TestAarch64CallArranger.java
+++ b/test/jdk/java/foreign/callarranger/TestAarch64CallArranger.java
@@ -33,12 +33,13 @@
  */
 
 import java.lang.foreign.FunctionDescriptor;
-import java.lang.foreign.Linker;
 import java.lang.foreign.MemoryLayout;
 import java.lang.foreign.MemorySegment;
 import jdk.internal.foreign.abi.Binding;
 import jdk.internal.foreign.abi.CallingSequence;
 import jdk.internal.foreign.abi.LinkerOptions;
+import jdk.internal.foreign.abi.StubLocations;
+import jdk.internal.foreign.abi.VMStorage;
 import jdk.internal.foreign.abi.aarch64.CallArranger;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -57,7 +58,8 @@ import static org.testng.Assert.assertTrue;
 
 public class TestAarch64CallArranger extends CallArrangerTestBase {
 
-    private static final short STACK_SLOT_SIZE = 8;
+    private static final VMStorage TARGET_ADDRESS_STORAGE = StubLocations.TARGET_ADDRESS.storage(StorageType.PLACEHOLDER);
+    private static final VMStorage RETURN_BUFFER_STORAGE = StubLocations.RETURN_BUFFER.storage(StorageType.PLACEHOLDER);
 
     @Test
     public void testEmpty() {
@@ -71,7 +73,7 @@ public class TestAarch64CallArranger extends CallArrangerTestBase {
         assertEquals(callingSequence.functionDesc(), fd.insertArgumentLayouts(0, ADDRESS));
 
         checkArgumentBindings(callingSequence, new Binding[][]{
-            { unboxAddress(), vmStore(r9, long.class) }
+            { unboxAddress(), vmStore(TARGET_ADDRESS_STORAGE, long.class) }
         });
 
         checkReturnBindings(callingSequence, new Binding[]{});
@@ -95,7 +97,7 @@ public class TestAarch64CallArranger extends CallArrangerTestBase {
         assertEquals(callingSequence.functionDesc(), fd.insertArgumentLayouts(0, ADDRESS));
 
         checkArgumentBindings(callingSequence, new Binding[][]{
-            { unboxAddress(), vmStore(r9, long.class) },
+            { unboxAddress(), vmStore(TARGET_ADDRESS_STORAGE, long.class) },
             { vmStore(r0, int.class) },
             { vmStore(r1, int.class) },
             { vmStore(r2, int.class) },
@@ -125,7 +127,7 @@ public class TestAarch64CallArranger extends CallArrangerTestBase {
         assertEquals(callingSequence.functionDesc(), fd.insertArgumentLayouts(0, ADDRESS));
 
         checkArgumentBindings(callingSequence, new Binding[][]{
-            { unboxAddress(), vmStore(r9, long.class) },
+            { unboxAddress(), vmStore(TARGET_ADDRESS_STORAGE, long.class) },
             { vmStore(r0, int.class) },
             { vmStore(r1, int.class) },
             { vmStore(v0, float.class) },
@@ -147,7 +149,7 @@ public class TestAarch64CallArranger extends CallArrangerTestBase {
         assertEquals(callingSequence.functionDesc(), fd.insertArgumentLayouts(0, ADDRESS));
 
         checkArgumentBindings(callingSequence, new Binding[][]{
-            { unboxAddress(), vmStore(r9, long.class) },
+            { unboxAddress(), vmStore(TARGET_ADDRESS_STORAGE, long.class) },
             expectedBindings
         });
 
@@ -207,7 +209,7 @@ public class TestAarch64CallArranger extends CallArrangerTestBase {
         assertEquals(callingSequence.functionDesc(), fd.insertArgumentLayouts(0, ADDRESS));
 
         checkArgumentBindings(callingSequence, new Binding[][]{
-            { unboxAddress(), vmStore(r9, long.class) },
+            { unboxAddress(), vmStore(TARGET_ADDRESS_STORAGE, long.class) },
             {
                 copy(struct1),
                 unboxAddress(),
@@ -238,7 +240,7 @@ public class TestAarch64CallArranger extends CallArrangerTestBase {
         assertEquals(callingSequence.functionDesc(), FunctionDescriptor.ofVoid(ADDRESS, C_POINTER));
 
         checkArgumentBindings(callingSequence, new Binding[][]{
-            { unboxAddress(), vmStore(r9, long.class) },
+            { unboxAddress(), vmStore(TARGET_ADDRESS_STORAGE, long.class) },
             {
                 unboxAddress(),
                 vmStore(r8, long.class)
@@ -262,8 +264,8 @@ public class TestAarch64CallArranger extends CallArrangerTestBase {
         assertEquals(callingSequence.functionDesc(), fd.insertArgumentLayouts(0, ADDRESS, ADDRESS));
 
         checkArgumentBindings(callingSequence, new Binding[][]{
-            { unboxAddress(), vmStore(r10, long.class) },
-            { unboxAddress(), vmStore(r9, long.class) }
+            { unboxAddress(), vmStore(RETURN_BUFFER_STORAGE, long.class) },
+            { unboxAddress(), vmStore(TARGET_ADDRESS_STORAGE, long.class) }
         });
 
         checkReturnBindings(callingSequence, new Binding[]{
@@ -291,8 +293,8 @@ public class TestAarch64CallArranger extends CallArrangerTestBase {
         assertEquals(callingSequence.functionDesc(), fd.insertArgumentLayouts(0, ADDRESS, ADDRESS));
 
         checkArgumentBindings(callingSequence, new Binding[][]{
-            { unboxAddress(), vmStore(r10, long.class) },
-            { unboxAddress(), vmStore(r9, long.class) },
+            { unboxAddress(), vmStore(RETURN_BUFFER_STORAGE, long.class) },
+            { unboxAddress(), vmStore(TARGET_ADDRESS_STORAGE, long.class) },
             { vmStore(v0, float.class) },
             { vmStore(r0, int.class) },
             {
@@ -329,7 +331,7 @@ public class TestAarch64CallArranger extends CallArrangerTestBase {
         assertEquals(callingSequence.functionDesc(), fd.insertArgumentLayouts(0, ADDRESS));
 
         checkArgumentBindings(callingSequence, new Binding[][]{
-            { unboxAddress(), vmStore(r9, long.class) },
+            { unboxAddress(), vmStore(TARGET_ADDRESS_STORAGE, long.class) },
             {
                 dup(),
                 bufferLoad(0, float.class),
@@ -383,7 +385,7 @@ public class TestAarch64CallArranger extends CallArrangerTestBase {
         assertEquals(callingSequence.functionDesc(), fd.insertArgumentLayouts(0, ADDRESS));
 
         checkArgumentBindings(callingSequence, new Binding[][]{
-            { unboxAddress(), vmStore(r9, long.class) },
+            { unboxAddress(), vmStore(TARGET_ADDRESS_STORAGE, long.class) },
             { copy(struct), unboxAddress(), vmStore(r0, long.class) },
             { copy(struct), unboxAddress(), vmStore(r1, long.class) },
             { vmStore(r2, int.class) },
@@ -413,7 +415,7 @@ public class TestAarch64CallArranger extends CallArrangerTestBase {
 
         // This is identical to the non-variadic calling sequence
         checkArgumentBindings(callingSequence, new Binding[][]{
-            { unboxAddress(), vmStore(r9, long.class) },
+            { unboxAddress(), vmStore(TARGET_ADDRESS_STORAGE, long.class) },
             { vmStore(r0, int.class) },
             { vmStore(r1, int.class) },
             { vmStore(v0, float.class) },
@@ -436,7 +438,7 @@ public class TestAarch64CallArranger extends CallArrangerTestBase {
 
         // The two variadic arguments should be allocated on the stack
         checkArgumentBindings(callingSequence, new Binding[][]{
-            { unboxAddress(), vmStore(r9, long.class) },
+            { unboxAddress(), vmStore(TARGET_ADDRESS_STORAGE, long.class) },
             { vmStore(r0, int.class) },
             { vmStore(stackStorage((short) 4, 0), int.class) },
             { vmStore(stackStorage((short) 4, 8), float.class) },

--- a/test/jdk/java/foreign/callarranger/TestSysVCallArranger.java
+++ b/test/jdk/java/foreign/callarranger/TestSysVCallArranger.java
@@ -38,6 +38,8 @@ import java.lang.foreign.MemoryLayout;
 import java.lang.foreign.MemorySegment;
 import jdk.internal.foreign.abi.Binding;
 import jdk.internal.foreign.abi.CallingSequence;
+import jdk.internal.foreign.abi.StubLocations;
+import jdk.internal.foreign.abi.VMStorage;
 import jdk.internal.foreign.abi.x64.sysv.CallArranger;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -56,6 +58,8 @@ import static org.testng.Assert.assertTrue;
 public class TestSysVCallArranger extends CallArrangerTestBase {
 
     private static final short STACK_SLOT_SIZE = 8;
+    private static final VMStorage TARGET_ADDRESS_STORAGE = StubLocations.TARGET_ADDRESS.storage(StorageType.PLACEHOLDER);
+    private static final VMStorage RETURN_BUFFER_STORAGE = StubLocations.RETURN_BUFFER.storage(StorageType.PLACEHOLDER);
 
     @Test
     public void testEmpty() {
@@ -69,7 +73,7 @@ public class TestSysVCallArranger extends CallArrangerTestBase {
         assertEquals(callingSequence.functionDesc(), fd.appendArgumentLayouts(C_LONG).insertArgumentLayouts(0, ADDRESS));
 
         checkArgumentBindings(callingSequence, new Binding[][]{
-            { unboxAddress(), vmStore(r10, long.class) },
+            { unboxAddress(), vmStore(TARGET_ADDRESS_STORAGE, long.class) },
             { vmStore(rax, long.class) }
         });
 
@@ -97,7 +101,7 @@ public class TestSysVCallArranger extends CallArrangerTestBase {
         assertEquals(callingSequence.functionDesc(), fd.appendArgumentLayouts(C_LONG).insertArgumentLayouts(0, ADDRESS));
 
         checkArgumentBindings(callingSequence, new Binding[][]{
-            { unboxAddress(), vmStore(r10, long.class) },
+            { unboxAddress(), vmStore(TARGET_ADDRESS_STORAGE, long.class) },
             { dup(), bufferLoad(0, long.class), vmStore(rdi, long.class),
               bufferLoad(8, int.class), vmStore(rsi, int.class)},
             { vmStore(rax, long.class) },
@@ -128,7 +132,7 @@ public class TestSysVCallArranger extends CallArrangerTestBase {
         assertEquals(callingSequence.functionDesc(), fd.appendArgumentLayouts(C_LONG).insertArgumentLayouts(0, ADDRESS));
 
         checkArgumentBindings(callingSequence, new Binding[][]{
-            { unboxAddress(), vmStore(r10, long.class) },
+            { unboxAddress(), vmStore(TARGET_ADDRESS_STORAGE, long.class) },
             { dup(), bufferLoad(0, long.class), vmStore(rdi, long.class),
                     bufferLoad(8, long.class), vmStore(rsi, long.class)},
             { vmStore(rax, long.class) },
@@ -158,7 +162,7 @@ public class TestSysVCallArranger extends CallArrangerTestBase {
         assertEquals(callingSequence.functionDesc(), fd.appendArgumentLayouts(C_LONG).insertArgumentLayouts(0, ADDRESS));
 
         checkArgumentBindings(callingSequence, new Binding[][]{
-            { unboxAddress(), vmStore(r10, long.class) },
+            { unboxAddress(), vmStore(TARGET_ADDRESS_STORAGE, long.class) },
             { dup(), bufferLoad(0, long.class), vmStore(stackStorage(STACK_SLOT_SIZE, 0), long.class),
                     bufferLoad(8, long.class), vmStore(stackStorage(STACK_SLOT_SIZE, 8), long.class)},
             { vmStore(rax, long.class) },
@@ -188,7 +192,7 @@ public class TestSysVCallArranger extends CallArrangerTestBase {
         assertEquals(callingSequence.functionDesc(), fd.appendArgumentLayouts(C_LONG).insertArgumentLayouts(0, ADDRESS));
 
         checkArgumentBindings(callingSequence, new Binding[][]{
-            { unboxAddress(), vmStore(r10, long.class) },
+            { unboxAddress(), vmStore(TARGET_ADDRESS_STORAGE, long.class) },
             { dup(), bufferLoad(0, long.class), vmStore(stackStorage(STACK_SLOT_SIZE, 0), long.class),
                     bufferLoad(8, int.class), vmStore(stackStorage(STACK_SLOT_SIZE, 8), int.class)},
             { vmStore(rax, long.class) },
@@ -213,7 +217,7 @@ public class TestSysVCallArranger extends CallArrangerTestBase {
         assertEquals(callingSequence.functionDesc(), fd.appendArgumentLayouts(C_LONG).insertArgumentLayouts(0, ADDRESS));
 
         checkArgumentBindings(callingSequence, new Binding[][]{
-            { unboxAddress(), vmStore(r10, long.class) },
+            { unboxAddress(), vmStore(TARGET_ADDRESS_STORAGE, long.class) },
             { vmStore(rdi, int.class) },
             { vmStore(rsi, int.class) },
             { vmStore(rdx, int.class) },
@@ -244,7 +248,7 @@ public class TestSysVCallArranger extends CallArrangerTestBase {
         assertEquals(callingSequence.functionDesc(), fd.appendArgumentLayouts(C_LONG).insertArgumentLayouts(0, ADDRESS));
 
         checkArgumentBindings(callingSequence, new Binding[][]{
-            { unboxAddress(), vmStore(r10, long.class) },
+            { unboxAddress(), vmStore(TARGET_ADDRESS_STORAGE, long.class) },
             { vmStore(xmm0, double.class) },
             { vmStore(xmm1, double.class) },
             { vmStore(xmm2, double.class) },
@@ -279,7 +283,7 @@ public class TestSysVCallArranger extends CallArrangerTestBase {
         assertEquals(callingSequence.functionDesc(), fd.appendArgumentLayouts(C_LONG).insertArgumentLayouts(0, ADDRESS));
 
         checkArgumentBindings(callingSequence, new Binding[][]{
-            { unboxAddress(), vmStore(r10, long.class) },
+            { unboxAddress(), vmStore(TARGET_ADDRESS_STORAGE, long.class) },
             { vmStore(rdi, long.class) },
             { vmStore(rsi, long.class) },
             { vmStore(rdx, long.class) },
@@ -336,7 +340,7 @@ public class TestSysVCallArranger extends CallArrangerTestBase {
         assertEquals(callingSequence.functionDesc(), fd.appendArgumentLayouts(C_LONG).insertArgumentLayouts(0, ADDRESS));
 
         checkArgumentBindings(callingSequence, new Binding[][]{
-            { unboxAddress(), vmStore(r10, long.class) },
+            { unboxAddress(), vmStore(TARGET_ADDRESS_STORAGE, long.class) },
             { vmStore(rdi, int.class) },
             { vmStore(rsi, int.class) },
             {
@@ -379,7 +383,7 @@ public class TestSysVCallArranger extends CallArrangerTestBase {
         assertEquals(callingSequence.functionDesc(), fd.appendArgumentLayouts(C_LONG).insertArgumentLayouts(0, ADDRESS));
 
         checkArgumentBindings(callingSequence, new Binding[][]{
-            { unboxAddress(), vmStore(r10, long.class) },
+            { unboxAddress(), vmStore(TARGET_ADDRESS_STORAGE, long.class) },
             { unboxAddress(), vmStore(rdi, long.class) },
             { vmStore(rax, long.class) },
         });
@@ -401,7 +405,7 @@ public class TestSysVCallArranger extends CallArrangerTestBase {
         assertEquals(callingSequence.functionDesc(), fd.appendArgumentLayouts(C_LONG).insertArgumentLayouts(0, ADDRESS));
 
         checkArgumentBindings(callingSequence, new Binding[][]{
-            { unboxAddress(), vmStore(r10, long.class) },
+            { unboxAddress(), vmStore(TARGET_ADDRESS_STORAGE, long.class) },
             expectedBindings,
             { vmStore(rax, long.class) },
         });
@@ -460,8 +464,8 @@ public class TestSysVCallArranger extends CallArrangerTestBase {
         assertEquals(callingSequence.functionDesc(), fd.appendArgumentLayouts(C_LONG).insertArgumentLayouts(0, ADDRESS, ADDRESS));
 
         checkArgumentBindings(callingSequence, new Binding[][]{
-            { unboxAddress(), vmStore(r11, long.class) },
-            { unboxAddress(), vmStore(r10, long.class) },
+            { unboxAddress(), vmStore(RETURN_BUFFER_STORAGE, long.class) },
+            { unboxAddress(), vmStore(TARGET_ADDRESS_STORAGE, long.class) },
             { vmStore(rax, long.class) }
         });
 
@@ -492,7 +496,7 @@ public class TestSysVCallArranger extends CallArrangerTestBase {
         assertEquals(callingSequence.functionDesc(), FunctionDescriptor.ofVoid(ADDRESS, C_POINTER, C_LONG));
 
         checkArgumentBindings(callingSequence, new Binding[][]{
-            { unboxAddress(), vmStore(r10, long.class) },
+            { unboxAddress(), vmStore(TARGET_ADDRESS_STORAGE, long.class) },
             { unboxAddress(), vmStore(rdi, long.class) },
             { vmStore(rax, long.class) }
         });

--- a/test/jdk/java/foreign/callarranger/TestWindowsCallArranger.java
+++ b/test/jdk/java/foreign/callarranger/TestWindowsCallArranger.java
@@ -34,12 +34,13 @@
  */
 
 import java.lang.foreign.FunctionDescriptor;
-import java.lang.foreign.Linker;
 import java.lang.foreign.MemoryLayout;
 import java.lang.foreign.MemorySegment;
 import jdk.internal.foreign.abi.Binding;
 import jdk.internal.foreign.abi.CallingSequence;
 import jdk.internal.foreign.abi.LinkerOptions;
+import jdk.internal.foreign.abi.StubLocations;
+import jdk.internal.foreign.abi.VMStorage;
 import jdk.internal.foreign.abi.x64.windows.CallArranger;
 import org.testng.annotations.Test;
 
@@ -57,6 +58,7 @@ import static org.testng.Assert.*;
 public class TestWindowsCallArranger extends CallArrangerTestBase {
 
     private static final short STACK_SLOT_SIZE = 8;
+    private static final VMStorage TARGET_ADDRESS_STORAGE = StubLocations.TARGET_ADDRESS.storage(StorageType.PLACEHOLDER);
 
     @Test
     public void testEmpty() {
@@ -70,7 +72,7 @@ public class TestWindowsCallArranger extends CallArrangerTestBase {
         assertEquals(callingSequence.functionDesc(), fd.insertArgumentLayouts(0, ADDRESS));
 
         checkArgumentBindings(callingSequence, new Binding[][]{
-            { unboxAddress(), vmStore(r10, long.class) }
+            { unboxAddress(), vmStore(TARGET_ADDRESS_STORAGE, long.class) }
         });
         checkReturnBindings(callingSequence, new Binding[]{});
     }
@@ -87,7 +89,7 @@ public class TestWindowsCallArranger extends CallArrangerTestBase {
         assertEquals(callingSequence.functionDesc(), fd.insertArgumentLayouts(0, ADDRESS));
 
         checkArgumentBindings(callingSequence, new Binding[][]{
-            { unboxAddress(), vmStore(r10, long.class) },
+            { unboxAddress(), vmStore(TARGET_ADDRESS_STORAGE, long.class) },
             { vmStore(rcx, int.class) },
             { vmStore(rdx, int.class) },
             { vmStore(r8, int.class) },
@@ -109,7 +111,7 @@ public class TestWindowsCallArranger extends CallArrangerTestBase {
         assertEquals(callingSequence.functionDesc(), fd.insertArgumentLayouts(0, ADDRESS));
 
         checkArgumentBindings(callingSequence, new Binding[][]{
-            { unboxAddress(), vmStore(r10, long.class) },
+            { unboxAddress(), vmStore(TARGET_ADDRESS_STORAGE, long.class) },
             { vmStore(xmm0, double.class) },
             { vmStore(xmm1, double.class) },
             { vmStore(xmm2, double.class) },
@@ -133,7 +135,7 @@ public class TestWindowsCallArranger extends CallArrangerTestBase {
         assertEquals(callingSequence.functionDesc(), fd.insertArgumentLayouts(0, ADDRESS));
 
         checkArgumentBindings(callingSequence, new Binding[][]{
-            { unboxAddress(), vmStore(r10, long.class) },
+            { unboxAddress(), vmStore(TARGET_ADDRESS_STORAGE, long.class) },
             { vmStore(rcx, long.class) },
             { vmStore(rdx, long.class) },
             { vmStore(xmm2, float.class) },
@@ -164,7 +166,7 @@ public class TestWindowsCallArranger extends CallArrangerTestBase {
         assertEquals(callingSequence.functionDesc(), fd.insertArgumentLayouts(0, ADDRESS));
 
         checkArgumentBindings(callingSequence, new Binding[][]{
-            { unboxAddress(), vmStore(r10, long.class) },
+            { unboxAddress(), vmStore(TARGET_ADDRESS_STORAGE, long.class) },
             { vmStore(rcx, int.class) },
             { vmStore(rdx, int.class) },
             {
@@ -201,7 +203,7 @@ public class TestWindowsCallArranger extends CallArrangerTestBase {
         assertEquals(callingSequence.functionDesc(), fdExpected);
 
         checkArgumentBindings(callingSequence, new Binding[][]{
-            { unboxAddress(), vmStore(r10, long.class) },
+            { unboxAddress(), vmStore(TARGET_ADDRESS_STORAGE, long.class) },
             { vmStore(rcx, int.class) },
             { vmStore(xmm1, double.class) },
             { vmStore(r8, int.class) },
@@ -235,7 +237,7 @@ public class TestWindowsCallArranger extends CallArrangerTestBase {
         assertEquals(callingSequence.functionDesc(), fd.insertArgumentLayouts(0, ADDRESS));
 
         checkArgumentBindings(callingSequence, new Binding[][]{
-            { unboxAddress(), vmStore(r10, long.class) },
+            { unboxAddress(), vmStore(TARGET_ADDRESS_STORAGE, long.class) },
             { bufferLoad(0, long.class), vmStore(rcx, long.class) }
         });
 
@@ -265,7 +267,7 @@ public class TestWindowsCallArranger extends CallArrangerTestBase {
         assertEquals(callingSequence.functionDesc(), fd.insertArgumentLayouts(0, ADDRESS));
 
         checkArgumentBindings(callingSequence, new Binding[][]{
-            { unboxAddress(), vmStore(r10, long.class) },
+            { unboxAddress(), vmStore(TARGET_ADDRESS_STORAGE, long.class) },
             {
                 copy(struct),
                 unboxAddress(),
@@ -296,7 +298,7 @@ public class TestWindowsCallArranger extends CallArrangerTestBase {
         assertEquals(callingSequence.functionDesc(), fd.insertArgumentLayouts(0, ADDRESS));
 
         checkArgumentBindings(callingSequence, new Binding[][]{
-            { unboxAddress(), vmStore(r10, long.class) },
+            { unboxAddress(), vmStore(TARGET_ADDRESS_STORAGE, long.class) },
             { unboxAddress(), vmStore(rcx, long.class) }
         });
 
@@ -317,7 +319,7 @@ public class TestWindowsCallArranger extends CallArrangerTestBase {
         assertEquals(callingSequence.functionDesc(), fd.insertArgumentLayouts(0, ADDRESS));
 
         checkArgumentBindings(callingSequence, new Binding[][]{
-            { unboxAddress(), vmStore(r10, long.class) },
+            { unboxAddress(), vmStore(TARGET_ADDRESS_STORAGE, long.class) },
         });
 
         checkReturnBindings(callingSequence,
@@ -341,7 +343,7 @@ public class TestWindowsCallArranger extends CallArrangerTestBase {
         assertEquals(callingSequence.functionDesc(), FunctionDescriptor.ofVoid(ADDRESS, C_POINTER));
 
         checkArgumentBindings(callingSequence, new Binding[][]{
-            { unboxAddress(), vmStore(r10, long.class) },
+            { unboxAddress(), vmStore(TARGET_ADDRESS_STORAGE, long.class) },
             { unboxAddress(), vmStore(rcx, long.class) }
         });
 
@@ -370,7 +372,7 @@ public class TestWindowsCallArranger extends CallArrangerTestBase {
         assertEquals(callingSequence.functionDesc(), fd.insertArgumentLayouts(0, ADDRESS));
 
         checkArgumentBindings(callingSequence, new Binding[][]{
-            { unboxAddress(), vmStore(r10, long.class) },
+            { unboxAddress(), vmStore(TARGET_ADDRESS_STORAGE, long.class) },
             { copy(struct), unboxAddress(), vmStore(rcx, long.class) },
             { vmStore(rdx, int.class) },
             { vmStore(xmm2, double.class) },


### PR DESCRIPTION
This patch refactors the handling of special values passed between stubs and Java code, such as the target address and the return buffer address.

Currently the Java code determines some registers that these values are stored in. This refactor changes that to use placeholders, and lets the stub generation code fill in the actual locations. This allows more special values (such as locations to store preserved thread locals), as well as storing things to a location in the frame, as opposed to a register.

To do this, this patch adds a Java enum and C++ helper class called StubLocations, which gives each special value an index (ordinal). The C++ helper class also has an array which maps this index to the actual location the stub gen code decides to use. This location is then used in shuffling code.

Instead of the ABIDescriptor being used to determine a register for the target address and return buffer address, it now has 2 scratch registers, which don't conflict with arguments being passed. They can be used by the stub gen code.

The patch also contains a minor renaming of a boolean value being used. I've also renamed StorageClasses, and RegType in Java and C++ code respectively to StorageType, to align the 2, since they also need to be kept in sync. The latter is responsible for a lot of changes in this patch.

The stub gen code now also has a special FRAME_DATA storage type, which is used to indicate locations in the stub frame. This is for instance used to store the return buffer address.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8295265](https://bugs.openjdk.org/browse/JDK-8295265): Refactor handling of special values passed to stubs


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.org/census#mcimadamore) (@mcimadamore - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/panama-foreign pull/740/head:pull/740` \
`$ git checkout pull/740`

Update a local copy of the PR: \
`$ git checkout pull/740` \
`$ git pull https://git.openjdk.org/panama-foreign pull/740/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 740`

View PR using the GUI difftool: \
`$ git pr show -t 740`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/panama-foreign/pull/740.diff">https://git.openjdk.org/panama-foreign/pull/740.diff</a>

</details>
