### PR TITLE
8313680: Disallow combining caputreCallState with isTrivial

### DIFF
--- a/src/java.base/share/classes/java/lang/foreign/Linker.java
+++ b/src/java.base/share/classes/java/lang/foreign/Linker.java
@@ -729,6 +729,8 @@ public sealed interface Linker permits AbstractLinker {
          * }
          * }
          *
+         * @apiNote This linker option can not be combined with {@link #isTrivial}.
+         *
          * @param capturedState the names of the values to save.
          * @throws IllegalArgumentException if at least one of the provided {@code capturedState} names
          *                                  is unsupported on the current platform.

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/LinkerOptions.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/LinkerOptions.java
@@ -63,7 +63,11 @@ public class LinkerOptions {
             optionMap.put(option.getClass(), opImpl);
         }
 
-        return new LinkerOptions(optionMap);
+        LinkerOptions linkerOptions = new LinkerOptions(optionMap);
+        if (linkerOptions.hasCapturedCallState() && linkerOptions.isTrivial()) {
+            throw new IllegalArgumentException("captureCallState and isTrivial are mutually exclusive");
+        }
+        return linkerOptions;
     }
 
     public static LinkerOptions empty() {

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/LinkerOptions.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/LinkerOptions.java
@@ -65,7 +65,7 @@ public class LinkerOptions {
 
         LinkerOptions linkerOptions = new LinkerOptions(optionMap);
         if (linkerOptions.hasCapturedCallState() && linkerOptions.isTrivial()) {
-            throw new IllegalArgumentException("captureCallState and isTrivial are mutually exclusive");
+            throw new IllegalArgumentException("Incompatible linker options: captureCallState, isTrivial");
         }
         return linkerOptions;
     }

--- a/test/jdk/java/foreign/TestIllegalLink.java
+++ b/test/jdk/java/foreign/TestIllegalLink.java
@@ -195,7 +195,7 @@ public class TestIllegalLink extends NativeTestHelper {
             {
                     FunctionDescriptor.ofVoid(),
                     new Linker.Option[]{Linker.Option.isTrivial(), Linker.Option.captureCallState("errno")},
-                    "captureCallState and isTrivial are mutually exclusive"
+                    "Incompatible linker options: captureCallState, isTrivial"
             },
         }));
 

--- a/test/jdk/java/foreign/TestIllegalLink.java
+++ b/test/jdk/java/foreign/TestIllegalLink.java
@@ -192,6 +192,11 @@ public class TestIllegalLink extends NativeTestHelper {
                     NO_OPTIONS,
                     "has unexpected size"
             },
+            {
+                    FunctionDescriptor.ofVoid(),
+                    new Linker.Option[]{Linker.Option.isTrivial(), Linker.Option.captureCallState("errno")},
+                    "captureCallState and isTrivial are mutually exclusive"
+            },
         }));
 
         for (ValueLayout illegalLayout : List.of(C_CHAR, ValueLayout.JAVA_CHAR, C_BOOL, C_SHORT, C_FLOAT)) {

--- a/test/jdk/java/foreign/capturecallstate/TestCaptureCallState.java
+++ b/test/jdk/java/foreign/capturecallstate/TestCaptureCallState.java
@@ -61,16 +61,12 @@ public class TestCaptureCallState extends NativeTestHelper {
         }
     }
 
-    private record SaveValuesCase(String nativeTarget, FunctionDescriptor nativeDesc, boolean trivial, String threadLocalName, Consumer<Object> resultCheck) {}
+    private record SaveValuesCase(String nativeTarget, FunctionDescriptor nativeDesc, String threadLocalName, Consumer<Object> resultCheck) {}
 
     @Test(dataProvider = "cases")
     public void testSavedThreadLocal(SaveValuesCase testCase) throws Throwable {
-        List<Linker.Option> options = new ArrayList<>();
-        options.add(Linker.Option.captureCallState(testCase.threadLocalName()));
-        if (testCase.trivial()) {
-            options.add(Linker.Option.isTrivial());
-        }
-        MethodHandle handle = downcallHandle(testCase.nativeTarget(), testCase.nativeDesc(), options.toArray(Linker.Option[]::new));
+        Linker.Option stl = Linker.Option.captureCallState(testCase.threadLocalName());
+        MethodHandle handle = downcallHandle(testCase.nativeTarget(), testCase.nativeDesc(), stl);
 
         StructLayout capturedStateLayout = Linker.Option.captureStateLayout();
         VarHandle errnoHandle = capturedStateLayout.varHandle(groupElement(testCase.threadLocalName()));
@@ -103,44 +99,36 @@ public class TestCaptureCallState extends NativeTestHelper {
         }
     }
 
