### PR TITLE
8312473: Return value corrupted when using CCS + isTrivial

### DIFF
--- a/src/hotspot/cpu/aarch64/downcallLinker_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/downcallLinker_aarch64.cpp
@@ -168,7 +168,7 @@ void DowncallStubGenerator::generate() {
   assert(_abi._shadow_space_bytes == 0, "not expecting shadow space on AArch64");
   allocated_frame_size += arg_shuffle.out_arg_bytes();
 
-  bool should_save_return_value = !_needs_return_buffer && _needs_transition;
+  bool should_save_return_value = !_needs_return_buffer;
   RegSpiller out_reg_spiller(_output_registers);
   int spill_offset = -1;
 

--- a/src/hotspot/cpu/ppc/downcallLinker_ppc.cpp
+++ b/src/hotspot/cpu/ppc/downcallLinker_ppc.cpp
@@ -165,7 +165,7 @@ void DowncallStubGenerator::generate() {
   int parameter_save_area_slots = MAX2(_input_registers.length(), 8);
   int allocated_frame_size = frame::native_abi_minframe_size + parameter_save_area_slots * BytesPerWord;
 
-  bool should_save_return_value = !_needs_return_buffer && _needs_transition;
+  bool should_save_return_value = !_needs_return_buffer;
   RegSpiller out_reg_spiller(_output_registers);
   int spill_offset = -1;
 

--- a/src/hotspot/cpu/riscv/downcallLinker_riscv.cpp
+++ b/src/hotspot/cpu/riscv/downcallLinker_riscv.cpp
@@ -165,7 +165,7 @@ void DowncallStubGenerator::generate() {
   assert(_abi._shadow_space_bytes == 0, "not expecting shadow space on RISCV64");
   allocated_frame_size += arg_shuffle.out_arg_bytes();
 
-  bool should_save_return_value = !_needs_return_buffer && _needs_transition;
+  bool should_save_return_value = !_needs_return_buffer;
   RegSpiller out_reg_spiller(_output_registers);
   int spill_offset = -1;
 

--- a/src/hotspot/cpu/x86/downcallLinker_x86_64.cpp
+++ b/src/hotspot/cpu/x86/downcallLinker_x86_64.cpp
@@ -166,7 +166,7 @@ void DowncallStubGenerator::generate() {
   allocated_frame_size += arg_shuffle.out_arg_bytes();
 
   // when we don't use a return buffer we need to spill the return value around our slow path calls
-  bool should_save_return_value = !_needs_return_buffer && _needs_transition;
+  bool should_save_return_value = !_needs_return_buffer;
   RegSpiller out_reg_spiller(_output_registers);
   int spill_rsp_offset = -1;
 

--- a/test/jdk/java/foreign/capturecallstate/TestCaptureCallState.java
+++ b/test/jdk/java/foreign/capturecallstate/TestCaptureCallState.java
@@ -63,12 +63,16 @@ public class TestCaptureCallState extends NativeTestHelper {
         }
     }
 
-    private record SaveValuesCase(String nativeTarget, FunctionDescriptor nativeDesc, String threadLocalName, Consumer<Object> resultCheck) {}
+    private record SaveValuesCase(String nativeTarget, FunctionDescriptor nativeDesc, boolean trivial, String threadLocalName, Consumer<Object> resultCheck) {}
 
     @Test(dataProvider = "cases")
     public void testSavedThreadLocal(SaveValuesCase testCase) throws Throwable {
-        Linker.Option stl = Linker.Option.captureCallState(testCase.threadLocalName());
-        MethodHandle handle = downcallHandle(testCase.nativeTarget(), testCase.nativeDesc(), stl);
+        List<Linker.Option> options = new ArrayList<>();
+        options.add(Linker.Option.captureCallState(testCase.threadLocalName()));
+        if (testCase.trivial()) {
+            options.add(Linker.Option.isTrivial());
+        }
+        MethodHandle handle = downcallHandle(testCase.nativeTarget(), testCase.nativeDesc(), options.toArray(Linker.Option[]::new));
 
         StructLayout capturedStateLayout = Linker.Option.captureStateLayout();
         VarHandle errnoHandle = capturedStateLayout.varHandle(groupElement(testCase.threadLocalName()));
@@ -101,36 +105,44 @@ public class TestCaptureCallState extends NativeTestHelper {
         }
     }
 
+    interface CaseAdder {
+      void addCase(String nativeTarget, FunctionDescriptor nativeDesc, String threadLocalName, Consumer<Object> resultCheck);
+    }
+
     @DataProvider
     public static Object[][] cases() {
         List<SaveValuesCase> cases = new ArrayList<>();
+        CaseAdder adder = (nativeTarget, nativeDesc, threadLocalName, resultCheck) -> {
+          cases.add(new SaveValuesCase(nativeTarget, nativeDesc, false, threadLocalName, resultCheck));
+          cases.add(new SaveValuesCase(nativeTarget, nativeDesc, true, threadLocalName, resultCheck));
+        };
 
-        cases.add(new SaveValuesCase("set_errno_V", FunctionDescriptor.ofVoid(JAVA_INT), "errno", o -> {}));
-        cases.add(new SaveValuesCase("set_errno_I", FunctionDescriptor.of(JAVA_INT, JAVA_INT), "errno", o -> assertEquals((int) o, 42)));
-        cases.add(new SaveValuesCase("set_errno_D", FunctionDescriptor.of(JAVA_DOUBLE, JAVA_INT), "errno", o -> assertEquals((double) o, 42.0)));
+        adder.addCase("set_errno_V", FunctionDescriptor.ofVoid(JAVA_INT), "errno", o -> {});
+        adder.addCase("set_errno_I", FunctionDescriptor.of(JAVA_INT, JAVA_INT), "errno", o -> assertEquals((int) o, 42));
+        adder.addCase("set_errno_D", FunctionDescriptor.of(JAVA_DOUBLE, JAVA_INT), "errno", o -> assertEquals((double) o, 42.0));
 
-        cases.add(structCase("SL",  Map.of(JAVA_LONG.withName("x"), 42L)));
-        cases.add(structCase("SLL", Map.of(JAVA_LONG.withName("x"), 42L,
-                                           JAVA_LONG.withName("y"), 42L)));
-        cases.add(structCase("SLLL", Map.of(JAVA_LONG.withName("x"), 42L,
-                                            JAVA_LONG.withName("y"), 42L,
-                                            JAVA_LONG.withName("z"), 42L)));
-        cases.add(structCase("SD",  Map.of(JAVA_DOUBLE.withName("x"), 42D)));
-        cases.add(structCase("SDD", Map.of(JAVA_DOUBLE.withName("x"), 42D,
-                                           JAVA_DOUBLE.withName("y"), 42D)));
-        cases.add(structCase("SDDD", Map.of(JAVA_DOUBLE.withName("x"), 42D,
-                                            JAVA_DOUBLE.withName("y"), 42D,
-                                            JAVA_DOUBLE.withName("z"), 42D)));
+        structCase(adder, "SL",  Map.of(JAVA_LONG.withName("x"), 42L));
+        structCase(adder, "SLL", Map.of(JAVA_LONG.withName("x"), 42L,
+                                         JAVA_LONG.withName("y"), 42L));
+        structCase(adder, "SLLL", Map.of(JAVA_LONG.withName("x"), 42L,
+                                         JAVA_LONG.withName("y"), 42L,
+                                         JAVA_LONG.withName("z"), 42L));
+        structCase(adder, "SD",  Map.of(JAVA_DOUBLE.withName("x"), 42D));
+        structCase(adder, "SDD", Map.of(JAVA_DOUBLE.withName("x"), 42D,
+                                         JAVA_DOUBLE.withName("y"), 42D));
+        structCase(adder, "SDDD", Map.of(JAVA_DOUBLE.withName("x"), 42D,
+                                         JAVA_DOUBLE.withName("y"), 42D,
+                                         JAVA_DOUBLE.withName("z"), 42D));
 
         if (IS_WINDOWS) {
-            cases.add(new SaveValuesCase("SetLastError", FunctionDescriptor.ofVoid(JAVA_INT), "GetLastError", o -> {}));
-            cases.add(new SaveValuesCase("WSASetLastError", FunctionDescriptor.ofVoid(JAVA_INT), "WSAGetLastError", o -> {}));
+            adder.addCase("SetLastError", FunctionDescriptor.ofVoid(JAVA_INT), "GetLastError", o -> {});
+            adder.addCase("WSASetLastError", FunctionDescriptor.ofVoid(JAVA_INT), "WSAGetLastError", o -> {});
         }
 
         return cases.stream().map(tc -> new Object[] {tc}).toArray(Object[][]::new);
     }
 
-    static SaveValuesCase structCase(String name, Map<MemoryLayout, Object> fields) {
+    static void structCase(CaseAdder adder, String name, Map<MemoryLayout, Object> fields) {
         StructLayout layout = MemoryLayout.structLayout(fields.keySet().toArray(MemoryLayout[]::new));
 
         Consumer<Object> check = o -> {};
@@ -141,7 +153,7 @@ public class TestCaptureCallState extends NativeTestHelper {
             check = check.andThen(o -> assertEquals(fieldHandle.get(o, 0L), value));
         }
 
-        return new SaveValuesCase("set_errno_" + name, FunctionDescriptor.of(layout, JAVA_INT), "errno", check);
+        adder.addCase("set_errno_" + name, FunctionDescriptor.of(layout, JAVA_INT), "errno", check);
     }
 
     @DataProvider


### PR DESCRIPTION
Due to a bug in the downcall linker stub generation, we don't save the return value when capturing call state for trivial functions, and the return value gets corrupted.

We try not to save the return register around calls on the return path of a downcall stub, if it is not needed. Currently we don't save the return register when we're using a return buffer, since we write the return value to the return buffer before the calls on the return path, which means it is safe for those calls to overwrite the return register. But, the current logic also says we don't need to save the return register if the function is trivial (`_needs_transition == false`). The logic behind this was initially that, since we don't have _any_ calls on the return path, we don't need to save the return register. But, after adding support for capturing call state, we now also have a call on the return path for trivial functions that capture call state, and around that call, we might need to save the return register.

The fix is to simply save the return register when capturing call state, regardless of whether the function is trivial or not. In the case of just a trivial function that doesn't capture call state, we still don't save the return register around the return path calls for the thread state transition (which is not needed), since we don't generate those thread state transitions in the first first place.

I've updated the capture call state test to also test all the cases in trivial mode.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8312473](https://bugs.openjdk.org/browse/JDK-8312473): Return value corrupted when using CCS + isTrivial (**Bug** - P2)


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.org/census#mcimadamore) (@mcimadamore - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/panama-foreign.git pull/848/head:pull/848` \
`$ git checkout pull/848`

Update a local copy of the PR: \
`$ git checkout pull/848` \
`$ git pull https://git.openjdk.org/panama-foreign.git pull/848/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 848`

View PR using the GUI difftool: \
`$ git pr show -t 848`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/panama-foreign/pull/848.diff">https://git.openjdk.org/panama-foreign/pull/848.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/panama-foreign/pull/848#issuecomment-1644523931)