### PR TITLE
Fix minor typos in ffi document

### DIFF
--- a/doc/panama_ffi.md
+++ b/doc/panama_ffi.md
@@ -32,7 +32,7 @@ try (Arena arena = Arena.ofConfined()) {
 int x = foreign.get(ValueLayout.JAVA_INT, 0); // throws IllegalStateException
 ```
 
-Note how the new segment will behave as if it was allocated in the provided arena: when the arena is closed, the new segment is no longer accessible.
+Note how the new segment behaves as if it was allocated in the provided arena: when the arena is closed, the new segment is no longer accessible.
 
 Alternatively, if the size of the foreign segment is known statically, clients can associate a *target layout* with the address layout used to obtain the segment. When an access operation, or a function descriptor that is passed to a downcall method handle (see below), uses an address value layout with target layout `T`, the runtime will wrap any corresponding raw addresses as segments with size set to `T.byteSize()`:
 ```java
@@ -203,7 +203,7 @@ MethodHandle comparHandle = MethodHandles.lookup()
                                                      comparDesc.toMethodType());
 ```
 
-To do that, we first create a function descriptor for the function pointer type. This descriptor uses address layouts that have a `JAVA_INT` target layout, to allow access operations inside the upcall method handle. We use the `CLinker::upcallType` to turn that function descriptor into a suitable `MethodType` instance to be used in a method handle lookup. Now that we have a method handle for our Java comparator function, we finally have all the ingredients to create an upcall stub, and pass it to the `qsort` downcall handle:
+To do that, we first create a function descriptor for the function pointer type. This descriptor uses address layouts that have a `JAVA_INT` target layout, to allow access operations inside the upcall method handle. We use the `FunctionDescriptor::toMethodType` to turn that function descriptor into a suitable `MethodType` instance to be used in a method handle lookup. Now that we have a method handle for our Java comparator function, we finally have all the ingredients to create an upcall stub, and pass it to the `qsort` downcall handle:
 
 ```java
 try (Arena arena = Arena.ofConfined()) {


### PR DESCRIPTION
In my previous PR, I have missed a couple of issues in the FFI document.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Reviewers
 * [Jorn Vernee](https://openjdk.org/census#jvernee) (@JornVernee - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/panama-foreign pull/819/head:pull/819` \
`$ git checkout pull/819`

Update a local copy of the PR: \
`$ git checkout pull/819` \
`$ git pull https://git.openjdk.org/panama-foreign pull/819/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 819`

View PR using the GUI difftool: \
`$ git pr show -t 819`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/panama-foreign/pull/819.diff">https://git.openjdk.org/panama-foreign/pull/819.diff</a>

</details>
