### PR TITLE
Fix build issue with MemoryInspectionUtil

### DIFF
--- a/src/java.base/share/classes/jdk/internal/foreign/MemoryInspectionUtil.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/MemoryInspectionUtil.java
@@ -109,7 +109,7 @@ final class MemoryInspectionUtil {
             return;
         }
         if (layout instanceof PaddingLayout paddingLayout) {
-            action.accept(state.indentSpaces() + paddingLayout.bitSize() + " padding bits");
+            action.accept(state.indentSpaces() + paddingLayout.byteSize() + " padding bytes");
             state.indexAndAdd(paddingLayout);
             return;
         }

--- a/test/jdk/java/foreign/TestMemoryInspection.java
+++ b/test/jdk/java/foreign/TestMemoryInspection.java
@@ -213,7 +213,7 @@ public class TestMemoryInspection {
         var u0 = MemoryLayout.structLayout(
                 ValueLayout.JAVA_INT.withName("x"),
                 ValueLayout.JAVA_INT.withName("y"),
-                MemoryLayout.paddingLayout(Integer.SIZE)
+                MemoryLayout.paddingLayout(Integer.BYTES)
         ).withName("Point");
 
         var u1 = MemoryLayout.structLayout(
@@ -229,7 +229,7 @@ public class TestMemoryInspection {
                     Point {
                         x=1,
                         y=2,
-                        32 padding bits
+                        4 padding bytes
                     }|
                     3D-Point {
                         x=1,


### PR DESCRIPTION
MemoryInspectionUtil (and corresponding test) is broken after https://git.openjdk.org/jdk/pull/14013.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Reviewers
 * [Per Minborg](https://openjdk.org/census#pminborg) (@minborg - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/panama-foreign.git pull/834/head:pull/834` \
`$ git checkout pull/834`

Update a local copy of the PR: \
`$ git checkout pull/834` \
`$ git pull https://git.openjdk.org/panama-foreign.git pull/834/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 834`

View PR using the GUI difftool: \
`$ git pr show -t 834`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/panama-foreign/pull/834.diff">https://git.openjdk.org/panama-foreign/pull/834.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/panama-foreign/pull/834#issuecomment-1567069216)