### PR TITLE
8303835: Remove uncaught exception handler linker option

### DIFF
--- a/src/java.base/share/classes/java/lang/foreign/Linker.java
+++ b/src/java.base/share/classes/java/lang/foreign/Linker.java
@@ -370,18 +370,5 @@ public sealed interface Linker permits AbstractLinker {
         static Option isTrivial() {
             return LinkerOptions.IsTrivial.INSTANCE;
         }
-
-        /**
-         * {@return a linker option that can be used to specify the uncaught exception handler that should be executed
-         *          if an exception is thrown, but not caught, during an upcall}
-         *
-         * @apiNote using a custom exception handler will not prevent the VM from exiting in the case of an uncaught
-         * exception during an upcall.
-         *
-         * @param handler the handler
-         */
-        static Option uncaughtExceptionHandler(Thread.UncaughtExceptionHandler handler) {
-            return new LinkerOptions.UncaughtExceptionHandler(Objects.requireNonNull(handler));
-        }
     }
 }

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/CallingSequence.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/CallingSequence.java
@@ -195,10 +195,6 @@ public class CallingSequence {
         return !linkerOptions.isTrivial();
     }
 
-    public Thread.UncaughtExceptionHandler uncaughtExceptionHandler() {
-        return linkerOptions.uncaughtExceptionHandler();
-    }
-
     public int numLeadingParams() {
         return 2 + (linkerOptions.hasCapturedCallState() ? 1 : 0); // 2 for addr, allocator
     }

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/LinkerOptions.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/LinkerOptions.java
@@ -98,11 +98,6 @@ public class LinkerOptions {
         return it != null;
     }
 
-    public Thread.UncaughtExceptionHandler uncaughtExceptionHandler() {
-        UncaughtExceptionHandler ueh = getOption(UncaughtExceptionHandler.class);
-        return ueh != null ? ueh.handler() : null;
-    }
-
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
@@ -116,7 +111,7 @@ public class LinkerOptions {
     }
 
     public sealed interface LinkerOptionImpl extends Linker.Option
