### PR TITLE
Fix typo in vector test template

### DIFF
--- a/test/jdk/jdk/incubator/vector/Byte128VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Byte128VectorLoadStoreTests.java
@@ -480,7 +480,7 @@ public class Byte128VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
     @Test(dataProvider = "byteByteProviderForIOOBE")
     static void loadMemorySegmentIOOBE(IntFunction<byte[]> fa, IntFunction<Integer> fi) {
         MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> Arena.ofAuto().allocate(i, Byte.SIZE));
-        MemorySegment r = , Arena.ofAuto().allocate(a.byteSize(), Byte.SIZE);
+        MemorySegment r = Arena.ofAuto().allocate(a.byteSize(), Byte.SIZE);
 
         int l = (int) a.byteSize();
         int s = SPECIES.vectorByteSize();

--- a/test/jdk/jdk/incubator/vector/Byte256VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Byte256VectorLoadStoreTests.java
@@ -480,7 +480,7 @@ public class Byte256VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
     @Test(dataProvider = "byteByteProviderForIOOBE")
     static void loadMemorySegmentIOOBE(IntFunction<byte[]> fa, IntFunction<Integer> fi) {
         MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> Arena.ofAuto().allocate(i, Byte.SIZE));
-        MemorySegment r = , Arena.ofAuto().allocate(a.byteSize(), Byte.SIZE);
+        MemorySegment r = Arena.ofAuto().allocate(a.byteSize(), Byte.SIZE);
 
         int l = (int) a.byteSize();
         int s = SPECIES.vectorByteSize();

--- a/test/jdk/jdk/incubator/vector/Byte512VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Byte512VectorLoadStoreTests.java
@@ -480,7 +480,7 @@ public class Byte512VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
     @Test(dataProvider = "byteByteProviderForIOOBE")
     static void loadMemorySegmentIOOBE(IntFunction<byte[]> fa, IntFunction<Integer> fi) {
         MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> Arena.ofAuto().allocate(i, Byte.SIZE));
-        MemorySegment r = , Arena.ofAuto().allocate(a.byteSize(), Byte.SIZE);
+        MemorySegment r = Arena.ofAuto().allocate(a.byteSize(), Byte.SIZE);
 
         int l = (int) a.byteSize();
         int s = SPECIES.vectorByteSize();

--- a/test/jdk/jdk/incubator/vector/Byte64VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Byte64VectorLoadStoreTests.java
@@ -480,7 +480,7 @@ public class Byte64VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
     @Test(dataProvider = "byteByteProviderForIOOBE")
     static void loadMemorySegmentIOOBE(IntFunction<byte[]> fa, IntFunction<Integer> fi) {
         MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> Arena.ofAuto().allocate(i, Byte.SIZE));
-        MemorySegment r = , Arena.ofAuto().allocate(a.byteSize(), Byte.SIZE);
+        MemorySegment r = Arena.ofAuto().allocate(a.byteSize(), Byte.SIZE);
 
         int l = (int) a.byteSize();
         int s = SPECIES.vectorByteSize();

