### PR TITLE
8311594: Avoid GlobalSession liveness check

### DIFF
--- a/src/java.base/share/classes/jdk/internal/foreign/GlobalSession.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/GlobalSession.java
@@ -67,4 +67,10 @@ final class GlobalSession extends MemorySessionImpl {
     public void justClose() {
         throw nonCloseable();
     }
+
+    @Override
+    @ForceInline
+    public void checkValidStateRaw() {
+        // do nothing, avoid liveness check
+    }
 }

--- a/test/micro/org/openjdk/bench/java/lang/foreign/LoopOverPollutedSegments.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/LoopOverPollutedSegments.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -46,7 +46,7 @@ import static java.lang.foreign.ValueLayout.*;
 @Measurement(iterations = 10, time = 500, timeUnit = TimeUnit.MILLISECONDS)
 @State(org.openjdk.jmh.annotations.Scope.Thread)
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
-@Fork(value = 3, jvmArgsAppend = "--enable-preview")
+@Fork(value = 3, jvmArgsAppend = {"--enable-preview", "--enable-native-access=ALL-UNNAMED"})
 public class LoopOverPollutedSegments extends JavaLayouts {
 
     static final int ELEM_SIZE = 1_000_000;
@@ -57,7 +57,7 @@ public class LoopOverPollutedSegments extends JavaLayouts {
 
 
     Arena confinedArena, sharedArena;
-    MemorySegment nativeSegment, nativeSharedSegment, heapSegmentBytes, heapSegmentFloats;
+    MemorySegment nativeSegment, nativeSharedSegment, nativeGlobal, heapSegmentBytes, heapSegmentFloats;
     byte[] arr;
     long addr;
 
@@ -74,6 +74,7 @@ public class LoopOverPollutedSegments extends JavaLayouts {
         nativeSegment = scope1.allocate(ALLOC_SIZE, 4);
         Arena scope = sharedArena;
         nativeSharedSegment = scope.allocate(ALLOC_SIZE, 4);
+        nativeGlobal = nativeSegment.reinterpret(Arena.global(), null);
         heapSegmentBytes = MemorySegment.ofArray(new byte[ALLOC_SIZE]);
         heapSegmentFloats = MemorySegment.ofArray(new float[ELEM_SIZE]);
 
@@ -84,6 +85,8 @@ public class LoopOverPollutedSegments extends JavaLayouts {
                 nativeSegment.setAtIndex(JAVA_FLOAT_UNALIGNED, i, i);
                 nativeSharedSegment.setAtIndex(JAVA_INT_UNALIGNED, i, i);
                 nativeSharedSegment.setAtIndex(JAVA_FLOAT_UNALIGNED, i, i);
+                nativeGlobal.setAtIndex(JAVA_INT_UNALIGNED, i, i);
+                nativeGlobal.setAtIndex(JAVA_FLOAT_UNALIGNED, i, i);
                 VH_INT_UNALIGNED.set(nativeSegment, (long)i, i);
                 heapSegmentBytes.setAtIndex(JAVA_INT_UNALIGNED, i, i);
                 heapSegmentBytes.setAtIndex(JAVA_FLOAT_UNALIGNED, i, i);

--- a/test/micro/org/openjdk/bench/java/lang/foreign/MemorySegmentCopyALL.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/MemorySegmentCopyALL.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.bench.java.lang.foreign;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.CompilerControl;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Warmup;
+import sun.misc.Unsafe;
+
+import java.lang.foreign.MemorySegment;
+import java.util.concurrent.TimeUnit;
+
+import static java.lang.foreign.ValueLayout.JAVA_INT;
+import static java.lang.foreign.ValueLayout.JAVA_INT_UNALIGNED;
+import static org.openjdk.jmh.annotations.CompilerControl.Mode.*;
+
+@BenchmarkMode(Mode.AverageTime)
+@Warmup(iterations = 5, time = 500, timeUnit = TimeUnit.MILLISECONDS)
+@Measurement(iterations = 10, time = 500, timeUnit = TimeUnit.MILLISECONDS)
+@State(org.openjdk.jmh.annotations.Scope.Thread)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Fork(value = 3, jvmArgsAppend = {"--enable-preview", "--enable-native-access=ALL-UNNAMED"})
+public class MemorySegmentCopyALL {
+
+    static final Unsafe UNSAFE = Utils.unsafe;
+
+    static final int ELEM_SIZE = 10;
+    static final int CARRIER_SIZE = (int)JAVA_INT.byteSize();
+    static final int BYTE_SIZE = ELEM_SIZE * CARRIER_SIZE;
+    static final MemorySegment ALL = MemorySegment.NULL.reinterpret(Long.MAX_VALUE);
+    static final int UNSAFE_INT_OFFSET = UNSAFE.arrayBaseOffset(int[].class);
+
+    long unsafe_src;
+    long unsafe_dst;
+    int[] ints;
+
+    @Setup
+    public void setup() {
+        unsafe_src = UNSAFE.allocateMemory(BYTE_SIZE);
+        unsafe_dst = UNSAFE.allocateMemory(BYTE_SIZE);
+        ints = new int[ELEM_SIZE];
+
+        for (int i = 0; i < ints.length ; i++) {
+            ints[i] = i;
+            ALL.set(JAVA_INT, unsafe_src, i);
+        }
+    }
+
+    @TearDown
+    public void TearDown() {
+        UNSAFE.freeMemory(unsafe_src);
+        UNSAFE.freeMemory(unsafe_dst);
+    }
+
+    @Benchmark
+    public void panamam_array_to_ALL() {
+        MemorySegment.copy(ints, 0, ALL, JAVA_INT_UNALIGNED, unsafe_dst, ELEM_SIZE);
+    }
+
+    @Benchmark
+    public void panamam_ALL_to_array() {
+        MemorySegment.copy(ALL, JAVA_INT_UNALIGNED, unsafe_src, ints, 0, ELEM_SIZE);
+    }
+
+    @Benchmark
+    public void panamam_ALL_to_ALL() {
+        MemorySegment.copy(ALL, JAVA_INT_UNALIGNED, unsafe_src, ALL, JAVA_INT_UNALIGNED, unsafe_dst, ELEM_SIZE);
+    }
+
+    @Benchmark
+    public void unsafe_array_to_addr() {
+        UNSAFE.copyMemory(ints, UNSAFE_INT_OFFSET, null, unsafe_dst, BYTE_SIZE);
+    }
+
+    @Benchmark
+    public void unsafe_addr_to_array() {
+        UNSAFE.copyMemory(null, unsafe_src, ints, UNSAFE_INT_OFFSET, BYTE_SIZE);
+    }
+
+    @Benchmark
+    public void unsafe_addr_to_addr() {
+        UNSAFE.copyMemory(null, unsafe_src, null, unsafe_dst, BYTE_SIZE);
+    }
+}

--- a/test/micro/org/openjdk/bench/java/lang/foreign/MemorySegmentCopyALL.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/MemorySegmentCopyALL.java
@@ -81,17 +81,17 @@ public class MemorySegmentCopyALL {
     }
 
     @Benchmark
-    public void panamam_array_to_ALL() {
+    public void panama_array_to_ALL() {
         MemorySegment.copy(ints, 0, ALL, JAVA_INT_UNALIGNED, unsafe_dst, ELEM_SIZE);
     }
 
     @Benchmark
-    public void panamam_ALL_to_array() {
+    public void panama_ALL_to_array() {
         MemorySegment.copy(ALL, JAVA_INT_UNALIGNED, unsafe_src, ints, 0, ELEM_SIZE);
     }
 
     @Benchmark
-    public void panamam_ALL_to_ALL() {
+    public void panama_ALL_to_ALL() {
         MemorySegment.copy(ALL, JAVA_INT_UNALIGNED, unsafe_src, ALL, JAVA_INT_UNALIGNED, unsafe_dst, ELEM_SIZE);
     }
 

--- a/test/micro/org/openjdk/bench/java/lang/foreign/MemorySegmentGet.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/MemorySegmentGet.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.bench.java.lang.foreign;
+
+import java.lang.foreign.Arena;
+import java.lang.foreign.MemorySegment;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.annotations.CompilerControl;
+
+import sun.misc.Unsafe;
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.util.concurrent.TimeUnit;
+
+import static java.lang.foreign.ValueLayout.*;
+import static org.openjdk.jmh.annotations.CompilerControl.Mode.*;
+
+@BenchmarkMode(Mode.AverageTime)
+@Warmup(iterations = 5, time = 500, timeUnit = TimeUnit.MILLISECONDS)
+@Measurement(iterations = 10, time = 500, timeUnit = TimeUnit.MILLISECONDS)
+@State(org.openjdk.jmh.annotations.Scope.Thread)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Fork(value = 3, jvmArgsAppend = { "--enable-preview", "--enable-native-access=ALL-UNNAMED" })
+public class MemorySegmentGet extends JavaLayouts {
+
+    static final Unsafe unsafe = Utils.unsafe;
+    static final int ALLOC_SIZE = (int)JAVA_INT.byteSize();
+    static final MemorySegment ALL = MemorySegment.NULL.reinterpret(Long.MAX_VALUE);
+
+    Arena arena;
+    MemorySegment segment;
+    long unsafe_addr;
+    ByteBuffer byteBuffer;
+
+    @Setup
+    public void setup() {
+        unsafe_addr = unsafe.allocateMemory(ALLOC_SIZE);
+        unsafe.putInt(unsafe_addr, 42);
+        arena = Arena.ofConfined();
+        segment = arena.allocate(ALLOC_SIZE, 1);
+        segment.set(JAVA_INT, 0L, 42);
+        byteBuffer = ByteBuffer.allocateDirect(ALLOC_SIZE).order(ByteOrder.nativeOrder());
+        byteBuffer.putInt(0, 42);
+    }
+
+    @TearDown
+    public void tearDown() {
+        arena.close();
+        unsafe.invokeCleaner(byteBuffer);
+        unsafe.freeMemory(unsafe_addr);
+    }
+
+    @Benchmark
+    public int unsafe() {
+        return unsafe.getInt(unsafe_addr);
+    }
+
+    @Benchmark
+    public int segment_VH() {
+        return (int) VH_INT.get(segment, 0L);
+    }
+
+    @Benchmark
+    public int segment_VH_unaligned() {
+        return (int) VH_INT_UNALIGNED.get(segment, 0L);
+    }
+
+    @Benchmark
+    public int segment_get() {
+        return segment.get(JAVA_INT, 0L);
+    }
+
+    @Benchmark
+    public int segment_get_unaligned() {
+        return segment.get(JAVA_INT_UNALIGNED, 0L);
+    }
+
+    @Benchmark
+    public int segment_ALL() {
+        return ALL.get(JAVA_INT, unsafe_addr);
+    }
+
+    @Benchmark
+    public int segment_ALL_unaligned() {
+        return ALL.get(JAVA_INT_UNALIGNED, unsafe_addr);
+    }
+
+    @Benchmark
+    public int BB() {
+        return byteBuffer.getInt(0);
+    }
+
+}


### PR DESCRIPTION
This patch overrides `checkValidStateRaw` in GlobalSession, to do nothing. The current `checkValidStateRaw` in MemorySessionImpl checks the owner thread, and liveness, which are both not needed for the global session.

Since the state field is mutable, I found that the JIT can not fold away the liveness check. This has a very marginal effect on performance, but since the fix is also very non-intrusive, I think it's okay to do.

I've added 2 new benchmarks that I've used to measure the difference. One measures the performance of MS::copy, and the other measures MS::get. Both use a special `ALL` segment which spans `0` to `Long.MAX_VALUE`, which means that the target address can be used as an offset when doing the accesses. This helps the bounds checks being eliminated, and makes the result of overriding `checkValidStateRaw` in GlobalSession easier to see.

Here are some of the interesting numbers:

Before:

```
Benchmark                                  Mode  Cnt  Score   Error  Units
MemorySegmentCopyALL.panama_ALL_to_ALL     avgt   30  7.788 ± 0.029  ns/op
MemorySegmentCopyALL.unsafe_array_to_addr  avgt   30  7.543 ± 0.018  ns/op

Benchmark                               Mode  Cnt  Score   Error  Units
MemorySegmentGet.segment_ALL_unaligned  avgt   30  0.486 ± 0.002  ns/op
MemorySegmentGet.unsafe                 avgt   30  0.398 ± 0.003  ns/op
```

After:

```
Benchmark                                  Mode  Cnt  Score   Error  Units
MemorySegmentCopyALL.panama_ALL_to_ALL     avgt   30  7.571 ± 0.017  ns/op
MemorySegmentCopyALL.unsafe_array_to_addr  avgt   30  7.550 ± 0.019  ns/op

Benchmark                               Mode  Cnt  Score   Error  Units
MemorySegmentGet.segment_ALL_unaligned  avgt   30  0.409 ± 0.002  ns/op
MemorySegmentGet.unsafe                 avgt   30  0.397 ± 0.003  ns/op
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8311594](https://bugs.openjdk.org/browse/JDK-8311594): Avoid GlobalSession liveness check (**Enhancement** - P3)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/panama-foreign.git pull/844/head:pull/844` \
`$ git checkout pull/844`

Update a local copy of the PR: \
`$ git checkout pull/844` \
`$ git pull https://git.openjdk.org/panama-foreign.git pull/844/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 844`

View PR using the GUI difftool: \
`$ git pr show -t 844`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/panama-foreign/pull/844.diff">https://git.openjdk.org/panama-foreign/pull/844.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/panama-foreign/pull/844#issuecomment-1626007188)