-            permits CaptureCallState, FirstVariadicArg, IsTrivial, UncaughtExceptionHandler {
+            permits CaptureCallState, FirstVariadicArg, IsTrivial {
         default void validateForDowncall(FunctionDescriptor descriptor) {
             throw new IllegalArgumentException("Not supported for downcall: " + this);
         }
@@ -147,13 +142,6 @@ public class LinkerOptions {
 
         @Override
         public void validateForDowncall(FunctionDescriptor descriptor) {
-            // always allowed
-        }
-    }
-
-    public record UncaughtExceptionHandler(Thread.UncaughtExceptionHandler handler) implements LinkerOptionImpl {
-        @Override
-        public void validateForUpcall(FunctionDescriptor descriptor) {
             // always allowed
         }
     }

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/SharedUtils.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/SharedUtils.java
@@ -311,9 +311,12 @@ public final class SharedUtils {
 
     public static void handleUncaughtException(Throwable t) {
         if (t != null) {
-            t.printStackTrace();
-            System.err.println("Unrecoverable uncaught exception encountered. The VM will now exit");
-            JLA.exit(1);
+            try {
+                t.printStackTrace();
+                System.err.println("Unrecoverable uncaught exception encountered. The VM will now exit");
+            } finally {
+                JLA.exit(1);
+            }
         }
     }
 

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/SharedUtils.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/SharedUtils.java
@@ -309,18 +309,11 @@ public final class SharedUtils {
         return MH_REACHABILITY_FENCE.asType(MethodType.methodType(void.class, type));
     }
 
-    public static void handleUncaughtException(Throwable t, Thread.UncaughtExceptionHandler handler) {
+    public static void handleUncaughtException(Throwable t) {
         if (t != null) {
-            try {
-                Thread currentThread = Thread.currentThread();
-                if (handler == null) {
-                     handler = currentThread.getUncaughtExceptionHandler();
-                }
-                handler.uncaughtException(currentThread, t);
-            } finally {
-                System.err.println("Unrecoverable uncaught exception encountered. The VM will now exit");
-                JLA.exit(1);
-            }
+            t.printStackTrace();
+            System.err.println("Unrecoverable uncaught exception encountered. The VM will now exit");
+            JLA.exit(1);
         }
     }
 

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/UpcallLinker.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/UpcallLinker.java
@@ -203,7 +203,7 @@ public class UpcallLinker {
                 return null;
             }
         } catch(Throwable t) {
-            SharedUtils.handleUncaughtException(t, invData.callingSequence().uncaughtExceptionHandler());
+            SharedUtils.handleUncaughtException(t);
             return null;
         }
     }

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/fallback/FallbackLinker.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/fallback/FallbackLinker.java
@@ -113,7 +113,7 @@ public final class FallbackLinker extends AbstractLinker {
 
         return (target, scope) -> {
             target = MethodHandles.insertArguments(doUpcallMH, 0, target);
-            return LibFallback.createClosure(cif, target, options.uncaughtExceptionHandler(), scope);
+            return LibFallback.createClosure(cif, target, scope);
         };
     }
 

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/fallback/LibFallback.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/fallback/LibFallback.java
@@ -121,16 +121,14 @@ class LibFallback {
      * @throws IllegalStateException if the call to {@code ffi_prep_closure_loc} returns a non-zero status code
      * @throws IllegalArgumentException if {@code target} does not have the right type
      */
-    static MemorySegment createClosure(MemorySegment cif, MethodHandle target,
-                                       Thread.UncaughtExceptionHandler handler, Arena arena)
+    static MemorySegment createClosure(MemorySegment cif, MethodHandle target, Arena arena)
             throws IllegalStateException, IllegalArgumentException {
         if (target.type() != UPCALL_TARGET_TYPE) {
             throw new IllegalArgumentException("Target handle has wrong type: " + target.type() + " != " + UPCALL_TARGET_TYPE);
         }
 
         long[] ptrs = new long[3];
-        UpcallData upcallData = new UpcallData(target, handler);
-        checkStatus(createClosure(cif.address(), upcallData, ptrs));
+        checkStatus(createClosure(cif.address(), target, ptrs));
         long closurePtr = ptrs[0];
         long execPtr = ptrs[1];
         long globalTarget = ptrs[2];
@@ -138,14 +136,12 @@ class LibFallback {
         return MemorySegment.ofAddress(execPtr).reinterpret(arena, unused -> freeClosure(closurePtr, globalTarget));
     }
 
-    private record UpcallData(MethodHandle target, Thread.UncaughtExceptionHandler handler) {}
-
     // the target function for a closure call
-    private static void doUpcall(long retPtr, long argPtrs, UpcallData data) {
+    private static void doUpcall(long retPtr, long argPtrs, MethodHandle target) {
         try {
-            data.target().invokeExact(MemorySegment.ofAddress(retPtr), MemorySegment.ofAddress(argPtrs));
+            target.invokeExact(MemorySegment.ofAddress(retPtr), MemorySegment.ofAddress(argPtrs));
         } catch (Throwable t) {
-            SharedUtils.handleUncaughtException(t, data.handler());
+            SharedUtils.handleUncaughtException(t);
         }
     }
 

--- a/src/java.base/share/native/libfallbackLinker/fallbackLinker.c
+++ b/src/java.base/share/native/libfallbackLinker/fallbackLinker.c
@@ -38,7 +38,7 @@
 static JavaVM* VM;
 static jclass LibFallback_class;
 static jmethodID LibFallback_doUpcall_ID;
-static const char* LibFallback_doUpcall_sig = "(JJLjdk/internal/foreign/abi/fallback/LibFallback$UpcallData;)V";
+static const char* LibFallback_doUpcall_sig = "(JJLjava/lang/invoke/MethodHandle;)V";
 
 JNIEXPORT void JNICALL
 Java_jdk_internal_foreign_abi_fallback_LibFallback_init(JNIEnv* env, jclass cls) {

--- a/test/jdk/java/foreign/TestIllegalLink.java
+++ b/test/jdk/java/foreign/TestIllegalLink.java
@@ -63,13 +63,6 @@ public class TestIllegalLink extends NativeTestHelper {
         }
     }
 
-    @Test(dataProvider = "upcallOnlyOptions",
-          expectedExceptions = IllegalArgumentException.class,
-          expectedExceptionsMessageRegExp = ".*Not supported for downcall.*")
-    public void testIllegalDowncallOptions(Linker.Option upcallOnlyOption) {
-        ABI.downcallHandle(DUMMY_TARGET, FunctionDescriptor.ofVoid(), upcallOnlyOption);
-    }
-
     @Test(dataProvider = "downcallOnlyOptions",
           expectedExceptions = IllegalArgumentException.class,
           expectedExceptionsMessageRegExp = ".*Not supported for upcall.*")
@@ -95,13 +88,6 @@ public class TestIllegalLink extends NativeTestHelper {
             };
         }
         return new Object[][]{};
-    }
-
-    @DataProvider
-    public static Object[][] upcallOnlyOptions() {
-        return new Object[][]{
-            { Linker.Option.uncaughtExceptionHandler((thread, ex) -> {}) }
-        };
     }
 
     @DataProvider

--- a/test/jdk/java/foreign/TestUpcallException.java
+++ b/test/jdk/java/foreign/TestUpcallException.java
@@ -81,42 +81,6 @@ public class TestUpcallException extends UpcallTestHelper {
         }
     }
 
-    //////////////////////////////////////////////////////////////////////////////////////////////////////////
-
-    @Test(dataProvider = "uncaughtHandlerCases")
-    public void testUncaughtExceptionHandlerOption(Class<?> target) throws InterruptedException, IOException {
-        runInNewProcess(target, true)
-                .assertStdOutContains("From uncaught exception handler");
-    }
-
-    @DataProvider
-    public static Object[][] uncaughtHandlerCases() {
-        return new Object[][]{
-            { UncaughtHandlerOptionRunner.class },
-            { UncaughtHandlerThreadRunner.class }
-        };
-    }
-
-    public static class UncaughtHandlerOptionRunner extends VoidUpcallRunner {
-        public static void main(String[] args) throws Throwable {
-            try (Arena arena = Arena.ofConfined()) {
-                MemorySegment stub = Linker.nativeLinker().upcallStub(VOID_TARGET, FunctionDescriptor.ofVoid(),
-                        arena, Linker.Option.uncaughtExceptionHandler(UNCAUGHT_EXCEPTION_HANDLER));
-                downcallVoid.invoke(stub);
-            }
-        }
-    }
-
-    public static class UncaughtHandlerThreadRunner extends VoidUpcallRunner {
-        public static void main(String[] args) throws Throwable {
-            Thread.currentThread().setUncaughtExceptionHandler(UNCAUGHT_EXCEPTION_HANDLER);
-            try (Arena arena = Arena.ofConfined()) {
-                MemorySegment stub = Linker.nativeLinker().upcallStub(VOID_TARGET, FunctionDescriptor.ofVoid(), arena);
-                downcallVoid.invoke(stub);
-            }
-        }
-    }
-
     // where
 
     private static class ExceptionRunnerBase {


### PR DESCRIPTION
Remove the uncaught exception handler linker option for now. It does not seem polished enough, and using the thread's uncaught exception handler seems problematic as well.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8303835](https://bugs.openjdk.org/browse/JDK-8303835): Remove uncaught exception handler linker option


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.org/census#mcimadamore) (@mcimadamore - Committer) ⚠️ Review applies to [8e820d7a](https://git.openjdk.org/panama-foreign/pull/813/files/8e820d7a5f26d8fd16e3122a7f7db39d2204fb06)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/panama-foreign pull/813/head:pull/813` \
`$ git checkout pull/813`

Update a local copy of the PR: \
`$ git checkout pull/813` \
`$ git pull https://git.openjdk.org/panama-foreign pull/813/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 813`

View PR using the GUI difftool: \
`$ git pr show -t 813`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/panama-foreign/pull/813.diff">https://git.openjdk.org/panama-foreign/pull/813.diff</a>

</details>