-    interface CaseAdder {
-      void addCase(String nativeTarget, FunctionDescriptor nativeDesc, String threadLocalName, Consumer<Object> resultCheck);
-    }
-
     @DataProvider
     public static Object[][] cases() {
         List<SaveValuesCase> cases = new ArrayList<>();
-        CaseAdder adder = (nativeTarget, nativeDesc, threadLocalName, resultCheck) -> {
-          cases.add(new SaveValuesCase(nativeTarget, nativeDesc, false, threadLocalName, resultCheck));
-          cases.add(new SaveValuesCase(nativeTarget, nativeDesc, true, threadLocalName, resultCheck));
-        };
 
-        adder.addCase("set_errno_V", FunctionDescriptor.ofVoid(JAVA_INT), "errno", o -> {});
-        adder.addCase("set_errno_I", FunctionDescriptor.of(JAVA_INT, JAVA_INT), "errno", o -> assertEquals((int) o, 42));
-        adder.addCase("set_errno_D", FunctionDescriptor.of(JAVA_DOUBLE, JAVA_INT), "errno", o -> assertEquals((double) o, 42.0));
+        cases.add(new SaveValuesCase("set_errno_V", FunctionDescriptor.ofVoid(JAVA_INT), "errno", o -> {}));
+        cases.add(new SaveValuesCase("set_errno_I", FunctionDescriptor.of(JAVA_INT, JAVA_INT), "errno", o -> assertEquals((int) o, 42)));
+        cases.add(new SaveValuesCase("set_errno_D", FunctionDescriptor.of(JAVA_DOUBLE, JAVA_INT), "errno", o -> assertEquals((double) o, 42.0)));
 
-        structCase(adder, "SL",  Map.of(JAVA_LONG.withName("x"), 42L));
-        structCase(adder, "SLL", Map.of(JAVA_LONG.withName("x"), 42L,
-                                         JAVA_LONG.withName("y"), 42L));
-        structCase(adder, "SLLL", Map.of(JAVA_LONG.withName("x"), 42L,
-                                         JAVA_LONG.withName("y"), 42L,
-                                         JAVA_LONG.withName("z"), 42L));
-        structCase(adder, "SD",  Map.of(JAVA_DOUBLE.withName("x"), 42D));
-        structCase(adder, "SDD", Map.of(JAVA_DOUBLE.withName("x"), 42D,
-                                         JAVA_DOUBLE.withName("y"), 42D));
-        structCase(adder, "SDDD", Map.of(JAVA_DOUBLE.withName("x"), 42D,
-                                         JAVA_DOUBLE.withName("y"), 42D,
-                                         JAVA_DOUBLE.withName("z"), 42D));
+        cases.add(structCase("SL",  Map.of(JAVA_LONG.withName("x"), 42L)));
+        cases.add(structCase("SLL", Map.of(JAVA_LONG.withName("x"), 42L,
+                                           JAVA_LONG.withName("y"), 42L)));
+        cases.add(structCase("SLLL", Map.of(JAVA_LONG.withName("x"), 42L,
+                                            JAVA_LONG.withName("y"), 42L,
+                                            JAVA_LONG.withName("z"), 42L)));
+        cases.add(structCase("SD",  Map.of(JAVA_DOUBLE.withName("x"), 42D)));
+        cases.add(structCase("SDD", Map.of(JAVA_DOUBLE.withName("x"), 42D,
+                                           JAVA_DOUBLE.withName("y"), 42D)));
+        cases.add(structCase("SDDD", Map.of(JAVA_DOUBLE.withName("x"), 42D,
+                                            JAVA_DOUBLE.withName("y"), 42D,
+                                            JAVA_DOUBLE.withName("z"), 42D)));
 
         if (IS_WINDOWS) {
-            adder.addCase("SetLastError", FunctionDescriptor.ofVoid(JAVA_INT), "GetLastError", o -> {});
-            adder.addCase("WSASetLastError", FunctionDescriptor.ofVoid(JAVA_INT), "WSAGetLastError", o -> {});
+            cases.add(new SaveValuesCase("SetLastError", FunctionDescriptor.ofVoid(JAVA_INT), "GetLastError", o -> {}));
+            cases.add(new SaveValuesCase("WSASetLastError", FunctionDescriptor.ofVoid(JAVA_INT), "WSAGetLastError", o -> {}));
         }
 
         return cases.stream().map(tc -> new Object[] {tc}).toArray(Object[][]::new);
     }
 
