### PR TITLE
Fix test failures following 8300201

### DIFF
--- a/src/java.base/share/classes/jdk/internal/foreign/NativeMemorySegmentImpl.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/NativeMemorySegmentImpl.java
@@ -54,7 +54,7 @@ public sealed class NativeMemorySegmentImpl extends AbstractMemorySegmentImpl pe
     @ForceInline
     NativeMemorySegmentImpl(long min, long length, boolean readOnly, SegmentScope scope) {
         super(length, readOnly, scope);
-        this.min = (UNSAFE.addressSize() == 4)
+        this.min = (Unsafe.ADDRESS_SIZE == 4)
                 // On 32-bit systems, normalize the upper unused 32-bits to zero
                 ? min & 0x0000_0000_FFFF_FFFFL
                 // On 64-bit systems, all the bits are used


### PR DESCRIPTION
The fix for JDK-8300201 has introduced an initialization issue involving `NativeMemorySegmentImpl`. The constructor of that class is accessing the `UNSAFE` static field (declared in same class), but that field seems to be set to `null` in some cases (probably because of a static initializer loop). This is something I also have observed when working on https://git.openjdk.org/panama-foreign/pull/781

The fix is to just use the Unsafe static field for getting the address size, and avoid the `UNSAFE` field in the constructor. More investigation might follow, to pinpoint exactly where the initialization problem is.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Reviewers
 * [Jorn Vernee](https://openjdk.org/census#jvernee) (@JornVernee - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/panama-foreign pull/782/head:pull/782` \
`$ git checkout pull/782`

Update a local copy of the PR: \
`$ git checkout pull/782` \
`$ git pull https://git.openjdk.org/panama-foreign pull/782/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 782`

View PR using the GUI difftool: \
`$ git pr show -t 782`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/panama-foreign/pull/782.diff">https://git.openjdk.org/panama-foreign/pull/782.diff</a>

</details>
