### PR TITLE
Fix so that heap segments work

### DIFF
--- a/src/java.base/share/classes/jdk/internal/foreign/StringSupport.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/StringSupport.java
@@ -119,12 +119,15 @@ public class StringSupport {
     }
 
     private static int native_strlen_byte(MemorySegment segment, long start) {
-        if (start > 0) {
-            segment = segment.asSlice(start);
-        }
+        // Heap segments must be handled by Java code
         if (!segment.isNative()) {
             return strlen_byte(segment, start);
         }
+
+        if (start > 0) {
+            segment = segment.asSlice(start);
+        }
+
         long segmentSize = segment.byteSize();
         final long len;
         if (SIZE_T_IS_INT) {
@@ -192,7 +195,7 @@ public class StringSupport {
     private static int strlen_byte(MemorySegment segment, long start) {
         // iterate until overflow (String can only hold a byte[], whose length can be expressed as an int)
         for (int offset = 0; offset >= 0; offset += 1) {
-            short curr = segment.get(JAVA_BYTE, start + offset);
+            byte curr = segment.get(JAVA_BYTE, start + offset);
             if (curr == 0) {
                 return offset;
             }


### PR DESCRIPTION
This PR fixes converting heap segments to strings.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Reviewers
 * [Jorn Vernee](https://openjdk.org/census#jvernee) (@JornVernee - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/panama-foreign.git pull/858/head:pull/858` \
`$ git checkout pull/858`

Update a local copy of the PR: \
`$ git checkout pull/858` \
`$ git pull https://git.openjdk.org/panama-foreign.git pull/858/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 858`

View PR using the GUI difftool: \
`$ git pr show -t 858`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/panama-foreign/pull/858.diff">https://git.openjdk.org/panama-foreign/pull/858.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/panama-foreign/pull/858#issuecomment-1667791703)