### PR TITLE
8300785: Add way to select group element paths by index

### DIFF
--- a/src/java.base/share/classes/java/lang/foreign/MemoryLayout.java
+++ b/src/java.base/share/classes/java/lang/foreign/MemoryLayout.java
@@ -487,6 +487,7 @@ public sealed interface MemoryLayout permits SequenceLayout, GroupLayout, Paddin
          *
          * @implSpec in case multiple group elements with a matching name exist, the path element returned by this
          * method will select the first one; that is, the group element with the lowest offset from current path is selected.
+         * In such cases, using {@link #groupElement(long)} might be preferable.
          *
          * @param name the name of the group element to be selected.
          * @return a path element which selects the group element with the given name.
@@ -495,6 +496,23 @@ public sealed interface MemoryLayout permits SequenceLayout, GroupLayout, Paddin
             Objects.requireNonNull(name);
             return new LayoutPath.PathElementImpl(PathKind.GROUP_ELEMENT,
                                                   path -> path.groupElement(name));
+        }
+
+        /**
+         * Returns a path element which selects a member layout with the given index in a group layout.
+         * The path element returned by this method does not alter the number of free dimensions of any path
+         * that is combined with such element.
+         *
+         * @param index the index of the group element to be selected.
+         * @return a path element which selects the group element with the given index.
+         * @throws IllegalArgumentException if {@code index < 0}.
+         */
+        static PathElement groupElement(long index) {
+            if (index < 0) {
+                throw new IllegalArgumentException("Index < 0");
+            }
+            return new LayoutPath.PathElementImpl(PathKind.GROUP_ELEMENT,
+                    path -> path.groupElement(index));
         }
 
         /**

--- a/src/java.base/share/classes/jdk/internal/foreign/LayoutPath.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/LayoutPath.java
@@ -137,6 +137,24 @@ public class LayoutPath {
         return LayoutPath.nestedPath(elem, this.offset + offset, strides, bounds, this);
     }
 
+    public LayoutPath groupElement(long index) {
+        check(GroupLayout.class, "attempting to select a group element from a non-group layout");
+        GroupLayout g = (GroupLayout)layout;
+        long elemSize = g.memberLayouts().size();
+        long offset = 0;
+        MemoryLayout elem = null;
+        for (int i = 0; i <= index; i++) {
+            if (i == elemSize) {
+                throw badLayoutPath("cannot resolve element " + index + " in layout " + layout);
+            }
+            elem = g.memberLayouts().get(i);
+            if (g instanceof StructLayout && i < index) {
+                offset += elem.bitSize();
+            }
+        }
+        return LayoutPath.nestedPath(elem, this.offset + offset, strides, bounds, this);
+    }
+
     // Layout path projections
 
     public long offset() {


### PR DESCRIPTION
This patch adds a new factory to MemoryLayout.PathElement, namely, to create a group element path from a long index, rather than a name. While named struct/union fields are common, there are cases where being able to access elements by index is important, such when doing a full (recursive) scan of the contents of a struct.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8300785](https://bugs.openjdk.org/browse/JDK-8300785): Add way to select group element paths by index


### Reviewers
 * [Jorn Vernee](https://openjdk.org/census#jvernee) (@JornVernee - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/panama-foreign pull/773/head:pull/773` \
`$ git checkout pull/773`

Update a local copy of the PR: \
`$ git checkout pull/773` \
`$ git pull https://git.openjdk.org/panama-foreign pull/773/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 773`

View PR using the GUI difftool: \
`$ git pr show -t 773`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/panama-foreign/pull/773.diff">https://git.openjdk.org/panama-foreign/pull/773.diff</a>

</details>
