### PR TITLE
8313265: Move the FFM API out of preview

### DIFF
--- a/src/java.base/share/classes/java/lang/Module.java
+++ b/src/java.base/share/classes/java/lang/Module.java
@@ -272,7 +272,7 @@ public final class Module implements AnnotatedElement {
      * <a href="foreign/package-summary.html#restricted"><em>restricted</em></a> methods.
      *
      * @return {@code true} if this module can access <em>restricted</em> methods.
-     * @since 20
+     * @since 22
      */
     public boolean isNativeAccessEnabled() {
         Module target = moduleForNativeAccess();

--- a/src/java.base/share/classes/java/lang/Module.java
+++ b/src/java.base/share/classes/java/lang/Module.java
@@ -274,7 +274,6 @@ public final class Module implements AnnotatedElement {
      * @return {@code true} if this module can access <em>restricted</em> methods.
      * @since 20
      */
-    @PreviewFeature(feature = PreviewFeature.Feature.FOREIGN)
     public boolean isNativeAccessEnabled() {
         Module target = moduleForNativeAccess();
         return EnableNativeAccess.isNativeAccessEnabled(target);

--- a/src/java.base/share/classes/java/lang/ModuleLayer.java
+++ b/src/java.base/share/classes/java/lang/ModuleLayer.java
@@ -323,7 +323,6 @@ public final class ModuleLayer {
          *
          * @since 20
          */
-        @PreviewFeature(feature=PreviewFeature.Feature.FOREIGN)
         @CallerSensitive
         public Controller enableNativeAccess(Module target) {
             ensureInLayer(target);

--- a/src/java.base/share/classes/java/lang/ModuleLayer.java
+++ b/src/java.base/share/classes/java/lang/ModuleLayer.java
@@ -321,7 +321,7 @@ public final class ModuleLayer {
          * @throws IllegalCallerException
          *         If the caller is in a module that does not have native access enabled
          *
-         * @since 20
+         * @since 22
          */
         @CallerSensitive
         public Controller enableNativeAccess(Module target) {

--- a/src/java.base/share/classes/java/lang/foreign/AddressLayout.java
+++ b/src/java.base/share/classes/java/lang/foreign/AddressLayout.java
@@ -27,7 +27,6 @@
 package java.lang.foreign;
 
 import jdk.internal.foreign.layout.ValueLayouts;
-import jdk.internal.javac.PreviewFeature;
 import jdk.internal.reflect.CallerSensitive;
 
 import java.lang.foreign.Linker.Option;
@@ -55,7 +54,6 @@ import java.util.Optional;
  * @see #ADDRESS_UNALIGNED
  * @since 19
  */
-@PreviewFeature(feature = PreviewFeature.Feature.FOREIGN)
 public sealed interface AddressLayout extends ValueLayout permits ValueLayouts.OfAddressImpl {
 
     /**

--- a/src/java.base/share/classes/java/lang/foreign/AddressLayout.java
+++ b/src/java.base/share/classes/java/lang/foreign/AddressLayout.java
@@ -52,7 +52,7 @@ import java.util.Optional;
  *
  * @see #ADDRESS
  * @see #ADDRESS_UNALIGNED
- * @since 19
+ * @since 22
  */
 public sealed interface AddressLayout extends ValueLayout permits ValueLayouts.OfAddressImpl {
 

--- a/src/java.base/share/classes/java/lang/foreign/Arena.java
+++ b/src/java.base/share/classes/java/lang/foreign/Arena.java
@@ -26,7 +26,6 @@
 package java.lang.foreign;
 
 import jdk.internal.foreign.MemorySessionImpl;
-import jdk.internal.javac.PreviewFeature;
 import jdk.internal.ref.CleanerFactory;
 
 import java.lang.foreign.MemorySegment.Scope;
@@ -197,7 +196,6 @@ import java.lang.foreign.MemorySegment.Scope;
  *
  * @since 20
  */
-@PreviewFeature(feature=PreviewFeature.Feature.FOREIGN)
 public interface Arena extends SegmentAllocator, AutoCloseable {
 
     /**

--- a/src/java.base/share/classes/java/lang/foreign/Arena.java
+++ b/src/java.base/share/classes/java/lang/foreign/Arena.java
@@ -194,7 +194,7 @@ import java.lang.foreign.MemorySegment.Scope;
  *
  * @see MemorySegment
  *
- * @since 20
+ * @since 22
  */
 public interface Arena extends SegmentAllocator, AutoCloseable {
 

--- a/src/java.base/share/classes/java/lang/foreign/FunctionDescriptor.java
+++ b/src/java.base/share/classes/java/lang/foreign/FunctionDescriptor.java
@@ -31,7 +31,6 @@ import java.util.Optional;
 import java.util.List;
 
 import jdk.internal.foreign.FunctionDescriptorImpl;
-import jdk.internal.javac.PreviewFeature;
 
 /**
  * A function descriptor models the signature of a foreign function. A function descriptor is made up of zero or more
@@ -45,7 +44,6 @@ import jdk.internal.javac.PreviewFeature;
  * @see MemoryLayout
  * @since 19
  */
-@PreviewFeature(feature=PreviewFeature.Feature.FOREIGN)
 public sealed interface FunctionDescriptor permits FunctionDescriptorImpl {
 
     /**

--- a/src/java.base/share/classes/java/lang/foreign/FunctionDescriptor.java
+++ b/src/java.base/share/classes/java/lang/foreign/FunctionDescriptor.java
@@ -42,7 +42,7 @@ import jdk.internal.foreign.FunctionDescriptorImpl;
  * Implementing classes are immutable, thread-safe and <a href="{@docRoot}/java.base/java/lang/doc-files/ValueBased.html">value-based</a>.
  *
  * @see MemoryLayout
- * @since 19
+ * @since 22
  */
 public sealed interface FunctionDescriptor permits FunctionDescriptorImpl {
 

--- a/src/java.base/share/classes/java/lang/foreign/GroupLayout.java
+++ b/src/java.base/share/classes/java/lang/foreign/GroupLayout.java
@@ -37,7 +37,7 @@ import java.util.List;
  * This class is immutable, thread-safe and <a href="{@docRoot}/java.base/java/lang/doc-files/ValueBased.html">value-based</a>.
  *
  * @sealedGraph
- * @since 19
+ * @since 22
  */
 public sealed interface GroupLayout extends MemoryLayout permits StructLayout, UnionLayout {
 

--- a/src/java.base/share/classes/java/lang/foreign/GroupLayout.java
+++ b/src/java.base/share/classes/java/lang/foreign/GroupLayout.java
@@ -26,7 +26,6 @@
 package java.lang.foreign;
 
 import java.util.List;
-import jdk.internal.javac.PreviewFeature;
 
 /**
  * A compound layout that is an aggregation of multiple, heterogeneous <em>member layouts</em>. There are two ways in which member layouts
@@ -40,7 +39,6 @@ import jdk.internal.javac.PreviewFeature;
  * @sealedGraph
  * @since 19
  */
-@PreviewFeature(feature=PreviewFeature.Feature.FOREIGN)
 public sealed interface GroupLayout extends MemoryLayout permits StructLayout, UnionLayout {
 
     /**

--- a/src/java.base/share/classes/java/lang/foreign/Linker.java
+++ b/src/java.base/share/classes/java/lang/foreign/Linker.java
@@ -29,7 +29,6 @@ import jdk.internal.foreign.abi.AbstractLinker;
 import jdk.internal.foreign.abi.LinkerOptions;
 import jdk.internal.foreign.abi.CapturableState;
 import jdk.internal.foreign.abi.SharedUtils;
-import jdk.internal.javac.PreviewFeature;
 import jdk.internal.reflect.CallerSensitive;
 
 import java.lang.invoke.MethodHandle;
@@ -496,7 +495,6 @@ import java.util.stream.Stream;
  *
  * @since 19
  */
-@PreviewFeature(feature=PreviewFeature.Feature.FOREIGN)
 public sealed interface Linker permits AbstractLinker {
 
     /**
@@ -667,7 +665,6 @@ public sealed interface Linker permits AbstractLinker {
      * A linker option is used to provide additional parameters to a linkage request.
      * @since 20
      */
-    @PreviewFeature(feature=PreviewFeature.Feature.FOREIGN)
     sealed interface Option
             permits LinkerOptions.LinkerOptionImpl {
 

--- a/src/java.base/share/classes/java/lang/foreign/Linker.java
+++ b/src/java.base/share/classes/java/lang/foreign/Linker.java
@@ -493,7 +493,7 @@ import java.util.stream.Stream;
  * @implSpec
  * Implementations of this interface are immutable, thread-safe and <a href="{@docRoot}/java.base/java/lang/doc-files/ValueBased.html">value-based</a>.
  *
- * @since 19
+ * @since 22
  */
 public sealed interface Linker permits AbstractLinker {
 
@@ -663,7 +663,7 @@ public sealed interface Linker permits AbstractLinker {
 
     /**
      * A linker option is used to provide additional parameters to a linkage request.
-     * @since 20
+     * @since 22
      */
     sealed interface Option
             permits LinkerOptions.LinkerOptionImpl {

--- a/src/java.base/share/classes/java/lang/foreign/MemoryLayout.java
+++ b/src/java.base/share/classes/java/lang/foreign/MemoryLayout.java
@@ -44,7 +44,6 @@ import jdk.internal.foreign.layout.PaddingLayoutImpl;
 import jdk.internal.foreign.layout.SequenceLayoutImpl;
 import jdk.internal.foreign.layout.StructLayoutImpl;
 import jdk.internal.foreign.layout.UnionLayoutImpl;
-import jdk.internal.javac.PreviewFeature;
 import jdk.internal.vm.annotation.ForceInline;
 
 /**
@@ -278,7 +277,6 @@ import jdk.internal.vm.annotation.ForceInline;
  * @sealedGraph
  * @since 19
  */
-@PreviewFeature(feature=PreviewFeature.Feature.FOREIGN)
 public sealed interface MemoryLayout permits SequenceLayout, GroupLayout, PaddingLayout, ValueLayout {
 
     /**
@@ -587,7 +585,6 @@ public sealed interface MemoryLayout permits SequenceLayout, GroupLayout, Paddin
      *
      * @since 19
      */
-    @PreviewFeature(feature=PreviewFeature.Feature.FOREIGN)
     sealed interface PathElement permits LayoutPath.PathElementImpl {
 
         /**

--- a/src/java.base/share/classes/java/lang/foreign/MemoryLayout.java
+++ b/src/java.base/share/classes/java/lang/foreign/MemoryLayout.java
@@ -275,7 +275,7 @@ import jdk.internal.vm.annotation.ForceInline;
  * Implementations of this interface are immutable, thread-safe and <a href="{@docRoot}/java.base/java/lang/doc-files/ValueBased.html">value-based</a>.
  *
  * @sealedGraph
- * @since 19
+ * @since 22
  */
 public sealed interface MemoryLayout permits SequenceLayout, GroupLayout, PaddingLayout, ValueLayout {
 
@@ -583,7 +583,7 @@ public sealed interface MemoryLayout permits SequenceLayout, GroupLayout, Paddin
      * @implSpec
      * Implementations of this interface are immutable, thread-safe and <a href="{@docRoot}/java.base/java/lang/doc-files/ValueBased.html">value-based</a>.
      *
-     * @since 19
+     * @since 22
      */
     sealed interface PathElement permits LayoutPath.PathElementImpl {
 

--- a/src/java.base/share/classes/java/lang/foreign/MemorySegment.java
+++ b/src/java.base/share/classes/java/lang/foreign/MemorySegment.java
@@ -47,7 +47,6 @@ import jdk.internal.foreign.MemorySessionImpl;
 import jdk.internal.foreign.NativeMemorySegmentImpl;
 import jdk.internal.foreign.StringSupport;
 import jdk.internal.foreign.Utils;
-import jdk.internal.javac.PreviewFeature;
 import jdk.internal.reflect.CallerSensitive;
 import jdk.internal.vm.annotation.ForceInline;
 
@@ -448,7 +447,6 @@ import jdk.internal.vm.annotation.ForceInline;
  *
  * @since 19
  */
-@PreviewFeature(feature=PreviewFeature.Feature.FOREIGN)
 public sealed interface MemorySegment permits AbstractMemorySegmentImpl {
 
     /**
@@ -2368,7 +2366,6 @@ public sealed interface MemorySegment permits AbstractMemorySegmentImpl {
      * Scope instances can be compared for equality. That is, two scopes
      * are considered {@linkplain #equals(Object)} if they denote the same lifetime.
      */
-    @PreviewFeature(feature=PreviewFeature.Feature.FOREIGN)
     sealed interface Scope permits MemorySessionImpl {
         /**
          * {@return {@code true}, if the regions of memory backing the memory segments associated with this scope are

--- a/src/java.base/share/classes/java/lang/foreign/MemorySegment.java
+++ b/src/java.base/share/classes/java/lang/foreign/MemorySegment.java
@@ -445,7 +445,7 @@ import jdk.internal.vm.annotation.ForceInline;
  * @implSpec
  * Implementations of this interface are immutable, thread-safe and <a href="{@docRoot}/java.base/java/lang/doc-files/ValueBased.html">value-based</a>.
  *
- * @since 19
+ * @since 22
  */
 public sealed interface MemorySegment permits AbstractMemorySegmentImpl {
 

--- a/src/java.base/share/classes/java/lang/foreign/PaddingLayout.java
+++ b/src/java.base/share/classes/java/lang/foreign/PaddingLayout.java
@@ -34,7 +34,7 @@ import jdk.internal.foreign.layout.PaddingLayoutImpl;
  * @implSpec
  * Implementing classes are immutable, thread-safe and <a href="{@docRoot}/java.base/java/lang/doc-files/ValueBased.html">value-based</a>.
  *
- * @since 20
+ * @since 22
  */
 public sealed interface PaddingLayout extends MemoryLayout permits PaddingLayoutImpl {
 

--- a/src/java.base/share/classes/java/lang/foreign/PaddingLayout.java
+++ b/src/java.base/share/classes/java/lang/foreign/PaddingLayout.java
@@ -26,7 +26,6 @@
 package java.lang.foreign;
 
 import jdk.internal.foreign.layout.PaddingLayoutImpl;
-import jdk.internal.javac.PreviewFeature;
 
 /**
  * A padding layout. A padding layout specifies the size of extra space which is typically not accessed by applications,
@@ -37,7 +36,6 @@ import jdk.internal.javac.PreviewFeature;
  *
  * @since 20
  */
-@PreviewFeature(feature=PreviewFeature.Feature.FOREIGN)
 public sealed interface PaddingLayout extends MemoryLayout permits PaddingLayoutImpl {
 
     /**

--- a/src/java.base/share/classes/java/lang/foreign/SegmentAllocator.java
+++ b/src/java.base/share/classes/java/lang/foreign/SegmentAllocator.java
@@ -34,7 +34,6 @@ import java.util.function.Function;
 import jdk.internal.foreign.AbstractMemorySegmentImpl;
 import jdk.internal.foreign.SlicingAllocator;
 import jdk.internal.foreign.StringSupport;
-import jdk.internal.javac.PreviewFeature;
 import jdk.internal.vm.annotation.ForceInline;
 
 /**
@@ -74,7 +73,6 @@ import jdk.internal.vm.annotation.ForceInline;
  * @since 19
  */
 @FunctionalInterface
-@PreviewFeature(feature=PreviewFeature.Feature.FOREIGN)
 public interface SegmentAllocator {
 
     /**

--- a/src/java.base/share/classes/java/lang/foreign/SegmentAllocator.java
+++ b/src/java.base/share/classes/java/lang/foreign/SegmentAllocator.java
@@ -70,7 +70,7 @@ import jdk.internal.vm.annotation.ForceInline;
  * Clients should consider using an {@linkplain Arena arena} instead, which, provides strong thread-safety,
  * lifetime and non-overlapping guarantees.
  *
- * @since 19
+ * @since 22
  */
 @FunctionalInterface
 public interface SegmentAllocator {

--- a/src/java.base/share/classes/java/lang/foreign/SequenceLayout.java
+++ b/src/java.base/share/classes/java/lang/foreign/SequenceLayout.java
@@ -26,7 +26,6 @@
 package java.lang.foreign;
 
 import jdk.internal.foreign.layout.SequenceLayoutImpl;
-import jdk.internal.javac.PreviewFeature;
 
 /**
  * A compound layout that denotes a homogeneous repetition of a given <em>element layout</em>.
@@ -52,7 +51,6 @@ import jdk.internal.javac.PreviewFeature;
  *
  * @since 19
  */
-@PreviewFeature(feature=PreviewFeature.Feature.FOREIGN)
 public sealed interface SequenceLayout extends MemoryLayout permits SequenceLayoutImpl {
 
 

--- a/src/java.base/share/classes/java/lang/foreign/SequenceLayout.java
+++ b/src/java.base/share/classes/java/lang/foreign/SequenceLayout.java
@@ -49,7 +49,7 @@ import jdk.internal.foreign.layout.SequenceLayoutImpl;
  * @implSpec
  * This class is immutable, thread-safe and <a href="{@docRoot}/java.base/java/lang/doc-files/ValueBased.html">value-based</a>.
  *
- * @since 19
+ * @since 22
  */
 public sealed interface SequenceLayout extends MemoryLayout permits SequenceLayoutImpl {
 

--- a/src/java.base/share/classes/java/lang/foreign/StructLayout.java
+++ b/src/java.base/share/classes/java/lang/foreign/StructLayout.java
@@ -33,7 +33,7 @@ import jdk.internal.foreign.layout.StructLayoutImpl;
  * @implSpec
  * Implementing classes are immutable, thread-safe and <a href="{@docRoot}/java.base/java/lang/doc-files/ValueBased.html">value-based</a>.
  *
- * @since 20
+ * @since 22
  */
 public sealed interface StructLayout extends GroupLayout permits StructLayoutImpl {
 

--- a/src/java.base/share/classes/java/lang/foreign/StructLayout.java
+++ b/src/java.base/share/classes/java/lang/foreign/StructLayout.java
@@ -26,7 +26,6 @@
 package java.lang.foreign;
 
 import jdk.internal.foreign.layout.StructLayoutImpl;
-import jdk.internal.javac.PreviewFeature;
 
 /**
  * A group layout whose member layouts are laid out one after the other.
@@ -36,7 +35,6 @@ import jdk.internal.javac.PreviewFeature;
  *
  * @since 20
  */
-@PreviewFeature(feature=PreviewFeature.Feature.FOREIGN)
 public sealed interface StructLayout extends GroupLayout permits StructLayoutImpl {
 
     /**

--- a/src/java.base/share/classes/java/lang/foreign/SymbolLookup.java
+++ b/src/java.base/share/classes/java/lang/foreign/SymbolLookup.java
@@ -118,7 +118,7 @@ import java.util.function.BiFunction;
  * MemorySegment malloc = stdlib.find("malloc").orElseThrow();
  *}
  *
- * @since 19
+ * @since 22
  */
 @FunctionalInterface
 public interface SymbolLookup {

--- a/src/java.base/share/classes/java/lang/foreign/SymbolLookup.java
+++ b/src/java.base/share/classes/java/lang/foreign/SymbolLookup.java
@@ -29,7 +29,6 @@ import jdk.internal.access.JavaLangAccess;
 import jdk.internal.access.SharedSecrets;
 import jdk.internal.foreign.MemorySessionImpl;
 import jdk.internal.foreign.Utils;
-import jdk.internal.javac.PreviewFeature;
 import jdk.internal.loader.BuiltinClassLoader;
 import jdk.internal.loader.NativeLibrary;
 import jdk.internal.loader.RawNativeLibraries;
@@ -121,7 +120,6 @@ import java.util.function.BiFunction;
  *
  * @since 19
  */
-@PreviewFeature(feature=PreviewFeature.Feature.FOREIGN)
 @FunctionalInterface
 public interface SymbolLookup {
 

--- a/src/java.base/share/classes/java/lang/foreign/UnionLayout.java
+++ b/src/java.base/share/classes/java/lang/foreign/UnionLayout.java
@@ -26,7 +26,6 @@
 package java.lang.foreign;
 
 import jdk.internal.foreign.layout.UnionLayoutImpl;
-import jdk.internal.javac.PreviewFeature;
 
 /**
  * A group layout whose member layouts are laid out at the same starting offset.
@@ -36,7 +35,6 @@ import jdk.internal.javac.PreviewFeature;
  *
  * @since 20
  */
-@PreviewFeature(feature=PreviewFeature.Feature.FOREIGN)
 public sealed interface UnionLayout extends GroupLayout permits UnionLayoutImpl {
 
     /**

--- a/src/java.base/share/classes/java/lang/foreign/UnionLayout.java
+++ b/src/java.base/share/classes/java/lang/foreign/UnionLayout.java
@@ -33,7 +33,7 @@ import jdk.internal.foreign.layout.UnionLayoutImpl;
  * @implSpec
  * Implementing classes are immutable, thread-safe and <a href="{@docRoot}/java.base/java/lang/doc-files/ValueBased.html">value-based</a>.
  *
- * @since 20
+ * @since 22
  */
 public sealed interface UnionLayout extends GroupLayout permits UnionLayoutImpl {
 

--- a/src/java.base/share/classes/java/lang/foreign/ValueLayout.java
+++ b/src/java.base/share/classes/java/lang/foreign/ValueLayout.java
@@ -28,7 +28,6 @@ package java.lang.foreign;
 import java.lang.invoke.VarHandle;
 import java.nio.ByteOrder;
 import jdk.internal.foreign.layout.ValueLayouts;
-import jdk.internal.javac.PreviewFeature;
 
 /**
  * A layout that models values of basic data types. Examples of values modelled by a value layout are
@@ -51,7 +50,6 @@ import jdk.internal.javac.PreviewFeature;
  * @sealedGraph
  * @since 19
  */
-@PreviewFeature(feature=PreviewFeature.Feature.FOREIGN)
 public sealed interface ValueLayout extends MemoryLayout permits
         ValueLayout.OfBoolean, ValueLayout.OfByte, ValueLayout.OfChar, ValueLayout.OfShort, ValueLayout.OfInt,
         ValueLayout.OfFloat, ValueLayout.OfLong, ValueLayout.OfDouble, AddressLayout {
@@ -120,8 +118,7 @@ public sealed interface ValueLayout extends MemoryLayout permits
      * @see #JAVA_BOOLEAN
      * @since 19
      */
-    @PreviewFeature(feature = PreviewFeature.Feature.FOREIGN)
-    sealed interface OfBoolean extends ValueLayout permits ValueLayouts.OfBooleanImpl {
+        sealed interface OfBoolean extends ValueLayout permits ValueLayouts.OfBooleanImpl {
 
         /**
          * {@inheritDoc}
@@ -156,8 +153,7 @@ public sealed interface ValueLayout extends MemoryLayout permits
      * @see #JAVA_BYTE
      * @since 19
      */
-    @PreviewFeature(feature = PreviewFeature.Feature.FOREIGN)
-    sealed interface OfByte extends ValueLayout permits ValueLayouts.OfByteImpl {
+        sealed interface OfByte extends ValueLayout permits ValueLayouts.OfByteImpl {
 
         /**
          * {@inheritDoc}
@@ -193,8 +189,7 @@ public sealed interface ValueLayout extends MemoryLayout permits
      * @see #JAVA_CHAR_UNALIGNED
      * @since 19
      */
-    @PreviewFeature(feature = PreviewFeature.Feature.FOREIGN)
-    sealed interface OfChar extends ValueLayout permits ValueLayouts.OfCharImpl {
+        sealed interface OfChar extends ValueLayout permits ValueLayouts.OfCharImpl {
 
         /**
          * {@inheritDoc}
@@ -230,8 +225,7 @@ public sealed interface ValueLayout extends MemoryLayout permits
      * @see #JAVA_SHORT_UNALIGNED
      * @since 19
      */
-    @PreviewFeature(feature = PreviewFeature.Feature.FOREIGN)
-    sealed interface OfShort extends ValueLayout permits ValueLayouts.OfShortImpl {
+        sealed interface OfShort extends ValueLayout permits ValueLayouts.OfShortImpl {
 
         /**
          * {@inheritDoc}
@@ -267,8 +261,7 @@ public sealed interface ValueLayout extends MemoryLayout permits
      * @see #JAVA_INT_UNALIGNED
      * @since 19
      */
-    @PreviewFeature(feature = PreviewFeature.Feature.FOREIGN)
-    sealed interface OfInt extends ValueLayout permits ValueLayouts.OfIntImpl {
+        sealed interface OfInt extends ValueLayout permits ValueLayouts.OfIntImpl {
 
         /**
          * {@inheritDoc}
@@ -304,8 +297,7 @@ public sealed interface ValueLayout extends MemoryLayout permits
      * @see #JAVA_FLOAT_UNALIGNED
      * @since 19
      */
-    @PreviewFeature(feature = PreviewFeature.Feature.FOREIGN)
-    sealed interface OfFloat extends ValueLayout permits ValueLayouts.OfFloatImpl {
+        sealed interface OfFloat extends ValueLayout permits ValueLayouts.OfFloatImpl {
 
         /**
          * {@inheritDoc}
@@ -340,8 +332,7 @@ public sealed interface ValueLayout extends MemoryLayout permits
      * @see #JAVA_LONG_UNALIGNED
      * @since 19
      */
-    @PreviewFeature(feature = PreviewFeature.Feature.FOREIGN)
-    sealed interface OfLong extends ValueLayout permits ValueLayouts.OfLongImpl {
+        sealed interface OfLong extends ValueLayout permits ValueLayouts.OfLongImpl {
 
         /**
          * {@inheritDoc}
@@ -377,8 +368,7 @@ public sealed interface ValueLayout extends MemoryLayout permits
      * @see #JAVA_DOUBLE_UNALIGNED
      * @since 19
      */
-    @PreviewFeature(feature = PreviewFeature.Feature.FOREIGN)
-    sealed interface OfDouble extends ValueLayout permits ValueLayouts.OfDoubleImpl {
+        sealed interface OfDouble extends ValueLayout permits ValueLayouts.OfDoubleImpl {
 
         /**
          * {@inheritDoc}

--- a/src/java.base/share/classes/java/lang/foreign/ValueLayout.java
+++ b/src/java.base/share/classes/java/lang/foreign/ValueLayout.java
@@ -48,7 +48,7 @@ import jdk.internal.foreign.layout.ValueLayouts;
  * @implSpec implementing classes and subclasses are immutable, thread-safe and <a href="{@docRoot}/java.base/java/lang/doc-files/ValueBased.html">value-based</a>.
  *
  * @sealedGraph
- * @since 19
+ * @since 22
  */
 public sealed interface ValueLayout extends MemoryLayout permits
         ValueLayout.OfBoolean, ValueLayout.OfByte, ValueLayout.OfChar, ValueLayout.OfShort, ValueLayout.OfInt,
@@ -116,7 +116,7 @@ public sealed interface ValueLayout extends MemoryLayout permits
      * A value layout whose carrier is {@code boolean.class}.
      *
      * @see #JAVA_BOOLEAN
-     * @since 19
+     * @since 22
      */
         sealed interface OfBoolean extends ValueLayout permits ValueLayouts.OfBooleanImpl {
 
@@ -151,7 +151,7 @@ public sealed interface ValueLayout extends MemoryLayout permits
      * A value layout whose carrier is {@code byte.class}.
      *
      * @see #JAVA_BYTE
-     * @since 19
+     * @since 22
      */
         sealed interface OfByte extends ValueLayout permits ValueLayouts.OfByteImpl {
 
@@ -187,7 +187,7 @@ public sealed interface ValueLayout extends MemoryLayout permits
      *
      * @see #JAVA_CHAR
      * @see #JAVA_CHAR_UNALIGNED
-     * @since 19
+     * @since 22
      */
         sealed interface OfChar extends ValueLayout permits ValueLayouts.OfCharImpl {
 
@@ -223,7 +223,7 @@ public sealed interface ValueLayout extends MemoryLayout permits
      *
      * @see #JAVA_SHORT
      * @see #JAVA_SHORT_UNALIGNED
-     * @since 19
+     * @since 22
      */
         sealed interface OfShort extends ValueLayout permits ValueLayouts.OfShortImpl {
 
@@ -259,7 +259,7 @@ public sealed interface ValueLayout extends MemoryLayout permits
      *
      * @see #JAVA_INT
      * @see #JAVA_INT_UNALIGNED
-     * @since 19
+     * @since 22
      */
         sealed interface OfInt extends ValueLayout permits ValueLayouts.OfIntImpl {
 
@@ -295,7 +295,7 @@ public sealed interface ValueLayout extends MemoryLayout permits
      *
      * @see #JAVA_FLOAT
      * @see #JAVA_FLOAT_UNALIGNED
-     * @since 19
+     * @since 22
      */
         sealed interface OfFloat extends ValueLayout permits ValueLayouts.OfFloatImpl {
 
@@ -330,7 +330,7 @@ public sealed interface ValueLayout extends MemoryLayout permits
      *
      * @see #JAVA_LONG
      * @see #JAVA_LONG_UNALIGNED
-     * @since 19
+     * @since 22
      */
         sealed interface OfLong extends ValueLayout permits ValueLayouts.OfLongImpl {
 
@@ -366,7 +366,7 @@ public sealed interface ValueLayout extends MemoryLayout permits
      *
      * @see #JAVA_DOUBLE
      * @see #JAVA_DOUBLE_UNALIGNED
-     * @since 19
+     * @since 22
      */
         sealed interface OfDouble extends ValueLayout permits ValueLayouts.OfDoubleImpl {
 

--- a/src/java.base/share/classes/java/lang/foreign/package-info.java
+++ b/src/java.base/share/classes/java/lang/foreign/package-info.java
@@ -148,7 +148,7 @@
  *
  * @spec jni/index.html Java Native Interface Specification
  *
- * @since 19
+ * @since 22
  */
 package java.lang.foreign;
 

--- a/src/java.base/share/classes/java/lang/foreign/package-info.java
+++ b/src/java.base/share/classes/java/lang/foreign/package-info.java
@@ -150,7 +150,5 @@
  *
  * @since 19
  */
-@PreviewFeature(feature=PreviewFeature.Feature.FOREIGN)
 package java.lang.foreign;
 
-import jdk.internal.javac.PreviewFeature;

--- a/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
+++ b/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
@@ -7992,7 +7992,6 @@ assertEquals("boojum", (String) catTrace.invokeExact("boo", "jum"));
      * @throws NullPointerException if any of the arguments is {@code null}.
      * @since 19
      */
-    @PreviewFeature(feature=PreviewFeature.Feature.FOREIGN)
     public static VarHandle filterValue(VarHandle target, MethodHandle filterToTarget, MethodHandle filterFromTarget) {
         return VarHandles.filterValue(target, filterToTarget, filterFromTarget);
     }
@@ -8028,7 +8027,6 @@ assertEquals("boojum", (String) catTrace.invokeExact("boo", "jum"));
      * @throws NullPointerException if any of the arguments is {@code null} or {@code filters} contains {@code null}.
      * @since 19
      */
-    @PreviewFeature(feature=PreviewFeature.Feature.FOREIGN)
     public static VarHandle filterCoordinates(VarHandle target, int pos, MethodHandle... filters) {
         return VarHandles.filterCoordinates(target, pos, filters);
     }
@@ -8060,7 +8058,6 @@ assertEquals("boojum", (String) catTrace.invokeExact("boo", "jum"));
      * @throws NullPointerException if any of the arguments is {@code null} or {@code values} contains {@code null}.
      * @since 19
      */
-    @PreviewFeature(feature=PreviewFeature.Feature.FOREIGN)
     public static VarHandle insertCoordinates(VarHandle target, int pos, Object... values) {
         return VarHandles.insertCoordinates(target, pos, values);
     }
@@ -8103,7 +8100,6 @@ assertEquals("boojum", (String) catTrace.invokeExact("boo", "jum"));
      * @throws NullPointerException if any of the arguments is {@code null} or {@code newCoordinates} contains {@code null}.
      * @since 19
      */
-    @PreviewFeature(feature=PreviewFeature.Feature.FOREIGN)
     public static VarHandle permuteCoordinates(VarHandle target, List<Class<?>> newCoordinates, int... reorder) {
         return VarHandles.permuteCoordinates(target, newCoordinates, reorder);
     }
@@ -8147,7 +8143,6 @@ assertEquals("boojum", (String) catTrace.invokeExact("boo", "jum"));
      * @throws NullPointerException if any of the arguments is {@code null}.
      * @since 19
      */
-    @PreviewFeature(feature=PreviewFeature.Feature.FOREIGN)
     public static VarHandle collectCoordinates(VarHandle target, int pos, MethodHandle filter) {
         return VarHandles.collectCoordinates(target, pos, filter);
     }
@@ -8173,7 +8168,6 @@ assertEquals("boojum", (String) catTrace.invokeExact("boo", "jum"));
      * @throws NullPointerException if any of the arguments is {@code null} or {@code valueTypes} contains {@code null}.
      * @since 19
      */
-    @PreviewFeature(feature=PreviewFeature.Feature.FOREIGN)
     public static VarHandle dropCoordinates(VarHandle target, int pos, Class<?>... valueTypes) {
         return VarHandles.dropCoordinates(target, pos, valueTypes);
     }

--- a/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
+++ b/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
@@ -7990,7 +7990,7 @@ assertEquals("boojum", (String) catTrace.invokeExact("boo", "jum"));
      * other than {@code (A... , S) -> T} and {@code (A... , T) -> S}, respectively, where {@code T} is the type of the target var handle,
      * or if it's determined that either {@code filterFromTarget} or {@code filterToTarget} throws any checked exceptions.
      * @throws NullPointerException if any of the arguments is {@code null}.
-     * @since 19
+     * @since 22
      */
     public static VarHandle filterValue(VarHandle target, MethodHandle filterToTarget, MethodHandle filterFromTarget) {
         return VarHandles.filterValue(target, filterToTarget, filterFromTarget);
@@ -8025,7 +8025,7 @@ assertEquals("boojum", (String) catTrace.invokeExact("boo", "jum"));
      * or if more filters are provided than the actual number of coordinate types available starting at {@code pos},
      * or if it's determined that any of the filters throws any checked exceptions.
      * @throws NullPointerException if any of the arguments is {@code null} or {@code filters} contains {@code null}.
-     * @since 19
+     * @since 22
      */
     public static VarHandle filterCoordinates(VarHandle target, int pos, MethodHandle... filters) {
         return VarHandles.filterCoordinates(target, pos, filters);
@@ -8056,7 +8056,7 @@ assertEquals("boojum", (String) catTrace.invokeExact("boo", "jum"));
      * other than {@code T1, T2 ... Tn }, where {@code T1, T2 ... Tn} are the coordinate types starting at position {@code pos}
      * of the target var handle.
      * @throws NullPointerException if any of the arguments is {@code null} or {@code values} contains {@code null}.
-     * @since 19
+     * @since 22
      */
     public static VarHandle insertCoordinates(VarHandle target, int pos, Object... values) {
         return VarHandles.insertCoordinates(target, pos, values);
@@ -8098,7 +8098,7 @@ assertEquals("boojum", (String) catTrace.invokeExact("boo", "jum"));
      * a coordinate of {@code newCoordinates}, or if two corresponding coordinate types in
      * the target var handle and in {@code newCoordinates} are not identical.
      * @throws NullPointerException if any of the arguments is {@code null} or {@code newCoordinates} contains {@code null}.
-     * @since 19
+     * @since 22
      */
     public static VarHandle permuteCoordinates(VarHandle target, List<Class<?>> newCoordinates, int... reorder) {
         return VarHandles.permuteCoordinates(target, newCoordinates, reorder);
@@ -8141,7 +8141,7 @@ assertEquals("boojum", (String) catTrace.invokeExact("boo", "jum"));
      * if the resulting var handle's type would have <a href="MethodHandle.html#maxarity">too many coordinates</a>,
      * or if it's determined that {@code filter} throws any checked exceptions.
      * @throws NullPointerException if any of the arguments is {@code null}.
-     * @since 19
+     * @since 22
      */
     public static VarHandle collectCoordinates(VarHandle target, int pos, MethodHandle filter) {
         return VarHandles.collectCoordinates(target, pos, filter);
@@ -8166,7 +8166,7 @@ assertEquals("boojum", (String) catTrace.invokeExact("boo", "jum"));
      *         before calling the target var handle
      * @throws IllegalArgumentException if {@code pos} is not between 0 and the target var handle coordinate arity, inclusive.
      * @throws NullPointerException if any of the arguments is {@code null} or {@code valueTypes} contains {@code null}.
-     * @since 19
+     * @since 22
      */
     public static VarHandle dropCoordinates(VarHandle target, int pos, Class<?>... valueTypes) {
         return VarHandles.dropCoordinates(target, pos, valueTypes);

--- a/src/java.base/share/classes/java/nio/channels/FileChannel.java
+++ b/src/java.base/share/classes/java/nio/channels/FileChannel.java
@@ -1090,7 +1090,6 @@ public abstract class FileChannel
      *
      * @since   19
      */
-    @PreviewFeature(feature=PreviewFeature.Feature.FOREIGN)
     public MemorySegment map(MapMode mode, long offset, long size, Arena arena)
         throws IOException
     {

--- a/src/java.base/share/classes/java/nio/channels/FileChannel.java
+++ b/src/java.base/share/classes/java/nio/channels/FileChannel.java
@@ -1088,7 +1088,7 @@ public abstract class FileChannel
      * @throws  UnsupportedOperationException
      *          If an unsupported map mode is specified.
      *
-     * @since   19
+     * @since   22
      */
     public MemorySegment map(MapMode mode, long offset, long size, Arena arena)
         throws IOException

--- a/src/java.base/share/classes/jdk/internal/javac/PreviewFeature.java
+++ b/src/java.base/share/classes/jdk/internal/javac/PreviewFeature.java
@@ -64,10 +64,10 @@ public @interface PreviewFeature {
      * Values should be annotated with the feature's {@code JEP}.
      */
     public enum Feature {
-        // not used
+        // not used, but required for interim javac to not warn.
         VIRTUAL_THREADS,
-        @JEP(number=442, title="Foreign Function & Memory API", status="Third Preview")
         FOREIGN,
+
         @JEP(number=430, title="String Templates")
         STRING_TEMPLATES,
         @JEP(number=443, title="Unnamed Patterns and Variables")

--- a/test/hotspot/jtreg/compiler/rangechecks/TestRangeCheckHoistingScaledIV.java
+++ b/test/hotspot/jtreg/compiler/rangechecks/TestRangeCheckHoistingScaledIV.java
@@ -28,8 +28,8 @@
  * @library /test/lib /
  * @requires vm.debug & vm.compiler2.enabled & (os.simpleArch == "x64" | os.arch == "aarch64")
  * @modules jdk.incubator.vector
- * @compile --enable-preview -source ${jdk.version} TestRangeCheckHoistingScaledIV.java
- * @run main/othervm --enable-preview compiler.rangechecks.TestRangeCheckHoistingScaledIV
+ * @compile -source ${jdk.version} TestRangeCheckHoistingScaledIV.java
+ * @run main/othervm compiler.rangechecks.TestRangeCheckHoistingScaledIV
  */
 
 package compiler.rangechecks;
@@ -83,7 +83,7 @@ public class TestRangeCheckHoistingScaledIV {
 
     public static void main(String[] args) throws Exception {
         ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(
-                "--enable-preview", "--add-modules", "jdk.incubator.vector",
+                "--add-modules", "jdk.incubator.vector",
                 "-Xbatch", "-XX:+TraceLoopPredicate", Launcher.class.getName());
         OutputAnalyzer analyzer = new OutputAnalyzer(pb.start());
         analyzer.shouldHaveExitValue(0);

--- a/test/hotspot/jtreg/compiler/vectorapi/TestIntrinsicBailOut.java
+++ b/test/hotspot/jtreg/compiler/vectorapi/TestIntrinsicBailOut.java
@@ -29,7 +29,6 @@ import java.nio.ByteOrder;
 
 /*
  * @test
- * @enablePreview
  * @bug 8262998
  * @summary Vector API intrinsincs should not modify IR when bailing out
  * @modules jdk.incubator.vector

--- a/test/hotspot/jtreg/compiler/vectorapi/TestVectorErgonomics.java
+++ b/test/hotspot/jtreg/compiler/vectorapi/TestVectorErgonomics.java
@@ -38,42 +38,42 @@ public class TestVectorErgonomics {
 
     public static void main(String[] args) throws Throwable {
         ProcessTools.executeTestJvm("--add-modules=jdk.incubator.vector", "-XX:+UnlockExperimentalVMOptions",
-                                    "-XX:+EnableVectorReboxing", "-Xlog:compilation", "-version", "--enable-preview")
+                                    "-XX:+EnableVectorReboxing", "-Xlog:compilation", "-version")
                     .shouldHaveExitValue(0)
                     .shouldContain("EnableVectorReboxing=true");
 
         ProcessTools.executeTestJvm("--add-modules=jdk.incubator.vector", "-XX:+UnlockExperimentalVMOptions",
-                                    "-XX:+EnableVectorAggressiveReboxing", "-Xlog:compilation", "-version", "--enable-preview")
+                                    "-XX:+EnableVectorAggressiveReboxing", "-Xlog:compilation", "-version")
                     .shouldHaveExitValue(0)
                     .shouldContain("EnableVectorAggressiveReboxing=true");
 
         ProcessTools.executeTestJvm("--add-modules=jdk.incubator.vector", "-XX:+UnlockExperimentalVMOptions",
-                                    "-XX:-EnableVectorReboxing", "-Xlog:compilation", "-version", "--enable-preview")
+                                    "-XX:-EnableVectorReboxing", "-Xlog:compilation", "-version")
                     .shouldHaveExitValue(0)
                     .shouldContain("EnableVectorReboxing=false")
                     .shouldContain("EnableVectorAggressiveReboxing=false");
 
         ProcessTools.executeTestJvm("--add-modules=jdk.incubator.vector", "-XX:+UnlockExperimentalVMOptions",
-                                    "-XX:-EnableVectorAggressiveReboxing", "-Xlog:compilation", "-version", "--enable-preview")
+                                    "-XX:-EnableVectorAggressiveReboxing", "-Xlog:compilation", "-version")
                     .shouldHaveExitValue(0)
                     .shouldContain("EnableVectorAggressiveReboxing=false");
 
         ProcessTools.executeTestJvm("--add-modules=jdk.incubator.vector", "-XX:+UnlockExperimentalVMOptions",
-                                    "-XX:-EnableVectorSupport", "-Xlog:compilation", "-version", "--enable-preview")
+                                    "-XX:-EnableVectorSupport", "-Xlog:compilation", "-version")
                     .shouldHaveExitValue(0)
                     .shouldContain("EnableVectorSupport=false")
                     .shouldContain("EnableVectorReboxing=false")
                     .shouldContain("EnableVectorAggressiveReboxing=false");
 
         ProcessTools.executeTestJvm("--add-modules=jdk.incubator.vector", "-XX:+UnlockExperimentalVMOptions",
-                                    "-XX:-EnableVectorSupport", "-XX:+EnableVectorReboxing", "-Xlog:compilation", "-version", "--enable-preview")
+                                    "-XX:-EnableVectorSupport", "-XX:+EnableVectorReboxing", "-Xlog:compilation", "-version")
                     .shouldHaveExitValue(0)
                     .shouldContain("EnableVectorSupport=false")
                     .shouldContain("EnableVectorReboxing=false")
                     .shouldContain("EnableVectorAggressiveReboxing=false");
 
         ProcessTools.executeTestJvm("--add-modules=jdk.incubator.vector", "-XX:+UnlockExperimentalVMOptions",
-                                    "-XX:-EnableVectorSupport", "-XX:+EnableVectorAggressiveReboxing", "-Xlog:compilation", "-version", "--enable-preview")
+                                    "-XX:-EnableVectorSupport", "-XX:+EnableVectorAggressiveReboxing", "-Xlog:compilation", "-version")
                     .shouldHaveExitValue(0)
                     .shouldContain("EnableVectorSupport=false")
                     .shouldContain("EnableVectorReboxing=false")

--- a/test/hotspot/jtreg/compiler/vectorapi/VectorMemoryAlias.java
+++ b/test/hotspot/jtreg/compiler/vectorapi/VectorMemoryAlias.java
@@ -26,7 +26,6 @@
 
 /*
  * @test
- * @enablePreview
  * @summary Test if memory ordering is preserved
  *
  * @run main/othervm -XX:-TieredCompilation -XX:+UnlockDiagnosticVMOptions -XX:+AbortVMOnCompilationFailure

--- a/test/hotspot/jtreg/compiler/vectorapi/VectorRebracket128Test.java
+++ b/test/hotspot/jtreg/compiler/vectorapi/VectorRebracket128Test.java
@@ -37,7 +37,6 @@ import jdk.internal.vm.annotation.ForceInline;
 /*
  * @test id=ZSinglegen
  * @bug 8260473
- * @enablePreview
  * @requires vm.gc.ZSinglegen
  * @modules jdk.incubator.vector
  * @modules java.base/jdk.internal.vm.annotation
@@ -48,7 +47,6 @@ import jdk.internal.vm.annotation.ForceInline;
 /*
  * @test id=ZGenerational
  * @bug 8260473
- * @enablePreview
  * @requires vm.gc.ZGenerational
  * @modules jdk.incubator.vector
  * @modules java.base/jdk.internal.vm.annotation

--- a/test/hotspot/jtreg/compiler/vectorapi/reshape/TestVectorCastAVX1.java
+++ b/test/hotspot/jtreg/compiler/vectorapi/reshape/TestVectorCastAVX1.java
@@ -30,7 +30,6 @@ import compiler.vectorapi.reshape.utils.VectorReshapeHelper;
 /*
  * @test
  * @bug 8259610
- * @enablePreview
  * @key randomness
  * @modules jdk.incubator.vector
  * @modules java.base/jdk.internal.misc

--- a/test/hotspot/jtreg/compiler/vectorapi/reshape/TestVectorCastAVX2.java
+++ b/test/hotspot/jtreg/compiler/vectorapi/reshape/TestVectorCastAVX2.java
@@ -30,7 +30,6 @@ import compiler.vectorapi.reshape.utils.VectorReshapeHelper;
 /*
  * @test
  * @bug 8259610
- * @enablePreview
  * @key randomness
  * @modules jdk.incubator.vector
  * @modules java.base/jdk.internal.misc

--- a/test/hotspot/jtreg/compiler/vectorapi/reshape/TestVectorCastAVX512.java
+++ b/test/hotspot/jtreg/compiler/vectorapi/reshape/TestVectorCastAVX512.java
@@ -30,7 +30,6 @@ import compiler.vectorapi.reshape.utils.VectorReshapeHelper;
 /*
  * @test
  * @bug 8259610
- * @enablePreview
  * @key randomness
  * @modules jdk.incubator.vector
  * @modules java.base/jdk.internal.misc

--- a/test/hotspot/jtreg/compiler/vectorapi/reshape/TestVectorCastAVX512BW.java
+++ b/test/hotspot/jtreg/compiler/vectorapi/reshape/TestVectorCastAVX512BW.java
@@ -30,7 +30,6 @@ import compiler.vectorapi.reshape.utils.VectorReshapeHelper;
 /*
  * @test
  * @bug 8278623
- * @enablePreview
  * @key randomness
  * @modules jdk.incubator.vector
  * @modules java.base/jdk.internal.misc

--- a/test/hotspot/jtreg/compiler/vectorapi/reshape/TestVectorCastAVX512DQ.java
+++ b/test/hotspot/jtreg/compiler/vectorapi/reshape/TestVectorCastAVX512DQ.java
@@ -30,7 +30,6 @@ import compiler.vectorapi.reshape.utils.VectorReshapeHelper;
 /*
  * @test
  * @bug 8259610
- * @enablePreview
  * @key randomness
  * @modules jdk.incubator.vector
  * @modules java.base/jdk.internal.misc

--- a/test/hotspot/jtreg/compiler/vectorapi/reshape/TestVectorCastNeon.java
+++ b/test/hotspot/jtreg/compiler/vectorapi/reshape/TestVectorCastNeon.java
@@ -30,7 +30,6 @@ import compiler.vectorapi.reshape.utils.VectorReshapeHelper;
 /*
  * @test
  * @bug 8259610
- * @enablePreview
  * @key randomness
  * @modules jdk.incubator.vector
  * @modules java.base/jdk.internal.misc

--- a/test/hotspot/jtreg/compiler/vectorapi/reshape/TestVectorCastSVE.java
+++ b/test/hotspot/jtreg/compiler/vectorapi/reshape/TestVectorCastSVE.java
@@ -30,7 +30,6 @@ import compiler.vectorapi.reshape.utils.VectorReshapeHelper;
 /*
  * @test
  * @bug 8259610
- * @enablePreview
  * @key randomness
  * @modules jdk.incubator.vector
  * @modules java.base/jdk.internal.misc

--- a/test/hotspot/jtreg/compiler/vectorapi/reshape/TestVectorReinterpret.java
+++ b/test/hotspot/jtreg/compiler/vectorapi/reshape/TestVectorReinterpret.java
@@ -36,7 +36,6 @@ import jdk.incubator.vector.VectorSpecies;
  * @test
  * @bug 8259610
  * @key randomness
- * @enablePreview
  * @modules jdk.incubator.vector
  * @modules java.base/jdk.internal.misc
  * @summary Test that vector reinterpret intrinsics work as intended.

--- a/test/hotspot/jtreg/compiler/vectorapi/reshape/utils/VectorReshapeHelper.java
+++ b/test/hotspot/jtreg/compiler/vectorapi/reshape/utils/VectorReshapeHelper.java
@@ -86,7 +86,7 @@ public class VectorReshapeHelper {
         var test = new TestFramework(testClass);
         test.setDefaultWarmup(1);
         test.addHelperClasses(VectorReshapeHelper.class);
-        test.addFlags("--add-modules=jdk.incubator.vector", "--add-exports=java.base/jdk.internal.misc=ALL-UNNAMED", "--enable-preview");
+        test.addFlags("--add-modules=jdk.incubator.vector", "--add-exports=java.base/jdk.internal.misc=ALL-UNNAMED");
         test.addFlags(flags);
         String testMethodNames = testMethods
                 .filter(p -> p.isp().length() <= VectorSpecies.ofLargestShape(p.isp().elementType()).length())

--- a/test/hotspot/jtreg/gc/shenandoah/compiler/TestLinkToNativeRBP.java
+++ b/test/hotspot/jtreg/gc/shenandoah/compiler/TestLinkToNativeRBP.java
@@ -23,7 +23,6 @@
 
 /**
  * @test
- * @enablePreview
  * @bug 8259937
  * @summary guarantee(loc != NULL) failed: missing saved register with native invoke
  *

--- a/test/hotspot/jtreg/runtime/ClassFile/ClassFileVersionTest.java
+++ b/test/hotspot/jtreg/runtime/ClassFile/ClassFileVersionTest.java
@@ -42,7 +42,7 @@ public class ClassFileVersionTest {
      * compilation. If a particular class becomes non-preview, any
      * currently preview class can be substituted in.
      */
-    private static final Class<?> PREVIEW_API = java.lang.foreign.MemorySegment.class;
+    private static final Class<?> PREVIEW_API = java.lang.ScopedValue.class;
     static Method m;
 
     public static void testIt(String className, int expectedResult) throws Exception {

--- a/test/jdk/java/foreign/CompositeLookupTest.java
+++ b/test/jdk/java/foreign/CompositeLookupTest.java
@@ -34,7 +34,6 @@ import static org.testng.Assert.*;
 
 /*
  * @test
- * @enablePreview
  * @run testng CompositeLookupTest
  */
 public class CompositeLookupTest {

--- a/test/jdk/java/foreign/LibraryLookupTest.java
+++ b/test/jdk/java/foreign/LibraryLookupTest.java
@@ -35,7 +35,6 @@ import static org.testng.Assert.*;
 
 /*
  * @test
- * @enablePreview
  * @run testng/othervm --enable-native-access=ALL-UNNAMED LibraryLookupTest
  */
 public class LibraryLookupTest {

--- a/test/jdk/java/foreign/MemoryLayoutPrincipalTotalityTest.java
+++ b/test/jdk/java/foreign/MemoryLayoutPrincipalTotalityTest.java
@@ -23,7 +23,6 @@
 
 /*
  * @test
- * @enablePreview
  * @run testng/othervm MemoryLayoutPrincipalTotalityTest
  */
 

--- a/test/jdk/java/foreign/MemoryLayoutTypeRetentionTest.java
+++ b/test/jdk/java/foreign/MemoryLayoutTypeRetentionTest.java
@@ -23,7 +23,6 @@
 
 /*
  * @test
- * @enablePreview
  * @run testng/othervm MemoryLayoutTypeRetentionTest
  */
 

--- a/test/jdk/java/foreign/SafeFunctionAccessTest.java
+++ b/test/jdk/java/foreign/SafeFunctionAccessTest.java
@@ -23,7 +23,6 @@
 
 /*
  * @test
- * @enablePreview
  * @run testng/othervm --enable-native-access=ALL-UNNAMED SafeFunctionAccessTest
  */
 

--- a/test/jdk/java/foreign/StdLibTest.java
+++ b/test/jdk/java/foreign/StdLibTest.java
@@ -23,7 +23,6 @@
 
 /*
  * @test
- * @enablePreview
  * @run testng/othervm --enable-native-access=ALL-UNNAMED StdLibTest
  */
 

--- a/test/jdk/java/foreign/TestAdaptVarHandles.java
+++ b/test/jdk/java/foreign/TestAdaptVarHandles.java
@@ -24,7 +24,6 @@
 
 /*
  * @test
- * @enablePreview
  * @run testng/othervm -Djava.lang.invoke.VarHandle.VAR_HANDLE_GUARDS=true -Djava.lang.invoke.VarHandle.VAR_HANDLE_IDENTITY_ADAPT=false -Xverify:all TestAdaptVarHandles
  * @run testng/othervm -Djava.lang.invoke.VarHandle.VAR_HANDLE_GUARDS=true -Djava.lang.invoke.VarHandle.VAR_HANDLE_IDENTITY_ADAPT=true -Xverify:all TestAdaptVarHandles
  * @run testng/othervm -Djava.lang.invoke.VarHandle.VAR_HANDLE_GUARDS=false -Djava.lang.invoke.VarHandle.VAR_HANDLE_IDENTITY_ADAPT=false -Xverify:all TestAdaptVarHandles

--- a/test/jdk/java/foreign/TestAddressDereference.java
+++ b/test/jdk/java/foreign/TestAddressDereference.java
@@ -23,7 +23,6 @@
 
 /*
  * @test
- * @enablePreview
  * @library ../ /test/lib
  * @run testng/othervm --enable-native-access=ALL-UNNAMED TestAddressDereference
  */

--- a/test/jdk/java/foreign/TestArrayCopy.java
+++ b/test/jdk/java/foreign/TestArrayCopy.java
@@ -23,7 +23,6 @@
 
 /*
  * @test
- * @enablePreview
  * @run testng TestArrayCopy
  */
 

--- a/test/jdk/java/foreign/TestArrays.java
+++ b/test/jdk/java/foreign/TestArrays.java
@@ -24,7 +24,6 @@
 
 /*
  * @test
- * @enablePreview
  * @run testng/othervm --enable-native-access=ALL-UNNAMED TestArrays
  */
 

--- a/test/jdk/java/foreign/TestByteBuffer.java
+++ b/test/jdk/java/foreign/TestByteBuffer.java
@@ -23,7 +23,6 @@
 
 /*
  * @test
- * @enablePreview
  * @modules java.base/sun.nio.ch java.base/jdk.internal.foreign
  * @run testng/othervm --enable-native-access=ALL-UNNAMED TestByteBuffer
  */

--- a/test/jdk/java/foreign/TestClassLoaderFindNative.java
+++ b/test/jdk/java/foreign/TestClassLoaderFindNative.java
@@ -23,7 +23,6 @@
 
 /*
  * @test
- * @enablePreview
  * @run testng/othervm --enable-native-access=ALL-UNNAMED TestClassLoaderFindNative
  */
 

--- a/test/jdk/java/foreign/TestDereferencePath.java
+++ b/test/jdk/java/foreign/TestDereferencePath.java
@@ -24,7 +24,6 @@
 
 /*
  * @test
- * @enablePreview
  * @run testng TestDereferencePath
  */
 

--- a/test/jdk/java/foreign/TestDowncallScope.java
+++ b/test/jdk/java/foreign/TestDowncallScope.java
@@ -23,7 +23,6 @@
 
 /*
  * @test
- * @enablePreview
  * @modules java.base/jdk.internal.foreign
  * @build NativeTestHelper CallGeneratorHelper TestDowncallBase
  *

--- a/test/jdk/java/foreign/TestDowncallStack.java
+++ b/test/jdk/java/foreign/TestDowncallStack.java
@@ -23,7 +23,6 @@
 
 /*
  * @test
- * @enablePreview
  * @modules java.base/jdk.internal.foreign
  * @build NativeTestHelper CallGeneratorHelper TestDowncallBase
  *

--- a/test/jdk/java/foreign/TestFallbackLookup.java
+++ b/test/jdk/java/foreign/TestFallbackLookup.java
@@ -23,7 +23,6 @@
 
 /*
  * @test
- * @enablePreview
  * @run testng/othervm -Dos.name=Windows --enable-native-access=ALL-UNNAMED TestFallbackLookup
  */
 

--- a/test/jdk/java/foreign/TestFree.java
+++ b/test/jdk/java/foreign/TestFree.java
@@ -24,7 +24,6 @@
 
 /*
  * @test
- * @enablePreview
  * @bug 8248421
  * @summary SystemCLinker should have a way to free memory allocated outside Java
  * @run testng/othervm --enable-native-access=ALL-UNNAMED TestFree

--- a/test/jdk/java/foreign/TestFunctionDescriptor.java
+++ b/test/jdk/java/foreign/TestFunctionDescriptor.java
@@ -24,7 +24,6 @@
 
 /*
  * @test
- * @enablePreview
  * @run testng/othervm --enable-native-access=ALL-UNNAMED TestFunctionDescriptor
  */
 

--- a/test/jdk/java/foreign/TestHFA.java
+++ b/test/jdk/java/foreign/TestHFA.java
@@ -27,7 +27,6 @@
 /*
  * @test
  * @summary Test passing of Homogeneous Float Aggregates.
- * @enablePreview
  *
  * @run testng/othervm --enable-native-access=ALL-UNNAMED TestHFA
  */

--- a/test/jdk/java/foreign/TestHandshake.java
+++ b/test/jdk/java/foreign/TestHandshake.java
@@ -23,7 +23,6 @@
 
 /*
  * @test
- * @enablePreview
  * @modules java.base/jdk.internal.vm.annotation java.base/jdk.internal.misc
  * @key randomness
  * @run testng/othervm TestHandshake

--- a/test/jdk/java/foreign/TestHeapAlignment.java
+++ b/test/jdk/java/foreign/TestHeapAlignment.java
@@ -24,7 +24,6 @@
 
 /*
  * @test
- * @enablePreview
  * @run testng/othervm --enable-native-access=ALL-UNNAMED TestHeapAlignment
  */
 

--- a/test/jdk/java/foreign/TestIllegalLink.java
+++ b/test/jdk/java/foreign/TestIllegalLink.java
@@ -24,7 +24,6 @@
 
 /*
  * @test
- * @enablePreview
  * @modules java.base/jdk.internal.foreign
  * @run testng/othervm --enable-native-access=ALL-UNNAMED TestIllegalLink
  */

--- a/test/jdk/java/foreign/TestIntrinsics.java
+++ b/test/jdk/java/foreign/TestIntrinsics.java
@@ -23,7 +23,6 @@
 
 /*
  * @test
- * @enablePreview
  * @run testng/othervm
  *   -Djdk.internal.foreign.DowncallLinker.USE_SPEC=true
  *   --enable-native-access=ALL-UNNAMED

--- a/test/jdk/java/foreign/TestLargeSegmentCopy.java
+++ b/test/jdk/java/foreign/TestLargeSegmentCopy.java
@@ -24,7 +24,6 @@
 
 /*
  * @test
- * @enablePreview
  * @requires sun.arch.data.model == "64"
  * @bug 8292851
  * @run testng/othervm -Xmx4G TestLargeSegmentCopy

--- a/test/jdk/java/foreign/TestLayoutPaths.java
+++ b/test/jdk/java/foreign/TestLayoutPaths.java
@@ -24,7 +24,6 @@
 
 /*
  * @test
- * @enablePreview
  * @run testng TestLayoutPaths
  */
 

--- a/test/jdk/java/foreign/TestLayouts.java
+++ b/test/jdk/java/foreign/TestLayouts.java
@@ -23,7 +23,6 @@
 
 /*
  * @test
- * @enablePreview
  * @run testng TestLayouts
  */
 

--- a/test/jdk/java/foreign/TestLinker.java
+++ b/test/jdk/java/foreign/TestLinker.java
@@ -23,7 +23,6 @@
 
 /*
  * @test
- * @enablePreview
  * @modules java.base/jdk.internal.foreign
  * @run testng TestLinker
  */

--- a/test/jdk/java/foreign/TestMatrix.java
+++ b/test/jdk/java/foreign/TestMatrix.java
@@ -32,7 +32,6 @@
  */
 
 /* @test id=UpcallHighArity-FF
- * @enablePreview
  * @modules java.base/jdk.internal.foreign
  * @build NativeTestHelper CallGeneratorHelper TestUpcallHighArity
  *
@@ -44,7 +43,6 @@
  */
 
 /* @test id=UpcallHighArity-TF
- * @enablePreview
  * @modules java.base/jdk.internal.foreign
  * @build NativeTestHelper CallGeneratorHelper TestUpcallHighArity
  *
@@ -56,7 +54,6 @@
  */
 
 /* @test id=UpcallHighArity-FT
- * @enablePreview
  * @modules java.base/jdk.internal.foreign
  * @build NativeTestHelper CallGeneratorHelper TestUpcallHighArity
  *
@@ -68,7 +65,6 @@
  */
 
 /* @test id=UpcallHighArity-TT
- * @enablePreview
  * @modules java.base/jdk.internal.foreign
  * @build NativeTestHelper CallGeneratorHelper TestUpcallHighArity
  *
@@ -80,7 +76,6 @@
  */
 
 /* @test id=DowncallScope-F
- * @enablePreview
  * @modules java.base/jdk.internal.foreign
  * @build NativeTestHelper CallGeneratorHelper TestDowncallBase
  *
@@ -91,7 +86,6 @@
  */
 
 /* @test id=DowncallScope-T
- * @enablePreview
  * @modules java.base/jdk.internal.foreign
  * @build NativeTestHelper CallGeneratorHelper TestDowncallBase
  *
@@ -102,7 +96,6 @@
  */
 
 /* @test id=DowncallStack-F
- * @enablePreview
  * @modules java.base/jdk.internal.foreign
  * @build NativeTestHelper CallGeneratorHelper TestDowncallBase
  *
@@ -113,7 +106,6 @@
  */
 
 /* @test id=DowncallStack-T
- * @enablePreview
  * @modules java.base/jdk.internal.foreign
  * @build NativeTestHelper CallGeneratorHelper TestDowncallBase
  *
@@ -124,7 +116,6 @@
  */
 
 /* @test id=UpcallScope-FF
- * @enablePreview
  * @modules java.base/jdk.internal.foreign
  * @build NativeTestHelper CallGeneratorHelper TestUpcallBase
  *
@@ -136,7 +127,6 @@
  */
 
 /* @test id=UpcallScope-TF
- * @enablePreview
  * @modules java.base/jdk.internal.foreign
  * @build NativeTestHelper CallGeneratorHelper TestUpcallBase
  *
@@ -148,7 +138,6 @@
  */
 
 /* @test id=UpcallScope-FT
- * @enablePreview
  * @modules java.base/jdk.internal.foreign
  * @build NativeTestHelper CallGeneratorHelper TestUpcallBase
  *
@@ -160,7 +149,6 @@
  */
 
 /* @test id=UpcallScope-TT
- * @enablePreview
  * @modules java.base/jdk.internal.foreign
  * @build NativeTestHelper CallGeneratorHelper TestUpcallBase
  *
@@ -172,7 +160,6 @@
  */
 
 /* @test id=UpcallAsync-FF
- * @enablePreview
  * @modules java.base/jdk.internal.foreign
  * @build NativeTestHelper CallGeneratorHelper TestUpcallBase
  *
@@ -184,7 +171,6 @@
  */
 
 /* @test id=UpcallAsync-TF
- * @enablePreview
  * @modules java.base/jdk.internal.foreign
  * @build NativeTestHelper CallGeneratorHelper TestUpcallBase
  *
@@ -196,7 +182,6 @@
  */
 
 /* @test id=UpcallAsync-FT
- * @enablePreview
  * @modules java.base/jdk.internal.foreign
  * @build NativeTestHelper CallGeneratorHelper TestUpcallBase
  *
@@ -208,7 +193,6 @@
  */
 
 /* @test id=UpcallAsync-TT
- * @enablePreview
  * @modules java.base/jdk.internal.foreign
  * @build NativeTestHelper CallGeneratorHelper TestUpcallBase
  *
@@ -220,7 +204,6 @@
  */
 
 /* @test id=UpcallStack-FF
- * @enablePreview
  * @modules java.base/jdk.internal.foreign
  * @build NativeTestHelper CallGeneratorHelper TestUpcallBase
  *
@@ -232,7 +215,6 @@
  */
 
 /* @test id=UpcallStack-TF
- * @enablePreview
  * @modules java.base/jdk.internal.foreign
  * @build NativeTestHelper CallGeneratorHelper TestUpcallBase
  *
@@ -244,7 +226,6 @@
  */
 
 /* @test id=UpcallStack-FT
- * @enablePreview
  * @modules java.base/jdk.internal.foreign
  * @build NativeTestHelper CallGeneratorHelper TestUpcallBase
  *
@@ -256,7 +237,6 @@
  */
 
 /* @test id=UpcallStack-TT
- * @enablePreview
  * @modules java.base/jdk.internal.foreign
  * @build NativeTestHelper CallGeneratorHelper TestUpcallBase
  *
@@ -269,7 +249,6 @@
 
 /*
  * @test id=VarArgs
- * @enablePreview
  * @modules java.base/jdk.internal.foreign
  * @build NativeTestHelper CallGeneratorHelper
  *

--- a/test/jdk/java/foreign/TestMemoryAccess.java
+++ b/test/jdk/java/foreign/TestMemoryAccess.java
@@ -23,7 +23,6 @@
 
 /*
  * @test
- * @enablePreview
  * @run testng/othervm -Djava.lang.invoke.VarHandle.VAR_HANDLE_GUARDS=true -Djava.lang.invoke.VarHandle.VAR_HANDLE_IDENTITY_ADAPT=false -Xverify:all TestMemoryAccess
  * @run testng/othervm -Djava.lang.invoke.VarHandle.VAR_HANDLE_GUARDS=true -Djava.lang.invoke.VarHandle.VAR_HANDLE_IDENTITY_ADAPT=true -Xverify:all TestMemoryAccess
  * @run testng/othervm -Djava.lang.invoke.VarHandle.VAR_HANDLE_GUARDS=false -Djava.lang.invoke.VarHandle.VAR_HANDLE_IDENTITY_ADAPT=false -Xverify:all TestMemoryAccess

--- a/test/jdk/java/foreign/TestMemoryAccessInstance.java
+++ b/test/jdk/java/foreign/TestMemoryAccessInstance.java
@@ -23,7 +23,6 @@
 
 /*
  * @test
- * @enablePreview
  * @run testng/othervm --enable-native-access=ALL-UNNAMED TestMemoryAccessInstance
  */
 

--- a/test/jdk/java/foreign/TestMemoryAlignment.java
+++ b/test/jdk/java/foreign/TestMemoryAlignment.java
@@ -23,7 +23,6 @@
 
 /*
  * @test
- * @enablePreview
  * @run testng TestMemoryAlignment
  */
 

--- a/test/jdk/java/foreign/TestMemoryDereference.java
+++ b/test/jdk/java/foreign/TestMemoryDereference.java
@@ -23,7 +23,6 @@
 
 /*
  * @test
- * @enablePreview
  * @run testng TestMemoryDereference
  */
 

--- a/test/jdk/java/foreign/TestMemoryInspection.java
+++ b/test/jdk/java/foreign/TestMemoryInspection.java
@@ -24,7 +24,6 @@
 
 /*
  * @test
- * @enablePreview
  * @modules java.base/jdk.internal.foreign
  * @run testng/othervm --enable-native-access=ALL-UNNAMED TestMemoryInspection
  */

--- a/test/jdk/java/foreign/TestMemorySession.java
+++ b/test/jdk/java/foreign/TestMemorySession.java
@@ -23,7 +23,6 @@
 
 /*
  * @test
- * @enablePreview
  * @modules java.base/jdk.internal.foreign
  * @run testng/othervm TestMemorySession
  */

--- a/test/jdk/java/foreign/TestMismatch.java
+++ b/test/jdk/java/foreign/TestMismatch.java
@@ -23,7 +23,6 @@
 
 /*
  * @test
- * @enablePreview
  * @run testng TestMismatch
  */
 

--- a/test/jdk/java/foreign/TestNULLAddress.java
+++ b/test/jdk/java/foreign/TestNULLAddress.java
@@ -23,7 +23,6 @@
 
 /*
  * @test
- * @enablePreview
  * @run testng/othervm
  *     --enable-native-access=ALL-UNNAMED
  *     TestNULLAddress

--- a/test/jdk/java/foreign/TestNative.java
+++ b/test/jdk/java/foreign/TestNative.java
@@ -24,7 +24,6 @@
 
 /*
  * @test
- * @enablePreview
  * @run testng/othervm --enable-native-access=ALL-UNNAMED TestNative
  */
 

--- a/test/jdk/java/foreign/TestNulls.java
+++ b/test/jdk/java/foreign/TestNulls.java
@@ -23,7 +23,6 @@
 
 /*
  * @test
- * @enablePreview
  * @modules java.base/jdk.internal.ref
  * @run testng/othervm
  *     --enable-native-access=ALL-UNNAMED

--- a/test/jdk/java/foreign/TestOfBufferIssue.java
+++ b/test/jdk/java/foreign/TestOfBufferIssue.java
@@ -33,7 +33,6 @@ import static org.testng.Assert.*;
  * @test
  * @bug 8294621
  * @summary test that StringCharBuffer is not accepted by MemorySegment::ofBuffer
- * @enablePreview
  * @run testng TestOfBufferIssue
  */
 

--- a/test/jdk/java/foreign/TestReshape.java
+++ b/test/jdk/java/foreign/TestReshape.java
@@ -23,7 +23,6 @@
 
 /*
  * @test
- * @enablePreview
  * @run testng TestReshape
  */
 

--- a/test/jdk/java/foreign/TestScopedOperations.java
+++ b/test/jdk/java/foreign/TestScopedOperations.java
@@ -23,7 +23,6 @@
 
 /*
  * @test
- * @enablePreview
  * @run testng/othervm --enable-native-access=ALL-UNNAMED TestScopedOperations
  */
 

--- a/test/jdk/java/foreign/TestSegmentAllocators.java
+++ b/test/jdk/java/foreign/TestSegmentAllocators.java
@@ -24,7 +24,6 @@
 
 /*
  * @test
- * @enablePreview
  * @modules java.base/jdk.internal.foreign
  * @run testng/othervm TestSegmentAllocators
  */

--- a/test/jdk/java/foreign/TestSegmentCopy.java
+++ b/test/jdk/java/foreign/TestSegmentCopy.java
@@ -24,7 +24,6 @@
 
 /*
  * @test
- * @enablePreview
  * @run testng TestSegmentCopy
  */
 

--- a/test/jdk/java/foreign/TestSegmentOffset.java
+++ b/test/jdk/java/foreign/TestSegmentOffset.java
@@ -23,7 +23,6 @@
 
 /*
  * @test
- * @enablePreview
  * @run testng TestSegmentOffset
  */
 

--- a/test/jdk/java/foreign/TestSegmentOverlap.java
+++ b/test/jdk/java/foreign/TestSegmentOverlap.java
@@ -23,7 +23,6 @@
 
 /*
  * @test
- * @enablePreview
  * @run testng/othervm TestSegmentOverlap
  */
 

--- a/test/jdk/java/foreign/TestSegments.java
+++ b/test/jdk/java/foreign/TestSegments.java
@@ -23,7 +23,6 @@
 
 /*
  * @test
- * @enablePreview
  * @requires vm.bits == 64
  * @run testng/othervm -Xmx4G -XX:MaxDirectMemorySize=1M --enable-native-access=ALL-UNNAMED TestSegments
  */

--- a/test/jdk/java/foreign/TestSharedAccess.java
+++ b/test/jdk/java/foreign/TestSharedAccess.java
@@ -24,7 +24,6 @@
 
 /*
  * @test
- * @enablePreview
  * @run testng/othervm --enable-native-access=ALL-UNNAMED TestSharedAccess
  */
 

--- a/test/jdk/java/foreign/TestSlices.java
+++ b/test/jdk/java/foreign/TestSlices.java
@@ -35,7 +35,6 @@ import static org.testng.Assert.*;
 
 /*
  * @test
- * @enablePreview
  * @run testng/othervm -Xverify:all TestSlices
  */
 public class TestSlices {

--- a/test/jdk/java/foreign/TestSpliterator.java
+++ b/test/jdk/java/foreign/TestSpliterator.java
@@ -23,7 +23,6 @@
 
 /*
  * @test
- * @enablePreview
  * @run testng TestSpliterator
  */
 

--- a/test/jdk/java/foreign/TestStringEncoding.java
+++ b/test/jdk/java/foreign/TestStringEncoding.java
@@ -33,7 +33,6 @@ import static org.testng.Assert.*;
 
 /*
  * @test
- * @enablePreview
  * @run testng TestStringEncoding
  */
 

--- a/test/jdk/java/foreign/TestTypeAccess.java
+++ b/test/jdk/java/foreign/TestTypeAccess.java
@@ -24,7 +24,6 @@
 
 /*
  * @test
- * @enablePreview
  * @run testng TestTypeAccess
  */
 

--- a/test/jdk/java/foreign/TestUnsupportedLinker.java
+++ b/test/jdk/java/foreign/TestUnsupportedLinker.java
@@ -23,7 +23,6 @@
 
 /*
  * @test
- * @enablePreview
  *
  * @run testng/othervm -Djdk.internal.foreign.CABI=UNSUPPORTED --enable-native-access=ALL-UNNAMED TestUnsupportedLinker
  */

--- a/test/jdk/java/foreign/TestUpcallAsync.java
+++ b/test/jdk/java/foreign/TestUpcallAsync.java
@@ -23,7 +23,6 @@
 
 /*
  * @test
- * @enablePreview
  * @requires !vm.musl
  * @modules java.base/jdk.internal.foreign
  * @build NativeTestHelper CallGeneratorHelper TestUpcallBase

--- a/test/jdk/java/foreign/TestUpcallException.java
+++ b/test/jdk/java/foreign/TestUpcallException.java
@@ -23,7 +23,6 @@
 
 /*
  * @test
- * @enablePreview
  * @library /test/lib
  * @build TestUpcallException
  *

--- a/test/jdk/java/foreign/TestUpcallHighArity.java
+++ b/test/jdk/java/foreign/TestUpcallHighArity.java
@@ -24,7 +24,6 @@
 
 /*
  * @test
- * @enablePreview
  * @modules java.base/jdk.internal.foreign
  * @build NativeTestHelper CallGeneratorHelper TestUpcallHighArity
  *

--- a/test/jdk/java/foreign/TestUpcallScope.java
+++ b/test/jdk/java/foreign/TestUpcallScope.java
@@ -23,7 +23,6 @@
 
 /*
  * @test
- * @enablePreview
  * @modules java.base/jdk.internal.foreign
  * @build NativeTestHelper CallGeneratorHelper TestUpcallBase
  *

--- a/test/jdk/java/foreign/TestUpcallStack.java
+++ b/test/jdk/java/foreign/TestUpcallStack.java
@@ -23,7 +23,6 @@
 
 /*
  * @test
- * @enablePreview
  * @requires (!(os.name == "Mac OS X" & os.arch == "aarch64") | jdk.foreign.linker != "FALLBACK")
  * @modules java.base/jdk.internal.foreign
  * @build NativeTestHelper CallGeneratorHelper TestUpcallBase

--- a/test/jdk/java/foreign/TestUpcallStructScope.java
+++ b/test/jdk/java/foreign/TestUpcallStructScope.java
@@ -24,7 +24,6 @@
 
 /*
  * @test
- * @enablePreview
  *
  * @run testng/othervm/native
  *   --enable-native-access=ALL-UNNAMED

--- a/test/jdk/java/foreign/TestValueLayouts.java
+++ b/test/jdk/java/foreign/TestValueLayouts.java
@@ -23,7 +23,6 @@
 
 /*
  * @test
- * @enablePreview
  * @modules java.base/jdk.internal.misc
  * @run testng TestValueLayouts
  */

--- a/test/jdk/java/foreign/TestVarArgs.java
+++ b/test/jdk/java/foreign/TestVarArgs.java
@@ -24,7 +24,6 @@
 
 /*
  * @test
- * @enablePreview
  * @modules java.base/jdk.internal.foreign
  * @run testng/othervm --enable-native-access=ALL-UNNAMED -Dgenerator.sample.factor=17 TestVarArgs
  */

--- a/test/jdk/java/foreign/TestVarHandleCombinators.java
+++ b/test/jdk/java/foreign/TestVarHandleCombinators.java
@@ -24,7 +24,6 @@
 
 /*
  * @test
- * @enablePreview
  * @run testng TestVarHandleCombinators
  */
 

--- a/test/jdk/java/foreign/UpcallTestHelper.java
+++ b/test/jdk/java/foreign/UpcallTestHelper.java
@@ -62,7 +62,6 @@ public class UpcallTestHelper extends NativeTestHelper {
                     .resolve("java")
                     .toAbsolutePath()
                     .toString(),
-            "--enable-preview",
             "--enable-native-access=ALL-UNNAMED",
             "-Djava.library.path=" + System.getProperty("java.library.path"),
             "-Djdk.internal.foreign.UpcallLinker.USE_SPEC=" + useSpec,

--- a/test/jdk/java/foreign/arraystructs/TestArrayStructs.java
+++ b/test/jdk/java/foreign/arraystructs/TestArrayStructs.java
@@ -23,7 +23,6 @@
 
 /*
  * @test id=specialized
- * @enablePreview
  * @library ../
  * @requires (!(os.name == "Mac OS X" & os.arch == "aarch64") | jdk.foreign.linker != "FALLBACK")
  * @modules java.base/jdk.internal.foreign
@@ -36,7 +35,6 @@
 
 /*
  * @test id=interpreted
- * @enablePreview
  * @library ../
  * @requires (!(os.name == "Mac OS X" & os.arch == "aarch64") | jdk.foreign.linker != "FALLBACK")
  * @modules java.base/jdk.internal.foreign

--- a/test/jdk/java/foreign/callarranger/TestLayoutEquality.java
+++ b/test/jdk/java/foreign/callarranger/TestLayoutEquality.java
@@ -24,7 +24,6 @@
 
 /*
  * @test
- * @enablePreview
  * @compile platform/PlatformLayouts.java
  * @modules java.base/jdk.internal.foreign.abi
  * @modules java.base/jdk.internal.foreign.layout

--- a/test/jdk/java/foreign/callarranger/TestLinuxAArch64CallArranger.java
+++ b/test/jdk/java/foreign/callarranger/TestLinuxAArch64CallArranger.java
@@ -24,7 +24,6 @@
 
 /*
  * @test
- * @enablePreview
  * @requires sun.arch.data.model == "64"
  * @compile platform/PlatformLayouts.java
  * @modules java.base/jdk.internal.foreign

--- a/test/jdk/java/foreign/callarranger/TestMacOsAArch64CallArranger.java
+++ b/test/jdk/java/foreign/callarranger/TestMacOsAArch64CallArranger.java
@@ -24,7 +24,6 @@
 
 /*
  * @test
- * @enablePreview
  * @requires sun.arch.data.model == "64"
  * @compile platform/PlatformLayouts.java
  * @modules java.base/jdk.internal.foreign

--- a/test/jdk/java/foreign/callarranger/TestRISCV64CallArranger.java
+++ b/test/jdk/java/foreign/callarranger/TestRISCV64CallArranger.java
@@ -26,7 +26,6 @@
 
 /*
  * @test
- * @enablePreview
  * @requires sun.arch.data.model == "64"
  * @compile platform/PlatformLayouts.java
  * @modules java.base/jdk.internal.foreign

--- a/test/jdk/java/foreign/callarranger/TestSysVCallArranger.java
+++ b/test/jdk/java/foreign/callarranger/TestSysVCallArranger.java
@@ -24,7 +24,6 @@
 
 /*
  * @test
- * @enablePreview
  * @compile platform/PlatformLayouts.java
  * @modules java.base/jdk.internal.foreign
  *          java.base/jdk.internal.foreign.abi

--- a/test/jdk/java/foreign/callarranger/TestWindowsAArch64CallArranger.java
+++ b/test/jdk/java/foreign/callarranger/TestWindowsAArch64CallArranger.java
@@ -24,7 +24,6 @@
 
 /*
  * @test
- * @enablePreview
  * @compile platform/PlatformLayouts.java
  * @modules java.base/jdk.internal.foreign
  *          java.base/jdk.internal.foreign.abi

--- a/test/jdk/java/foreign/callarranger/TestWindowsCallArranger.java
+++ b/test/jdk/java/foreign/callarranger/TestWindowsCallArranger.java
@@ -24,7 +24,6 @@
 
 /*
  * @test
- * @enablePreview
  * @requires sun.arch.data.model == "64"
  * @compile platform/PlatformLayouts.java
  * @modules java.base/jdk.internal.foreign

--- a/test/jdk/java/foreign/capturecallstate/TestCaptureCallState.java
+++ b/test/jdk/java/foreign/capturecallstate/TestCaptureCallState.java
@@ -23,7 +23,6 @@
 
 /*
  * @test
- * @enablePreview
  * @library ../ /test/lib
  * @run testng/othervm --enable-native-access=ALL-UNNAMED TestCaptureCallState
  */

--- a/test/jdk/java/foreign/channels/TestAsyncSocketChannels.java
+++ b/test/jdk/java/foreign/channels/TestAsyncSocketChannels.java
@@ -23,7 +23,6 @@
 
 /*
  * @test
- * @enablePreview
  * @library /test/lib
  * @modules java.base/sun.nio.ch
  * @key randomness

--- a/test/jdk/java/foreign/channels/TestSocketChannels.java
+++ b/test/jdk/java/foreign/channels/TestSocketChannels.java
@@ -23,7 +23,6 @@
 
 /*
  * @test
- * @enablePreview
  * @library /test/lib
  * @modules java.base/sun.nio.ch
  * @key randomness

--- a/test/jdk/java/foreign/dontrelease/TestDontRelease.java
+++ b/test/jdk/java/foreign/dontrelease/TestDontRelease.java
@@ -23,7 +23,6 @@
 
 /*
  * @test
- * @enablePreview
  * @library ../ /test/lib
  * @modules java.base/jdk.internal.ref java.base/jdk.internal.foreign
  * @run testng/othervm --enable-native-access=ALL-UNNAMED TestDontRelease

--- a/test/jdk/java/foreign/enablenativeaccess/TestEnableNativeAccess.java
+++ b/test/jdk/java/foreign/enablenativeaccess/TestEnableNativeAccess.java
@@ -23,7 +23,6 @@
 
 /*
  * @test
- * @enablePreview
  * @requires !vm.musl
  *
  * @library /test/lib
@@ -91,8 +90,8 @@ public class TestEnableNativeAccess extends TestEnableNativeAccessBase {
         Stream<String> s1 = Stream.concat(
                 Stream.of(vmopts),
                 Stream.of("-Djava.library.path=" + System.getProperty("java.library.path")));
-        Stream<String> s2 = cls.equals(UNNAMED) ? Stream.of("--enable-preview", "-p", MODULE_PATH, cls, action)
-                : Stream.of("--enable-preview", "-p", MODULE_PATH, "-m", cls, action);
+        Stream<String> s2 = cls.equals(UNNAMED) ? Stream.of("-p", MODULE_PATH, cls, action)
+                : Stream.of("-p", MODULE_PATH, "-m", cls, action);
         String[] opts = Stream.concat(s1, s2).toArray(String[]::new);
         OutputAnalyzer outputAnalyzer = ProcessTools
                 .executeTestJava(opts)

--- a/test/jdk/java/foreign/enablenativeaccess/TestEnableNativeAccessDynamic.java
+++ b/test/jdk/java/foreign/enablenativeaccess/TestEnableNativeAccessDynamic.java
@@ -23,7 +23,6 @@
 
 /*
  * @test
- * @enablePreview
  * @requires !vm.musl
  *
  * @library /test/lib
@@ -74,7 +73,6 @@ public class TestEnableNativeAccessDynamic extends TestEnableNativeAccessBase {
             Result expectedResult, boolean panamaModuleInBootLayer) throws Exception
     {
         List<String> list = new ArrayList<>();
-        list.add("--enable-preview");
         if (panamaModuleInBootLayer) {
             list.addAll(List.of("-p", MODULE_PATH));
             list.add("--add-modules=panama_module");

--- a/test/jdk/java/foreign/enablenativeaccess/TestEnableNativeAccessJarManifest.java
+++ b/test/jdk/java/foreign/enablenativeaccess/TestEnableNativeAccessJarManifest.java
@@ -28,11 +28,10 @@
  * @library /test/lib
  * @requires !vm.musl
  *
- * @enablePreview
  * @build TestEnableNativeAccessJarManifest
  *        panama_module/*
  *        org.openjdk.foreigntest.unnamed.PanamaMainUnnamedModule
- * @run testng TestEnableNativeAccessJarManifest
+ * @run testng/othervm TestEnableNativeAccessJarManifest
  */
 
 import java.nio.file.Files;
@@ -77,7 +76,6 @@ public class TestEnableNativeAccessJarManifest extends TestEnableNativeAccessBas
 
         // java -jar test.jar
         List<String> command = new ArrayList<>(List.of(
-            "--enable-preview",
             "-Djava.library.path=" + System.getProperty("java.library.path")
         ));
         command.addAll(vmArgs);

--- a/test/jdk/java/foreign/handles/Driver.java
+++ b/test/jdk/java/foreign/handles/Driver.java
@@ -23,7 +23,6 @@
 
 /*
  * @test
- * @enablePreview
  * @build invoker_module/* lookup_module/*
  * @run testng/othervm --enable-native-access=invoker_module
  *                     lookup_module/handle.lookup.MethodHandleLookup

--- a/test/jdk/java/foreign/largestub/TestLargeStub.java
+++ b/test/jdk/java/foreign/largestub/TestLargeStub.java
@@ -23,7 +23,6 @@
 
 /*
  * @test
- * @enablePreview
  * @library ../
  * @modules java.base/jdk.internal.foreign
  * @run testng/othervm --enable-native-access=ALL-UNNAMED TestLargeStub

--- a/test/jdk/java/foreign/loaderLookup/TestLoaderLookup.java
+++ b/test/jdk/java/foreign/loaderLookup/TestLoaderLookup.java
@@ -23,7 +23,6 @@
 
 /*
  * @test
- * @enablePreview
  * @compile lookup/Lookup.java
  * @compile invoker/Invoker.java
  * @run main/othervm --enable-native-access=ALL-UNNAMED TestLoaderLookup

--- a/test/jdk/java/foreign/loaderLookup/TestLoaderLookupJNI.java
+++ b/test/jdk/java/foreign/loaderLookup/TestLoaderLookupJNI.java
@@ -29,7 +29,6 @@ import static org.testng.Assert.*;
 
 /*
  * @test
- * @enablePreview
  * @run testng/othervm TestLoaderLookupJNI
  */
 public class TestLoaderLookupJNI {

--- a/test/jdk/java/foreign/nested/TestNested.java
+++ b/test/jdk/java/foreign/nested/TestNested.java
@@ -23,7 +23,6 @@
 
 /*
  * @test
- * @enablePreview
  * @library ../ /test/lib
  * @requires jdk.foreign.linker != "FALLBACK"
  * @build NativeTestHelper

--- a/test/jdk/java/foreign/normalize/TestNormalize.java
+++ b/test/jdk/java/foreign/normalize/TestNormalize.java
@@ -23,7 +23,6 @@
 
 /*
  * @test
- * @enablePreview
  * @library ../
  * @run testng/othervm
  *   --enable-native-access=ALL-UNNAMED

--- a/test/jdk/java/foreign/passheapsegment/TestPassHeapSegment.java
+++ b/test/jdk/java/foreign/passheapsegment/TestPassHeapSegment.java
@@ -23,7 +23,6 @@
 
 /*
  * @test
- * @enablePreview
  * @library ../ /test/lib
  * @run testng/othervm --enable-native-access=ALL-UNNAMED TestPassHeapSegment
  */

--- a/test/jdk/java/foreign/stackwalk/TestAsyncStackWalk.java
+++ b/test/jdk/java/foreign/stackwalk/TestAsyncStackWalk.java
@@ -23,7 +23,6 @@
 
 /*
  * @test id=default_gc
- * @enablePreview
  * @requires vm.gc != "Z"
  * @library /test/lib
  * @library ../
@@ -41,7 +40,6 @@
 
 /*
  * @test id=ZSinglegen
- * @enablePreview
  * @requires vm.gc.ZSinglegen
  * @library /test/lib
  * @library ../
@@ -60,7 +58,6 @@
 
 /*
  * @test id=ZGenerational
- * @enablePreview
  * @requires vm.gc.ZGenerational
  * @library /test/lib
  * @library ../
@@ -79,7 +76,6 @@
 
 /*
  * @test id=shenandoah
- * @enablePreview
  * @requires vm.gc.Shenandoah
  * @library /test/lib
  * @library ../

--- a/test/jdk/java/foreign/stackwalk/TestReentrantUpcalls.java
+++ b/test/jdk/java/foreign/stackwalk/TestReentrantUpcalls.java
@@ -23,7 +23,6 @@
 
 /*
  * @test
- * @enablePreview
  * @library /test/lib
  * @library ../
  * @build jdk.test.whitebox.WhiteBox

--- a/test/jdk/java/foreign/stackwalk/TestStackWalk.java
+++ b/test/jdk/java/foreign/stackwalk/TestStackWalk.java
@@ -23,7 +23,6 @@
 
 /*
  * @test id=default_gc
- * @enablePreview
  * @requires vm.gc != "Z"
  * @library /test/lib
  * @library ../
@@ -41,7 +40,6 @@
 
 /*
  * @test id=ZSinglegen
- * @enablePreview
  * @requires vm.gc.ZSinglegen
  * @library /test/lib
  * @library ../
@@ -60,7 +58,6 @@
 
 /*
  * @test id=ZGenerational
- * @enablePreview
  * @requires vm.gc.ZGenerational
  * @library /test/lib
  * @library ../
@@ -79,7 +76,6 @@
 
 /*
  * @test id=shenandoah
- * @enablePreview
  * @requires vm.gc.Shenandoah
  * @library /test/lib
  * @library ../

--- a/test/jdk/java/foreign/trivial/TestTrivial.java
+++ b/test/jdk/java/foreign/trivial/TestTrivial.java
@@ -23,7 +23,6 @@
 
 /*
  * @test
- * @enablePreview
  * @library ../ /test/lib
  * @run testng/othervm --enable-native-access=ALL-UNNAMED TestTrivial
  */

--- a/test/jdk/java/foreign/trivial/TestTrivialUpcall.java
+++ b/test/jdk/java/foreign/trivial/TestTrivialUpcall.java
@@ -23,7 +23,6 @@
 
 /*
  * @test
- * @enablePreview
  * @library ../ /test/lib
  * @requires jdk.foreign.linker != "FALLBACK"
  * @run testng/othervm --enable-native-access=ALL-UNNAMED TestTrivialUpcall

--- a/test/jdk/java/foreign/upcalldeopt/TestUpcallDeopt.java
+++ b/test/jdk/java/foreign/upcalldeopt/TestUpcallDeopt.java
@@ -23,7 +23,6 @@
 
 /*
  * @test id=default_gc
- * @enablePreview
  * @bug 8277602
  * @library /test/lib
  * @library ../

--- a/test/jdk/java/foreign/virtual/TestVirtualCalls.java
+++ b/test/jdk/java/foreign/virtual/TestVirtualCalls.java
@@ -23,7 +23,6 @@
 
 /*
  * @test
- * @enablePreview
  * @library ../
  * @run testng/othervm
  *   --enable-native-access=ALL-UNNAMED

--- a/test/jdk/java/lang/Thread/jni/AttachCurrentThread/AttachTest.java
+++ b/test/jdk/java/lang/Thread/jni/AttachCurrentThread/AttachTest.java
@@ -38,10 +38,10 @@
  * @summary Test native threads attaching implicitly to the VM by means of an upcall
  * @requires (os.family == "linux" | os.family == "mac") & (sun.arch.data.model == "64")
  * @library /test/lib
- * @compile --enable-preview -source ${jdk.version} ImplicitAttach.java
- * @run main AttachTest --enable-preview --enable-native-access=ALL-UNNAMED ImplicitAttach 1
- * @run main AttachTest --enable-preview --enable-native-access=ALL-UNNAMED ImplicitAttach 2
- * @run main AttachTest --enable-preview --enable-native-access=ALL-UNNAMED ImplicitAttach 4
+ * @compile -source ${jdk.version} ImplicitAttach.java
+ * @run main AttachTest --enable-native-access=ALL-UNNAMED ImplicitAttach 1
+ * @run main AttachTest --enable-native-access=ALL-UNNAMED ImplicitAttach 2
+ * @run main AttachTest --enable-native-access=ALL-UNNAMED ImplicitAttach 4
  */
 
 import java.util.stream.Stream;

--- a/test/jdk/java/lang/invoke/VarHandles/VarHandleTestExact.java
+++ b/test/jdk/java/lang/invoke/VarHandles/VarHandleTestExact.java
@@ -23,7 +23,6 @@
 
 /*
  * @test
- * @enablePreview
  * @modules java.base/jdk.internal.access.foreign
  * @modules java.base/jdk.internal.foreign.layout
  *

--- a/test/jdk/java/nio/channels/FileChannel/LargeMapTest.java
+++ b/test/jdk/java/nio/channels/FileChannel/LargeMapTest.java
@@ -37,7 +37,6 @@ import static java.nio.file.StandardOpenOption.*;
 
 /*
  * @test
- * @enablePreview
  * @bug 8286637
  * @summary Ensure that memory mapping beyond 32-bit range does not cause an
  *          EXCEPTION_ACCESS_VIOLATION.

--- a/test/jdk/java/nio/channels/FileChannel/MapToMemorySegmentTest.java
+++ b/test/jdk/java/nio/channels/FileChannel/MapToMemorySegmentTest.java
@@ -22,7 +22,6 @@
  */
 
 /* @test
- * @enablePreview
  * @bug 8281412
  * @summary Test FileChannel::map to MemorySegment with custom file channel
  * @run testng/othervm MapToMemorySegmentTest

--- a/test/jdk/java/util/stream/test/TEST.properties
+++ b/test/jdk/java/util/stream/test/TEST.properties
@@ -6,6 +6,3 @@ lib.dirs = /lib/testlibrary/bootlib
 
 # Tests that must run in othervm mode
 othervm.dirs= /java/util/stream
-
-# To compile and run tests that use the foreign memory access API
-enablePreview=true

--- a/test/jdk/jdk/incubator/vector/Byte128VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Byte128VectorLoadStoreTests.java
@@ -23,7 +23,6 @@
 
 /*
  * @test
- * @enablePreview
  * @modules jdk.incubator.vector java.base/jdk.internal.vm.annotation
  * @run testng/othervm -XX:-TieredCompilation Byte128VectorLoadStoreTests
  *

--- a/test/jdk/jdk/incubator/vector/Byte256VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Byte256VectorLoadStoreTests.java
@@ -23,7 +23,6 @@
 
 /*
  * @test
- * @enablePreview
  * @modules jdk.incubator.vector java.base/jdk.internal.vm.annotation
  * @run testng/othervm -XX:-TieredCompilation Byte256VectorLoadStoreTests
  *

--- a/test/jdk/jdk/incubator/vector/Byte512VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Byte512VectorLoadStoreTests.java
@@ -23,7 +23,6 @@
 
 /*
  * @test
- * @enablePreview
  * @modules jdk.incubator.vector java.base/jdk.internal.vm.annotation
  * @run testng/othervm -XX:-TieredCompilation Byte512VectorLoadStoreTests
  *

--- a/test/jdk/jdk/incubator/vector/Byte64VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Byte64VectorLoadStoreTests.java
@@ -23,7 +23,6 @@
 
 /*
  * @test
- * @enablePreview
  * @modules jdk.incubator.vector java.base/jdk.internal.vm.annotation
  * @run testng/othervm -XX:-TieredCompilation Byte64VectorLoadStoreTests
  *

--- a/test/jdk/jdk/incubator/vector/ByteMaxVectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/ByteMaxVectorLoadStoreTests.java
@@ -23,7 +23,6 @@
 
 /*
  * @test
- * @enablePreview
  * @modules jdk.incubator.vector java.base/jdk.internal.vm.annotation
  * @run testng/othervm --add-opens jdk.incubator.vector/jdk.incubator.vector=ALL-UNNAMED
  *      -XX:-TieredCompilation ByteMaxVectorLoadStoreTests

--- a/test/jdk/jdk/incubator/vector/Double128VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Double128VectorLoadStoreTests.java
@@ -23,7 +23,6 @@
 
 /*
  * @test
- * @enablePreview
  * @modules jdk.incubator.vector java.base/jdk.internal.vm.annotation
  * @run testng/othervm -XX:-TieredCompilation Double128VectorLoadStoreTests
  *

--- a/test/jdk/jdk/incubator/vector/Double256VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Double256VectorLoadStoreTests.java
@@ -23,7 +23,6 @@
 
 /*
  * @test
- * @enablePreview
  * @modules jdk.incubator.vector java.base/jdk.internal.vm.annotation
  * @run testng/othervm -XX:-TieredCompilation Double256VectorLoadStoreTests
  *

--- a/test/jdk/jdk/incubator/vector/Double512VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Double512VectorLoadStoreTests.java
@@ -23,7 +23,6 @@
 
 /*
  * @test
- * @enablePreview
  * @modules jdk.incubator.vector java.base/jdk.internal.vm.annotation
  * @run testng/othervm -XX:-TieredCompilation Double512VectorLoadStoreTests
  *

--- a/test/jdk/jdk/incubator/vector/Double64VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Double64VectorLoadStoreTests.java
@@ -23,7 +23,6 @@
 
 /*
  * @test
- * @enablePreview
  * @modules jdk.incubator.vector java.base/jdk.internal.vm.annotation
  * @run testng/othervm -XX:-TieredCompilation Double64VectorLoadStoreTests
  *

--- a/test/jdk/jdk/incubator/vector/DoubleMaxVectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/DoubleMaxVectorLoadStoreTests.java
@@ -23,7 +23,6 @@
 
 /*
  * @test
- * @enablePreview
  * @modules jdk.incubator.vector java.base/jdk.internal.vm.annotation
  * @run testng/othervm --add-opens jdk.incubator.vector/jdk.incubator.vector=ALL-UNNAMED
  *      -XX:-TieredCompilation DoubleMaxVectorLoadStoreTests

--- a/test/jdk/jdk/incubator/vector/Float128VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Float128VectorLoadStoreTests.java
@@ -23,7 +23,6 @@
 
 /*
  * @test
- * @enablePreview
  * @modules jdk.incubator.vector java.base/jdk.internal.vm.annotation
  * @run testng/othervm -XX:-TieredCompilation Float128VectorLoadStoreTests
  *

--- a/test/jdk/jdk/incubator/vector/Float256VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Float256VectorLoadStoreTests.java
@@ -23,7 +23,6 @@
 
 /*
  * @test
- * @enablePreview
  * @modules jdk.incubator.vector java.base/jdk.internal.vm.annotation
  * @run testng/othervm -XX:-TieredCompilation Float256VectorLoadStoreTests
  *

--- a/test/jdk/jdk/incubator/vector/Float512VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Float512VectorLoadStoreTests.java
@@ -23,7 +23,6 @@
 
 /*
  * @test
- * @enablePreview
  * @modules jdk.incubator.vector java.base/jdk.internal.vm.annotation
  * @run testng/othervm -XX:-TieredCompilation Float512VectorLoadStoreTests
  *

--- a/test/jdk/jdk/incubator/vector/Float64VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Float64VectorLoadStoreTests.java
@@ -23,7 +23,6 @@
 
 /*
  * @test
- * @enablePreview
  * @modules jdk.incubator.vector java.base/jdk.internal.vm.annotation
  * @run testng/othervm -XX:-TieredCompilation Float64VectorLoadStoreTests
  *

--- a/test/jdk/jdk/incubator/vector/FloatMaxVectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/FloatMaxVectorLoadStoreTests.java
@@ -23,7 +23,6 @@
 
 /*
  * @test
- * @enablePreview
  * @modules jdk.incubator.vector java.base/jdk.internal.vm.annotation
  * @run testng/othervm --add-opens jdk.incubator.vector/jdk.incubator.vector=ALL-UNNAMED
  *      -XX:-TieredCompilation FloatMaxVectorLoadStoreTests

--- a/test/jdk/jdk/incubator/vector/Int128VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Int128VectorLoadStoreTests.java
@@ -23,7 +23,6 @@
 
 /*
  * @test
- * @enablePreview
  * @modules jdk.incubator.vector java.base/jdk.internal.vm.annotation
  * @run testng/othervm -XX:-TieredCompilation Int128VectorLoadStoreTests
  *

--- a/test/jdk/jdk/incubator/vector/Int256VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Int256VectorLoadStoreTests.java
@@ -23,7 +23,6 @@
 
 /*
  * @test
- * @enablePreview
  * @modules jdk.incubator.vector java.base/jdk.internal.vm.annotation
  * @run testng/othervm -XX:-TieredCompilation Int256VectorLoadStoreTests
  *

--- a/test/jdk/jdk/incubator/vector/Int512VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Int512VectorLoadStoreTests.java
@@ -23,7 +23,6 @@
 
 /*
  * @test
- * @enablePreview
  * @modules jdk.incubator.vector java.base/jdk.internal.vm.annotation
  * @run testng/othervm -XX:-TieredCompilation Int512VectorLoadStoreTests
  *

--- a/test/jdk/jdk/incubator/vector/Int64VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Int64VectorLoadStoreTests.java
@@ -23,7 +23,6 @@
 
 /*
  * @test
- * @enablePreview
  * @modules jdk.incubator.vector java.base/jdk.internal.vm.annotation
  * @run testng/othervm -XX:-TieredCompilation Int64VectorLoadStoreTests
  *

--- a/test/jdk/jdk/incubator/vector/IntMaxVectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/IntMaxVectorLoadStoreTests.java
@@ -23,7 +23,6 @@
 
 /*
  * @test
- * @enablePreview
  * @modules jdk.incubator.vector java.base/jdk.internal.vm.annotation
  * @run testng/othervm --add-opens jdk.incubator.vector/jdk.incubator.vector=ALL-UNNAMED
  *      -XX:-TieredCompilation IntMaxVectorLoadStoreTests

--- a/test/jdk/jdk/incubator/vector/Long128VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Long128VectorLoadStoreTests.java
@@ -23,7 +23,6 @@
 
 /*
  * @test
- * @enablePreview
  * @modules jdk.incubator.vector java.base/jdk.internal.vm.annotation
  * @run testng/othervm -XX:-TieredCompilation Long128VectorLoadStoreTests
  *

--- a/test/jdk/jdk/incubator/vector/Long256VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Long256VectorLoadStoreTests.java
@@ -23,7 +23,6 @@
 
 /*
  * @test
- * @enablePreview
  * @modules jdk.incubator.vector java.base/jdk.internal.vm.annotation
  * @run testng/othervm -XX:-TieredCompilation Long256VectorLoadStoreTests
  *

--- a/test/jdk/jdk/incubator/vector/Long512VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Long512VectorLoadStoreTests.java
@@ -23,7 +23,6 @@
 
 /*
  * @test
- * @enablePreview
  * @modules jdk.incubator.vector java.base/jdk.internal.vm.annotation
  * @run testng/othervm -XX:-TieredCompilation Long512VectorLoadStoreTests
  *

--- a/test/jdk/jdk/incubator/vector/Long64VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Long64VectorLoadStoreTests.java
@@ -23,7 +23,6 @@
 
 /*
  * @test
- * @enablePreview
  * @modules jdk.incubator.vector java.base/jdk.internal.vm.annotation
  * @run testng/othervm -XX:-TieredCompilation Long64VectorLoadStoreTests
  *

--- a/test/jdk/jdk/incubator/vector/LongMaxVectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/LongMaxVectorLoadStoreTests.java
@@ -23,7 +23,6 @@
 
 /*
  * @test
- * @enablePreview
  * @modules jdk.incubator.vector java.base/jdk.internal.vm.annotation
  * @run testng/othervm --add-opens jdk.incubator.vector/jdk.incubator.vector=ALL-UNNAMED
  *      -XX:-TieredCompilation LongMaxVectorLoadStoreTests

--- a/test/jdk/jdk/incubator/vector/Short128VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Short128VectorLoadStoreTests.java
@@ -23,7 +23,6 @@
 
 /*
  * @test
- * @enablePreview
  * @modules jdk.incubator.vector java.base/jdk.internal.vm.annotation
  * @run testng/othervm -XX:-TieredCompilation Short128VectorLoadStoreTests
  *

--- a/test/jdk/jdk/incubator/vector/Short256VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Short256VectorLoadStoreTests.java
@@ -23,7 +23,6 @@
 
 /*
  * @test
- * @enablePreview
  * @modules jdk.incubator.vector java.base/jdk.internal.vm.annotation
  * @run testng/othervm -XX:-TieredCompilation Short256VectorLoadStoreTests
  *

--- a/test/jdk/jdk/incubator/vector/Short512VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Short512VectorLoadStoreTests.java
@@ -23,7 +23,6 @@
 
 /*
  * @test
- * @enablePreview
  * @modules jdk.incubator.vector java.base/jdk.internal.vm.annotation
  * @run testng/othervm -XX:-TieredCompilation Short512VectorLoadStoreTests
  *

--- a/test/jdk/jdk/incubator/vector/Short64VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Short64VectorLoadStoreTests.java
@@ -23,7 +23,6 @@
 
 /*
  * @test
- * @enablePreview
  * @modules jdk.incubator.vector java.base/jdk.internal.vm.annotation
  * @run testng/othervm -XX:-TieredCompilation Short64VectorLoadStoreTests
  *

--- a/test/jdk/jdk/incubator/vector/ShortMaxVectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/ShortMaxVectorLoadStoreTests.java
@@ -23,7 +23,6 @@
 
 /*
  * @test
- * @enablePreview
  * @modules jdk.incubator.vector java.base/jdk.internal.vm.annotation
  * @run testng/othervm --add-opens jdk.incubator.vector/jdk.incubator.vector=ALL-UNNAMED
  *      -XX:-TieredCompilation ShortMaxVectorLoadStoreTests

--- a/test/jdk/jdk/incubator/vector/VectorReshapeTests.java
+++ b/test/jdk/jdk/incubator/vector/VectorReshapeTests.java
@@ -36,7 +36,6 @@ import jdk.incubator.vector.VectorSpecies;
 
 /**
  * @test
- * @enablePreview
  * @modules jdk.incubator.vector
  * @modules java.base/jdk.internal.vm.annotation
  * @run testng/othervm/timeout=240 --add-opens jdk.incubator.vector/jdk.incubator.vector=ALL-UNNAMED

--- a/test/jdk/jdk/incubator/vector/templates/X-LoadStoreTest.java.template
+++ b/test/jdk/jdk/incubator/vector/templates/X-LoadStoreTest.java.template
@@ -23,7 +23,6 @@
 
 /*
  * @test
- * @enablePreview
  * @modules jdk.incubator.vector java.base/jdk.internal.vm.annotation
 #if[MaxBit]
  * @run testng/othervm --add-opens jdk.incubator.vector/jdk.incubator.vector=ALL-UNNAMED

--- a/test/micro/org/openjdk/bench/java/lang/foreign/BulkOps.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/BulkOps.java
@@ -51,7 +51,7 @@ import static java.lang.foreign.ValueLayout.JAVA_INT_UNALIGNED;
 @Measurement(iterations = 10, time = 500, timeUnit = TimeUnit.MILLISECONDS)
 @State(org.openjdk.jmh.annotations.Scope.Thread)
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
-@Fork(value = 3, jvmArgsAppend = "--enable-preview")
+@Fork(3)
 public class BulkOps {
 
     static final Unsafe unsafe = Utils.unsafe;

--- a/test/micro/org/openjdk/bench/java/lang/foreign/CallOverheadConstant.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/CallOverheadConstant.java
@@ -41,7 +41,7 @@ import static org.openjdk.bench.java.lang.foreign.CallOverheadHelper.*;
 @Measurement(iterations = 10, time = 500, timeUnit = TimeUnit.MILLISECONDS)
 @State(org.openjdk.jmh.annotations.Scope.Thread)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
-@Fork(value = 3, jvmArgsAppend = { "--enable-native-access=ALL-UNNAMED", "--enable-preview" })
+@Fork(value = 3, jvmArgsAppend = { "--enable-native-access=ALL-UNNAMED" })
 public class CallOverheadConstant {
 
     @Benchmark

--- a/test/micro/org/openjdk/bench/java/lang/foreign/CallOverheadVirtual.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/CallOverheadVirtual.java
@@ -41,7 +41,7 @@ import static org.openjdk.bench.java.lang.foreign.CallOverheadHelper.*;
 @Measurement(iterations = 10, time = 500, timeUnit = TimeUnit.MILLISECONDS)
 @State(org.openjdk.jmh.annotations.Scope.Thread)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
-@Fork(value = 3, jvmArgsAppend = { "--enable-native-access=ALL-UNNAMED", "--enable-preview" })
+@Fork(value = 3, jvmArgsAppend = { "--enable-native-access=ALL-UNNAMED" })
 public class CallOverheadVirtual {
 
     @Benchmark

--- a/test/micro/org/openjdk/bench/java/lang/foreign/LinkUpcall.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/LinkUpcall.java
@@ -47,7 +47,7 @@ import static java.lang.invoke.MethodHandles.lookup;
 @Measurement(iterations = 10, time = 500, timeUnit = TimeUnit.MILLISECONDS)
 @State(Scope.Benchmark)
 @OutputTimeUnit(TimeUnit.MICROSECONDS)
-@Fork(value = 3, jvmArgsAppend = { "--enable-native-access=ALL-UNNAMED", "--enable-preview" })
+@Fork(value = 3, jvmArgsAppend = { "--enable-native-access=ALL-UNNAMED" })
 public class LinkUpcall extends CLayouts {
 
     static final Linker LINKER = Linker.nativeLinker();

--- a/test/micro/org/openjdk/bench/java/lang/foreign/LoopOverConstant.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/LoopOverConstant.java
@@ -48,7 +48,7 @@ import static java.lang.foreign.ValueLayout.*;
 @Measurement(iterations = 10, time = 500, timeUnit = TimeUnit.MILLISECONDS)
 @State(org.openjdk.jmh.annotations.Scope.Thread)
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
-@Fork(value = 3, jvmArgsAppend = "--enable-preview")
+@Fork(3)
 public class LoopOverConstant extends JavaLayouts {
 
     static final Unsafe unsafe = Utils.unsafe;

--- a/test/micro/org/openjdk/bench/java/lang/foreign/LoopOverNew.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/LoopOverNew.java
@@ -47,7 +47,7 @@ import static java.lang.foreign.ValueLayout.*;
 @Measurement(iterations = 10, time = 500, timeUnit = TimeUnit.MILLISECONDS)
 @State(org.openjdk.jmh.annotations.Scope.Thread)
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
-@Fork(value = 3, jvmArgsAppend = "--enable-preview")
+@Fork(3)
 public class LoopOverNew extends JavaLayouts {
 
     static final Unsafe unsafe = Utils.unsafe;

--- a/test/micro/org/openjdk/bench/java/lang/foreign/LoopOverNewHeap.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/LoopOverNewHeap.java
@@ -47,7 +47,7 @@ import static java.lang.foreign.ValueLayout.*;
 @Measurement(iterations = 10, time = 500, timeUnit = TimeUnit.MILLISECONDS)
 @State(org.openjdk.jmh.annotations.Scope.Thread)
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
-@Fork(value = 3, jvmArgsAppend = "--enable-preview")
+@Fork(3)
 public class LoopOverNewHeap extends JavaLayouts {
 
     static final Unsafe unsafe = Utils.unsafe;

--- a/test/micro/org/openjdk/bench/java/lang/foreign/LoopOverNonConstant.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/LoopOverNonConstant.java
@@ -48,7 +48,7 @@ import static java.lang.foreign.ValueLayout.*;
 @Measurement(iterations = 10, time = 500, timeUnit = TimeUnit.MILLISECONDS)
 @State(org.openjdk.jmh.annotations.Scope.Thread)
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
-@Fork(value = 3, jvmArgsAppend = { "--enable-preview", "--enable-native-access=ALL-UNNAMED" })
+@Fork(value = 3, jvmArgsAppend = { "--enable-native-access=ALL-UNNAMED" })
 public class LoopOverNonConstant extends JavaLayouts {
 
     static final Unsafe unsafe = Utils.unsafe;

--- a/test/micro/org/openjdk/bench/java/lang/foreign/LoopOverNonConstantFP.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/LoopOverNonConstantFP.java
@@ -48,7 +48,7 @@ import static java.lang.foreign.ValueLayout.JAVA_DOUBLE;
 @Measurement(iterations = 10, time = 500, timeUnit = TimeUnit.MILLISECONDS)
 @State(org.openjdk.jmh.annotations.Scope.Thread)
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
-@Fork(value = 3, jvmArgsAppend = "--enable-preview")
+@Fork(3)
 public class LoopOverNonConstantFP {
 
     static final Unsafe unsafe = Utils.unsafe;

--- a/test/micro/org/openjdk/bench/java/lang/foreign/LoopOverNonConstantHeap.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/LoopOverNonConstantHeap.java
@@ -49,7 +49,7 @@ import static java.lang.foreign.ValueLayout.*;
 @Measurement(iterations = 10, time = 500, timeUnit = TimeUnit.MILLISECONDS)
 @State(org.openjdk.jmh.annotations.Scope.Thread)
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
-@Fork(value = 3, jvmArgsAppend = "--enable-preview")
+@Fork(3)
 public class LoopOverNonConstantHeap extends JavaLayouts {
 
     static final Unsafe unsafe = Utils.unsafe;

--- a/test/micro/org/openjdk/bench/java/lang/foreign/LoopOverNonConstantMapped.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/LoopOverNonConstantMapped.java
@@ -55,7 +55,7 @@ import static java.lang.foreign.ValueLayout.*;
 @Measurement(iterations = 10, time = 500, timeUnit = TimeUnit.MILLISECONDS)
 @State(org.openjdk.jmh.annotations.Scope.Thread)
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
-@Fork(value = 3, jvmArgsAppend = "--enable-preview")
+@Fork(3)
 public class LoopOverNonConstantMapped extends JavaLayouts {
 
     static final Unsafe unsafe = Utils.unsafe;

--- a/test/micro/org/openjdk/bench/java/lang/foreign/LoopOverNonConstantShared.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/LoopOverNonConstantShared.java
@@ -48,7 +48,7 @@ import static java.lang.foreign.ValueLayout.JAVA_INT;
 @Measurement(iterations = 10, time = 500, timeUnit = TimeUnit.MILLISECONDS)
 @State(org.openjdk.jmh.annotations.Scope.Thread)
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
-@Fork(value = 3, jvmArgsAppend = "--enable-preview")
+@Fork(3)
 public class LoopOverNonConstantShared extends JavaLayouts {
 
     static final Unsafe unsafe = Utils.unsafe;

--- a/test/micro/org/openjdk/bench/java/lang/foreign/LoopOverOfAddress.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/LoopOverOfAddress.java
@@ -43,7 +43,7 @@ import java.util.concurrent.TimeUnit;
 @Measurement(iterations = 10, time = 500, timeUnit = TimeUnit.MILLISECONDS)
 @State(org.openjdk.jmh.annotations.Scope.Thread)
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
-@Fork(value = 3, jvmArgsAppend = "--enable-preview")
+@Fork(3)
 public class LoopOverOfAddress extends JavaLayouts {
 
     static final int ITERATIONS = 1_000_000;

--- a/test/micro/org/openjdk/bench/java/lang/foreign/LoopOverPollutedBuffer.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/LoopOverPollutedBuffer.java
@@ -49,7 +49,7 @@ import static java.lang.foreign.ValueLayout.JAVA_INT;
 @Measurement(iterations = 10, time = 500, timeUnit = TimeUnit.MILLISECONDS)
 @State(org.openjdk.jmh.annotations.Scope.Thread)
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
-@Fork(value = 3, jvmArgsAppend = "--enable-preview")
+@Fork(3)
 public class LoopOverPollutedBuffer {
 
     static final int ELEM_SIZE = 1_000_000;

--- a/test/micro/org/openjdk/bench/java/lang/foreign/LoopOverPollutedSegments.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/LoopOverPollutedSegments.java
@@ -46,7 +46,7 @@ import static java.lang.foreign.ValueLayout.*;
 @Measurement(iterations = 10, time = 500, timeUnit = TimeUnit.MILLISECONDS)
 @State(org.openjdk.jmh.annotations.Scope.Thread)
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
-@Fork(value = 3, jvmArgsAppend = "--enable-preview")
+@Fork(3)
 public class LoopOverPollutedSegments extends JavaLayouts {
 
     static final int ELEM_SIZE = 1_000_000;

--- a/test/micro/org/openjdk/bench/java/lang/foreign/LoopOverSlice.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/LoopOverSlice.java
@@ -49,7 +49,7 @@ import static java.lang.foreign.ValueLayout.JAVA_INT;
 @Measurement(iterations = 10, time = 500, timeUnit = TimeUnit.MILLISECONDS)
 @State(org.openjdk.jmh.annotations.Scope.Thread)
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
-@Fork(value = 3, jvmArgsAppend = { "--enable-preview", "--enable-native-access=ALL-UNNAMED" })
+@Fork(value = 3, jvmArgsAppend = { "--enable-native-access=ALL-UNNAMED" })
 
 public class LoopOverSlice {
 

--- a/test/micro/org/openjdk/bench/java/lang/foreign/MemorySegmentCopyUnsafe.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/MemorySegmentCopyUnsafe.java
@@ -45,7 +45,7 @@ import static java.lang.foreign.ValueLayout.*;
 @Measurement(iterations = 10, time = 500, timeUnit = TimeUnit.MILLISECONDS)
 @State(org.openjdk.jmh.annotations.Scope.Thread)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
-@Fork(value = 3, jvmArgsAppend = {"--enable-preview", "--enable-native-access=ALL-UNNAMED"})
+@Fork(value = 3, jvmArgsAppend = {"--enable-native-access=ALL-UNNAMED"})
 public class MemorySegmentCopyUnsafe {
 
     static final Unsafe UNSAFE = Utils.unsafe;

--- a/test/micro/org/openjdk/bench/java/lang/foreign/MemorySegmentGetUnsafe.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/MemorySegmentGetUnsafe.java
@@ -50,7 +50,7 @@ import static java.lang.foreign.ValueLayout.*;
 @Measurement(iterations = 10, time = 500, timeUnit = TimeUnit.MILLISECONDS)
 @State(org.openjdk.jmh.annotations.Scope.Thread)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
-@Fork(value = 3, jvmArgsAppend = {"--enable-preview", "--enable-native-access=ALL-UNNAMED"})
+@Fork(value = 3, jvmArgsAppend = {"--enable-native-access=ALL-UNNAMED"})
 public class MemorySegmentGetUnsafe {
 
     static final Unsafe UNSAFE = Utils.unsafe;

--- a/test/micro/org/openjdk/bench/java/lang/foreign/MemorySegmentVsBits.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/MemorySegmentVsBits.java
@@ -60,7 +60,7 @@ import static java.nio.ByteOrder.BIG_ENDIAN;
 @Measurement(iterations = 10, time = 500, timeUnit = TimeUnit.MILLISECONDS)
 @State(org.openjdk.jmh.annotations.Scope.Thread)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
-@Fork(value = 3, jvmArgsAppend = {"--enable-native-access=ALL-UNNAMED", "--enable-preview"})
+@Fork(value = 3, jvmArgsAppend = {"--enable-native-access=ALL-UNNAMED"})
 public class MemorySegmentVsBits {
 
     public static final VarHandle LONG_ARRAY_VH = MethodHandles.byteArrayViewVarHandle(long[].class, BIG_ENDIAN);

--- a/test/micro/org/openjdk/bench/java/lang/foreign/MemorySessionClose.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/MemorySessionClose.java
@@ -46,7 +46,7 @@ import java.util.concurrent.TimeUnit;
 @Measurement(iterations = 10, time = 500, timeUnit = TimeUnit.MILLISECONDS)
 @State(org.openjdk.jmh.annotations.Scope.Thread)
 @OutputTimeUnit(TimeUnit.MICROSECONDS)
-@Fork(value = 3, jvmArgsAppend = "--enable-preview")
+@Fork(3)
 public class MemorySessionClose {
 
     static final int ALLOC_SIZE = 1024;

--- a/test/micro/org/openjdk/bench/java/lang/foreign/ParallelSum.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/ParallelSum.java
@@ -52,7 +52,7 @@ import java.util.function.ToIntFunction;
 @Measurement(iterations = 10, time = 500, timeUnit = TimeUnit.MILLISECONDS)
 @State(org.openjdk.jmh.annotations.Scope.Thread)
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
-@Fork(value = 3, jvmArgsAppend = "--enable-preview")
+@Fork(3)
 public class ParallelSum extends JavaLayouts {
 
     final static int CARRIER_SIZE = 4;

--- a/test/micro/org/openjdk/bench/java/lang/foreign/PointerInvoke.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/PointerInvoke.java
@@ -45,7 +45,7 @@ import java.util.concurrent.TimeUnit;
 @Measurement(iterations = 10, time = 500, timeUnit = TimeUnit.MILLISECONDS)
 @State(org.openjdk.jmh.annotations.Scope.Thread)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
-@Fork(value = 3, jvmArgsAppend = { "--enable-native-access=ALL-UNNAMED", "--enable-preview" })
+@Fork(value = 3, jvmArgsAppend = { "--enable-native-access=ALL-UNNAMED" })
 public class PointerInvoke extends CLayouts {
 
     Arena arena = Arena.ofConfined();

--- a/test/micro/org/openjdk/bench/java/lang/foreign/QSort.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/QSort.java
@@ -46,7 +46,7 @@ import static java.lang.foreign.ValueLayout.JAVA_INT;
 @Measurement(iterations = 10, time = 500, timeUnit = TimeUnit.MILLISECONDS)
 @State(org.openjdk.jmh.annotations.Scope.Thread)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
-@Fork(value = 3, jvmArgsAppend = { "--enable-native-access=ALL-UNNAMED", "--enable-preview" })
+@Fork(value = 3, jvmArgsAppend = { "--enable-native-access=ALL-UNNAMED" })
 public class QSort extends CLayouts {
 
     static final Linker abi = Linker.nativeLinker();

--- a/test/micro/org/openjdk/bench/java/lang/foreign/StrLenTest.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/StrLenTest.java
@@ -50,7 +50,7 @@ import static java.lang.foreign.ValueLayout.JAVA_BYTE;
 @Measurement(iterations = 10, time = 500, timeUnit = TimeUnit.MILLISECONDS)
 @State(org.openjdk.jmh.annotations.Scope.Thread)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
-@Fork(value = 3, jvmArgsAppend = { "--enable-native-access=ALL-UNNAMED", "--enable-preview" })
+@Fork(value = 3, jvmArgsAppend = { "--enable-native-access=ALL-UNNAMED" })
 public class StrLenTest extends CLayouts {
 
     Arena arena = Arena.ofConfined();

--- a/test/micro/org/openjdk/bench/java/lang/foreign/TestAdaptVarHandles.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/TestAdaptVarHandles.java
@@ -47,7 +47,7 @@ import java.util.concurrent.TimeUnit;
 @Measurement(iterations = 10, time = 500, timeUnit = TimeUnit.MILLISECONDS)
 @State(org.openjdk.jmh.annotations.Scope.Thread)
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
-@Fork(value = 3, jvmArgsAppend = "--enable-preview")
+@Fork(3)
 public class TestAdaptVarHandles extends JavaLayouts {
 
     static class IntBox {

--- a/test/micro/org/openjdk/bench/java/lang/foreign/TestLoadBytes.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/TestLoadBytes.java
@@ -50,8 +50,7 @@ import static java.lang.foreign.ValueLayout.JAVA_BYTE;
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
 @Fork(value = 1, jvmArgsAppend = {
         "-Dforeign.restricted=permit",
-        "--enable-native-access", "ALL-UNNAMED",
-        "--enable-preview"})
+        "--enable-native-access", "ALL-UNNAMED"})
 public class TestLoadBytes {
     @Param("1024")
     private int size;

--- a/test/micro/org/openjdk/bench/java/lang/foreign/UnrolledAccess.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/UnrolledAccess.java
@@ -40,7 +40,7 @@ import static java.lang.foreign.ValueLayout.*;
 @Measurement(iterations = 10, time = 500, timeUnit = TimeUnit.MILLISECONDS)
 @State(org.openjdk.jmh.annotations.Scope.Thread)
 @OutputTimeUnit(TimeUnit.MICROSECONDS)
-@Fork(value = 3, jvmArgsAppend = { "--enable-preview", "--enable-native-access=ALL-UNNAMED" })
+@Fork(value = 3, jvmArgsAppend = { "--enable-native-access=ALL-UNNAMED" })
 public class UnrolledAccess extends JavaLayouts {
 
     static final Unsafe U = Utils.unsafe;

--- a/test/micro/org/openjdk/bench/java/lang/foreign/Upcalls.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/Upcalls.java
@@ -45,7 +45,7 @@ import static java.lang.invoke.MethodHandles.lookup;
 @Measurement(iterations = 10, time = 500, timeUnit = TimeUnit.MILLISECONDS)
 @State(org.openjdk.jmh.annotations.Scope.Thread)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
-@Fork(value = 3, jvmArgsAppend = { "--enable-native-access=ALL-UNNAMED", "--enable-preview" })
+@Fork(value = 3, jvmArgsAppend = { "--enable-native-access=ALL-UNNAMED" })
 public class Upcalls extends CLayouts {
 
     static final Linker abi = Linker.nativeLinker();

--- a/test/micro/org/openjdk/bench/java/lang/foreign/VarHandleExact.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/VarHandleExact.java
@@ -47,7 +47,7 @@ import static java.lang.foreign.ValueLayout.JAVA_INT;
 @Measurement(iterations = 10, time = 500, timeUnit = TimeUnit.MILLISECONDS)
 @State(org.openjdk.jmh.annotations.Scope.Thread)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
-@Fork(value = 3, jvmArgsAppend = "--enable-preview")
+@Fork(3)
 public class VarHandleExact {
 
     static final VarHandle exact;

--- a/test/micro/org/openjdk/bench/java/lang/foreign/pointers/PointerBench.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/pointers/PointerBench.java
@@ -46,7 +46,7 @@ import java.util.concurrent.TimeUnit;
 @Warmup(iterations = 3, time = 500, timeUnit = TimeUnit.MILLISECONDS)
 @Measurement(iterations = 10, time = 500, timeUnit = TimeUnit.MILLISECONDS)
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
-@Fork(value = 3, jvmArgsAppend = "--enable-preview")
+@Fork(3)
 @State(Scope.Benchmark)
 public class PointerBench {
 

--- a/test/micro/org/openjdk/bench/jdk/incubator/vector/MemorySegmentVectorAccess.java
+++ b/test/micro/org/openjdk/bench/jdk/incubator/vector/MemorySegmentVectorAccess.java
@@ -50,7 +50,6 @@ import org.openjdk.jmh.annotations.Warmup;
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
 @Fork(value = 1, jvmArgsAppend = {
     "--add-modules=jdk.incubator.vector",
-    "--enable-preview",
     "--enable-native-access", "ALL-UNNAMED"})
 public class MemorySegmentVectorAccess {
   private static final VectorSpecies<Byte> SPECIES = VectorSpecies.ofLargestShape(byte.class);

--- a/test/micro/org/openjdk/bench/jdk/incubator/vector/TestLoadStoreBytes.java
+++ b/test/micro/org/openjdk/bench/jdk/incubator/vector/TestLoadStoreBytes.java
@@ -49,7 +49,6 @@ import org.openjdk.jmh.annotations.Warmup;
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
 @Fork(value = 1, jvmArgsAppend = {
     "--add-modules=jdk.incubator.vector",
-    "--enable-preview",
     "--enable-native-access", "ALL-UNNAMED",
     "-Djdk.incubator.vector.VECTOR_ACCESS_OOB_CHECK=1"})
 public class TestLoadStoreBytes {

--- a/test/micro/org/openjdk/bench/jdk/incubator/vector/TestLoadStoreShorts.java
+++ b/test/micro/org/openjdk/bench/jdk/incubator/vector/TestLoadStoreShorts.java
@@ -52,7 +52,6 @@ import org.openjdk.jmh.annotations.Warmup;
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
 @Fork(value = 1, jvmArgsAppend = {
     "--add-modules=jdk.incubator.vector",
-    "--enable-preview",
     "--enable-native-access", "ALL-UNNAMED"})
 public class TestLoadStoreShorts {
   private static final VectorSpecies<Short> SPECIES = VectorSpecies.ofLargestShape(short.class);


### PR DESCRIPTION
Move the FFM API out of preview, by removing preview feature annotations from the implementation, and adjusting the tests to no longer use `--enable-preview`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8313265](https://bugs.openjdk.org/browse/JDK-8313265): Move the FFM API out of preview (**Enhancement** - P2)


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.org/census#mcimadamore) (@mcimadamore - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/panama-foreign.git pull/853/head:pull/853` \
`$ git checkout pull/853`

Update a local copy of the PR: \
`$ git checkout pull/853` \
`$ git pull https://git.openjdk.org/panama-foreign.git pull/853/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 853`

View PR using the GUI difftool: \
`$ git pr show -t 853`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/panama-foreign/pull/853.diff">https://git.openjdk.org/panama-foreign/pull/853.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/panama-foreign/pull/853#issuecomment-1654582176)