### PR TITLE
8301803: Rename MemorySegment::array

### DIFF
--- a/src/java.base/share/classes/java/lang/foreign/MemorySegment.java
+++ b/src/java.base/share/classes/java/lang/foreign/MemorySegment.java
@@ -52,9 +52,7 @@ import jdk.internal.foreign.Utils;
 import jdk.internal.foreign.abi.SharedUtils;
 import jdk.internal.foreign.layout.ValueLayouts;
 import jdk.internal.javac.PreviewFeature;
-import jdk.internal.misc.ScopedMemoryAccess;
 import jdk.internal.reflect.CallerSensitive;
-import jdk.internal.reflect.Reflection;
 import jdk.internal.vm.annotation.ForceInline;
 
 /**
@@ -435,9 +433,13 @@ public sealed interface MemorySegment permits AbstractMemorySegmentImpl {
     long address();
 
     /**
-     * {@return the Java array associated with this memory segment, if any}
+     * Returns the Java object stored in the on-heap memory region backing this memory segment, if any. For instance, if this
+     * memory segment is a heap segment created with the {@link #ofArray(byte[])} factory method, this method will return the
+     * {@code byte[]} object which was used to obtain the segment. This method returns an empty {@code Optional} value
+     * if either this segment is a {@linkplain #isNative() native} segment, or if this segment is {@linkplain #isReadOnly() read-only}.
+     * @return the Java object associated with this memory segment, if any.
      */
-    Optional<Object> array();
+    Optional<Object> heapBase();
 
     /**
      * Returns a spliterator for this memory segment. The returned spliterator reports {@link Spliterator#SIZED},

--- a/src/java.base/share/classes/jdk/internal/foreign/AbstractMemorySegmentImpl.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/AbstractMemorySegmentImpl.java
@@ -500,7 +500,7 @@ public abstract sealed class AbstractMemorySegmentImpl
 
     @Override
     public String toString() {
-        return "MemorySegment{ array: " + array() + " address:" + address() + " limit: " + length + " }";
+        return "MemorySegment{ heapBase: " + heapBase() + " address:" + address() + " limit: " + length + " }";
     }
 
     @Override

--- a/src/java.base/share/classes/jdk/internal/foreign/HeapMemorySegmentImpl.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/HeapMemorySegmentImpl.java
@@ -61,8 +61,10 @@ public abstract sealed class HeapMemorySegmentImpl extends AbstractMemorySegment
     final Object base;
 
     @Override
-    public Optional<Object> array() {
-        return Optional.of(base);
+    public Optional<Object> heapBase() {
+        return readOnly ?
+                Optional.empty() :
+                Optional.of(base);
     }
 
     @ForceInline

--- a/src/java.base/share/classes/jdk/internal/foreign/NativeMemorySegmentImpl.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/NativeMemorySegmentImpl.java
@@ -77,7 +77,7 @@ public sealed class NativeMemorySegmentImpl extends AbstractMemorySegmentImpl pe
     }
 
     @Override
-    public Optional<Object> array() {
+    public Optional<Object> heapBase() {
         return Optional.empty();
     }
 

--- a/test/jdk/java/foreign/TestByteBuffer.java
+++ b/test/jdk/java/foreign/TestByteBuffer.java
@@ -307,7 +307,7 @@ public class TestByteBuffer {
 
     @Test(dataProvider = "fromArrays")
     public void testAsByteBufferFromNonByteArray(MemorySegment segment) {
-        if (!segment.array().map(a -> a instanceof byte[]).get()) {
+        if (!segment.heapBase().map(a -> a instanceof byte[]).get()) {
             // This should not work as the segment is not backed by a byte array
             assertThrows(UnsupportedOperationException.class, segment::asByteBuffer);
         }

--- a/test/jdk/java/foreign/TestSegments.java
+++ b/test/jdk/java/foreign/TestSegments.java
@@ -271,9 +271,11 @@ public class TestSegments {
     }
 
     @Test(dataProvider = "segmentFactories")
-    public void testNativeSegments(Supplier<MemorySegment> segmentSupplier) {
+    public void testHeapBase(Supplier<MemorySegment> segmentSupplier) {
         MemorySegment segment = segmentSupplier.get();
-        assertEquals(segment.isNative(), !segment.array().isPresent());
+        assertEquals(segment.isNative(), !segment.heapBase().isPresent());
+        segment = segment.asReadOnly();
+        assertTrue(segment.heapBase().isEmpty());
     }
 
     @Test


### PR DESCRIPTION
This patch picks up a loose end from Java 20: the name of `MemorySegment::array` is potentially too specific and will not scale when memory segment will be able to cover parts of Java objects contained flattened value types. The method is renamed here to `heapBase`, which is more general.

As I was fixing this, I realized that the behavior of this method was undocumented - that is, the method returns an empty optional for native segments. Also, I realized that for heap segments we did not check the reado-only status. The ByteBuffer does this, to prevent the contents of a read-only buffer to be written using the array. We should do the same here.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8301803](https://bugs.openjdk.org/browse/JDK-8301803): Rename MemorySegment::array


### Reviewers
 * [Jorn Vernee](https://openjdk.org/census#jvernee) (@JornVernee - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/panama-foreign pull/809/head:pull/809` \
`$ git checkout pull/809`

Update a local copy of the PR: \
`$ git checkout pull/809` \
`$ git pull https://git.openjdk.org/panama-foreign pull/809/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 809`

View PR using the GUI difftool: \
`$ git pr show -t 809`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/panama-foreign/pull/809.diff">https://git.openjdk.org/panama-foreign/pull/809.diff</a>

</details>
