### PR TITLE
8303879: Add MemoryLayout.withoutName()

### DIFF
--- a/src/java.base/share/classes/java/lang/foreign/AddressLayout.java
+++ b/src/java.base/share/classes/java/lang/foreign/AddressLayout.java
@@ -68,7 +68,7 @@ sealed public interface AddressLayout extends ValueLayout permits ValueLayouts.O
      * {@inheritDoc}
      */
     @Override
-    AddressLayout withNoName();
+    AddressLayout withoutName();
 
     /**
      * {@inheritDoc}

--- a/src/java.base/share/classes/java/lang/foreign/AddressLayout.java
+++ b/src/java.base/share/classes/java/lang/foreign/AddressLayout.java
@@ -68,6 +68,12 @@ sealed public interface AddressLayout extends ValueLayout permits ValueLayouts.O
      * {@inheritDoc}
      */
     @Override
+    AddressLayout withNoName();
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
     AddressLayout withBitAlignment(long bitAlignment);
 
     /**

--- a/src/java.base/share/classes/java/lang/foreign/GroupLayout.java
+++ b/src/java.base/share/classes/java/lang/foreign/GroupLayout.java
@@ -63,5 +63,11 @@ public sealed interface GroupLayout extends MemoryLayout permits StructLayout, U
      * {@inheritDoc}
      */
     @Override
+    GroupLayout withNoName();
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
     GroupLayout withBitAlignment(long bitAlignment);
 }

--- a/src/java.base/share/classes/java/lang/foreign/GroupLayout.java
+++ b/src/java.base/share/classes/java/lang/foreign/GroupLayout.java
@@ -63,7 +63,7 @@ public sealed interface GroupLayout extends MemoryLayout permits StructLayout, U
      * {@inheritDoc}
      */
     @Override
-    GroupLayout withNoName();
+    GroupLayout withoutName();
 
     /**
      * {@inheritDoc}

--- a/src/java.base/share/classes/java/lang/foreign/MemoryLayout.java
+++ b/src/java.base/share/classes/java/lang/foreign/MemoryLayout.java
@@ -202,6 +202,17 @@ public sealed interface MemoryLayout permits SequenceLayout, GroupLayout, Paddin
     MemoryLayout withName(String name);
 
     /**
+     * Returns a memory layout of the same type with the same size and alignment constraint as this layout,
+     * but with no name.
+     * <p>
+     * Nameless layouts can be checked for equality to see if they are otherwise equal.
+     *
+     * @return a memory layout with no name.
+     * @see MemoryLayout#name()
+     */
+    MemoryLayout withNoName();
+
+    /**
      * Returns the alignment constraint associated with this layout, expressed in bits. Layout alignment defines a power
      * of two {@code A} which is the bit-wise alignment of the layout. If {@code A <= 8} then {@code A/8} is the number of
      * bytes that must be aligned for any pointer that correctly points to this layout. Thus:

--- a/src/java.base/share/classes/java/lang/foreign/MemoryLayout.java
+++ b/src/java.base/share/classes/java/lang/foreign/MemoryLayout.java
@@ -28,7 +28,6 @@ package java.lang.foreign;
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.VarHandle;
-import java.nio.ByteOrder;
 import java.util.EnumSet;
 import java.util.Objects;
 import java.util.Optional;
@@ -45,7 +44,6 @@ import jdk.internal.foreign.layout.PaddingLayoutImpl;
 import jdk.internal.foreign.layout.SequenceLayoutImpl;
 import jdk.internal.foreign.layout.StructLayoutImpl;
 import jdk.internal.foreign.layout.UnionLayoutImpl;
-import jdk.internal.foreign.layout.ValueLayouts;
 import jdk.internal.javac.PreviewFeature;
 
 /**
@@ -203,14 +201,14 @@ public sealed interface MemoryLayout permits SequenceLayout, GroupLayout, Paddin
 
     /**
      * Returns a memory layout of the same type with the same size and alignment constraint as this layout,
-     * but with no name.
+     * but without a name.
      * <p>
      * Nameless layouts can be checked for equality to see if they are otherwise equal.
      *
-     * @return a memory layout with no name.
+     * @return a memory layout without a name.
      * @see MemoryLayout#name()
      */
-    MemoryLayout withNoName();
+    MemoryLayout withoutName();
 
     /**
      * Returns the alignment constraint associated with this layout, expressed in bits. Layout alignment defines a power

--- a/src/java.base/share/classes/java/lang/foreign/MemoryLayout.java
+++ b/src/java.base/share/classes/java/lang/foreign/MemoryLayout.java
@@ -203,7 +203,7 @@ public sealed interface MemoryLayout permits SequenceLayout, GroupLayout, Paddin
      * Returns a memory layout of the same type with the same size and alignment constraint as this layout,
      * but without a name.
      * <p>
-     * Nameless layouts can be checked for equality to see if they are otherwise equal.
+     * This can be useful to compare two layouts that have different names, but are otherwise equal.
      *
      * @return a memory layout without a name.
      * @see MemoryLayout#name()

--- a/src/java.base/share/classes/java/lang/foreign/PaddingLayout.java
+++ b/src/java.base/share/classes/java/lang/foreign/PaddingLayout.java
@@ -50,7 +50,7 @@ public sealed interface PaddingLayout extends MemoryLayout permits PaddingLayout
      * {@inheritDoc}
      */
     @Override
