### PR TITLE
8299911: Refactor struct handling in AArch64 CallArranger

### DIFF
--- a/src/java.base/share/classes/jdk/internal/foreign/abi/SharedUtils.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/SharedUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/SharedUtils.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/SharedUtils.java
@@ -156,25 +156,29 @@ public final class SharedUtils {
     }
 
     public static Class<?> primitiveCarrierForSize(long size, boolean useFloat) {
+        return primitiveLayoutForSize(size, useFloat).carrier();
+    }
+
+    public static ValueLayout primitiveLayoutForSize(long size, boolean useFloat) {
         if (useFloat) {
             if (size == 4) {
-                return float.class;
+                return JAVA_FLOAT;
             } else if (size == 8) {
-                return double.class;
+                return JAVA_DOUBLE;
             }
         } else {
             if (size == 1) {
-                return byte.class;
+                return JAVA_BYTE;
             } else if (size == 2) {
-                return short.class;
+                return JAVA_SHORT;
             } else if (size <= 4) {
-                return int.class;
+                return JAVA_INT;
             } else if (size <= 8) {
-                return long.class;
+                return JAVA_LONG;
             }
         }
 
-        throw new IllegalArgumentException("No type for size: " + size + " isFloat=" + useFloat);
+        throw new IllegalArgumentException("No layout for size: " + size + " isFloat=" + useFloat);
     }
 
     public static Linker getSystemLinker() {

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/aarch64/CallArranger.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/aarch64/CallArranger.java
@@ -298,7 +298,7 @@ public abstract class CallArranger {
             for (int i = 0; i < structStorages.length; i++) {
                 ValueLayout copyLayout;
                 if (isFieldWise) {
-                    // We only expect to see fields here, no padding (the cast would fail)
+                    // We should only get here for HFAs, which can't have padding (the cast would fail)
                     copyLayout = (ValueLayout) layout.memberLayouts().get(i);
                 } else {
                     // chunk-wise copy

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/aarch64/CallArranger.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/aarch64/CallArranger.java
@@ -243,7 +243,7 @@ public abstract class CallArranger {
         The struct is split into 8-byte chunks, and those chunks are either passed in registers and/or on the stack.
 
         Homogeneous float aggregates (HFAs) can be copied in a field-wise manner, i.e. the struct is split into it's
-        fields and those fields are the chunks which are passed. The rules are more complicated and ABI based:
+        fields and those fields are the chunks which are passed. For HFAs the rules are more complicated and ABI based:
 
                 | enough registers | some registers, but not enough  | no registers
         --------+------------------+---------------------------------+-------------------------
@@ -293,9 +293,9 @@ public abstract class CallArranger {
                 VMStorage storage = nextStorage(regType, copyLayout);
                 Class<?> carrier = copyLayout.carrier();
                 if (isFieldWise && storage.type() == StorageType.STACK) {
-                    // chunkLayout is a field of an HFA
+                    // copyLayout is a field of an HFA
                     // Don't use floats on the stack
-                    carrier = adjustCarrierForStack(copyLayout.carrier());
+                    carrier = adjustCarrierForStack(carrier);
                 }
                 structStorages[i] = new StructStorage(offset, carrier, storage);
                 offset += copyLayout.byteSize();

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/aarch64/CallArranger.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/aarch64/CallArranger.java
@@ -298,7 +298,7 @@ public abstract class CallArranger {
             for (int i = 0; i < structStorages.length; i++) {
                 ValueLayout copyLayout;
                 if (isFieldWise) {
-                    // fields only, no padding
+                    // We only expect to see fields here, no padding (the cast would fail)
                     copyLayout = (ValueLayout) layout.memberLayouts().get(i);
                 } else {
                     // chunk-wise copy

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/aarch64/CallArranger.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/aarch64/CallArranger.java
@@ -298,7 +298,7 @@ public abstract class CallArranger {
             for (int i = 0; i < structStorages.length; i++) {
                 ValueLayout copyLayout;
                 if (isFieldWise) {
-                    // We should only get here for HFAs, which can't have padding (the cast would fail)
+                    // We should only get here for HFAs, which can't have padding
                     copyLayout = (ValueLayout) layout.memberLayouts().get(i);
                 } else {
                     // chunk-wise copy

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/aarch64/CallArranger.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/aarch64/CallArranger.java
@@ -245,12 +245,23 @@ public abstract class CallArranger {
         Homogeneous float aggregates (HFAs) can be copied in a field-wise manner, i.e. the struct is split into it's
         fields and those fields are the chunks which are passed. For HFAs the rules are more complicated and ABI based:
 
-                | enough registers | some registers, but not enough  | no registers
-        --------+------------------+---------------------------------+-------------------------
-        Linux   | FW in regs       | CW on the stack                 | CW on the stack
-        MacOs   | FW in regs       | FW on the stack                 | FW on the stack
-        Windows | FW in regs       | FW split between regs and stack | CW on the stack
-        (where FW = Field-wise copy, and CW = Chunk-wise copy)
+                        | enough registers | some registers, but not enough  | no registers
+        ----------------+------------------+---------------------------------+-------------------------
+        Linux           | FW in regs       | CW on the stack                 | CW on the stack
+        MacOs, non-VA   | FW in regs       | FW on the stack                 | FW on the stack
+        MacOs, VA       | FW in regs       | CW on the stack                 | CW on the stack
+        Windows, non-VF | FW in regs       | CW on the stack                 | CW on the stack
+        Windows, VF     | FW in regs       | CW split between regs and stack | CW on the stack
+        (where FW = Field-wise copy, CW = Chunk-wise copy, VA is a variadic argument, and VF is a variadic function)
+
+        For regular structs, the rules are as follows:
+
+                        | enough registers | some registers, but not enough  | no registers
+        ----------------+------------------+---------------------------------+-------------------------
+        Linux           | CW in regs       | CW on the stack                 | CW on the stack
+        MacOs           | CW in regs       | CW on the stack                 | CW on the stack
+        Windows, non-VF | CW in regs       | CW on the stack                 | CW on the stack
+        Windows, VF     | CW in regs       | CW split between regs and stack | CW on the stack
          */
         StructStorage[] structStorages(GroupLayout layout, boolean forHFA) {
             int regType = forHFA ? StorageType.VECTOR : StorageType.INTEGER;

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/aarch64/CallArranger.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/aarch64/CallArranger.java
@@ -312,7 +312,7 @@ public abstract class CallArranger {
                 offset += copyLayout.byteSize();
             }
 
-            if (requiresSubSlotStackPacking()) {
+            if (requiresSubSlotStackPacking() && !isFieldWise) {
                 // Pad to the next stack slot boundary instead of packing
                 // additional arguments into the unused space.
                 stackOffset = Utils.alignUp(stackOffset, STACK_SLOT_SIZE);

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/aarch64/CallArranger.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/aarch64/CallArranger.java
@@ -287,6 +287,12 @@ public abstract class CallArranger {
                 nRegs[regType] = MAX_REGISTER_ARGUMENTS;
             }
 
+            if (requiresSubSlotStackPacking() && !isFieldWise) {
+                // Pad to the next stack slot boundary instead of packing
+                // additional arguments into the unused space.
+                alignStack(STACK_SLOT_SIZE);
+            }
+
             StructStorage[] structStorages = new StructStorage[requiredStorages];
             long offset = 0;
             for (int i = 0; i < structStorages.length; i++) {
@@ -315,10 +321,14 @@ public abstract class CallArranger {
             if (requiresSubSlotStackPacking() && !isFieldWise) {
                 // Pad to the next stack slot boundary instead of packing
                 // additional arguments into the unused space.
-                stackOffset = Utils.alignUp(stackOffset, STACK_SLOT_SIZE);
+                alignStack(STACK_SLOT_SIZE);
             }
 
             return structStorages;
+        }
+
+        private void alignStack(long alignment) {
+            stackOffset = Utils.alignUp(stackOffset, alignment);
         }
 
         // allocate a single ValueLayout, either in a register or on the stack

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/aarch64/CallArranger.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/aarch64/CallArranger.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2023, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2019, 2022, Arm Limited. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/aarch64/CallArranger.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/aarch64/CallArranger.java
@@ -44,6 +44,7 @@ import jdk.internal.foreign.abi.aarch64.windows.WindowsAArch64CallArranger;
 import jdk.internal.foreign.Utils;
 
 import java.lang.foreign.SegmentScope;
+import java.lang.foreign.ValueLayout;
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodType;
 import java.util.List;
@@ -65,6 +66,7 @@ import static jdk.internal.foreign.abi.aarch64.AArch64Architecture.Regs.*;
  */
 public abstract class CallArranger {
     private static final int STACK_SLOT_SIZE = 8;
+    private static final int MAX_COPY_SIZE = 8;
     public static final int MAX_REGISTER_ARGUMENTS = 8;
 
     private static final VMStorage INDIRECT_RESULT = r8;
@@ -217,106 +219,125 @@ public abstract class CallArranger {
             this.forVariadicFunction = forVariadicFunction;
         }
 
-        void alignStack(long alignment) {
-            stackOffset = Utils.alignUp(stackOffset, alignment);
+        private boolean hasRegister(int type) {
+            return hasEnoughRegisters(type, 1);
         }
 
-        VMStorage stackAlloc(long size, long alignment) {
+        private boolean hasEnoughRegisters(int type, int count) {
+            return nRegs[type] + count <= MAX_REGISTER_ARGUMENTS;
+        }
+
+        private Class<?> adjustCarrier(Class<?> carrier) {
+            if (carrier == float.class) {
+                carrier = int.class;
+            } else if (carrier == double.class) {
+                carrier = long.class;
+            }
+            return carrier;
+        }
+
+        record StructCopy(long offset, Class<?> carrier, VMStorage storage) {}
+
+        /*
+        In the simplest case structs are copied in chunks. i.e. the fields don't matter, just the size.
+        The struct is split into 8-byte chunks, and those chunks are either passed in registers or on the stack.
+
+        Homogeneous float aggregates (HFAs) can be copied in a field-wise manner, i.e. the struct is split into it's fields
+        and those fields are the chunks which are passed. The rules are more complicated and ABI based:
+
+                | enough registers | some registers, but not enough  | no registers
+        --------+------------------------------------------------------------------------------
+        Linux   | Field-wise copy  | CW on the stack                 | CW on the stack
+        MacOs   | Field-wise copy  | FW on the stack                 | FW on the stack
+        Windows | Field-wise copy  | FW split between regs and stack | CW on the stack
+        (where FW = Field-wise copy, and CW = Chunk-wise copy)
+         */
+        StructCopy[] allocForStruct(GroupLayout layout, boolean forHFA) {
+            int regType = forHFA ? StorageType.VECTOR : StorageType.INTEGER;
+            int numChunks = (int)Utils.alignUp(layout.byteSize(), MAX_COPY_SIZE) / MAX_COPY_SIZE;
+            int requiredStorages = forHFA ? layout.memberLayouts().size() : numChunks;
+            boolean hasEnoughRegisters = hasEnoughRegisters(regType, requiredStorages);
+
+            // For the ABI variants that pack arguments spilled to the
+            // stack, HFA arguments are spilled as if their individual
+            // fields had been allocated separately rather than as if the
+            // struct had been spilled as a whole.
+            boolean useFieldWiseSpill = requiresSubSlotStackPacking() && !forVarArgs;
+            boolean isFieldWise = forHFA && (hasEnoughRegisters || useFieldWiseSpill);
+            if (!isFieldWise) {
+                requiredStorages = numChunks;
+            }
+
+            boolean spillPartially = forVariadicFunction && spillsVariadicStructsPartially();
+            boolean furtherAllocationFromTheStack = !hasEnoughRegisters && !spillPartially;
+            if (furtherAllocationFromTheStack) {
+                // Any further allocations for this register type must
+                // be from the stack.
+                nRegs[regType] = MAX_REGISTER_ARGUMENTS;
+            }
+
+            StructCopy[] copies = new StructCopy[requiredStorages];
+            long offset = 0;
+            for (int i = 0; i < copies.length; i++) {
+                boolean isRegCopy = hasRegister(regType);
+                // Don't use floats for the stack
+                boolean useFloat = isRegCopy && regType == StorageType.VECTOR;
+
+                ValueLayout copyLayout;
+                if (isFieldWise) {
+                    copyLayout = (ValueLayout) layout.memberLayouts().get(i);
+                } else {
+                    long copySize = Math.min(layout.byteSize() - offset, MAX_COPY_SIZE);
+                    copyLayout = SharedUtils.primitiveLayoutForSize(copySize, useFloat);
+                }
+
+                VMStorage storage = isRegCopy ? regAlloc(regType) : stackAlloc(copyLayout);
+                Class<?> carrier = copyLayout.carrier();
+                if (isFieldWise && !useFloat) {
+                    carrier = adjustCarrier(copyLayout.carrier());
+                }
+                copies[i] = new StructCopy(offset, carrier, storage);
+                offset += copyLayout.byteSize();
+            }
+
+            if (requiresSubSlotStackPacking()) {
+                // Pad to the next stack slot boundary instead of packing
+                // additional arguments into the unused space.
+                stackOffset = Utils.alignUp(stackOffset, STACK_SLOT_SIZE);
+            }
+
+            return copies;
+        }
+
+        // allocate a single ValueLayout, either in a register or on the stack
+        VMStorage nextStorage(int type, ValueLayout layout) {
+            if (hasRegister(type)) {
+                return regAlloc(type);
+            }
+
+            return stackAlloc(layout);
+        }
+
+        private VMStorage regAlloc(int type) {
+            ABIDescriptor abiDescriptor = abiDescriptor();
+            VMStorage[] source =
+                    (forArguments ? abiDescriptor.inputStorage : abiDescriptor.outputStorage)[type];
+            return source[nRegs[type]++];
+        }
+
+        private VMStorage stackAlloc(ValueLayout layout) {
             assert forArguments : "no stack returns";
-            long alignedStackOffset = Utils.alignUp(stackOffset, alignment);
-
-            short encodedSize = (short) size;
-            assert (encodedSize & 0xFFFF) == size;
-
-            VMStorage storage =
-                AArch64Architecture.stackStorage(encodedSize, (int)alignedStackOffset);
-            stackOffset = alignedStackOffset + size;
-            return storage;
-        }
-
-        VMStorage stackAlloc(MemoryLayout layout) {
             long stackSlotAlignment = requiresSubSlotStackPacking() && !forVarArgs
                     ? layout.byteAlignment()
                     : Math.max(layout.byteAlignment(), STACK_SLOT_SIZE);
-            return stackAlloc(layout.byteSize(), stackSlotAlignment);
-        }
+            long alignedStackOffset = Utils.alignUp(stackOffset, stackSlotAlignment);
 
-        VMStorage[] regAlloc(int type, int count) {
-            if (nRegs[type] + count <= MAX_REGISTER_ARGUMENTS) {
-                ABIDescriptor abiDescriptor = abiDescriptor();
-                VMStorage[] source =
-                    (forArguments ? abiDescriptor.inputStorage : abiDescriptor.outputStorage)[type];
-                VMStorage[] result = new VMStorage[count];
-                for (int i = 0; i < count; i++) {
-                    result[i] = source[nRegs[type]++];
-                }
-                return result;
-            } else {
-                // Any further allocations for this register type must
-                // be from the stack.
-                nRegs[type] = MAX_REGISTER_ARGUMENTS;
-                return null;
-            }
-        }
+            short encodedSize = (short) layout.byteSize();
+            assert (encodedSize & 0xFFFF) == layout.byteSize();
 
-        VMStorage[] regAlloc(int type, MemoryLayout layout) {
-            boolean spillRegistersPartially = forVariadicFunction && spillsVariadicStructsPartially();
-
-            return spillRegistersPartially ?
-                regAllocPartial(type, layout) :
-                regAlloc(type, requiredRegisters(layout));
-        }
-
-        int requiredRegisters(MemoryLayout layout) {
-            return (int)Utils.alignUp(layout.byteSize(), 8) / 8;
-        }
-
-        VMStorage[] regAllocPartial(int type, MemoryLayout layout) {
-            int availableRegisters = MAX_REGISTER_ARGUMENTS - nRegs[type];
-            if (availableRegisters <= 0) {
-                return null;
-            }
-
-            int requestRegisters = Math.min(requiredRegisters(layout), availableRegisters);
-            return regAlloc(type, requestRegisters);
-        }
-
-        VMStorage nextStorage(int type, MemoryLayout layout) {
-            if (type == StorageType.VECTOR) {
-                boolean forVariadicFunctionArgs = forArguments && forVariadicFunction;
-                boolean useIntRegsForFloatingPointArgs = forVariadicFunctionArgs && useIntRegsForVariadicFloatingPointArgs();
-
-                if (useIntRegsForFloatingPointArgs) {
-                    type = StorageType.INTEGER;
-                }
-            }
-
-            VMStorage[] storage = regAlloc(type, 1);
-            if (storage == null) {
-                return stackAlloc(layout);
-            }
-
-            return storage[0];
-        }
-
-        VMStorage[] nextStorageForHFA(GroupLayout group) {
-            final int nFields = group.memberLayouts().size();
-            VMStorage[] regs = regAlloc(StorageType.VECTOR, nFields);
-            if (regs == null && requiresSubSlotStackPacking() && !forVarArgs) {
-                // For the ABI variants that pack arguments spilled to the
-                // stack, HFA arguments are spilled as if their individual
-                // fields had been allocated separately rather than as if the
-                // struct had been spilled as a whole.
-
-                VMStorage[] slots = new VMStorage[nFields];
-                for (int i = 0; i < nFields; i++) {
-                    slots[i] = stackAlloc(group.memberLayouts().get(i));
-                }
-
-                return slots;
-            } else {
-                return regs;
-            }
+            VMStorage storage = AArch64Architecture.stackStorage(encodedSize, (int)alignedStackOffset);
+            stackOffset = alignedStackOffset + layout.byteSize();
+            return storage;
         }
 
         void adjustForVarArgs() {
@@ -333,61 +354,6 @@ public abstract class CallArranger {
 
         protected BindingCalculator(boolean forArguments, boolean forVariadicFunction) {
             this.storageCalculator = new StorageCalculator(forArguments, forVariadicFunction);
-        }
-
-        protected void spillStructUnbox(Binding.Builder bindings, MemoryLayout layout) {
-            // If a struct has been assigned register or HFA class but
-            // there are not enough free registers to hold the entire
-            // struct, it must be passed on the stack. I.e. not split
-            // between registers and stack.
-
-            spillPartialStructUnbox(bindings, layout, 0);
-        }
-
-        protected void spillPartialStructUnbox(Binding.Builder bindings, MemoryLayout layout, long offset) {
-            while (offset < layout.byteSize()) {
-                long copy = Math.min(layout.byteSize() - offset, STACK_SLOT_SIZE);
-                VMStorage storage =
-                    storageCalculator.stackAlloc(copy, STACK_SLOT_SIZE);
-                if (offset + STACK_SLOT_SIZE < layout.byteSize()) {
-                    bindings.dup();
-                }
-                Class<?> type = SharedUtils.primitiveCarrierForSize(copy, false);
-                bindings.bufferLoad(offset, type)
-                        .vmStore(storage, type);
-                offset += STACK_SLOT_SIZE;
-            }
-
-            if (requiresSubSlotStackPacking()) {
-                // Pad to the next stack slot boundary instead of packing
-                // additional arguments into the unused space.
-                storageCalculator.alignStack(STACK_SLOT_SIZE);
-            }
-        }
-
-        protected void spillStructBox(Binding.Builder bindings, MemoryLayout layout) {
-            // If a struct has been assigned register or HFA class but
-            // there are not enough free registers to hold the entire
-            // struct, it must be passed on the stack. I.e. not split
-            // between registers and stack.
-
-            long offset = 0;
-            while (offset < layout.byteSize()) {
-                long copy = Math.min(layout.byteSize() - offset, STACK_SLOT_SIZE);
-                VMStorage storage =
-                    storageCalculator.stackAlloc(copy, STACK_SLOT_SIZE);
-                Class<?> type = SharedUtils.primitiveCarrierForSize(copy, false);
-                bindings.dup()
-                        .vmLoad(storage, type)
-                        .bufferStore(offset, type);
-                offset += STACK_SLOT_SIZE;
-            }
-
-            if (requiresSubSlotStackPacking()) {
-                // Pad to the next stack slot boundary instead of packing
-                // additional arguments into the unused space.
-                storageCalculator.alignStack(STACK_SLOT_SIZE);
-            }
         }
 
         abstract List<Binding> getBindings(Class<?> carrier, MemoryLayout layout);
@@ -419,87 +385,47 @@ public abstract class CallArranger {
             Binding.Builder bindings = Binding.builder();
 
             switch (argumentClass) {
-                case STRUCT_REGISTER: {
+                case STRUCT_REGISTER, STRUCT_HFA -> {
                     assert carrier == MemorySegment.class;
-                    VMStorage[] regs = storageCalculator.regAlloc(StorageType.INTEGER, layout);
+                    boolean isHFA = argumentClass == TypeClass.STRUCT_HFA;
+                    StorageCalculator.StructCopy[] storages = storageCalculator.allocForStruct((GroupLayout) layout, isHFA);
 
-                    if (regs != null) {
-                        int regIndex = 0;
-                        long offset = 0;
-                        while (offset < layout.byteSize() && regIndex < regs.length) {
-                            final long copy = Math.min(layout.byteSize() - offset, 8);
-                            VMStorage storage = regs[regIndex++];
-                            Class<?> type = SharedUtils.primitiveCarrierForSize(copy, false);
-                            if (offset + copy < layout.byteSize()) {
-                                bindings.dup();
-                            }
-                            bindings.bufferLoad(offset, type)
-                                    .vmStore(storage, type);
-                            offset += copy;
+                    for (int i = 0; i < storages.length; i++) {
+                        StorageCalculator.StructCopy copy = storages[i];
+                        if (i < storages.length - 1) {
+                            bindings.dup();
                         }
-
-                        final long bytesLeft = Math.min(layout.byteSize() - offset, 8);
-                        if (bytesLeft > 0) {
-                            spillPartialStructUnbox(bindings, layout, offset);
-                        }
-                    } else {
-                        spillStructUnbox(bindings, layout);
+                        bindings.bufferLoad(copy.offset(), copy.carrier())
+                                .vmStore(copy.storage(), copy.carrier());
                     }
-                    break;
                 }
-                case STRUCT_REFERENCE: {
+                case STRUCT_REFERENCE -> {
                     assert carrier == MemorySegment.class;
                     bindings.copy(layout)
                             .unboxAddress();
                     VMStorage storage = storageCalculator.nextStorage(
-                        StorageType.INTEGER, AArch64.C_POINTER);
+                            StorageType.INTEGER, AArch64.C_POINTER);
                     bindings.vmStore(storage, long.class);
-                    break;
                 }
-                case STRUCT_HFA: {
-                    assert carrier == MemorySegment.class;
-                    GroupLayout group = (GroupLayout)layout;
-                    VMStorage[] regs = storageCalculator.nextStorageForHFA(group);
-                    if (regs != null) {
-                        long offset = 0;
-                        for (int i = 0; i < group.memberLayouts().size(); i++) {
-                            VMStorage storage = regs[i];
-                            final long size = group.memberLayouts().get(i).byteSize();
-                            boolean useFloat = storage.type() == StorageType.VECTOR;
-                            Class<?> type = SharedUtils.primitiveCarrierForSize(size, useFloat);
-                            if (i + 1 < group.memberLayouts().size()) {
-                                bindings.dup();
-                            }
-                            bindings.bufferLoad(offset, type)
-                                    .vmStore(storage, type);
-                            offset += size;
-                        }
-                    } else {
-                        spillStructUnbox(bindings, layout);
-                    }
-                    break;
-                }
-                case POINTER: {
+                case POINTER -> {
                     bindings.unboxAddress();
-                    VMStorage storage =
-                        storageCalculator.nextStorage(StorageType.INTEGER, layout);
+                    VMStorage storage = storageCalculator.nextStorage(StorageType.INTEGER, (ValueLayout) layout);
                     bindings.vmStore(storage, long.class);
-                    break;
                 }
-                case INTEGER: {
+                case INTEGER -> {
                     VMStorage storage =
-                        storageCalculator.nextStorage(StorageType.INTEGER, layout);
+                            storageCalculator.nextStorage(StorageType.INTEGER, (ValueLayout) layout);
                     bindings.vmStore(storage, carrier);
-                    break;
                 }
-                case FLOAT: {
-                    VMStorage storage =
-                        storageCalculator.nextStorage(StorageType.VECTOR, layout);
+                case FLOAT -> {
+                    boolean forVariadicFunctionArgs = forArguments && forVariadicFunction;
+                    boolean useIntRegsForFloatingPointArgs = forVariadicFunctionArgs && useIntRegsForVariadicFloatingPointArgs();
+
+                    int type = useIntRegsForFloatingPointArgs ? StorageType.INTEGER : StorageType.VECTOR;
+                    VMStorage storage = storageCalculator.nextStorage(type, (ValueLayout) layout);
                     bindings.vmStore(storage, carrier);
-                    break;
                 }
-                default:
-                    throw new UnsupportedOperationException("Unhandled class " + argumentClass);
+                default -> throw new UnsupportedOperationException("Unhandled class " + argumentClass);
             }
             return bindings.build();
         }
@@ -523,26 +449,16 @@ public abstract class CallArranger {
             TypeClass argumentClass = TypeClass.classifyLayout(layout);
             Binding.Builder bindings = Binding.builder();
             switch (argumentClass) {
-                case STRUCT_REGISTER -> {
+                case STRUCT_REGISTER, STRUCT_HFA -> {
                     assert carrier == MemorySegment.class;
+                    boolean isHFA = argumentClass == TypeClass.STRUCT_HFA;
                     bindings.allocate(layout);
-                    VMStorage[] regs = storageCalculator.regAlloc(
-                            StorageType.INTEGER, layout);
-                    if (regs != null) {
-                        int regIndex = 0;
-                        long offset = 0;
-                        while (offset < layout.byteSize()) {
-                            final long copy = Math.min(layout.byteSize() - offset, 8);
-                            VMStorage storage = regs[regIndex++];
-                            bindings.dup();
-                            boolean useFloat = storage.type() == StorageType.VECTOR;
-                            Class<?> type = SharedUtils.primitiveCarrierForSize(copy, useFloat);
-                            bindings.vmLoad(storage, type)
-                                    .bufferStore(offset, type);
-                            offset += copy;
-                        }
-                    } else {
-                        spillStructBox(bindings, layout);
+                    StorageCalculator.StructCopy[] copies = storageCalculator.allocForStruct((GroupLayout) layout, isHFA);
+
+                    for (StorageCalculator.StructCopy copy : copies) {
+                        bindings.dup();
+                        bindings.vmLoad(copy.storage(), copy.carrier())
+                                .bufferStore(copy.offset(), copy.carrier());
                     }
                 }
                 case STRUCT_REFERENCE -> {
@@ -552,41 +468,20 @@ public abstract class CallArranger {
                     bindings.vmLoad(storage, long.class)
                             .boxAddress(layout);
                 }
-                case STRUCT_HFA -> {
-                    assert carrier == MemorySegment.class;
-                    bindings.allocate(layout);
-                    GroupLayout group = (GroupLayout) layout;
-                    VMStorage[] regs = storageCalculator.nextStorageForHFA(group);
-                    if (regs != null) {
-                        long offset = 0;
-                        for (int i = 0; i < group.memberLayouts().size(); i++) {
-                            VMStorage storage = regs[i];
-                            final long size = group.memberLayouts().get(i).byteSize();
-                            boolean useFloat = storage.type() == StorageType.VECTOR;
-                            Class<?> type = SharedUtils.primitiveCarrierForSize(size, useFloat);
-                            bindings.dup()
-                                    .vmLoad(storage, type)
-                                    .bufferStore(offset, type);
-                            offset += size;
-                        }
-                    } else {
-                        spillStructBox(bindings, layout);
-                    }
-                }
                 case POINTER -> {
                     VMStorage storage =
-                            storageCalculator.nextStorage(StorageType.INTEGER, layout);
+                            storageCalculator.nextStorage(StorageType.INTEGER, (ValueLayout) layout);
                     bindings.vmLoad(storage, long.class)
                             .boxAddressRaw(Utils.pointeeSize(layout));
                 }
                 case INTEGER -> {
                     VMStorage storage =
-                            storageCalculator.nextStorage(StorageType.INTEGER, layout);
+                            storageCalculator.nextStorage(StorageType.INTEGER, (ValueLayout) layout);
                     bindings.vmLoad(storage, carrier);
                 }
                 case FLOAT -> {
                     VMStorage storage =
-                            storageCalculator.nextStorage(StorageType.VECTOR, layout);
+                            storageCalculator.nextStorage(StorageType.VECTOR, (ValueLayout) layout);
                     bindings.vmLoad(storage, carrier);
                 }
                 default -> throw new UnsupportedOperationException("Unhandled class " + argumentClass);

--- a/test/jdk/java/foreign/callarranger/TestMacOsAArch64CallArranger.java
+++ b/test/jdk/java/foreign/callarranger/TestMacOsAArch64CallArranger.java
@@ -281,6 +281,7 @@ public class TestMacOsAArch64CallArranger extends CallArrangerTestBase {
         checkReturnBindings(callingSequence, new Binding[]{});
     }
 
+    // structs that are passed field-wise should not have padding after them
     @Test
     public void testMacArgsOnStack5() {
         StructLayout struct = MemoryLayout.structLayout(
@@ -334,6 +335,7 @@ public class TestMacOsAArch64CallArranger extends CallArrangerTestBase {
         checkReturnBindings(callingSequence, new Binding[]{});
     }
 
+    // structs that are passed chunk-wise should have padding before them, as well as after
     @Test
     public void testMacArgsOnStack6() {
         StructLayout struct = MemoryLayout.structLayout(

--- a/test/jdk/java/foreign/callarranger/TestMacOsAArch64CallArranger.java
+++ b/test/jdk/java/foreign/callarranger/TestMacOsAArch64CallArranger.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2023, Oracle and/or its affiliates. All rights reserved.
  *  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  *  This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/java/foreign/callarranger/TestMacOsAArch64CallArranger.java
+++ b/test/jdk/java/foreign/callarranger/TestMacOsAArch64CallArranger.java
@@ -280,4 +280,111 @@ public class TestMacOsAArch64CallArranger extends CallArrangerTestBase {
 
         checkReturnBindings(callingSequence, new Binding[]{});
     }
+
+    @Test
+    public void testMacArgsOnStack5() {
+        StructLayout struct = MemoryLayout.structLayout(
+            C_FLOAT
+        );
+        MethodType mt = MethodType.methodType(void.class,
+                long.class, long.class, long.class, long.class,
+                long.class, long.class, long.class, long.class,
+                double.class, double.class, double.class, double.class,
+                double.class, double.class, double.class, double.class,
+                MemorySegment.class, int.class, MemorySegment.class);
+        FunctionDescriptor fd = FunctionDescriptor.ofVoid(
+                C_LONG_LONG, C_LONG_LONG, C_LONG_LONG, C_LONG_LONG,
+                C_LONG_LONG, C_LONG_LONG, C_LONG_LONG, C_LONG_LONG,
+                C_DOUBLE, C_DOUBLE, C_DOUBLE, C_DOUBLE,
+                C_DOUBLE, C_DOUBLE, C_DOUBLE, C_DOUBLE,
+                struct, C_INT, C_POINTER);
+        CallArranger.Bindings bindings = CallArranger.MACOS.getBindings(mt, fd, false);
+
+        assertFalse(bindings.isInMemoryReturn());
+        CallingSequence callingSequence = bindings.callingSequence();
+        assertEquals(callingSequence.callerMethodType(), mt.insertParameterTypes(0, MemorySegment.class));
+        assertEquals(callingSequence.functionDesc(), fd.insertArgumentLayouts(0, ADDRESS));
+
+        checkArgumentBindings(callingSequence, new Binding[][]{
+            { unboxAddress(), vmStore(TARGET_ADDRESS_STORAGE, long.class) },
+            { vmStore(r0, long.class) },
+            { vmStore(r1, long.class) },
+            { vmStore(r2, long.class) },
+            { vmStore(r3, long.class) },
+            { vmStore(r4, long.class) },
+            { vmStore(r5, long.class) },
+            { vmStore(r6, long.class) },
+            { vmStore(r7, long.class) },
+            { vmStore(v0, double.class) },
+            { vmStore(v1, double.class) },
+            { vmStore(v2, double.class) },
+            { vmStore(v3, double.class) },
+            { vmStore(v4, double.class) },
+            { vmStore(v5, double.class) },
+            { vmStore(v6, double.class) },
+            { vmStore(v7, double.class) },
+            {
+                bufferLoad(0, int.class),
+                vmStore(stackStorage((short) 4, 0), int.class),
+            },
+            { vmStore(stackStorage((short) 4, 4), int.class) },
+            { unboxAddress(), vmStore(stackStorage((short) 8, 8), long.class) },
+        });
+
+        checkReturnBindings(callingSequence, new Binding[]{});
+    }
+
+    @Test
+    public void testMacArgsOnStack6() {
+        StructLayout struct = MemoryLayout.structLayout(
+            C_INT
+        );
+        MethodType mt = MethodType.methodType(void.class,
+                long.class, long.class, long.class, long.class,
+                long.class, long.class, long.class, long.class,
+                double.class, double.class, double.class, double.class,
+                double.class, double.class, double.class, double.class,
+                int.class, MemorySegment.class, double.class, MemorySegment.class);
+        FunctionDescriptor fd = FunctionDescriptor.ofVoid(
+                C_LONG_LONG, C_LONG_LONG, C_LONG_LONG, C_LONG_LONG,
+                C_LONG_LONG, C_LONG_LONG, C_LONG_LONG, C_LONG_LONG,
+                C_DOUBLE, C_DOUBLE, C_DOUBLE, C_DOUBLE,
+                C_DOUBLE, C_DOUBLE, C_DOUBLE, C_DOUBLE,
+                C_INT, struct, C_DOUBLE, C_POINTER);
+        CallArranger.Bindings bindings = CallArranger.MACOS.getBindings(mt, fd, false);
+
+        assertFalse(bindings.isInMemoryReturn());
+        CallingSequence callingSequence = bindings.callingSequence();
+        assertEquals(callingSequence.callerMethodType(), mt.insertParameterTypes(0, MemorySegment.class));
+        assertEquals(callingSequence.functionDesc(), fd.insertArgumentLayouts(0, ADDRESS));
+
+        checkArgumentBindings(callingSequence, new Binding[][]{
+            { unboxAddress(), vmStore(TARGET_ADDRESS_STORAGE, long.class) },
+            { vmStore(r0, long.class) },
+            { vmStore(r1, long.class) },
+            { vmStore(r2, long.class) },
+            { vmStore(r3, long.class) },
+            { vmStore(r4, long.class) },
+            { vmStore(r5, long.class) },
+            { vmStore(r6, long.class) },
+            { vmStore(r7, long.class) },
+            { vmStore(v0, double.class) },
+            { vmStore(v1, double.class) },
+            { vmStore(v2, double.class) },
+            { vmStore(v3, double.class) },
+            { vmStore(v4, double.class) },
+            { vmStore(v5, double.class) },
+            { vmStore(v6, double.class) },
+            { vmStore(v7, double.class) },
+            { vmStore(stackStorage((short) 4, 0), int.class) },
+            {
+                bufferLoad(0, int.class),
+                vmStore(stackStorage((short) 4, 8), int.class),
+            },
+            { vmStore(stackStorage((short) 8, 16), double.class) },
+            { unboxAddress(), vmStore(stackStorage((short) 8, 24), long.class) },
+        });
+
+        checkReturnBindings(callingSequence, new Binding[]{});
+    }
 }


### PR DESCRIPTION
Refactor struct handling in AArch64 CallArranger.

Instead of having 6 very similar looking while loops, I've consolidated the storage allocation code for structs into a single helper method (`StorageCalculator::structStorages`). This should make it much easier to see which logic is being used for a particular case.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8299911](https://bugs.openjdk.org/browse/JDK-8299911): Refactor struct handling in AArch64 CallArranger


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.org/census#mcimadamore) (@mcimadamore - Committer) ⚠️ Review applies to [3ac117fd](https://git.openjdk.org/panama-foreign/pull/765/files/3ac117fd66af111064c2a1912386df2baaa964c9)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/panama-foreign pull/765/head:pull/765` \
`$ git checkout pull/765`

Update a local copy of the PR: \
`$ git checkout pull/765` \
`$ git pull https://git.openjdk.org/panama-foreign pull/765/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 765`

View PR using the GUI difftool: \
`$ git pr show -t 765`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/panama-foreign/pull/765.diff">https://git.openjdk.org/panama-foreign/pull/765.diff</a>

</details>
