### PR TITLE
ValueLayouts: Improve test coverage and more

### DIFF
--- a/src/java.base/share/classes/jdk/internal/foreign/layout/ValueLayouts.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/layout/ValueLayouts.java
@@ -147,16 +147,24 @@ public final class ValueLayouts {
 
         static void assertCarrierSize(Class<?> carrier, long bitSize) {
             assert isValidCarrier(carrier);
-            assert carrier == MemorySegment.class
-                    ? bitSize == ADDRESS_SIZE_BITS
-                    : true;
-            assert carrier.isPrimitive()
-                    ? bitSize == (carrier == boolean.class ? 8 : Wrapper.forPrimitiveType(carrier).bitWidth())
-                    : true;
+            assert carrier != MemorySegment.class
+                    // MemorySegment bitSize must always equal ADDRESS_SIZE_BITS
+                    || bitSize == ADDRESS_SIZE_BITS;
+            assert !carrier.isPrimitive() ||
+                    // Primitive class bitSize must always correspond
+                    bitSize == (carrier == boolean.class ? 8 : Wrapper.forPrimitiveType(carrier).bitWidth());
         }
 
         static boolean isValidCarrier(Class<?> carrier) {
-            return carrier.isPrimitive()
+            // void.class is not valid
+            return carrier == boolean.class
+                    || carrier == byte.class
+                    || carrier == short.class
+                    || carrier == char.class
+                    || carrier == int.class
+                    || carrier == long.class
+                    || carrier == float.class
+                    || carrier == double.class
                     || carrier == MemorySegment.class;
         }
 

--- a/test/jdk/java/foreign/TestLayouts.java
+++ b/test/jdk/java/foreign/TestLayouts.java
@@ -32,16 +32,12 @@ import java.lang.foreign.*;
 import java.lang.invoke.VarHandle;
 import java.nio.ByteOrder;
 import java.util.List;
-import java.util.function.Function;
 import java.util.function.LongFunction;
 import java.util.stream.Stream;
 
 import org.testng.annotations.*;
 
-import static java.lang.foreign.ValueLayout.JAVA_BYTE;
-import static java.lang.foreign.ValueLayout.JAVA_INT;
-import static java.lang.foreign.ValueLayout.JAVA_LONG;
-import static java.lang.foreign.ValueLayout.JAVA_SHORT;
+import static java.lang.foreign.ValueLayout.*;
 import static org.testng.Assert.*;
 
 public class TestLayouts {
@@ -49,6 +45,34 @@ public class TestLayouts {
     @Test(dataProvider = "badAlignments", expectedExceptions = IllegalArgumentException.class)
     public void testBadLayoutAlignment(MemoryLayout layout, long alignment) {
         layout.withBitAlignment(alignment);
+    }
+
+    @Test
+    public void testNotEquals() {
+        List<MemoryLayout> basic = Stream.concat(Stream.of(basicLayouts), Stream.of(ADDRESS)).toList();
+        MemoryLayout differentName = JAVA_INT.withName("CustomName");
+        basic.forEach(l ->
+                assertFalse(l.equals(differentName))
+        );
+        // Swap endian
+        MemoryLayout differentOrder = JAVA_INT.withOrder(JAVA_INT.order() == ByteOrder.BIG_ENDIAN ? ByteOrder.LITTLE_ENDIAN : ByteOrder.BIG_ENDIAN);
+        basic.forEach(l ->
+                assertFalse(l.equals(differentOrder))
+        );
+
+        // Something totally different
+        basic.forEach(l ->
+                assertFalse(l.equals("A"))
+        );
+        // Null
+        basic.forEach(l ->
+                assertFalse(l.equals(null))
+        );
+    }
+
+    public void testTargetLayoutEquals() {
+        MemoryLayout differentTargetLayout = ADDRESS.withTargetLayout(JAVA_CHAR);
+        assertFalse(ADDRESS.equals(differentTargetLayout));
     }
 
     @Test

--- a/test/jdk/java/foreign/TestLayouts.java
+++ b/test/jdk/java/foreign/TestLayouts.java
@@ -47,27 +47,26 @@ public class TestLayouts {
         layout.withBitAlignment(alignment);
     }
 
-    @Test
-    public void testNotEquals() {
-        List<MemoryLayout> basic = Stream.concat(Stream.of(basicLayouts), Stream.of(ADDRESS)).toList();
-        MemoryLayout differentName = JAVA_INT.withName("CustomName");
-        basic.forEach(l ->
-                assertFalse(l.equals(differentName))
-        );
+    @Test(dataProvider = "basicLayoutsAndAddress")
+    public void testNotEquals(MemoryLayout layout) {
+
+        // Use another Type
+        MemoryLayout differentType = MemoryLayout.paddingLayout(8);
+        assertFalse(layout.equals(differentType));
+
+        // Use another name
+        MemoryLayout differentName = layout.withName("CustomName");
+        assertFalse(layout.equals(differentName));
+
         // Swap endian
         MemoryLayout differentOrder = JAVA_INT.withOrder(JAVA_INT.order() == ByteOrder.BIG_ENDIAN ? ByteOrder.LITTLE_ENDIAN : ByteOrder.BIG_ENDIAN);
-        basic.forEach(l ->
-                assertFalse(l.equals(differentOrder))
-        );
+        assertFalse(layout.equals(differentOrder));
 
         // Something totally different
-        basic.forEach(l ->
-                assertFalse(l.equals("A"))
-        );
+        assertFalse(layout.equals("A"));
+
         // Null
-        basic.forEach(l ->
-                assertFalse(l.equals(null))
-        );
+        assertFalse(layout.equals(null));
     }
 
     public void testTargetLayoutEquals() {
@@ -300,6 +299,13 @@ public class TestLayouts {
     @DataProvider(name = "basicLayouts")
     public Object[][] basicLayouts() {
         return Stream.of(basicLayouts)
+                .map(l -> new Object[] { l })
+                .toArray(Object[][]::new);
+    }
+
+    @DataProvider(name = "basicLayoutsAndAddress")
+    public Object[][] basicLayoutsAndAddress() {
+        return Stream.concat(Stream.of(basicLayouts), Stream.of(ADDRESS))
                 .map(l -> new Object[] { l })
                 .toArray(Object[][]::new);
     }


### PR DESCRIPTION
This PR:

* Adds tests to `ValueLayout` methods
* Simplifies an `equals()` method
* Changes from exception throwing to assert for parameters that cannot be changed client-side

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Reviewers
 * [Jorn Vernee](https://openjdk.org/census#jvernee) (@JornVernee - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/panama-foreign pull/786/head:pull/786` \
`$ git checkout pull/786`

Update a local copy of the PR: \
`$ git checkout pull/786` \
`$ git pull https://git.openjdk.org/panama-foreign pull/786/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 786`

View PR using the GUI difftool: \
`$ git pr show -t 786`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/panama-foreign/pull/786.diff">https://git.openjdk.org/panama-foreign/pull/786.diff</a>

</details>
