### PR TITLE
8295780: API doc enhancement needed for MemorySegment.get/setUtf8String, MemoryAddress.ofLong

### DIFF
--- a/src/java.base/share/classes/java/lang/foreign/MemorySegment.java
+++ b/src/java.base/share/classes/java/lang/foreign/MemorySegment.java
@@ -881,7 +881,7 @@ public sealed interface MemorySegment permits AbstractMemorySegmentImpl {
      * @return a Java string constructed from the bytes read from the given starting address up to (but not including)
      * the first {@code '\0'} terminator character (assuming one is found).
      * @throws IllegalArgumentException if the size of the UTF-8 string is greater than the largest string supported by the platform.
-     * @throws IndexOutOfBoundsException if {@code S + offset > byteSize()}, where {@code S} is the size of the UTF-8
+     * @throws IndexOutOfBoundsException if {@code offset < 0} or {@code S + offset > byteSize()}, where {@code S} is the size of the UTF-8
      * string (including the terminator character).
      * @throws IllegalStateException if the {@linkplain #session() session} associated with this segment is not
      * {@linkplain MemorySession#isAlive() alive}.
@@ -907,7 +907,7 @@ public sealed interface MemorySegment permits AbstractMemorySegmentImpl {
      * @param offset offset in bytes (relative to this segment address) at which this access operation will occur.
      *               the final address of this write operation can be expressed as {@code address() + offset}.
      * @param str the Java string to be written into this segment.
-     * @throws IndexOutOfBoundsException if {@code str.getBytes().length() + offset >= byteSize()}.
+     * @throws IndexOutOfBoundsException if {@code offset < 0} or {@code str.getBytes().length() + offset >= byteSize()}.
      * @throws IllegalStateException if the {@linkplain #session() session} associated with this segment is not
      * {@linkplain MemorySession#isAlive() alive}.
      * @throws WrongThreadException if this method is called from a thread other than the thread owning


### PR DESCRIPTION
This PR adds negative case for some `@throws IndexOutOfBoundsException` JavaDocs.

Note that `MemoryAddress` does not exist in Java 20.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8295780](https://bugs.openjdk.org/browse/JDK-8295780): API doc enhancement needed for MemorySegment.get/setUtf8String, MemoryAddress.ofLong


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.org/census#mcimadamore) (@mcimadamore - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/panama-foreign pull/748/head:pull/748` \
`$ git checkout pull/748`

Update a local copy of the PR: \
`$ git checkout pull/748` \
`$ git pull https://git.openjdk.org/panama-foreign pull/748/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 748`

View PR using the GUI difftool: \
`$ git pr show -t 748`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/panama-foreign/pull/748.diff">https://git.openjdk.org/panama-foreign/pull/748.diff</a>

</details>
