### PR TITLE
8305170: Add MemoryLayout::withoutAlignment as an alias for withAlignment(8)

### DIFF
--- a/src/java.base/share/classes/java/lang/foreign/AddressLayout.java
+++ b/src/java.base/share/classes/java/lang/foreign/AddressLayout.java
@@ -80,6 +80,12 @@ public sealed interface AddressLayout extends ValueLayout permits ValueLayouts.O
      * {@inheritDoc}
      */
     @Override
+    AddressLayout withoutByteAlignment();
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
     AddressLayout withOrder(ByteOrder order);
 
     /**

--- a/src/java.base/share/classes/java/lang/foreign/GroupLayout.java
+++ b/src/java.base/share/classes/java/lang/foreign/GroupLayout.java
@@ -72,4 +72,11 @@ public sealed interface GroupLayout extends MemoryLayout permits StructLayout, U
      */
     @Override
     GroupLayout withByteAlignment(long byteAlignment);
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    GroupLayout withoutByteAlignment();
+
 }

--- a/src/java.base/share/classes/java/lang/foreign/MemoryLayout.java
+++ b/src/java.base/share/classes/java/lang/foreign/MemoryLayout.java
@@ -334,6 +334,14 @@ public sealed interface MemoryLayout permits SequenceLayout, GroupLayout, Paddin
     MemoryLayout withByteAlignment(long byteAlignment);
 
     /**
+     * {@return a memory layout with the same characteristics as this layout, but with an alignment
+     * constraint of 1 byte (unaligned)}
+     *
+     * @see MemoryLayout#byteAlignment()
+     */
+    MemoryLayout withoutByteAlignment();
+
+    /**
      * {@return {@code offset + (byteSize() * index)}}
      *
      * @param offset the base offset

--- a/src/java.base/share/classes/java/lang/foreign/PaddingLayout.java
+++ b/src/java.base/share/classes/java/lang/foreign/PaddingLayout.java
@@ -57,4 +57,10 @@ public sealed interface PaddingLayout extends MemoryLayout permits PaddingLayout
      * @throws IllegalArgumentException {@inheritDoc}
      */
     PaddingLayout withByteAlignment(long byteAlignment);
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    PaddingLayout withoutByteAlignment();
 }

--- a/src/java.base/share/classes/java/lang/foreign/SequenceLayout.java
+++ b/src/java.base/share/classes/java/lang/foreign/SequenceLayout.java
@@ -154,4 +154,10 @@ public sealed interface SequenceLayout extends MemoryLayout permits SequenceLayo
      * @throws IllegalArgumentException if {@code byteAlignment < elementLayout().byteAlignment()}.
      */
     SequenceLayout withByteAlignment(long byteAlignment);
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    SequenceLayout withoutByteAlignment();
 }

--- a/src/java.base/share/classes/java/lang/foreign/StructLayout.java
+++ b/src/java.base/share/classes/java/lang/foreign/StructLayout.java
@@ -57,4 +57,11 @@ public sealed interface StructLayout extends GroupLayout permits StructLayoutImp
      */
     @Override
     StructLayout withByteAlignment(long byteAlignment);
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    StructLayout withoutByteAlignment();
+
 }

--- a/src/java.base/share/classes/java/lang/foreign/UnionLayout.java
+++ b/src/java.base/share/classes/java/lang/foreign/UnionLayout.java
@@ -57,4 +57,11 @@ public sealed interface UnionLayout extends GroupLayout permits UnionLayoutImpl 
      */
     @Override
     UnionLayout withByteAlignment(long byteAlignment);
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    UnionLayout withoutByteAlignment();
+
 }

