### PR TITLE
Fix TestSegmentAllocators

### DIFF
--- a/src/java.base/share/classes/jdk/internal/foreign/ArenaImpl.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/ArenaImpl.java
@@ -26,10 +26,8 @@
 package jdk.internal.foreign;
 
 import java.lang.foreign.Arena;
-import java.lang.foreign.MemoryLayout;
 import java.lang.foreign.MemorySegment;
 import java.lang.foreign.MemorySegment.Scope;
-import java.util.Objects;
 
 public final class ArenaImpl implements Arena {
 

--- a/test/jdk/java/foreign/TestSegmentAllocators.java
+++ b/test/jdk/java/foreign/TestSegmentAllocators.java
@@ -164,17 +164,9 @@ public class TestSegmentAllocators {
     @Test
     public void testArrayAllocateDelegation() {
         AtomicInteger calls = new AtomicInteger();
-        SegmentAllocator allocator = new SegmentAllocator() {
-            @Override
-            public MemorySegment allocate(long bytesSize, long byteAlignment) {
-                return null;
-            }
-
-            @Override
-            public MemorySegment allocate(MemoryLayout elementLayout, long count) {
-                calls.incrementAndGet();
-                return null;
-            };
+        SegmentAllocator allocator = (bytesSize, byteAlignment) -> {
+            calls.incrementAndGet();
+            return null;
         };
         allocator.allocateFrom(ValueLayout.JAVA_BYTE);
         allocator.allocateFrom(ValueLayout.JAVA_SHORT);
@@ -189,18 +181,9 @@ public class TestSegmentAllocators {
     @Test
     public void testStringAllocateDelegation() {
         AtomicInteger calls = new AtomicInteger();
-        SegmentAllocator allocator = new SegmentAllocator() {
-            @Override
-
-            public MemorySegment allocate(long byteSize, long byteAlignment) {
-                return Arena.ofAuto().allocate(byteSize, byteAlignment);
-            }
-
-            @Override
-            public MemorySegment allocate(long size) {
-                calls.incrementAndGet();
-                return allocate(size, 1);
-            };
+        SegmentAllocator allocator = (byteSize, byteAlignment) -> {
+            calls.incrementAndGet();
+            return Arena.ofAuto().allocate(byteSize, byteAlignment);
         };
         allocator.allocateFrom("Hello");
         assertEquals(calls.get(), 1);


### PR DESCRIPTION
This patch fixes a test which started to fail as we have changed the delegation order in the SegmentAllocator methods.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Reviewers
 * [Jorn Vernee](https://openjdk.org/census#jvernee) (@JornVernee - Committer) ⚠️ Review applies to [f8963086](https://git.openjdk.org/panama-foreign/pull/867/files/f8963086a4c5f14bac58a5f3090bdc204dc7dd1b)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/panama-foreign.git pull/867/head:pull/867` \
`$ git checkout pull/867`

Update a local copy of the PR: \
`$ git checkout pull/867` \
`$ git pull https://git.openjdk.org/panama-foreign.git pull/867/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 867`

View PR using the GUI difftool: \
`$ git pr show -t 867`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/panama-foreign/pull/867.diff">https://git.openjdk.org/panama-foreign/pull/867.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/panama-foreign/pull/867#issuecomment-1682396091)