-    PaddingLayout withNoName();
+    PaddingLayout withoutName();
 
     /**
      * {@inheritDoc}

--- a/src/java.base/share/classes/java/lang/foreign/PaddingLayout.java
+++ b/src/java.base/share/classes/java/lang/foreign/PaddingLayout.java
@@ -50,5 +50,11 @@ public sealed interface PaddingLayout extends MemoryLayout permits PaddingLayout
      * {@inheritDoc}
      */
     @Override
+    PaddingLayout withNoName();
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
     PaddingLayout withBitAlignment(long bitAlignment);
 }

--- a/src/java.base/share/classes/java/lang/foreign/SequenceLayout.java
+++ b/src/java.base/share/classes/java/lang/foreign/SequenceLayout.java
@@ -128,9 +128,21 @@ public sealed interface SequenceLayout extends MemoryLayout permits SequenceLayo
      */
     SequenceLayout flatten();
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     SequenceLayout withName(String name);
 
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    MemoryLayout withNoName();
+
+    /**
+     * {@inheritDoc}
+     */
     @Override
     SequenceLayout withBitAlignment(long bitAlignment);
 }

--- a/src/java.base/share/classes/java/lang/foreign/SequenceLayout.java
+++ b/src/java.base/share/classes/java/lang/foreign/SequenceLayout.java
@@ -138,7 +138,7 @@ public sealed interface SequenceLayout extends MemoryLayout permits SequenceLayo
      * {@inheritDoc}
      */
     @Override
-    MemoryLayout withNoName();
+    MemoryLayout withoutName();
 
     /**
      * {@inheritDoc}

--- a/src/java.base/share/classes/java/lang/foreign/StructLayout.java
+++ b/src/java.base/share/classes/java/lang/foreign/StructLayout.java
@@ -39,9 +39,21 @@ import jdk.internal.javac.PreviewFeature;
 @PreviewFeature(feature=PreviewFeature.Feature.FOREIGN)
 public sealed interface StructLayout extends GroupLayout permits StructLayoutImpl {
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     StructLayout withName(String name);
 
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    StructLayout withNoName();
+
+    /**
+     * {@inheritDoc}
+     */
     @Override
     StructLayout withBitAlignment(long bitAlignment);
 }

--- a/src/java.base/share/classes/java/lang/foreign/StructLayout.java
+++ b/src/java.base/share/classes/java/lang/foreign/StructLayout.java
@@ -49,7 +49,7 @@ public sealed interface StructLayout extends GroupLayout permits StructLayoutImp
      * {@inheritDoc}
      */
     @Override
-    StructLayout withNoName();
+    StructLayout withoutName();
 
     /**
      * {@inheritDoc}

--- a/src/java.base/share/classes/java/lang/foreign/UnionLayout.java
+++ b/src/java.base/share/classes/java/lang/foreign/UnionLayout.java
@@ -49,5 +49,11 @@ public sealed interface UnionLayout extends GroupLayout permits UnionLayoutImpl 
      * {@inheritDoc}
      */
     @Override
+    UnionLayout withNoName();
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
     UnionLayout withBitAlignment(long bitAlignment);
 }

--- a/src/java.base/share/classes/java/lang/foreign/UnionLayout.java
+++ b/src/java.base/share/classes/java/lang/foreign/UnionLayout.java
@@ -49,7 +49,7 @@ public sealed interface UnionLayout extends GroupLayout permits UnionLayoutImpl 
      * {@inheritDoc}
      */
     @Override
-    UnionLayout withNoName();
+    UnionLayout withoutName();
 
     /**
      * {@inheritDoc}

--- a/src/java.base/share/classes/java/lang/foreign/ValueLayout.java
+++ b/src/java.base/share/classes/java/lang/foreign/ValueLayout.java
@@ -167,6 +167,12 @@ public sealed interface ValueLayout extends MemoryLayout permits
          * {@inheritDoc}
          */
         @Override
+        OfBoolean withNoName();
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
         OfBoolean withBitAlignment(long bitAlignment);
 
         /**
@@ -191,6 +197,12 @@ public sealed interface ValueLayout extends MemoryLayout permits
          */
         @Override
         OfByte withName(String name);
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        OfByte withNoName();
 
         /**
          * {@inheritDoc}
@@ -226,6 +238,12 @@ public sealed interface ValueLayout extends MemoryLayout permits
          * {@inheritDoc}
          */
         @Override
+        OfChar withNoName();
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
         OfChar withBitAlignment(long bitAlignment);
 
         /**
@@ -251,6 +269,12 @@ public sealed interface ValueLayout extends MemoryLayout permits
          */
         @Override
         OfShort withName(String name);
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        OfShort withNoName();
 
         /**
          * {@inheritDoc}
@@ -286,6 +310,12 @@ public sealed interface ValueLayout extends MemoryLayout permits
          * {@inheritDoc}
          */
         @Override
+        OfInt withNoName();
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
         OfInt withBitAlignment(long bitAlignment);
 
         /**
@@ -311,6 +341,12 @@ public sealed interface ValueLayout extends MemoryLayout permits
          */
         @Override
         OfFloat withName(String name);
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        OfFloat withNoName();
 
         /**
          * {@inheritDoc}
@@ -346,6 +382,12 @@ public sealed interface ValueLayout extends MemoryLayout permits
          * {@inheritDoc}
          */
         @Override
