### PR TITLE
Add getAtIndex and setAddIndex for byte and boolean

### DIFF
--- a/src/java.base/share/classes/java/lang/foreign/MemorySegment.java
+++ b/src/java.base/share/classes/java/lang/foreign/MemorySegment.java
@@ -1708,6 +1708,105 @@ public sealed interface MemorySegment permits AbstractMemorySegmentImpl {
     }
 
     /**
+     * Reads a byte from this segment at the given index, scaled by the given layout size.
+     *
+     * @param layout the layout of the region of memory to be read.
+     * @param index a logical index. The offset in bytes (relative to this segment address) at which the access operation
+     *              will occur can be expressed as {@code (index * layout.byteSize())}.
+     * @return a byte value read from this segment.
+     * @throws IllegalStateException if the {@linkplain #session() session} associated with this segment is not
+     * {@linkplain MemorySession#isAlive() alive}.
+     * @throws WrongThreadException if this method is called from a thread other than the thread owning
+     * the {@linkplain #session() session} associated with this segment.
+     * @throws IllegalArgumentException if the access operation is
+     * <a href="MemorySegment.html#segment-alignment">incompatible with the alignment constraint</a> in the provided layout,
+     * or if the layout alignment is greater than its size.
+     * @throws IndexOutOfBoundsException when the access operation falls outside the <em>spatial bounds</em> of the
+     * memory segment.
+     */
+    @ForceInline
+    default byte getAtIndex(ValueLayout.OfByte layout, long index) {
+        Utils.checkElementAlignment(layout, "Layout alignment greater than its size");
+        // note: we know size is a small value (as it comes from ValueLayout::byteSize())
+        return (byte) ((ValueLayouts.OfByteImpl) layout).accessHandle().get(this, index * layout.byteSize());
+    }
+
+    /**
+     * Writes a byte into this segment at the given index, scaled by the given layout size.
+     *
+     * @param layout the layout of the region of memory to be written.
+     * @param index a logical index. The offset in bytes (relative to this segment address) at which the access operation
+     *              will occur can be expressed as {@code (index * layout.byteSize())}.
+     * @param value the byte value to be written.
+     * @throws IllegalStateException if the {@linkplain #session() session} associated with this segment is not
+     * {@linkplain MemorySession#isAlive() alive}.
+     * @throws WrongThreadException if this method is called from a thread other than the thread owning
+     * the {@linkplain #session() session} associated with this segment.
+     * @throws IllegalArgumentException if the access operation is
+     * <a href="MemorySegment.html#segment-alignment">incompatible with the alignment constraint</a> in the provided layout,
+     * or if the layout alignment is greater than its size.
+     * @throws IndexOutOfBoundsException when the access operation falls outside the <em>spatial bounds</em> of the
+     * memory segment.
+     * @throws UnsupportedOperationException if this segment is {@linkplain #isReadOnly() read-only}.
+     */
+    @ForceInline
+    default void setAtIndex(ValueLayout.OfByte layout, long index, byte value) {
+        Utils.checkElementAlignment(layout, "Layout alignment greater than its size");
+        // note: we know size is a small value (as it comes from ValueLayout::byteSize())
+        ((ValueLayouts.OfByteImpl) layout).accessHandle().set(this, index * layout.byteSize(), value);
+    }
+
+    /**
+     * Reads a boolean from this segment at the given index, scaled by the given layout size.
+     *
+     * @param layout the layout of the region of memory to be read.
+     * @param index a logical index. The offset in bytes (relative to this segment address) at which the access operation
+     *              will occur can be expressed as {@code (index * layout.byteSize())}.
+     * @return a boolean value read from this segment.
+     * @throws IllegalStateException if the {@linkplain #session() session} associated with this segment is not
+     * {@linkplain MemorySession#isAlive() alive}.
+     * @throws WrongThreadException if this method is called from a thread other than the thread owning
+     * the {@linkplain #session() session} associated with this segment.
+     * @throws IllegalArgumentException if the access operation is
+     * <a href="MemorySegment.html#segment-alignment">incompatible with the alignment constraint</a> in the provided layout,
+     * or if the layout alignment is greater than its size.
+     * @throws IndexOutOfBoundsException when the access operation falls outside the <em>spatial bounds</em> of the
+     * memory segment.
+     */
+    @ForceInline
+    default boolean getAtIndex(ValueLayout.OfBoolean layout, long index) {
+        Utils.checkElementAlignment(layout, "Layout alignment greater than its size");
+        // note: we know size is a small value (as it comes from ValueLayout::byteSize())
+        return (boolean) ((ValueLayouts.OfBooleanImpl) layout).accessHandle().get(this, index * layout.byteSize());
+    }
+
+    /**
+     * Writes a boolean into this segment at the given index, scaled by the given layout size.
+     *
+     * @param layout the layout of the region of memory to be written.
+     * @param index a logical index. The offset in bytes (relative to this segment address) at which the access operation
+     *              will occur can be expressed as {@code (index * layout.byteSize())}.
+     * @param value the boolean value to be written.
+     * @throws IllegalStateException if the {@linkplain #session() session} associated with this segment is not
+     * {@linkplain MemorySession#isAlive() alive}.
+     * @throws WrongThreadException if this method is called from a thread other than the thread owning
+     * the {@linkplain #session() session} associated with this segment.
+     * @throws IllegalArgumentException if the access operation is
+     * <a href="MemorySegment.html#segment-alignment">incompatible with the alignment constraint</a> in the provided layout,
+     * or if the layout alignment is greater than its size.
+     * @throws IndexOutOfBoundsException when the access operation falls outside the <em>spatial bounds</em> of the
+     * memory segment.
+     * @throws UnsupportedOperationException if this segment is {@linkplain #isReadOnly() read-only}.
+     */
+    @ForceInline
+    default void setAtIndex(ValueLayout.OfBoolean layout, long index, boolean value) {
+        Utils.checkElementAlignment(layout, "Layout alignment greater than its size");
+        // note: we know size is a small value (as it comes from ValueLayout::byteSize())
+        ((ValueLayouts.OfBooleanImpl) layout).accessHandle().set(this, index * layout.byteSize(), value);
+    }
+
+
+    /**
      * Reads a char from this segment at the given index, scaled by the given layout size.
      *
      * @param layout the layout of the region of memory to be read.


### PR DESCRIPTION
This PR adds 2 new overloads for the getAtIndex and setAtIndex methods of the MemorySegment Interface for byte and boolean.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Error
&nbsp;⚠️ OCA signatory status must be verified

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/panama-foreign pull/745/head:pull/745` \
`$ git checkout pull/745`

Update a local copy of the PR: \
`$ git checkout pull/745` \
`$ git pull https://git.openjdk.org/panama-foreign pull/745/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 745`

View PR using the GUI difftool: \
`$ git pr show -t 745`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/panama-foreign/pull/745.diff">https://git.openjdk.org/panama-foreign/pull/745.diff</a>

</details>