--- a/src/java.base/share/classes/java/lang/foreign/ValueLayout.java
+++ b/src/java.base/share/classes/java/lang/foreign/ValueLayout.java
@@ -94,6 +94,12 @@ public sealed interface ValueLayout extends MemoryLayout permits
     ValueLayout withByteAlignment(long byteAlignment);
 
     /**
+     * {@inheritDoc}
+     */
+    @Override
+    ValueLayout withoutByteAlignment();
+
+    /**
      * {@return a var handle which can be used to access values described by this value layout, in a given memory segment.}
      * <p>
      * The returned var handle's {@linkplain VarHandle#varType() var type} is the {@linkplain ValueLayout#carrier() carrier type} of
@@ -146,6 +152,12 @@ public sealed interface ValueLayout extends MemoryLayout permits
          * {@inheritDoc}
          */
         @Override
+        OfBoolean withoutByteAlignment();
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
         OfBoolean withOrder(ByteOrder order);
 
     }
@@ -177,6 +189,12 @@ public sealed interface ValueLayout extends MemoryLayout permits
          */
         @Override
         OfByte withByteAlignment(long byteAlignment);
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        OfByte withoutByteAlignment();
 
         /**
          * {@inheritDoc}
@@ -219,6 +237,12 @@ public sealed interface ValueLayout extends MemoryLayout permits
          * {@inheritDoc}
          */
         @Override
+        OfChar withoutByteAlignment();
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
         OfChar withOrder(ByteOrder order);
 
     }
@@ -251,6 +275,12 @@ public sealed interface ValueLayout extends MemoryLayout permits
          */
         @Override
         OfShort withByteAlignment(long byteAlignment);
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        OfShort withoutByteAlignment();
 
         /**
          * {@inheritDoc}
@@ -293,6 +323,12 @@ public sealed interface ValueLayout extends MemoryLayout permits
          * {@inheritDoc}
          */
         @Override
+        OfInt withoutByteAlignment();
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
         OfInt withOrder(ByteOrder order);
 
     }
@@ -324,6 +360,12 @@ public sealed interface ValueLayout extends MemoryLayout permits
          */
         @Override
         OfFloat withByteAlignment(long byteAlignment);
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        OfFloat withoutByteAlignment();
 
         /**
          * {@inheritDoc}
@@ -366,6 +408,12 @@ public sealed interface ValueLayout extends MemoryLayout permits
          * {@inheritDoc}
          */
         @Override
+        OfLong withoutByteAlignment();
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
         OfLong withOrder(ByteOrder order);
 
     }
@@ -398,6 +446,12 @@ public sealed interface ValueLayout extends MemoryLayout permits
          */
         @Override
         OfDouble withByteAlignment(long byteAlignment);
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        OfDouble withoutByteAlignment();
 
         /**
          * {@inheritDoc}
@@ -468,83 +522,83 @@ public sealed interface ValueLayout extends MemoryLayout permits
      * and byte order set to {@link ByteOrder#nativeOrder()}.
      * Equivalent to the following code:
      * {@snippet lang=java :
-     * ADDRESS.withByteAlignment(1);
+     * ADDRESS.withoutByteAlignment();
      * }
      * @apiNote Care should be taken when using unaligned value layouts as they may induce
      *          performance and portability issues.
      */
-    AddressLayout ADDRESS_UNALIGNED = ADDRESS.withByteAlignment(1);
+    AddressLayout ADDRESS_UNALIGNED = ADDRESS.withoutByteAlignment();
 
     /**
      * An unaligned value layout constant whose size is the same as that of a Java {@code char}
      * and byte order set to {@link ByteOrder#nativeOrder()}.
      * Equivalent to the following code:
      * {@snippet lang=java :
-     * JAVA_CHAR.withByteAlignment(1);
+     * JAVA_CHAR.withoutByteAlignment();
      * }
      * @apiNote Care should be taken when using unaligned value layouts as they may induce
      *          performance and portability issues.
      */