+        OfLong withNoName();
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
         OfLong withBitAlignment(long bitAlignment);
 
         /**
@@ -376,6 +418,12 @@ public sealed interface ValueLayout extends MemoryLayout permits
          * {@inheritDoc}
          */
         @Override
+        OfDouble withNoName();
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
         OfDouble withBitAlignment(long bitAlignment);
 
         /**
@@ -387,61 +435,61 @@ public sealed interface ValueLayout extends MemoryLayout permits
     }
 
     /**
-     * A value layout constant whose size is the same as that of a machine address ({@code size_t}),
+     * A nameless value layout constant whose size is the same as that of a machine address ({@code size_t}),
      * bit alignment set to {@code sizeof(size_t) * 8}, byte order set to {@link ByteOrder#nativeOrder()}.
      */
     AddressLayout ADDRESS = ValueLayouts.OfAddressImpl.of(ByteOrder.nativeOrder());
 
     /**
-     * A value layout constant whose size is the same as that of a Java {@code byte},
+     * A nameless value layout constant whose size is the same as that of a Java {@code byte},
      * bit alignment set to 8, and byte order set to {@link ByteOrder#nativeOrder()}.
      */
     OfByte JAVA_BYTE = ValueLayouts.OfByteImpl.of(ByteOrder.nativeOrder());
 
     /**
-     * A value layout constant whose size is the same as that of a Java {@code boolean},
+     * A nameless value layout constant whose size is the same as that of a Java {@code boolean},
      * bit alignment set to 8, and byte order set to {@link ByteOrder#nativeOrder()}.
      */
     OfBoolean JAVA_BOOLEAN = ValueLayouts.OfBooleanImpl.of(ByteOrder.nativeOrder());
 
     /**
-     * A value layout constant whose size is the same as that of a Java {@code char},
+     * A nameless value layout constant whose size is the same as that of a Java {@code char},
      * bit alignment set to 16, and byte order set to {@link ByteOrder#nativeOrder()}.
      */
     OfChar JAVA_CHAR = ValueLayouts.OfCharImpl.of(ByteOrder.nativeOrder());
 
     /**
-     * A value layout constant whose size is the same as that of a Java {@code short},
+     * A nameless value layout constant whose size is the same as that of a Java {@code short},
      * bit alignment set to 16, and byte order set to {@link ByteOrder#nativeOrder()}.
      */
     OfShort JAVA_SHORT = ValueLayouts.OfShortImpl.of(ByteOrder.nativeOrder());
 
     /**
-     * A value layout constant whose size is the same as that of a Java {@code int},
+     * A nameless value layout constant whose size is the same as that of a Java {@code int},
      * bit alignment set to 32, and byte order set to {@link ByteOrder#nativeOrder()}.
      */
     OfInt JAVA_INT = ValueLayouts.OfIntImpl.of(ByteOrder.nativeOrder());
 
     /**
-     * A value layout constant whose size is the same as that of a Java {@code long},
+     * A nameless value layout constant whose size is the same as that of a Java {@code long},
      * bit alignment set to 64, and byte order set to {@link ByteOrder#nativeOrder()}.
      */
     OfLong JAVA_LONG = ValueLayouts.OfLongImpl.of(ByteOrder.nativeOrder());
 
     /**
-     * A value layout constant whose size is the same as that of a Java {@code float},
+     * A nameless value layout constant whose size is the same as that of a Java {@code float},
      * bit alignment set to 32, and byte order set to {@link ByteOrder#nativeOrder()}.
      */
     OfFloat JAVA_FLOAT = ValueLayouts.OfFloatImpl.of(ByteOrder.nativeOrder());
 
     /**
-     * A value layout constant whose size is the same as that of a Java {@code double},
+     * A nameless value layout constant whose size is the same as that of a Java {@code double},
      * bit alignment set to 64, and byte order set to {@link ByteOrder#nativeOrder()}.
      */
     OfDouble JAVA_DOUBLE = ValueLayouts.OfDoubleImpl.of(ByteOrder.nativeOrder());
 
     /**
-     * An unaligned value layout constant whose size is the same as that of a machine address ({@code size_t}),
+     * A nameless unaligned value layout constant whose size is the same as that of a machine address ({@code size_t}),
      * and byte order set to {@link ByteOrder#nativeOrder()}.
      * Equivalent to the following code:
      * {@snippet lang=java :
@@ -453,7 +501,7 @@ public sealed interface ValueLayout extends MemoryLayout permits
     AddressLayout ADDRESS_UNALIGNED = ADDRESS.withBitAlignment(8);
 
     /**
-     * An unaligned value layout constant whose size is the same as that of a Java {@code char}
+     * A nameless unaligned value layout constant whose size is the same as that of a Java {@code char}
      * and byte order set to {@link ByteOrder#nativeOrder()}.
      * Equivalent to the following code:
      * {@snippet lang=java :
@@ -465,7 +513,7 @@ public sealed interface ValueLayout extends MemoryLayout permits
     OfChar JAVA_CHAR_UNALIGNED = JAVA_CHAR.withBitAlignment(8);
 
     /**
-     * An unaligned value layout constant whose size is the same as that of a Java {@code short}
+     * A nameless unaligned value layout constant whose size is the same as that of a Java {@code short}
      * and byte order set to {@link ByteOrder#nativeOrder()}.
      * Equivalent to the following code:
      * {@snippet lang=java :
@@ -477,7 +525,7 @@ public sealed interface ValueLayout extends MemoryLayout permits
     OfShort JAVA_SHORT_UNALIGNED = JAVA_SHORT.withBitAlignment(8);
 
     /**
-     * An unaligned value layout constant whose size is the same as that of a Java {@code int}
+     * A nameless unaligned value layout constant whose size is the same as that of a Java {@code int}
      * and byte order set to {@link ByteOrder#nativeOrder()}.
      * Equivalent to the following code:
      * {@snippet lang=java :
@@ -489,7 +537,7 @@ public sealed interface ValueLayout extends MemoryLayout permits
     OfInt JAVA_INT_UNALIGNED = JAVA_INT.withBitAlignment(8);
 
     /**
-     * An unaligned value layout constant whose size is the same as that of a Java {@code long}
+     * A nameless unaligned value layout constant whose size is the same as that of a Java {@code long}
      * and byte order set to {@link ByteOrder#nativeOrder()}.
      * Equivalent to the following code:
      * {@snippet lang=java :
@@ -501,7 +549,7 @@ public sealed interface ValueLayout extends MemoryLayout permits
     OfLong JAVA_LONG_UNALIGNED = JAVA_LONG.withBitAlignment(8);
 
     /**
-     * An unaligned value layout constant whose size is the same as that of a Java {@code float}
+     * A nameless unaligned value layout constant whose size is the same as that of a Java {@code float}
      * and byte order set to {@link ByteOrder#nativeOrder()}.
      * Equivalent to the following code:
      * {@snippet lang=java :
@@ -513,7 +561,7 @@ public sealed interface ValueLayout extends MemoryLayout permits
     OfFloat JAVA_FLOAT_UNALIGNED = JAVA_FLOAT.withBitAlignment(8);
 
     /**
-     * An unaligned value layout constant whose size is the same as that of a Java {@code double}
+     * A nameless unaligned value layout constant whose size is the same as that of a Java {@code double}
      * and byte order set to {@link ByteOrder#nativeOrder()}.
      * Equivalent to the following code:
      * {@snippet lang=java :

--- a/src/java.base/share/classes/java/lang/foreign/ValueLayout.java
+++ b/src/java.base/share/classes/java/lang/foreign/ValueLayout.java
@@ -167,7 +167,7 @@ public sealed interface ValueLayout extends MemoryLayout permits
          * {@inheritDoc}
          */
         @Override
