### PR TITLE
8312186: TestStringEncodingFails for UTF-32

### DIFF
--- a/test/jdk/java/foreign/TestStringEncoding.java
+++ b/test/jdk/java/foreign/TestStringEncoding.java
@@ -51,6 +51,7 @@ public class TestStringEncoding {
                     if (charset == StandardCharsets.UTF_16) {
                         terminatorSize -= 2; // drop BOM
                     }
+                    // note that UTF_32 doesn't use a BOM
 
                     int expectedByteLength =
                             testString.getBytes(charset).length +

--- a/test/jdk/java/foreign/TestStringEncoding.java
+++ b/test/jdk/java/foreign/TestStringEncoding.java
@@ -51,7 +51,9 @@ public class TestStringEncoding {
                     if (charset == StandardCharsets.UTF_16) {
                         terminatorSize -= 2; // drop BOM
                     }
-                    // note that UTF_32 doesn't use a BOM
+                    // Note that the JDK's UTF_32 encoder doesn't add a BOM.
+                    // This is legal under the Unicode standard, and means the byte order is BE.
+                    // See: https://unicode.org/faq/utf_bom.html#gen7
 
                     int expectedByteLength =
                             testString.getBytes(charset).length +


### PR DESCRIPTION
The test is failing because there are now several UTF 32-based char sets in StandardCharsets, and the  FFM API can not handle these yet.

This patch adds support for the UTF 32 based char sets to `MemorySegment::getString(long, Charset)`, `MemorySegment::setString(long, String, Charset)`, and `SegmentAllocator::allocateFrom(String, Charset)`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8312186](https://bugs.openjdk.org/browse/JDK-8312186): TestStringEncodingFails for UTF-32 (**Bug** - P2)


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.org/census#mcimadamore) (@mcimadamore - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/panama-foreign.git pull/847/head:pull/847` \
`$ git checkout pull/847`

Update a local copy of the PR: \
`$ git checkout pull/847` \
`$ git pull https://git.openjdk.org/panama-foreign.git pull/847/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 847`

View PR using the GUI difftool: \
`$ git pr show -t 847`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/panama-foreign/pull/847.diff">https://git.openjdk.org/panama-foreign/pull/847.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/panama-foreign/pull/847#issuecomment-1638825995)