### PR TITLE
Fix override in ValueLayout

### DIFF
--- a/src/java.base/share/classes/java/lang/foreign/ValueLayout.java
+++ b/src/java.base/share/classes/java/lang/foreign/ValueLayout.java
@@ -71,6 +71,12 @@ public sealed interface ValueLayout extends MemoryLayout permits
     ValueLayout withOrder(ByteOrder order);
 
     /**
+     * {@inheritDoc}
+     */
+    @Override
+    ValueLayout withoutName();
+
+    /**
      * Creates a <em>strided</em> var handle that can be used to access a memory segment as multi-dimensional
      * array. The layout of this array is a sequence layout with {@code shape.length} nested sequence layouts. The element
      * layout of the sequence layout at depth {@code shape.length} is this value layout.

--- a/test/jdk/java/foreign/MemoryLayoutTypeRetentionTest.java
+++ b/test/jdk/java/foreign/MemoryLayoutTypeRetentionTest.java
@@ -127,6 +127,16 @@ public class MemoryLayoutTypeRetentionTest {
     }
 
     @Test
+    public void testValueLayout() {
+        ValueLayout v = ((ValueLayout) JAVA_INT)
+                .withBitAlignment(BIT_ALIGNMENT)
+                .withoutName()
+                .withName(NAME)
+                .withOrder(BYTE_ORDER);
+        check(v);
+    }
+
+    @Test
     public void testAddressLayout() {
         AddressLayout v = ADDRESS
                 .withBitAlignment(BIT_ALIGNMENT)


### PR DESCRIPTION
This PR fixes an override of `withoutName()` that is missed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Reviewers
 * [Maurizio Cimadamore](https://openjdk.org/census#mcimadamore) (@mcimadamore - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/panama-foreign pull/816/head:pull/816` \
`$ git checkout pull/816`

Update a local copy of the PR: \
`$ git checkout pull/816` \
`$ git pull https://git.openjdk.org/panama-foreign pull/816/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 816`

View PR using the GUI difftool: \
`$ git pr show -t 816`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/panama-foreign/pull/816.diff">https://git.openjdk.org/panama-foreign/pull/816.diff</a>

</details>
