### PR TITLE
Add `final` to AbstractMemorySegmentImpl::asUnbounded

### DIFF
--- a/src/java.base/share/classes/jdk/internal/foreign/AbstractMemorySegmentImpl.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/AbstractMemorySegmentImpl.java
@@ -125,7 +125,7 @@ public abstract sealed class AbstractMemorySegmentImpl
 
     @Override
     @CallerSensitive
-    public AbstractMemorySegmentImpl asUnbounded() {
+    public final AbstractMemorySegmentImpl asUnbounded() {
         Reflection.ensureNativeAccess(Reflection.getCallerClass(), MemorySegment.class, "asUnbounded");
         if (!isNative()) throw new UnsupportedOperationException("Not a native segment");
         return asSliceNoCheck(0, Long.MAX_VALUE);


### PR DESCRIPTION
The recent changes in https://git.openjdk.org/panama-foreign/pull/775 cause some issue in a test which ensures that caller sensitive methods are declared correctly. More specifically, the test fails whenever a non-final caller sensitive method is found. The fix is to simply add `final` to `AbstractMemorySegmentImpl::asUnbounded`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Reviewers
 * [Jorn Vernee](https://openjdk.org/census#jvernee) (@JornVernee - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/panama-foreign pull/784/head:pull/784` \
`$ git checkout pull/784`

Update a local copy of the PR: \
`$ git checkout pull/784` \
`$ git pull https://git.openjdk.org/panama-foreign pull/784/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 784`

View PR using the GUI difftool: \
`$ git pr show -t 784`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/panama-foreign/pull/784.diff">https://git.openjdk.org/panama-foreign/pull/784.diff</a>

</details>
