### PR TITLE
8302885: Implementations of MemorySegment::reinterpret should be final

### DIFF
--- a/src/java.base/share/classes/jdk/internal/foreign/AbstractMemorySegmentImpl.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/AbstractMemorySegmentImpl.java
@@ -122,19 +122,19 @@ public abstract sealed class AbstractMemorySegmentImpl
 
     @Override
     @CallerSensitive
-    public MemorySegment reinterpret(long newSize, Scope newScope, Consumer<MemorySegment> cleanup) {
+    public final MemorySegment reinterpret(long newSize, Scope newScope, Consumer<MemorySegment> cleanup) {
         return reinterpretInternal(Reflection.getCallerClass(), newSize, newScope, null);
     }
 
     @Override
     @CallerSensitive
-    public MemorySegment reinterpret(long newSize) {
+    public final MemorySegment reinterpret(long newSize) {
         return reinterpretInternal(Reflection.getCallerClass(), newSize, scope, null);
     }
 
     @Override
     @CallerSensitive
-    public MemorySegment reinterpret(Scope newScope, Consumer<MemorySegment> cleanup) {
+    public final MemorySegment reinterpret(Scope newScope, Consumer<MemorySegment> cleanup) {
         return reinterpretInternal(Reflection.getCallerClass(), byteSize(), newScope, cleanup);
     }
 

--- a/test/jdk/TEST.groups
+++ b/test/jdk/TEST.groups
@@ -359,6 +359,7 @@ jdk_svc = \
 
 jdk_foreign = \
     java/foreign \
+    jdk/internal/reflect/CallerSensitive/CheckCSMs.java \
     -java/foreign/TestMatrix.java
 
 jdk_vector = \


### PR DESCRIPTION
This patch fixes an issue introduced in a recent API change [1], which causes a failure in a caller sensitive method sanity test (e.g. all caller sensitive methods must be `final`).

[1] - https://git.openjdk.org/panama-foreign/pull/797

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8302885](https://bugs.openjdk.org/browse/JDK-8302885): Implementations of MemorySegment::reinterpret should be final


### Reviewers
 * [Jorn Vernee](https://openjdk.org/census#jvernee) (@JornVernee - Committer)
 * [Athijegannathan Sundararajan](https://openjdk.org/census#sundar) (@sundararajana - Committer) ⚠️ Review applies to [dfa6a1e2](https://git.openjdk.org/panama-foreign/pull/802/files/dfa6a1e2aee613204720be58db41558b19a1439b)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/panama-foreign pull/802/head:pull/802` \
`$ git checkout pull/802`

Update a local copy of the PR: \
`$ git checkout pull/802` \
`$ git pull https://git.openjdk.org/panama-foreign pull/802/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 802`

View PR using the GUI difftool: \
`$ git pr show -t 802`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/panama-foreign/pull/802.diff">https://git.openjdk.org/panama-foreign/pull/802.diff</a>

</details>
