### PR TITLE
8310048: Drop sequence layout factory with inferred count

### DIFF
--- a/src/java.base/share/classes/java/lang/foreign/AddressLayout.java
+++ b/src/java.base/share/classes/java/lang/foreign/AddressLayout.java
@@ -95,7 +95,7 @@ public sealed interface AddressLayout extends ValueLayout permits ValueLayouts.O
      * {@snippet lang = java:
      * AddressLayout addressLayout   = ...
      * AddressLayout unboundedLayout = addressLayout.withTargetLayout(
-     *         MemoryLayout.sequenceLayout(ValueLayout.JAVA_BYTE));
+     *         MemoryLayout.sequenceLayout(Long.MAX_VALUE, ValueLayout.JAVA_BYTE));
      *}
      * <p>
      * This method is <a href="package-summary.html#restricted"><em>restricted</em></a>.

--- a/src/java.base/share/classes/java/lang/foreign/MemoryLayout.java
+++ b/src/java.base/share/classes/java/lang/foreign/MemoryLayout.java
@@ -662,24 +662,6 @@ public sealed interface MemoryLayout permits SequenceLayout, GroupLayout, Paddin
     }
 
     /**
-     * Creates a sequence layout with the given element layout and the maximum element
-     * count such that it does not overflow a {@code long}.
-     *
-     * This is equivalent to the following code:
-     * {@snippet lang = java:
-     * sequenceLayout(Long.MAX_VALUE / elementLayout.byteSize(), elementLayout);
-     * }
-     *
-     * @param elementLayout the sequence element layout.
-     * @return a new sequence layout with the given element layout and maximum element count.
-     * @throws IllegalArgumentException if {@code elementLayout.byteSize() % elementLayout.byteAlignment() != 0}.
-     */
-    static SequenceLayout sequenceLayout(MemoryLayout elementLayout) {
-        Objects.requireNonNull(elementLayout);
-        return sequenceLayout(Long.MAX_VALUE / elementLayout.byteSize(), elementLayout);
-    }
-
-    /**
      * Creates a struct layout with the given member layouts.
      *
      * @param elements The member layouts of the struct layout.

--- a/src/java.base/share/classes/java/lang/foreign/MemorySegment.java
+++ b/src/java.base/share/classes/java/lang/foreign/MemorySegment.java
@@ -768,7 +768,7 @@ public sealed interface MemorySegment permits AbstractMemorySegmentImpl {
      *
      * {@snippet lang=java :
      * for (long offset = 0; offset < segment.byteSize(); offset++) {
-     *     byteHandle.set(ValueLayout.JAVA_BYTE, offset, value);
+     *     segment.set(ValueLayout.JAVA_BYTE, offset, value);
      * }
      * }
      *

--- a/src/java.base/share/classes/java/lang/foreign/ValueLayout.java
+++ b/src/java.base/share/classes/java/lang/foreign/ValueLayout.java
@@ -92,8 +92,9 @@ public sealed interface ValueLayout extends MemoryLayout permits
      * Is equivalent to the following code:
      *
      * {@snippet lang = java:
-     * SequenceLayout notionalLayout = MemoryLayout.sequenceLayout(
- *                                         MemoryLayout.sequenceLayout(10, MemoryLayout.sequenceLayout(20, ValueLayout.JAVA_INT)));
+     * MemoryLayout innerLayout = MemoryLayout.sequenceLayout(10,
+     *         MemoryLayout.sequenceLayout(20, ValueLayout.JAVA_INT));
+     * SequenceLayout notionalLayout = MemoryLayout.sequenceLayout(Long.MAX_VALUE / innerLayout.byteSize(), innerLayout);
      * VarHandle arrayHandle = notionalLayout.varHandle(PathElement.sequenceElement(),
      *                                                  PathElement.sequenceElement(),
      *                                                  PathElement.sequenceElement());

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/SharedUtils.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/SharedUtils.java
@@ -81,7 +81,7 @@ public final class SharedUtils {
     private static final MethodHandle MH_CHECK_CAPTURE_SEGMENT;
 
     public static final AddressLayout C_POINTER = ADDRESS
-            .withTargetLayout(MemoryLayout.sequenceLayout(JAVA_BYTE));
+            .withTargetLayout(MemoryLayout.sequenceLayout(Long.MAX_VALUE, JAVA_BYTE));
 
     public static final Arena DUMMY_ARENA = new Arena() {
         @Override

--- a/src/java.base/share/classes/jdk/internal/foreign/layout/ValueLayouts.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/layout/ValueLayouts.java
@@ -128,7 +128,7 @@ public final class ValueLayouts {
                 layout = MemoryLayout.sequenceLayout(size, layout);
                 path.add(MemoryLayout.PathElement.sequenceElement());
             }
-            layout = MemoryLayout.sequenceLayout(layout);
+            layout = MemoryLayout.sequenceLayout(Long.MAX_VALUE / layout.byteSize(), layout);
             path.add(MemoryLayout.PathElement.sequenceElement());
             return layout.varHandle(path.toArray(new MemoryLayout.PathElement[0]));
         }

--- a/test/jdk/java/foreign/NativeTestHelper.java
+++ b/test/jdk/java/foreign/NativeTestHelper.java
@@ -122,7 +122,7 @@ public class NativeTestHelper {
      * The {@code T*} native type.
      */
     public static final AddressLayout C_POINTER = ValueLayout.ADDRESS
