### PR TITLE
8294871: The spec on the method MemorySegment::segmentOffset() should be corrected

### DIFF
--- a/src/java.base/share/classes/java/lang/foreign/MemorySegment.java
+++ b/src/java.base/share/classes/java/lang/foreign/MemorySegment.java
@@ -549,7 +549,7 @@ public sealed interface MemorySegment permits AbstractMemorySegmentImpl {
      * can be computed as follows:
      *
      * {@snippet lang=java :
-     * other.address() - segment.baseAddress()
+     * other.address() - segment.address()
      * }
      *
      * If the segments share the same address, {@code 0} is returned. If


### PR DESCRIPTION
This PR fixes the snippet in `MemorySegment::segmentOffset`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8294871](https://bugs.openjdk.org/browse/JDK-8294871): The spec on the method MemorySegment::segmentOffset() should be corrected


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.org/census#mcimadamore) (@mcimadamore - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/panama-foreign pull/749/head:pull/749` \
`$ git checkout pull/749`

Update a local copy of the PR: \
`$ git checkout pull/749` \
`$ git pull https://git.openjdk.org/panama-foreign pull/749/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 749`

View PR using the GUI difftool: \
`$ git pr show -t 749`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/panama-foreign/pull/749.diff">https://git.openjdk.org/panama-foreign/pull/749.diff</a>

</details>
