### PR TITLE
Add @apiNote to package-info

### DIFF
--- a/src/java.base/share/classes/java/lang/foreign/package-info.java
+++ b/src/java.base/share/classes/java/lang/foreign/package-info.java
@@ -215,7 +215,7 @@
  * type must not be null, and any null argument will elicit a {@code NullPointerException}.  This fact is not individually
  * documented for methods of this API.
  *
- * @apiNote The normal Java Ojbect access control, guarantees and constraints, for example stated in
+ * @apiNote Usual memory model guarantees, for example stated in
  * {@jls 6.6} and {@jls 10.4}, do not apply when accessing native memory segments as these segments are
  * backed by off-heap regions of memory.
  */

--- a/src/java.base/share/classes/java/lang/foreign/package-info.java
+++ b/src/java.base/share/classes/java/lang/foreign/package-info.java
@@ -214,5 +214,9 @@
  * For every class in this package, unless specified otherwise, any method arguments of reference
  * type must not be null, and any null argument will elicit a {@code NullPointerException}.  This fact is not individually
  * documented for methods of this API.
+ *
+ * @apiNote The normal Java Ojbect access control, guarantees and constraints, for example stated in
+ * {@jls 6.6} and {@jls 10.4}, do not apply when accessing native memory segments as these segments are
+ * backed by off-heap regions of memory.
  */
 package java.lang.foreign;


### PR DESCRIPTION
This PR proposes an additional `@apiNote` saying native memory behaves differently that normal Java objects.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/panama-foreign pull/751/head:pull/751` \
`$ git checkout pull/751`

Update a local copy of the PR: \
`$ git checkout pull/751` \
`$ git pull https://git.openjdk.org/panama-foreign pull/751/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 751`

View PR using the GUI difftool: \
`$ git pr show -t 751`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/panama-foreign/pull/751.diff">https://git.openjdk.org/panama-foreign/pull/751.diff</a>

</details>
