### PR TITLE
8301262: Simplify the CaptureCallState support

### DIFF
--- a/src/hotspot/share/prims/downcallLinker.cpp
+++ b/src/hotspot/share/prims/downcallLinker.cpp
@@ -41,12 +41,12 @@ void DowncallLinker::capture_state(int32_t* value_ptr, int captured_state_mask) 
 #ifdef _WIN64
   if (captured_state_mask & GET_LAST_ERROR) {
     *value_ptr = GetLastError();
-    value_ptr++;
   }
+  value_ptr++;
   if (captured_state_mask & WSA_GET_LAST_ERROR) {
     *value_ptr = WSAGetLastError();
-    value_ptr++;
   }
+  value_ptr++;
 #endif
   if (captured_state_mask & ERRNO) {
     *value_ptr = errno;

--- a/src/java.base/share/classes/java/lang/foreign/Linker.java
+++ b/src/java.base/share/classes/java/lang/foreign/Linker.java
@@ -306,13 +306,14 @@ public sealed interface Linker permits AbstractLinker {
          * For this purpose, a downcall method handle linked with the this
          * option will feature an additional {@link MemorySegment} parameter directly
          * following the target address, and optional {@link SegmentAllocator} parameters.
-         * This parameter represents the native segment into which the captured state is written.
+         * This parameter, called the 'capture state segment', represents the native segment into which
+         * the captured state is written.
          * <p>
-         * The native segment should have the layout returned by {@linkplain #capturedStateLayout}.
+         * The capture state segment should have the layout returned by {@linkplain #captureStateLayout}.
          * This layout is a struct layout which has a named field for each captured value.
          * <p>
-         * Captured state can be retrieved from this native segment by constructing var handles
-         * from the {@linkplain #capturedStateLayout captured state layout}.
+         * Captured state can be retrieved from the capture state segment by constructing var handles
+         * from the {@linkplain #captureStateLayout capture state layout}.
          * <p>
          * The following example demonstrates the use of this linker option:
          * {@snippet lang = "java":
@@ -331,7 +332,7 @@ public sealed interface Linker permits AbstractLinker {
          * }
          *
          * @param capturedState the names of the values to save.
-         * @see #capturedStateLayout()
+         * @see #captureStateLayout()
          */
         static Option captureCallState(String... capturedState) {
             Set<CapturableState> set = Stream.of(capturedState)
@@ -341,10 +342,12 @@ public sealed interface Linker permits AbstractLinker {
         }
 
          /**
-         * {@return A struct layout that represents the layout of the native segment passed
-         *          to a downcall handle linked with this {@code CapturedCallState} instance}
+         * {@return A struct layout that represents the layout of the capture state segment that is passed
+         *          to a downcall handle linked with {@link #captureCallState(String...)}}
+         *
+         * @see #captureCallState(String...)
          */
-        static StructLayout capturedStateLayout() {
+        static StructLayout captureStateLayout() {
             return CapturableState.LAYOUT;
         }
 

--- a/src/java.base/share/classes/jdk/internal/foreign/SystemLookup.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/SystemLookup.java
@@ -43,8 +43,6 @@ import static sun.security.action.GetPropertyAction.privilegedGetProperty;
 
 public final class SystemLookup implements SymbolLookup {
 
-    private static final boolean IS_WINDOWS = privilegedGetProperty("os.name").startsWith("Windows");
-
     private SystemLookup() { }
 
     private static final SystemLookup INSTANCE = new SystemLookup();
@@ -60,7 +58,7 @@ public final class SystemLookup implements SymbolLookup {
 
     private static SymbolLookup makeSystemLookup() {
         try {
-            if (IS_WINDOWS) {
+            if (Utils.IS_WINDOWS) {
                 return makeWindowsLookup();
             } else {
                 return libLookup(libs -> libs.load(jdkLibraryPath("syslookup")));
@@ -122,7 +120,7 @@ public final class SystemLookup implements SymbolLookup {
      */
     private static Path jdkLibraryPath(String name) {
         Path javahome = Path.of(GetPropertyAction.privilegedGetProperty("java.home"));
-        String lib = IS_WINDOWS ? "bin" : "lib";
+        String lib = Utils.IS_WINDOWS ? "bin" : "lib";
         String libname = System.mapLibraryName(name);
         return javahome.resolve(lib).resolve(libname);
     }

--- a/src/java.base/share/classes/jdk/internal/foreign/Utils.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/Utils.java
@@ -45,11 +45,14 @@ import jdk.internal.access.SharedSecrets;
 import jdk.internal.foreign.abi.SharedUtils;
 import jdk.internal.vm.annotation.ForceInline;
 import static java.lang.foreign.ValueLayout.JAVA_BYTE;
+import static sun.security.action.GetPropertyAction.privilegedGetProperty;
 
 /**
  * This class contains misc helper functions to support creation of memory segments.
  */
 public final class Utils {
+
+    public static final boolean IS_WINDOWS = privilegedGetProperty("os.name").startsWith("Windows");
 
     private Utils() {}
 

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/CapturableState.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/CapturableState.java
@@ -41,10 +41,7 @@ public enum CapturableState {
     ERRNO             ("errno",           JAVA_INT, 1 << 2, true);
 
     public static final StructLayout LAYOUT = MemoryLayout.structLayout(
-        Stream.of(values())
-              .filter(CapturableState::isSupported)
-              .map(CapturableState::layout)
-              .toArray(MemoryLayout[]::new));
+        supportedStates().map(CapturableState::layout).toArray(MemoryLayout[]::new));
 
     private final String stateName;
     private final ValueLayout layout;
@@ -58,6 +55,10 @@ public enum CapturableState {
         this.isSupported = isSupported;
     }
 
+    private static Stream<CapturableState> supportedStates() {
+        return Stream.of(values()).filter(CapturableState::isSupported);
+    }
+
     public static CapturableState forName(String name) {
         return Stream.of(values())
                 .filter(stl -> stl.stateName().equals(name))
@@ -65,7 +66,7 @@ public enum CapturableState {
                 .findAny()
                 .orElseThrow(() -> new IllegalArgumentException(
                         "Unknown name: " + name +", must be one of: "
-                            + Stream.of(CapturableState.values())
+                            + supportedStates()
                                     .map(CapturableState::stateName)
                                     .collect(Collectors.joining(", "))));
     }

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/CapturableState.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/CapturableState.java
@@ -24,30 +24,44 @@
  */
 package jdk.internal.foreign.abi;
 
+import jdk.internal.foreign.Utils;
+
+import java.lang.foreign.MemoryLayout;
+import java.lang.foreign.StructLayout;
 import java.lang.foreign.ValueLayout;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static java.lang.foreign.ValueLayout.JAVA_INT;
+import static sun.security.action.GetPropertyAction.privilegedGetProperty;
 
 public enum CapturableState {
-    GET_LAST_ERROR    ("GetLastError",    JAVA_INT, 1 << 0),
-    WSA_GET_LAST_ERROR("WSAGetLastError", JAVA_INT, 1 << 1),
-    ERRNO             ("errno",           JAVA_INT, 1 << 2);
+    GET_LAST_ERROR    ("GetLastError",    JAVA_INT, 1 << 0, Utils.IS_WINDOWS),
+    WSA_GET_LAST_ERROR("WSAGetLastError", JAVA_INT, 1 << 1, Utils.IS_WINDOWS),
+    ERRNO             ("errno",           JAVA_INT, 1 << 2, true);
+
+    public static final StructLayout LAYOUT = MemoryLayout.structLayout(
+        Stream.of(values())
+              .filter(CapturableState::isSupported)
+              .map(CapturableState::layout)
+              .toArray(MemoryLayout[]::new));
 
     private final String stateName;
     private final ValueLayout layout;
     private final int mask;
+    private final boolean isSupported;
 
-    CapturableState(String stateName, ValueLayout layout, int mask) {
+    CapturableState(String stateName, ValueLayout layout, int mask, boolean isSupported) {
         this.stateName = stateName;
         this.layout = layout.withName(stateName);
         this.mask = mask;
+        this.isSupported = isSupported;
     }
 
     public static CapturableState forName(String name) {
         return Stream.of(values())
                 .filter(stl -> stl.stateName().equals(name))
+                .filter(CapturableState::isSupported)
                 .findAny()
                 .orElseThrow(() -> new IllegalArgumentException(
                         "Unknown name: " + name +", must be one of: "
@@ -66,5 +80,9 @@ public enum CapturableState {
 
     public int mask() {
         return mask;
+    }
+
+    public boolean isSupported() {
+        return isSupported;
     }
 }

--- a/test/jdk/java/foreign/TestIllegalLink.java
+++ b/test/jdk/java/foreign/TestIllegalLink.java
@@ -76,7 +76,25 @@ public class TestIllegalLink extends NativeTestHelper {
         ABI.upcallStub(DUMMY_TARGET_MH, FunctionDescriptor.ofVoid(), SegmentScope.auto(), downcallOnlyOption);
     }
 
+    @Test(dataProvider = "illegalCaptureState",
+          expectedExceptions = IllegalArgumentException.class,
+          expectedExceptionsMessageRegExp = ".*Unknown name.*")
+    public void testIllegalCaptureState(String name) {
+        Linker.Option.captureCallState(name);
+    }
+
     // where
+
+    @DataProvider
+    public static Object[][] illegalCaptureState() {
+        if (!IS_WINDOWS) {
+            return new Object[][]{
+                { "GetLastError" },
+                { "WSAGetLastError" },
+            };
+        }
+        return new Object[][]{};
+    }
 
     @DataProvider
     public static Object[][] upcallOnlyOptions() {

--- a/test/jdk/java/foreign/capturecallstate/TestCaptureCallState.java
+++ b/test/jdk/java/foreign/capturecallstate/TestCaptureCallState.java
@@ -66,13 +66,14 @@ public class TestCaptureCallState extends NativeTestHelper {
 
     @Test(dataProvider = "cases")
     public void testSavedThreadLocal(SaveValuesCase testCase) throws Throwable {
-        Linker.Option.CaptureCallState stl = Linker.Option.captureCallState(testCase.threadLocalName());
+        Linker.Option stl = Linker.Option.captureCallState(testCase.threadLocalName());
         MethodHandle handle = downcallHandle(testCase.nativeTarget(), testCase.nativeDesc(), stl);
 
-        VarHandle errnoHandle = stl.layout().varHandle(groupElement(testCase.threadLocalName()));
+        StructLayout capturedStateLayout = Linker.Option.capturedStateLayout();
+        VarHandle errnoHandle = capturedStateLayout.varHandle(groupElement(testCase.threadLocalName()));
 
         try (Arena arena = Arena.openConfined()) {
-            MemorySegment saveSeg = arena.allocate(stl.layout());
+            MemorySegment saveSeg = arena.allocate(capturedStateLayout);
             int testValue = 42;
             boolean needsAllocator = testCase.nativeDesc().returnLayout().map(StructLayout.class::isInstance).orElse(false);
             Object result = needsAllocator
@@ -128,4 +129,3 @@ public class TestCaptureCallState extends NativeTestHelper {
     }
 
 }
-

--- a/test/jdk/java/foreign/capturecallstate/TestCaptureCallState.java
+++ b/test/jdk/java/foreign/capturecallstate/TestCaptureCallState.java
@@ -69,7 +69,7 @@ public class TestCaptureCallState extends NativeTestHelper {
         Linker.Option stl = Linker.Option.captureCallState(testCase.threadLocalName());
         MethodHandle handle = downcallHandle(testCase.nativeTarget(), testCase.nativeDesc(), stl);
 
-        StructLayout capturedStateLayout = Linker.Option.capturedStateLayout();
+        StructLayout capturedStateLayout = Linker.Option.captureStateLayout();
         VarHandle errnoHandle = capturedStateLayout.varHandle(groupElement(testCase.threadLocalName()));
 
         try (Arena arena = Arena.openConfined()) {

--- a/test/jdk/java/foreign/trivial/TestTrivial.java
+++ b/test/jdk/java/foreign/trivial/TestTrivial.java
@@ -84,7 +84,7 @@ public class TestTrivial extends NativeTestHelper {
     public void testCaptureErrno() throws Throwable {
         Linker.Option ccs = Linker.Option.captureCallState("errno");
         MethodHandle handle = downcallHandle("capture_errno", FunctionDescriptor.ofVoid(C_INT), Linker.Option.isTrivial(), ccs);
-        StructLayout capturedStateLayout = Linker.Option.capturedStateLayout();
+        StructLayout capturedStateLayout = Linker.Option.captureStateLayout();
         VarHandle errnoHandle = capturedStateLayout.varHandle(MemoryLayout.PathElement.groupElement("errno"));
         try (Arena arena  = Arena.openConfined()) {
             MemorySegment captureSeg = arena.allocate(capturedStateLayout);

--- a/test/jdk/java/foreign/trivial/TestTrivial.java
+++ b/test/jdk/java/foreign/trivial/TestTrivial.java
@@ -82,11 +82,12 @@ public class TestTrivial extends NativeTestHelper {
 
     @Test
     public void testCaptureErrno() throws Throwable {
-        Linker.Option.CaptureCallState ccs = Linker.Option.captureCallState("errno");
+        Linker.Option ccs = Linker.Option.captureCallState("errno");
         MethodHandle handle = downcallHandle("capture_errno", FunctionDescriptor.ofVoid(C_INT), Linker.Option.isTrivial(), ccs);
-        VarHandle errnoHandle = ccs.layout().varHandle(MemoryLayout.PathElement.groupElement("errno"));
+        StructLayout capturedStateLayout = Linker.Option.capturedStateLayout();
+        VarHandle errnoHandle = capturedStateLayout.varHandle(MemoryLayout.PathElement.groupElement("errno"));
         try (Arena arena  = Arena.openConfined()) {
-            MemorySegment captureSeg = arena.allocate(ccs.layout());
+            MemorySegment captureSeg = arena.allocate(capturedStateLayout);
             handle.invokeExact(captureSeg, 42);
             int capturedErrno = (int) errnoHandle.get(captureSeg);
             assertEquals(capturedErrno, 42);


### PR DESCRIPTION
Simplify capture call state support based on Maurizio's suggestion.

We currently compute a layout to write the captured state into based on the values that the user wants to capture. However, we could simplify the API by using the same layout every time, that can hold every value that someone might want to capture. This is only 12 bytes, so the memory usage is not a big deal. The important part is to not read every thread local value every time, which works just as it does today.

The second issue in today's implementation, is that it is still possible to create a capture state linker option that captures `GetLastError` on Linux. But, this doesn't make any sense. In the new implementation the GetLastError and WSAGetLastError options are only available on Windows.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8301262](https://bugs.openjdk.org/browse/JDK-8301262): Simplify the CaptureCallState support


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.org/census#mcimadamore) (@mcimadamore - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/panama-foreign pull/778/head:pull/778` \
`$ git checkout pull/778`

Update a local copy of the PR: \
`$ git checkout pull/778` \
`$ git pull https://git.openjdk.org/panama-foreign pull/778/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 778`

View PR using the GUI difftool: \
`$ git pr show -t 778`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/panama-foreign/pull/778.diff">https://git.openjdk.org/panama-foreign/pull/778.diff</a>

</details>
