### PR TITLE
Remove specialized zero-lenght mapped segment

### DIFF
--- a/src/java.base/share/classes/java/nio/Buffer.java
+++ b/src/java.base/share/classes/java/nio/Buffer.java
@@ -815,7 +815,9 @@ public abstract sealed class Buffer
 
                 @Override
                 public ByteBuffer newMappedByteBuffer(UnmapperProxy unmapperProxy, long address, int cap, Object obj, MemorySegment segment) {
-                    return new DirectByteBuffer(address, cap, obj, unmapperProxy.fileDescriptor(), unmapperProxy.isSync(), segment);
+                    return unmapperProxy == null
+                            ? new DirectByteBuffer(address, cap, obj, segment)
+                            : new DirectByteBuffer(address, cap, obj, unmapperProxy.fileDescriptor(), unmapperProxy.isSync(), segment);
                 }
 
                 @Override

--- a/src/java.base/share/classes/jdk/internal/foreign/MappedMemorySegmentImpl.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/MappedMemorySegmentImpl.java
@@ -36,7 +36,7 @@ import jdk.internal.misc.ScopedMemoryAccess;
  * memory mapped segment, such as the file descriptor associated with the mapping. This information is crucial
  * in order to correctly reconstruct a byte buffer object from the segment (see {@link #makeByteBuffer()}).
  */
-public sealed class MappedMemorySegmentImpl extends NativeMemorySegmentImpl {
+public final class MappedMemorySegmentImpl extends NativeMemorySegmentImpl {
 
     private final UnmapperProxy unmapper;
 
@@ -77,45 +77,25 @@ public sealed class MappedMemorySegmentImpl extends NativeMemorySegmentImpl {
     }
 
     public void load() {
-        SCOPED_MEMORY_ACCESS.load(sessionImpl(), min, unmapper.isSync(), length);
+        if (unmapper != null) {
+            SCOPED_MEMORY_ACCESS.load(sessionImpl(), min, unmapper.isSync(), length);
+        }
     }
 
     public void unload() {
-        SCOPED_MEMORY_ACCESS.unload(sessionImpl(), min, unmapper.isSync(), length);
+        if (unmapper != null) {
+            SCOPED_MEMORY_ACCESS.unload(sessionImpl(), min, unmapper.isSync(), length);
+        }
     }
 
     public boolean isLoaded() {
-        return SCOPED_MEMORY_ACCESS.isLoaded(sessionImpl(), min, unmapper.isSync(), length);
+        return unmapper == null || SCOPED_MEMORY_ACCESS.isLoaded(sessionImpl(), min, unmapper.isSync(), length);
     }
 
     public void force() {
-        SCOPED_MEMORY_ACCESS.force(sessionImpl(), unmapper.fileDescriptor(), min, unmapper.isSync(), 0, length);
-    }
-
-    public static final class EmptyMappedMemorySegmentImpl extends MappedMemorySegmentImpl {
-
-        public EmptyMappedMemorySegmentImpl(boolean readOnly, MemorySessionImpl session) {
-            super(0, null, 0, readOnly, session);
-        }
-
-        @Override
-        public void load() {
-            // do nothing
-        }
-
-        @Override
-        public void unload() {
-            // do nothing
-        }
-
-        @Override
-        public boolean isLoaded() {
-            return true;
-        }
-
-        @Override
-        public void force() {
-            // do nothing
+        if (unmapper != null) {
+            SCOPED_MEMORY_ACCESS.force(sessionImpl(), unmapper.fileDescriptor(), min, unmapper.isSync(), 0, length);
         }
     }
+
 }

--- a/src/java.base/share/classes/sun/nio/ch/FileChannelImpl.java
+++ b/src/java.base/share/classes/sun/nio/ch/FileChannelImpl.java
@@ -1241,7 +1241,7 @@ public class FileChannelImpl
             sessionImpl.addOrCleanupIfFail(resource);
             return segment;
         } else {
-            return new MappedMemorySegmentImpl.EmptyMappedMemorySegmentImpl(readOnly, sessionImpl);
+            return new MappedMemorySegmentImpl(0, null, 0, readOnly, sessionImpl);
         }
     }
 

--- a/test/jdk/java/foreign/TestByteBuffer.java
+++ b/test/jdk/java/foreign/TestByteBuffer.java
@@ -552,6 +552,9 @@ public class TestByteBuffer {
             segment.load();
             segment.isLoaded();
             segment.unload();
+            ByteBuffer byteBuffer = segment.asByteBuffer();
+            assertEquals(byteBuffer.capacity(), 0);
+            assertFalse(byteBuffer.isReadOnly());
         }
         //RO
         try (Arena arena = Arena.ofConfined();
@@ -564,6 +567,9 @@ public class TestByteBuffer {
             segment.load();
             segment.isLoaded();
             segment.unload();
+            ByteBuffer byteBuffer = segment.asByteBuffer();
+            assertEquals(byteBuffer.capacity(), 0);
+            assertTrue(byteBuffer.isReadOnly());
         }
     }
 


### PR DESCRIPTION
This PR proposes to remove the specialized zero-length MappedMemorySegment.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Reviewers
 * [Maurizio Cimadamore](https://openjdk.org/census#mcimadamore) (@mcimadamore - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/panama-foreign pull/793/head:pull/793` \
`$ git checkout pull/793`

Update a local copy of the PR: \
`$ git checkout pull/793` \
`$ git pull https://git.openjdk.org/panama-foreign pull/793/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 793`

View PR using the GUI difftool: \
`$ git pr show -t 793`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/panama-foreign/pull/793.diff">https://git.openjdk.org/panama-foreign/pull/793.diff</a>

</details>
