### PR TITLE
8275584: Incorrect stack spilling in CallArranger on MacOS/AArch64 

### DIFF
--- a/src/hotspot/cpu/aarch64/foreignGlobals_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/foreignGlobals_aarch64.cpp
@@ -131,8 +131,6 @@ static void move_stack(MacroAssembler* masm, Register tmp_reg, int in_stk_bias, 
     case StorageType::INTEGER:
       assert(to_reg.segment_mask() == REG64_MASK, "only moves to 64-bit registers supported");
       switch (from_reg.stack_size()) {
-        // FIXME these loads zero upper bits of the register
-        // should we sign extend instead?
         case 8: masm->ldr (as_Register(to_reg), from_addr); break;
         case 4: masm->ldrw(as_Register(to_reg), from_addr); break;
         case 2: masm->ldrh(as_Register(to_reg), from_addr); break;

--- a/src/hotspot/cpu/aarch64/foreignGlobals_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/foreignGlobals_aarch64.cpp
@@ -110,7 +110,7 @@ static void move_reg64(MacroAssembler* masm, int out_stk_bias,
     case StorageType::STACK:
       out_bias = out_stk_bias;
     case StorageType::FRAME_DATA: {
-      Address dest(sp, to_reg.index() + out_bias);
+      Address dest(sp, to_reg.offset() + out_bias);
       switch (to_reg.stack_size()) {
         case 8: masm->str (from_reg, dest); break;
         case 4: masm->strw(from_reg, dest); break;
@@ -182,17 +182,14 @@ static void move_v128(MacroAssembler* masm, int out_stk_bias,
       assert(to_reg.segment_mask() == V128_MASK, "only moves to v128 registers supported");
       masm->fmovd(as_FloatRegister(to_reg), from_reg);
       break;
-    case StorageType::STACK:
-      switch(to_reg.stack_size()) {
-        case 8:
-          masm->strd(from_reg, Address(sp, to_reg.offset() + out_stk_bias));
-        break;
-        case 4:
-          masm->strs(from_reg, Address(sp, to_reg.offset() + out_stk_bias));
-        break;
+    case StorageType::STACK: {
+      Address dest(sp, to_reg.offset() + out_stk_bias);
+      switch (to_reg.stack_size()) {
+        case 8: masm->strd(from_reg, dest); break;
+        case 4: masm->strs(from_reg, dest); break;
         default: ShouldNotReachHere();
       }
-      break;
+    } break;
     default: ShouldNotReachHere();
   }
 }

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/aarch64/CallArranger.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/aarch64/CallArranger.java
@@ -262,7 +262,7 @@ public abstract class CallArranger {
             while (offset < layout.byteSize()) {
                 long copy = Math.min(layout.byteSize() - offset, STACK_SLOT_SIZE);
                 VMStorage storage =
-                    storageCalculator.stackAlloc(copy, STACK_SLOT_SIZE);
+                    storageCalculator.stackAlloc(copy, layout.byteAlignment());
                 if (offset + STACK_SLOT_SIZE < layout.byteSize()) {
                     bindings.dup();
                 }
@@ -283,7 +283,7 @@ public abstract class CallArranger {
             while (offset < layout.byteSize()) {
                 long copy = Math.min(layout.byteSize() - offset, STACK_SLOT_SIZE);
                 VMStorage storage =
-                    storageCalculator.stackAlloc(copy, STACK_SLOT_SIZE);
+                    storageCalculator.stackAlloc(copy, layout.byteAlignment());
                 Class<?> type = SharedUtils.primitiveCarrierForSize(copy, false);
                 bindings.dup()
                         .vmLoad(storage, type)

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/aarch64/CallArranger.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/aarch64/CallArranger.java
@@ -188,19 +188,10 @@ public abstract class CallArranger {
 
         VMStorage stackAlloc(long size, long alignment) {
             assert forArguments : "no stack returns";
-            // Implementation limit: each arg must take up at least an 8 byte stack slot (on the Java side)
-            // There is currently no way to address stack offsets that are not multiples of 8 bytes
-            // The VM can only address multiple-of-4-bytes offsets, which is also not good enough for some ABIs
-            // see JDK-8283462 and related issues
-            long stackSlotAlignment = Math.max(alignment, STACK_SLOT_SIZE);
+            long stackSlotAlignment = requiresSubSlotStackPacking() && !forVarArgs
+                    ? alignment
+                    : Math.max(alignment, STACK_SLOT_SIZE);
             long alignedStackOffset = Utils.alignUp(stackOffset, stackSlotAlignment);
-            // macos-aarch64 ABI potentially requires addressing stack offsets that are not multiples of 8 bytes
-            // Reject such call types here, to prevent undefined behavior down the line
-            // Reject if the above stack-slot-aligned offset does not match the offset the ABI really wants
-            // Except for variadic arguments, which _are_ passed at 8-byte-aligned offsets
-            if (requiresSubSlotStackPacking() && alignedStackOffset != Utils.alignUp(stackOffset, alignment)
-                    && !forVarArgs) // varargs are given a pass on all aarch64 ABIs
-                throw new UnsupportedOperationException("Call type not supported on this platform");
 
             short encodedSize = (short) size;
             assert (encodedSize & 0xFFFF) == size;

--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -479,13 +479,6 @@ java/beans/XMLEncoder/Test6570354.java 8015593 macosx-all
 
 ############################################################################
 
-# jdk_foreign
-
-java/foreign/TestUpcallStack.java 8275584 macosx-aarch64
-java/foreign/TestDowncallStack.java 8275584 macosx-aarch64
-
-############################################################################
-
 # jdk_lang
 
 java/lang/ProcessHandle/InfoTest.java                           8211847 aix-ppc64

--- a/test/jdk/java/foreign/callarranger/CallArrangerTestBase.java
+++ b/test/jdk/java/foreign/callarranger/CallArrangerTestBase.java
@@ -32,16 +32,17 @@ import static org.testng.Assert.assertEquals;
 public class CallArrangerTestBase {
 
     public static void checkArgumentBindings(CallingSequence callingSequence, Binding[][] argumentBindings) {
-        assertEquals(callingSequence.argumentBindingsCount(), argumentBindings.length);
+        assertEquals(callingSequence.argumentBindingsCount(), argumentBindings.length,
+          callingSequence.asString() + " != " + Arrays.deepToString(argumentBindings));
 
         for (int i = 0; i < callingSequence.argumentBindingsCount(); i++) {
             List<Binding> actual = callingSequence.argumentBindings(i);
             Binding[] expected = argumentBindings[i];
-            assertEquals(actual, Arrays.asList(expected), "bindings at: " + i);
+            assertEquals(actual, Arrays.asList(expected), "bindings at: " + i + ": " + actual + " != " + Arrays.toString(expected));
         }
     }
 
     public static void checkReturnBindings(CallingSequence callingSequence, Binding[] returnBindings) {
-        assertEquals(callingSequence.returnBindings(), Arrays.asList(returnBindings));
+        assertEquals(callingSequence.returnBindings(), Arrays.asList(returnBindings), callingSequence.returnBindings() + " != " + Arrays.toString(returnBindings));
     }
 }

--- a/test/jdk/java/foreign/callarranger/CallArrangerTestBase.java
+++ b/test/jdk/java/foreign/callarranger/CallArrangerTestBase.java
@@ -37,7 +37,7 @@ public class CallArrangerTestBase {
         for (int i = 0; i < callingSequence.argumentBindingsCount(); i++) {
             List<Binding> actual = callingSequence.argumentBindings(i);
             Binding[] expected = argumentBindings[i];
-            assertEquals(actual, Arrays.asList(expected));
+            assertEquals(actual, Arrays.asList(expected), "bindings at: " + i);
         }
     }
 

--- a/test/jdk/java/foreign/callarranger/TestAarch64CallArranger.java
+++ b/test/jdk/java/foreign/callarranger/TestAarch64CallArranger.java
@@ -34,6 +34,7 @@
 
 import java.lang.foreign.FunctionDescriptor;
 import java.lang.foreign.MemoryLayout;
+import java.lang.foreign.StructLayout;
 import java.lang.foreign.MemorySegment;
 import jdk.internal.foreign.abi.Binding;
 import jdk.internal.foreign.abi.CallingSequence;
@@ -478,6 +479,161 @@ public class TestAarch64CallArranger extends CallArrangerTestBase {
             { vmStore(stackStorage((short) 4, 4), int.class) },
             { cast(short.class, int.class), vmStore(stackStorage((short) 2, 8), int.class) },
             { cast(byte.class, int.class), vmStore(stackStorage((short) 1, 10), int.class) },
+        });
+
+        checkReturnBindings(callingSequence, new Binding[]{});
+    }
+
+    @Test
+    public void testMacArgsOnStack2() {
+        StructLayout struct = MemoryLayout.structLayout(
+            C_FLOAT,
+            C_FLOAT
+        );
+        MethodType mt = MethodType.methodType(void.class,
+                long.class, long.class, long.class, long.class,
+                long.class, long.class, long.class, long.class,
+                double.class, double.class, double.class, double.class,
+                double.class, double.class, double.class, double.class,
+                int.class, MemorySegment.class);
+        FunctionDescriptor fd = FunctionDescriptor.ofVoid(
+                C_LONG_LONG, C_LONG_LONG, C_LONG_LONG, C_LONG_LONG,
+                C_LONG_LONG, C_LONG_LONG, C_LONG_LONG, C_LONG_LONG,
+                C_DOUBLE, C_DOUBLE, C_DOUBLE, C_DOUBLE,
+                C_DOUBLE, C_DOUBLE, C_DOUBLE, C_DOUBLE,
+                C_INT, struct);
+        CallArranger.Bindings bindings = CallArranger.MACOS.getBindings(mt, fd, false);
+
+        assertFalse(bindings.isInMemoryReturn);
+        CallingSequence callingSequence = bindings.callingSequence;
+        assertEquals(callingSequence.callerMethodType(), mt.insertParameterTypes(0, MemorySegment.class));
+        assertEquals(callingSequence.functionDesc(), fd.insertArgumentLayouts(0, ADDRESS));
+
+        checkArgumentBindings(callingSequence, new Binding[][]{
+            { unboxAddress(), vmStore(r9, long.class) },
+            { vmStore(r0, long.class) },
+            { vmStore(r1, long.class) },
+            { vmStore(r2, long.class) },
+            { vmStore(r3, long.class) },
+            { vmStore(r4, long.class) },
+            { vmStore(r5, long.class) },
+            { vmStore(r6, long.class) },
+            { vmStore(r7, long.class) },
+            { vmStore(v0, double.class) },
+            { vmStore(v1, double.class) },
+            { vmStore(v2, double.class) },
+            { vmStore(v3, double.class) },
+            { vmStore(v4, double.class) },
+            { vmStore(v5, double.class) },
+            { vmStore(v6, double.class) },
+            { vmStore(v7, double.class) },
+            { vmStore(stackStorage((short) 4, 0), int.class) },
+            { bufferLoad(0, long.class), vmStore(stackStorage((short) 8, 4), long.class) },
+        });
+
+        checkReturnBindings(callingSequence, new Binding[]{});
+    }
+
+    @Test
+    public void testMacArgsOnStack3() {
+        StructLayout struct = MemoryLayout.structLayout(
+            C_POINTER,
+            C_POINTER
+        );
+        MethodType mt = MethodType.methodType(void.class,
+                long.class, long.class, long.class, long.class,
+                long.class, long.class, long.class, long.class,
+                double.class, double.class, double.class, double.class,
+                double.class, double.class, double.class, double.class,
+                MemorySegment.class, float.class);
+        FunctionDescriptor fd = FunctionDescriptor.ofVoid(
+                C_LONG_LONG, C_LONG_LONG, C_LONG_LONG, C_LONG_LONG,
+                C_LONG_LONG, C_LONG_LONG, C_LONG_LONG, C_LONG_LONG,
+                C_DOUBLE, C_DOUBLE, C_DOUBLE, C_DOUBLE,
+                C_DOUBLE, C_DOUBLE, C_DOUBLE, C_DOUBLE,
+                struct, C_FLOAT);
+        CallArranger.Bindings bindings = CallArranger.MACOS.getBindings(mt, fd, false);
+
+        assertFalse(bindings.isInMemoryReturn);
+        CallingSequence callingSequence = bindings.callingSequence;
+        assertEquals(callingSequence.callerMethodType(), mt.insertParameterTypes(0, MemorySegment.class));
+        assertEquals(callingSequence.functionDesc(), fd.insertArgumentLayouts(0, ADDRESS));
+
+        checkArgumentBindings(callingSequence, new Binding[][]{
+            { unboxAddress(), vmStore(r9, long.class) },
+            { vmStore(r0, long.class) },
+            { vmStore(r1, long.class) },
+            { vmStore(r2, long.class) },
+            { vmStore(r3, long.class) },
+            { vmStore(r4, long.class) },
+            { vmStore(r5, long.class) },
+            { vmStore(r6, long.class) },
+            { vmStore(r7, long.class) },
+            { vmStore(v0, double.class) },
+            { vmStore(v1, double.class) },
+            { vmStore(v2, double.class) },
+            { vmStore(v3, double.class) },
+            { vmStore(v4, double.class) },
+            { vmStore(v5, double.class) },
+            { vmStore(v6, double.class) },
+            { vmStore(v7, double.class) },
+            { dup(),
+                bufferLoad(0, long.class), vmStore(stackStorage((short) 8, 0), long.class),
+                bufferLoad(8, long.class), vmStore(stackStorage((short) 8, 8), long.class) },
+            { vmStore(stackStorage((short) 4, 16), float.class) },
+        });
+
+        checkReturnBindings(callingSequence, new Binding[]{});
+    }
+
+    @Test
+    public void testMacArgsOnStack4() {
+        StructLayout struct = MemoryLayout.structLayout(
+            C_INT,
+            C_INT,
+            C_POINTER
+        );
+        MethodType mt = MethodType.methodType(void.class,
+                long.class, long.class, long.class, long.class,
+                long.class, long.class, long.class, long.class,
+                double.class, double.class, double.class, double.class,
+                double.class, double.class, double.class, double.class,
+                float.class, MemorySegment.class);
+        FunctionDescriptor fd = FunctionDescriptor.ofVoid(
+                C_LONG_LONG, C_LONG_LONG, C_LONG_LONG, C_LONG_LONG,
+                C_LONG_LONG, C_LONG_LONG, C_LONG_LONG, C_LONG_LONG,
+                C_DOUBLE, C_DOUBLE, C_DOUBLE, C_DOUBLE,
+                C_DOUBLE, C_DOUBLE, C_DOUBLE, C_DOUBLE,
+                C_FLOAT, struct);
+        CallArranger.Bindings bindings = CallArranger.MACOS.getBindings(mt, fd, false);
+
+        assertFalse(bindings.isInMemoryReturn);
+        CallingSequence callingSequence = bindings.callingSequence;
+        assertEquals(callingSequence.callerMethodType(), mt.insertParameterTypes(0, MemorySegment.class));
+        assertEquals(callingSequence.functionDesc(), fd.insertArgumentLayouts(0, ADDRESS));
+
+        checkArgumentBindings(callingSequence, new Binding[][]{
+            { unboxAddress(), vmStore(r9, long.class) },
+            { vmStore(r0, long.class) },
+            { vmStore(r1, long.class) },
+            { vmStore(r2, long.class) },
+            { vmStore(r3, long.class) },
+            { vmStore(r4, long.class) },
+            { vmStore(r5, long.class) },
+            { vmStore(r6, long.class) },
+            { vmStore(r7, long.class) },
+            { vmStore(v0, double.class) },
+            { vmStore(v1, double.class) },
+            { vmStore(v2, double.class) },
+            { vmStore(v3, double.class) },
+            { vmStore(v4, double.class) },
+            { vmStore(v5, double.class) },
+            { vmStore(v6, double.class) },
+            { vmStore(v7, double.class) },
+            { vmStore(stackStorage((short) 4, 0), float.class) },
+            { dup(),
+                bufferLoad(0, long.class), vmStore(stackStorage((short) 8, 8), long.class),
+                bufferLoad(8, long.class), vmStore(stackStorage((short) 8, 16), long.class) },
         });
 
         checkReturnBindings(callingSequence, new Binding[]{});

--- a/test/jdk/java/foreign/callarranger/TestAarch64CallArranger.java
+++ b/test/jdk/java/foreign/callarranger/TestAarch64CallArranger.java
@@ -460,13 +460,13 @@ public class TestAarch64CallArranger extends CallArrangerTestBase {
                 C_INT, C_INT, C_SHORT, C_CHAR);
         CallArranger.Bindings bindings = CallArranger.MACOS.getBindings(mt, fd, false);
 
-        assertFalse(bindings.isInMemoryReturn);
-        CallingSequence callingSequence = bindings.callingSequence;
+        assertFalse(bindings.isInMemoryReturn());
+        CallingSequence callingSequence = bindings.callingSequence();
         assertEquals(callingSequence.callerMethodType(), mt.insertParameterTypes(0, MemorySegment.class));
         assertEquals(callingSequence.functionDesc(), fd.insertArgumentLayouts(0, ADDRESS));
 
         checkArgumentBindings(callingSequence, new Binding[][]{
-            { unboxAddress(), vmStore(r9, long.class) },
+            { unboxAddress(), vmStore(TARGET_ADDRESS_STORAGE, long.class) },
             { vmStore(r0, int.class) },
             { vmStore(r1, int.class) },
             { vmStore(r2, int.class) },
@@ -504,13 +504,13 @@ public class TestAarch64CallArranger extends CallArrangerTestBase {
                 C_INT, struct);
         CallArranger.Bindings bindings = CallArranger.MACOS.getBindings(mt, fd, false);
 
-        assertFalse(bindings.isInMemoryReturn);
-        CallingSequence callingSequence = bindings.callingSequence;
+        assertFalse(bindings.isInMemoryReturn());
+        CallingSequence callingSequence = bindings.callingSequence();
         assertEquals(callingSequence.callerMethodType(), mt.insertParameterTypes(0, MemorySegment.class));
         assertEquals(callingSequence.functionDesc(), fd.insertArgumentLayouts(0, ADDRESS));
 
         checkArgumentBindings(callingSequence, new Binding[][]{
-            { unboxAddress(), vmStore(r9, long.class) },
+            { unboxAddress(), vmStore(TARGET_ADDRESS_STORAGE, long.class) },
             { vmStore(r0, long.class) },
             { vmStore(r1, long.class) },
             { vmStore(r2, long.class) },
@@ -528,7 +528,13 @@ public class TestAarch64CallArranger extends CallArrangerTestBase {
             { vmStore(v6, double.class) },
             { vmStore(v7, double.class) },
             { vmStore(stackStorage((short) 4, 0), int.class) },
-            { bufferLoad(0, long.class), vmStore(stackStorage((short) 8, 4), long.class) },
+            {
+                dup(),
+                bufferLoad(0, int.class),
+                vmStore(stackStorage((short) 4, 4), int.class),
+                bufferLoad(4, int.class),
+                vmStore(stackStorage((short) 4, 8), int.class),
+            }
         });
 
         checkReturnBindings(callingSequence, new Binding[]{});
@@ -554,13 +560,13 @@ public class TestAarch64CallArranger extends CallArrangerTestBase {
                 struct, C_FLOAT);
         CallArranger.Bindings bindings = CallArranger.MACOS.getBindings(mt, fd, false);
 
-        assertFalse(bindings.isInMemoryReturn);
-        CallingSequence callingSequence = bindings.callingSequence;
+        assertFalse(bindings.isInMemoryReturn());
+        CallingSequence callingSequence = bindings.callingSequence();
         assertEquals(callingSequence.callerMethodType(), mt.insertParameterTypes(0, MemorySegment.class));
         assertEquals(callingSequence.functionDesc(), fd.insertArgumentLayouts(0, ADDRESS));
 
         checkArgumentBindings(callingSequence, new Binding[][]{
-            { unboxAddress(), vmStore(r9, long.class) },
+            { unboxAddress(), vmStore(TARGET_ADDRESS_STORAGE, long.class) },
             { vmStore(r0, long.class) },
             { vmStore(r1, long.class) },
             { vmStore(r2, long.class) },
@@ -607,13 +613,13 @@ public class TestAarch64CallArranger extends CallArrangerTestBase {
                 C_FLOAT, struct);
         CallArranger.Bindings bindings = CallArranger.MACOS.getBindings(mt, fd, false);
 
-        assertFalse(bindings.isInMemoryReturn);
-        CallingSequence callingSequence = bindings.callingSequence;
+        assertFalse(bindings.isInMemoryReturn());
+        CallingSequence callingSequence = bindings.callingSequence();
         assertEquals(callingSequence.callerMethodType(), mt.insertParameterTypes(0, MemorySegment.class));
         assertEquals(callingSequence.functionDesc(), fd.insertArgumentLayouts(0, ADDRESS));
 
         checkArgumentBindings(callingSequence, new Binding[][]{
-            { unboxAddress(), vmStore(r9, long.class) },
+            { unboxAddress(), vmStore(TARGET_ADDRESS_STORAGE, long.class) },
             { vmStore(r0, long.class) },
             { vmStore(r1, long.class) },
             { vmStore(r2, long.class) },


### PR DESCRIPTION
This patch adds special handling for argument spilling on M1 Mac which does not follow the standard AArch64.  In the standard ABI arguments are first extended to the full 64-bit register width and then spilled but on macOS the arguments are spilled according to their original width and packed using theior natural.  @JornVernee  did most of the work to support this but there were a few issues remaining related to structspilling which I've fixed up in the last commit here.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8275584](https://bugs.openjdk.org/browse/JDK-8275584): Incorrect stack spilling in CallArranger on MacOS/AArch64


### Reviewers
 * [Jorn Vernee](https://openjdk.org/census#jvernee) (@JornVernee - Committer)


### Contributors
 * Jorn Vernee `<jvernee@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/panama-foreign pull/746/head:pull/746` \
`$ git checkout pull/746`

Update a local copy of the PR: \
`$ git checkout pull/746` \
`$ git pull https://git.openjdk.org/panama-foreign pull/746/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 746`

View PR using the GUI difftool: \
`$ git pr show -t 746`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/panama-foreign/pull/746.diff">https://git.openjdk.org/panama-foreign/pull/746.diff</a>

</details>
