### PR TITLE
8312615: Ensure jdk_foreign tests pass on linux-x86

### DIFF
--- a/make/conf/jib-profiles.js
+++ b/make/conf/jib-profiles.js
@@ -426,9 +426,14 @@ var getJibProfilesProfiles = function (input, common, data) {
             target_os: "linux",
             target_cpu: "x86",
             build_cpu: "x64",
-            dependencies: ["devkit", "gtest"],
-            configure_args: concat(common.configure_args_32bit,
-                "--with-jvm-variants=minimal,server", "--with-zlib=system"),
+            dependencies: ["devkit", "gtest", "libffi"],
+            configure_args: concat(common.configure_args_32bit, [
+                "--with-jvm-variants=minimal,server",
+                "--with-zlib=system",
+                "--with-libffi=" + input.get("libffi", "home_path"),
+                "--enable-libffi-bundling",
+                "--enable-fallback-linker"
+            ])
         },
 
         "macosx-x64": {

--- a/test/jdk/java/foreign/NativeTestHelper.java
+++ b/test/jdk/java/foreign/NativeTestHelper.java
@@ -128,6 +128,21 @@ public class NativeTestHelper {
      */
     public static final ValueLayout C_SIZE_T = ValueLayout.ADDRESS.byteSize() == 8 ? C_LONG_LONG : C_INT;
 
+    // Common layout shared by some tests
+    // struct S_PDI { void* p0; double p1; int p2; };
+    public static final MemoryLayout S_PDI_LAYOUT = switch ((int) ValueLayout.ADDRESS.byteSize()) {
+        case 8 -> MemoryLayout.structLayout(
+            C_POINTER.withName("p0"),
+            C_DOUBLE.withName("p1"),
+            C_INT.withName("p2"),
+            MemoryLayout.paddingLayout(4));
+        case 4 -> MemoryLayout.structLayout(
+            C_POINTER.withName("p0"),
+            C_DOUBLE.withName("p1"),
+            C_INT.withName("p2"));
+        default -> throw new UnsupportedOperationException("Unsupported address size");
+    };
+
     public static final Linker LINKER = Linker.nativeLinker();
 
     private static final MethodHandle FREE = LINKER.downcallHandle(

--- a/test/jdk/java/foreign/NativeTestHelper.java
+++ b/test/jdk/java/foreign/NativeTestHelper.java
@@ -87,46 +87,48 @@ public class NativeTestHelper {
         return layout instanceof ValueLayout valueLayout && valueLayout.carrier() == MemorySegment.class;
     }
 
+    public static final Linker LINKER = Linker.nativeLinker();
+
     // the constants below are useful aliases for C types. The type/carrier association is only valid for 64-bit platforms.
 
     /**
      * The layout for the {@code bool} C type
      */
-    public static final ValueLayout.OfBoolean C_BOOL = ValueLayout.JAVA_BOOLEAN;
+    public static final ValueLayout.OfBoolean C_BOOL = (ValueLayout.OfBoolean) LINKER.canonicalLayouts().get("bool");
     /**
      * The layout for the {@code char} C type
      */
-    public static final ValueLayout.OfByte C_CHAR = ValueLayout.JAVA_BYTE;
+    public static final ValueLayout.OfByte C_CHAR = (ValueLayout.OfByte) LINKER.canonicalLayouts().get("char");
     /**
      * The layout for the {@code short} C type
      */
-    public static final ValueLayout.OfShort C_SHORT = ValueLayout.JAVA_SHORT;
+    public static final ValueLayout.OfShort C_SHORT = (ValueLayout.OfShort) LINKER.canonicalLayouts().get("short");
     /**
      * The layout for the {@code int} C type
      */
-    public static final ValueLayout.OfInt C_INT = ValueLayout.JAVA_INT;
+    public static final ValueLayout.OfInt C_INT = (ValueLayout.OfInt) LINKER.canonicalLayouts().get("int");
 
     /**
      * The layout for the {@code long long} C type.
      */
-    public static final ValueLayout.OfLong C_LONG_LONG = ValueLayout.JAVA_LONG;
+    public static final ValueLayout.OfLong C_LONG_LONG = (ValueLayout.OfLong) LINKER.canonicalLayouts().get("long long");
     /**
      * The layout for the {@code float} C type
      */
-    public static final ValueLayout.OfFloat C_FLOAT = ValueLayout.JAVA_FLOAT;
+    public static final ValueLayout.OfFloat C_FLOAT = (ValueLayout.OfFloat) LINKER.canonicalLayouts().get("float");
     /**
      * The layout for the {@code double} C type
      */
-    public static final ValueLayout.OfDouble C_DOUBLE = ValueLayout.JAVA_DOUBLE;
+    public static final ValueLayout.OfDouble C_DOUBLE = (ValueLayout.OfDouble) LINKER.canonicalLayouts().get("double");
     /**
      * The {@code T*} native type.
      */
-    public static final AddressLayout C_POINTER = ValueLayout.ADDRESS
+    public static final AddressLayout C_POINTER = ((AddressLayout) LINKER.canonicalLayouts().get("void*"))
             .withTargetLayout(MemoryLayout.sequenceLayout(Long.MAX_VALUE, C_CHAR));
     /**
      * The layout for the {@code size_t} C type
      */
-    public static final ValueLayout C_SIZE_T = ValueLayout.ADDRESS.byteSize() == 8 ? C_LONG_LONG : C_INT;
+    public static final ValueLayout C_SIZE_T = (ValueLayout) LINKER.canonicalLayouts().get("size_t");
 
     // Common layout shared by some tests
     // struct S_PDI { void* p0; double p1; int p2; };
@@ -142,8 +144,6 @@ public class NativeTestHelper {
             C_INT.withName("p2"));
         default -> throw new UnsupportedOperationException("Unsupported address size");
     };
-
-    public static final Linker LINKER = Linker.nativeLinker();
 
     private static final MethodHandle FREE = LINKER.downcallHandle(
             LINKER.defaultLookup().find("free").get(), FunctionDescriptor.ofVoid(C_POINTER));

--- a/test/jdk/java/foreign/NativeTestHelper.java
+++ b/test/jdk/java/foreign/NativeTestHelper.java
@@ -123,6 +123,10 @@ public class NativeTestHelper {
      */
     public static final AddressLayout C_POINTER = ValueLayout.ADDRESS
             .withTargetLayout(MemoryLayout.sequenceLayout(Long.MAX_VALUE, C_CHAR));
+    /**
+     * The layout for the {@code size_t} C type
+     */
+    public static final ValueLayout C_SIZE_T = ValueLayout.ADDRESS.byteSize() == 8 ? C_LONG_LONG : C_INT;
 
     public static final Linker LINKER = Linker.nativeLinker();
 

--- a/test/jdk/java/foreign/TestAddressDereference.java
+++ b/test/jdk/java/foreign/TestAddressDereference.java
@@ -40,6 +40,8 @@ import java.lang.invoke.MethodHandles;
 import java.lang.invoke.MethodType;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import org.testng.annotations.*;
 
@@ -184,18 +186,23 @@ public class TestAddressDereference extends UpcallTestHelper {
             this.layout = segment;
         }
 
+        private static final Pattern LAYOUT_PATTERN = Pattern.compile("^(?<align>\\d+%)?(?<char>[azcsifjdAZCSIFJD])\\d+$");
+
         static LayoutKind parse(String layoutString) {
-            return switch (layoutString.charAt(0)) {
-                case 'A','a' -> ADDRESS;
-                case 'z','Z' -> BOOL;
-                case 'c','C' -> CHAR;
-                case 's','S' -> SHORT;
-                case 'i','I' -> INT;
-                case 'f','F' -> FLOAT;
-                case 'j','J' -> LONG;
-                case 'd','D' -> DOUBLE;
-                default -> throw new AssertionError("Invalid layout string: " + layoutString);
-            };
+            Matcher matcher = LAYOUT_PATTERN.matcher(layoutString);
+            if (matcher.matches()) {
+                switch (matcher.group("char")) {
+                    case "A","a": return ADDRESS;
+                    case "z","Z": return BOOL;
+                    case "c","C": return CHAR;
+                    case "s","S": return SHORT;
+                    case "i","I": return INT;
+                    case "f","F": return FLOAT;
+                    case "j","J": return LONG;
+                    case "d","D": return DOUBLE;
+                };
+            }
+            throw new AssertionError("Invalid layout string: " + layoutString);
         }
     }
 }

--- a/test/jdk/java/foreign/TestIllegalLink.java
+++ b/test/jdk/java/foreign/TestIllegalLink.java
@@ -214,7 +214,7 @@ public class TestIllegalLink extends NativeTestHelper {
                     "GroupLayout is too large"
             });
         }
