### PR TITLE
Simplify code now that bitSize is always aligned to byte boundaries

### DIFF
--- a/src/java.base/share/classes/java/lang/foreign/MemoryLayout.java
+++ b/src/java.base/share/classes/java/lang/foreign/MemoryLayout.java
@@ -318,7 +318,7 @@ public sealed interface MemoryLayout permits SequenceLayout, GroupLayout, Paddin
      * in {@code elements} is {@code null}.
      */
     default long byteOffset(PathElement... elements) {
-        return Utils.bitsToBytesOrThrow(bitOffset(elements), Utils.BITS_TO_BYTES_THROW_OFFSET);
+        return Utils.bitsToBytes(bitOffset(elements));
     }
 
     /**
@@ -356,7 +356,7 @@ public sealed interface MemoryLayout permits SequenceLayout, GroupLayout, Paddin
      */
     default MethodHandle byteOffsetHandle(PathElement... elements) {
         MethodHandle mh = bitOffsetHandle(elements);
-        mh = MethodHandles.filterReturnValue(mh, Utils.MH_BITS_TO_BYTES_OR_THROW_FOR_OFFSET);
+        mh = MethodHandles.filterReturnValue(mh, Utils.MH_BITS_TO_BYTES_FOR_OFFSET);
         return mh;
     }
 

--- a/src/java.base/share/classes/java/lang/foreign/MemoryLayout.java
+++ b/src/java.base/share/classes/java/lang/foreign/MemoryLayout.java
@@ -356,7 +356,7 @@ public sealed interface MemoryLayout permits SequenceLayout, GroupLayout, Paddin
      */
     default MethodHandle byteOffsetHandle(PathElement... elements) {
         MethodHandle mh = bitOffsetHandle(elements);
-        mh = MethodHandles.filterReturnValue(mh, Utils.MH_BITS_TO_BYTES_FOR_OFFSET);
+        mh = MethodHandles.filterReturnValue(mh, Utils.BITS_TO_BYTES);
         return mh;
     }
 

--- a/src/java.base/share/classes/jdk/internal/foreign/LayoutPath.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/LayoutPath.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
+ *  Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
  *  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  *  This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/jdk/internal/foreign/LayoutPath.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/LayoutPath.java