-        OfBoolean withNoName();
+        OfBoolean withoutName();
 
         /**
          * {@inheritDoc}
@@ -202,7 +202,7 @@ public sealed interface ValueLayout extends MemoryLayout permits
          * {@inheritDoc}
          */
         @Override
-        OfByte withNoName();
+        OfByte withoutName();
 
         /**
          * {@inheritDoc}
@@ -238,7 +238,7 @@ public sealed interface ValueLayout extends MemoryLayout permits
          * {@inheritDoc}
          */
         @Override
-        OfChar withNoName();
+        OfChar withoutName();
 
         /**
          * {@inheritDoc}
@@ -274,7 +274,7 @@ public sealed interface ValueLayout extends MemoryLayout permits
          * {@inheritDoc}
          */
         @Override
-        OfShort withNoName();
+        OfShort withoutName();
 
         /**
          * {@inheritDoc}
@@ -310,7 +310,7 @@ public sealed interface ValueLayout extends MemoryLayout permits
          * {@inheritDoc}
          */
         @Override
-        OfInt withNoName();
+        OfInt withoutName();
 
         /**
          * {@inheritDoc}
@@ -346,7 +346,7 @@ public sealed interface ValueLayout extends MemoryLayout permits
          * {@inheritDoc}
          */
         @Override
-        OfFloat withNoName();
+        OfFloat withoutName();
 
         /**
          * {@inheritDoc}
@@ -382,7 +382,7 @@ public sealed interface ValueLayout extends MemoryLayout permits
          * {@inheritDoc}
          */
         @Override
-        OfLong withNoName();
+        OfLong withoutName();
 
         /**
          * {@inheritDoc}
@@ -418,7 +418,7 @@ public sealed interface ValueLayout extends MemoryLayout permits
          * {@inheritDoc}
          */
         @Override
