### PR TITLE
8312059: Clarify the documention for variadic functions

### DIFF
--- a/src/java.base/share/classes/java/lang/foreign/Linker.java
+++ b/src/java.base/share/classes/java/lang/foreign/Linker.java
@@ -421,8 +421,8 @@ import java.util.stream.Stream;
  * </ul>
  * whereby the signed-ness of the source type corresponds to the signed-ness of the promoted type. The complete process
  * of default argument promotion is described in the C specification. In effect these promotions place limits on the
- * types that can be used to replace the {@code ...}, as the variadic parameters of the specialized form will always
- * have a promoted type.
+ * types that can be used to replace the {@code ...}, as the variadic parameters of the specialized form of a variadic
+ * function will always have a promoted type.
  * <p>
  * The native linker only supports linking the specialized form of a variadic function. A variadic function in its specialized
  * form can be linked using a function descriptor describing the specialized form. Additionally, the
@@ -430,14 +430,13 @@ import java.util.stream.Stream;
  * the parameter list. The corresponding argument layout (if any), and all following argument layouts in the specialized
  * function descriptor, are called <em>variadic argument layouts</em>.
  * <p>
- * The native linker does not automatically perform default argument promotions, since it would be ambiguous whether sign
- * extension should take place. However, since passing an argument of a non-promoted type as a variadic argument is not
- * supported in C, the native linker will reject an attempt to link a specialized function descriptor with any variadic
- * argument layouts corresponding to a non-promoted C type. Since the size of the C {@code int} type is platform-specific,
- * exactly which layouts will be rejected is platform-specific as well. As an example: on Linux/x64 the layouts
- * corresponding to the C types {@code _Bool}, {@code (unsigned) char}, {@code (unsigned) short}, and {@code float}
- * (among others), will be rejected by the linker. The {@link #canonicalLayouts()} API can be used to find which layout
- * corresponds to a particular C type.
+ * The native linker does not automatically perform default argument promotions. However, since passing an argument of a
+ * non-promoted type as a variadic argument is not supported in C, the native linker will reject an attempt to link a
+ * specialized function descriptor with any variadic argument value layouts corresponding to a non-promoted C type.
+ * Since the size of the C {@code int} type is platform-specific, exactly which layouts will be rejected is
+ * platform-specific as well. As an example: on Linux/x64 the layouts corresponding to the C types {@code _Bool},
+ * {@code (unsigned) char}, {@code (unsigned) short}, and {@code float} (among others), will be rejected by the linker.
+ * The {@link #canonicalLayouts()} API can be used to find which layout corresponds to a particular C type.
  * <p>
  * A well-known variadic function is the {@code printf} function, defined in the C standard library:
  *

--- a/src/java.base/share/classes/java/lang/foreign/Linker.java
+++ b/src/java.base/share/classes/java/lang/foreign/Linker.java
@@ -405,7 +405,7 @@ import java.util.stream.Stream;
  *
  * <h3 id="variadic-funcs">Variadic functions</h3>
  *
- * Variadic functions are C functions which can accept a variable number and type of arguments. They are declared With a
+ * Variadic functions are C functions which can accept a variable number and type of arguments. They are declared with a
  * trailing ellipsis ({@code ...}) at the end of the formal parameter list, such as: {@code void foo(int x, ...);}.
  * The arguments passed in place of the ellipsis are called <em>variadic arguments</em>. Variadic functions are,
  * essentially, templates that can be <em>specialized</em> into multiple non-variadic functions by replacing the

--- a/src/java.base/share/classes/java/lang/foreign/Linker.java
+++ b/src/java.base/share/classes/java/lang/foreign/Linker.java
@@ -475,6 +475,7 @@ import java.util.stream.Stream;
  * try (Arena arena = Arena.ofConfined()) {
  *     int res = (int)printf.invokeExact(arena.allocateFrom("%d plus %d equals %d"), 2, 2, 4); //prints "2 plus 2 equals 4"
  * }
+ *}
  *
  * <h2 id="safety">Safety considerations</h2>
  *

--- a/src/java.base/share/classes/java/lang/foreign/Linker.java
+++ b/src/java.base/share/classes/java/lang/foreign/Linker.java
@@ -436,7 +436,7 @@ import java.util.stream.Stream;
  * Since the size of the C {@code int} type is platform-specific, exactly which layouts will be rejected is
  * platform-specific as well. As an example: on Linux/x64 the layouts corresponding to the C types {@code _Bool},
  * {@code (unsigned) char}, {@code (unsigned) short}, and {@code float} (among others), will be rejected by the linker.
- * The {@link #canonicalLayouts()} API can be used to find which layout corresponds to a particular C type.
+ * The {@link #canonicalLayouts()} method can be used to find which layout corresponds to a particular C type.
  * <p>
  * A well-known variadic function is the {@code printf} function, defined in the C standard library:
  *

--- a/src/java.base/share/classes/java/lang/foreign/Linker.java
+++ b/src/java.base/share/classes/java/lang/foreign/Linker.java
@@ -431,7 +431,7 @@ import java.util.stream.Stream;
  * function descriptor, are called <em>variadic argument layouts</em>.
  * <p>
  * The native linker does not automatically perform default argument promotions, since it would be ambiguous whether sign
- * extension should take place. However, since passing arguments of a non-promoted type as a variadic argument is not
+ * extension should take place. However, since passing an argument of a non-promoted type as a variadic argument is not
  * supported in C, the native linker will reject an attempt to link a specialized function descriptor with any variadic
  * argument layouts corresponding to a non-promoted C type. Since the size of the C {@code int} type is platform-specific,
  * exactly which layouts will be rejected is platform-specific as well. As an example: on Linux/x64 the layouts

--- a/src/java.base/share/classes/java/lang/foreign/Linker.java
+++ b/src/java.base/share/classes/java/lang/foreign/Linker.java
@@ -405,15 +405,11 @@ import java.util.stream.Stream;
  *
  * <h3 id="variadic-funcs">Variadic functions</h3>
  *
- * Variadic functions are C functions which can accept a variable number and type of arguments. They are declared:
- * <ol>
- * <li>With a trailing ellipsis ({@code ...}) at the end of the formal parameter list, such as: {@code void foo(int x, ...);}</li>
- * <li>With an empty formal parameter list, called a prototype-less function, such as: {@code void foo();}</li>
- * </ol>
- * The arguments passed in place of the ellipsis, or the arguments passed to a prototype-less function are called
- * <em>variadic arguments</em>. Variadic functions are, essentially, templates that can be <em>specialized</em> into multiple
- * non-variadic functions by replacing the {@code ...} or empty formal parameter list with a list of <em>variadic parameters</em>
- * of a fixed number and type.
+ * Variadic functions are C functions which can accept a variable number and type of arguments. They are declared With a
+ * trailing ellipsis ({@code ...}) at the end of the formal parameter list, such as: {@code void foo(int x, ...);}.
+ * The arguments passed in place of the ellipsis are called <em>variadic arguments</em>. Variadic functions are,
+ * essentially, templates that can be <em>specialized</em> into multiple non-variadic functions by replacing the
+ * {@code ...} with a list of <em>variadic parameters</em> of a fixed number and type.
  * <p>
  * It should be noted that values passed as variadic arguments undergo default argument promotion in C. For instance, the
  * following argument promotions are applied:
@@ -425,21 +421,23 @@ import java.util.stream.Stream;
  * </ul>
  * whereby the signed-ness of the source type corresponds to the signed-ness of the promoted type. The complete process
  * of default argument promotion is described in the C specification. In effect these promotions place limits on the
- * specialized form of a variadic function, as the variadic parameters of the specialized form will always have a promoted
- * type.
+ * types that can be used to replace the {@code ...}, as the variadic parameters of the specialized form will always
+ * have a promoted type.
  * <p>
  * The native linker only supports linking the specialized form of a variadic function. A variadic function in its specialized
  * form can be linked using a function descriptor describing the specialized form. Additionally, the
  * {@link Linker.Option#firstVariadicArg(int)} linker option must be provided to indicate the first variadic parameter in
  * the parameter list. The corresponding argument layout (if any), and all following argument layouts in the specialized
- * function descriptor, are called <em>variadic argument layouts</em>. For a prototype-less function, the index passed to
- * {@link Linker.Option#firstVariadicArg(int)} should always be {@code 0}.
+ * function descriptor, are called <em>variadic argument layouts</em>.
  * <p>
- * The native linker will reject an attempt to link a specialized function descriptor with any variadic argument layouts
- * corresponding to a C type that would be subject to default argument promotion (as described above). Exactly which layouts
- * will be rejected is platform specific, but as an example: on Linux/x64 the layouts {@link ValueLayout#JAVA_BOOLEAN},
- * {@link ValueLayout#JAVA_BYTE}, {@link ValueLayout#JAVA_CHAR}, {@link ValueLayout#JAVA_SHORT}, and
- * {@link ValueLayout#JAVA_FLOAT} will be rejected.
+ * The native linker does not automatically perform default argument promotions, since it would be ambiguous whether sign
+ * extension should take place. However, since passing arguments of a non-promoted type as a variadic argument is not
+ * supported in C, the native linker will reject an attempt to link a specialized function descriptor with any variadic
+ * argument layouts corresponding to a non-promoted C type. Since the size of the C {@code int} type is platform-specific,
+ * exactly which layouts will be rejected is platform-specific as well. As an example: on Linux/x64 the layouts
+ * corresponding to the C types {@code _Bool}, {@code (unsigned) char}, {@code (unsigned) short}, and {@code float}
+ * (among others), will be rejected by the linker. The {@link #canonicalLayouts()} API can be used to find which layout
+ * corresponds to a particular C type.
  * <p>
  * A well-known variadic function is the {@code printf} function, defined in the C standard library:
  *
@@ -477,7 +475,6 @@ import java.util.stream.Stream;
  * try (Arena arena = Arena.ofConfined()) {
  *     int res = (int)printf.invokeExact(arena.allocateFrom("%d plus %d equals %d"), 2, 2, 4); //prints "2 plus 2 equals 4"
  * }
- *}
  *
  * <h2 id="safety">Safety considerations</h2>
  *


### PR DESCRIPTION
This patch attempts to refine the javadoc for variadic functions further. Particularly, it tries to make it clearer that the layouts the native linker rejects are derived from the C specification. Instead of trying to say which layouts are reject, we say which C types are rejected, and then give a hint about how to map those C types into layouts, using `canonicalLayouts()`, which would tell a client which layouts are rejected.

Additionally, this patch removes the mentions of prototype-less functions, which are not considered variadic functions in C. It is also not clear whether arguments passed to such a function should be treated as variadic or not in the ABI (see linked issue). Finally the latest C standard, C23, prototype-less functions no longer exist, and a declaration of the form `void foo()` instead means the same as `void foo(void)`. For these reason, passing arguments to prototype-less functions will also not be supported (officially) by the linker. I wasn't sure about whether to add a specific note about that. I figured that just not saying they are supported, combined with the state of the latest C standard, would make this obvious enough (?).

/solves JDK-8310646

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issues
 * [JDK-8312059](https://bugs.openjdk.org/browse/JDK-8312059): Clarify the documention for variadic functions (**Enhancement** - P4)
 * [JDK-8310646](https://bugs.openjdk.org/browse/JDK-8310646): Javadoc around prototype-less functions might be incorrect (**Bug** - P3)


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.org/census#mcimadamore) (@mcimadamore - Committer) ⚠️ Review applies to [f06e7530](https://git.openjdk.org/panama-foreign/pull/846/files/f06e75303defb8af2158d5e3a1fdc1ee06d0ba88)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/panama-foreign.git pull/846/head:pull/846` \
`$ git checkout pull/846`

Update a local copy of the PR: \
`$ git checkout pull/846` \
`$ git pull https://git.openjdk.org/panama-foreign.git pull/846/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 846`

View PR using the GUI difftool: \
`$ git pr show -t 846`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/panama-foreign/pull/846.diff">https://git.openjdk.org/panama-foreign/pull/846.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/panama-foreign/pull/846#issuecomment-1636125266)