-    static void structCase(CaseAdder adder, String name, Map<MemoryLayout, Object> fields) {
+    static SaveValuesCase structCase(String name, Map<MemoryLayout, Object> fields) {
         StructLayout layout = MemoryLayout.structLayout(fields.keySet().toArray(MemoryLayout[]::new));
 
         Consumer<Object> check = o -> {};
@@ -151,7 +139,7 @@ public class TestCaptureCallState extends NativeTestHelper {
             check = check.andThen(o -> assertEquals(fieldHandle.get(o, 0L), value));
         }
 
-        adder.addCase("set_errno_" + name, FunctionDescriptor.of(layout, JAVA_INT), "errno", check);
+        return new SaveValuesCase("set_errno_" + name, FunctionDescriptor.of(layout, JAVA_INT), "errno", check);
     }
 
     @DataProvider

--- a/test/jdk/java/foreign/trivial/TestTrivial.java
+++ b/test/jdk/java/foreign/trivial/TestTrivial.java
@@ -78,19 +78,4 @@ public class TestTrivial extends NativeTestHelper {
         }
     }
 
-    @Test
-    public void testCaptureErrno() throws Throwable {
-        Linker.Option ccs = Linker.Option.captureCallState("errno");
-        MethodHandle handle = downcallHandle("capture_errno", FunctionDescriptor.ofVoid(C_INT), Linker.Option.isTrivial(), ccs);
-        StructLayout capturedStateLayout = Linker.Option.captureStateLayout();
-        VarHandle errnoHandle = capturedStateLayout.varHandle(MemoryLayout.PathElement.groupElement("errno"));
-        try (Arena arena = Arena.ofConfined()) {
-            MemorySegment captureSeg = arena.allocate(capturedStateLayout);
-            handle.invokeExact(captureSeg, 42);
-            int capturedErrno = (int) errnoHandle.get(captureSeg, 0L);
-            assertEquals(capturedErrno, 42);
-        }
-    }
-
-
 }

--- a/test/jdk/java/foreign/trivial/libTrivial.c
+++ b/test/jdk/java/foreign/trivial/libTrivial.c
@@ -48,10 +48,6 @@ EXPORT struct Big with_return_buffer() {
     return b;
 }
 
-EXPORT void capture_errno(int value) {
-    errno = value;
-}
-
 EXPORT void do_upcall(void(*f)(void)) {
     f();
 }


### PR DESCRIPTION
Native functions that modify call state (errno) are by definition not 'trivial'. Capturing call state would also prevent intrinsification of a trivial call. I think to be on the safe side, we just want to disallow combining these two for now.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8313680](https://bugs.openjdk.org/browse/JDK-8313680): Disallow combining caputreCallState with isTrivial (**Bug** - P3)


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.org/census#mcimadamore) (@mcimadamore - Committer) ⚠️ Review applies to [0f243ad0](https://git.openjdk.org/panama-foreign/pull/856/files/0f243ad03b12af818839206708fb19e5bd520102)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/panama-foreign.git pull/856/head:pull/856` \
`$ git checkout pull/856`

Update a local copy of the PR: \
`$ git checkout pull/856` \
`$ git pull https://git.openjdk.org/panama-foreign.git pull/856/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 856`

View PR using the GUI difftool: \
`$ git pr show -t 856`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/panama-foreign/pull/856.diff">https://git.openjdk.org/panama-foreign/pull/856.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/panama-foreign/pull/856#issuecomment-1665435208)