### PR TITLE
8303888: Add AddressLayout.withoutTargetLayout

### DIFF
--- a/src/java.base/share/classes/java/lang/foreign/AddressLayout.java
+++ b/src/java.base/share/classes/java/lang/foreign/AddressLayout.java
@@ -106,6 +106,15 @@ sealed public interface AddressLayout extends ValueLayout permits ValueLayouts.O
     AddressLayout withTargetLayout(MemoryLayout layout);
 
     /**
+     * Returns an address layout with the same carrier, alignment constraint, name and order as this address layout,
+     * but without any specified target layout. Thus, the returned address is a raw address.
+     *
+     * @return an address layout with same characteristics as this layout, but with no target layout.
+     * @see #targetLayout()
+     */
+    AddressLayout withoutTargetLayout();
+
+    /**
      * {@return the target layout associated with this address layout (if any)}.
      */
     Optional<MemoryLayout> targetLayout();

--- a/src/java.base/share/classes/java/lang/foreign/AddressLayout.java
+++ b/src/java.base/share/classes/java/lang/foreign/AddressLayout.java
@@ -107,7 +107,9 @@ sealed public interface AddressLayout extends ValueLayout permits ValueLayouts.O
 
     /**
      * Returns an address layout with the same carrier, alignment constraint, name and order as this address layout,
-     * but without any specified target layout. Thus, the returned address is a raw address.
+     * but without any specified target layout.
+     * <p>
+     * This can be useful to compare two address layouts that have different target layouts, but are otherwise equal.
      *
      * @return an address layout with same characteristics as this layout, but with no target layout.
      * @see #targetLayout()

--- a/src/java.base/share/classes/jdk/internal/foreign/layout/ValueLayouts.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/layout/ValueLayouts.java
@@ -350,6 +350,11 @@ public final class ValueLayouts {
         }
 
         @Override
+        public AddressLayout withoutTargetLayout() {
+            return new OfAddressImpl(order(), bitSize(), bitAlignment(), null, name());
+        }
+
+        @Override
         public Optional<MemoryLayout> targetLayout() {
             return Optional.ofNullable(targetLayout);
         }

--- a/test/jdk/java/foreign/MemoryLayoutTypeRetentionTest.java
+++ b/test/jdk/java/foreign/MemoryLayoutTypeRetentionTest.java
@@ -121,12 +121,14 @@ public class MemoryLayoutTypeRetentionTest {
         AddressLayout v = ADDRESS
                 .withBitAlignment(BIT_ALIGNMENT)
                 .withName(NAME)
+                .withoutTargetLayout()
                 .withOrder(BYTE_ORDER);
         check(v);
         assertFalse(v.targetLayout().isPresent());
         AddressLayout v2 = v.withTargetLayout(JAVA_INT);
         assertTrue(v2.targetLayout().isPresent());
         assertEquals(v2.targetLayout().get(), JAVA_INT);
+        assertTrue(v2.withoutTargetLayout().targetLayout().isEmpty());
     }
 
     @Test


### PR DESCRIPTION
This PR proposes to add a `AddressLayout.withoutTargetLayout()` method for symmetry reasons. This allows  AddressLayout to be converted back to raw addresses.

Discussion point: Should this method require native access?

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8303888](https://bugs.openjdk.org/browse/JDK-8303888): Add AddressLayout.withoutTargetLayout


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.org/census#mcimadamore) (@mcimadamore - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/panama-foreign pull/815/head:pull/815` \
`$ git checkout pull/815`

Update a local copy of the PR: \
`$ git checkout pull/815` \
`$ git pull https://git.openjdk.org/panama-foreign pull/815/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 815`

View PR using the GUI difftool: \
`$ git pr show -t 815`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/panama-foreign/pull/815.diff">https://git.openjdk.org/panama-foreign/pull/815.diff</a>

</details>
