### PR TITLE
8314260: Unable to load system libraries on Windows when using a SecurityManager

### DIFF
--- a/src/java.base/share/classes/jdk/internal/foreign/SystemLookup.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/SystemLookup.java
@@ -29,6 +29,8 @@ import java.lang.foreign.*;
 import java.lang.invoke.MethodHandles;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.security.AccessController;
+import java.security.PrivilegedAction;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Function;
@@ -72,7 +74,15 @@ public final class SystemLookup implements SymbolLookup {
     }
 
     private static SymbolLookup makeWindowsLookup() {
-        Path system32 = Path.of(System.getenv("SystemRoot"), "System32");
+        @SuppressWarnings("removal")
+        String systemRoot = AccessController.doPrivileged(new PrivilegedAction<String>() {
+            @Override
+            public String run() {
+                return System.getenv("SystemRoot");
+            }
+        });
+
+        Path system32 = Path.of(systemRoot, "System32");
         Path ucrtbase = system32.resolve("ucrtbase.dll");
         Path msvcrt = system32.resolve("msvcrt.dll");
 


### PR DESCRIPTION
This PR proposes to read the system environment variable "SystemRoot" using a privileged operation so it will work in the event a default `SecurityManager` is in place.