### PR TITLE
8298532: Declare private constructors for FFM internal Architecture implementations

### DIFF
--- a/src/java.base/share/classes/jdk/internal/foreign/abi/aarch64/AArch64Architecture.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/aarch64/AArch64Architecture.java
@@ -40,7 +40,7 @@ public final class AArch64Architecture implements Architecture {
     private static final int VECTOR_REG_SIZE = 16;
 
     // Suppresses default constructor, ensuring non-instantiability.
-    public AArch64Architecture() {}
+    private AArch64Architecture() {}
 
     @Override
     public boolean isStackType(int cls) {

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/aarch64/AArch64Architecture.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/aarch64/AArch64Architecture.java
@@ -30,7 +30,7 @@ import jdk.internal.foreign.abi.Architecture;
 import jdk.internal.foreign.abi.StubLocations;
 import jdk.internal.foreign.abi.VMStorage;
 
-public class AArch64Architecture implements Architecture {
+public final class AArch64Architecture implements Architecture {
     public static final Architecture INSTANCE = new AArch64Architecture();
 
     private static final short REG64_MASK = 0b0000_0000_0000_0001;
@@ -38,6 +38,9 @@ public class AArch64Architecture implements Architecture {
 
     private static final int INTEGER_REG_SIZE = 8;
     private static final int VECTOR_REG_SIZE = 16;
+
+    // Suppresses default constructor, ensuring non-instantiability.
+    public AArch64Architecture() {}
 
     @Override
     public boolean isStackType(int cls) {

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/x64/X86_64Architecture.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/x64/X86_64Architecture.java
@@ -31,7 +31,7 @@ import jdk.internal.foreign.abi.VMStorage;
 
 import java.util.stream.IntStream;
 
-public class X86_64Architecture implements Architecture {
+public final class X86_64Architecture implements Architecture {
     public static final Architecture INSTANCE = new X86_64Architecture();
 
     private static final short REG8_H_MASK = 0b0000_0000_0000_0010;
@@ -47,6 +47,9 @@ public class X86_64Architecture implements Architecture {
     private static final int INTEGER_REG_SIZE = 8; // bytes
     private static final int VECTOR_REG_SIZE = 16; // size of XMM register
     private static final int X87_REG_SIZE = 16;
+
+    // Suppresses default constructor, ensuring non-instantiability.
+    private X86_64Architecture() {}
 
     @Override
     public boolean isStackType(int cls) {


### PR DESCRIPTION
This PR proposes declaring AArch64Architecture and X86_64Architecture final and creating a private constructor so that this redundant byte code can be eliminated:

```
 public jdk.internal.foreign.abi.x64.X86_64Architecture(); 
    Code: 
       0: aload_0 
       1: invokespecial #1 // Method java/lang/Object."<init>":()V 
       4: return 

 public jdk.internal.foreign.abi.aarch64.AArch64Architectur(); 
    Code: 
       0: aload_0 
       1: invokespecial #1 // Method java/lang/Object."<init>":()V 
       4: return 
```

and other potential optimizations can be unlocked.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8298532](https://bugs.openjdk.org/browse/JDK-8298532): Declare private constructors for FFM internal Architecture implementations


### Reviewers
 * [Jorn Vernee](https://openjdk.org/census#jvernee) (@JornVernee - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/panama-foreign pull/760/head:pull/760` \
`$ git checkout pull/760`

Update a local copy of the PR: \
`$ git checkout pull/760` \
`$ git pull https://git.openjdk.org/panama-foreign pull/760/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 760`

View PR using the GUI difftool: \
`$ git pr show -t 760`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/panama-foreign/pull/760.diff">https://git.openjdk.org/panama-foreign/pull/760.diff</a>

</details>
