### PR TITLE
8305087: MemoryLayout API checks should be more eager

### DIFF
--- a/src/java.base/share/classes/java/lang/foreign/GroupLayout.java
+++ b/src/java.base/share/classes/java/lang/foreign/GroupLayout.java
@@ -68,7 +68,7 @@ public sealed interface GroupLayout extends MemoryLayout permits StructLayout, U
     /**
      * {@inheritDoc}
      * @throws IllegalArgumentException {@inheritDoc}
-     * @throws IllegalArgumentException if {@code bitAlignment} is {@code M}, where {@code M} is the maximum alignment
+     * @throws IllegalArgumentException if {@code bitAlignment} is less than {@code M}, where {@code M} is the maximum alignment
      * constraint in any of the member layouts associated with this group layout.
      */
     @Override

--- a/src/java.base/share/classes/java/lang/foreign/GroupLayout.java
+++ b/src/java.base/share/classes/java/lang/foreign/GroupLayout.java
@@ -67,6 +67,9 @@ public sealed interface GroupLayout extends MemoryLayout permits StructLayout, U
 
     /**
      * {@inheritDoc}
+     * @throws IllegalArgumentException {@inheritDoc}
+     * @throws IllegalArgumentException if {@code bitAlignment} is {@code M}, where {@code M} is the maximum alignment
+     * constraint in any of the member layouts associated with this group layout.
      */
     @Override
     GroupLayout withBitAlignment(long bitAlignment);

--- a/src/java.base/share/classes/java/lang/foreign/MemoryLayout.java
+++ b/src/java.base/share/classes/java/lang/foreign/MemoryLayout.java
@@ -704,10 +704,12 @@ public sealed interface MemoryLayout permits SequenceLayout, GroupLayout, Paddin
      * @param elementLayout the sequence element layout.
      * @return the new sequence layout with the given element layout and size.
      * @throws IllegalArgumentException if {@code elementCount } is negative.
+     * @throws IllegalArgumentException if {@code elementLayout.bitAlignment() > elementLayout.bitSize()}.
      */
     static SequenceLayout sequenceLayout(long elementCount, MemoryLayout elementLayout) {
         MemoryLayoutUtil.requireNonNegative(elementCount);
         Objects.requireNonNull(elementLayout);
+        Utils.checkElementAlignment(elementLayout, "Element layout alignment greater than its size");
         return wrapOverflow(() ->
                 SequenceLayoutImpl.of(elementCount, elementLayout));
     }
@@ -723,6 +725,7 @@ public sealed interface MemoryLayout permits SequenceLayout, GroupLayout, Paddin
      *
      * @param elementLayout the sequence element layout.
      * @return a new sequence layout with the given element layout and maximum element count.
+     * @throws IllegalArgumentException if {@code elementLayout.bitAlignment() > elementLayout.bitSize()}.
      */
     static SequenceLayout sequenceLayout(MemoryLayout elementLayout) {
         Objects.requireNonNull(elementLayout);

--- a/src/java.base/share/classes/java/lang/foreign/PaddingLayout.java
+++ b/src/java.base/share/classes/java/lang/foreign/PaddingLayout.java
@@ -54,6 +54,7 @@ public sealed interface PaddingLayout extends MemoryLayout permits PaddingLayout
 
     /**
      * {@inheritDoc}
+     * @throws IllegalArgumentException {@inheritDoc}
      */
     @Override
     PaddingLayout withBitAlignment(long bitAlignment);

--- a/src/java.base/share/classes/java/lang/foreign/SequenceLayout.java
+++ b/src/java.base/share/classes/java/lang/foreign/SequenceLayout.java
@@ -142,7 +142,8 @@ public sealed interface SequenceLayout extends MemoryLayout permits SequenceLayo
 
     /**
      * {@inheritDoc}
+     * @throws IllegalArgumentException {@inheritDoc}
+     * @throws IllegalArgumentException if {@code bitAlignment < elementLayout().bitAlignment()}.
      */
-    @Override
     SequenceLayout withBitAlignment(long bitAlignment);
 }

