### PR TITLE
Fix typo in TestLayouts

### DIFF
--- a/test/jdk/java/foreign/TestLayouts.java
+++ b/test/jdk/java/foreign/TestLayouts.java
@@ -413,7 +413,7 @@ public class TestLayouts {
                 .toArray(Object[][]::new);
     }
 
-    @DataProvider(name = "valueCarriers")
+    @DataProvider(name = "validCarriers")
     public Object[][] validCarriers() {
         return Stream.of(
                         boolean.class,


### PR DESCRIPTION
There is name mismatch in a data provider in `TestLayouts` which causes the test to fail. This patch fixes it.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Reviewers
 * [Jorn Vernee](https://openjdk.org/census#jvernee) (@JornVernee - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/panama-foreign pull/803/head:pull/803` \
`$ git checkout pull/803`

Update a local copy of the PR: \
`$ git checkout pull/803` \
`$ git pull https://git.openjdk.org/panama-foreign pull/803/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 803`

View PR using the GUI difftool: \
`$ git pr show -t 803`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/panama-foreign/pull/803.diff">https://git.openjdk.org/panama-foreign/pull/803.diff</a>

</details>