-        if (ADDRESS.byteSize() == 8) {
+        if (ValueLayout.JAVA_LONG.byteAlignment() == 8) {
             cases.add(new Object[]{
                     FunctionDescriptor.ofVoid(MemoryLayout.structLayout(
                             ValueLayout.JAVA_LONG,

--- a/test/jdk/java/foreign/TestIllegalLink.java
+++ b/test/jdk/java/foreign/TestIllegalLink.java
@@ -48,6 +48,8 @@ import jdk.internal.foreign.CABI;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
+import static java.lang.foreign.ValueLayout.*;
+
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
 
@@ -128,7 +130,7 @@ public class TestIllegalLink extends NativeTestHelper {
             {
                     FunctionDescriptor.ofVoid(C_POINTER.withByteAlignment(2)),
                     NO_OPTIONS,
-                    "Unsupported layout: 2%a8"
+                    "Unsupported layout: 2%a" + ADDRESS.byteSize()
             },
             {
                     FunctionDescriptor.ofVoid(ValueLayout.JAVA_CHAR.withByteAlignment(4)),
@@ -187,13 +189,6 @@ public class TestIllegalLink extends NativeTestHelper {
             },
             {
                     FunctionDescriptor.ofVoid(MemoryLayout.structLayout(
-                            ValueLayout.JAVA_LONG,
-                            ValueLayout.JAVA_INT)), // missing trailing padding
-                    NO_OPTIONS,
-                    "has unexpected size"
-            },
-            {
-                    FunctionDescriptor.ofVoid(MemoryLayout.structLayout(
                             ValueLayout.JAVA_INT,
                             MemoryLayout.paddingLayout(4))), // too much trailing padding
                     NO_OPTIONS,
@@ -217,6 +212,15 @@ public class TestIllegalLink extends NativeTestHelper {
                             ))),
                     NO_OPTIONS,
                     "GroupLayout is too large"
+            });
+        }
+        if (ADDRESS.byteSize() == 8) {
+            cases.add(new Object[]{
+                    FunctionDescriptor.ofVoid(MemoryLayout.structLayout(
+                            ValueLayout.JAVA_LONG,
+                            ValueLayout.JAVA_INT)), // missing trailing padding
+                    NO_OPTIONS,
+                    "has unexpected size"
             });
         }
         return cases.toArray(Object[][]::new);

--- a/test/jdk/java/foreign/TestLinker.java
+++ b/test/jdk/java/foreign/TestLinker.java
@@ -93,10 +93,6 @@ public class TestLinker extends NativeTestHelper {
                     FunctionDescriptor.ofVoid(structLayout(C_INT).withName("x")) },
             { FunctionDescriptor.ofVoid(structLayout(C_INT)),
                     FunctionDescriptor.ofVoid(structLayout(C_INT.withName("x"))) },
-            { FunctionDescriptor.ofVoid(structLayout(C_INT, paddingLayout(4), C_LONG_LONG)),
-                    FunctionDescriptor.ofVoid(structLayout(C_INT, paddingLayout(4), C_LONG_LONG.withName("x"))) },
-            { FunctionDescriptor.ofVoid(structLayout(C_INT, paddingLayout(4), C_LONG_LONG)),
-                    FunctionDescriptor.ofVoid(structLayout(C_INT, paddingLayout(4).withName("x"), C_LONG_LONG)) },
             { FunctionDescriptor.ofVoid(structLayout(sequenceLayout(1, C_INT))),
                     FunctionDescriptor.ofVoid(structLayout(sequenceLayout(1, C_INT).withName("x"))) },
             { FunctionDescriptor.ofVoid(structLayout(sequenceLayout(1, C_INT))),
@@ -114,6 +110,12 @@ public class TestLinker extends NativeTestHelper {
                     FunctionDescriptor.ofVoid(unionLayout(C_INT).withName("x")) });
             cases.add(new Object[]{ FunctionDescriptor.ofVoid(unionLayout(C_INT)),
                     FunctionDescriptor.ofVoid(unionLayout(C_INT.withName("x"))) });
+        }
+        if (C_LONG_LONG.byteAlignment() == 8) {
+            cases.add(new Object[]{ FunctionDescriptor.ofVoid(structLayout(C_INT, paddingLayout(4), C_LONG_LONG)),
+                    FunctionDescriptor.ofVoid(structLayout(C_INT, paddingLayout(4), C_LONG_LONG.withName("x"))) });
+            cases.add(new Object[]{ FunctionDescriptor.ofVoid(structLayout(C_INT, paddingLayout(4), C_LONG_LONG)),
+                    FunctionDescriptor.ofVoid(structLayout(C_INT, paddingLayout(4).withName("x"), C_LONG_LONG)) });
         }
 
         return cases.toArray(Object[][]::new);

--- a/test/jdk/java/foreign/TestSegments.java
+++ b/test/jdk/java/foreign/TestSegments.java
@@ -25,6 +25,7 @@
  * @test
  * @enablePreview
  * @requires jdk.foreign.linker != "UNSUPPORTED"
+ * @requires vm.bits == 64
  * @run testng/othervm -Xmx4G -XX:MaxDirectMemorySize=1M --enable-native-access=ALL-UNNAMED TestSegments
  */
 

--- a/test/jdk/java/foreign/TestUpcallHighArity.java
+++ b/test/jdk/java/foreign/TestUpcallHighArity.java
@@ -51,12 +51,16 @@ public class TestUpcallHighArity extends CallGeneratorHelper {
     static final Linker LINKER = Linker.nativeLinker();
 
     // struct S_PDI { void* p0; double p1; int p2; };
-    static final MemoryLayout S_PDI_LAYOUT = MemoryLayout.structLayout(
-        C_POINTER.withName("p0"),
-        C_DOUBLE.withName("p1"),
-        C_INT.withName("p2"),
-        MemoryLayout.paddingLayout(4)
-    );
+    static final MemoryLayout S_PDI_LAYOUT = ValueLayout.ADDRESS.byteSize() == 8
+        ? MemoryLayout.structLayout(
+            C_POINTER.withName("p0"),
+            C_DOUBLE.withName("p1"),
+            C_INT.withName("p2"),
+            MemoryLayout.paddingLayout(4))
+        : MemoryLayout.structLayout(
+            C_POINTER.withName("p0"),
+            C_DOUBLE.withName("p1"),
+            C_INT.withName("p2"));
 
     static {
         System.loadLibrary("TestUpcallHighArity");

--- a/test/jdk/java/foreign/TestUpcallHighArity.java
+++ b/test/jdk/java/foreign/TestUpcallHighArity.java
@@ -48,19 +48,6 @@ import java.util.function.Consumer;
 
 public class TestUpcallHighArity extends CallGeneratorHelper {
     static final MethodHandle MH_do_upcall;
-    static final Linker LINKER = Linker.nativeLinker();
-
-    // struct S_PDI { void* p0; double p1; int p2; };
-    static final MemoryLayout S_PDI_LAYOUT = ValueLayout.ADDRESS.byteSize() == 8
-        ? MemoryLayout.structLayout(
-            C_POINTER.withName("p0"),
-            C_DOUBLE.withName("p1"),
-            C_INT.withName("p2"),
-            MemoryLayout.paddingLayout(4))
-        : MemoryLayout.structLayout(
-            C_POINTER.withName("p0"),
-            C_DOUBLE.withName("p1"),
-            C_INT.withName("p2"));
 
     static {
         System.loadLibrary("TestUpcallHighArity");

--- a/test/jdk/java/foreign/TestUpcallStructScope.java
+++ b/test/jdk/java/foreign/TestUpcallStructScope.java
@@ -51,20 +51,7 @@ import static org.testng.Assert.assertFalse;
 
 public class TestUpcallStructScope extends NativeTestHelper {
     static final MethodHandle MH_do_upcall;
-    static final Linker LINKER = Linker.nativeLinker();
     static final MethodHandle MH_Consumer_accept;
-
-    // struct S_PDI { void* p0; double p1; int p2; };
-    static final MemoryLayout S_PDI_LAYOUT = ValueLayout.ADDRESS.byteSize() == 8
-        ? MemoryLayout.structLayout(
-            C_POINTER.withName("p0"),
-            C_DOUBLE.withName("p1"),
-            C_INT.withName("p2"),
-            MemoryLayout.paddingLayout(4))
-        : MemoryLayout.structLayout(
-            C_POINTER.withName("p0"),
-            C_DOUBLE.withName("p1"),
-            C_INT.withName("p2"));
 
     static {
         System.loadLibrary("TestUpcallStructScope");

--- a/test/jdk/java/foreign/TestUpcallStructScope.java
+++ b/test/jdk/java/foreign/TestUpcallStructScope.java
@@ -55,12 +55,16 @@ public class TestUpcallStructScope extends NativeTestHelper {
     static final MethodHandle MH_Consumer_accept;
 
     // struct S_PDI { void* p0; double p1; int p2; };
-    static final MemoryLayout S_PDI_LAYOUT = MemoryLayout.structLayout(
-        C_POINTER.withName("p0"),
-        C_DOUBLE.withName("p1"),
-        C_INT.withName("p2"),
-        MemoryLayout.paddingLayout(4)
-    );
+    static final MemoryLayout S_PDI_LAYOUT = ValueLayout.ADDRESS.byteSize() == 8
+        ? MemoryLayout.structLayout(
+            C_POINTER.withName("p0"),
+            C_DOUBLE.withName("p1"),
+            C_INT.withName("p2"),
+            MemoryLayout.paddingLayout(4))
+        : MemoryLayout.structLayout(
+            C_POINTER.withName("p0"),
+            C_DOUBLE.withName("p1"),
+            C_INT.withName("p2"));
 
     static {
         System.loadLibrary("TestUpcallStructScope");


### PR DESCRIPTION
Ensure that the jdk_foreign tests pass on linux-x86.

This is useful to ensure that there are no hard to fix issues (that would require API changes) when trying to use the linker API on a 32-bit platform. This is a good indication that the FFM API is ready for finalization.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8312615](https://bugs.openjdk.org/browse/JDK-8312615): Ensure jdk_foreign tests pass on linux-x86 (**Enhancement** - P3)


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.org/census#mcimadamore) (@mcimadamore - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/panama-foreign.git pull/849/head:pull/849` \
`$ git checkout pull/849`

Update a local copy of the PR: \
`$ git checkout pull/849` \
`$ git pull https://git.openjdk.org/panama-foreign.git pull/849/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 849`

View PR using the GUI difftool: \
`$ git pr show -t 849`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/panama-foreign/pull/849.diff">https://git.openjdk.org/panama-foreign/pull/849.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/panama-foreign/pull/849#issuecomment-1648257339)