@@ -196,14 +196,14 @@ public class LayoutPath {
         VarHandle handle = Utils.makeSegmentViewVarHandle(valueLayout);
         for (int i = strides.length - 1; i >= 0; i--) {
             MethodHandle collector = MethodHandles.insertArguments(MH_ADD_SCALED_OFFSET, 2,
-                    Utils.bitsToBytesOrThrow(strides[i], IllegalArgumentException::new),
+                    Utils.bitsToBytes(strides[i]),
                     bounds[i]);
             // (J, ...) -> J to (J, J, ...) -> J
             // i.e. new coord is prefixed. Last coord will correspond to innermost layout
             handle = MethodHandles.collectCoordinates(handle, 1, collector);
         }
         handle = MethodHandles.insertCoordinates(handle, 1,
-                Utils.bitsToBytesOrThrow(offset, IllegalArgumentException::new));
+                Utils.bitsToBytes(offset));
 
         if (adapt) {
             for (int i = derefAdapters.length; i > 0; i--) {
@@ -232,13 +232,8 @@ public class LayoutPath {
     }
 
     public MethodHandle sliceHandle() {
-        if (strides.length == 0) {
-            // trigger checks eagerly
-            Utils.bitsToBytesOrThrow(offset, Utils.BITS_TO_BYTES_THROW_OFFSET);
-        }
-
         MethodHandle offsetHandle = offsetHandle(); // bit offset
-        offsetHandle = MethodHandles.filterReturnValue(offsetHandle, Utils.MH_BITS_TO_BYTES_OR_THROW_FOR_OFFSET); // byte offset
+        offsetHandle = MethodHandles.filterReturnValue(offsetHandle, Utils.MH_BITS_TO_BYTES_FOR_OFFSET); // byte offset
 
         MethodHandle sliceHandle = MH_SLICE; // (MS, long, long) -> MS
         sliceHandle = MethodHandles.insertArguments(sliceHandle, 2, layout.byteSize()); // (MS, long) -> MS

--- a/src/java.base/share/classes/jdk/internal/foreign/LayoutPath.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/LayoutPath.java
@@ -233,7 +233,7 @@ public class LayoutPath {
 
     public MethodHandle sliceHandle() {
         MethodHandle offsetHandle = offsetHandle(); // bit offset
-        offsetHandle = MethodHandles.filterReturnValue(offsetHandle, Utils.MH_BITS_TO_BYTES_FOR_OFFSET); // byte offset
+        offsetHandle = MethodHandles.filterReturnValue(offsetHandle, Utils.BITS_TO_BYTES); // byte offset
 
         MethodHandle sliceHandle = MH_SLICE; // (MS, long, long) -> MS
         sliceHandle = MethodHandles.insertArguments(sliceHandle, 2, layout.byteSize()); // (MS, long) -> MS

--- a/src/java.base/share/classes/jdk/internal/foreign/Utils.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/Utils.java
@@ -60,7 +60,7 @@ public final class Utils {
     private static final MethodHandle BOOL_TO_BYTE;
     private static final MethodHandle ADDRESS_TO_LONG;
     private static final MethodHandle LONG_TO_ADDRESS;
-    public static final MethodHandle MH_BITS_TO_BYTES_FOR_OFFSET;
+    public static final MethodHandle BITS_TO_BYTES;
 
     static {
         try {
@@ -73,7 +73,7 @@ public final class Utils {
                     MethodType.methodType(long.class, MemorySegment.class));
             LONG_TO_ADDRESS = lookup.findStatic(Utils.class, "longToAddress",
                     MethodType.methodType(MemorySegment.class, long.class, long.class, long.class));
-            MH_BITS_TO_BYTES_FOR_OFFSET = lookup.findStatic(Utils.class, "bitsToBytes",
+            BITS_TO_BYTES = lookup.findStatic(Utils.class, "bitsToBytes",
                     MethodType.methodType(long.class, long.class));
         } catch (Throwable ex) {
             throw new ExceptionInInitializerError(ex);
@@ -90,7 +90,7 @@ public final class Utils {
     }
 
     public static long bitsToBytes(long bits) {
-        // We are always bit-aligned at a byte boundary
+        assert Utils.isAligned(bits, 8);
         return bits / Byte.SIZE;
     }
 

--- a/src/java.base/share/classes/jdk/internal/foreign/Utils.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/Utils.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
+ *  Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
  *  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  *  This code is free software; you can redistribute it and/or modify it
@@ -73,9 +73,8 @@ public final class Utils {
                     MethodType.methodType(long.class, MemorySegment.class));
             LONG_TO_ADDRESS = lookup.findStatic(Utils.class, "longToAddress",
                     MethodType.methodType(MemorySegment.class, long.class, long.class, long.class));
-            MH_BITS_TO_BYTES_FOR_OFFSET =
-                    lookup.findStatic(Utils.class, "bitsToBytes",
-                            MethodType.methodType(long.class, long.class));
+            MH_BITS_TO_BYTES_FOR_OFFSET = lookup.findStatic(Utils.class, "bitsToBytes",
+                    MethodType.methodType(long.class, long.class));
         } catch (Throwable ex) {
             throw new ExceptionInInitializerError(ex);
         }

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/aarch64/CallArranger.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/aarch64/CallArranger.java
@@ -28,7 +28,6 @@ package jdk.internal.foreign.abi.aarch64;
 import java.lang.foreign.Arena;
 import java.lang.foreign.FunctionDescriptor;
 import java.lang.foreign.GroupLayout;
-import java.lang.foreign.Linker;
 import java.lang.foreign.MemoryLayout;
 import java.lang.foreign.MemorySegment;
 import jdk.internal.foreign.abi.ABIDescriptor;
@@ -494,9 +493,10 @@ public abstract class CallArranger {
                             .boxAddress(layout);
                 }
                 case POINTER -> {
-                    VMStorage storage = storageCalculator.nextStorage(StorageType.INTEGER, (ValueLayout) layout);
+                    ValueLayout.OfAddress addressLayout = (ValueLayout.OfAddress)layout;
+                    VMStorage storage = storageCalculator.nextStorage(StorageType.INTEGER, addressLayout);
                     bindings.vmLoad(storage, long.class)
-                            .boxAddressRaw(Utils.pointeeSize(layout), Utils.pointeeAlign(layout));
+                            .boxAddressRaw(Utils.pointeeByteSize(addressLayout), Utils.pointeeByteAlign(addressLayout));
                 }
                 case INTEGER -> {
                     VMStorage storage = storageCalculator.nextStorage(StorageType.INTEGER, (ValueLayout) layout);

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/riscv64/linux/LinuxRISCV64CallArranger.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/riscv64/linux/LinuxRISCV64CallArranger.java
@@ -42,6 +42,7 @@ import jdk.internal.foreign.abi.SharedUtils;
 import jdk.internal.foreign.abi.VMStorage;
 import jdk.internal.foreign.Utils;
 
+import java.lang.foreign.ValueLayout;
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodType;
 import java.util.List;
@@ -393,9 +394,10 @@ public class LinuxRISCV64CallArranger {
                     bindings.vmLoad(storage, carrier);
                 }
                 case POINTER -> {
+                    ValueLayout.OfAddress addressLayout = (ValueLayout.OfAddress)layout;
                     VMStorage storage = storageCalculator.getStorage(StorageType.INTEGER);
                     bindings.vmLoad(storage, long.class)
-                            .boxAddressRaw(Utils.pointeeSize(layout), Utils.pointeeAlign(layout));
+                            .boxAddressRaw(Utils.pointeeByteSize(addressLayout), Utils.pointeeByteAlign(addressLayout));
                 }
                 case STRUCT_REGISTER_X -> {
                     assert carrier == MemorySegment.class;

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/x64/sysv/CallArranger.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/x64/sysv/CallArranger.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
+ *  Copyright (c) 2020, 2023, Oracle and/or its affiliates. All rights reserved.
  *  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  *  This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/x64/sysv/CallArranger.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/x64/sysv/CallArranger.java
@@ -42,6 +42,7 @@ import java.lang.foreign.FunctionDescriptor;
 import java.lang.foreign.GroupLayout;
 import java.lang.foreign.MemoryLayout;
 import java.lang.foreign.MemorySegment;
+import java.lang.foreign.ValueLayout;
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.MethodType;
@@ -316,9 +317,10 @@ public class CallArranger {
                     }
                 }
                 case POINTER -> {
+                    ValueLayout.OfAddress addressLayout = (ValueLayout.OfAddress)layout;
                     VMStorage storage = storageCalculator.nextStorage(StorageType.INTEGER);
                     bindings.vmLoad(storage, long.class)
-                            .boxAddressRaw(Utils.pointeeSize(layout), Utils.pointeeAlign(layout));
+                            .boxAddressRaw(Utils.pointeeByteSize(addressLayout), Utils.pointeeByteAlign(addressLayout));
                 }
                 case INTEGER -> {
                     VMStorage storage = storageCalculator.nextStorage(StorageType.INTEGER);

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/x64/windows/CallArranger.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/x64/windows/CallArranger.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/x64/windows/CallArranger.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/x64/windows/CallArranger.java
@@ -41,6 +41,7 @@ import java.lang.foreign.FunctionDescriptor;
 import java.lang.foreign.GroupLayout;
 import java.lang.foreign.MemoryLayout;
 import java.lang.foreign.MemorySegment;
+import java.lang.foreign.ValueLayout;
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodType;
 import java.util.List;
@@ -276,9 +277,10 @@ public class CallArranger {
                     break;
                 }
                 case POINTER: {
+                    ValueLayout.OfAddress addressLayout = (ValueLayout.OfAddress)layout;
                     VMStorage storage = storageCalculator.nextStorage(StorageType.INTEGER);
                     bindings.vmLoad(storage, long.class)
-                            .boxAddressRaw(Utils.pointeeSize(layout), Utils.pointeeAlign(layout));
+                            .boxAddressRaw(Utils.pointeeByteSize(addressLayout), Utils.pointeeByteAlign(addressLayout));
                     break;
                 }
                 case INTEGER: {


### PR DESCRIPTION
This PR suggests some simplifications now that layouts are always aligned to byte boundaries. 

The PR also contains some other simplifications/cleanups.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Reviewers
 * [Maurizio Cimadamore](https://openjdk.org/census#mcimadamore) (@mcimadamore - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/panama-foreign pull/796/head:pull/796` \
`$ git checkout pull/796`

Update a local copy of the PR: \
`$ git checkout pull/796` \
`$ git pull https://git.openjdk.org/panama-foreign pull/796/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 796`

View PR using the GUI difftool: \
`$ git pr show -t 796`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/panama-foreign/pull/796.diff">https://git.openjdk.org/panama-foreign/pull/796.diff</a>

</details>