--- a/test/jdk/jdk/incubator/vector/ByteMaxVectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/ByteMaxVectorLoadStoreTests.java
@@ -487,7 +487,7 @@ public class ByteMaxVectorLoadStoreTests extends AbstractVectorLoadStoreTest {
     @Test(dataProvider = "byteByteProviderForIOOBE")
     static void loadMemorySegmentIOOBE(IntFunction<byte[]> fa, IntFunction<Integer> fi) {
         MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> Arena.ofAuto().allocate(i, Byte.SIZE));
-        MemorySegment r = , Arena.ofAuto().allocate(a.byteSize(), Byte.SIZE);
+        MemorySegment r = Arena.ofAuto().allocate(a.byteSize(), Byte.SIZE);
 
         int l = (int) a.byteSize();
         int s = SPECIES.vectorByteSize();

--- a/test/jdk/jdk/incubator/vector/Double128VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Double128VectorLoadStoreTests.java
@@ -480,7 +480,7 @@ public class Double128VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
     @Test(dataProvider = "doubleByteProviderForIOOBE")
     static void loadMemorySegmentIOOBE(IntFunction<double[]> fa, IntFunction<Integer> fi) {
         MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> Arena.ofAuto().allocate(i, Double.SIZE));
-        MemorySegment r = , Arena.ofAuto().allocate(a.byteSize(), Double.SIZE);
+        MemorySegment r = Arena.ofAuto().allocate(a.byteSize(), Double.SIZE);
 
         int l = (int) a.byteSize();
         int s = SPECIES.vectorByteSize();

--- a/test/jdk/jdk/incubator/vector/Double256VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Double256VectorLoadStoreTests.java
@@ -480,7 +480,7 @@ public class Double256VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
     @Test(dataProvider = "doubleByteProviderForIOOBE")
     static void loadMemorySegmentIOOBE(IntFunction<double[]> fa, IntFunction<Integer> fi) {
         MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> Arena.ofAuto().allocate(i, Double.SIZE));
-        MemorySegment r = , Arena.ofAuto().allocate(a.byteSize(), Double.SIZE);
+        MemorySegment r = Arena.ofAuto().allocate(a.byteSize(), Double.SIZE);
 
         int l = (int) a.byteSize();
         int s = SPECIES.vectorByteSize();

--- a/test/jdk/jdk/incubator/vector/Double512VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Double512VectorLoadStoreTests.java
@@ -480,7 +480,7 @@ public class Double512VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
     @Test(dataProvider = "doubleByteProviderForIOOBE")
     static void loadMemorySegmentIOOBE(IntFunction<double[]> fa, IntFunction<Integer> fi) {
         MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> Arena.ofAuto().allocate(i, Double.SIZE));
-        MemorySegment r = , Arena.ofAuto().allocate(a.byteSize(), Double.SIZE);
+        MemorySegment r = Arena.ofAuto().allocate(a.byteSize(), Double.SIZE);
 
         int l = (int) a.byteSize();
         int s = SPECIES.vectorByteSize();

--- a/test/jdk/jdk/incubator/vector/Double64VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Double64VectorLoadStoreTests.java
@@ -480,7 +480,7 @@ public class Double64VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
     @Test(dataProvider = "doubleByteProviderForIOOBE")
     static void loadMemorySegmentIOOBE(IntFunction<double[]> fa, IntFunction<Integer> fi) {
         MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> Arena.ofAuto().allocate(i, Double.SIZE));
-        MemorySegment r = , Arena.ofAuto().allocate(a.byteSize(), Double.SIZE);
+        MemorySegment r = Arena.ofAuto().allocate(a.byteSize(), Double.SIZE);
 
         int l = (int) a.byteSize();
         int s = SPECIES.vectorByteSize();

--- a/test/jdk/jdk/incubator/vector/DoubleMaxVectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/DoubleMaxVectorLoadStoreTests.java
@@ -487,7 +487,7 @@ public class DoubleMaxVectorLoadStoreTests extends AbstractVectorLoadStoreTest {
     @Test(dataProvider = "doubleByteProviderForIOOBE")
     static void loadMemorySegmentIOOBE(IntFunction<double[]> fa, IntFunction<Integer> fi) {
         MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> Arena.ofAuto().allocate(i, Double.SIZE));
-        MemorySegment r = , Arena.ofAuto().allocate(a.byteSize(), Double.SIZE);
+        MemorySegment r = Arena.ofAuto().allocate(a.byteSize(), Double.SIZE);
 
         int l = (int) a.byteSize();
         int s = SPECIES.vectorByteSize();

--- a/test/jdk/jdk/incubator/vector/Float128VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Float128VectorLoadStoreTests.java
@@ -480,7 +480,7 @@ public class Float128VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
     @Test(dataProvider = "floatByteProviderForIOOBE")
     static void loadMemorySegmentIOOBE(IntFunction<float[]> fa, IntFunction<Integer> fi) {
         MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> Arena.ofAuto().allocate(i, Float.SIZE));
-        MemorySegment r = , Arena.ofAuto().allocate(a.byteSize(), Float.SIZE);
+        MemorySegment r = Arena.ofAuto().allocate(a.byteSize(), Float.SIZE);
 
         int l = (int) a.byteSize();
         int s = SPECIES.vectorByteSize();

--- a/test/jdk/jdk/incubator/vector/Float256VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Float256VectorLoadStoreTests.java
@@ -480,7 +480,7 @@ public class Float256VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
     @Test(dataProvider = "floatByteProviderForIOOBE")
     static void loadMemorySegmentIOOBE(IntFunction<float[]> fa, IntFunction<Integer> fi) {
         MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> Arena.ofAuto().allocate(i, Float.SIZE));
-        MemorySegment r = , Arena.ofAuto().allocate(a.byteSize(), Float.SIZE);
+        MemorySegment r = Arena.ofAuto().allocate(a.byteSize(), Float.SIZE);
 
         int l = (int) a.byteSize();
         int s = SPECIES.vectorByteSize();

--- a/test/jdk/jdk/incubator/vector/Float512VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Float512VectorLoadStoreTests.java
@@ -480,7 +480,7 @@ public class Float512VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
     @Test(dataProvider = "floatByteProviderForIOOBE")
     static void loadMemorySegmentIOOBE(IntFunction<float[]> fa, IntFunction<Integer> fi) {
         MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> Arena.ofAuto().allocate(i, Float.SIZE));
-        MemorySegment r = , Arena.ofAuto().allocate(a.byteSize(), Float.SIZE);
+        MemorySegment r = Arena.ofAuto().allocate(a.byteSize(), Float.SIZE);
 
         int l = (int) a.byteSize();
         int s = SPECIES.vectorByteSize();

--- a/test/jdk/jdk/incubator/vector/Float64VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Float64VectorLoadStoreTests.java
@@ -480,7 +480,7 @@ public class Float64VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
     @Test(dataProvider = "floatByteProviderForIOOBE")
     static void loadMemorySegmentIOOBE(IntFunction<float[]> fa, IntFunction<Integer> fi) {
         MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> Arena.ofAuto().allocate(i, Float.SIZE));
-        MemorySegment r = , Arena.ofAuto().allocate(a.byteSize(), Float.SIZE);
+        MemorySegment r = Arena.ofAuto().allocate(a.byteSize(), Float.SIZE);
 
         int l = (int) a.byteSize();
         int s = SPECIES.vectorByteSize();

--- a/test/jdk/jdk/incubator/vector/FloatMaxVectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/FloatMaxVectorLoadStoreTests.java
@@ -487,7 +487,7 @@ public class FloatMaxVectorLoadStoreTests extends AbstractVectorLoadStoreTest {
     @Test(dataProvider = "floatByteProviderForIOOBE")
     static void loadMemorySegmentIOOBE(IntFunction<float[]> fa, IntFunction<Integer> fi) {
         MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> Arena.ofAuto().allocate(i, Float.SIZE));
-        MemorySegment r = , Arena.ofAuto().allocate(a.byteSize(), Float.SIZE);
+        MemorySegment r = Arena.ofAuto().allocate(a.byteSize(), Float.SIZE);
 
         int l = (int) a.byteSize();
         int s = SPECIES.vectorByteSize();

--- a/test/jdk/jdk/incubator/vector/Int128VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Int128VectorLoadStoreTests.java
@@ -480,7 +480,7 @@ public class Int128VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
     @Test(dataProvider = "intByteProviderForIOOBE")
     static void loadMemorySegmentIOOBE(IntFunction<int[]> fa, IntFunction<Integer> fi) {
         MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> Arena.ofAuto().allocate(i, Integer.SIZE));
-        MemorySegment r = , Arena.ofAuto().allocate(a.byteSize(), Integer.SIZE);
+        MemorySegment r = Arena.ofAuto().allocate(a.byteSize(), Integer.SIZE);
 
         int l = (int) a.byteSize();
         int s = SPECIES.vectorByteSize();

--- a/test/jdk/jdk/incubator/vector/Int256VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Int256VectorLoadStoreTests.java
@@ -480,7 +480,7 @@ public class Int256VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
     @Test(dataProvider = "intByteProviderForIOOBE")
     static void loadMemorySegmentIOOBE(IntFunction<int[]> fa, IntFunction<Integer> fi) {
         MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> Arena.ofAuto().allocate(i, Integer.SIZE));
-        MemorySegment r = , Arena.ofAuto().allocate(a.byteSize(), Integer.SIZE);
+        MemorySegment r = Arena.ofAuto().allocate(a.byteSize(), Integer.SIZE);
 
         int l = (int) a.byteSize();
         int s = SPECIES.vectorByteSize();

--- a/test/jdk/jdk/incubator/vector/Int512VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Int512VectorLoadStoreTests.java
@@ -480,7 +480,7 @@ public class Int512VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
     @Test(dataProvider = "intByteProviderForIOOBE")
     static void loadMemorySegmentIOOBE(IntFunction<int[]> fa, IntFunction<Integer> fi) {
         MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> Arena.ofAuto().allocate(i, Integer.SIZE));
-        MemorySegment r = , Arena.ofAuto().allocate(a.byteSize(), Integer.SIZE);
+        MemorySegment r = Arena.ofAuto().allocate(a.byteSize(), Integer.SIZE);
 
         int l = (int) a.byteSize();
         int s = SPECIES.vectorByteSize();

--- a/test/jdk/jdk/incubator/vector/Int64VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Int64VectorLoadStoreTests.java
@@ -480,7 +480,7 @@ public class Int64VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
     @Test(dataProvider = "intByteProviderForIOOBE")
     static void loadMemorySegmentIOOBE(IntFunction<int[]> fa, IntFunction<Integer> fi) {
         MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> Arena.ofAuto().allocate(i, Integer.SIZE));
-        MemorySegment r = , Arena.ofAuto().allocate(a.byteSize(), Integer.SIZE);
+        MemorySegment r = Arena.ofAuto().allocate(a.byteSize(), Integer.SIZE);
 
         int l = (int) a.byteSize();
         int s = SPECIES.vectorByteSize();

--- a/test/jdk/jdk/incubator/vector/IntMaxVectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/IntMaxVectorLoadStoreTests.java
@@ -487,7 +487,7 @@ public class IntMaxVectorLoadStoreTests extends AbstractVectorLoadStoreTest {
     @Test(dataProvider = "intByteProviderForIOOBE")
     static void loadMemorySegmentIOOBE(IntFunction<int[]> fa, IntFunction<Integer> fi) {
         MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> Arena.ofAuto().allocate(i, Integer.SIZE));
-        MemorySegment r = , Arena.ofAuto().allocate(a.byteSize(), Integer.SIZE);
+        MemorySegment r = Arena.ofAuto().allocate(a.byteSize(), Integer.SIZE);
 
         int l = (int) a.byteSize();
         int s = SPECIES.vectorByteSize();

--- a/test/jdk/jdk/incubator/vector/Long128VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Long128VectorLoadStoreTests.java
@@ -480,7 +480,7 @@ public class Long128VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
     @Test(dataProvider = "longByteProviderForIOOBE")
     static void loadMemorySegmentIOOBE(IntFunction<long[]> fa, IntFunction<Integer> fi) {
         MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> Arena.ofAuto().allocate(i, Long.SIZE));
-        MemorySegment r = , Arena.ofAuto().allocate(a.byteSize(), Long.SIZE);
+        MemorySegment r = Arena.ofAuto().allocate(a.byteSize(), Long.SIZE);
 
         int l = (int) a.byteSize();
         int s = SPECIES.vectorByteSize();

--- a/test/jdk/jdk/incubator/vector/Long256VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Long256VectorLoadStoreTests.java
@@ -480,7 +480,7 @@ public class Long256VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
     @Test(dataProvider = "longByteProviderForIOOBE")
     static void loadMemorySegmentIOOBE(IntFunction<long[]> fa, IntFunction<Integer> fi) {
         MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> Arena.ofAuto().allocate(i, Long.SIZE));
-        MemorySegment r = , Arena.ofAuto().allocate(a.byteSize(), Long.SIZE);
+        MemorySegment r = Arena.ofAuto().allocate(a.byteSize(), Long.SIZE);
 
         int l = (int) a.byteSize();
         int s = SPECIES.vectorByteSize();

--- a/test/jdk/jdk/incubator/vector/Long512VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Long512VectorLoadStoreTests.java
@@ -480,7 +480,7 @@ public class Long512VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
     @Test(dataProvider = "longByteProviderForIOOBE")
     static void loadMemorySegmentIOOBE(IntFunction<long[]> fa, IntFunction<Integer> fi) {
         MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> Arena.ofAuto().allocate(i, Long.SIZE));
-        MemorySegment r = , Arena.ofAuto().allocate(a.byteSize(), Long.SIZE);
+        MemorySegment r = Arena.ofAuto().allocate(a.byteSize(), Long.SIZE);
 
         int l = (int) a.byteSize();
         int s = SPECIES.vectorByteSize();

--- a/test/jdk/jdk/incubator/vector/Long64VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Long64VectorLoadStoreTests.java
@@ -480,7 +480,7 @@ public class Long64VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
     @Test(dataProvider = "longByteProviderForIOOBE")
     static void loadMemorySegmentIOOBE(IntFunction<long[]> fa, IntFunction<Integer> fi) {
         MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> Arena.ofAuto().allocate(i, Long.SIZE));
-        MemorySegment r = , Arena.ofAuto().allocate(a.byteSize(), Long.SIZE);
+        MemorySegment r = Arena.ofAuto().allocate(a.byteSize(), Long.SIZE);
 
         int l = (int) a.byteSize();
         int s = SPECIES.vectorByteSize();

--- a/test/jdk/jdk/incubator/vector/LongMaxVectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/LongMaxVectorLoadStoreTests.java
@@ -487,7 +487,7 @@ public class LongMaxVectorLoadStoreTests extends AbstractVectorLoadStoreTest {
     @Test(dataProvider = "longByteProviderForIOOBE")
     static void loadMemorySegmentIOOBE(IntFunction<long[]> fa, IntFunction<Integer> fi) {
         MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> Arena.ofAuto().allocate(i, Long.SIZE));
-        MemorySegment r = , Arena.ofAuto().allocate(a.byteSize(), Long.SIZE);
+        MemorySegment r = Arena.ofAuto().allocate(a.byteSize(), Long.SIZE);
 
         int l = (int) a.byteSize();
         int s = SPECIES.vectorByteSize();

--- a/test/jdk/jdk/incubator/vector/Short128VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Short128VectorLoadStoreTests.java
@@ -480,7 +480,7 @@ public class Short128VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
     @Test(dataProvider = "shortByteProviderForIOOBE")
     static void loadMemorySegmentIOOBE(IntFunction<short[]> fa, IntFunction<Integer> fi) {
         MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> Arena.ofAuto().allocate(i, Short.SIZE));
-        MemorySegment r = , Arena.ofAuto().allocate(a.byteSize(), Short.SIZE);
+        MemorySegment r = Arena.ofAuto().allocate(a.byteSize(), Short.SIZE);
 
         int l = (int) a.byteSize();
         int s = SPECIES.vectorByteSize();

--- a/test/jdk/jdk/incubator/vector/Short256VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Short256VectorLoadStoreTests.java
@@ -480,7 +480,7 @@ public class Short256VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
     @Test(dataProvider = "shortByteProviderForIOOBE")
     static void loadMemorySegmentIOOBE(IntFunction<short[]> fa, IntFunction<Integer> fi) {
         MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> Arena.ofAuto().allocate(i, Short.SIZE));
-        MemorySegment r = , Arena.ofAuto().allocate(a.byteSize(), Short.SIZE);
+        MemorySegment r = Arena.ofAuto().allocate(a.byteSize(), Short.SIZE);
 
         int l = (int) a.byteSize();
         int s = SPECIES.vectorByteSize();

--- a/test/jdk/jdk/incubator/vector/Short512VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Short512VectorLoadStoreTests.java
@@ -480,7 +480,7 @@ public class Short512VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
     @Test(dataProvider = "shortByteProviderForIOOBE")
     static void loadMemorySegmentIOOBE(IntFunction<short[]> fa, IntFunction<Integer> fi) {
         MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> Arena.ofAuto().allocate(i, Short.SIZE));
-        MemorySegment r = , Arena.ofAuto().allocate(a.byteSize(), Short.SIZE);
+        MemorySegment r = Arena.ofAuto().allocate(a.byteSize(), Short.SIZE);
 
         int l = (int) a.byteSize();
         int s = SPECIES.vectorByteSize();

--- a/test/jdk/jdk/incubator/vector/Short64VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Short64VectorLoadStoreTests.java
@@ -480,7 +480,7 @@ public class Short64VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
     @Test(dataProvider = "shortByteProviderForIOOBE")
     static void loadMemorySegmentIOOBE(IntFunction<short[]> fa, IntFunction<Integer> fi) {
         MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> Arena.ofAuto().allocate(i, Short.SIZE));
-        MemorySegment r = , Arena.ofAuto().allocate(a.byteSize(), Short.SIZE);
+        MemorySegment r = Arena.ofAuto().allocate(a.byteSize(), Short.SIZE);
 
         int l = (int) a.byteSize();
         int s = SPECIES.vectorByteSize();

--- a/test/jdk/jdk/incubator/vector/ShortMaxVectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/ShortMaxVectorLoadStoreTests.java
@@ -487,7 +487,7 @@ public class ShortMaxVectorLoadStoreTests extends AbstractVectorLoadStoreTest {
     @Test(dataProvider = "shortByteProviderForIOOBE")
     static void loadMemorySegmentIOOBE(IntFunction<short[]> fa, IntFunction<Integer> fi) {
         MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> Arena.ofAuto().allocate(i, Short.SIZE));
-        MemorySegment r = , Arena.ofAuto().allocate(a.byteSize(), Short.SIZE);
+        MemorySegment r = Arena.ofAuto().allocate(a.byteSize(), Short.SIZE);
 
         int l = (int) a.byteSize();
         int s = SPECIES.vectorByteSize();

--- a/test/jdk/jdk/incubator/vector/templates/X-LoadStoreTest.java.template
+++ b/test/jdk/jdk/incubator/vector/templates/X-LoadStoreTest.java.template
@@ -500,7 +500,7 @@ public class $vectorteststype$ extends AbstractVectorLoadStoreTest {
     @Test(dataProvider = "$type$ByteProviderForIOOBE")
     static void loadMemorySegmentIOOBE(IntFunction<$type$[]> fa, IntFunction<Integer> fi) {
         MemorySegment a = toSegment(fa.apply(SPECIES.length()), i -> Arena.ofAuto().allocate(i, $Boxtype$.SIZE));
-        MemorySegment r = , Arena.ofAuto().allocate(a.byteSize(), $Boxtype$.SIZE);
+        MemorySegment r = Arena.ofAuto().allocate(a.byteSize(), $Boxtype$.SIZE);
 
         int l = (int) a.byteSize();
         int s = SPECIES.vectorByteSize();


### PR DESCRIPTION
When fixing vector tests as part of https://git.openjdk.org/panama-foreign/pull/786 I have accidentally introduced a typo. This patch fixes that.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Reviewers
 * [Jorn Vernee](https://openjdk.org/census#jvernee) (@JornVernee - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/panama-foreign pull/789/head:pull/789` \
`$ git checkout pull/789`

Update a local copy of the PR: \
`$ git checkout pull/789` \
`$ git pull https://git.openjdk.org/panama-foreign pull/789/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 789`

View PR using the GUI difftool: \
`$ git pr show -t 789`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/panama-foreign/pull/789.diff">https://git.openjdk.org/panama-foreign/pull/789.diff</a>

</details>
