### PR TITLE
8301806: TestNulls does not cover all API classes

### DIFF
--- a/src/java.base/share/classes/java/lang/foreign/Linker.java
+++ b/src/java.base/share/classes/java/lang/foreign/Linker.java
@@ -35,6 +35,7 @@ import jdk.internal.reflect.Reflection;
 
 import java.lang.foreign.ValueLayout.OfAddress;
 import java.lang.invoke.MethodHandle;
+import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -335,7 +336,8 @@ public sealed interface Linker permits AbstractLinker {
          * @see #captureStateLayout()
          */
         static Option captureCallState(String... capturedState) {
-            Set<CapturableState> set = Stream.of(capturedState)
+            Set<CapturableState> set = Stream.of(Objects.requireNonNull(capturedState))
+                    .map(Objects::requireNonNull)
                     .map(CapturableState::forName)
                     .collect(Collectors.toSet());
             return new LinkerOptions.CaptureCallState(set);
@@ -377,7 +379,7 @@ public sealed interface Linker permits AbstractLinker {
          * @param handler the handler
          */
         static Option uncaughtExceptionHandler(Thread.UncaughtExceptionHandler handler) {
-            return new LinkerOptions.UncaughtExceptionHandler(handler);
+            return new LinkerOptions.UncaughtExceptionHandler(Objects.requireNonNull(handler));
         }
     }
 }

--- a/test/jdk/java/foreign/TestNulls.java
+++ b/test/jdk/java/foreign/TestNulls.java
@@ -95,7 +95,10 @@ public class TestNulls {
             ValueLayout.OfLong.class,
             ValueLayout.OfDouble.class,
             ValueLayout.OfAddress.class,
+            PaddingLayout.class,
             GroupLayout.class,
+            StructLayout.class,
+            UnionLayout.class,
             Linker.class,
             Linker.Option.class,
             FunctionDescriptor.class,
@@ -173,7 +176,10 @@ public class TestNulls {
         addDefaultMapping(ValueLayout.OfFloat.class, ValueLayout.JAVA_FLOAT);
         addDefaultMapping(ValueLayout.OfLong.class, JAVA_LONG);
         addDefaultMapping(ValueLayout.OfDouble.class, ValueLayout.JAVA_DOUBLE);
+        addDefaultMapping(PaddingLayout.class, MemoryLayout.paddingLayout(32));
         addDefaultMapping(GroupLayout.class, MemoryLayout.structLayout(ValueLayout.JAVA_INT));
+        addDefaultMapping(StructLayout.class, MemoryLayout.structLayout(ValueLayout.JAVA_INT));
+        addDefaultMapping(UnionLayout.class, MemoryLayout.unionLayout(ValueLayout.JAVA_INT));
         addDefaultMapping(SequenceLayout.class, MemoryLayout.sequenceLayout(1, ValueLayout.JAVA_INT));
         addDefaultMapping(SymbolLookup.class, SymbolLookup.loaderLookup());
         addDefaultMapping(MemorySegment.class, MemorySegment.ofArray(new byte[10]));

--- a/test/jdk/java/foreign/TestNulls.java
+++ b/test/jdk/java/foreign/TestNulls.java
@@ -97,6 +97,7 @@ public class TestNulls {
             ValueLayout.OfAddress.class,
             GroupLayout.class,
             Linker.class,
+            Linker.Option.class,
             FunctionDescriptor.class,
             SegmentAllocator.class,
             SegmentScope.class,
@@ -183,6 +184,7 @@ public class TestNulls {
         addDefaultMapping(SegmentAllocator.class, SegmentAllocator.prefixAllocator(MemorySegment.ofArray(new byte[10])));
         addDefaultMapping(Supplier.class, () -> null);
         addDefaultMapping(ClassLoader.class, TestNulls.class.getClassLoader());
+        addDefaultMapping(Thread.UncaughtExceptionHandler.class, (thread, ex) -> {});
     }
 
     static final Map<Class<?>, Object[]> REPLACEMENT_VALUES = new HashMap<>();


### PR DESCRIPTION
The TestNulls test does not cover the following API classes: Linker.Option, PaddingLayout, StructLayout, UnionLayout.

This patch adds coverage, and fixes several places where we weren't checking for `null`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8301806](https://bugs.openjdk.org/browse/JDK-8301806): TestNulls does not cover all API classes


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.org/census#mcimadamore) (@mcimadamore - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/panama-foreign pull/787/head:pull/787` \
`$ git checkout pull/787`

Update a local copy of the PR: \
`$ git checkout pull/787` \
`$ git pull https://git.openjdk.org/panama-foreign pull/787/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 787`

View PR using the GUI difftool: \
`$ git pr show -t 787`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/panama-foreign/pull/787.diff">https://git.openjdk.org/panama-foreign/pull/787.diff</a>

</details>
