### PR TITLE
8303519: Replace Binding.Context with an arena

### DIFF
--- a/src/java.base/share/classes/jdk/internal/foreign/abi/BindingInterpreter.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/BindingInterpreter.java
@@ -24,25 +24,26 @@
  */
 package jdk.internal.foreign.abi;
 
+import java.lang.foreign.SegmentAllocator;
 import java.util.ArrayDeque;
 import java.util.Deque;
 import java.util.List;
 
 public class BindingInterpreter {
 
-    static void unbox(Object arg, List<Binding> bindings, StoreFunc storeFunc, Binding.Context context) {
+    static void unbox(Object arg, List<Binding> bindings, StoreFunc storeFunc, SegmentAllocator allocator) {
         Deque<Object> stack = new ArrayDeque<>();
 
         stack.push(arg);
         for (Binding b : bindings) {
-            b.interpret(stack, storeFunc, null, context);
+            b.interpret(stack, storeFunc, null, allocator);
         }
     }
 
-    static Object box(List<Binding> bindings, LoadFunc loadFunc, Binding.Context context) {
+    static Object box(List<Binding> bindings, LoadFunc loadFunc, SegmentAllocator allocator) {
         Deque<Object> stack = new ArrayDeque<>();
         for (Binding b : bindings) {
-            b.interpret(stack, null, loadFunc, context);
+            b.interpret(stack, null, loadFunc, allocator);
         }
        return stack.pop();
     }

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/SharedUtils.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/SharedUtils.java
@@ -38,11 +38,13 @@ import jdk.internal.foreign.abi.x64.sysv.SysVx64Linker;
 import jdk.internal.foreign.abi.x64.windows.Windowsx64Linker;
 import jdk.internal.vm.annotation.ForceInline;
 
+import java.lang.foreign.Arena;
 import java.lang.foreign.Linker;
 import java.lang.foreign.FunctionDescriptor;
 import java.lang.foreign.GroupLayout;
 import java.lang.foreign.MemoryLayout;
 import java.lang.foreign.MemorySegment;
+import java.lang.foreign.MemorySegment.Scope;
 import java.lang.foreign.SegmentAllocator;
 import java.lang.foreign.ValueLayout;
 import java.lang.invoke.MethodHandle;
@@ -77,6 +79,23 @@ public final class SharedUtils {
     public static final ValueLayout.OfAddress C_POINTER = ADDRESS
             .withBitAlignment(64)
             .withTargetLayout(MemoryLayout.sequenceLayout(JAVA_BYTE));
+
+    public static final Arena DUMMY_ARENA = new Arena() {
+        @Override
+        public Scope scope() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public MemorySegment allocate(long byteSize) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void close() {
+            // do nothing
+        }
+    };
 
     static {
         try {
@@ -337,6 +356,49 @@ public final class SharedUtils {
             throw new IllegalArgumentException(
                     String.format("Invalid operand type: %s. %s expected", actualType, expectedType));
         }
+    }
+
+    public static Arena newBoundedArena(long size) {
+        return new Arena() {
+            final Arena arena = Arena.ofConfined();
+            final SegmentAllocator slicingAllocator = SegmentAllocator.slicingAllocator(arena.allocate(size));
+
+            @Override
+            public Scope scope() {
+                return arena.scope();
+            }
+
+            @Override
+            public void close() {
+                arena.close();
+            }
+
+            @Override
+            public MemorySegment allocate(long byteSize, long byteAlignment) {
+                return slicingAllocator.allocate(byteSize, byteAlignment);
+            }
+        };
+    }
+
+    public static Arena newEmptyArena() {
+        return new Arena() {
+            final Arena arena = Arena.ofConfined();
+
+            @Override
+            public Scope scope() {
+                return arena.scope();
+            }
+
+            @Override
+            public void close() {
+                arena.close();
+            }
+
+            @Override
+            public MemorySegment allocate(long byteSize, long byteAlignment) {
+                throw new UnsupportedOperationException();
+            }
+        };
     }
 
     public static final class SimpleVaArg {

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/UpcallLinker.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/UpcallLinker.java
@@ -28,6 +28,7 @@ package jdk.internal.foreign.abi;
 import jdk.internal.foreign.abi.AbstractLinker.UpcallStubFactory;
 import sun.security.action.GetPropertyAction;
 
+import java.lang.foreign.Arena;
 import java.lang.foreign.MemorySegment;
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
@@ -140,9 +141,9 @@ public class UpcallLinker {
                                   ABIDescriptor abi) {}
 
     private static Object invokeInterpBindings(MethodHandle leaf, Object[] lowLevelArgs, InvocationData invData) throws Throwable {
-        Binding.Context allocator = invData.callingSequence.allocationSize() != 0
-                ? Binding.Context.ofBoundedAllocator(invData.callingSequence.allocationSize())
-                : Binding.Context.ofScope();
+        Arena allocator = invData.callingSequence.allocationSize() != 0
+                ? SharedUtils.newBoundedArena(invData.callingSequence.allocationSize())
+                : SharedUtils.newEmptyArena();
         try (allocator) {
             /// Invoke interpreter, got array of high-level arguments back
             Object[] highLevelArgs = new Object[invData.callingSequence.calleeMethodType().parameterCount()];


### PR DESCRIPTION
This patch contains a cleanup I wanted to do for some time. Basically, the linker uses an internal class (`Binding.Context`) to perform allocation needed during a native call/upcall. This context class used to provide both a scope (e.g. `ResourceScope`) and an allocator (`SegmentAllocator`).

Given that in recent iteratons of the API, `Arena` *is* an allocator, we can tweak bindings to accept a segment allocator parameter (instead of a context object). For bindings that only need to allocate, they can just call one of the `SegmentAllocator::allocate`) overloads. This simplifies the case where we need to use an external allocation for structs returned by value - as we can now just pass the external allocator - no need to wrap it in a "context".

If, on the other hand, the binding needs access to the scope, we can still implement that, by downcasting the segment allocator to `Arena` and then get the scope from there. This is always sound, because this arena is always internally created by the linker.

I moved some helper methods/fields to provide ready-made arena flavors in `SharedUtils`, so as to keep `Bindings.java` all about bindings. I think the result is rather nice, and in principle it should perform a little better, given that we don't need to wrap everything into a separate context object.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8303519](https://bugs.openjdk.org/browse/JDK-8303519): Replace Binding.Context with an arena


### Reviewers
 * [Jorn Vernee](https://openjdk.org/census#jvernee) (@JornVernee - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/panama-foreign pull/807/head:pull/807` \
`$ git checkout pull/807`

Update a local copy of the PR: \
`$ git checkout pull/807` \
`$ git pull https://git.openjdk.org/panama-foreign pull/807/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 807`

View PR using the GUI difftool: \
`$ git pr show -t 807`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/panama-foreign/pull/807.diff">https://git.openjdk.org/panama-foreign/pull/807.diff</a>

</details>
