### PR TITLE
8310893: VarHandleTestExact fails

### DIFF
--- a/test/jdk/java/lang/invoke/VarHandles/VarHandleTestExact.java
+++ b/test/jdk/java/lang/invoke/VarHandles/VarHandleTestExact.java
@@ -171,7 +171,7 @@ public class VarHandleTestExact {
 
     @Test(dataProvider = "dataSetMemorySegment")
     public void testExactSegmentSet(Class<?> carrier, Object testValue, SetSegmentX setter) {
-        VarHandle vh = MethodHandles.memorySegmentViewVarHandle(ValueLayouts.valueLayout(carrier, ByteOrder.nativeOrder()));
+        VarHandle vh = ValueLayouts.valueLayout(carrier, ByteOrder.nativeOrder()).varHandle();
         try (Arena arena = Arena.ofConfined()) {
             MemorySegment seg = arena.allocate(8);
             doTest(vh,


### PR DESCRIPTION
Simple change of `memorySegmentViewVarHandle` -> `varHandle`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8310893](https://bugs.openjdk.org/browse/JDK-8310893): VarHandleTestExact fails (**Bug** - P4)


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.org/census#mcimadamore) (@mcimadamore - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/panama-foreign.git pull/842/head:pull/842` \
`$ git checkout pull/842`

Update a local copy of the PR: \
`$ git checkout pull/842` \
`$ git pull https://git.openjdk.org/panama-foreign.git pull/842/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 842`

View PR using the GUI difftool: \
`$ git pr show -t 842`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/panama-foreign/pull/842.diff">https://git.openjdk.org/panama-foreign/pull/842.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/panama-foreign/pull/842#issuecomment-1607439939)