### PR TITLE
8313005: Ensure native access check can fold away

### DIFF
--- a/src/java.base/share/classes/java/lang/Class.java
+++ b/src/java.base/share/classes/java/lang/Class.java
@@ -83,6 +83,7 @@ import jdk.internal.reflect.Reflection;
 import jdk.internal.reflect.ReflectionFactory;
 import jdk.internal.vm.annotation.ForceInline;
 import jdk.internal.vm.annotation.IntrinsicCandidate;
+import jdk.internal.vm.annotation.Stable;
 
 import sun.invoke.util.Wrapper;
 import sun.reflect.generics.factory.CoreReflectionFactory;
@@ -1060,6 +1061,7 @@ public final class Class<T> implements java.io.Serializable,
     }
 
     // set by VM
+    @Stable
     private transient Module module;
 
     // Initialized in JVM not by private constructor

--- a/src/java.base/share/classes/jdk/internal/reflect/Reflection.java
+++ b/src/java.base/share/classes/jdk/internal/reflect/Reflection.java
@@ -31,6 +31,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 
+import jdk.internal.access.JavaLangAccess;
 import jdk.internal.access.SharedSecrets;
 import jdk.internal.misc.VM;
 import jdk.internal.module.ModuleBootstrap;
@@ -115,7 +116,10 @@ public class Reflection {
         Module module = currentClass != null ?
                 currentClass.getModule() :
                 ClassLoader.getSystemClassLoader().getUnnamedModule();
-        SharedSecrets.getJavaLangAccess().ensureNativeAccess(module, owner, methodName);
+        class Holder {
+            static final JavaLangAccess JLA = SharedSecrets.getJavaLangAccess();
+        }
+        Holder.JLA.ensureNativeAccess(module, owner, methodName);
     }
 
     /**

--- a/test/micro/org/openjdk/bench/java/lang/foreign/MemorySegmentCopyUnsafe.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/MemorySegmentCopyUnsafe.java
@@ -22,14 +22,8 @@
  */
 package org.openjdk.bench.java.lang.foreign;
 
-import java.awt.Desktop;
 import java.lang.foreign.Arena;
 import java.lang.foreign.MemorySegment;
-
-import java.lang.invoke.MethodHandle;
-import java.lang.invoke.MethodHandles;
-import java.lang.invoke.MethodType;
-import java.lang.invoke.VarHandle;
 
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;

--- a/test/micro/org/openjdk/bench/java/lang/foreign/MemorySegmentCopyUnsafe.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/MemorySegmentCopyUnsafe.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.bench.java.lang.foreign;
+
+import java.awt.Desktop;
+import java.lang.foreign.Arena;
+import java.lang.foreign.MemorySegment;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+import java.lang.invoke.VarHandle;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import sun.misc.Unsafe;
+
+import java.util.concurrent.TimeUnit;
+
+import static java.lang.foreign.ValueLayout.*;
+
+@BenchmarkMode(Mode.AverageTime)
+@Warmup(iterations = 5, time = 500, timeUnit = TimeUnit.MILLISECONDS)
+@Measurement(iterations = 10, time = 500, timeUnit = TimeUnit.MILLISECONDS)
+@State(org.openjdk.jmh.annotations.Scope.Thread)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Fork(value = 3, jvmArgsAppend = {"--enable-preview", "--enable-native-access=ALL-UNNAMED"})
+public class MemorySegmentCopyUnsafe {
+
+    static final Unsafe UNSAFE = Utils.unsafe;
+
+    long src;
+    long dst;
+
+    @Setup
+    public void setup() throws Throwable {
+        src = Arena.global().allocate(JAVA_INT).address();
+        dst = Arena.global().allocate(JAVA_INT).address();
+    }
+
+    @Benchmark
+    public void panama() {
+        MemorySegment srcSeg = MemorySegment.ofAddress(src).reinterpret(JAVA_INT.byteSize());
+        MemorySegment dstSeg = MemorySegment.ofAddress(dst).reinterpret(JAVA_INT.byteSize());
+        dstSeg.copyFrom(srcSeg);
+    }
+
+    @Benchmark
+    public void unsafe() {
+        UNSAFE.copyMemory(src, dst, JAVA_INT.byteSize());
+    }
+}

