### PR TITLE
8299181: PaddingLayout unable to return byteAlignment value

### DIFF
--- a/src/java.base/share/classes/java/lang/foreign/MemoryLayout.java
+++ b/src/java.base/share/classes/java/lang/foreign/MemoryLayout.java
@@ -30,7 +30,6 @@ import java.lang.invoke.MethodHandles;
 import java.lang.invoke.VarHandle;
 import java.nio.ByteOrder;
 import java.util.EnumSet;
-import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
@@ -173,7 +172,7 @@ import jdk.internal.javac.PreviewFeature;
  * @since 19
  */
 @PreviewFeature(feature=PreviewFeature.Feature.FOREIGN)
-public sealed interface MemoryLayout permits GroupLayout, PaddingLayout, SequenceLayout, ValueLayout {
+public sealed interface MemoryLayout permits SequenceLayout, GroupLayout, PaddingLayout, ValueLayout {
 
     /**
      * {@return the layout size, in bits}
@@ -707,9 +706,10 @@ public sealed interface MemoryLayout permits GroupLayout, PaddingLayout, Sequenc
      */
     static StructLayout structLayout(MemoryLayout... elements) {
         Objects.requireNonNull(elements);
-        return wrapOverflow(() -> StructLayoutImpl.of(Stream.of(elements)
-                .map(Objects::requireNonNull)
-                .toList()));
+        return wrapOverflow(() ->
+                StructLayoutImpl.of(Stream.of(elements)
+                        .map(Objects::requireNonNull)
+                        .toList()));
     }
 
     /**

--- a/src/java.base/share/classes/java/lang/foreign/MemoryLayout.java
+++ b/src/java.base/share/classes/java/lang/foreign/MemoryLayout.java
@@ -36,6 +36,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.function.Supplier;
+import java.util.stream.Stream;
 
 import jdk.internal.foreign.LayoutPath;
 import jdk.internal.foreign.LayoutPath.PathElementImpl.PathKind;
@@ -616,10 +617,7 @@ public sealed interface MemoryLayout permits GroupLayout, PaddingLayout, Sequenc
      * @throws IllegalArgumentException if {@code bitSize < 0} or {@code bitSize % 8 != 0}
      */
     static PaddingLayout paddingLayout(long bitSize) {
-        if (bitSize < 0 || bitSize % 8 != 0) {
-            throw new IllegalArgumentException("bitSize cannot be " + bitSize);
-        }
-        return PaddingLayoutImpl.of(bitSize);
+        return PaddingLayoutImpl.of(MemoryLayoutUtil.requireBitSizeValid(bitSize));
     }
 
     /**
@@ -709,7 +707,9 @@ public sealed interface MemoryLayout permits GroupLayout, PaddingLayout, Sequenc
      */
     static StructLayout structLayout(MemoryLayout... elements) {
         Objects.requireNonNull(elements);
-        return wrapOverflow(() -> StructLayoutImpl.of(List.of(elements)));
+        return wrapOverflow(() -> StructLayoutImpl.of(Stream.of(elements)
+                .map(Objects::requireNonNull)
+                .toList()));
     }
 
     /**
@@ -720,7 +720,9 @@ public sealed interface MemoryLayout permits GroupLayout, PaddingLayout, Sequenc
      */
     static UnionLayout unionLayout(MemoryLayout... elements) {
         Objects.requireNonNull(elements);
-        return UnionLayoutImpl.of(List.of(elements));
+        return UnionLayoutImpl.of(Stream.of(elements)
+                .map(Objects::requireNonNull)
+                .toList());
     }
 
     private static <L extends MemoryLayout> L wrapOverflow(Supplier<L> layoutSupplier) {

--- a/src/java.base/share/classes/java/lang/foreign/MemoryLayout.java
+++ b/src/java.base/share/classes/java/lang/foreign/MemoryLayout.java
@@ -36,7 +36,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.function.Supplier;
-import java.util.stream.Stream;
+
 import jdk.internal.foreign.LayoutPath;
 import jdk.internal.foreign.LayoutPath.PathElementImpl.PathKind;
 import jdk.internal.foreign.Utils;
@@ -679,7 +679,7 @@ public sealed interface MemoryLayout permits SequenceLayout, GroupLayout, Paddin
      * @throws IllegalArgumentException if {@code elementCount } is negative.
      */
     static SequenceLayout sequenceLayout(long elementCount, MemoryLayout elementLayout) {
-        MemoryLayoutUtil.checkSize(elementCount, true);
+        MemoryLayoutUtil.requireNonNegative(elementCount);
         Objects.requireNonNull(elementLayout);
         return wrapOverflow(() ->
                 SequenceLayoutImpl.of(elementCount, elementLayout));

--- a/src/java.base/share/classes/java/lang/foreign/MemoryLayout.java
+++ b/src/java.base/share/classes/java/lang/foreign/MemoryLayout.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
+ *  Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
  *  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  *  This code is free software; you can redistribute it and/or modify it
@@ -172,7 +172,7 @@ import jdk.internal.javac.PreviewFeature;
  * @since 19
  */
 @PreviewFeature(feature=PreviewFeature.Feature.FOREIGN)
-public sealed interface MemoryLayout permits SequenceLayout, GroupLayout, PaddingLayout, ValueLayout {
+public sealed interface MemoryLayout permits GroupLayout, PaddingLayout, SequenceLayout, ValueLayout {
 
     /**
      * {@return the layout size, in bits}
@@ -236,10 +236,7 @@ public sealed interface MemoryLayout permits SequenceLayout, GroupLayout, Paddin
      * @return the layout alignment constraint, in bytes.
      * @throws UnsupportedOperationException if {@code bitAlignment()} is not a multiple of 8.
      */
-    default long byteAlignment() {
-        return Utils.bitsToBytesOrThrow(bitAlignment(),
-                () -> new UnsupportedOperationException("Cannot compute byte alignment; bit alignment is not a multiple of 8"));
-    }
+    long byteAlignment();
 
     /**
      * Returns a memory layout of the same type with the same size and name as this layout,

--- a/src/java.base/share/classes/java/lang/foreign/MemoryLayout.java
+++ b/src/java.base/share/classes/java/lang/foreign/MemoryLayout.java
@@ -616,10 +616,10 @@ public sealed interface MemoryLayout permits SequenceLayout, GroupLayout, Paddin
      *
      * @param bitSize the padding size in bits.
      * @return the new selector layout.
-     * @throws IllegalArgumentException if {@code bitSize < 8} or {@code bitSize % 8 != 0}
+     * @throws IllegalArgumentException if {@code bitSize < 0} or {@code bitSize % 8 != 0}
      */
     static PaddingLayout paddingLayout(long bitSize) {
-        if (bitSize < 8 || bitSize % 8 != 0) {
+        if (bitSize < 0 || bitSize % 8 != 0) {
             throw new IllegalArgumentException("bitSize cannot be " + bitSize);
         }
         return PaddingLayoutImpl.of(bitSize);

--- a/src/java.base/share/classes/java/lang/foreign/ValueLayout.java
+++ b/src/java.base/share/classes/java/lang/foreign/ValueLayout.java
@@ -49,6 +49,7 @@ import jdk.internal.reflect.CallerSensitive;
  *
  * @implSpec implementing classes and subclasses are immutable, thread-safe and <a href="{@docRoot}/java.base/java/lang/doc-files/ValueBased.html">value-based</a>.
  *
+ * @sealedGraph
  * @since 19
  */
 @PreviewFeature(feature=PreviewFeature.Feature.FOREIGN)

--- a/src/java.base/share/classes/java/lang/foreign/ValueLayout.java
+++ b/src/java.base/share/classes/java/lang/foreign/ValueLayout.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
+ *  Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
  *  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  *  This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/jdk/internal/foreign/layout/AbstractGroupLayout.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/layout/AbstractGroupLayout.java
@@ -145,7 +145,7 @@ public sealed abstract class AbstractGroupLayout<L extends AbstractGroupLayout<L
             return elems.stream()
                     .mapToLong(MemoryLayout::bitAlignment)
                     .max() // max alignment in case we have member layouts
-                    .orElse(1); // or minimal alignment if no member layout is given
+                    .orElse(8); // or minimal alignment if no member layout is given
         }
     }
 }

--- a/src/java.base/share/classes/jdk/internal/foreign/layout/AbstractGroupLayout.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/layout/AbstractGroupLayout.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
+ *  Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
  *  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  *  This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/jdk/internal/foreign/layout/AbstractLayout.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/layout/AbstractLayout.java
@@ -48,7 +48,7 @@ public abstract sealed class AbstractLayout<L extends AbstractLayout<L> & Memory
     private long byteSize;
 
     AbstractLayout(long bitSize, long bitAlignment, Optional<String> name) {
-        this.bitSize = MemoryLayoutUtil.checkSize(bitSize, true);
+        this.bitSize = MemoryLayoutUtil.requireBitSizeValid(bitSize);
         this.bitAlignment = requirePowerOfTwoAndGreaterOrEqualToEight(bitAlignment);
         this.name = Objects.requireNonNull(name);
     }

--- a/src/java.base/share/classes/jdk/internal/foreign/layout/AbstractLayout.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/layout/AbstractLayout.java
@@ -48,9 +48,9 @@ public abstract sealed class AbstractLayout<L extends AbstractLayout<L> & Memory
     private long byteSize;
 
     AbstractLayout(long bitSize, long bitAlignment, Optional<String> name) {
-        this.bitSize = bitSize;
-        this.bitAlignment = bitAlignment;
-        this.name = name;
+        this.bitSize = MemoryLayoutUtil.checkSize(bitSize, true);
+        this.bitAlignment = requirePowerOfTwoAndGreaterOrEqualToEight(bitAlignment);
+        this.name = Objects.requireNonNull(name);
     }
 
     public final L withName(String name) {
@@ -63,7 +63,6 @@ public abstract sealed class AbstractLayout<L extends AbstractLayout<L> & Memory
     }
 
     public final L withBitAlignment(long bitAlignment) {
-        checkAlignment(bitAlignment);
         return dup(bitAlignment, name);
     }
 
@@ -145,12 +144,12 @@ public abstract sealed class AbstractLayout<L extends AbstractLayout<L> & Memory
         return s;
     }
 
-    private static void checkAlignment(long alignmentBitCount) {
-        if (((alignmentBitCount & (alignmentBitCount - 1)) != 0L) || //alignment must be a power of two
-                (alignmentBitCount < 8)) { //alignment must be greater than 8
-            throw new IllegalArgumentException("Invalid alignment: " + alignmentBitCount);
+    private static long requirePowerOfTwoAndGreaterOrEqualToEight(long value) {
+        if (((value & (value - 1)) != 0L) || // value must be a power of two
+                (value < 8)) { // value must be greater or equal to 8
+            throw new IllegalArgumentException("Invalid alignment: " + value);
         }
+        return value;
     }
-
 
 }

--- a/src/java.base/share/classes/jdk/internal/foreign/layout/MemoryLayoutUtil.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/layout/MemoryLayoutUtil.java
@@ -30,14 +30,15 @@ public final class MemoryLayoutUtil {
     private MemoryLayoutUtil() {
     }
 
-    public static void checkSize(long size) {
-        checkSize(size, false);
+    public static long checkSize(long size) {
+        return checkSize(size, false);
     }
 
-    public static void checkSize(long size, boolean includeZero) {
-        if (size < 0 || (!includeZero && size == 0)) {
+    public static long checkSize(long size, boolean allowZero) {
+        if (size < 0 || (!allowZero && size == 0)) {
             throw new IllegalArgumentException("Invalid size for layout: " + size);
         }
+        return size;
     }
 
 }

--- a/src/java.base/share/classes/jdk/internal/foreign/layout/MemoryLayoutUtil.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/layout/MemoryLayoutUtil.java
@@ -30,15 +30,18 @@ public final class MemoryLayoutUtil {
     private MemoryLayoutUtil() {
     }
 
-    public static long checkSize(long size) {
-        return checkSize(size, false);
+    public static long requireNonNegative(long value) {
+        if (value < 0) {
+            throw new IllegalArgumentException("The provided value was negative: " + value);
+        }
+        return value;
     }
 
-    public static long checkSize(long size, boolean allowZero) {
-        if (size < 0 || (!allowZero && size == 0)) {
-            throw new IllegalArgumentException("Invalid size for layout: " + size);
+    public static long requireBitSizeValid(long bitSize) {
+        if (bitSize < 0 || bitSize % 8 != 0) {
+            throw new IllegalArgumentException("Invalid bitSize: " + bitSize);
         }
-        return size;
+        return bitSize;
     }
 
 }

--- a/src/java.base/share/classes/jdk/internal/foreign/layout/MemoryLayoutUtil.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/layout/MemoryLayoutUtil.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
+ *  Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
  *  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  *  This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/jdk/internal/foreign/layout/PaddingLayoutImpl.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/layout/PaddingLayoutImpl.java
@@ -32,7 +32,7 @@ import java.util.Optional;
 public final class PaddingLayoutImpl extends AbstractLayout<PaddingLayoutImpl> implements PaddingLayout {
 
     private PaddingLayoutImpl(long bitSize) {
-        this(bitSize, 1, Optional.empty());
+        this(bitSize, 8, Optional.empty());
     }
 
     private PaddingLayoutImpl(long bitSize, long bitAlignment, Optional<String> name) {

--- a/src/java.base/share/classes/jdk/internal/foreign/layout/PaddingLayoutImpl.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/layout/PaddingLayoutImpl.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
+ *  Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
  *  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  *  This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/jdk/internal/foreign/layout/SequenceLayoutImpl.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/layout/SequenceLayoutImpl.java
@@ -68,7 +68,6 @@ public final class SequenceLayoutImpl extends AbstractLayout<SequenceLayoutImpl>
      * @throws IllegalArgumentException if {@code elementCount < 0}.
      */
     public SequenceLayout withElementCount(long elementCount) {
-        MemoryLayoutUtil.checkSize(elementCount, true);
         return new SequenceLayoutImpl(elementCount, elementLayout, bitAlignment(), name());
     }
 

--- a/src/java.base/share/classes/jdk/internal/foreign/layout/SequenceLayoutImpl.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/layout/SequenceLayoutImpl.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
+ *  Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
  *  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  *  This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/java/foreign/TestLayoutPaths.java
+++ b/test/jdk/java/foreign/TestLayoutPaths.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
  *  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  *  This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/java/foreign/TestLayouts.java
+++ b/test/jdk/java/foreign/TestLayouts.java
@@ -31,6 +31,8 @@ import java.lang.foreign.*;
 
 import java.lang.invoke.VarHandle;
 import java.nio.ByteOrder;
+import java.util.List;
+import java.util.function.Function;
 import java.util.function.LongFunction;
 import java.util.stream.Stream;
 
@@ -79,11 +81,11 @@ public class TestLayouts {
     public void testEmptyGroup() {
         MemoryLayout struct = MemoryLayout.structLayout();
         assertEquals(struct.bitSize(), 0);
-        assertEquals(struct.bitAlignment(), 1);
+        assertEquals(struct.bitAlignment(), 8);
 
         MemoryLayout union = MemoryLayout.unionLayout();
         assertEquals(union.bitSize(), 0);
-        assertEquals(union.bitAlignment(), 1);
+        assertEquals(union.bitAlignment(), 8);
     }
 
     @Test
@@ -101,7 +103,7 @@ public class TestLayouts {
 
     @Test(dataProvider="basicLayouts")
     public void testPaddingNoAlign(MemoryLayout layout) {
-        assertEquals(MemoryLayout.paddingLayout(layout.bitSize()).bitAlignment(), 1);
+        assertEquals(MemoryLayout.paddingLayout(layout.bitSize()).bitAlignment(), 8);
     }
 
     @Test(dataProvider="basicLayouts")
@@ -164,6 +166,45 @@ public class TestLayouts {
                 () -> MemoryLayout.structLayout(MemoryLayout.sequenceLayout(Long.MAX_VALUE, JAVA_BYTE),
                                                 MemoryLayout.sequenceLayout(Long.MAX_VALUE, JAVA_BYTE),
                                                 MemoryLayout.sequenceLayout(Long.MAX_VALUE, JAVA_BYTE)));
+    }
+
+    @Test
+    public void testPadding() {
+        var padding = MemoryLayout.paddingLayout(8);
+        assertEquals(padding.byteAlignment(), 1);
+    }
+
+    @Test
+    public void testPaddingInStruct() {
+        var padding = MemoryLayout.paddingLayout(8);
+        var struct = MemoryLayout.structLayout(padding);
+        assertEquals(struct.byteAlignment(), 1);
+    }
+
+    @Test
+    public void testPaddingIllegalBitSize() {
+        for (long bitSize : List.of(-1L, 0L, 1L, 7L)) {
+            try {
+                MemoryLayout.paddingLayout(bitSize);
+                fail("bitSize cannot be " + bitSize);
+            } catch (IllegalArgumentException ignore) {
+                // Happy path
+            }
+        }
+    }
+    @Test
+    public void testNullMember() {
+        var illegalLayouts = new MemoryLayout[]{JAVA_INT, null, JAVA_INT};
+        var factories = List.<Function<MemoryLayout[], GroupLayout>>
+                of(MemoryLayout::structLayout, MemoryLayout::unionLayout);
+        for (var factory : factories) {
+            try {
+                factory.apply(illegalLayouts);
+                fail("Factory did not throw for null elements");
+            } catch (NullPointerException ignore) {
+                // Happy path
+            }
+        }
     }
 
     @Test(dataProvider = "layoutKinds")

--- a/test/jdk/java/foreign/TestLayouts.java
+++ b/test/jdk/java/foreign/TestLayouts.java
@@ -198,21 +198,6 @@ public class TestLayouts {
         MemoryLayout.paddingLayout(0);
     }
 
-    @Test
-    public void testNullMember() {
-        var illegalLayouts = new MemoryLayout[]{JAVA_INT, null, JAVA_INT};
-        var factories = List.<Function<MemoryLayout[], GroupLayout>>
-                of(MemoryLayout::structLayout, MemoryLayout::unionLayout);
-        for (var factory : factories) {
-            try {
-                factory.apply(illegalLayouts);
-                fail("Factory did not throw for null elements");
-            } catch (NullPointerException ignore) {
-                // Happy path
-            }
-        }
-    }
-
     @Test(dataProvider = "layoutKinds")
     public void testPadding(LayoutKind kind) {
         assertEquals(kind == LayoutKind.PADDING, kind.layout instanceof PaddingLayout);

--- a/test/jdk/java/foreign/TestLayouts.java
+++ b/test/jdk/java/foreign/TestLayouts.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
+ *  Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
  *  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  *  This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/java/foreign/TestLayouts.java
+++ b/test/jdk/java/foreign/TestLayouts.java
@@ -183,7 +183,7 @@ public class TestLayouts {
 
     @Test
     public void testPaddingIllegalBitSize() {
-        for (long bitSize : List.of(-1L, 0L, 1L, 7L)) {
+        for (long bitSize : List.of(-1L, 1L, 7L)) {
             try {
                 MemoryLayout.paddingLayout(bitSize);
                 fail("bitSize cannot be " + bitSize);
@@ -192,6 +192,12 @@ public class TestLayouts {
             }
         }
     }
+
+    @Test
+    public void testPaddingZeroBitSize() {
+        MemoryLayout.paddingLayout(0);
+    }
+
     @Test
     public void testNullMember() {
         var illegalLayouts = new MemoryLayout[]{JAVA_INT, null, JAVA_INT};


### PR DESCRIPTION
This PR proposes bit-aligning `PaddingLayout` to 8 by default as opposed to the current  value of 1.

More generally, the PR restricts `PaddingLayout` bit-alignment to non-negative values that are an even multiple of 8 (i.e. 0, 8, 16, ...). There are no mechanism to derive `VarHandle` objects for sub-byte access anyhow and trying to obtain a miss-aligned `VarHandle` would throw an exception. 

If integrated, all `MemoryLayout` types would be byte-aligned.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8299181](https://bugs.openjdk.org/browse/JDK-8299181): PaddingLayout unable to return byteAlignment value


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.org/census#mcimadamore) (@mcimadamore - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/panama-foreign pull/766/head:pull/766` \
`$ git checkout pull/766`

Update a local copy of the PR: \
`$ git checkout pull/766` \
`$ git pull https://git.openjdk.org/panama-foreign pull/766/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 766`

View PR using the GUI difftool: \
`$ git pr show -t 766`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/panama-foreign/pull/766.diff">https://git.openjdk.org/panama-foreign/pull/766.diff</a>

</details>
