### PR TITLE
8303666: Move address layout outside of ValueLayout namespace

### DIFF
--- a/src/java.base/share/classes/java/lang/foreign/AddressLayout.java
+++ b/src/java.base/share/classes/java/lang/foreign/AddressLayout.java
@@ -1,0 +1,87 @@
+package java.lang.foreign;
+
+import jdk.internal.foreign.layout.ValueLayouts;
+import jdk.internal.javac.PreviewFeature;
+import jdk.internal.reflect.CallerSensitive;
+
+import java.lang.foreign.Linker.Option;
+import java.lang.invoke.MethodHandle;
+import java.nio.ByteOrder;
+import java.util.Optional;
+
+/**
+ * A value layout used to model the address of some region of memory. The carrier associated with an address layout is
+ * {@code MemorySegment.class}. The size and alignment of an address layout are platform dependent
+ * (e.g. on a 64-bit platform, the size and alignment of an address layout are set to 64 bits).
+ * <p>
+ * An address layout may optionally feature a {@linkplain #targetLayout() target layout}. The target layout of an address
+ * layout is used to model the layout of the region of memory whose address is described by that address layout.
+ * For instance, if an address layout has target layout {@link ValueLayout#JAVA_INT}, the region of memory pointed to by the address
+ * described by the address layout is 4 bytes long. Specifying a target layout can be useful in the following situations:
+ * <ul>
+ *     <li>When accessing a memory segment that has been obtained by reading an address from another
+ *     memory segment, e.g. using {@link MemorySegment#getAtIndex(AddressLayout, long)};</li>
+ *     <li>When creating a downcall method handle, using {@link Linker#downcallHandle(FunctionDescriptor, Option...)};
+ *     <li>When creating an upcall stub, using {@link Linker#upcallStub(MethodHandle, FunctionDescriptor, Arena, Option...)}.
+ * </ul>
+ *
+ * @see #ADDRESS
+ * @see #ADDRESS_UNALIGNED
+ * @since 19
+ */
+@PreviewFeature(feature = PreviewFeature.Feature.FOREIGN)
+sealed public interface AddressLayout extends ValueLayout permits ValueLayouts.OfAddressImpl {
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    AddressLayout withName(String name);
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    AddressLayout withBitAlignment(long bitAlignment);
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    AddressLayout withOrder(ByteOrder order);
+
+    /**
+     * Returns an address layout with the same carrier, alignment constraint, name and order as this address layout,
+     * but associated with the specified target layout. The returned address layout allows raw addresses to be accessed
+     * as {@linkplain MemorySegment memory segments} whose size is set to the size of the specified layout. Moreover,
+     * if the accessed raw address is not compatible with the alignment constraint in the provided layout,
+     * {@linkplain IllegalArgumentException} will be thrown.
+     * @apiNote
+     * This method can also be used to create an address layout which, when used, creates native memory
+     * segments with maximal size (e.g. {@linkplain Long#MAX_VALUE}. This can be done by using a target sequence
+     * layout with unspecified size, as follows:
+     * {@snippet lang = java:
+     * AddressLayout addressLayout   = ...
+     * AddressLayout unboundedLayout = addressLayout.withTargetLayout(
+     *         MemoryLayout.sequenceLayout(ValueLayout.JAVA_BYTE));
+     *}
+     * <p>
+     * This method is <a href="package-summary.html#restricted"><em>restricted</em></a>.
+     * Restricted methods are unsafe, and, if used incorrectly, their use might crash
+     * the JVM or, worse, silently result in memory corruption. Thus, clients should refrain from depending on
+     * restricted methods, and use safe and supported functionalities, where possible.
+     *
+     * @param layout the target layout.
+     * @return an address layout with same characteristics as this layout, but with the provided target layout.
+     * @throws IllegalCallerException If the caller is in a module that does not have native access enabled.
+     * @see #targetLayout()
+     */
+    @CallerSensitive
+    AddressLayout withTargetLayout(MemoryLayout layout);
+
+    /**
+     * {@return the target layout associated with this address layout (if any)}.
+     */
+    Optional<MemoryLayout> targetLayout();
+
+}

--- a/src/java.base/share/classes/java/lang/foreign/AddressLayout.java
+++ b/src/java.base/share/classes/java/lang/foreign/AddressLayout.java
@@ -40,10 +40,10 @@ import java.util.Optional;
  * {@code MemorySegment.class}. The size and alignment of an address layout are platform dependent
  * (e.g. on a 64-bit platform, the size and alignment of an address layout are set to 64 bits).
  * <p>