--- a/test/micro/org/openjdk/bench/java/lang/foreign/MemorySegmentGetUnsafe.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/MemorySegmentGetUnsafe.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.bench.java.lang.foreign;
+
+import java.lang.foreign.Arena;
+import java.lang.foreign.MemorySegment;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+import java.lang.invoke.VarHandle;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import sun.misc.Unsafe;
+
+import java.util.concurrent.TimeUnit;
+
+import static java.lang.foreign.ValueLayout.*;
+
+@BenchmarkMode(Mode.AverageTime)
+@Warmup(iterations = 5, time = 500, timeUnit = TimeUnit.MILLISECONDS)
+@Measurement(iterations = 10, time = 500, timeUnit = TimeUnit.MILLISECONDS)
+@State(org.openjdk.jmh.annotations.Scope.Thread)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Fork(value = 3, jvmArgsAppend = {"--enable-preview", "--enable-native-access=ALL-UNNAMED"})
+public class MemorySegmentGetUnsafe {
+
+    static final Unsafe UNSAFE = Utils.unsafe;
+    static final MethodHandle OF_ADDRESS_UNSAFE;
+
+    static {
+        try {
+            OF_ADDRESS_UNSAFE = MethodHandles.lookup().findStatic(MemorySegmentGetUnsafe.class,
+                    "ofAddressUnsafe", MethodType.methodType(MemorySegment.class, long.class));
+        } catch (ReflectiveOperationException e) {
+            throw new ExceptionInInitializerError(e);
+        }
+    }
+
+    static final VarHandle INT_HANDLE = adaptSegmentHandle(JAVA_INT.varHandle());
+
+    static VarHandle adaptSegmentHandle(VarHandle handle) {
+        handle = MethodHandles.insertCoordinates(handle, 1, 0L);
+        handle = MethodHandles.filterCoordinates(handle, 0, OF_ADDRESS_UNSAFE);
+        return handle;
+    }
+
+    static MemorySegment ofAddressUnsafe(long address) {
+        return MemorySegment.ofAddress(address).reinterpret(JAVA_INT.byteSize());
+    }
+
+    long addr;
+
+    @Setup
+    public void setup() throws Throwable {
+        addr = Arena.global().allocate(JAVA_INT).address();
+    }
+
+    @Benchmark
+    public int panama() {
+        return (int) INT_HANDLE.get(addr);
+    }
+
+    @Benchmark
+    public int unsafe() {
+        return UNSAFE.getInt(addr);
+    }
+}


### PR DESCRIPTION
This patch helps to ensure that native access checks done by restricted methods can completely fold away (see JBS for details).

This is accomplished by:
1. Marking the `module` field of `java.lang.Class` `@Stable`
2. Using a constant `JavaLangAccess` instance.

I've also added 2 new benchmarks that show the improvement (in two separate classes so that the benchmark methods in each class are comparable to each other in terms of numbers).

Numbers on my machine are as follows:

Before:
```
Benchmark                       Mode  Cnt  Score   Error  Units
MemorySegmentGetUnsafe.panama   avgt   30  0.817 ± 0.002  ns/op
MemorySegmentGetUnsafe.unsafe   avgt   30  0.400 ± 0.003  ns/op

MemorySegmentCopyUnsafe.panama  avgt   30  8.145 ± 0.016  ns/op
MemorySegmentCopyUnsafe.unsafe  avgt   30  7.744 ± 0.012  ns/op
```

After:
```
Benchmark                       Mode  Cnt  Score   Error  Units
MemorySegmentGetUnsafe.panama   avgt   30  0.411 ± 0.002  ns/op
MemorySegmentGetUnsafe.unsafe   avgt   30  0.404 ± 0.003  ns/op

MemorySegmentCopyUnsafe.panama  avgt   30  7.737 ± 0.013  ns/op
MemorySegmentCopyUnsafe.unsafe  avgt   30  7.728 ± 0.011  ns/op
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8313005](https://bugs.openjdk.org/browse/JDK-8313005): Ensure native access check can fold away (**Enhancement** - P3)


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.org/census#mcimadamore) (@mcimadamore - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/panama-foreign.git pull/851/head:pull/851` \
`$ git checkout pull/851`

Update a local copy of the PR: \
`$ git checkout pull/851` \
`$ git pull https://git.openjdk.org/panama-foreign.git pull/851/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 851`

View PR using the GUI difftool: \
`$ git pr show -t 851`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/panama-foreign/pull/851.diff">https://git.openjdk.org/panama-foreign/pull/851.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/panama-foreign/pull/851#issuecomment-1650368288)