### PR TITLE
8306668: Some foreign tests fail on x86

### DIFF
--- a/src/java.base/share/classes/jdk/internal/foreign/Utils.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/Utils.java
@@ -124,9 +124,10 @@ public final class Utils {
             handle = MethodHandles.filterValue(handle, BOOL_TO_BYTE, BYTE_TO_BOOL);
         } else if (layout instanceof AddressLayout addressLayout) {
             handle = MethodHandles.filterValue(handle,
-                    ADDRESS_TO_LONG,
-                    MethodHandles.insertArguments(LONG_TO_ADDRESS, 1,
-                            pointeeByteSize(addressLayout), pointeeByteAlign(addressLayout)));
+                    MethodHandles.explicitCastArguments(ADDRESS_TO_LONG, MethodType.methodType(baseCarrier, MemorySegment.class)),
+                    MethodHandles.explicitCastArguments(MethodHandles.insertArguments(LONG_TO_ADDRESS, 1,
+                            pointeeByteSize(addressLayout), pointeeByteAlign(addressLayout)),
+                            MethodType.methodType(MemorySegment.class, baseCarrier)));
         }
         return VarHandleCache.put(layout, handle);
     }

--- a/test/jdk/java/foreign/callarranger/TestWindowsCallArranger.java
+++ b/test/jdk/java/foreign/callarranger/TestWindowsCallArranger.java
@@ -25,7 +25,7 @@
 /*
  * @test
  * @enablePreview
- * @requires ((os.arch == "amd64" | os.arch == "x86_64") & sun.arch.data.model == "64") | os.arch == "aarch64"
+ * @requires sun.arch.data.model == "64"
  * @compile platform/PlatformLayouts.java
  * @modules java.base/jdk.internal.foreign
  *          java.base/jdk.internal.foreign.abi

--- a/test/jdk/java/foreign/callarranger/TestWindowsCallArranger.java
+++ b/test/jdk/java/foreign/callarranger/TestWindowsCallArranger.java
@@ -25,6 +25,7 @@
 /*
  * @test
  * @enablePreview
+ * @requires ((os.arch == "amd64" | os.arch == "x86_64") & sun.arch.data.model == "64") | os.arch == "aarch64"
  * @compile platform/PlatformLayouts.java
  * @modules java.base/jdk.internal.foreign
  *          java.base/jdk.internal.foreign.abi

--- a/test/micro/org/openjdk/bench/java/lang/foreign/libPtr.c
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/libPtr.c
@@ -29,16 +29,18 @@
 #define EXPORT
 #endif
 
+#include <stddef.h>
+
 EXPORT long long id_long_long(long long value) {
   return value;
 }
 
 EXPORT long long id_ptr_long(void* ptr) {
-  return (long long)ptr;
+  return (long long)(size_t)ptr;
 }
 
 EXPORT void* id_long_ptr(long long value) {
-  return (void*)value;
+  return (void*)(size_t)value;
 }
 
 EXPORT void* id_ptr_ptr(void* ptr) {


### PR DESCRIPTION
Some foreign tests fail on x86, as a result of the changes in https://github.com/openjdk/panama-foreign/pull/775.
This patch reverts the `long` -> `int` conversion logic in `Utils`, and it also fixes the following:
* a new microbenchmark fails compilation on x86 because of a bad cast from pointer to long
* exclude WindowsCallArrangerTest on x86

I've tested this by building (and testing) a 32-bit JDK on my Linux x64 using `--with-target-bits=32`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8306668](https://bugs.openjdk.org/browse/JDK-8306668): Some foreign tests fail on x86


### Reviewers
 * [Jorn Vernee](https://openjdk.org/census#jvernee) (@JornVernee - Committer) ⚠️ Review applies to [b609e5e4](https://git.openjdk.org/panama-foreign/pull/828/files/b609e5e463fa3d8cc63a6b066775a727976bc424)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/panama-foreign.git pull/828/head:pull/828` \
`$ git checkout pull/828`

Update a local copy of the PR: \
`$ git checkout pull/828` \
`$ git pull https://git.openjdk.org/panama-foreign.git pull/828/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 828`

View PR using the GUI difftool: \
`$ git pr show -t 828`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/panama-foreign/pull/828.diff">https://git.openjdk.org/panama-foreign/pull/828.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/panama-foreign/pull/828#issuecomment-1517610020)