### PR TITLE
8301360: Add dereference layout paths to memory layout API

### DIFF
--- a/src/java.base/share/classes/java/lang/foreign/MemoryLayout.java
+++ b/src/java.base/share/classes/java/lang/foreign/MemoryLayout.java
@@ -259,7 +259,7 @@ public sealed interface MemoryLayout permits SequenceLayout, GroupLayout, Paddin
      * layout path contains one or more path elements that select multiple sequence element indices
      * (see {@link PathElement#sequenceElement()} and {@link PathElement#sequenceElement(long, long)}).
      * @throws IllegalArgumentException if the layout path contains one or more dereference path elements
-     * (see {@link PathElement#dereferenceElement()} and {@link PathElement#dereferenceElement(MemoryLayout)}).
+     * (see {@link PathElement#dereferenceElement()}).
      * @throws NullPointerException if either {@code elements == null}, or if any of the elements
      * in {@code elements} is {@code null}.
      */
@@ -295,7 +295,7 @@ public sealed interface MemoryLayout permits SequenceLayout, GroupLayout, Paddin
      * @throws IllegalArgumentException if the layout path contains one or more path elements that select
      * multiple sequence element indices (see {@link PathElement#sequenceElement(long, long)}).
      * @throws IllegalArgumentException if the layout path contains one or more dereference path elements
-     * (see {@link PathElement#dereferenceElement()} and {@link PathElement#dereferenceElement(MemoryLayout)}).
+     * (see {@link PathElement#dereferenceElement()}).
      */
     default MethodHandle bitOffsetHandle(PathElement... elements) {
         return computePathOp(LayoutPath.rootPath(this), LayoutPath::offsetHandle,
@@ -312,7 +312,7 @@ public sealed interface MemoryLayout permits SequenceLayout, GroupLayout, Paddin
      * layout path contains one or more path elements that select multiple sequence element indices
      * (see {@link PathElement#sequenceElement()} and {@link PathElement#sequenceElement(long, long)}).
      * @throws IllegalArgumentException if the layout path contains one or more dereference path elements
-     * (see {@link PathElement#dereferenceElement()} and {@link PathElement#dereferenceElement(MemoryLayout)}).
+     * (see {@link PathElement#dereferenceElement()}).
      * @throws UnsupportedOperationException if {@code bitOffset(elements)} is not a multiple of 8.
      * @throws NullPointerException if either {@code elements == null}, or if any of the elements
      * in {@code elements} is {@code null}.
@@ -352,7 +352,7 @@ public sealed interface MemoryLayout permits SequenceLayout, GroupLayout, Paddin
      * @throws IllegalArgumentException if the layout path contains one or more path elements that select
      * multiple sequence element indices (see {@link PathElement#sequenceElement(long, long)}).
      * @throws IllegalArgumentException if the layout path contains one or more dereference path elements
-     * (see {@link PathElement#dereferenceElement()} and {@link PathElement#dereferenceElement(MemoryLayout)}).
+     * (see {@link PathElement#dereferenceElement()}).
      */
     default MethodHandle byteOffsetHandle(PathElement... elements) {
         MethodHandle mh = bitOffsetHandle(elements);
@@ -417,6 +417,8 @@ public sealed interface MemoryLayout permits SequenceLayout, GroupLayout, Paddin
      * @return a var handle which can be used to access a memory segment at the (possibly nested) layout selected by the layout path in {@code elements}.
      * @throws UnsupportedOperationException if the layout path has one or more elements with incompatible alignment constraint.
      * @throws IllegalArgumentException if the layout path in {@code elements} does not select a value layout (see {@link ValueLayout}).
+     * @throws IllegalArgumentException if the layout path in {@code elements} contains a {@linkplain PathElement#dereferenceElement()
+     * dereference path element} for an address layout that has no {@linkplain OfAddress#targetLayout() target layout}.
      * @see MethodHandles#memorySegmentViewVarHandle(ValueLayout)
      */
     default VarHandle varHandle(PathElement... elements) {
@@ -462,7 +464,7 @@ public sealed interface MemoryLayout permits SequenceLayout, GroupLayout, Paddin
      * @return a method handle which can be used to create a slice of the selected layout element, given a segment.
      * @throws UnsupportedOperationException if the size of the selected layout in bits is not a multiple of 8.
      * @throws IllegalArgumentException if the layout path contains one or more dereference path elements
-     * (see {@link PathElement#dereferenceElement()} and {@link PathElement#dereferenceElement(MemoryLayout)}).
+     * (see {@link PathElement#dereferenceElement()}).
      */
     default MethodHandle sliceHandle(PathElement... elements) {
         return computePathOp(LayoutPath.rootPath(this), LayoutPath::sliceHandle,
@@ -478,7 +480,7 @@ public sealed interface MemoryLayout permits SequenceLayout, GroupLayout, Paddin
      * or if the layout path contains one or more path elements that select one or more sequence element indices
      * (see {@link PathElement#sequenceElement(long)} and {@link PathElement#sequenceElement(long, long)}).
      * @throws IllegalArgumentException if the layout path contains one or more dereference path elements
-     * (see {@link PathElement#dereferenceElement()} and {@link PathElement#dereferenceElement(MemoryLayout)}).
+     * (see {@link PathElement#dereferenceElement()}).
      */
     default MemoryLayout select(PathElement... elements) {
         return computePathOp(LayoutPath.rootPath(this), LayoutPath::layout,
@@ -643,21 +645,6 @@ public sealed interface MemoryLayout permits SequenceLayout, GroupLayout, Paddin
         static PathElement dereferenceElement() {
             return new LayoutPath.PathElementImpl(PathKind.DEREF_ELEMENT,
                     LayoutPath::derefElement);
-        }
-
-        /**
-         * Returns a path element which dereferences an address layout as the given layout.
-         * The path element returned by this method does not alter the number of free dimensions of any path
-         * that is combined with such element. Using this path layout to dereference an address layout
-         * that already has a target layout results in an {@link IllegalArgumentException} (e.g. when
-         * a var handle is {@linkplain #varHandle(PathElement...) obtained}).
-         *
-         * @param layout the
-         * @return a path element which dereferences an address layout.
-         */
-        static PathElement dereferenceElement(MemoryLayout layout) {
-            return new LayoutPath.PathElementImpl(PathKind.DEREF_ELEMENT,
-                    path -> path.derefElement(layout));
         }
     }
 

--- a/src/java.base/share/classes/jdk/internal/foreign/LayoutPath.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/LayoutPath.java
@@ -167,18 +167,7 @@ public class LayoutPath {
                 addressLayout.targetLayout().isEmpty()) {
             throw badLayoutPath("Cannot dereference layout: " + layout);
         }
-        return derefElementInternal(addressLayout.targetLayout().get());
-    }
-
-    public LayoutPath derefElement(MemoryLayout derefLayout) {
-        if (!(layout instanceof ValueLayout.OfAddress addressLayout) ||
-            !addressLayout.targetLayout().isEmpty()) {
-            throw badLayoutPath("Cannot dereference layout: " + layout);
-        }
-        return derefElementInternal(derefLayout);
-    }
-
-    private LayoutPath derefElementInternal(MemoryLayout derefLayout) {
+        MemoryLayout derefLayout = addressLayout.targetLayout().get();
         MethodHandle handle = dereferenceHandle(false).toMethodHandle(VarHandle.AccessMode.GET);
         handle = MethodHandles.filterReturnValue(handle,
                 MethodHandles.insertArguments(MH_SEGMENT_RESIZE, 1, derefLayout));
@@ -274,8 +263,7 @@ public class LayoutPath {
     }
 
     private static LayoutPath derefPath(MemoryLayout layout, MethodHandle handle, LayoutPath encl) {
-        MethodHandle[] handles = new MethodHandle[encl.derefAdapters.length + 1];
-        System.arraycopy(encl.derefAdapters, 0, handles, 0, encl.derefAdapters.length);
+        MethodHandle[] handles = Arrays.copyOf(encl.derefAdapters, encl.derefAdapters.length + 1);
         handles[encl.derefAdapters.length] = handle;
         return new LayoutPath(layout, 0L, EMPTY_STRIDES, EMPTY_BOUNDS, handles, null);
     }

--- a/test/jdk/java/foreign/TestDereferencePath.java
+++ b/test/jdk/java/foreign/TestDereferencePath.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
+ *  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ *  This code is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License version 2 only, as
+ *  published by the Free Software Foundation.
+ *
+ *  This code is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ *  version 2 for more details (a copy is included in the LICENSE file that
+ *  accompanied this code).
+ *
+ *  You should have received a copy of the GNU General Public License version
+ *  2 along with this work; if not, write to the Free Software Foundation,
+ *  Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ *   Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ *  or visit www.oracle.com if you need additional information or have any
+ *  questions.
+ *
+ */
+
+/*
+ * @test
+ * @enablePreview
+ * @run testng TestDereferencePath
+ */
+
+import java.lang.foreign.MemoryLayout;
+import java.lang.foreign.MemoryLayout.PathElement;
+import java.lang.foreign.MemorySegment;
+import java.lang.foreign.MemorySession;
+
+import java.lang.foreign.ValueLayout;
+import org.testng.annotations.*;
+
+import java.lang.invoke.VarHandle;
+import static org.testng.Assert.*;
+
+public class TestDereferencePath {
+
+    static final MemoryLayout A = MemoryLayout.structLayout(
+            ValueLayout.ADDRESS.withName("b")
+    );
+
+    static final MemoryLayout B = MemoryLayout.structLayout(
+            ValueLayout.ADDRESS.withName("c")
+    );
+
+    static final MemoryLayout C = MemoryLayout.structLayout(
+            ValueLayout.JAVA_INT.withName("x")
+    );
+
+    static final VarHandle abcx = A.varHandle(
+            PathElement.groupElement("b"), PathElement.derefElement(B),
+            PathElement.groupElement("c"), PathElement.derefElement(C),
+            PathElement.groupElement("x"));
+
+    @Test
+    public void testSingle() {
+        try (MemorySession session = MemorySession.openConfined()) {
+            // init structs
+            MemorySegment a = MemorySegment.allocateNative(A, session);
+            MemorySegment b = MemorySegment.allocateNative(B, session);
+            MemorySegment c = MemorySegment.allocateNative(C, session);
+            // init struct fields
+            a.set(ValueLayout.ADDRESS, 0, b);
+            b.set(ValueLayout.ADDRESS, 0, c);
+            c.set(ValueLayout.JAVA_INT, 0, 42);
+            // dereference
+            int val = (int) abcx.get(a);
+            assertEquals(val, 42);
+        }
+    }
+
+    static final VarHandle abcx_multi = A.varHandle(
+            PathElement.groupElement("b"), PathElement.derefElement(MemoryLayout.sequenceLayout(2, B)), PathElement.sequenceElement(),
+            PathElement.groupElement("c"), PathElement.derefElement(MemoryLayout.sequenceLayout(2, C)), PathElement.sequenceElement(),
+            PathElement.groupElement("x"));
+
+    @Test
+    public void testMulti() {
+        try (MemorySession session = MemorySession.openConfined()) {
+            // init structs
+            MemorySegment a = session.allocate(A);
+            MemorySegment b = session.allocateArray(B, 2);
+            MemorySegment c = session.allocateArray(C, 4);
+            // init struct fields
+            a.set(ValueLayout.ADDRESS, 0, b);
+            b.set(ValueLayout.ADDRESS, 0, c);
+            b.setAtIndex(ValueLayout.ADDRESS, 1, c.asSlice(C.byteSize() * 2));
+            c.setAtIndex(ValueLayout.JAVA_INT, 0, 1);
+            c.setAtIndex(ValueLayout.JAVA_INT, 1, 2);
+            c.setAtIndex(ValueLayout.JAVA_INT, 2, 3);
+            c.setAtIndex(ValueLayout.JAVA_INT, 3, 4);
+            // dereference
+            int val00 = (int) abcx_multi.get(a, 0, 0); // a->b[0]->c[0] = 1
+            assertEquals(val00, 1);
+            int val10 = (int) abcx_multi.get(a, 1, 0); // a->b[1]->c[0] = 3
+            assertEquals(val10, 3);
+            int val01 = (int) abcx_multi.get(a, 0, 1); // a->b[0]->c[1] = 2
+            assertEquals(val01, 2);
+            int val11 = (int) abcx_multi.get(a, 1, 1); // a->b[1]->c[1] = 4
+            assertEquals(val11, 4);
+        }
+    }
+}


### PR DESCRIPTION
Now that we have a more general way to attach target layouts to address layouts (see https://git.openjdk.org/panama-foreign/pull/775), it might be useful to add support for layout paths which perform dereference of a given address value. Consider this case:

```
struct b {
   int x;
};

struct a {
    struct b *b;
};
```

Here, our goal is to construct a layout path for "a->b.x".

To do this, we use a *dereference path element* (see `PathElement#dereferenceElement`). These comes in two flavors:

* no argument factory - this assumes that the address layout being dereferenced has some target layout set;
* layout argument factory - this assumes that the address layout being dereferenced does *not* have a target layout set (e.g. it is not always possible to associate a target layout, especially in cyclic cases like a -> b -> a).

When a dereference element is applied to an existing path, a var handle that fetches the address pointed to by the current path is pushed on the stack, and a new layout path is started. This way, dereference path can be used to "chain" together multiple layout paths. All the intermediate memory read operations occur using a *plain* get. For more complex access operation (e.g. if atomic access is required for the whole dereference chain), multiple var handles have to be obtained.

It is an error to pass a dereference path to other layout operations such as `select`, `byte/bitOffset[Handle]`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8301360](https://bugs.openjdk.org/browse/JDK-8301360): Add dereference layout paths to memory layout API


### Reviewers
 * [Jorn Vernee](https://openjdk.org/census#jvernee) (@JornVernee - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/panama-foreign pull/776/head:pull/776` \
`$ git checkout pull/776`

Update a local copy of the PR: \
`$ git checkout pull/776` \
`$ git pull https://git.openjdk.org/panama-foreign pull/776/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 776`

View PR using the GUI difftool: \
`$ git pr show -t 776`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/panama-foreign/pull/776.diff">https://git.openjdk.org/panama-foreign/pull/776.diff</a>

</details>
