### PR TITLE
FFM Allocation benchmark

### DIFF
--- a/test/micro/org/openjdk/bench/java/lang/foreign/AllocTest.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/AllocTest.java
@@ -1,0 +1,259 @@
+/*
+ * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package org.openjdk.bench.java.lang.foreign;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Warmup;
+
+import java.lang.foreign.Arena;
+import java.lang.foreign.MemorySegment;
+import java.lang.foreign.MemorySegment.Scope;
+import java.lang.foreign.SegmentAllocator;
+import java.util.concurrent.TimeUnit;
+
+@BenchmarkMode(Mode.AverageTime)
+@Warmup(iterations = 5, time = 500, timeUnit = TimeUnit.MILLISECONDS)
+@Measurement(iterations = 10, time = 500, timeUnit = TimeUnit.MILLISECONDS)
+@State(org.openjdk.jmh.annotations.Scope.Thread)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Fork(value = 3, jvmArgsAppend = { "--enable-native-access=ALL-UNNAMED", "--enable-preview" })
+public class AllocTest extends CLayouts {
+
+    Arena arena = Arena.ofConfined();
+
+    SlicingPool pool = new SlicingPool();
+
+    @Param({"5", "20", "100", "500", "1000"})
+    public int size;
+
+    @TearDown
+    public void tearDown() {
+        arena.close();
+    }
+
+    @Benchmark
+    public MemorySegment alloc() {
+        Arena arena = Arena.ofConfined();
+        MemorySegment segment = arena.allocate(size);
+        arena.close();
+        return segment;
+    }
+
+    @Benchmark
+    @Fork(value = 3, jvmArgsAppend = {"--enable-preview", "--enable-native-access=ALL-UNNAMED", "-Djdk.internal.foreign.skipZeroMemory=true"})
+    public MemorySegment alloc_skipzero() {
+        Arena arena = Arena.ofConfined();
+        MemorySegment segment = arena.allocate(size);
+        arena.close();
+        return segment;
+    }
+
+    @Benchmark
+    @Fork(value = 3, jvmArgsAppend = {"--enable-preview", "--enable-native-access=ALL-UNNAMED", "-Djdk.internal.foreign.skipReserveMemory=true"})
+    public MemorySegment alloc_skip_reserve() {
+        Arena arena = Arena.ofConfined();
+        MemorySegment segment = arena.allocate(size);
+        arena.close();
+        return segment;
+    }
+
+    @Benchmark
+    @Fork(value = 3, jvmArgsAppend = {"--enable-preview", "--enable-native-access=ALL-UNNAMED", "-Djdk.internal.foreign.skipZeroMemory=true", "-Djdk.internal.foreign.skipReserveMemory=true"})
+    public MemorySegment alloc_skipzero_skipreserve() {
+        Arena arena = Arena.ofConfined();
+        MemorySegment segment = arena.allocate(size);
+        arena.close();
+        return segment;
+    }
+
+    @Benchmark
+    public long alloc_malloc_arena() {
+        MallocArena arena = new MallocArena();
+        MemorySegment segment = arena.allocate(size);
+        arena.close();
+        return segment.address();
+    }
+
+    @Benchmark
+    public long alloc_calloc_arena() {
+        CallocArena arena = new CallocArena();
+        MemorySegment segment = arena.allocate(size);
+        arena.close();
+        return segment.address();
+    }
+
+    @Benchmark
+    public long alloc_unsafe_arena() {
+        UnsafeArena arena = new UnsafeArena();
+        MemorySegment segment = arena.allocate(size);
+        arena.close();
+        return segment.address();
+    }
+
+    @Benchmark
+    public long alloc_unsafe_and_set_arena() {
+        UnsafeSetArena arena = new UnsafeSetArena();
+        MemorySegment segment = arena.allocate(size);
+        arena.close();
+        return segment.address();
+    }
+
+    @Benchmark
+    public long alloc_pool_arena() {
+        Arena arena = pool.acquire();
+        MemorySegment segment = arena.allocate(size);
+        arena.close();
+        return segment.address();
+    }
+
+    static class SlicingPool {
+        final MemorySegment pool = Arena.ofAuto().allocate(1024);
+        boolean isAcquired = false;
+
+        public Arena acquire() {
+            if (isAcquired) {
+                throw new IllegalStateException("An allocator is already in use");
+            }
+            isAcquired = true;
+            return new SlicingPoolAllocator();
+        }
+
+        class SlicingPoolAllocator implements Arena {
+
+            final Arena arena = Arena.ofConfined();
+            final SegmentAllocator slicing = SegmentAllocator.slicingAllocator(pool);
+
+            public MemorySegment allocate(long byteSize, long byteAlignment) {
+                return slicing.allocate(byteSize, byteAlignment)
+                        .reinterpret(arena, null);
+            }
+
+            @Override
+            public Scope scope() {
+                return arena.scope();
+            }
+
+            public void close() {
+                isAcquired = false;
+                arena.close();
+            }
+        }
+    }
+
+    public static class MallocArena implements Arena {
+
+        final Arena arena = Arena.ofConfined();
+
+        @Override
+        public Scope scope() {
+            return arena.scope();
+        }
+
+        @Override
+        public void close() {
+            arena.close();
+        }
+
+        @Override
+        public MemorySegment allocate(long byteSize, long byteAlignment) {
+            return CLayouts.allocateMemory(byteSize)
+                    .reinterpret(byteSize, arena, CLayouts::freeMemory);
+        }
+    }
+
+    public static class CallocArena implements Arena {
+
+        final Arena arena = Arena.ofConfined();
+
+        @Override
+        public Scope scope() {
+            return arena.scope();
+        }
+
+        @Override
+        public void close() {
+            arena.close();
+        }
+
+        @Override
+        public MemorySegment allocate(long byteSize, long byteAlignment) {
+            return CLayouts.callocateMemory(1, byteSize)
+                    .reinterpret(byteSize, arena, CLayouts::freeMemory);
+        }
+    }
+
+    public static class UnsafeArena implements Arena {
+
+        final Arena arena = Arena.ofConfined();
+
+        @Override
+        public Scope scope() {
+            return arena.scope();
+        }
+
+        @Override
+        public void close() {
+            arena.close();
+        }
+
+        @Override
+        public MemorySegment allocate(long byteSize, long byteAlignment) {
+            return MemorySegment.ofAddress(Utils.unsafe.allocateMemory(byteSize))
+                    .reinterpret(byteSize, arena, ms -> Utils.unsafe.freeMemory(ms.address()));
+        }
+    }
+
+    public static class UnsafeSetArena implements Arena {
+
+        final Arena arena = Arena.ofConfined();
+
+        @Override
+        public Scope scope() {
+            return arena.scope();
+        }
+
+        @Override
+        public void close() {
+            arena.close();
+        }
+
+        @Override
+        public MemorySegment allocate(long byteSize, long byteAlignment) {
+            MemorySegment segment = MemorySegment.ofAddress(Utils.unsafe.allocateMemory(byteSize));
+            Utils.unsafe.setMemory(segment.address(), byteSize, (byte)0);
+            return segment.reinterpret(byteSize, arena, ms -> Utils.unsafe.freeMemory(segment.address()));
+        }
+    }
+}

--- a/test/micro/org/openjdk/bench/java/lang/foreign/CLayouts.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/CLayouts.java
@@ -74,10 +74,13 @@ public class CLayouts {
     private static Linker LINKER = Linker.nativeLinker();
 
     private static final MethodHandle FREE = LINKER.downcallHandle(
-            LINKER.defaultLookup().find("free").get(), FunctionDescriptor.ofVoid(C_POINTER));
+            LINKER.defaultLookup().find("free").get(), FunctionDescriptor.ofVoid(C_POINTER), Linker.Option.isTrivial());
 
     private static final MethodHandle MALLOC = LINKER.downcallHandle(
-            LINKER.defaultLookup().find("malloc").get(), FunctionDescriptor.of(C_POINTER, ValueLayout.JAVA_LONG));
+            LINKER.defaultLookup().find("malloc").get(), FunctionDescriptor.of(C_POINTER, ValueLayout.JAVA_LONG), Linker.Option.isTrivial());
+
+    private static final MethodHandle CALLOC = LINKER.downcallHandle(
+            LINKER.defaultLookup().find("calloc").get(), FunctionDescriptor.of(C_POINTER, ValueLayout.JAVA_LONG, ValueLayout.JAVA_LONG), Linker.Option.isTrivial());
 
     public static void freeMemory(MemorySegment address) {
         try {
@@ -90,6 +93,14 @@ public class CLayouts {
     public static MemorySegment allocateMemory(long size) {
         try {
             return (MemorySegment)MALLOC.invokeExact(size);
+        } catch (Throwable ex) {
+            throw new IllegalStateException(ex);
+        }
+    }
+
+    public static MemorySegment callocateMemory(long nmemb, long size) {
+        try {
+            return (MemorySegment)CALLOC.invokeExact(nmemb, size);
         } catch (Throwable ex) {
             throw new IllegalStateException(ex);
         }


### PR DESCRIPTION
The purpose of this PR is to add a benchmark on off-heap memory allocation using the FFM API. Different kinds of arenas are used (some more safe than others). The main goal is to see how far idiomatic usage of the FFM API is from the best performing solutions, and where the main bottlenecks are.