--- a/src/java.base/share/classes/java/lang/foreign/StructLayout.java
+++ b/src/java.base/share/classes/java/lang/foreign/StructLayout.java
@@ -53,6 +53,7 @@ public sealed interface StructLayout extends GroupLayout permits StructLayoutImp
 
     /**
      * {@inheritDoc}
+     * @throws IllegalArgumentException {@inheritDoc}
      */
     @Override
     StructLayout withBitAlignment(long bitAlignment);

--- a/src/java.base/share/classes/java/lang/foreign/UnionLayout.java
+++ b/src/java.base/share/classes/java/lang/foreign/UnionLayout.java
@@ -53,6 +53,7 @@ public sealed interface UnionLayout extends GroupLayout permits UnionLayoutImpl 
 
     /**
      * {@inheritDoc}
+     * @throws IllegalArgumentException {@inheritDoc}
      */
     @Override
     UnionLayout withBitAlignment(long bitAlignment);

--- a/src/java.base/share/classes/java/lang/foreign/ValueLayout.java
+++ b/src/java.base/share/classes/java/lang/foreign/ValueLayout.java
@@ -149,9 +149,9 @@ public sealed interface ValueLayout extends MemoryLayout permits
 
     /**
      * {@inheritDoc}
+     * @throws IllegalArgumentException {@inheritDoc}
      */
     @Override
-
     ValueLayout withBitAlignment(long bitAlignment);
 
     /**
@@ -177,6 +177,7 @@ public sealed interface ValueLayout extends MemoryLayout permits
 
         /**
          * {@inheritDoc}
+         * @throws IllegalArgumentException {@inheritDoc}
          */
         @Override
         OfBoolean withBitAlignment(long bitAlignment);
@@ -212,6 +213,7 @@ public sealed interface ValueLayout extends MemoryLayout permits
 
         /**
          * {@inheritDoc}
+         * @throws IllegalArgumentException {@inheritDoc}
          */
         @Override
         OfByte withBitAlignment(long bitAlignment);
@@ -248,6 +250,7 @@ public sealed interface ValueLayout extends MemoryLayout permits
 
         /**
          * {@inheritDoc}
+         * @throws IllegalArgumentException {@inheritDoc}
          */
         @Override
         OfChar withBitAlignment(long bitAlignment);
@@ -284,6 +287,7 @@ public sealed interface ValueLayout extends MemoryLayout permits
 
         /**
          * {@inheritDoc}
+         * @throws IllegalArgumentException {@inheritDoc}
          */
         @Override
         OfShort withBitAlignment(long bitAlignment);
@@ -320,6 +324,7 @@ public sealed interface ValueLayout extends MemoryLayout permits
 
         /**
          * {@inheritDoc}
+         * @throws IllegalArgumentException {@inheritDoc}
          */
         @Override
         OfInt withBitAlignment(long bitAlignment);
@@ -392,6 +397,7 @@ public sealed interface ValueLayout extends MemoryLayout permits
 
         /**
          * {@inheritDoc}
+         * @throws IllegalArgumentException {@inheritDoc}
          */
         @Override
         OfLong withBitAlignment(long bitAlignment);
@@ -428,6 +434,7 @@ public sealed interface ValueLayout extends MemoryLayout permits
 
         /**
          * {@inheritDoc}
+         * @throws IllegalArgumentException {@inheritDoc}
          */
         @Override
         OfDouble withBitAlignment(long bitAlignment);