-            .withTargetLayout(MemoryLayout.sequenceLayout(C_CHAR));
+            .withTargetLayout(MemoryLayout.sequenceLayout(Long.MAX_VALUE, C_CHAR));
 
     public static final Linker LINKER = Linker.nativeLinker();
 

--- a/test/jdk/java/foreign/TestIllegalLink.java
+++ b/test/jdk/java/foreign/TestIllegalLink.java
@@ -156,7 +156,7 @@ public class TestIllegalLink extends NativeTestHelper {
             },
             {
                     FunctionDescriptor.ofVoid(MemoryLayout.structLayout(
-                            MemoryLayout.sequenceLayout(
+                            MemoryLayout.sequenceLayout(1,
                                 C_INT.withByteAlignment(1)
                             ))),
                     NO_OPTIONS,
@@ -181,7 +181,7 @@ public class TestIllegalLink extends NativeTestHelper {
                     "Unsupported layout: I4"
             },
             {
-                    FunctionDescriptor.of(MemoryLayout.structLayout(MemoryLayout.sequenceLayout(C_INT.withOrder(nonNativeOrder())))),
+                    FunctionDescriptor.of(MemoryLayout.structLayout(MemoryLayout.sequenceLayout(1, C_INT.withOrder(nonNativeOrder())))),
                     NO_OPTIONS,
                     "Unsupported layout: I4"
             },
@@ -212,7 +212,7 @@ public class TestIllegalLink extends NativeTestHelper {
         if (IS_SYSV) {
             cases.add(new Object[] {
                     FunctionDescriptor.ofVoid(MemoryLayout.structLayout(
-                            MemoryLayout.sequenceLayout(
+                            MemoryLayout.sequenceLayout(Long.MAX_VALUE / C_INT.byteSize(),
                                 C_INT
                             ))),
                     NO_OPTIONS,

--- a/test/jdk/java/foreign/TestLayouts.java
+++ b/test/jdk/java/foreign/TestLayouts.java
@@ -201,12 +201,7 @@ public class TestLayouts {
                 () -> MemoryLayout.sequenceLayout(-2, JAVA_SHORT));
     }
 
-    @Test(dataProvider = "basicLayouts")
-    public void testSequenceInferredCount(MemoryLayout layout) {
-        assertEquals(MemoryLayout.sequenceLayout(layout),
-                     MemoryLayout.sequenceLayout(Long.MAX_VALUE / layout.byteSize(), layout));
-    }
-
+    @Test
     public void testSequenceNegativeElementCount() {
         assertThrows(IllegalArgumentException.class, // negative
                 () -> MemoryLayout.sequenceLayout(-1, JAVA_SHORT));
@@ -297,14 +292,14 @@ public class TestLayouts {
     @Test(dataProvider="layoutsAndAlignments", expectedExceptions = IllegalArgumentException.class)
     public void testBadSequenceElementAlignmentTooBig(MemoryLayout layout, long byteAlign) {
         layout = layout.withByteAlignment(layout.byteSize() * 2); // hyper-align
-        MemoryLayout.sequenceLayout(layout);
+        MemoryLayout.sequenceLayout(1, layout);
     }
 
     @Test(dataProvider="layoutsAndAlignments")
     public void testBadSequenceElementSizeNotMultipleOfAlignment(MemoryLayout layout, long byteAlign) {
         boolean shouldFail = layout.byteSize() % layout.byteAlignment() != 0;
         try {
-            MemoryLayout.sequenceLayout(layout);
+            MemoryLayout.sequenceLayout(1, layout);
             assertFalse(shouldFail);
         } catch (IllegalArgumentException ex) {
             assertTrue(shouldFail);
@@ -493,7 +488,6 @@ public class TestLayouts {
     static Stream<MemoryLayout> groupLayoutStream() {
         return Stream.of(
                 MemoryLayout.sequenceLayout(10, JAVA_INT),
-                MemoryLayout.sequenceLayout(JAVA_INT),
                 MemoryLayout.structLayout(JAVA_INT, MemoryLayout.paddingLayout(4), JAVA_LONG),
                 MemoryLayout.unionLayout(JAVA_LONG, JAVA_DOUBLE)
         );

--- a/test/micro/org/openjdk/bench/java/lang/foreign/CLayouts.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/CLayouts.java
@@ -69,7 +69,7 @@ public class CLayouts {
      * The {@code T*} native type.
      */
     public static final AddressLayout C_POINTER = ValueLayout.ADDRESS
-            .withTargetLayout(MemoryLayout.sequenceLayout(C_CHAR));
+            .withTargetLayout(MemoryLayout.sequenceLayout(Long.MAX_VALUE, C_CHAR));
 
     private static Linker LINKER = Linker.nativeLinker();
 

--- a/test/micro/org/openjdk/bench/java/lang/foreign/pointers/NativeType.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/pointers/NativeType.java
@@ -40,7 +40,7 @@ public sealed abstract class NativeType<X> {
     }
 
     private static final AddressLayout UNSAFE_ADDRESS = ValueLayout.ADDRESS
-            .withTargetLayout(MemoryLayout.sequenceLayout(ValueLayout.JAVA_BYTE));
+            .withTargetLayout(MemoryLayout.sequenceLayout(Long.MAX_VALUE, ValueLayout.JAVA_BYTE));
 
     public final static class OfPointer<X> extends NativeType<X> {
         public AddressLayout layout() {

--- a/test/micro/org/openjdk/bench/java/lang/foreign/pointers/PointerBench.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/pointers/PointerBench.java
@@ -60,7 +60,7 @@ public class PointerBench {
     MemorySegment pointSegment = pointPointer.segment();
 
     public static final AddressLayout UNSAFE_ADDRESS = ValueLayout.ADDRESS
-            .withTargetLayout(MemoryLayout.sequenceLayout(ValueLayout.JAVA_BYTE));
+            .withTargetLayout(MemoryLayout.sequenceLayout(Long.MAX_VALUE, ValueLayout.JAVA_BYTE));
 
     @Setup
     public void setup() {


### PR DESCRIPTION
The sequence layout factory that accepts only the element layout makes it too easy for developers to reach for the wrong thing (and creating an insanely huge layout).

We should keep in sync with the WYSIWYG spirit of the various layout factories and make sequence layout count always explicit.
Developers should almost never need to create a sequence layout whose size is `Long.MAX_VALUE`, except in the specific case when they would like to create an address layout whose target layout has a size that is statically unknown (and they's like the FFM API to automatically resize the resulting segment to the biggest available size).

We have other patches in the work which will help developers deal with cases where they have to deal with access to elements of an array whose size is not known statically.
