### PR TITLE
8310820: Remove MemorySegment::segmentOffset

### DIFF
--- a/src/java.base/share/classes/java/lang/foreign/MemorySegment.java
+++ b/src/java.base/share/classes/java/lang/foreign/MemorySegment.java
@@ -749,30 +749,6 @@ public sealed interface MemorySegment permits AbstractMemorySegmentImpl {
     Optional<MemorySegment> asOverlappingSlice(MemorySegment other);
 
     /**
-     * Returns the offset, in bytes, of the provided segment, relative to this
-     * segment.
-     *
-     * <p>The offset is relative to the address of this segment and can be
-     * a negative or positive value. For instance, if both segments are native
-     * segments, or heap segments backed by the same array, the resulting offset
-     * can be computed as follows:
-     *
-     * {@snippet lang=java :
-     * other.address() - address()
-     * }
-     *
-     * If the segments share the same address, {@code 0} is returned. If
-     * {@code other} is a slice of this segment, the offset is always
-     * {@code 0 <= x < this.byteSize()}.
-     *
-     * @param other the segment to retrieve an offset to.
-     * @throws UnsupportedOperationException if the two segments cannot be compared, e.g. because they are of
-     * different kinds, or because they are backed by different Java arrays.
-     * @return the relative offset, in bytes, of the provided segment.
-     */
-    long segmentOffset(MemorySegment other);
-
-    /**
      * Fills the contents of this memory segment with the given value.
      * <p>
      * More specifically, the given value is written into each address of this

--- a/src/java.base/share/classes/jdk/internal/foreign/AbstractMemorySegmentImpl.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/AbstractMemorySegmentImpl.java
@@ -264,21 +264,12 @@ public abstract sealed class AbstractMemorySegmentImpl
             final long thatEnd = thatStart + that.byteSize();
 
             if (thisStart < thatEnd && thisEnd > thatStart) {  //overlap occurs
-                long offsetToThat = this.segmentOffset(that);
+                long offsetToThat = that.address() - this.address();
                 long newOffset = offsetToThat >= 0 ? offsetToThat : 0;
                 return Optional.of(asSlice(newOffset, Math.min(this.byteSize() - newOffset, that.byteSize() + offsetToThat)));
             }
         }
         return Optional.empty();
-    }
-
-    @Override
-    public final long segmentOffset(MemorySegment other) {
-        AbstractMemorySegmentImpl that = (AbstractMemorySegmentImpl) Objects.requireNonNull(other);
-        if (unsafeGetBase() == that.unsafeGetBase()) {
-            return that.unsafeGetOffset() - this.unsafeGetOffset();
-        }
-        throw new UnsupportedOperationException("Cannot compute offset from native to heap (or vice versa).");
     }
 
     @Override

--- a/test/jdk/java/foreign/TestSegmentOffset.java
+++ b/test/jdk/java/foreign/TestSegmentOffset.java
@@ -30,6 +30,7 @@
 import java.lang.foreign.Arena;
 import java.lang.foreign.MemorySegment;
 
+import org.testng.SkipException;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
@@ -44,27 +45,21 @@ public class TestSegmentOffset {
 
     @Test(dataProvider = "slices")
     public void testOffset(SegmentSlice s1, SegmentSlice s2) {
+        if (s1.kind != s2.kind) {
+            throw new SkipException("Slices of different segment kinds");
+        }
         if (s1.contains(s2)) {
             // check that a segment and its overlapping segment point to same elements
-            long offset = s1.segment.segmentOffset(s2.segment);
+            long offset = s1.offset(s2);
             for (int i = 0; i < s2.size(); i++) {
                 out.format("testOffset s1:%s, s2:%s, offset:%d, i:%s\n", s1, s2, offset, i);
                 byte expected = s2.segment.get(JAVA_BYTE, i);
                 byte found = s1.segment.get(JAVA_BYTE, i + offset);
                 assertEquals(found, expected);
             }
-        } else if (s1.kind != s2.kind) {
-            // check that offset from s1 to s2 fails
-            try {
-                long offset = s1.segment.segmentOffset(s2.segment);
-                out.format("testOffset s1:%s, s2:%s, offset:%d\n", s1, s2, offset);
-                fail("offset unexpectedly passed!");
-            } catch (UnsupportedOperationException ex) {
-                assertTrue(ex.getMessage().contains("Cannot compute offset from native to heap (or vice versa)."));
-            }
         } else if (!s2.contains(s1)) {
             // disjoint segments - check that offset is out of bounds
-            long offset = s1.segment.segmentOffset(s2.segment);
+            long offset = s1.offset(s2);
             for (int i = 0; i < s2.size(); i++) {
                 out.format("testOffset s1:%s, s2:%s, offset:%d, i:%s\n", s1, s2, offset, i);
                 s2.segment.get(JAVA_BYTE, i);
@@ -115,6 +110,10 @@ public class TestSegmentOffset {
 
         int size() {
             return last - first + 1;
+        }
+
+        long offset(SegmentSlice that) {
+            return that.segment.address() - segment.address();
         }
     }
 

--- a/test/micro/org/openjdk/bench/java/lang/foreign/StrLenTest.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/StrLenTest.java
@@ -164,7 +164,7 @@ public class StrLenTest extends CLayouts {
                 reset();
             }
             MemorySegment res = current.allocate(byteSize, byteAlignment);
-            long lastOffset = segment.segmentOffset(res) + res.byteSize();
+            long lastOffset = res.address() - segment.address() + res.byteSize();
             rem = segment.byteSize() - lastOffset;
             return res;
         }


### PR DESCRIPTION
This method was added a long time ago, mostly to support the use case of "rebasing" a safe segment over the unsafe "everything" segment. We have other ways to express these use cases in the current API.

On top of that, this method can return negative offsets, which would then lead to failures when used with access APIs.

Finally, since we have unified memory segments with addresses, computing relative offset between segment is fairly easy (just subtract the segment addresses). 