-    OfChar JAVA_CHAR_UNALIGNED = JAVA_CHAR.withByteAlignment(1);
+    OfChar JAVA_CHAR_UNALIGNED = JAVA_CHAR.withoutByteAlignment();
 
     /**
      * An unaligned value layout constant whose size is the same as that of a Java {@code short}
      * and byte order set to {@link ByteOrder#nativeOrder()}.
      * Equivalent to the following code:
      * {@snippet lang=java :
-     * JAVA_SHORT.withByteAlignment(1);
+     * JAVA_SHORT.withoutByteAlignment();
      * }
      * @apiNote Care should be taken when using unaligned value layouts as they may induce
      *          performance and portability issues.
      */
-    OfShort JAVA_SHORT_UNALIGNED = JAVA_SHORT.withByteAlignment(1);
+    OfShort JAVA_SHORT_UNALIGNED = JAVA_SHORT.withoutByteAlignment();
 
     /**
      * An unaligned value layout constant whose size is the same as that of a Java {@code int}
      * and byte order set to {@link ByteOrder#nativeOrder()}.
      * Equivalent to the following code:
      * {@snippet lang=java :
-     * JAVA_INT.withByteAlignment(1);
+     * JAVA_INT.withoutByteAlignment();
      * }
      * @apiNote Care should be taken when using unaligned value layouts as they may induce
      *          performance and portability issues.
      */
-    OfInt JAVA_INT_UNALIGNED = JAVA_INT.withByteAlignment(1);
+    OfInt JAVA_INT_UNALIGNED = JAVA_INT.withoutByteAlignment();
 
     /**
      * An unaligned value layout constant whose size is the same as that of a Java {@code long}
      * and byte order set to {@link ByteOrder#nativeOrder()}.
      * Equivalent to the following code:
      * {@snippet lang=java :
-     * JAVA_LONG.withByteAlignment(1);
+     * JAVA_LONG.withoutByteAlignment();
      * }
      * @apiNote Care should be taken when using unaligned value layouts as they may induce
      *          performance and portability issues.
      */
-    OfLong JAVA_LONG_UNALIGNED = JAVA_LONG.withByteAlignment(1);
+    OfLong JAVA_LONG_UNALIGNED = JAVA_LONG.withoutByteAlignment();
 
     /**
      * An unaligned value layout constant whose size is the same as that of a Java {@code float}
      * and byte order set to {@link ByteOrder#nativeOrder()}.
      * Equivalent to the following code:
      * {@snippet lang=java :
-     * JAVA_FLOAT.withByteAlignment(1);
+     * JAVA_FLOAT.withoutByteAlignment();
      * }
      * @apiNote Care should be taken when using unaligned value layouts as they may induce
      *          performance and portability issues.
      */
-    OfFloat JAVA_FLOAT_UNALIGNED = JAVA_FLOAT.withByteAlignment(1);
+    OfFloat JAVA_FLOAT_UNALIGNED = JAVA_FLOAT.withoutByteAlignment();
 
     /**
      * An unaligned value layout constant whose size is the same as that of a Java {@code double}
      * and byte order set to {@link ByteOrder#nativeOrder()}.
      * Equivalent to the following code:
      * {@snippet lang=java :
-     * JAVA_DOUBLE.withByteAlignment(1);
+     * JAVA_DOUBLE.withoutByteAlignment();
      * }
      * @apiNote Care should be taken when using unaligned value layouts as they may induce
      *          performance and portability issues.
      */
-    OfDouble JAVA_DOUBLE_UNALIGNED = JAVA_DOUBLE.withByteAlignment(1);
+    OfDouble JAVA_DOUBLE_UNALIGNED = JAVA_DOUBLE.withoutByteAlignment();
 
 }

