### PR TITLE
8303667: Drop MemoryLayout::valueLayout factory

### DIFF
--- a/src/java.base/share/classes/java/lang/foreign/MemoryLayout.java
+++ b/src/java.base/share/classes/java/lang/foreign/MemoryLayout.java
@@ -690,51 +690,6 @@ public sealed interface MemoryLayout permits SequenceLayout, GroupLayout, Paddin
     }
 
     /**
-     * Creates a value layout of given Java carrier and byte order. The type of resulting value layout is determined
-     * by the carrier provided:
-     * <ul>
-     *     <li>{@link ValueLayout.OfBoolean}, for {@code boolean.class}</li>
-     *     <li>{@link ValueLayout.OfByte}, for {@code byte.class}</li>
-     *     <li>{@link ValueLayout.OfShort}, for {@code short.class}</li>
-     *     <li>{@link ValueLayout.OfChar}, for {@code char.class}</li>
-     *     <li>{@link ValueLayout.OfInt}, for {@code int.class}</li>
-     *     <li>{@link ValueLayout.OfFloat}, for {@code float.class}</li>
-     *     <li>{@link ValueLayout.OfLong}, for {@code long.class}</li>
-     *     <li>{@link ValueLayout.OfDouble}, for {@code double.class}</li>
-     *     <li>{@link ValueLayout.OfAddress}, for {@code MemorySegment.class}</li>
-     * </ul>
-     * @param carrier the value layout carrier.
-     * @param order the value layout's byte order.
-     * @return a value layout with the given Java carrier and byte-order.
-     * @throws IllegalArgumentException if the carrier type is not supported.
-     */
-    static ValueLayout valueLayout(Class<?> carrier, ByteOrder order) {
-        Objects.requireNonNull(carrier);
-        Objects.requireNonNull(order);
-        if (carrier == boolean.class) {
-            return ValueLayouts.OfBooleanImpl.of(order);
-        } else if (carrier == char.class) {
-            return ValueLayouts.OfCharImpl.of(order);
-        } else if (carrier == byte.class) {
-            return ValueLayouts.OfByteImpl.of(order);
-        } else if (carrier == short.class) {
-            return ValueLayouts.OfShortImpl.of(order);
-        } else if (carrier == int.class) {
-            return ValueLayouts.OfIntImpl.of(order);
-        } else if (carrier == float.class) {
-            return ValueLayouts.OfFloatImpl.of(order);
-        } else if (carrier == long.class) {
-            return ValueLayouts.OfLongImpl.of(order);
-        } else if (carrier == double.class) {
-            return ValueLayouts.OfDoubleImpl.of(order);
-        } else if (carrier == MemorySegment.class) {
-            return ValueLayouts.OfAddressImpl.of(order);
-        } else {
-            throw new IllegalArgumentException("Unsupported carrier: " + carrier.getName());
-        }
-    }
-
-    /**
      * Creates a sequence layout with the given element layout and element count.
      *
      * @param elementCount the sequence element count.

--- a/src/java.base/share/classes/java/lang/foreign/ValueLayout.java
+++ b/src/java.base/share/classes/java/lang/foreign/ValueLayout.java
@@ -455,90 +455,54 @@ public sealed interface ValueLayout extends MemoryLayout {
     /**
      * A value layout constant whose size is the same as that of a machine address ({@code size_t}),
      * bit alignment set to {@code sizeof(size_t) * 8}, byte order set to {@link ByteOrder#nativeOrder()}.
-     * Equivalent to the following code:
-     * {@snippet lang=java :
-     * MemoryLayout.valueLayout(MemorySegment.class, ByteOrder.nativeOrder());
-     * }
      */
     OfAddress ADDRESS = ValueLayouts.OfAddressImpl.of(ByteOrder.nativeOrder());
 
     /**
      * A value layout constant whose size is the same as that of a Java {@code byte},
      * bit alignment set to 8, and byte order set to {@link ByteOrder#nativeOrder()}.
-     * Equivalent to the following code:
-     * {@snippet lang=java :
-     * MemoryLayout.valueLayout(byte.class, ByteOrder.nativeOrder());
-     * }
      */
     OfByte JAVA_BYTE = ValueLayouts.OfByteImpl.of(ByteOrder.nativeOrder());
 
     /**
      * A value layout constant whose size is the same as that of a Java {@code boolean},
      * bit alignment set to 8, and byte order set to {@link ByteOrder#nativeOrder()}.
-     * Equivalent to the following code:
-     * {@snippet lang=java :
-     * MemoryLayout.valueLayout(boolean.class, ByteOrder.nativeOrder());
-     * }
      */
     OfBoolean JAVA_BOOLEAN = ValueLayouts.OfBooleanImpl.of(ByteOrder.nativeOrder());
 
     /**
      * A value layout constant whose size is the same as that of a Java {@code char},
      * bit alignment set to 16, and byte order set to {@link ByteOrder#nativeOrder()}.
-     * Equivalent to the following code:
-     * {@snippet lang=java :
-     * MemoryLayout.valueLayout(char.class, ByteOrder.nativeOrder());
-     * }
      */
     OfChar JAVA_CHAR = ValueLayouts.OfCharImpl.of(ByteOrder.nativeOrder());
 
     /**
      * A value layout constant whose size is the same as that of a Java {@code short},
      * bit alignment set to 16, and byte order set to {@link ByteOrder#nativeOrder()}.
-     * Equivalent to the following code:
-     * {@snippet lang=java :
-     * MemoryLayout.valueLayout(short.class, ByteOrder.nativeOrder());
-     * }
      */
     OfShort JAVA_SHORT = ValueLayouts.OfShortImpl.of(ByteOrder.nativeOrder());
 
     /**
      * A value layout constant whose size is the same as that of a Java {@code int},
      * bit alignment set to 32, and byte order set to {@link ByteOrder#nativeOrder()}.
-     * Equivalent to the following code:
-     * {@snippet lang=java :
-     * MemoryLayout.valueLayout(int.class, ByteOrder.nativeOrder());
-     * }
      */
     OfInt JAVA_INT = ValueLayouts.OfIntImpl.of(ByteOrder.nativeOrder());
 
     /**
      * A value layout constant whose size is the same as that of a Java {@code long},
      * bit alignment set to 64, and byte order set to {@link ByteOrder#nativeOrder()}.
-     * Equivalent to the following code:
-     * {@snippet lang=java :
-     * MemoryLayout.valueLayout(long.class, ByteOrder.nativeOrder());
-     * }
      */
     OfLong JAVA_LONG = ValueLayouts.OfLongImpl.of(ByteOrder.nativeOrder());
 
     /**
      * A value layout constant whose size is the same as that of a Java {@code float},
      * bit alignment set to 32, and byte order set to {@link ByteOrder#nativeOrder()}.
-     * Equivalent to the following code:
-     * {@snippet lang=java :
-     * MemoryLayout.valueLayout(float.class, ByteOrder.nativeOrder()).withBitAlignment(32);
-     * }
      */
     OfFloat JAVA_FLOAT = ValueLayouts.OfFloatImpl.of(ByteOrder.nativeOrder());
 
     /**
      * A value layout constant whose size is the same as that of a Java {@code double},
      * bit alignment set to 64, and byte order set to {@link ByteOrder#nativeOrder()}.
-     * Equivalent to the following code:
-     * {@snippet lang=java :
-     * MemoryLayout.valueLayout(double.class, ByteOrder.nativeOrder());
-     * }
      */
     OfDouble JAVA_DOUBLE = ValueLayouts.OfDoubleImpl.of(ByteOrder.nativeOrder());
 

