### PR TITLE
Fix build problem on linux-x86

### DIFF
--- a/test/jdk/java/foreign/callarranger/TestMacOsAArch64CallArranger.java
+++ b/test/jdk/java/foreign/callarranger/TestMacOsAArch64CallArranger.java
@@ -25,6 +25,7 @@
 /*
  * @test
  * @enablePreview
+ * @requires sun.arch.data.model == "64"
  * @modules java.base/jdk.internal.foreign
  *          java.base/jdk.internal.foreign.abi
  *          java.base/jdk.internal.foreign.abi.aarch64

--- a/test/jdk/java/foreign/callarranger/TestMacOsAArch64CallArranger.java
+++ b/test/jdk/java/foreign/callarranger/TestMacOsAArch64CallArranger.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2023, Oracle and/or its affiliates. All rights reserved.
  *  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  *  This code is free software; you can redistribute it and/or modify it


### PR DESCRIPTION
This PR presumably fixes a GH action build that fails under linux-x86.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Reviewers
 * [Jorn Vernee](https://openjdk.org/census#jvernee) (@JornVernee - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/panama-foreign pull/768/head:pull/768` \
`$ git checkout pull/768`

Update a local copy of the PR: \
`$ git checkout pull/768` \
`$ git pull https://git.openjdk.org/panama-foreign pull/768/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 768`

View PR using the GUI difftool: \
`$ git pr show -t 768`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/panama-foreign/pull/768.diff">https://git.openjdk.org/panama-foreign/pull/768.diff</a>

</details>