--- a/src/java.base/share/classes/jdk/internal/foreign/LayoutPath.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/LayoutPath.java
@@ -206,7 +206,7 @@ public class LayoutPath {
 
         // If we have an enclosing layout, drop the alignment check for the accessed element,
         // we check the root layout instead
-        ValueLayout accessedLayout = enclosing != null ? valueLayout.withByteAlignment(1) : valueLayout;
+        ValueLayout accessedLayout = enclosing != null ? valueLayout.withoutByteAlignment() : valueLayout;
         VarHandle handle = accessedLayout.varHandle();
         handle = MethodHandles.collectCoordinates(handle, 1, offsetHandle());
 

--- a/src/java.base/share/classes/jdk/internal/foreign/layout/AbstractLayout.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/layout/AbstractLayout.java
@@ -66,6 +66,10 @@ public abstract sealed class AbstractLayout<L extends AbstractLayout<L> & Memory
         return dup(byteAlignment, name);
     }
 
+    public final L withoutByteAlignment() {
+        return withByteAlignment(1);
+    }
+
     public final long byteAlignment() {
         return byteAlignment;
     }

--- a/test/jdk/java/foreign/MemoryLayoutTypeRetentionTest.java
+++ b/test/jdk/java/foreign/MemoryLayoutTypeRetentionTest.java
@@ -49,6 +49,7 @@ public class MemoryLayoutTypeRetentionTest {
     @Test
     public void testOfBoolean() {
         OfBoolean v = JAVA_BOOLEAN
+                .withoutByteAlignment()
                 .withByteAlignment(BYTE_ALIGNMENT)
                 .withoutName()
                 .withName(NAME)
@@ -59,6 +60,7 @@ public class MemoryLayoutTypeRetentionTest {
     @Test
     public void testOfByte() {
         OfByte v = JAVA_BYTE
+                .withoutByteAlignment()
                 .withByteAlignment(BYTE_ALIGNMENT)
                 .withoutName()
                 .withName(NAME)
@@ -69,6 +71,7 @@ public class MemoryLayoutTypeRetentionTest {
     @Test
     public void testOfShort() {
         OfShort v = JAVA_SHORT
+                .withoutByteAlignment()
                 .withByteAlignment(BYTE_ALIGNMENT)
                 .withoutName()
                 .withName(NAME)
@@ -79,6 +82,7 @@ public class MemoryLayoutTypeRetentionTest {
     @Test
     public void testOfInt() {
         OfInt v = JAVA_INT
+                .withoutByteAlignment()
                 .withByteAlignment(BYTE_ALIGNMENT)
                 .withoutName()
                 .withName(NAME)
@@ -89,6 +93,7 @@ public class MemoryLayoutTypeRetentionTest {
     @Test
     public void testOfChar() {
         OfChar v = JAVA_CHAR
+                .withoutByteAlignment()
                 .withByteAlignment(BYTE_ALIGNMENT)
                 .withoutName()
                 .withName(NAME)
@@ -99,6 +104,7 @@ public class MemoryLayoutTypeRetentionTest {
     @Test
     public void testOfLong() {
         OfLong v = JAVA_LONG
+                .withoutByteAlignment()
                 .withByteAlignment(BYTE_ALIGNMENT)
                 .withoutName()
                 .withName(NAME)
@@ -109,6 +115,7 @@ public class MemoryLayoutTypeRetentionTest {
     @Test
     public void testOfFloat() {
         OfFloat v = JAVA_FLOAT
+                .withoutByteAlignment()
                 .withByteAlignment(BYTE_ALIGNMENT)
                 .withoutName()
                 .withName(NAME)
@@ -119,6 +126,7 @@ public class MemoryLayoutTypeRetentionTest {
     @Test
     public void testOfDouble() {
         OfDouble v = JAVA_DOUBLE
+                .withoutByteAlignment()
                 .withByteAlignment(BYTE_ALIGNMENT)
                 .withoutName()
                 .withName(NAME)
@@ -129,6 +137,7 @@ public class MemoryLayoutTypeRetentionTest {
     @Test
     public void testValueLayout() {
         ValueLayout v = ((ValueLayout) JAVA_INT)
+                .withoutByteAlignment()
                 .withByteAlignment(BYTE_ALIGNMENT)
                 .withoutName()
                 .withName(NAME)
@@ -139,6 +148,7 @@ public class MemoryLayoutTypeRetentionTest {
     @Test
     public void testAddressLayout() {
         AddressLayout v = ADDRESS
+                .withoutByteAlignment()
                 .withByteAlignment(BYTE_ALIGNMENT)
                 .withoutName()
                 .withName(NAME)
@@ -157,6 +167,7 @@ public class MemoryLayoutTypeRetentionTest {
     @Test
     public void testPaddingLayout() {
         PaddingLayout v = MemoryLayout.paddingLayout(1)
+                .withoutByteAlignment()
                 .withByteAlignment(BYTE_ALIGNMENT)
                 .withoutName()
                 .withName(NAME);
@@ -168,6 +179,7 @@ public class MemoryLayoutTypeRetentionTest {
         GroupLayout v = MemoryLayout.structLayout(
                         JAVA_INT.withByteAlignment(BYTE_ALIGNMENT),
                         JAVA_LONG.withByteAlignment(BYTE_ALIGNMENT))
+                .withoutByteAlignment()
                 .withByteAlignment(BYTE_ALIGNMENT)
                 .withoutName()
                 .withName(NAME);
@@ -179,6 +191,7 @@ public class MemoryLayoutTypeRetentionTest {
         StructLayout v = MemoryLayout.structLayout(
                         JAVA_INT.withByteAlignment(BYTE_ALIGNMENT),
                         JAVA_LONG.withByteAlignment(BYTE_ALIGNMENT))
+                .withoutByteAlignment()
                 .withByteAlignment(BYTE_ALIGNMENT)
                 .withoutName()
                 .withName(NAME);
@@ -190,6 +203,7 @@ public class MemoryLayoutTypeRetentionTest {
         UnionLayout v = MemoryLayout.unionLayout(
                     JAVA_INT.withByteAlignment(BYTE_ALIGNMENT),
                     JAVA_LONG.withByteAlignment(BYTE_ALIGNMENT))
+                .withoutByteAlignment()
                 .withByteAlignment(BYTE_ALIGNMENT)
                 .withoutName()
                 .withName(NAME);

--- a/test/jdk/java/foreign/TestLayouts.java
+++ b/test/jdk/java/foreign/TestLayouts.java
@@ -336,6 +336,17 @@ public class TestLayouts {
         MemoryLayout.structLayout(layout, layout);
     }
 
+    @Test(dataProvider="layoutsAndAlignments")
+    public void testWithoutAlignment(MemoryLayout layout, long byteAlign) {
+        if ((layout instanceof GroupLayout || layout instanceof SequenceLayout) && byteAlign != 1) {
+            // Group and sequence layouts are not generally able to be unaligned
+            return;
+        }
+        layout = layout.withoutByteAlignment();
+        assertEquals(layout.byteAlignment(), 1);
+
+    }
+
     @Test(expectedExceptions = IllegalArgumentException.class)
     public void testSequenceElement() {
         SequenceLayout layout = MemoryLayout.sequenceLayout(10, JAVA_INT);


### PR DESCRIPTION
This PR proposes to add new methods to the many MemoryLayout classes called `withoutAlignment()` and that is an alias of calling `withAlignment(1)`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8305170](https://bugs.openjdk.org/browse/JDK-8305170): Add MemoryLayout::withoutAlignment as an alias for withAlignment(8) (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/panama-foreign.git pull/852/head:pull/852` \
`$ git checkout pull/852`

Update a local copy of the PR: \
`$ git checkout pull/852` \
`$ git pull https://git.openjdk.org/panama-foreign.git pull/852/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 852`

View PR using the GUI difftool: \
`$ git pr show -t 852`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/panama-foreign/pull/852.diff">https://git.openjdk.org/panama-foreign/pull/852.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/panama-foreign/pull/852#issuecomment-1653051165)