### PR TITLE
Generalize PointerInvoke to benchmark by-ref segment return

### DIFF
--- a/test/micro/org/openjdk/bench/java/lang/foreign/PointerInvoke.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/PointerInvoke.java
@@ -92,18 +92,18 @@ public class PointerInvoke extends CLayouts {
     }
 
     @Benchmark
-    public MemorySegment long_to_ptr() throws Throwable {
-        return (MemorySegment)F_LONG_PTR.invokeExact(segment.address());
+    public long long_to_ptr() throws Throwable {
+        return ((MemorySegment)F_LONG_PTR.invokeExact(segment.address())).address();
     }
 
     @Benchmark
-    public MemorySegment ptr_to_ptr() throws Throwable {
-        return (MemorySegment)F_PTR_PTR.invokeExact(segment);
+    public long ptr_to_ptr() throws Throwable {
+        return ((MemorySegment)F_PTR_PTR.invokeExact(segment)).address();
     }
 
     @Benchmark
-    public MemorySegment ptr_to_ptr_new_segment() throws Throwable {
+    public long ptr_to_ptr_new_segment() throws Throwable {
         MemorySegment newSegment = MemorySegment.ofAddress(segment.address(), 100, arena);
-        return (MemorySegment)F_PTR_PTR.invokeExact(newSegment);
+        return ((MemorySegment)F_PTR_PTR.invokeExact(newSegment)).address();
     }
 }

--- a/test/micro/org/openjdk/bench/java/lang/foreign/libPtr.c
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/libPtr.c
@@ -29,10 +29,18 @@
 #define EXPORT
 #endif
 
-EXPORT int func_as_long(long long value) {
-  return 0;
+EXPORT long long id_long_long(long long value) {
+  return value;
 }
 
-EXPORT int func_as_ptr(void* ptr) {
-  return 0;
+EXPORT long long id_ptr_long(void* ptr) {
+  return (long long)ptr;
+}
+
+EXPORT void* id_long_ptr(long long value) {
+  return (void*)value;
+}
+
+EXPORT void* id_ptr_ptr(void* ptr) {
+  return ptr;
 }


### PR DESCRIPTION
I've generalized an existing benchmark to test by-reference segment return in downcalls.
Ideally, we should see scalarization of the returned segment, and no GC activity.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Reviewers
 * [Jorn Vernee](https://openjdk.org/census#jvernee) (@JornVernee - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/panama-foreign pull/788/head:pull/788` \
`$ git checkout pull/788`

Update a local copy of the PR: \
`$ git checkout pull/788` \
`$ git pull https://git.openjdk.org/panama-foreign pull/788/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 788`

View PR using the GUI difftool: \
`$ git pr show -t 788`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/panama-foreign/pull/788.diff">https://git.openjdk.org/panama-foreign/pull/788.diff</a>

</details>