--- a/src/java.base/share/classes/jdk/internal/foreign/layout/ValueLayouts.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/layout/ValueLayouts.java
@@ -371,4 +371,48 @@ public final class ValueLayouts {
         }
     }
 
+    /**
+     * Creates a value layout of given Java carrier and byte order. The type of resulting value layout is determined
+     * by the carrier provided:
+     * <ul>
+     *     <li>{@link ValueLayout.OfBoolean}, for {@code boolean.class}</li>
+     *     <li>{@link ValueLayout.OfByte}, for {@code byte.class}</li>
+     *     <li>{@link ValueLayout.OfShort}, for {@code short.class}</li>
+     *     <li>{@link ValueLayout.OfChar}, for {@code char.class}</li>
+     *     <li>{@link ValueLayout.OfInt}, for {@code int.class}</li>
+     *     <li>{@link ValueLayout.OfFloat}, for {@code float.class}</li>
+     *     <li>{@link ValueLayout.OfLong}, for {@code long.class}</li>
+     *     <li>{@link ValueLayout.OfDouble}, for {@code double.class}</li>
+     *     <li>{@link ValueLayout.OfAddress}, for {@code MemorySegment.class}</li>
+     * </ul>
+     * @param carrier the value layout carrier.
+     * @param order the value layout's byte order.
+     * @return a value layout with the given Java carrier and byte-order.
+     * @throws IllegalArgumentException if the carrier type is not supported.
+     */
+    public static ValueLayout valueLayout(Class<?> carrier, ByteOrder order) {
+        Objects.requireNonNull(carrier);
+        Objects.requireNonNull(order);
+        if (carrier == boolean.class) {
+            return ValueLayouts.OfBooleanImpl.of(order);
+        } else if (carrier == char.class) {
+            return ValueLayouts.OfCharImpl.of(order);
+        } else if (carrier == byte.class) {
+            return ValueLayouts.OfByteImpl.of(order);
+        } else if (carrier == short.class) {
+            return ValueLayouts.OfShortImpl.of(order);
+        } else if (carrier == int.class) {
+            return ValueLayouts.OfIntImpl.of(order);
+        } else if (carrier == float.class) {
+            return ValueLayouts.OfFloatImpl.of(order);
+        } else if (carrier == long.class) {
+            return ValueLayouts.OfLongImpl.of(order);
+        } else if (carrier == double.class) {
+            return ValueLayouts.OfDoubleImpl.of(order);
+        } else if (carrier == MemorySegment.class) {
+            return ValueLayouts.OfAddressImpl.of(order);
+        } else {
+            throw new IllegalArgumentException("Unsupported carrier: " + carrier.getName());
+        }
+    }
 }