-        OfDouble withNoName();
+        OfDouble withoutName();
 
         /**
          * {@inheritDoc}

--- a/src/java.base/share/classes/java/lang/foreign/ValueLayout.java
+++ b/src/java.base/share/classes/java/lang/foreign/ValueLayout.java
@@ -435,61 +435,61 @@ public sealed interface ValueLayout extends MemoryLayout permits
     }
 
     /**
-     * A nameless value layout constant whose size is the same as that of a machine address ({@code size_t}),
+     * A value layout constant whose size is the same as that of a machine address ({@code size_t}),
      * bit alignment set to {@code sizeof(size_t) * 8}, byte order set to {@link ByteOrder#nativeOrder()}.
      */
     AddressLayout ADDRESS = ValueLayouts.OfAddressImpl.of(ByteOrder.nativeOrder());
 
     /**
-     * A nameless value layout constant whose size is the same as that of a Java {@code byte},
+     * A value layout constant whose size is the same as that of a Java {@code byte},
      * bit alignment set to 8, and byte order set to {@link ByteOrder#nativeOrder()}.
      */
     OfByte JAVA_BYTE = ValueLayouts.OfByteImpl.of(ByteOrder.nativeOrder());
 
     /**
-     * A nameless value layout constant whose size is the same as that of a Java {@code boolean},
+     * A value layout constant whose size is the same as that of a Java {@code boolean},
      * bit alignment set to 8, and byte order set to {@link ByteOrder#nativeOrder()}.
      */
     OfBoolean JAVA_BOOLEAN = ValueLayouts.OfBooleanImpl.of(ByteOrder.nativeOrder());
 
     /**
-     * A nameless value layout constant whose size is the same as that of a Java {@code char},
+     * A value layout constant whose size is the same as that of a Java {@code char},
      * bit alignment set to 16, and byte order set to {@link ByteOrder#nativeOrder()}.
      */
     OfChar JAVA_CHAR = ValueLayouts.OfCharImpl.of(ByteOrder.nativeOrder());
 
     /**
-     * A nameless value layout constant whose size is the same as that of a Java {@code short},
+     * A value layout constant whose size is the same as that of a Java {@code short},
      * bit alignment set to 16, and byte order set to {@link ByteOrder#nativeOrder()}.
      */
     OfShort JAVA_SHORT = ValueLayouts.OfShortImpl.of(ByteOrder.nativeOrder());
 
     /**
-     * A nameless value layout constant whose size is the same as that of a Java {@code int},
+     * A value layout constant whose size is the same as that of a Java {@code int},
      * bit alignment set to 32, and byte order set to {@link ByteOrder#nativeOrder()}.
      */
     OfInt JAVA_INT = ValueLayouts.OfIntImpl.of(ByteOrder.nativeOrder());
 
     /**
-     * A nameless value layout constant whose size is the same as that of a Java {@code long},
+     * A value layout constant whose size is the same as that of a Java {@code long},
      * bit alignment set to 64, and byte order set to {@link ByteOrder#nativeOrder()}.
      */
     OfLong JAVA_LONG = ValueLayouts.OfLongImpl.of(ByteOrder.nativeOrder());
 
     /**
-     * A nameless value layout constant whose size is the same as that of a Java {@code float},
+     * A value layout constant whose size is the same as that of a Java {@code float},
      * bit alignment set to 32, and byte order set to {@link ByteOrder#nativeOrder()}.
      */
     OfFloat JAVA_FLOAT = ValueLayouts.OfFloatImpl.of(ByteOrder.nativeOrder());
 
     /**
-     * A nameless value layout constant whose size is the same as that of a Java {@code double},
+     * A value layout constant whose size is the same as that of a Java {@code double},
      * bit alignment set to 64, and byte order set to {@link ByteOrder#nativeOrder()}.
      */
     OfDouble JAVA_DOUBLE = ValueLayouts.OfDoubleImpl.of(ByteOrder.nativeOrder());
 
     /**
-     * A nameless unaligned value layout constant whose size is the same as that of a machine address ({@code size_t}),
+     * An unaligned value layout constant whose size is the same as that of a machine address ({@code size_t}),
      * and byte order set to {@link ByteOrder#nativeOrder()}.
      * Equivalent to the following code:
      * {@snippet lang=java :
@@ -501,7 +501,7 @@ public sealed interface ValueLayout extends MemoryLayout permits
     AddressLayout ADDRESS_UNALIGNED = ADDRESS.withBitAlignment(8);
 
     /**
-     * A nameless unaligned value layout constant whose size is the same as that of a Java {@code char}
+     * An unaligned value layout constant whose size is the same as that of a Java {@code char}
      * and byte order set to {@link ByteOrder#nativeOrder()}.
      * Equivalent to the following code:
      * {@snippet lang=java :
@@ -513,7 +513,7 @@ public sealed interface ValueLayout extends MemoryLayout permits
     OfChar JAVA_CHAR_UNALIGNED = JAVA_CHAR.withBitAlignment(8);
 
     /**
-     * A nameless unaligned value layout constant whose size is the same as that of a Java {@code short}
+     * An unaligned value layout constant whose size is the same as that of a Java {@code short}
      * and byte order set to {@link ByteOrder#nativeOrder()}.
      * Equivalent to the following code:
      * {@snippet lang=java :
@@ -525,7 +525,7 @@ public sealed interface ValueLayout extends MemoryLayout permits
     OfShort JAVA_SHORT_UNALIGNED = JAVA_SHORT.withBitAlignment(8);
 
     /**
-     * A nameless unaligned value layout constant whose size is the same as that of a Java {@code int}
+     * An unaligned value layout constant whose size is the same as that of a Java {@code int}
      * and byte order set to {@link ByteOrder#nativeOrder()}.
      * Equivalent to the following code:
      * {@snippet lang=java :
@@ -537,7 +537,7 @@ public sealed interface ValueLayout extends MemoryLayout permits
     OfInt JAVA_INT_UNALIGNED = JAVA_INT.withBitAlignment(8);
 
     /**
-     * A nameless unaligned value layout constant whose size is the same as that of a Java {@code long}
+     * An unaligned value layout constant whose size is the same as that of a Java {@code long}
      * and byte order set to {@link ByteOrder#nativeOrder()}.
      * Equivalent to the following code:
      * {@snippet lang=java :
@@ -549,7 +549,7 @@ public sealed interface ValueLayout extends MemoryLayout permits
     OfLong JAVA_LONG_UNALIGNED = JAVA_LONG.withBitAlignment(8);
 
     /**
-     * A nameless unaligned value layout constant whose size is the same as that of a Java {@code float}
+     * An unaligned value layout constant whose size is the same as that of a Java {@code float}
      * and byte order set to {@link ByteOrder#nativeOrder()}.
      * Equivalent to the following code:
      * {@snippet lang=java :
@@ -561,7 +561,7 @@ public sealed interface ValueLayout extends MemoryLayout permits
     OfFloat JAVA_FLOAT_UNALIGNED = JAVA_FLOAT.withBitAlignment(8);
 
     /**
-     * A nameless unaligned value layout constant whose size is the same as that of a Java {@code double}
+     * An unaligned value layout constant whose size is the same as that of a Java {@code double}
      * and byte order set to {@link ByteOrder#nativeOrder()}.
      * Equivalent to the following code:
      * {@snippet lang=java :

--- a/src/java.base/share/classes/jdk/internal/foreign/layout/AbstractLayout.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/layout/AbstractLayout.java
@@ -51,6 +51,10 @@ public abstract sealed class AbstractLayout<L extends AbstractLayout<L> & Memory
         return dup(bitAlignment(), Optional.of(name));
     }
 
+    public final L withNoName() {
+        return dup(bitAlignment(), Optional.empty());
+    }
+
     public final Optional<String> name() {
         return name;
     }

--- a/src/java.base/share/classes/jdk/internal/foreign/layout/AbstractLayout.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/layout/AbstractLayout.java
@@ -51,7 +51,7 @@ public abstract sealed class AbstractLayout<L extends AbstractLayout<L> & Memory
         return dup(bitAlignment(), Optional.of(name));
     }
 
-    public final L withNoName() {
+    public final L withoutName() {
         return dup(bitAlignment(), Optional.empty());
     }
 

--- a/test/jdk/java/foreign/MemoryLayoutTypeRetentionTest.java
+++ b/test/jdk/java/foreign/MemoryLayoutTypeRetentionTest.java
@@ -50,7 +50,7 @@ public class MemoryLayoutTypeRetentionTest {
     public void testOfBoolean() {
         OfBoolean v = JAVA_BOOLEAN
                 .withBitAlignment(BIT_ALIGNMENT)
-                .withNoName()
+                .withoutName()
                 .withName(NAME)
                 .withOrder(BYTE_ORDER);
         check(v);
@@ -60,7 +60,7 @@ public class MemoryLayoutTypeRetentionTest {
     public void testOfByte() {
         OfByte v = JAVA_BYTE
                 .withBitAlignment(BIT_ALIGNMENT)
-                .withNoName()
+                .withoutName()
                 .withName(NAME)
                 .withOrder(BYTE_ORDER);
         check(v);
@@ -70,7 +70,7 @@ public class MemoryLayoutTypeRetentionTest {
     public void testOfShort() {
         OfShort v = JAVA_SHORT
                 .withBitAlignment(BIT_ALIGNMENT)
-                .withNoName()
+                .withoutName()
                 .withName(NAME)
                 .withOrder(BYTE_ORDER);
         check(v);
@@ -80,7 +80,7 @@ public class MemoryLayoutTypeRetentionTest {
     public void testOfInt() {
         OfInt v = JAVA_INT
                 .withBitAlignment(BIT_ALIGNMENT)
-                .withNoName()
+                .withoutName()
                 .withName(NAME)
                 .withOrder(BYTE_ORDER);
         check(v);
@@ -90,7 +90,7 @@ public class MemoryLayoutTypeRetentionTest {
     public void testOfChar() {
         OfChar v = JAVA_CHAR
                 .withBitAlignment(BIT_ALIGNMENT)
-                .withNoName()
+                .withoutName()
                 .withName(NAME)
                 .withOrder(BYTE_ORDER);
         check(v);
@@ -100,7 +100,7 @@ public class MemoryLayoutTypeRetentionTest {
     public void testOfLong() {
         OfLong v = JAVA_LONG
                 .withBitAlignment(BIT_ALIGNMENT)
-                .withNoName()
+                .withoutName()
                 .withName(NAME)
                 .withOrder(BYTE_ORDER);
         check(v);
@@ -110,7 +110,7 @@ public class MemoryLayoutTypeRetentionTest {
     public void testOfFloat() {
         OfFloat v = JAVA_FLOAT
                 .withBitAlignment(BIT_ALIGNMENT)
-                .withNoName()
+                .withoutName()
                 .withName(NAME)
                 .withOrder(BYTE_ORDER);
         check(v);
@@ -120,7 +120,7 @@ public class MemoryLayoutTypeRetentionTest {
     public void testOfDouble() {
         OfDouble v = JAVA_DOUBLE
                 .withBitAlignment(BIT_ALIGNMENT)
-                .withNoName()
+                .withoutName()
                 .withName(NAME)
                 .withOrder(BYTE_ORDER);
         check(v);
@@ -130,7 +130,7 @@ public class MemoryLayoutTypeRetentionTest {
     public void testAddressLayout() {
         AddressLayout v = ADDRESS
                 .withBitAlignment(BIT_ALIGNMENT)
-                .withNoName()
+                .withoutName()
                 .withName(NAME)
                 .withOrder(BYTE_ORDER);
         check(v);
@@ -146,7 +146,7 @@ public class MemoryLayoutTypeRetentionTest {
     public void testPaddingLayout() {
         PaddingLayout v = MemoryLayout.paddingLayout(8)
                 .withBitAlignment(BIT_ALIGNMENT)
-                .withNoName()
+                .withoutName()
                 .withName(NAME);
         check(v);
     }
@@ -155,7 +155,7 @@ public class MemoryLayoutTypeRetentionTest {
     public void testGroupLayout() {
         GroupLayout v = MemoryLayout.structLayout(JAVA_INT, JAVA_LONG)
                 .withBitAlignment(BIT_ALIGNMENT)
-                .withNoName()
+                .withoutName()
                 .withName(NAME);
         check(v);
     }
@@ -164,7 +164,7 @@ public class MemoryLayoutTypeRetentionTest {
     public void testStructLayout() {
         StructLayout v = MemoryLayout.structLayout(JAVA_INT, JAVA_LONG)
                 .withBitAlignment(BIT_ALIGNMENT)
-                .withNoName()
+                .withoutName()
                 .withName(NAME);
         check(v);
     }
@@ -173,7 +173,7 @@ public class MemoryLayoutTypeRetentionTest {
     public void testUnionLayout() {
         UnionLayout v = MemoryLayout.unionLayout(JAVA_INT, JAVA_LONG)
                 .withBitAlignment(BIT_ALIGNMENT)
-                .withNoName()
+                .withoutName()
                 .withName(NAME);
         check(v);
     }
@@ -186,7 +186,7 @@ public class MemoryLayoutTypeRetentionTest {
     public void check(MemoryLayout v) {
         // Check name properties
         assertEquals(v.name().orElseThrow(), NAME);
-        assertTrue(v.withNoName().name().isEmpty());
+        assertTrue(v.withoutName().name().isEmpty());
 
         assertEquals(v.bitAlignment(), BIT_ALIGNMENT);
         assertEquals(v.byteSize() * 8, v.bitSize());

--- a/test/jdk/java/foreign/MemoryLayoutTypeRetentionTest.java
+++ b/test/jdk/java/foreign/MemoryLayoutTypeRetentionTest.java
@@ -41,13 +41,16 @@ public class MemoryLayoutTypeRetentionTest {
     // withName() et al. should return the same type as the original object.
 
     private static final String NAME = "a";
-    private static final long BIT_ALIGNMENT = 64;
-    private static final ByteOrder BYTE_ORDER = ByteOrder.LITTLE_ENDIAN;
+    private static final long BIT_ALIGNMENT = Long.SIZE * 2;
+    private static final ByteOrder BYTE_ORDER = ByteOrder.nativeOrder() == ByteOrder.BIG_ENDIAN
+            ? ByteOrder.LITTLE_ENDIAN
+            : ByteOrder.BIG_ENDIAN;
 
     @Test
     public void testOfBoolean() {
         OfBoolean v = JAVA_BOOLEAN
                 .withBitAlignment(BIT_ALIGNMENT)
+                .withNoName()
                 .withName(NAME)
                 .withOrder(BYTE_ORDER);
         check(v);
@@ -57,6 +60,7 @@ public class MemoryLayoutTypeRetentionTest {
     public void testOfByte() {
         OfByte v = JAVA_BYTE
                 .withBitAlignment(BIT_ALIGNMENT)
+                .withNoName()
                 .withName(NAME)
                 .withOrder(BYTE_ORDER);
         check(v);
@@ -66,6 +70,7 @@ public class MemoryLayoutTypeRetentionTest {
     public void testOfShort() {
         OfShort v = JAVA_SHORT
                 .withBitAlignment(BIT_ALIGNMENT)
+                .withNoName()
                 .withName(NAME)
                 .withOrder(BYTE_ORDER);
         check(v);
@@ -75,6 +80,7 @@ public class MemoryLayoutTypeRetentionTest {
     public void testOfInt() {
         OfInt v = JAVA_INT
                 .withBitAlignment(BIT_ALIGNMENT)
+                .withNoName()
                 .withName(NAME)
                 .withOrder(BYTE_ORDER);
         check(v);
@@ -84,6 +90,7 @@ public class MemoryLayoutTypeRetentionTest {
     public void testOfChar() {
         OfChar v = JAVA_CHAR
                 .withBitAlignment(BIT_ALIGNMENT)
+                .withNoName()
                 .withName(NAME)
                 .withOrder(BYTE_ORDER);
         check(v);
@@ -93,6 +100,7 @@ public class MemoryLayoutTypeRetentionTest {
     public void testOfLong() {
         OfLong v = JAVA_LONG
                 .withBitAlignment(BIT_ALIGNMENT)
+                .withNoName()
                 .withName(NAME)
                 .withOrder(BYTE_ORDER);
         check(v);
@@ -102,6 +110,7 @@ public class MemoryLayoutTypeRetentionTest {
     public void testOfFloat() {
         OfFloat v = JAVA_FLOAT
                 .withBitAlignment(BIT_ALIGNMENT)
+                .withNoName()
                 .withName(NAME)
                 .withOrder(BYTE_ORDER);
         check(v);
@@ -111,18 +120,22 @@ public class MemoryLayoutTypeRetentionTest {
     public void testOfDouble() {
         OfDouble v = JAVA_DOUBLE
                 .withBitAlignment(BIT_ALIGNMENT)
+                .withNoName()
                 .withName(NAME)
                 .withOrder(BYTE_ORDER);
         check(v);
     }
 
     @Test
-    public void testOfAddress() {
+    public void testAddressLayout() {
         AddressLayout v = ADDRESS
                 .withBitAlignment(BIT_ALIGNMENT)
+                .withNoName()
                 .withName(NAME)
                 .withOrder(BYTE_ORDER);
         check(v);
+        assertEquals(v.order(), BYTE_ORDER);
+
         assertFalse(v.targetLayout().isPresent());
         AddressLayout v2 = v.withTargetLayout(JAVA_INT);
         assertTrue(v2.targetLayout().isPresent());
@@ -133,6 +146,7 @@ public class MemoryLayoutTypeRetentionTest {
     public void testPaddingLayout() {
         PaddingLayout v = MemoryLayout.paddingLayout(8)
                 .withBitAlignment(BIT_ALIGNMENT)
+                .withNoName()
                 .withName(NAME);
         check(v);
     }
@@ -141,6 +155,7 @@ public class MemoryLayoutTypeRetentionTest {
     public void testGroupLayout() {
         GroupLayout v = MemoryLayout.structLayout(JAVA_INT, JAVA_LONG)
                 .withBitAlignment(BIT_ALIGNMENT)
+                .withNoName()
                 .withName(NAME);
         check(v);
     }
@@ -149,6 +164,7 @@ public class MemoryLayoutTypeRetentionTest {
     public void testStructLayout() {
         StructLayout v = MemoryLayout.structLayout(JAVA_INT, JAVA_LONG)
                 .withBitAlignment(BIT_ALIGNMENT)
+                .withNoName()
                 .withName(NAME);
         check(v);
     }
@@ -157,6 +173,7 @@ public class MemoryLayoutTypeRetentionTest {
     public void testUnionLayout() {
         UnionLayout v = MemoryLayout.unionLayout(JAVA_INT, JAVA_LONG)
                 .withBitAlignment(BIT_ALIGNMENT)
+                .withNoName()
                 .withName(NAME);
         check(v);
     }
@@ -165,9 +182,17 @@ public class MemoryLayoutTypeRetentionTest {
         check((MemoryLayout) v);
         assertEquals(v.order(), BYTE_ORDER);
     }
-
     public void check(MemoryLayout v) {
-        assertEquals(v.name().orElseThrow(), NAME);
+        check(v, false);
+        check(v.withNoName(), true);
+    }
+
+    private void check(MemoryLayout v, boolean nameless) {
+        if (nameless) {
+            assertTrue(v.name().isEmpty());
+        } else {
+            assertEquals(v.name().orElseThrow(), NAME);
+        }
         assertEquals(v.bitAlignment(), BIT_ALIGNMENT);
         assertEquals(v.byteSize() * 8, v.bitSize());
     }

--- a/test/jdk/java/foreign/MemoryLayoutTypeRetentionTest.java
+++ b/test/jdk/java/foreign/MemoryLayoutTypeRetentionTest.java
@@ -182,17 +182,12 @@ public class MemoryLayoutTypeRetentionTest {
         check((MemoryLayout) v);
         assertEquals(v.order(), BYTE_ORDER);
     }
-    public void check(MemoryLayout v) {
-        check(v, false);
-        check(v.withNoName(), true);
-    }
 
-    private void check(MemoryLayout v, boolean nameless) {
-        if (nameless) {
-            assertTrue(v.name().isEmpty());
-        } else {
-            assertEquals(v.name().orElseThrow(), NAME);
-        }
+    public void check(MemoryLayout v) {
+        // Check name properties
+        assertEquals(v.name().orElseThrow(), NAME);
+        assertTrue(v.withNoName().name().isEmpty());
+
         assertEquals(v.bitAlignment(), BIT_ALIGNMENT);
         assertEquals(v.byteSize() * 8, v.bitSize());
     }


### PR DESCRIPTION
This PR proposes to add a method `MemoryLayout::withoutName` which allows `MemoryLayout` instances to be checked for functional equivalence (i.e. "everything except the name is the same"). This might be useful for reuse, caching etc. of MemoryLayouts and constructs that consists/depends on one or more `MemoryLayout` instance.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8303879](https://bugs.openjdk.org/browse/JDK-8303879): Add MemoryLayout.withoutName()


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.org/census#mcimadamore) (@mcimadamore - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/panama-foreign pull/814/head:pull/814` \
`$ git checkout pull/814`

Update a local copy of the PR: \
`$ git checkout pull/814` \
`$ git pull https://git.openjdk.org/panama-foreign pull/814/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 814`

View PR using the GUI difftool: \
`$ git pr show -t 814`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/panama-foreign/pull/814.diff">https://git.openjdk.org/panama-foreign/pull/814.diff</a>

</details>