- * An address layout may optionally feature a {@linkplain #targetLayout() target layout}. The target layout of an address
- * layout is used to model the layout of the region of memory whose address is described by that address layout.
- * For instance, if an address layout has target layout {@link ValueLayout#JAVA_INT}, the region of memory pointed to by the address
- * described by the address layout is 4 bytes long. Specifying a target layout can be useful in the following situations:
+ * An address layout may optionally feature a {@linkplain #targetLayout() target layout}. An address layout with
+ * target layout {@code T} can be used to model the address of a region of memory whose layout is {@code T}.
+ * For instance, an address layout with target layout {@link ValueLayout#JAVA_INT} can be used to model the address
+ * of a region of memory that is 4 bytes long. Specifying a target layout can be useful in the following situations:
  * <ul>
  *     <li>When accessing a memory segment that has been obtained by reading an address from another
  *     memory segment, e.g. using {@link MemorySegment#getAtIndex(AddressLayout, long)};</li>

--- a/src/java.base/share/classes/java/lang/foreign/AddressLayout.java
+++ b/src/java.base/share/classes/java/lang/foreign/AddressLayout.java
@@ -1,3 +1,29 @@
+/*
+ *  Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ *  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ *  This code is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License version 2 only, as
+ *  published by the Free Software Foundation.  Oracle designates this
+ *  particular file as subject to the "Classpath" exception as provided
+ *  by Oracle in the LICENSE file that accompanied this code.
+ *
+ *  This code is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ *  version 2 for more details (a copy is included in the LICENSE file that
+ *  accompanied this code).
+ *
+ *  You should have received a copy of the GNU General Public License version
+ *  2 along with this work; if not, write to the Free Software Foundation,
+ *  Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ *   Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ *  or visit www.oracle.com if you need additional information or have any
+ *  questions.
+ *
+ */
+
 package java.lang.foreign;
 
 import jdk.internal.foreign.layout.ValueLayouts;

--- a/src/java.base/share/classes/java/lang/foreign/Linker.java
+++ b/src/java.base/share/classes/java/lang/foreign/Linker.java
@@ -33,7 +33,6 @@ import jdk.internal.javac.PreviewFeature;
 import jdk.internal.reflect.CallerSensitive;
 import jdk.internal.reflect.Reflection;
 
-import java.lang.foreign.ValueLayout.OfAddress;
 import java.lang.invoke.MethodHandle;
 import java.util.Objects;
 import java.util.Set;
@@ -115,9 +114,9 @@ import java.util.stream.Stream;
  *     the confined arena while the downcall method handle is executing will result in a {@link IllegalStateException}.</li>
  *</ul>
  * A downcall method handle created from a function descriptor whose return layout is an
- * {@linkplain ValueLayout.OfAddress address layout} returns a native segment associated with
+ * {@linkplain AddressLayout address layout} returns a native segment associated with
  * a fresh scope that is always alive. Under normal conditions, the size of the returned segment is {@code 0}.
- * However, if the return address layout has a {@linkplain OfAddress#targetLayout()} {@code T}, then the size of the returned segment
+ * However, if the return address layout has a {@linkplain AddressLayout#targetLayout()} {@code T}, then the size of the returned segment
  * is set to {@code T.byteSize()}.
  * <p>
  * When creating upcall stubs the linker runtime validates the type of the target method handle against the provided
@@ -128,10 +127,10 @@ import java.util.stream.Stream;
  * that this address cannot become invalid after the upcall completes. This can lead to unspecified behavior,
  * and even JVM crashes, since an upcall is typically executed in the context of a downcall method handle invocation.
  * <p>
- * An upcall stub argument whose corresponding layout is an {@linkplain ValueLayout.OfAddress address layout}
+ * An upcall stub argument whose corresponding layout is an {@linkplain AddressLayout address layout}
  * is a native segment associated with a fresh scope that is always alive.
  * Under normal conditions, the size of this segment argument is {@code 0}.
- * However, if the address layout has a {@linkplain OfAddress#targetLayout()} {@code T}, then the size of the
+ * However, if the address layout has a {@linkplain AddressLayout#targetLayout()} {@code T}, then the size of the
  * segment argument is set to {@code T.byteSize()}.
  *
  * @implSpec

--- a/src/java.base/share/classes/java/lang/foreign/MemoryLayout.java
+++ b/src/java.base/share/classes/java/lang/foreign/MemoryLayout.java
@@ -25,7 +25,6 @@
  */
 package java.lang.foreign;
 
-import java.lang.foreign.ValueLayout.OfAddress;
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.VarHandle;
@@ -418,7 +417,7 @@ public sealed interface MemoryLayout permits SequenceLayout, GroupLayout, Paddin
      * @throws UnsupportedOperationException if the layout path has one or more elements with incompatible alignment constraint.
      * @throws IllegalArgumentException if the layout path in {@code elements} does not select a value layout (see {@link ValueLayout}).
      * @throws IllegalArgumentException if the layout path in {@code elements} contains a {@linkplain PathElement#dereferenceElement()
-     * dereference path element} for an address layout that has no {@linkplain OfAddress#targetLayout() target layout}.
+     * dereference path element} for an address layout that has no {@linkplain AddressLayout#targetLayout() target layout}.
      * @see MethodHandles#memorySegmentViewVarHandle(ValueLayout)
      */
     default VarHandle varHandle(PathElement... elements) {
@@ -634,7 +633,7 @@ public sealed interface MemoryLayout permits SequenceLayout, GroupLayout, Paddin
 
         /**
          * Returns a path element which dereferences an address layout as its
-         * {@linkplain OfAddress#targetLayout() target layout} (where set).
+         * {@linkplain AddressLayout#targetLayout() target layout} (where set).
          * The path element returned by this method does not alter the number of free dimensions of any path
          * that is combined with such element. Using this path layout to dereference an address layout
          * that has no target layout results in an {@link IllegalArgumentException} (e.g. when
@@ -701,7 +700,7 @@ public sealed interface MemoryLayout permits SequenceLayout, GroupLayout, Paddin
      *     <li>{@link ValueLayout.OfFloat}, for {@code float.class}</li>
      *     <li>{@link ValueLayout.OfLong}, for {@code long.class}</li>
      *     <li>{@link ValueLayout.OfDouble}, for {@code double.class}</li>
-     *     <li>{@link ValueLayout.OfAddress}, for {@code MemorySegment.class}</li>
+     *     <li>{@link AddressLayout}, for {@code MemorySegment.class}</li>
      * </ul>
      * @param carrier the value layout carrier.
      * @param order the value layout's byte order.

--- a/src/java.base/share/classes/java/lang/foreign/SegmentAllocator.java
+++ b/src/java.base/share/classes/java/lang/foreign/SegmentAllocator.java
@@ -32,7 +32,6 @@ import java.nio.charset.StandardCharsets;
 import java.util.Objects;
 import java.util.function.Function;
 import jdk.internal.foreign.AbstractMemorySegmentImpl;
-import jdk.internal.foreign.MemorySessionImpl;
 import jdk.internal.foreign.SlicingAllocator;
 import jdk.internal.foreign.Utils;
 import jdk.internal.javac.PreviewFeature;
@@ -199,7 +198,7 @@ public interface SegmentAllocator {
      * @param value the value to be set on the newly allocated memory block.
      * @return a segment for the newly allocated memory block.
      */
-    default MemorySegment allocate(ValueLayout.OfAddress layout, MemorySegment value) {
+    default MemorySegment allocate(AddressLayout layout, MemorySegment value) {
         Objects.requireNonNull(value);
         Objects.requireNonNull(layout);
         MemorySegment segment = allocate(layout);

--- a/src/java.base/share/classes/java/lang/foreign/SymbolLookup.java
+++ b/src/java.base/share/classes/java/lang/foreign/SymbolLookup.java
@@ -52,7 +52,7 @@ import java.util.function.BiFunction;
  * <ul>
  *     <li>It can be passed to a {@link Linker} to create a downcall method handle, which can then be used to call the foreign function at the segment's address.</li>
  *     <li>It can be passed to an existing {@linkplain Linker#downcallHandle(FunctionDescriptor, Linker.Option...) downcall method handle}, as an argument to the underlying foreign function.</li>
- *     <li>It can be {@linkplain MemorySegment#set(ValueLayout.OfAddress, long, MemorySegment) stored} inside another memory segment.</li>
+ *     <li>It can be {@linkplain MemorySegment#set(AddressLayout, long, MemorySegment) stored} inside another memory segment.</li>
  *     <li>It can be used to access the region of memory backing a global variable (this might require
  *     {@link MemorySegment#reinterpret(long)} () resizing} the segment first).</li>
  * </ul>

--- a/src/java.base/share/classes/jdk/internal/foreign/LayoutPath.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/LayoutPath.java
@@ -27,6 +27,7 @@ package jdk.internal.foreign;
 
 import jdk.internal.vm.annotation.ForceInline;
 
+import java.lang.foreign.AddressLayout;
 import java.lang.foreign.GroupLayout;
 import java.lang.foreign.MemoryLayout;
 import java.lang.foreign.MemorySegment;
@@ -162,7 +163,7 @@ public class LayoutPath {
     }
 
     public LayoutPath derefElement() {
-        if (!(layout instanceof ValueLayout.OfAddress addressLayout) ||
+        if (!(layout instanceof AddressLayout addressLayout) ||
                 addressLayout.targetLayout().isEmpty()) {
             throw badLayoutPath("Cannot dereference layout: " + layout);
         }

--- a/src/java.base/share/classes/jdk/internal/foreign/MemoryInspectionUtil.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/MemoryInspectionUtil.java
@@ -25,6 +25,7 @@
 
 package jdk.internal.foreign;
 
+import java.lang.foreign.AddressLayout;
 import java.lang.foreign.GroupLayout;
 import java.lang.foreign.MemoryLayout;
 import java.lang.foreign.MemorySegment;
@@ -103,7 +104,7 @@ final class MemoryInspectionUtil {
             action.accept(renderValueLayout(state, ofChar, renderer.apply(ofChar, segment.get(ofChar, state.indexAndAdd(ofChar))), suffix));
             return;
         }
-        if (layout instanceof ValueLayout.OfAddress ofAddress) {
+        if (layout instanceof AddressLayout ofAddress) {
             action.accept(renderValueLayout(state, ofAddress, renderer.apply(ofAddress, segment.get(ofAddress, state.indexAndAdd(ofAddress))), suffix));
             return;
         }
@@ -252,7 +253,7 @@ final class MemoryInspectionUtil {
             if (layout instanceof ValueLayout.OfChar ofChar && o instanceof Character c) {
                 return Character.toString(c);
             }
-            if (layout instanceof ValueLayout.OfAddress ofAddress && o instanceof MemorySegment m) {
+            if (layout instanceof AddressLayout ofAddress && o instanceof MemorySegment m) {
                 return String.format("0x%0" + (ValueLayout.ADDRESS.byteSize() * 2) + "X", m.address());
             }
             throw new UnsupportedOperationException("layout " + layout + " for " + o.getClass().getName() + " not supported");

--- a/src/java.base/share/classes/jdk/internal/foreign/Utils.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/Utils.java
@@ -26,6 +26,7 @@
 
 package jdk.internal.foreign;
 
+import java.lang.foreign.AddressLayout;
 import java.lang.foreign.MemoryLayout;
 import java.lang.foreign.MemorySegment;
 import java.lang.foreign.SegmentAllocator;
@@ -121,7 +122,7 @@ public final class Utils {
 
         if (layout.carrier() == boolean.class) {
             handle = MethodHandles.filterValue(handle, BOOL_TO_BYTE, BYTE_TO_BOOL);
-        } else if (layout instanceof ValueLayout.OfAddress addressLayout) {
+        } else if (layout instanceof AddressLayout addressLayout) {
             handle = MethodHandles.filterValue(handle,
                     ADDRESS_TO_LONG,
                     MethodHandles.insertArguments(LONG_TO_ADDRESS, 1,
@@ -178,13 +179,13 @@ public final class Utils {
         }
     }
 
-    public static long pointeeByteSize(ValueLayout.OfAddress addressLayout) {
+    public static long pointeeByteSize(AddressLayout addressLayout) {
         return addressLayout.targetLayout()
                 .map(MemoryLayout::byteSize)
                 .orElse(0L);
     }
 
-    public static long pointeeByteAlign(ValueLayout.OfAddress addressLayout) {
+    public static long pointeeByteAlign(AddressLayout addressLayout) {
         return addressLayout.targetLayout()
                 .map(MemoryLayout::byteAlignment)
                 .orElse(1L);

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/BindingSpecializer.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/BindingSpecializer.java
@@ -446,7 +446,7 @@ public class BindingSpecializer {
                                               .get(paramIndex - offset);
 
         // is this an address layout?
-        return paramLayout instanceof ValueLayout.OfAddress;
+        return paramLayout instanceof AddressLayout;
     }
 
     private void emitCleanup() {
@@ -929,7 +929,7 @@ public class BindingSpecializer {
         } else if (type == double.class) {
             return ValueLayout.OfDouble.class;
         } else if (type == MemorySegment.class) {
-            return ValueLayout.OfAddress.class;
+            return AddressLayout.class;
         } else {
             throw new IllegalStateException("Unknown type: " + type);
         }

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/SharedUtils.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/SharedUtils.java
@@ -38,6 +38,7 @@ import jdk.internal.foreign.abi.x64.sysv.SysVx64Linker;
 import jdk.internal.foreign.abi.x64.windows.Windowsx64Linker;
 import jdk.internal.vm.annotation.ForceInline;
 
+import java.lang.foreign.AddressLayout;
 import java.lang.foreign.Arena;
 import java.lang.foreign.Linker;
 import java.lang.foreign.FunctionDescriptor;
@@ -77,7 +78,7 @@ public final class SharedUtils {
     private static final MethodHandle MH_REACHABILITY_FENCE;
     public static final MethodHandle MH_CHECK_SYMBOL;
 
-    public static final ValueLayout.OfAddress C_POINTER = ADDRESS
+    public static final AddressLayout C_POINTER = ADDRESS
             .withBitAlignment(64)
             .withTargetLayout(MemoryLayout.sequenceLayout(JAVA_BYTE));
 

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/aarch64/CallArranger.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/aarch64/CallArranger.java
@@ -25,6 +25,7 @@
  */
 package jdk.internal.foreign.abi.aarch64;
 
+import java.lang.foreign.AddressLayout;
 import java.lang.foreign.FunctionDescriptor;
 import java.lang.foreign.GroupLayout;
 import java.lang.foreign.MemoryLayout;
@@ -492,7 +493,7 @@ public abstract class CallArranger {
                             .boxAddress(layout);
                 }
                 case POINTER -> {
-                    ValueLayout.OfAddress addressLayout = (ValueLayout.OfAddress)layout;
+                    AddressLayout addressLayout = (AddressLayout) layout;
                     VMStorage storage = storageCalculator.nextStorage(StorageType.INTEGER, addressLayout);
                     bindings.vmLoad(storage, long.class)
                             .boxAddressRaw(Utils.pointeeByteSize(addressLayout), Utils.pointeeByteAlign(addressLayout));

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/fallback/FallbackLinker.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/fallback/FallbackLinker.java
@@ -31,6 +31,7 @@ import jdk.internal.foreign.abi.CapturableState;
 import jdk.internal.foreign.abi.LinkerOptions;
 import jdk.internal.foreign.abi.SharedUtils;
 
+import java.lang.foreign.AddressLayout;
 import java.lang.foreign.Arena;
 import java.lang.foreign.FunctionDescriptor;
 import java.lang.foreign.GroupLayout;
@@ -232,7 +233,7 @@ public final class FallbackLinker extends AbstractLinker {
             argSeg.set(fl, 0, (Float) arg);
         } else if (layout instanceof ValueLayout.OfDouble dl) {
             argSeg.set(dl, 0, (Double) arg);
-        } else if (layout instanceof ValueLayout.OfAddress al) {
+        } else if (layout instanceof AddressLayout al) {
             MemorySegment addrArg = (MemorySegment) arg;
             acquireCallback.accept(addrArg);
             argSeg.set(al, 0, addrArg);
@@ -260,7 +261,7 @@ public final class FallbackLinker extends AbstractLinker {
             return seg.get(fl, 0);
         } else if (layout instanceof ValueLayout.OfDouble dl) {
             return seg.get(dl, 0);
-        } else if (layout instanceof ValueLayout.OfAddress al) {
+        } else if (layout instanceof AddressLayout al) {
             return seg.get(al, 0);
         } else if (layout instanceof GroupLayout) {
             return seg;

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/riscv64/linux/LinuxRISCV64CallArranger.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/riscv64/linux/LinuxRISCV64CallArranger.java
@@ -26,6 +26,7 @@
 
 package jdk.internal.foreign.abi.riscv64.linux;
 
+import java.lang.foreign.AddressLayout;
 import java.lang.foreign.FunctionDescriptor;
 import java.lang.foreign.GroupLayout;
 import java.lang.foreign.MemoryLayout;
@@ -390,7 +391,7 @@ public class LinuxRISCV64CallArranger {
                     bindings.vmLoad(storage, carrier);
                 }
                 case POINTER -> {
-                    ValueLayout.OfAddress addressLayout = (ValueLayout.OfAddress)layout;
+                    AddressLayout addressLayout = (AddressLayout) layout;
                     VMStorage storage = storageCalculator.getStorage(StorageType.INTEGER);
                     bindings.vmLoad(storage, long.class)
                             .boxAddressRaw(Utils.pointeeByteSize(addressLayout), Utils.pointeeByteAlign(addressLayout));

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/x64/sysv/CallArranger.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/x64/sysv/CallArranger.java
@@ -38,6 +38,7 @@ import jdk.internal.foreign.abi.UpcallLinker;
 import jdk.internal.foreign.abi.VMStorage;
 import jdk.internal.foreign.abi.x64.X86_64Architecture;
 
+import java.lang.foreign.AddressLayout;
 import java.lang.foreign.FunctionDescriptor;
 import java.lang.foreign.GroupLayout;
 import java.lang.foreign.MemoryLayout;
@@ -318,7 +319,7 @@ public class CallArranger {
                     }
                 }
                 case POINTER -> {
-                    ValueLayout.OfAddress addressLayout = (ValueLayout.OfAddress)layout;
+                    AddressLayout addressLayout = (AddressLayout) layout;
                     VMStorage storage = storageCalculator.nextStorage(StorageType.INTEGER);
                     bindings.vmLoad(storage, long.class)
                             .boxAddressRaw(Utils.pointeeByteSize(addressLayout), Utils.pointeeByteAlign(addressLayout));

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/x64/windows/CallArranger.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/x64/windows/CallArranger.java
@@ -37,6 +37,7 @@ import jdk.internal.foreign.abi.UpcallLinker;
 import jdk.internal.foreign.abi.VMStorage;
 import jdk.internal.foreign.abi.x64.X86_64Architecture;
 
+import java.lang.foreign.AddressLayout;
 import java.lang.foreign.FunctionDescriptor;
 import java.lang.foreign.GroupLayout;
 import java.lang.foreign.MemoryLayout;
@@ -273,7 +274,7 @@ public class CallArranger {
                     break;
                 }
                 case POINTER: {
-                    ValueLayout.OfAddress addressLayout = (ValueLayout.OfAddress)layout;
+                    AddressLayout addressLayout = (AddressLayout) layout;
                     VMStorage storage = storageCalculator.nextStorage(StorageType.INTEGER);
                     bindings.vmLoad(storage, long.class)
                             .boxAddressRaw(Utils.pointeeByteSize(addressLayout), Utils.pointeeByteAlign(addressLayout));

--- a/src/java.base/share/classes/jdk/internal/foreign/layout/ValueLayouts.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/layout/ValueLayouts.java
@@ -35,6 +35,7 @@ import sun.invoke.util.Wrapper;
 
 import java.lang.foreign.MemoryLayout;
 import java.lang.foreign.MemorySegment;
+import java.lang.foreign.AddressLayout;
 import java.lang.foreign.ValueLayout;
 import java.lang.invoke.VarHandle;
 import java.nio.ByteOrder;
@@ -315,7 +316,7 @@ public final class ValueLayouts {
 
     }
 
-    public static final class OfAddressImpl extends AbstractValueLayout<OfAddressImpl> implements ValueLayout.OfAddress {
+    public static final class OfAddressImpl extends AbstractValueLayout<OfAddressImpl> implements AddressLayout {
 
         private final MemoryLayout targetLayout;
 
@@ -342,8 +343,8 @@ public final class ValueLayouts {
 
         @Override
         @CallerSensitive
-        public OfAddress withTargetLayout(MemoryLayout layout) {
-            Reflection.ensureNativeAccess(Reflection.getCallerClass(), OfAddress.class, "withTargetLayout");
+        public AddressLayout withTargetLayout(MemoryLayout layout) {
+            Reflection.ensureNativeAccess(Reflection.getCallerClass(), AddressLayout.class, "withTargetLayout");
             Objects.requireNonNull(layout);
             return new OfAddressImpl(order(), bitSize(), bitAlignment(), layout, name());
         }
@@ -353,7 +354,7 @@ public final class ValueLayouts {
             return Optional.ofNullable(targetLayout);
         }
 
-        public static OfAddress of(ByteOrder order) {
+        public static AddressLayout of(ByteOrder order) {
             return new OfAddressImpl(order, ADDRESS_SIZE_BITS, ADDRESS_SIZE_BITS, null, Optional.empty());
         }
 

--- a/test/jdk/java/foreign/MemoryLayoutPrincipalTotalityTest.java
+++ b/test/jdk/java/foreign/MemoryLayoutPrincipalTotalityTest.java
@@ -80,7 +80,7 @@ public class MemoryLayoutPrincipalTotalityTest {
             case SequenceLayout sl -> 0; // leaf
             case StructLayout sl -> 0; // leaf
             case UnionLayout ul -> 0; // leaf
-            case OfAddress oa -> 0; // leaf
+            case AddressLayout oa -> 0; // leaf
             case OfBoolean ob -> 0; // leaf
             case OfByte ob -> 0; // leaf
             case OfChar oc -> 0; // leaf
@@ -100,7 +100,7 @@ public class MemoryLayoutPrincipalTotalityTest {
             case GroupLayout gl -> 0;
             case PaddingLayout pl -> 0; // leaf
             case SequenceLayout sl -> 0; // leaf
-            case OfAddress oa -> 0; // leaf
+            case AddressLayout oa -> 0; // leaf
             case OfBoolean ob -> 0; // leaf
             case OfByte ob -> 0; // leaf
             case OfChar oc -> 0; // leaf

--- a/test/jdk/java/foreign/MemoryLayoutTypeRetentionTest.java
+++ b/test/jdk/java/foreign/MemoryLayoutTypeRetentionTest.java
@@ -118,13 +118,13 @@ public class MemoryLayoutTypeRetentionTest {
 
     @Test
     public void testOfAddress() {
-        OfAddress v = ADDRESS
+        AddressLayout v = ADDRESS
                 .withBitAlignment(BIT_ALIGNMENT)
                 .withName(NAME)
                 .withOrder(BYTE_ORDER);
         check(v);
         assertFalse(v.targetLayout().isPresent());
-        OfAddress v2 = v.withTargetLayout(JAVA_INT);
+        AddressLayout v2 = v.withTargetLayout(JAVA_INT);
         assertTrue(v2.targetLayout().isPresent());
         assertEquals(v2.targetLayout().get(), JAVA_INT);
     }

--- a/test/jdk/java/foreign/NativeTestHelper.java
+++ b/test/jdk/java/foreign/NativeTestHelper.java
@@ -22,6 +22,7 @@
  *
  */
 
+import java.lang.foreign.AddressLayout;
 import java.lang.foreign.Arena;
 import java.lang.foreign.FunctionDescriptor;
 import java.lang.foreign.GroupLayout;
@@ -120,7 +121,7 @@ public class NativeTestHelper {
     /**
      * The {@code T*} native type.
      */
-    public static final ValueLayout.OfAddress C_POINTER = ValueLayout.ADDRESS.withBitAlignment(64)
+    public static final AddressLayout C_POINTER = ValueLayout.ADDRESS.withBitAlignment(64)
             .withTargetLayout(MemoryLayout.sequenceLayout(C_CHAR));
 
     public static final Linker LINKER = Linker.nativeLinker();
@@ -209,7 +210,7 @@ public class NativeTestHelper {
                 elementChecks.add(initField(random, segment, array, array.elementLayout(), sequenceElement(i), allocator));
             }
             return new TestValue(segment, actual -> elementChecks.forEach(check -> check.accept(actual)));
-        } else if (layout instanceof ValueLayout.OfAddress) {
+        } else if (layout instanceof AddressLayout) {
             MemorySegment value = MemorySegment.ofAddress(random.nextLong());
             return new TestValue(value, actual -> assertEquals(actual, value));
         }else if (layout instanceof ValueLayout.OfByte) {

--- a/test/jdk/java/foreign/TestHeapAlignment.java
+++ b/test/jdk/java/foreign/TestHeapAlignment.java
@@ -29,6 +29,7 @@
  * @run testng/othervm --enable-native-access=ALL-UNNAMED TestHeapAlignment
  */
 
+import java.lang.foreign.AddressLayout;
 import java.lang.foreign.MemoryLayout;
 import java.lang.foreign.MemorySegment;
 import java.lang.foreign.Arena;
@@ -90,7 +91,7 @@ public class TestHeapAlignment {
     static final ValueLayout.OfFloat JAVA_FLOAT_ALIGNED = ValueLayout.JAVA_FLOAT.withBitAlignment(32);
     static final ValueLayout.OfLong JAVA_LONG_ALIGNED = ValueLayout.JAVA_LONG.withBitAlignment(64);
     static final ValueLayout.OfDouble JAVA_DOUBLE_ALIGNED = ValueLayout.JAVA_DOUBLE.withBitAlignment(64);
-    static final ValueLayout.OfAddress ADDRESS_ALIGNED = ValueLayout.ADDRESS.withBitAlignment(ValueLayout.ADDRESS.bitSize());
+    static final AddressLayout ADDRESS_ALIGNED = ValueLayout.ADDRESS.withBitAlignment(ValueLayout.ADDRESS.bitSize());
 
     enum SegmentAndAlignment {
         HEAP_BYTE(MemorySegment.ofArray(new byte[8]), 1),

--- a/test/jdk/java/foreign/TestNulls.java
+++ b/test/jdk/java/foreign/TestNulls.java
@@ -94,7 +94,7 @@ public class TestNulls {
             ValueLayout.OfFloat.class,
             ValueLayout.OfLong.class,
             ValueLayout.OfDouble.class,
-            ValueLayout.OfAddress.class,
+            AddressLayout.class,
             PaddingLayout.class,
             GroupLayout.class,
             StructLayout.class,
@@ -152,7 +152,7 @@ public class TestNulls {
         addDefaultMapping(MethodType.class, MethodType.methodType(void.class));
         addDefaultMapping(MemoryLayout.class, ValueLayout.JAVA_INT);
         addDefaultMapping(ValueLayout.class, ValueLayout.JAVA_INT);
-        addDefaultMapping(ValueLayout.OfAddress.class, ValueLayout.ADDRESS);
+        addDefaultMapping(AddressLayout.class, ValueLayout.ADDRESS);
         addDefaultMapping(ValueLayout.OfByte.class, ValueLayout.JAVA_BYTE);
         addDefaultMapping(ValueLayout.OfBoolean.class, ValueLayout.JAVA_BOOLEAN);
         addDefaultMapping(ValueLayout.OfChar.class, ValueLayout.JAVA_CHAR);

--- a/test/jdk/java/foreign/TestSegmentAllocators.java
+++ b/test/jdk/java/foreign/TestSegmentAllocators.java
@@ -360,7 +360,7 @@ public class TestSegmentAllocators {
         interface OfFloat extends AllocationFunction<Float, ValueLayout.OfFloat> { }
         interface OfLong extends AllocationFunction<Long, ValueLayout.OfLong> { }
         interface OfDouble extends AllocationFunction<Double, ValueLayout.OfDouble> { }
-        interface OfAddress extends AllocationFunction<MemorySegment, ValueLayout.OfAddress> { }
+        interface OfAddress extends AllocationFunction<MemorySegment, AddressLayout> { }
 
         interface OfByteArray extends AllocationFunction<byte[], ValueLayout.OfByte> { }
         interface OfCharArray extends AllocationFunction<char[], ValueLayout.OfChar> { }

--- a/test/jdk/java/foreign/callarranger/TestLayoutEquality.java
+++ b/test/jdk/java/foreign/callarranger/TestLayoutEquality.java
@@ -30,6 +30,7 @@
  * @run testng TestLayoutEquality
  */
 
+import java.lang.foreign.AddressLayout;
 import java.lang.foreign.MemoryLayout;
 import java.lang.foreign.ValueLayout;
 import platform.PlatformLayouts;
@@ -48,8 +49,8 @@ public class TestLayoutEquality {
     public void testReconstructedEquality(ValueLayout layout) {
         ValueLayout newLayout = MemoryLayout.valueLayout(layout.carrier(), layout.order());
         newLayout = newLayout.withBitAlignment(layout.bitAlignment());
-        if (layout instanceof ValueLayout.OfAddress addressLayout && addressLayout.targetLayout().isPresent()) {
-            newLayout = ((ValueLayout.OfAddress)newLayout).withTargetLayout(addressLayout.targetLayout().get());
+        if (layout instanceof AddressLayout addressLayout && addressLayout.targetLayout().isPresent()) {
+            newLayout = ((AddressLayout)newLayout).withTargetLayout(addressLayout.targetLayout().get());
         }
 
         // properties should be equal

--- a/test/jdk/java/foreign/callarranger/platform/PlatformLayouts.java
+++ b/test/jdk/java/foreign/callarranger/platform/PlatformLayouts.java
@@ -27,6 +27,7 @@ package platform;
 
 import jdk.internal.foreign.abi.SharedUtils;
 
+import java.lang.foreign.AddressLayout;
 import java.lang.foreign.ValueLayout;
 
 public final class PlatformLayouts {
@@ -85,7 +86,7 @@ public final class PlatformLayouts {
         /**
          * The {@code T*} native type.
          */
-        public static final ValueLayout.OfAddress C_POINTER = SharedUtils.C_POINTER;;
+        public static final AddressLayout C_POINTER = SharedUtils.C_POINTER;;
 
     }
 
@@ -139,7 +140,7 @@ public final class PlatformLayouts {
         /**
          * The {@code T*} native type.
          */
-        public static final ValueLayout.OfAddress C_POINTER = SharedUtils.C_POINTER;
+        public static final AddressLayout C_POINTER = SharedUtils.C_POINTER;
 
     }
 
@@ -194,7 +195,7 @@ public final class PlatformLayouts {
         /**
          * The {@code T*} native type.
          */
-        public static final ValueLayout.OfAddress C_POINTER = SharedUtils.C_POINTER;
+        public static final AddressLayout C_POINTER = SharedUtils.C_POINTER;
 
     }
 
@@ -246,7 +247,7 @@ public final class PlatformLayouts {
         /**
          * The {@code T*} native type.
          */
-        public static final ValueLayout.OfAddress C_POINTER = SharedUtils.C_POINTER;
+        public static final AddressLayout C_POINTER = SharedUtils.C_POINTER;
 
     }
 

--- a/test/jdk/java/foreign/handles/invoker_module/handle/invoker/MethodHandleInvoker.java
+++ b/test/jdk/java/foreign/handles/invoker_module/handle/invoker/MethodHandleInvoker.java
@@ -23,6 +23,7 @@
 
 package handle.invoker;
 
+import java.lang.foreign.AddressLayout;
 import java.lang.foreign.Arena;
 import java.lang.foreign.Linker;
 import java.lang.foreign.FunctionDescriptor;
@@ -84,7 +85,7 @@ public class MethodHandleInvoker {
         addDefaultMapping(ValueLayout.OfFloat.class, ValueLayout.JAVA_FLOAT);
         addDefaultMapping(ValueLayout.OfLong.class, ValueLayout.JAVA_LONG);
         addDefaultMapping(ValueLayout.OfDouble.class, ValueLayout.JAVA_DOUBLE);
-        addDefaultMapping(ValueLayout.OfAddress.class, ValueLayout.ADDRESS);
+        addDefaultMapping(AddressLayout.class, ValueLayout.ADDRESS);
         addDefaultMapping(SymbolLookup.class, SymbolLookup.loaderLookup());
         addDefaultMapping(Consumer.class, (Consumer<Object>)(Object o) -> {});
         addDefaultMapping(byte.class, (byte)0);

--- a/test/jdk/java/lang/Thread/jni/AttachCurrentThread/ImplicitAttach.java
+++ b/test/jdk/java/lang/Thread/jni/AttachCurrentThread/ImplicitAttach.java
@@ -32,7 +32,7 @@ import java.util.concurrent.CountDownLatch;
  */
 public class ImplicitAttach {
     private static final ValueLayout.OfInt C_INT = ValueLayout.JAVA_INT.withBitAlignment(32);
-    private static final ValueLayout.OfAddress C_POINTER = ValueLayout.ADDRESS.withBitAlignment(64);
+    private static final AddressLayout C_POINTER = ValueLayout.ADDRESS.withBitAlignment(64);
 
     private static volatile CountDownLatch latch;
 

--- a/test/micro/org/openjdk/bench/java/lang/foreign/CLayouts.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/CLayouts.java
@@ -23,6 +23,7 @@
 
 package org.openjdk.bench.java.lang.foreign;
 
+import java.lang.foreign.AddressLayout;
 import java.lang.foreign.Linker;
 import java.lang.foreign.FunctionDescriptor;
 import java.lang.foreign.MemoryLayout;
@@ -67,7 +68,7 @@ public class CLayouts {
     /**
      * The {@code T*} native type.
      */
-    public static final ValueLayout.OfAddress C_POINTER = ValueLayout.ADDRESS
+    public static final AddressLayout C_POINTER = ValueLayout.ADDRESS
             .withTargetLayout(MemoryLayout.sequenceLayout(C_CHAR));
 
     private static Linker LINKER = Linker.nativeLinker();

--- a/test/micro/org/openjdk/bench/java/lang/foreign/pointers/NativeType.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/pointers/NativeType.java
@@ -23,6 +23,7 @@
 
 package org.openjdk.bench.java.lang.foreign.pointers;
 
+import java.lang.foreign.AddressLayout;
 import java.lang.foreign.GroupLayout;
 import java.lang.foreign.MemoryLayout;
 import java.lang.foreign.ValueLayout;
@@ -38,11 +39,11 @@ public sealed abstract class NativeType<X> {
         public abstract ValueLayout.OfDouble layout();
     }
 
-    private static final ValueLayout.OfAddress UNSAFE_ADDRESS = ValueLayout.ADDRESS
+    private static final AddressLayout UNSAFE_ADDRESS = ValueLayout.ADDRESS
             .withTargetLayout(MemoryLayout.sequenceLayout(ValueLayout.JAVA_BYTE));
 
     public final static class OfPointer<X> extends NativeType<X> {
-        public ValueLayout.OfAddress layout() {
+        public AddressLayout layout() {
             return UNSAFE_ADDRESS;
         }
     }

--- a/test/micro/org/openjdk/bench/java/lang/foreign/pointers/PointerBench.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/pointers/PointerBench.java
@@ -35,6 +35,7 @@ import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.annotations.TearDown;
 import org.openjdk.jmh.annotations.Warmup;
 
+import java.lang.foreign.AddressLayout;
 import java.lang.foreign.Arena;
 import java.lang.foreign.MemoryLayout;
 import java.lang.foreign.MemorySegment;
@@ -58,7 +59,7 @@ public class PointerBench {
     MemorySegment intPointerSegment = intPointerPointer.segment();
     MemorySegment pointSegment = pointPointer.segment();
 
-    public static final ValueLayout.OfAddress UNSAFE_ADDRESS = ValueLayout.ADDRESS
+    public static final AddressLayout UNSAFE_ADDRESS = ValueLayout.ADDRESS
             .withTargetLayout(MemoryLayout.sequenceLayout(ValueLayout.JAVA_BYTE));
 
     @Setup


### PR DESCRIPTION
This patch moves ValueLayout.OfAddress into a toplevel class. This seems desirable since address layouts are very important in the FFM API, and also provides seadditional methods on top of `ValueLayout` to get/set a *target layout*.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8303666](https://bugs.openjdk.org/browse/JDK-8303666): Move address layout outside of ValueLayout namespace


### Reviewers
 * [Jorn Vernee](https://openjdk.org/census#jvernee) (@JornVernee - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/panama-foreign pull/811/head:pull/811` \
`$ git checkout pull/811`

Update a local copy of the PR: \
`$ git checkout pull/811` \
`$ git pull https://git.openjdk.org/panama-foreign pull/811/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 811`

View PR using the GUI difftool: \
`$ git pr show -t 811`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/panama-foreign/pull/811.diff">https://git.openjdk.org/panama-foreign/pull/811.diff</a>

</details>
