### PR TITLE
8302098: Fix initialization order in NativeMemorySegmentImpl

### DIFF
--- a/src/java.base/share/classes/java/lang/foreign/MemorySegment.java
+++ b/src/java.base/share/classes/java/lang/foreign/MemorySegment.java
@@ -1113,7 +1113,7 @@ public sealed interface MemorySegment permits AbstractMemorySegmentImpl {
     /**
      * A zero-length native segment modelling the {@code NULL} address.
      */
-    MemorySegment NULL = NativeMemorySegmentImpl.makeNativeSegmentUnchecked(0L, 0);
+    MemorySegment NULL = new NativeMemorySegmentImpl();
 
     /**
      * Creates a zero-length native segment from the given {@linkplain #address() address value}.

--- a/src/java.base/share/classes/jdk/internal/foreign/NativeMemorySegmentImpl.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/NativeMemorySegmentImpl.java
@@ -54,11 +54,22 @@ public sealed class NativeMemorySegmentImpl extends AbstractMemorySegmentImpl pe
     @ForceInline
     NativeMemorySegmentImpl(long min, long length, boolean readOnly, SegmentScope scope) {
         super(length, readOnly, scope);
-        this.min = (Unsafe.ADDRESS_SIZE == 4)
+        this.min = (UNSAFE.addressSize() == 4)
                 // On 32-bit systems, normalize the upper unused 32-bits to zero
                 ? min & 0x0000_0000_FFFF_FFFFL
                 // On 64-bit systems, all the bits are used
                 : min;
+    }
+
+    /**
+     * This constructor should only be used when initializing {@link MemorySegment#NULL}. Note: because of the memory
+     * segment class hierarchy, it is possible to end up in a situation where this constructor is called
+     * when the static fields in this class are not yet initialized.
+     */
+    @ForceInline
+    public NativeMemorySegmentImpl() {
+        super(0L, false, MemorySessionImpl.GLOBAL);
+        this.min = 0L;
     }
 
     @Override


### PR DESCRIPTION
Hi,
the recent fix for 8300201 [1] exposed a latent initialization bug in the FFM API implementation. That fix added a call to `UNSAFE.addressSize()` in the constructor of `NativeMemorySegmentImpl` (in order to perform some normalization of the incoming address on 32-bit platforms). After we integrated that change we have started to see some failures in our nightly builds. Most failures had to do with creating memory mapped segments and manifested themselves as NPEs when tryin to call `UNSAFE.addressSize()` (because the `UNSAFE` static field was `null`).

Yesterday I have integrated a PR in order to fix these issues [2] - the fix simply replaces `UNSAFE.addressSize()` with `UNSAFE.ADDRESS_SIZE` (e.g. replace instance method call with static field access).

Today I've spent more time investigating what's actually wrong with the code, given that I couldn't see any obvious looping logic. After staring at the code for some time, I realized that we indeed suffer from cyclic initialization. The cycle goes as follows:

* A client calls `FileChannel::map`
* That method wants to create a new instance of `MappedMemorySegmentImpl`
* To do that, we need to load `MappedMemorySegmentImpl` and run its static initializers
* But, to do that, we need to load `NativeMemorySegmentImpl` and run its static initializers
* But, but, to do that, we need to load `AbstractMemorySegmentImpl` and run its static initializers
* But, but, but, to do that, we need to load `MemorySegment` and run its static initializers
* Unfortunately, `MemorySegment` has a static final field, namely `NULL` which calls the static method `NativeMemorySegment.makeNativeSegmentUnchecked`
* This method creates a new `NativeMemorySegmentImpl` (for `NULL`), but when evaluating the constructor, no static field in the class is set; hence we NPE.

In other words, while initializing a subclass, we initialize a superclass - but that initialization points back to the subclass. Hence the cycle.

To solve this w/o having to change the public API, I have added a dedicated, simple constructor which can be used to construct the memory segment instance for `NULL`. This constructor has some documentation which explains the initialization issues, and should be left alone (other than when initializing `NULL`).

[1] - https://git.openjdk.org/panama-foreign/pull/774
[2] - https://git.openjdk.org/panama-foreign/pull/782

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8302098](https://bugs.openjdk.org/browse/JDK-8302098): Fix initialization order in NativeMemorySegmentImpl


### Reviewers
 * [Jorn Vernee](https://openjdk.org/census#jvernee) (@JornVernee - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/panama-foreign pull/783/head:pull/783` \
`$ git checkout pull/783`

Update a local copy of the PR: \
`$ git checkout pull/783` \
`$ git pull https://git.openjdk.org/panama-foreign pull/783/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 783`

View PR using the GUI difftool: \
`$ git pr show -t 783`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/panama-foreign/pull/783.diff">https://git.openjdk.org/panama-foreign/pull/783.diff</a>

</details>