--- a/src/java.base/share/classes/jdk/internal/foreign/LayoutPath.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/LayoutPath.java
@@ -192,7 +192,6 @@ public class LayoutPath {
         if (!(layout instanceof ValueLayout valueLayout)) {
             throw new IllegalArgumentException("Path does not select a value layout");
         }
-        checkAlignment(this);
 
         VarHandle handle = Utils.makeSegmentViewVarHandle(valueLayout);
         for (int i = strides.length - 1; i >= 0; i--) {
@@ -279,26 +278,6 @@ public class LayoutPath {
 
     private static IllegalArgumentException badLayoutPath(String cause) {
         return new IllegalArgumentException("Bad layout path: " + cause);
-    }
-
-    private static void checkAlignment(LayoutPath path) {
-        MemoryLayout layout = path.layout;
-        long alignment = layout.bitAlignment();
-        if (!Utils.isAligned(path.offset, alignment)) {
-            throw new UnsupportedOperationException("Invalid alignment requirements for layout " + layout);
-        }
-        for (long stride : path.strides) {
-            if (!Utils.isAligned(stride, alignment)) {
-                throw new UnsupportedOperationException("Alignment requirements for layout " + layout + " do not match stride " + stride);
-            }
-        }
-        LayoutPath encl = path.enclosing;
-        if (encl != null) {
-            if (encl.layout.bitAlignment() < alignment) {
-                throw new UnsupportedOperationException("Alignment requirements for layout " + layout + " do not match those for enclosing layout " + encl.layout);
-            }
-            checkAlignment(encl);
-        }
     }
 
     private long[] addStride(long stride) {

--- a/src/java.base/share/classes/jdk/internal/foreign/layout/AbstractGroupLayout.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/layout/AbstractGroupLayout.java
@@ -49,15 +49,13 @@ public sealed abstract class AbstractGroupLayout<L extends AbstractGroupLayout<L
 
     private final Kind kind;
     private final List<MemoryLayout> elements;
+    final long minBitAlignment;
 
-    AbstractGroupLayout(Kind kind, List<MemoryLayout> elements) {
-        this(kind, elements, kind.alignof(elements), Optional.empty());
-    }
-
-    AbstractGroupLayout(Kind kind, List<MemoryLayout> elements, long bitAlignment, Optional<String> name) {
-        super(kind.sizeof(elements), bitAlignment, name); // Subclassing creates toctou problems here
+    AbstractGroupLayout(Kind kind, List<MemoryLayout> elements, long bitSize, long bitAlignment, long minBitAlignment, Optional<String> name) {
+        super(bitSize, bitAlignment, name); // Subclassing creates toctou problems here
         this.kind = kind;
         this.elements = List.copyOf(elements);
+        this.minBitAlignment = minBitAlignment;
     }
 
     /**
@@ -85,7 +83,7 @@ public sealed abstract class AbstractGroupLayout<L extends AbstractGroupLayout<L
 
     @Override
     public L withBitAlignment(long bitAlignment) {
-        if (bitAlignment < kind.alignof(elements)) {
+        if (bitAlignment < minBitAlignment) {
             throw new IllegalArgumentException("Invalid alignment constraint");
         }
         return super.withBitAlignment(bitAlignment);
@@ -113,7 +111,7 @@ public sealed abstract class AbstractGroupLayout<L extends AbstractGroupLayout<L
 
     @Override
     public final boolean hasNaturalAlignment() {
-        return bitAlignment() == kind.alignof(elements);
+        return bitAlignment() == minBitAlignment;
     }
 
     /**
@@ -123,36 +121,16 @@ public sealed abstract class AbstractGroupLayout<L extends AbstractGroupLayout<L
         /**
          * A 'struct' kind.
          */
-        STRUCT("", Math::addExact),
+        STRUCT(""),
         /**
          * A 'union' kind.
          */
-        UNION("|", Math::max);
+        UNION("|");
 
         final String delimTag;
-        final LongBinaryOperator sizeOp;
 
-        Kind(String delimTag, LongBinaryOperator sizeOp) {
+        Kind(String delimTag) {
             this.delimTag = delimTag;
-            this.sizeOp = sizeOp;
-        }
-
-        long sizeof(List<MemoryLayout> elems) {
-            long size = 0;
-            for (MemoryLayout elem : elems) {
-                if (this == STRUCT && (size % elem.bitAlignment() != 0)) {
-                    throw new IllegalArgumentException("Invalid alignment constraint for member layout: " + elem);
-                }
-                size = sizeOp.applyAsLong(size, elem.bitSize());
-            }
-            return size;
-        }
-
-        long alignof(List<MemoryLayout> elems) {
-            return elems.stream()
-                    .mapToLong(MemoryLayout::bitAlignment)
-                    .max() // max alignment in case we have member layouts
-                    .orElse(8); // or minimal alignment if no member layout is given
         }
     }
 }

--- a/src/java.base/share/classes/jdk/internal/foreign/layout/AbstractGroupLayout.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/layout/AbstractGroupLayout.java
@@ -83,6 +83,14 @@ public sealed abstract class AbstractGroupLayout<L extends AbstractGroupLayout<L
                 .collect(Collectors.joining(kind.delimTag, "[", "]")));
     }
 
+    @Override
+    public L withBitAlignment(long bitAlignment) {
+        if (bitAlignment < kind.alignof(elements)) {
+            throw new IllegalArgumentException("Invalid alignment constraint");
+        }
+        return super.withBitAlignment(bitAlignment);
+    }
+
     /**
      * {@inheritDoc}
      */
@@ -132,6 +140,9 @@ public sealed abstract class AbstractGroupLayout<L extends AbstractGroupLayout<L
         long sizeof(List<MemoryLayout> elems) {
             long size = 0;
             for (MemoryLayout elem : elems) {
+                if (this == STRUCT && (size % elem.bitAlignment() != 0)) {
+                    throw new IllegalArgumentException("Invalid alignment constraint for member layout: " + elem);
+                }
                 size = sizeOp.applyAsLong(size, elem.bitSize());
             }
             return size;

--- a/src/java.base/share/classes/jdk/internal/foreign/layout/AbstractLayout.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/layout/AbstractLayout.java
@@ -59,7 +59,7 @@ public abstract sealed class AbstractLayout<L extends AbstractLayout<L> & Memory
         return name;
     }
 
-    public final L withBitAlignment(long bitAlignment) {
+    public L withBitAlignment(long bitAlignment) {
         return dup(bitAlignment, name);
     }
 

--- a/src/java.base/share/classes/jdk/internal/foreign/layout/SequenceLayoutImpl.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/layout/SequenceLayoutImpl.java
@@ -201,6 +201,14 @@ public final class SequenceLayoutImpl extends AbstractLayout<SequenceLayoutImpl>
     }
 
     @Override
+    public SequenceLayoutImpl withBitAlignment(long bitAlignment) {
+        if (bitAlignment < elementLayout.bitAlignment()) {
+            throw new IllegalArgumentException("Invalid alignment constraint");
+        }
+        return super.withBitAlignment(bitAlignment);
+    }
+
+    @Override
     public boolean hasNaturalAlignment() {
         return bitAlignment() == elementLayout.bitAlignment();
     }

--- a/src/java.base/share/classes/jdk/internal/foreign/layout/UnionLayoutImpl.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/layout/UnionLayoutImpl.java
@@ -26,27 +26,30 @@
 package jdk.internal.foreign.layout;
 
 import java.lang.foreign.MemoryLayout;
+import java.lang.foreign.StructLayout;
 import java.lang.foreign.UnionLayout;
 import java.util.List;
 import java.util.Optional;
 
 public final class UnionLayoutImpl extends AbstractGroupLayout<UnionLayoutImpl> implements UnionLayout {
 
-    private UnionLayoutImpl(List<MemoryLayout> elements) {
-        super(Kind.UNION, elements);
-    }
-
-    private UnionLayoutImpl(List<MemoryLayout> elements, long bitAlignment, Optional<String> name) {
-        super(Kind.UNION, elements, bitAlignment, name);
+    private UnionLayoutImpl(List<MemoryLayout> elements, long bitSize, long bitAlignment, long minBitAlignment, Optional<String> name) {
+        super(Kind.UNION, elements, bitSize, bitAlignment, minBitAlignment, name);
     }
 
     @Override
     UnionLayoutImpl dup(long bitAlignment, Optional<String> name) {
-        return new UnionLayoutImpl(memberLayouts(), bitAlignment, name);
+        return new UnionLayoutImpl(memberLayouts(), bitSize(), bitAlignment, minBitAlignment, name);
     }
 
     public static UnionLayout of(List<MemoryLayout> elements) {
-        return new UnionLayoutImpl(elements);
+        long size = 0;
+        long align = 8;
+        for (MemoryLayout elem : elements) {
+            size = Math.max(size, elem.bitSize());
+            align = Math.max(align, elem.bitAlignment());
+        }
+        return new UnionLayoutImpl(elements, size, align, align, Optional.empty());
     }
 
 }

--- a/src/java.base/share/classes/jdk/internal/foreign/layout/UnionLayoutImpl.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/layout/UnionLayoutImpl.java
@@ -26,7 +26,6 @@
 package jdk.internal.foreign.layout;
 
 import java.lang.foreign.MemoryLayout;
-import java.lang.foreign.StructLayout;
 import java.lang.foreign.UnionLayout;
 import java.util.List;
 import java.util.Optional;

--- a/test/jdk/java/foreign/MemoryLayoutTypeRetentionTest.java
+++ b/test/jdk/java/foreign/MemoryLayoutTypeRetentionTest.java
@@ -41,7 +41,7 @@ public class MemoryLayoutTypeRetentionTest {
     // withName() et al. should return the same type as the original object.
 
     private static final String NAME = "a";
-    private static final long BIT_ALIGNMENT = Long.SIZE * 2;
+    private static final long BIT_ALIGNMENT = Byte.SIZE;
     private static final ByteOrder BYTE_ORDER = ByteOrder.nativeOrder() == ByteOrder.BIG_ENDIAN
             ? ByteOrder.LITTLE_ENDIAN
             : ByteOrder.BIG_ENDIAN;
@@ -165,7 +165,9 @@ public class MemoryLayoutTypeRetentionTest {
 
     @Test
     public void testGroupLayout() {
-        GroupLayout v = MemoryLayout.structLayout(JAVA_INT, JAVA_LONG)
+        GroupLayout v = MemoryLayout.structLayout(
+                        JAVA_INT.withBitAlignment(BIT_ALIGNMENT),
+                        JAVA_LONG.withBitAlignment(BIT_ALIGNMENT))
                 .withBitAlignment(BIT_ALIGNMENT)
                 .withoutName()
                 .withName(NAME);
@@ -174,7 +176,9 @@ public class MemoryLayoutTypeRetentionTest {
 
     @Test
     public void testStructLayout() {
-        StructLayout v = MemoryLayout.structLayout(JAVA_INT, JAVA_LONG)
+        StructLayout v = MemoryLayout.structLayout(
+                        JAVA_INT.withBitAlignment(BIT_ALIGNMENT),
+                        JAVA_LONG.withBitAlignment(BIT_ALIGNMENT))
                 .withBitAlignment(BIT_ALIGNMENT)
                 .withoutName()
                 .withName(NAME);
@@ -183,7 +187,9 @@ public class MemoryLayoutTypeRetentionTest {
 
     @Test
     public void testUnionLayout() {
-        UnionLayout v = MemoryLayout.unionLayout(JAVA_INT, JAVA_LONG)
+        UnionLayout v = MemoryLayout.unionLayout(
+                    JAVA_INT.withBitAlignment(BIT_ALIGNMENT),
+                    JAVA_LONG.withBitAlignment(BIT_ALIGNMENT))
                 .withBitAlignment(BIT_ALIGNMENT)
                 .withoutName()
                 .withName(NAME);

--- a/test/jdk/java/foreign/TestLayoutPaths.java
+++ b/test/jdk/java/foreign/TestLayoutPaths.java
@@ -177,44 +177,6 @@ public class TestLayoutPaths {
     }
 
     @Test
-    public void testBadContainerAlign() {
-        GroupLayout g = MemoryLayout.structLayout(JAVA_INT.withBitAlignment(16).withName("foo")).withBitAlignment(8);
-        try {
-            g.bitOffset(groupElement("foo"));
-            g.byteOffset(groupElement("foo"));
-        } catch (Throwable ex) {
-            throw new AssertionError(ex); // should be ok!
-        }
-        try {
-            g.varHandle(groupElement("foo")); //ok
-            assertTrue(false); //should fail!
-        } catch (UnsupportedOperationException ex) {
-            //ok
-        } catch (Throwable ex) {
-            throw new AssertionError(ex); //should fail!
-        }
-    }
-
-    @Test
-    public void testBadAlignOffset() {
-        GroupLayout g = MemoryLayout.structLayout(MemoryLayout.paddingLayout(8), JAVA_INT.withBitAlignment(16).withName("foo"));
-        try {
-            g.bitOffset(groupElement("foo"));
-            g.byteOffset(groupElement("foo"));
-        } catch (Throwable ex) {
-            throw new AssertionError(ex); // should be ok!
-        }
-        try {
-            g.varHandle(groupElement("foo")); //ok
-            assertTrue(false); //should fail!
-        } catch (UnsupportedOperationException ex) {
-            //ok
-        } catch (Throwable ex) {
-            throw new AssertionError(ex); //should fail!
-        }
-    }
-
-    @Test
     public void testBadSequencePathInOffset() {
         SequenceLayout seq = MemoryLayout.sequenceLayout(10, JAVA_INT);
         // bad path elements
@@ -252,9 +214,9 @@ public class TestLayoutPaths {
         long[] offsets = { 0, 8, 24, 56 };
         GroupLayout g = MemoryLayout.structLayout(
                 ValueLayout.JAVA_BYTE.withName("0"),
-                ValueLayout.JAVA_CHAR.withName("1"),
-                ValueLayout.JAVA_FLOAT.withName("2"),
-                ValueLayout.JAVA_LONG.withName("3")
+                ValueLayout.JAVA_CHAR.withBitAlignment(8).withName("1"),
+                ValueLayout.JAVA_FLOAT.withBitAlignment(8).withName("2"),
+                ValueLayout.JAVA_LONG.withBitAlignment(8).withName("3")
         );
 
         // test select
@@ -361,10 +323,10 @@ public class TestLayoutPaths {
             (JAVA_INT.bitSize() * 2) * 4 + JAVA_INT.bitSize()
         });
         testCases.add(new Object[] {
-            MemoryLayout.sequenceLayout(10, MemoryLayout.structLayout(MemoryLayout.paddingLayout(8), JAVA_INT.withName("y"))),
+            MemoryLayout.sequenceLayout(10, MemoryLayout.structLayout(MemoryLayout.paddingLayout(32), JAVA_INT.withName("y"))),
             new PathElement[] { sequenceElement(), groupElement("y") },
             new long[] { 4 },
-            (JAVA_INT.bitSize() + 8) * 4 + 8
+            (JAVA_INT.bitSize() + 32) * 4 + 32
         });
         testCases.add(new Object[] {
             MemoryLayout.sequenceLayout(10, JAVA_INT),

--- a/test/jdk/java/foreign/TestLayouts.java
+++ b/test/jdk/java/foreign/TestLayouts.java
@@ -277,11 +277,35 @@ public class TestLayouts {
     public void testAlignmentString(MemoryLayout layout, long bitAlign) {
         long[] alignments = { 8, 16, 32, 64, 128 };
         for (long a : alignments) {
-            if (layout.bitAlignment() == layout.bitSize()) {
+            if (layout.bitAlignment() == bitAlign) {
                 assertFalse(layout.toString().contains("%"));
-                assertEquals(layout.withBitAlignment(a).toString().contains("%"), a != bitAlign);
+                if (a >= layout.bitAlignment()) {
+                    assertEquals(layout.withBitAlignment(a).toString().contains("%"), a != bitAlign);
+                }
             }
         }
+    }
+
+    @Test(dataProvider="layoutsAndAlignments")
+    public void testBadBitAlignment(MemoryLayout layout, long bitAlign) {
+        long[] alignments = { 8, 16, 32, 64, 128 };
+        for (long a : alignments) {
+            if (a < bitAlign && !(layout instanceof ValueLayout)) {
+                assertThrows(IllegalArgumentException.class, () -> layout.withBitAlignment(a));
+            }
+        }
+    }
+
+    @Test(dataProvider="layoutsAndAlignments", expectedExceptions = IllegalArgumentException.class)
+    public void testBadSequence(MemoryLayout layout, long bitAlign) {
+        layout = layout.withBitAlignment(layout.bitSize() * 2); // hyper-align
+        MemoryLayout.sequenceLayout(layout);
+    }
+
+    @Test(dataProvider="layoutsAndAlignments", expectedExceptions = IllegalArgumentException.class)
+    public void testBadStruct(MemoryLayout layout, long bitAlign) {
+        layout = layout.withBitAlignment(layout.bitSize() * 2); // hyper-align
+        MemoryLayout.structLayout(layout, layout);
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class)
@@ -422,7 +446,7 @@ public class TestLayouts {
         return Stream.of(
                 MemoryLayout.sequenceLayout(10, JAVA_INT),
                 MemoryLayout.sequenceLayout(JAVA_INT),
-                MemoryLayout.structLayout(JAVA_INT, JAVA_LONG),
+                MemoryLayout.structLayout(JAVA_INT, MemoryLayout.paddingLayout(32), JAVA_LONG),
                 MemoryLayout.unionLayout(JAVA_LONG, JAVA_DOUBLE)
         );
     }

--- a/test/jdk/java/foreign/callarranger/TestRISCV64CallArranger.java
+++ b/test/jdk/java/foreign/callarranger/TestRISCV64CallArranger.java
@@ -213,27 +213,6 @@ public class TestRISCV64CallArranger extends CallArrangerTestBase {
                     // s.b
                     bufferLoad(8, double.class), vmStore(f11, double.class),
                 }
-            },
-            // struct __attribute__((__packed__)) s { float a; double b; };
-            { MemoryLayout.structLayout(C_FLOAT, C_DOUBLE),
-                new Binding[]{
-                    dup(),
-                    // s.a
-                    bufferLoad(0, float.class), vmStore(f10, float.class),
-                    // s.b
-                    bufferLoad(4, double.class), vmStore(f11, double.class),
-                }
-            },
-            // struct s { float a; float b __attribute__ ((aligned (8))); }
-            { MemoryLayout.structLayout(C_FLOAT, MemoryLayout.paddingLayout(32),
-                C_FLOAT, MemoryLayout.paddingLayout(32)),
-                new Binding[]{
-                    dup(),
-                    // s.a
-                    bufferLoad(0, float.class), vmStore(f10, float.class),
-                    // s.b
-                    bufferLoad(8, float.class), vmStore(f11, float.class),
-                }
             }
         };
     }
@@ -278,7 +257,7 @@ public class TestRISCV64CallArranger extends CallArrangerTestBase {
 
     @Test
     public void testStructFA2() {
-        MemoryLayout fa = MemoryLayout.structLayout(C_FLOAT, C_DOUBLE);
+        MemoryLayout fa = MemoryLayout.structLayout(C_FLOAT, MemoryLayout.paddingLayout(32), C_DOUBLE);
 
         MethodType mt = MethodType.methodType(MemorySegment.class, float.class, int.class, MemorySegment.class);
         FunctionDescriptor fd = FunctionDescriptor.of(fa, C_FLOAT, C_INT, fa);
@@ -298,7 +277,7 @@ public class TestRISCV64CallArranger extends CallArrangerTestBase {
                 dup(),
                 bufferLoad(0, float.class),
                 vmStore(f11, float.class),
-                bufferLoad(4, double.class),
+                bufferLoad(8, double.class),
                 vmStore(f12, double.class)
             }
         });
@@ -310,7 +289,7 @@ public class TestRISCV64CallArranger extends CallArrangerTestBase {
             bufferStore(0, float.class),
             dup(),
             vmLoad(f11, double.class),
-            bufferStore(4, double.class)
+            bufferStore(8, double.class)
         });
     }
 

--- a/test/jdk/java/foreign/callarranger/TestSysVCallArranger.java
+++ b/test/jdk/java/foreign/callarranger/TestSysVCallArranger.java
@@ -146,66 +146,6 @@ public class TestSysVCallArranger extends CallArrangerTestBase {
     }
 
     @Test
-    public void testNestedStructsUnaligned() {
-        MemoryLayout POINT = MemoryLayout.structLayout(
-                C_INT,
-                MemoryLayout.structLayout(
-                        C_LONG,
-                        C_INT
-                )
-        );
-        MethodType mt = MethodType.methodType(void.class, MemorySegment.class);
-        FunctionDescriptor fd = FunctionDescriptor.ofVoid(POINT);
-        CallArranger.Bindings bindings = CallArranger.getBindings(mt, fd, false);
-
-        assertFalse(bindings.isInMemoryReturn());
-        CallingSequence callingSequence = bindings.callingSequence();
-        assertEquals(callingSequence.callerMethodType(), mt.appendParameterTypes(long.class).insertParameterTypes(0, MemorySegment.class));
-        assertEquals(callingSequence.functionDesc(), fd.appendArgumentLayouts(C_LONG).insertArgumentLayouts(0, ADDRESS));
-
-        checkArgumentBindings(callingSequence, new Binding[][]{
-            { unboxAddress(), vmStore(TARGET_ADDRESS_STORAGE, long.class) },
-            { dup(), bufferLoad(0, long.class), vmStore(stackStorage(STACK_SLOT_SIZE, 0), long.class),
-                    bufferLoad(8, long.class), vmStore(stackStorage(STACK_SLOT_SIZE, 8), long.class)},
-            { vmStore(rax, long.class) },
-        });
-
-        checkReturnBindings(callingSequence, new Binding[]{});
-
-        assertEquals(bindings.nVectorArgs(), 0);
-    }
-
-    @Test
-    public void testNestedUnionUnaligned() {
-        MemoryLayout POINT = MemoryLayout.structLayout(
-                C_INT,
-                MemoryLayout.unionLayout(
-                        MemoryLayout.structLayout(C_INT, C_INT),
-                        C_LONG
-                )
-        );
-        MethodType mt = MethodType.methodType(void.class, MemorySegment.class);
-        FunctionDescriptor fd = FunctionDescriptor.ofVoid(POINT);
-        CallArranger.Bindings bindings = CallArranger.getBindings(mt, fd, false);
-
-        assertFalse(bindings.isInMemoryReturn());
-        CallingSequence callingSequence = bindings.callingSequence();
-        assertEquals(callingSequence.callerMethodType(), mt.appendParameterTypes(long.class).insertParameterTypes(0, MemorySegment.class));
-        assertEquals(callingSequence.functionDesc(), fd.appendArgumentLayouts(C_LONG).insertArgumentLayouts(0, ADDRESS));
-
-        checkArgumentBindings(callingSequence, new Binding[][]{
-            { unboxAddress(), vmStore(TARGET_ADDRESS_STORAGE, long.class) },
-            { dup(), bufferLoad(0, long.class), vmStore(stackStorage(STACK_SLOT_SIZE, 0), long.class),
-                    bufferLoad(8, int.class), vmStore(stackStorage(STACK_SLOT_SIZE, 8), int.class)},
-            { vmStore(rax, long.class) },
-        });
-
-        checkReturnBindings(callingSequence, new Binding[]{});
-
-        assertEquals(bindings.nVectorArgs(), 0);
-    }
-
-    @Test
     public void testIntegerRegs() {
         MethodType mt = MethodType.methodType(void.class,
                 int.class, int.class, int.class, int.class, int.class, int.class);


### PR DESCRIPTION
This patch adds eager check on construction of sequence and group layouts. More specifically:

* sequenceLayout(L) is well-formed iff L.bitAlignment() <= L.bitSize()
* groupLayout(L1, … Ln) is well-formed iff for-each 1..n, offset(Li) % Li.bitAlignment() == 0

Moreover, this patch also validates the alignment parameter to calls of `MemoryLayout::withBitAlignment` on sequence and group layouts:

* sequenceLayout(L).withBitAlignment(a) is well-formed iff L.bitAlignment() <= a
* groupLayout(L1, ..., Ln).withBitAlignment(a) is well-formed iff max(L1.bitAlignment(), ...,  Ln.bitAlignment()) <= a

These checks prevent bad layouts from being constructed (either with factories, or with bad calls to `withBitAlignment`), w/o restricting the expressiveness of the memory layout API.
Moreover, since all layouts are now well-formed by construction, we no longer need lazy checks when creating a deferefence var handle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8305087](https://bugs.openjdk.org/browse/JDK-8305087): MemoryLayout API checks should be more eager


### Reviewers
 * [Jorn Vernee](https://openjdk.org/census#jvernee) (@JornVernee - Committer)
 * [Per Minborg](https://openjdk.org/census#pminborg) (@minborg - Committer) ⚠️ Review applies to [49b83016](https://git.openjdk.org/panama-foreign/pull/824/files/49b8301666135298b6aa894177be6a3d273dc756)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/panama-foreign.git pull/824/head:pull/824` \
`$ git checkout pull/824`

Update a local copy of the PR: \
`$ git checkout pull/824` \
`$ git pull https://git.openjdk.org/panama-foreign.git pull/824/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 824`

View PR using the GUI difftool: \
`$ git pr show -t 824`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/panama-foreign/pull/824.diff">https://git.openjdk.org/panama-foreign/pull/824.diff</a>

</details>
