### PR TITLE
8300201: When storing MemoryAddress.ofLong(0x0000000080000000L), MemorySegment.get is not equal to MemorySegment.set because of the expanded sign

### DIFF
--- a/src/java.base/share/classes/java/lang/foreign/MemorySegment.java
+++ b/src/java.base/share/classes/java/lang/foreign/MemorySegment.java
@@ -1068,8 +1068,8 @@ public sealed interface MemorySegment permits AbstractMemorySegmentImpl {
      * restricted methods, and use safe and supported functionalities, where possible.
      * <p>
      * On 32-bit platforms, the given address value will be normalized such that the
-     * returned memory segment's method {@link MemorySegment#address() address} will always return
-     * zeros for the upper 32 bits of the address.
+     * upper 32 bits of the {@link MemorySegment#address() address} of returned memory segment
+     * are set to zero.
      *
      * @param address the address of the returned native segment.
      * @param byteSize the size (in bytes) of the returned native segment.
@@ -1102,8 +1102,8 @@ public sealed interface MemorySegment permits AbstractMemorySegmentImpl {
      * restricted methods, and use safe and supported functionalities, where possible.
      * <p>
      * On 32-bit platforms, the given address value will be normalized such that the
-     * returned memory segment's method {@link MemorySegment#address() address} will always return
-     * zeros for the upper 32 bits of the address.
+     * upper 32 bits of the {@link MemorySegment#address() address} of returned memory segment
+     * are set to zero.
      *
      * @param address the returned segment's address.
      * @param byteSize the desired size.
@@ -1145,8 +1145,8 @@ public sealed interface MemorySegment permits AbstractMemorySegmentImpl {
      * restricted methods, and use safe and supported functionalities, where possible.
      * <p>
      * On 32-bit platforms, the given address value will be normalized such that the
-     * returned memory segment's method {@link MemorySegment#address() address} will always return
-     * zeros for the upper 32 bits of the address.
+     * upper 32 bits of the {@link MemorySegment#address() address} of returned memory segment
+     * are set to zero.
      *
      * @param address the returned segment's address.
      * @param byteSize the desired size.

--- a/src/java.base/share/classes/java/lang/foreign/MemorySegment.java
+++ b/src/java.base/share/classes/java/lang/foreign/MemorySegment.java
@@ -1042,6 +1042,11 @@ public sealed interface MemorySegment permits AbstractMemorySegmentImpl {
      * {@snippet lang = java:
      * ofAddress(address, 0);
      *}
+     * <p>
+     * On 32-bit platforms, the given address value will be normalized such that the
+     * returned memory segment's method {@link MemorySegment#address() address} will always return
+     * zeros for the upper 32-bits of the address.
+     *
      * @param address the address of the returned native segment.
      * @return a zero-length native segment with the given address.
      */
@@ -1061,6 +1066,11 @@ public sealed interface MemorySegment permits AbstractMemorySegmentImpl {
      * Restricted methods are unsafe, and, if used incorrectly, their use might crash
      * the JVM or, worse, silently result in memory corruption. Thus, clients should refrain from depending on
      * restricted methods, and use safe and supported functionalities, where possible.
+     * <p>
+     * On 32-bit platforms, the given address value will be normalized such that the
+     * returned memory segment's method {@link MemorySegment#address() address} will always return
+     * zeros for the upper 32-bits of the address.
+     *
      * @param address the address of the returned native segment.
      * @param byteSize the size (in bytes) of the returned native segment.
      * @return a zero-length native segment with the given address and size.
@@ -1090,6 +1100,11 @@ public sealed interface MemorySegment permits AbstractMemorySegmentImpl {
      * Restricted methods are unsafe, and, if used incorrectly, their use might crash
      * the JVM or, worse, silently result in memory corruption. Thus, clients should refrain from depending on
      * restricted methods, and use safe and supported functionalities, where possible.
+     * <p>
+     * On 32-bit platforms, the given address value will be normalized such that the
+     * returned memory segment's method {@link MemorySegment#address() address} will always return
+     * zeros for the upper 32-bits of the address.
+     *
      * @param address the returned segment's address.
      * @param byteSize the desired size.
      * @param scope the scope associated with the returned native segment.
@@ -1128,7 +1143,10 @@ public sealed interface MemorySegment permits AbstractMemorySegmentImpl {
      * Restricted methods are unsafe, and, if used incorrectly, their use might crash
      * the JVM or, worse, silently result in memory corruption. Thus, clients should refrain from depending on
      * restricted methods, and use safe and supported functionalities, where possible.
-     *
+     * <p>
+     * On 32-bit platforms, the given address value will be normalized such that the
+     * returned memory segment's method {@link MemorySegment#address() address} will always return
+     * zeros for the upper 32-bits of the address.
      *
      * @param address the returned segment's address.
      * @param byteSize the desired size.

--- a/src/java.base/share/classes/java/lang/foreign/MemorySegment.java
+++ b/src/java.base/share/classes/java/lang/foreign/MemorySegment.java
@@ -1045,7 +1045,7 @@ public sealed interface MemorySegment permits AbstractMemorySegmentImpl {
      * <p>
      * On 32-bit platforms, the given address value will be normalized such that the
      * returned memory segment's method {@link MemorySegment#address() address} will always return
-     * zeros for the upper 32-bits of the address.
+     * zeros for the upper 32 bits of the address.
      *
      * @param address the address of the returned native segment.
      * @return a zero-length native segment with the given address.
@@ -1069,7 +1069,7 @@ public sealed interface MemorySegment permits AbstractMemorySegmentImpl {
      * <p>
      * On 32-bit platforms, the given address value will be normalized such that the
      * returned memory segment's method {@link MemorySegment#address() address} will always return
-     * zeros for the upper 32-bits of the address.
+     * zeros for the upper 32 bits of the address.
      *
      * @param address the address of the returned native segment.
      * @param byteSize the size (in bytes) of the returned native segment.
@@ -1103,7 +1103,7 @@ public sealed interface MemorySegment permits AbstractMemorySegmentImpl {
      * <p>
      * On 32-bit platforms, the given address value will be normalized such that the
      * returned memory segment's method {@link MemorySegment#address() address} will always return
-     * zeros for the upper 32-bits of the address.
+     * zeros for the upper 32 bits of the address.
      *
      * @param address the returned segment's address.
      * @param byteSize the desired size.
@@ -1146,7 +1146,7 @@ public sealed interface MemorySegment permits AbstractMemorySegmentImpl {
      * <p>
      * On 32-bit platforms, the given address value will be normalized such that the
      * returned memory segment's method {@link MemorySegment#address() address} will always return
-     * zeros for the upper 32-bits of the address.
+     * zeros for the upper 32 bits of the address.
      *
      * @param address the returned segment's address.
      * @param byteSize the desired size.

--- a/src/java.base/share/classes/java/lang/foreign/MemorySegment.java
+++ b/src/java.base/share/classes/java/lang/foreign/MemorySegment.java
@@ -1044,8 +1044,8 @@ public sealed interface MemorySegment permits AbstractMemorySegmentImpl {
      *}
      * <p>
      * On 32-bit platforms, the given address value will be normalized such that the
-     * returned memory segment's method {@link MemorySegment#address() address} will always return
-     * zeros for the upper 32 bits of the address.
+     * upper 32 bits of the {@link MemorySegment#address() address} of returned memory segment
+     * are set to zero.
      *
      * @param address the address of the returned native segment.
      * @return a zero-length native segment with the given address.

--- a/src/java.base/share/classes/java/lang/foreign/MemorySegment.java
+++ b/src/java.base/share/classes/java/lang/foreign/MemorySegment.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
+ *  Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
  *  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  *  This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/jdk/internal/foreign/NativeMemorySegmentImpl.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/NativeMemorySegmentImpl.java
@@ -54,7 +54,11 @@ public sealed class NativeMemorySegmentImpl extends AbstractMemorySegmentImpl pe
     @ForceInline
     NativeMemorySegmentImpl(long min, long length, boolean readOnly, SegmentScope scope) {
         super(length, readOnly, scope);
-        this.min = min;
+        this.min = (UNSAFE.addressSize() == 4)
+                // On 32-bit systems, normalize the upper unused 32-bits to zero
+                ? min & 0x0000_0000_FFFF_FFFFL
+                // On 64-bit systems, all the bits are used
+                : min;
     }
 
     @Override

--- a/src/java.base/share/classes/jdk/internal/foreign/NativeMemorySegmentImpl.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/NativeMemorySegmentImpl.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
+ *  Copyright (c) 2020, 2023, Oracle and/or its affiliates. All rights reserved.
  *  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  *  This code is free software; you can redistribute it and/or modify it


### PR DESCRIPTION
This PR proposes to normalize the upper 32-bit to zero on 32-bit systems.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8300201](https://bugs.openjdk.org/browse/JDK-8300201): When storing MemoryAddress.ofLong(0x0000000080000000L), MemorySegment.get is not equal to MemorySegment.set because of the expanded sign


### Reviewers
 * [Jorn Vernee](https://openjdk.org/census#jvernee) (@JornVernee - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/panama-foreign pull/774/head:pull/774` \
`$ git checkout pull/774`

Update a local copy of the PR: \
`$ git checkout pull/774` \
`$ git pull https://git.openjdk.org/panama-foreign pull/774/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 774`

View PR using the GUI difftool: \
`$ git pr show -t 774`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/panama-foreign/pull/774.diff">https://git.openjdk.org/panama-foreign/pull/774.diff</a>

</details>
