### PR TITLE
Fix javadoc "highest-order" rather than "upper"

### DIFF
--- a/src/java.base/share/classes/java/lang/foreign/MemorySegment.java
+++ b/src/java.base/share/classes/java/lang/foreign/MemorySegment.java
@@ -1125,8 +1125,8 @@ public sealed interface MemorySegment permits AbstractMemorySegmentImpl {
      *}
      * <p>
      * On 32-bit platforms, the given address value will be normalized such that the
-     * upper 32 bits of the {@link MemorySegment#address() address} of returned memory segment
-     * are set to zero.
+     * highest-order ("leftmost") 32 bits of the {@link MemorySegment#address() address}
+     * of the returned memory segment are set to zero.
      *
      * @param address the address of the returned native segment.
      * @return a zero-length native segment with the given address.
@@ -1149,8 +1149,8 @@ public sealed interface MemorySegment permits AbstractMemorySegmentImpl {
      * restricted methods, and use safe and supported functionalities, where possible.
      * <p>
      * On 32-bit platforms, the given address value will be normalized such that the
-     * upper 32 bits of the {@link MemorySegment#address() address} of returned memory segment
-     * are set to zero.
+     * highest-order ("leftmost") 32 bits of the {@link MemorySegment#address() address}
+     * of the returned memory segment are set to zero.
      *
      * @param address the address of the returned native segment.
      * @param byteSize the size (in bytes) of the returned native segment.
@@ -1183,8 +1183,8 @@ public sealed interface MemorySegment permits AbstractMemorySegmentImpl {
      * restricted methods, and use safe and supported functionalities, where possible.
      * <p>
      * On 32-bit platforms, the given address value will be normalized such that the
-     * upper 32 bits of the {@link MemorySegment#address() address} of returned memory segment
-     * are set to zero.
+     * highest-order ("leftmost") 32 bits of the {@link MemorySegment#address() address}
+     * of the returned memory segment are set to zero.
      *
      * @param address the returned segment's address.
      * @param byteSize the desired size.
@@ -1226,8 +1226,8 @@ public sealed interface MemorySegment permits AbstractMemorySegmentImpl {
      * restricted methods, and use safe and supported functionalities, where possible.
      * <p>
      * On 32-bit platforms, the given address value will be normalized such that the
-     * upper 32 bits of the {@link MemorySegment#address() address} of returned memory segment
-     * are set to zero.
+     * highest-order ("leftmost") 32 bits of the {@link MemorySegment#address() address}
+     * of the returned memory segment are set to zero.
      *
      * @param address the returned segment's address.
      * @param byteSize the desired size.


### PR DESCRIPTION
Minor Javadoc improvements

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Reviewers
 * [Maurizio Cimadamore](https://openjdk.org/census#mcimadamore) (@mcimadamore - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/panama-foreign pull/779/head:pull/779` \
`$ git checkout pull/779`

Update a local copy of the PR: \
`$ git checkout pull/779` \
`$ git pull https://git.openjdk.org/panama-foreign pull/779/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 779`

View PR using the GUI difftool: \
`$ git pr show -t 779`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/panama-foreign/pull/779.diff">https://git.openjdk.org/panama-foreign/pull/779.diff</a>

</details>