--- a/test/jdk/java/foreign/TestIllegalLink.java
+++ b/test/jdk/java/foreign/TestIllegalLink.java
@@ -34,6 +34,7 @@ import java.lang.foreign.Linker;
 import java.lang.foreign.FunctionDescriptor;
 import java.lang.foreign.MemorySegment;
 import java.lang.foreign.MemoryLayout;
+import java.lang.foreign.ValueLayout;
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.MethodType;
@@ -140,7 +141,7 @@ public class TestIllegalLink extends NativeTestHelper {
                     "Layout bit alignment must be natural alignment"
             },
             {
-                    FunctionDescriptor.ofVoid(MemoryLayout.valueLayout(char.class, ByteOrder.nativeOrder()).withBitAlignment(32)),
+                    FunctionDescriptor.ofVoid(ValueLayout.JAVA_CHAR.withBitAlignment(32)),
                     "Layout bit alignment must be natural alignment"
             },
             {

--- a/test/jdk/java/foreign/TestLayouts.java
+++ b/test/jdk/java/foreign/TestLayouts.java
@@ -291,18 +291,6 @@ public class TestLayouts {
         PathElement.sequenceElement(3, 0);
     }
 
-    @Test(expectedExceptions = IllegalArgumentException.class)
-    public void testBadValueCarrier() {
-        // Strings have no value layout
-        MemoryLayout.valueLayout(String.class, ByteOrder.LITTLE_ENDIAN);
-    }
-
-    @Test(dataProvider = "validCarriers")
-    public void testValueLayout(Class<?> carrier) {
-        ValueLayout layout = MemoryLayout.valueLayout(carrier, ByteOrder.nativeOrder());
-        assertEquals(layout.carrier(), carrier);
-    }
-
     @DataProvider(name = "badAlignments")
     public Object[][] layoutsAndBadAlignments() {
         LayoutKind[] layoutKinds = LayoutKind.values();

--- a/test/jdk/java/foreign/callarranger/TestLayoutEquality.java
+++ b/test/jdk/java/foreign/callarranger/TestLayoutEquality.java
@@ -27,11 +27,13 @@
  * @enablePreview
  * @compile platform/PlatformLayouts.java
  * @modules java.base/jdk.internal.foreign.abi
+ * @modules java.base/jdk.internal.foreign.layout
  * @run testng TestLayoutEquality
  */
 
-import java.lang.foreign.MemoryLayout;
 import java.lang.foreign.ValueLayout;
+
+import jdk.internal.foreign.layout.ValueLayouts;
 import platform.PlatformLayouts;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -46,7 +48,7 @@ public class TestLayoutEquality {
 
     @Test(dataProvider = "layoutConstants")
     public void testReconstructedEquality(ValueLayout layout) {
-        ValueLayout newLayout = MemoryLayout.valueLayout(layout.carrier(), layout.order());
+        ValueLayout newLayout = ValueLayouts.valueLayout(layout.carrier(), layout.order());
         newLayout = newLayout.withBitAlignment(layout.bitAlignment());
         if (layout instanceof ValueLayout.OfAddress addressLayout && addressLayout.targetLayout().isPresent()) {
             newLayout = ((ValueLayout.OfAddress)newLayout).withTargetLayout(addressLayout.targetLayout().get());

--- a/test/jdk/java/lang/invoke/VarHandles/VarHandleTestExact.java
+++ b/test/jdk/java/lang/invoke/VarHandles/VarHandleTestExact.java
@@ -25,6 +25,7 @@
  * @test
  * @enablePreview
  * @modules java.base/jdk.internal.access.foreign
+ * @modules java.base/jdk.internal.foreign.layout
  *
  * @run testng/othervm -Xverify:all
  *   -Djdk.internal.foreign.SHOULD_ADAPT_HANDLES=false
@@ -47,8 +48,9 @@
  */
 
 import java.lang.foreign.Arena;
-import java.lang.foreign.MemoryLayout;
 import java.lang.foreign.MemorySegment;
+
+import jdk.internal.foreign.layout.ValueLayouts;
 import org.testng.SkipException;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -169,7 +171,7 @@ public class VarHandleTestExact {
 
     @Test(dataProvider = "dataSetMemorySegment")
     public void testExactSegmentSet(Class<?> carrier, Object testValue, SetSegmentX setter) {
-        VarHandle vh = MethodHandles.memorySegmentViewVarHandle(MemoryLayout.valueLayout(carrier, ByteOrder.nativeOrder()));
+        VarHandle vh = MethodHandles.memorySegmentViewVarHandle(ValueLayouts.valueLayout(carrier, ByteOrder.nativeOrder()));
         try (Arena arena = Arena.ofConfined()) {
             MemorySegment seg = arena.allocate(8);
             doTest(vh,


### PR DESCRIPTION
We have been thinking more about how the layout API might be affected by Valhalla specialized types. With Valhalla, it might be possible to, eventually, get rid of hand-specialized classes such as `ValueLayout.OfInt` and friends, and replace them either with `ValueLayout<int>`, or some `ScalarLayout<int>` (where `ScalarLayout<X> extends ValueLayout`). This would allow us to, also eventually, only provide _one_ accessor for all value/scalar layouts in `MemorySegment`.

Under this migration scenario, having a toplevel factory such as `MemoryLayout::valueLayout`, whose semantics is strictly defined in terms of the hand-specialzied classes doesn't seem a great idea.

Since this factory is only used rarely (mostly in tests - we could not find any usage in existing GitHub projects targeting the FFM API), it would be better to remove it, to avoid having to deal with pesky migration issues later. 

Of course, if you are aware of cases we missed where the factory is used in the wild, please let us know. (Although, in general, it is not too difficult to re-iimplement a similar method using the `ValueLayout` constants - `jextract` will need to do this, for instance).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8303667](https://bugs.openjdk.org/browse/JDK-8303667): Drop MemoryLayout::valueLayout factory


### Reviewers
 * [Jorn Vernee](https://openjdk.org/census#jvernee) (@JornVernee - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/panama-foreign pull/810/head:pull/810` \
`$ git checkout pull/810`

Update a local copy of the PR: \
`$ git checkout pull/810` \
`$ git pull https://git.openjdk.org/panama-foreign pull/810/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 810`

View PR using the GUI difftool: \
`$ git pr show -t 810`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/panama-foreign/pull/810.diff">https://git.openjdk.org/panama-foreign/pull/810.diff</a>

</details>
