### PR TITLE
8298096: Refine javadoc for Linker

### DIFF
--- a/src/java.base/share/classes/java/lang/foreign/Linker.java
+++ b/src/java.base/share/classes/java/lang/foreign/Linker.java
@@ -415,6 +415,11 @@ public sealed interface Linker permits AbstractLinker {
     /**
      * Returns a linker for the ABI associated with the underlying native platform. The underlying native platform
      * is the combination of OS and processor where the Java runtime is currently executing.
+     * <p>
+     * This method is <a href="package-summary.html#restricted"><em>restricted</em></a>.
+     * Restricted methods are unsafe, and, if used incorrectly, their use might crash
+     * the JVM or, worse, silently result in memory corruption. Thus, clients should refrain from depending on
+     * restricted methods, and use safe and supported functionalities, where possible.
      *
      * @apiNote It is not currently possible to obtain a linker for a different combination of OS and processor.
      * @implNote The libraries exposed by the {@linkplain #defaultLookup() default lookup} associated with the returned

--- a/src/java.base/share/classes/java/lang/foreign/Linker.java
+++ b/src/java.base/share/classes/java/lang/foreign/Linker.java
@@ -109,8 +109,10 @@ import java.util.stream.Stream;
  * <p>
  * Composite types are modelled as {@linkplain GroupLayout group layouts}. More specifically, a C {@code struct} type
  * maps to a {@linkplain StructLayout struct layout}, whereas a C {@code union} type maps to a {@link UnionLayout union
- * layout}. Depending on the ABI implemented by the native linker, additional {@linkplain MemoryLayout#paddingLayout(long) padding}
- * member layouts might be required to conform to the size and alignment constraint of a composite type definition in C.
+ * layout}. When defining a struct or union layout, clients must pay attention to the size and alignment constraint
+ * of the corresponding composite type definition in C. For instance, padding between two struct fields
+ * must be modelled explicitly, by adding an adequately sized {@linkplain PaddingLayout padding layout} member
+ * to the resulting struct layout.
  * <p>
  * Finally, pointer types such as {@code int**} and {@code int(*)(size_t*, size_t*)} are modelled as
  * {@linkplain AddressLayout address layouts}. When the spatial bounds of the pointer type are known statically,

--- a/src/java.base/share/classes/java/lang/foreign/Linker.java
+++ b/src/java.base/share/classes/java/lang/foreign/Linker.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
+ *  Copyright (c) 2020, 2023, Oracle and/or its affiliates. All rights reserved.
  *  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  *  This code is free software; you can redistribute it and/or modify it
@@ -36,6 +36,7 @@ import jdk.internal.reflect.Reflection;
 import java.lang.invoke.MethodHandle;
 import java.util.Objects;
 import java.util.Set;
+import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -60,41 +61,332 @@ import java.util.stream.Stream;
  * chooses a set of libraries that are commonly used on the OS and processor combination associated with the ABI.
  * For example, a linker for Linux/x64 might choose two libraries: {@code libc} and {@code libm}. The functions in these
  * libraries are exposed via a {@linkplain #defaultLookup() symbol lookup}.
- * <p>
- * The {@link #nativeLinker()} method provides a linker for the ABI associated with the OS and processor where the Java runtime
- * is currently executing. This linker also provides access, via its {@linkplain #defaultLookup() default lookup},
- * to the native libraries loaded with the Java runtime.
  *
- * <h2 id="downcall-method-handles">Downcall method handles</h2>
+ * <h2 id="native-linker">Calling native functions</h2>
  *
- * {@linkplain #downcallHandle(FunctionDescriptor, Option...) Linking a foreign function} is a process which requires a function descriptor,
- * a set of memory layouts which, together, specify the signature of the foreign function to be linked, and returns,
- * when complete, a downcall method handle, that is, a method handle that can be used to invoke the target foreign function.
- * <p>
- * The Java {@linkplain java.lang.invoke.MethodType method type} associated with the returned method handle is
- * {@linkplain FunctionDescriptor#toMethodType() derived} from the argument and return layouts in the function descriptor.
- * The downcall method handle type, might then be decorated by additional leading parameters, in the given order if both are present:
- * <ul>
- * <li>If the downcall method handle is created {@linkplain #downcallHandle(FunctionDescriptor, Option...) without specifying a target address},
- * the downcall method handle type features a leading parameter of type {@link MemorySegment}, from which the
- * address of the target foreign function can be derived.</li>
- * <li>If the function descriptor's return layout is a group layout, the resulting downcall method handle accepts
- * an additional leading parameter of type {@link SegmentAllocator}, which is used by the linker runtime to allocate the
- * memory region associated with the struct returned by the downcall method handle.</li>
- * </ul>
+ * The {@linkplain #nativeLinker() native linker} can be used to link against functions
+ * defined in C libraries (native functions). Suppose we wish to downcall from Java to the {@code strlen} function
+ * defined in the standard C library:
+ * {@snippet lang = c:
+ * size_t strlen(const char *s);
+ * }
+ * A downcall method handle that exposes {@code strlen} is obtained, using the native linker, as follows:
  *
- * <h2 id="upcall-stubs">Upcall stubs</h2>
+ * {@snippet lang = java:
+ * Linker linker = Linker.nativeLinker();
+ * MethodHandle strlen = linker.downcallHandle(
+ *     linker.defaultLookup().find("strlen").get(),
+ *     FunctionDescriptor.of(JAVA_LONG, ADDRESS)
+ * );
+ * }
  *
- * {@linkplain #upcallStub(MethodHandle, FunctionDescriptor, Arena, Option...) Creating an upcall stub} requires a method
- * handle and a function descriptor; in this case, the set of memory layouts in the function descriptor
- * specify the signature of the function pointer associated with the upcall stub.
+ * Note how the native linker also provides access, via its {@linkplain #defaultLookup() default lookup},
+ * to the native functions defined by the C libraries loaded with the Java runtime. Above, the default lookup
+ * is used to search the address of the {@code strlen} native function. That address is then passed, along with
+ * a <em>platform-dependent description</em> of the signature of the function expressed as a
+ * {@link FunctionDescriptor} (more on that below) to the native linker's
+ * {@link #downcallHandle(MemorySegment, FunctionDescriptor, Option...)} method.
+ * The obtained downcall method handle is then invoked as follows:
+ *
+ * {@snippet lang = java:
+ * try (Arena arena = Arena.openConfined()) {
+ *     MemorySegment str = arena.allocateUtf8String("Hello");
+ *     long len          = strlen.invoke(str);  // 5
+ * }
+ * }
+ * <h3 id="describing-c-sigs">Describing C signatures</h3>
+ *
+ * When interacting with the native linker, clients must provide a platform-dependent description of the signature
+ * of the C function they wish to link against. This description, a {@link FunctionDescriptor function descriptor},
+ * defines the layouts associated with the parameter types and return type (if any) of the C function.
  * <p>
- * The type of the provided method handle's type has to match the method type associated with the upcall stub,
- * which is {@linkplain FunctionDescriptor#toMethodType() derived} from the provided function descriptor.
+ * Scalar C types such as {@code bool}, {@code int} are modelled as {@linkplain ValueLayout value layouts}
+ * of a suitable carrier. The mapping between a scalar type and its corresponding layout is dependent on the ABI
+ * implemented by the native linker. For instance, the C type {@code long} maps to the layout constant
+ * {@link ValueLayout#JAVA_LONG} on Linux/x64, but maps to the layout constant {@link ValueLayout#JAVA_INT} on
+ * Windows/x64. Similarly, the C type {@code size_t} maps to the layout constant {@link ValueLayout#JAVA_LONG}
+ * on 64-bit platforms, but maps to the layout constant {@link ValueLayout#JAVA_INT} on 32-bit platforms.
  * <p>
- * Upcall stubs are modelled by instances of type {@link MemorySegment}; upcall stubs can be passed by reference to other
- * downcall method handles. An upcall stub can be released by {@linkplain Arena#close() closing} the arena which was used
- * to create it.
+ * Composite types are modelled as {@linkplain GroupLayout group layouts}. More specifically, a C {@code struct} type
+ * maps to a {@linkplain StructLayout struct layout}, whereas a C {@code union} type maps to a {@link UnionLayout union
+ * layout}. Depending on the ABI implemented by the native linker, additional {@linkplain MemoryLayout#paddingLayout(long) padding}
+ * member layouts might be required to conform to the size and alignment constraint of a composite type definition in C.
+ * <p>
+ * Finally, pointer types such as {@code int**} and {@code int(*)(size_t*, size_t*)} are modelled as
+ * {@linkplain AddressLayout address layouts}. When the spatial bounds of the pointer type are known statically,
+ * the address layout can be associated with a {@linkplain AddressLayout#targetLayout() target layout}. For instance,
+ * a pointer that is known to point to a C {@code int[2]} array can be modelled as an address layout whose
+ * target layout is a sequence layout whose element count is 2, and whose element type is {@link ValueLayout#JAVA_INT}.
+ * <p>
+ * The following table shows some examples of how C types are modelled in Linux/x64:
+ *
+ * <blockquote><table class="plain">
+ * <caption style="display:none">Mapping C types</caption>
+ * <thead>
+ * <tr>
+ *     <th scope="col">C type</th>
+ *     <th scope="col">Layout</th>
+ *     <th scope="col">Java type</th>
+ * </tr>
+ * </thead>
+ * <tbody>
+ * <tr><th scope="row" style="font-weight:normal">{@code bool}</th>
+ *     <td style="text-align:center;">{@link ValueLayout#JAVA_BOOLEAN}</td>
+ *     <td style="text-align:center;">{@code boolean}</td>
+ * <tr><th scope="row" style="font-weight:normal">{@code char}</th>
+ *     <td style="text-align:center;">{@link ValueLayout#JAVA_BYTE}</td>
+ *     <td style="text-align:center;">{@code byte}</td>
+ * <tr><th scope="row" style="font-weight:normal">{@code short}</th>
+ *     <td style="text-align:center;">{@link ValueLayout#JAVA_SHORT}</td>
+ *     <td style="text-align:center;">{@code short}</td>
+ * <tr><th scope="row" style="font-weight:normal">{@code int}</th>
+ *     <td style="text-align:center;">{@link ValueLayout#JAVA_INT}</td>
+ *     <td style="text-align:center;">{@code int}</td>
+ * <tr><th scope="row" style="font-weight:normal">{@code long}</th>
+ *     <td style="text-align:center;">{@link ValueLayout#JAVA_LONG}</td>
+ *     <td style="text-align:center;">{@code long}</td>
+ * <tr><th scope="row" style="font-weight:normal">{@code long long}</th>
+ *     <td style="text-align:center;">{@link ValueLayout#JAVA_LONG}</td>
+ *     <td style="text-align:center;">{@code long}</td>
+ * <tr><th scope="row" style="font-weight:normal">{@code float}</th>
+ *     <td style="text-align:center;">{@link ValueLayout#JAVA_FLOAT}</td>
+ *     <td style="text-align:center;">{@code float}</td>
+ * <tr><th scope="row" style="font-weight:normal">{@code double}</th>
+ *     <td style="text-align:center;">{@link ValueLayout#JAVA_DOUBLE}</td>
+ *     <td style="text-align:center;">{@code double}</td>
+ <tr><th scope="row" style="font-weight:normal">{@code size_t}</th>
+ *     <td style="text-align:center;">{@link ValueLayout#JAVA_LONG}</td>
+ *     <td style="text-align:center;">{@code long}</td>
+ * <tr><th scope="row" style="font-weight:normal">{@code char*}, {@code int**}, {@code struct Point*}</th>
+ *     <td style="text-align:center;">{@link ValueLayout#ADDRESS}</td>
+ *     <td style="text-align:center;">{@link MemorySegment}</td>
+ * <tr><th scope="row" style="font-weight:normal">{@code int (*foo)[10]}</th>
+ *     <td style="text-align:left;">
+ * <pre>
+ * ValueLayout.ADDRESS.withTargetLayout(
+ *     MemoryLayout.sequenceLayout(10,
+ *         ValueLayout.JAVA_INT)
+ * );
+ * </pre>
+ *     <td style="text-align:center;">{@link MemorySegment}</td>
+ * <tr><th scope="row" style="font-weight:normal"><code>struct Point { int x; long y; };</code></th>
+ *     <td style="text-align:left;">
+ * <pre>
+ * MemoryLayout.structLayout(
+ *     ValueLayout.JAVA_INT.withName("x"),
+ *     MemoryLayout.paddingLayout(32),
+ *     ValueLayout.JAVA_LONG.withName("y")
+ * );
+ * </pre>
+ *     </td>
+ *     <td style="text-align:center;">{@link MemorySegment}</td>
+ * <tr><th scope="row" style="font-weight:normal"><code>union Choice { float a; int b; }</code></th>
+ *     <td style="text-align:left;">
+ * <pre>
+ * MemoryLayout.unionLayout(
+ *     ValueLayout.JAVA_FLOAT.withName("a"),
+ *     ValueLayout.JAVA_INT.withName("b")
+ * );
+ * </pre>
+ *     </td>
+ *     <td style="text-align:center;">{@link MemorySegment}</td>
+ * </tbody>
+ * </table></blockquote>
+ *
+ * <h3 id="function-pointers">Function pointers</h3>
+ *
+ * Sometimes, it is useful to pass Java code as a function pointer to some native function; this is achieved by using
+ * an {@linkplain #upcallStub(MethodHandle, FunctionDescriptor, Arena, Option...) upcall stub}. To demonstrate this,
+ * let's consider the following function from the C standard library:
+ *
+ * {@snippet lang = c:
+ * void qsort(void *base, size_t nmemb, size_t size,
+ *            int (*compar)(const void *, const void *));
+ * }
+ *
+ * The {@code qsort} function can be used to sort the contents of an array, using a custom comparator function which is
+ * passed as a function pointer (the {@code compar} parameter). To be able to call {@code qsort} function from Java,
+ * we must first create a downcall method handle for it, as follows:
+ *
+ * {@snippet lang = java:
+ * Linker linker = Linker.nativeLinker();
+ * MethodHandle qsort = linker.downcallHandle(
+ * 		linker.defaultLookup().find("qsort").get(),
+ *         FunctionDescriptor.ofVoid(ADDRESS, JAVA_LONG, JAVA_LONG, ADDRESS)
+ * );
+ * }
+ *
+ * As before, we use {@link ValueLayout#JAVA_LONG} to map the C type {@code size_t} type, and {@link ValueLayout#ADDRESS}
+ * for both the first pointer parameter (the array pointer) and the last parameter (the function pointer).
+ * <p>
+ * To invoke the {@code qsort} downcall handle obtained above, we need a function pointer to be passed as the last
+ * parameter. That is, we need to create a function pointer out of an existing method handle. First, let's write a
+ * Java method that can compare two int elements passed as pointers (i.e. as {@linkplain MemorySegment memory segments}):
+ *
+ * {@snippet lang = java:
+ * class Qsort {
+ *     static int qsortCompare(MemorySegment elem1, MemorySegmet elem2) {
+ *         return Integer.compare(elem1.get(JAVA_INT, 0), elem2.get(JAVA_INT, 0));
+ *     }
+ * }
+ * }
+ *
+ * Now let's create a method handle for the comparator method defined above:
+ *
+ * {@snippet lang = java:
+ * FunctionDescriptor comparDesc = FunctionDescriptor.of(JAVA_INT,
+ *                                                       ADDRESS.withTargetLayout(JAVA_INT),
+ *                                                       ADDRESS.withTargetLayout(JAVA_INT));
+ * MethodHandle comparHandle = MethodHandles.lookup()
+ *                                          .findStatic(Qsort.class, "qsortCompare",
+ *                                                      comparDesc.toMethodType());
+ * }
+ *
+ * First, we create a function descriptor for the function pointer type. Since we know that the parameters passed to
+ * the comparator method will be pointers to elements of a C {@code int[]} array, we can specify {@link ValueLayout#JAVA_INT}
+ * as the target layout for the address layouts of both parameters. This will allow the comparator method to access
+ * the contents of the array elements to be compared. We then {@linkplain FunctionDescriptor#toMethodType() turn}
+ * that function descriptor into a suitable {@linkplain java.lang.invoke.MethodType method type} which we then use to look up
+ * the comparator method handle. We can now create an upcall stub which points to that method, and pass it, as a function
+ * pointer, to the {@code qsort} downcall handle, as follows:
+ *
+ * {@snippet lang = java:
+ * try (Arena arena = Arena.ofConfined()) {
+ *     MemorySegment comparFunc = linker.upcallStub(comparHandle, comparDesc, arena);
+ *     MemorySegment array = session.allocateArray(0, 9, 3, 4, 6, 5, 1, 8, 2, 7);
+ *     qsort.invokeExact(array, 10L, 4L, comparFunc);
+ *     int[] sorted = array.toArray(JAVA_INT); // [ 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 ]
+ * }
+ * }
+ *
+ * This code creates an off-heap array, copies the contents of a Java array into it, and then passes the array to the
+ * {@code qsort} method handle along with the comparator function we obtained from the native linker. After the invocation, the contents
+ * of the off-heap array will be sorted according to our comparator function, written in Java. We then extract a
+ * new Java array from the segment, which contains the sorted elements.
+ *
+ * <h3 id="by-ref">Functions returning pointers</h3>
+ *
+ * When interacting with native functions, it is common for those functions to allocate a region of memory and return
+ * a pointer to that region. Let's consider the following function from the C standard library:
+ *
+ * {@snippet lang = c:
+ * void *malloc(size_t size);
+ * }
+ *
+ * The {@code malloc} function allocates a region of memory of given size,
+ * and returns a pointer to that region of memory, which is later deallocated using another function from
+ * the C standard library:
+ *
+ * {@snippet lang = c:
+ * void free(void *ptr);
+ * }
+ *
+ * The {@code free} function takes a pointer to a region of memory and deallocates that region. In this section we
+ * will show how to interact with these native functions, with the aim of providing a <em>safe</em> allocation
+ * API (the approach outlined below can of course be generalized to allocation functions other than {@code malloc}
+ * and {@code free}).
+ * <p>
+ * First, we need to create the downcall method handles for {@code malloc} and {@code free}, as follows:
+ *
+ * {@snippet lang = java:
+ * Linker linker = Linker.nativeLinker();
+ *
+ * MethodHandle malloc = linker.downcallHandle(
+ *     linker.defaultLookup().find("malloc").get(),
+ *     FunctionDescriptor.of(ADDRESS, JAVA_LONG)
+ * );
+ *
+ * MethodHandle free = linker.downcallHandle(
+ *     linker.defaultLookup().find("free").get(),
+ *     FunctionDescriptor.ofVoid(ADDRESS)
+ * );
+ * }
+ *
+ * When interacting with a native functions returning a pointer (such as {@code malloc}), the Java runtime has no insight
+ * into the size or the lifetime of the returned pointer. Consider the following code:
+ *
+ * {@snippet lang = java:
+ * MemorySegment segment = (MemorySegment)malloc.invokeExact(100);
+ * }
+ *
+ * The size of the segment returned by the {@code malloc} downcall method handle is
+ * <a href="MemorySegment.html#wrapping-addresses">zero</a>. Moreover, the scope of the
+ * returned segment is a fresh scope that is always alive. To provide safe access to the segment, we must,
+ * unsafely, resize the segment to the desired size (100, in this case). It might also be desirable to
+ * attach the segment to some existing {@linkplain Arena arena}, so that the lifetime of the region of memory
+ * backing the segment can be managed automatically, as for any other native segment created directly from Java code.
+ * Both these operations are accomplished using the restricted {@link MemorySegment#reinterpret(long, Arena, Consumer)}
+ * method, as follows:
+ *
+ * {@snippet lang = java:
+ * MemorySegment allocateMemory(long byteSize, Arena arena) {
+ *     MemorySegment segment = (MemorySegment)malloc.invokeExact(byteSize);   // size = byteSize, scope = always alive
+ *     return segment.reinterpret(size, arena, s -> free.invokeExact(s));     // size = byteSize, scope = arena.scope()
+ * }
+ * }
+ *
+ * The {@code allocateMemory} method defined above accepts two parameters: a size and an arena. The method calls the
+ * {@code malloc} downcall method handle, and unsafely reinterprets the returned segment, by giving it a new size
+ * (the size passed to the {@code allocateMemory} method) and a new scope (the scope of the provided arena).
+ * The method also specifies a <em>cleanup action</em> to be executed when the provided arena is closed. Unsurprisingly,
+ * the cleanup action passes the segment to the {@code free} downcall method handle, to deallocate the underlying
+ * region of memory. We can use the {@code allocateMemory} method as follows:
+ *
+ * {@snippet lang = java:
+ * try (Arena arena = Arena.ofConfined()) {
+ *     MemorySegment segment = allocateMemory(100, arena);
+ * } // 'free' called here
+ * }
+ *
+ * Note how the segment obtained from {@code allocateMemory} acts as any other segment managed by the confined arena. More
+ * specifically, the obtained segment has the desired size, can only be accessed by a single thread (the thread which created
+ * the confined arena), and its lifetime is tied to the surrounding <em>try-with-resources</em> block.
+ *
+ * <h3 id="variadic-funcs">Variadic functions</h3>
+ *
+ * Variadic functions (e.g. a C function declared with a trailing ellipses {@code ...} at the end of the formal parameter
+ * list or with an empty formal parameter list) are not supported directly by the native linker. However, it is still possible
+ * to link a variadic function by using a <em>specialized</em> function descriptor, together with a
+ * {@linkplain Linker.Option#firstVariadicArg(int) a linker option} which indicates the position of the first variadic argument
+ * in that specialized descriptor.
+ * <p>
+ * A well-known variadic function is the {@code printf} function, defined in the C standard library:
+ *
+ * {@snippet lang = c:
+ * int printf(const char *format, ...);
+ * }
+ *
+ * This function takes a format string, and a number of additional arguments (the number of such arguments is
+ * dictated by the format string). Consider the following variadic call:
+ *
+ * {@snippet lang = c:
+ * printf("%d plus %d equals %d", 2, 2, 4);
+ * }
+ *
+ * To perform an equivalent call using a downcall method handle we must create a function descriptor which
+ * describes the specialized signature of the C function we want to call. This descriptor must include layouts for any
+ * additional variadic argument we intend to provide. In this case, the specialized signature of the C
+ * function is {@code (char*, int, int, int)} as the format string accepts three integer parameters. Then, we need to use
+ * a linker option to specify the position of the first variadic layout in the provided function descriptor (starting from 0).
+ * In this case, since the first parameter is the format string (a non-variadic argument), the first variadic index
+ * needs to be set to 1, as follows:
+ *
+ * {@snippet lang = java:
+ * Linker linker = Linker.nativeLinker();
+ * MethodHandle printf = linker.downcallHandle(
+ * 		linker.defaultLookup().lookup("printf").get(),
+ *         FunctionDescriptor.of(JAVA_INT, ADDRESS, JAVA_INT, JAVA_INT, JAVA_INT)
+ *         Linker.Option.firstVariadicArg(1) // first int is variadic
+ * );
+ * }
+ *
+ * We can then call the specialized downcall handle as usual:
+ *
+ * {@snippet lang = java:
+ * try (Arena arena = Arena.ofConfined()) {
+ *     int res = (int)printf.invokeExact(arena.allocateUtf8String("%d plus %d equals %d"), 2, 2, 4); //prints "2 plus 2 equals 4"
+ * }
+ * }
  *
  * <h2 id="safety">Safety considerations</h2>
  *
@@ -102,22 +394,7 @@ import java.util.stream.Stream;
  * contain enough signature information (e.g. arity and types of foreign function parameters). As a consequence,
  * the linker runtime cannot validate linkage requests. When a client interacts with a downcall method handle obtained
  * through an invalid linkage request (e.g. by specifying a function descriptor featuring too many argument layouts),
- * the result of such interaction is unspecified and can lead to JVM crashes. On downcall handle invocation,
- * the linker runtime guarantees the following for any argument {@code A} of type {@link MemorySegment} whose corresponding
- * layout is {@link ValueLayout#ADDRESS}:
- * <ul>
- *     <li>{@code A.scope().isAlive() == true}. Otherwise, the invocation throws {@link IllegalStateException};</li>
- *     <li>The invocation occurs in a thread {@code T} such that {@code A.isAccessibleBy(T) == true}.
- *     Otherwise, the invocation throws {@link WrongThreadException}; and</li>
- *     <li>{@code A} is kept alive during the invocation. For instance, if {@code A} has been obtained using a
- *     {@linkplain Arena#ofConfined() confined arena}, any attempt to {@linkplain Arena#close() close}
- *     the confined arena while the downcall method handle is executing will result in a {@link IllegalStateException}.</li>
- *</ul>
- * A downcall method handle created from a function descriptor whose return layout is an
- * {@linkplain AddressLayout address layout} returns a native segment associated with
- * a fresh scope that is always alive. Under normal conditions, the size of the returned segment is {@code 0}.
- * However, if the return address layout has a {@linkplain AddressLayout#targetLayout()} {@code T}, then the size of the returned segment
- * is set to {@code T.byteSize()}.
+ * the result of such interaction is unspecified and can lead to JVM crashes.
  * <p>
  * When creating upcall stubs the linker runtime validates the type of the target method handle against the provided
  * function descriptor and report an error if any mismatch is detected. As for downcalls, JVM crashes might occur,
@@ -126,12 +403,6 @@ import java.util.stream.Stream;
  * handle associated with an upcall stub returns a {@linkplain MemorySegment memory segment}, clients must ensure
  * that this address cannot become invalid after the upcall completes. This can lead to unspecified behavior,
  * and even JVM crashes, since an upcall is typically executed in the context of a downcall method handle invocation.
- * <p>
- * An upcall stub argument whose corresponding layout is an {@linkplain AddressLayout address layout}
- * is a native segment associated with a fresh scope that is always alive.
- * Under normal conditions, the size of this segment argument is {@code 0}.
- * However, if the address layout has a {@linkplain AddressLayout#targetLayout()} {@code T}, then the size of the
- * segment argument is set to {@code T.byteSize()}.
  *
  * @implSpec
  * Implementations of this interface are immutable, thread-safe and <a href="{@docRoot}/java.base/java/lang/doc-files/ValueBased.html">value-based</a>.
@@ -144,42 +415,13 @@ public sealed interface Linker permits AbstractLinker {
     /**
      * Returns a linker for the ABI associated with the underlying native platform. The underlying native platform
      * is the combination of OS and processor where the Java runtime is currently executing.
-     * <p>
-     * When interacting with the returned linker, clients must describe the signature of a foreign function using a
-     * {@link FunctionDescriptor function descriptor} whose argument and return layouts are specified as follows:
-     * <ul>
-     *     <li>Scalar types are modelled by a {@linkplain ValueLayout value layout} instance of a suitable carrier. Example
-     *     of scalar types in C are {@code int}, {@code long}, {@code size_t}, etc. The mapping between a scalar type
-     *     and its corresponding layout is dependent on the ABI of the returned linker;
-     *     <li>Composite types are modelled by a {@linkplain GroupLayout group layout}. Depending on the ABI of the
-     *     returned linker, additional {@linkplain MemoryLayout#paddingLayout(long) padding} member layouts might be required to conform
-     *     to the size and alignment constraint of a composite type definition in C (e.g. using {@code struct} or {@code union}); and</li>
-     *     <li>Pointer types are modelled by a {@linkplain ValueLayout value layout} instance with carrier {@link MemorySegment}.
-     *     Examples of pointer types in C are {@code int**} and {@code int(*)(size_t*, size_t*)};</li>
-     * </ul>
-     * <p>
-     * Any layout not listed above is <em>unsupported</em>; function descriptors containing unsupported layouts
-     * will cause an {@link IllegalArgumentException} to be thrown, when used to create a
-     * {@link #downcallHandle(MemorySegment, FunctionDescriptor, Option...) downcall method handle} or an
-     * {@linkplain #upcallStub(MethodHandle, FunctionDescriptor, Arena, Option...) upcall stub}.
-     * <p>
-     * Variadic functions (e.g. a C function declared with a trailing ellipses {@code ...} at the end of the formal parameter
-     * list or with an empty formal parameter list) are not supported directly. However, it is possible to link a
-     * variadic function by using {@linkplain Linker.Option#firstVariadicArg(int) a linker option} to indicate
-     * the start of the list of variadic arguments, together with a specialized function descriptor describing a
-     * given variable arity callsite.
-     * <p>
-     * This method is <a href="package-summary.html#restricted"><em>restricted</em></a>.
-     * Restricted methods are unsafe, and, if used incorrectly, their use might crash
-     * the JVM or, worse, silently result in memory corruption. Thus, clients should refrain from depending on
-     * restricted methods, and use safe and supported functionalities, where possible.
      *
      * @apiNote It is not currently possible to obtain a linker for a different combination of OS and processor.
      * @implNote The libraries exposed by the {@linkplain #defaultLookup() default lookup} associated with the returned
      * linker are the native libraries loaded in the process where the Java runtime is currently executing. For example,
      * on Linux, these libraries typically include {@code libc}, {@code libm} and {@code libdl}.
      *
-     * @return a linker for the ABI associated with the OS and processor where the Java runtime is currently executing.
+     * @return a linker for the ABI associated with the underlying native platform.
      * @throws UnsupportedOperationException if the underlying native platform is not supported.
      * @throws IllegalCallerException If the caller is in a module that does not have native access enabled.
      */
@@ -190,11 +432,7 @@ public sealed interface Linker permits AbstractLinker {
     }
 
     /**
-     * Creates a method handle which can be used to call a foreign function with the given signature and address.
-     * <p>
-     * If the provided method type's return type is {@code MemorySegment}, then the resulting method handle features
-     * an additional prefix parameter, of type {@link SegmentAllocator}, which will be used by the linker to allocate
-     * structs returned by-value.
+     * Creates a method handle which is used to call a foreign function with the given signature and address.
      * <p>
      * Calling this method is equivalent to the following code:
      * {@snippet lang=java :
@@ -215,17 +453,35 @@ public sealed interface Linker permits AbstractLinker {
     }
 
     /**
-     * Creates a method handle which can be used to call a foreign function with the given signature.
-     * The resulting method handle features a prefix parameter (as the first parameter) corresponding to the foreign function
-     * entry point, of type {@link MemorySegment}, which is used to specify the address of the target function
-     * to be called.
+     * Creates a method handle which is used to call a foreign function with the given signature.
      * <p>
-     * If the provided function descriptor's return layout is a {@link GroupLayout}, then the resulting method handle features an
-     * additional prefix parameter (inserted immediately after the address parameter), of type {@link SegmentAllocator}),
-     * which will be used by the linker to allocate structs returned by-value.
+     * The Java {@linkplain java.lang.invoke.MethodType method type} associated with the returned method handle is
+     * {@linkplain FunctionDescriptor#toMethodType() derived} from the argument and return layouts in the function descriptor,
+     * but features an additional leading parameter of type {@link MemorySegment}, from which the address of the target
+     * foreign function is derived. Moreover, if the function descriptor's return layout is a group layout, the resulting
+     * downcall method handle accepts an additional leading parameter of type {@link SegmentAllocator}, which is used by
+     * the linker runtime to allocate the memory region associated with the struct returned by the downcall method handle.
      * <p>
-     * The returned method handle will throw an {@link IllegalArgumentException} if the {@link MemorySegment} parameter passed to it is
-     * associated with the {@link MemorySegment#NULL} address, or a {@link NullPointerException} if that parameter is {@code null}.
+     * Upon invoking a downcall method handle, the linker runtime will guarantee the following for any argument
+     * {@code A} of type {@link MemorySegment} whose corresponding layout is an {@linkplain AddressLayout address layout}:
+     * <ul>
+     *     <li>{@code A.scope().isAlive() == true}. Otherwise, the invocation throws {@link IllegalStateException};</li>
+     *     <li>The invocation occurs in a thread {@code T} such that {@code A.isAccessibleBy(T) == true}.
+     *     Otherwise, the invocation throws {@link WrongThreadException}; and</li>
+     *     <li>{@code A} is kept alive during the invocation. For instance, if {@code A} has been obtained using a
+     *     {@linkplain Arena#ofConfined() confined arena}, any attempt to {@linkplain Arena#close() close}
+     *     the confined arena while the downcall method handle is executing will result in a {@link IllegalStateException}.</li>
+     *</ul>
+     * <p>
+     * Moreover, if the provided function descriptor's return layout is an {@linkplain AddressLayout address layout},
+     * invoking the returned method handle will return a native segment associated with
+     * a fresh scope that is always alive. Under normal conditions, the size of the returned segment is {@code 0}.
+     * However, if the function descriptor's return layout has a {@linkplain AddressLayout#targetLayout()} {@code T},
+     * then the size of the returned segment is set to {@code T.byteSize()}.
+     * <p>
+     * Finally, the returned method handle will throw an {@link IllegalArgumentException} if the {@link MemorySegment}
+     * parameter passed to it is associated with the {@link MemorySegment#NULL} address, or a {@link NullPointerException}
+     * if that parameter is {@code null}.
      *
      * @param function the function descriptor of the target function.
      * @param options  any linker options.
@@ -245,6 +501,12 @@ public sealed interface Linker permits AbstractLinker {
      * the provided arena. As such, the lifetime of the returned upcall stub segment is controlled by the
      * provided arena. For instance, if the provided arena is a confined arena, the returned
      * upcall stub segment will be deallocated when the provided confined arena is {@linkplain Arena#close() closed}.
+     * <p>
+     * An upcall stub argument whose corresponding layout is an {@linkplain AddressLayout address layout}
+     * is a native segment associated with a fresh scope that is always alive.
+     * Under normal conditions, the size of this segment argument is {@code 0}.
+     * However, if the address layout has a {@linkplain AddressLayout#targetLayout()} {@code T}, then the size of the
+     * segment argument is set to {@code T.byteSize()}.
      * <p>
      * The target method handle should not throw any exceptions. If the target method handle does throw an exception,
      * the VM will exit with a non-zero exit code. To avoid the VM aborting due to an uncaught exception, clients

--- a/src/java.base/share/classes/java/lang/foreign/Linker.java
+++ b/src/java.base/share/classes/java/lang/foreign/Linker.java
@@ -320,7 +320,7 @@ import java.util.stream.Stream;
  *
  * {@snippet lang = java:
  * MemorySegment allocateMemory(long byteSize, Arena arena) {
- *     MemorySegment segment = (MemorySegment)malloc.invokeExact(byteSize);   // size = byteSize, scope = always alive
+ *     MemorySegment segment = (MemorySegment)malloc.invokeExact(byteSize);   // size = 0, scope = always alive
  *     return segment.reinterpret(size, arena, s -> free.invokeExact(s));     // size = byteSize, scope = arena.scope()
  * }
  * }

--- a/src/java.base/share/classes/java/lang/foreign/Linker.java
+++ b/src/java.base/share/classes/java/lang/foreign/Linker.java
@@ -211,7 +211,7 @@ import java.util.stream.Stream;
  * {@snippet lang = java:
  * Linker linker = Linker.nativeLinker();
  * MethodHandle qsort = linker.downcallHandle(
- * 		linker.defaultLookup().find("qsort").get(),
+ *     linker.defaultLookup().find("qsort").get(),
  *         FunctionDescriptor.ofVoid(ADDRESS, JAVA_LONG, JAVA_LONG, ADDRESS)
  * );
  * }
@@ -374,8 +374,8 @@ import java.util.stream.Stream;
  * {@snippet lang = java:
  * Linker linker = Linker.nativeLinker();
  * MethodHandle printf = linker.downcallHandle(
- * 		linker.defaultLookup().lookup("printf").get(),
- *         FunctionDescriptor.of(JAVA_INT, ADDRESS, JAVA_INT, JAVA_INT, JAVA_INT)
+ *     linker.defaultLookup().lookup("printf").get(),
+ *         FunctionDescriptor.of(JAVA_INT, ADDRESS, JAVA_INT, JAVA_INT, JAVA_INT),
  *         Linker.Option.firstVariadicArg(1) // first int is variadic
  * );
  * }

--- a/src/java.base/share/classes/java/lang/foreign/Linker.java
+++ b/src/java.base/share/classes/java/lang/foreign/Linker.java
@@ -205,7 +205,7 @@ import java.util.stream.Stream;
  * }
  *
  * The {@code qsort} function can be used to sort the contents of an array, using a custom comparator function which is
- * passed as a function pointer (the {@code compar} parameter). To be able to call {@code qsort} function from Java,
+ * passed as a function pointer (the {@code compar} parameter). To be able to call the {@code qsort} function from Java,
  * we must first create a downcall method handle for it, as follows:
  *
  * {@snippet lang = java:

--- a/src/java.base/share/classes/java/lang/foreign/package-info.java
+++ b/src/java.base/share/classes/java/lang/foreign/package-info.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
+ *  Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
  *  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  *  This code is free software; you can redistribute it and/or modify it
@@ -31,49 +31,17 @@
  *
  * <p>
  * The main abstraction introduced to support foreign memory access is {@link java.lang.foreign.MemorySegment}, which
- * models a contiguous region of memory, residing either inside or outside the Java heap. The contents of a memory
- * segment can be described using a {@link java.lang.foreign.MemoryLayout memory layout}, which provides
- * basic operations to query sizes, offsets and alignment constraints. Memory layouts also provide
- * an alternate, more abstract way, to <a href=MemorySegment.html#segment-deref>access memory segments</a>
- * using {@linkplain java.lang.foreign.MemoryLayout#varHandle(java.lang.foreign.MemoryLayout.PathElement...) var handles},
+ * models a contiguous region of memory, residing either inside or outside the Java heap. Memory segments are
+ * typically allocated using an {@link java.lang.foreign.Arena}, which controls the lifetime of the regions of memory
+ * backing the segments it allocates. The contents of a memory segment can be described using a
+ * {@link java.lang.foreign.MemoryLayout memory layout}, which provides basic operations to query sizes, offsets and
+ * alignment constraints. Memory layouts also provide an alternate, more abstract way, to
+ * <a href=MemorySegment.html#segment-deref>access memory segments</a> using
+ * {@linkplain java.lang.foreign.MemoryLayout#varHandle(java.lang.foreign.MemoryLayout.PathElement...) var handles},
  * which can be computed using <a href="MemoryLayout.html#layout-paths"><em>layout paths</em></a>.
  *
  * For example, to allocate an off-heap region of memory big enough to hold 10 values of the primitive type {@code int},
  * and fill it with values ranging from {@code 0} to {@code 9}, we can use the following code:
- *
- * {@snippet lang = java:
- * MemorySegment segment = Arena.ofAuto().allocate(10 * 4, 1);
- * for (int i = 0 ; i < 10 ; i++) {
- *     segment.setAtIndex(ValueLayout.JAVA_INT, i, i);
- * }
- *}
- *
- * This code creates a <em>native</em> memory segment, that is, a memory segment backed by
- * off-heap memory; the size of the segment is 40 bytes, enough to store 10 values of the primitive type {@code int}.
- * Native segments are allocated using an {@link Arena}. An arena controls the lifetime of all the segments allocated
- * from it. In this case, as the segment is allocated using an {@linkplain java.lang.foreign.Arena#ofAuto() automatic arena}. This
- * means that the off-heap region of memory backing the segment is managed, automatically, by the garbage collector.
- * As such, the off-heap memory backing the native segment will be released at some unspecified
- * point <em>after</em> the segment becomes <a href="../../../java/lang/ref/package.html#reachability">unreachable</a>.
- * This is similar to what happens with direct buffers created via {@link java.nio.ByteBuffer#allocateDirect(int)}.
- * It is also possible to manage the lifecycle of allocated native segments more directly, as shown in a later section.
- * <p>
- * Inside a loop, we then initialize the contents of the memory segment; note how the
- * {@linkplain java.lang.foreign.MemorySegment#setAtIndex(ValueLayout.OfInt, long, int) access method}
- * accepts a {@linkplain java.lang.foreign.ValueLayout value layout}, which specifies the size, alignment constraint,
- * byte order as well as the Java type ({@code int}, in this case) associated with the access operation. More specifically,
- * if we view the memory segment as a set of 10 adjacent slots, {@code s[i]}, where {@code 0 <= i < 10},
- * where the size of each slot is exactly 4 bytes, the initialization logic above will set each slot
- * so that {@code s[i] = i}, again where {@code 0 <= i < 10}.
- *
- * <h3 id="deallocation">Deterministic deallocation</h3>
- *
- * When writing code that manipulates memory segments, especially if backed by memory which resides outside the Java heap, it is
- * often crucial that the resources associated with a memory segment are released when the segment is no longer in use,
- * and in a timely fashion. For this reason, there might be cases where waiting for the garbage collector to determine that a segment
- * is <a href="../../../java/lang/ref/package.html#reachability">unreachable</a> is not optimal.
- * Clients that operate under these assumptions might want to programmatically release the memory backing a memory segment.
- * This can be done, using a <em>confined arena</em>, as shown below:
  *
  * {@snippet lang = java:
  * try (Arena arena = Arena.ofConfined()) {
@@ -82,24 +50,25 @@
  *         segment.setAtIndex(ValueLayout.JAVA_INT, i, i);
  *     }
  * }
- *}
+ * }
  *
- * A confined arena can be {@linkplain java.lang.foreign.Arena#close() closed}. When a confined
- * arena is closed, all the segments allocated by it are invalidated, and become inaccessible.
- * Note the use of the <em>try-with-resources</em> construct: this idiom ensures
- * that the off-heap region of memory backing the native segment will be released at the end of the block, according to
- * the semantics described in Section {@jls 14.20.3} of <cite>The Java Language Specification</cite>.
- *
- * <h3 id="safety">Safety</h3>
- *
- * This API provides strong safety guarantees when it comes to memory access. First, when dereferencing a memory segment,
+ * This code creates a <em>native</em> memory segment, that is, a memory segment backed by
+ * off-heap memory; the size of the segment is 40 bytes, enough to store 10 values of the primitive type {@code int}.
+ * The native segment is allocated using a {@linkplain java.lang.foreign.Arena#ofConfined() confined arena}.
+ * As such, access to the native segment is restricted to the current thread (the thread that created the arena).
+ * Moreover, when the arena is closed, the native segment is invalidated, and its backing region of memory is
+ * deallocated. Note the use of the <em>try-with-resources</em> construct: this idiom ensures that the off-heap region
+ * of memory backing the native segment will be released at the end of the block, according to the semantics described
+ * in Section {@jls 14.20.3} of <cite>The Java Language Specification</cite>.
+ * <p>
+ * Memory segments provide strong safety guarantees when it comes to memory access. First, when accessing a memory segment,
  * the access coordinates are validated (upon access), to make sure that access does not occur at any address which resides
  * <em>outside</em> the boundaries of the memory segment used by the access operation. We call this guarantee <em>spatial safety</em>;
  * in other words, access to memory segments is bounds-checked, in the same way as array access is, as described in
  * Section {@jls 15.10.4} of <cite>The Java Language Specification</cite>.
  * <p>
- * Since memory segments created with an arena can become invalid (see above), segments are also validated (upon access) to make sure that
- * the arena from which the segment has been obtained has not been closed.
+ * Since memory segments created with an arena become invalid (see above) when the arena is closed, segments are also
+ * validated (upon access) to make sure that the arena from which the segment has been obtained has not been closed.
  * We call this guarantee <em>temporal safety</em>. Together, spatial and temporal safety ensure that each memory access
  * operation either succeeds - and accesses a valid location within the region of memory backing the memory segment - or fails.
  *
@@ -141,58 +110,6 @@
  * interacting with foreign code, such as
  * {@linkplain java.lang.foreign.SegmentAllocator#allocateUtf8String(java.lang.String) converting} Java strings into
  * zero-terminated, UTF-8 strings, as demonstrated in the above example.
- *
- * <h3 id="upcalls">Upcalls</h3>
- * The {@link java.lang.foreign.Linker} interface also allows clients to turn an existing method handle (which might point
- * to a Java method) into a memory segment, so that Java code can effectively be passed to other foreign functions.
- * For instance, we can write a method that compares two integer values, as follows:
- *
- * {@snippet lang=java :
- * class IntComparator {
- *     static int intCompare(MemorySegment addr1, MemorySegment addr2) {
- *         return addr1.get(ValueLayout.JAVA_INT, 0) -
- *                addr2.get(ValueLayout.JAVA_INT, 0);
- *
- *     }
- * }
- * }
- *
- * The above method accesses two foreign memory segments containing an integer value, and performs a simple comparison
- * by returning the difference between such values. We can then obtain a method handle which targets the above static
- * method, as follows:
- *
- * {@snippet lang = java:
- * FunctionDescriptor intCompareDescriptor = FunctionDescriptor.of(ValueLayout.JAVA_INT,
- *                                                                 ValueLayout.ADDRESS.asUnbounded(),
- *                                                                 ValueLayout.ADDRESS.asUnbounded());
- * MethodHandle intCompareHandle = MethodHandles.lookup().findStatic(IntComparator.class,
- *                                                 "intCompare",
- *                                                 intCompareDescriptor.toMethodType());
- *}
- *
- * As before, we need to create a {@link java.lang.foreign.FunctionDescriptor} instance, this time describing the signature
- * of the function pointer we want to create. The descriptor can be used to
- * {@linkplain java.lang.foreign.FunctionDescriptor#toMethodType() derive} a method type
- * that can be used to look up the method handle for {@code IntComparator.intCompare}.
- * <p>
- * Now that we have a method handle instance, we can turn it into a fresh function pointer,
- * using the {@link java.lang.foreign.Linker} interface, as follows:
- *
- * {@snippet lang = java:
- * Arena arena = ...
- * MemorySegment comparFunc = Linker.nativeLinker().upcallStub(
- *     intCompareHandle, intCompareDescriptor, arena);
- * );
- *}
- *
- * The {@link java.lang.foreign.FunctionDescriptor} instance created in the previous step is then used to
- * {@linkplain java.lang.foreign.Linker#upcallStub(java.lang.invoke.MethodHandle, FunctionDescriptor, Arena, Linker.Option...) create}
- * a new upcall stub; the layouts in the function descriptors allow the linker to determine the sequence of steps which
- * allow foreign code to call the stub for {@code intCompareHandle} according to the rules specified by the ABI of the
- * underlying platform.
- * The lifecycle of the upcall stub is tied to the {@linkplain java.lang.foreign.Arena arena}
- * provided when the upcall stub is created. If the provided arena is a confined arena,
- * the upcall stub will be deallocated when the confined arena is {@linkplain java.lang.foreign.Arena#close() closed}.
  *
  * <h2 id="restricted">Restricted methods</h2>
  * Some methods in this package are considered <em>restricted</em>. Restricted methods are typically used to bind native


### PR DESCRIPTION
The javadoc for the `Linker` interface is very abstract: it defines the general characteristics of downcall method handles and upcall stubs, and it does so in a very general way, so as not to bias the discussion towards a specific kind of linker implementation.

The result is that, looking at the `Linker` javadoc, one has very little clues on how this interface is meant to be used e.g. to write native interop code. While the toplevel package javadoc provides some examples, these examples are relatively simple and do not cover all the features provided by the FFM API.

To rectify this, I did another pass on the `Linker` javadoc. I retained the very good general intro (the first few paras). But then, instead of talking about "downcalls" and "upcalls" - we immediately start talking about "Calling native functions" and we ground the discussion on the native linker. This gives us the opportunity to discuss native calls, function pointers, variadic calls, and even how to deal with functions returning pointers.

The text of the sections on upcalls/downcall (which is normative text) has been moved in the javadoc of the relevant methods.

Finally, since with the new examples there was some overlapping between the toplevel package javadoc and the `Linker` javadoc, I also decided to take another pass at the package javadoc, and simplify it further: now there are only 3 sections: foreign memory, foreign function, restricted methods. For each of the first two sections there's a quick summary (which describes the main abstractions and their roles), followed by an idiomatic example. Restricted methods also belong here, as they are a cross-cutting concern of the FFM API.

Overall, I believe this iteration is much better than what we had, and more useful. While covering all the details of native interop would be outside the scope of the FFM javadoc, I think the new `Linker` javadoc strikes a good balance.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8298096](https://bugs.openjdk.org/browse/JDK-8298096): Refine javadoc for Linker


### Reviewers
 * [Jorn Vernee](https://openjdk.org/census#jvernee) (@JornVernee - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/panama-foreign pull/820/head:pull/820` \
`$ git checkout pull/820`

Update a local copy of the PR: \
`$ git checkout pull/820` \
`$ git pull https://git.openjdk.org/panama-foreign pull/820/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 820`

View PR using the GUI difftool: \
`$ git pr show -t 820`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/panama-foreign/pull/820.diff">https://git.openjdk.org/panama-foreign/pull/820.diff</a>

</details>
