### PR TITLE
Revert SegmentAllocator API changes

### DIFF
--- a/src/java.base/share/classes/java/lang/foreign/SegmentAllocator.java
+++ b/src/java.base/share/classes/java/lang/foreign/SegmentAllocator.java
@@ -112,7 +112,7 @@ public interface SegmentAllocator {
      * @return a new native segment containing the converted C string.
      * @throws UnsupportedOperationException if {@code charset} is not a {@linkplain StandardCharsets standard charset}.
      * @implSpec the default implementation for this method copies the contents of the provided Java string
-     * into a new memory segment obtained by calling {@code this.allocate(B + N, 1)}, where:
+     * into a new memory segment obtained by calling {@code this.allocate(B + N)}, where:
      * <ul>
      *     <li>{@code B} is the size, in bytes, of the string encoded using the provided charset
      *     (e.g. {@code str.getBytes(charset).length});</li>
@@ -126,7 +126,7 @@ public interface SegmentAllocator {
         Objects.requireNonNull(str);
         int termCharSize = StringSupport.CharsetKind.of(charset).terminatorCharSize();
         byte[] bytes = str.getBytes(charset);
-        MemorySegment segment = allocateNoInit(bytes.length + termCharSize, 1);
+        MemorySegment segment = allocateNoInit(bytes.length + termCharSize);
         MemorySegment.copy(bytes, 0, segment, ValueLayout.JAVA_BYTE, 0, bytes.length);
         for (int i = 0 ; i < termCharSize ; i++) {
             segment.set(ValueLayout.JAVA_BYTE, bytes.length + i, (byte)0);
@@ -136,105 +136,98 @@ public interface SegmentAllocator {
 
     /**
      * Allocates a memory segment with the given layout and initializes it with the given byte value.
-     * @implSpec the default implementation for this method calls
-     * {@code this.allocate(layout.byteSize(), layout.byteAlignment())}.
+     * @implSpec the default implementation for this method calls {@code this.allocate(layout)}.
      * @param layout the layout of the block of memory to be allocated.
      * @param value the value to be set on the newly allocated memory block.
      * @return a segment for the newly allocated memory block.
      */
     default MemorySegment allocateFrom(ValueLayout.OfByte layout, byte value) {
         Objects.requireNonNull(layout);
-        MemorySegment addr = allocateNoInit(layout.byteSize(), layout.byteAlignment());
+        MemorySegment addr = allocateNoInit(layout);
         addr.set(layout, 0, value);
         return addr;
     }
 
     /**
      * Allocates a memory segment with the given layout and initializes it with the given char value.
-     * @implSpec the default implementation for this method calls
-     * {@code this.allocate(layout.byteSize(), layout.byteAlignment())}.
+     * @implSpec the default implementation for this method calls {@code this.allocate(layout)}.
      * @param layout the layout of the block of memory to be allocated.
      * @param value the value to be set on the newly allocated memory block.
      * @return a segment for the newly allocated memory block.
      */
     default MemorySegment allocateFrom(ValueLayout.OfChar layout, char value) {
         Objects.requireNonNull(layout);
-        MemorySegment addr = allocateNoInit(layout.byteSize(), layout.byteAlignment());
+        MemorySegment addr = allocateNoInit(layout);
         addr.set(layout, 0, value);
         return addr;
     }
 
     /**
      * Allocates a memory segment with the given layout and initializes it with the given short value.
-     * @implSpec the default implementation for this method calls
-     * {@code this.allocate(layout.byteSize(), layout.byteAlignment())}.
+     * @implSpec the default implementation for this method calls {@code this.allocate(layout)}.
      * @param layout the layout of the block of memory to be allocated.
      * @param value the value to be set on the newly allocated memory block.
      * @return a segment for the newly allocated memory block.
      */
     default MemorySegment allocateFrom(ValueLayout.OfShort layout, short value) {
         Objects.requireNonNull(layout);
-        MemorySegment addr = allocateNoInit(layout.byteSize(), layout.byteAlignment());
+        MemorySegment addr = allocateNoInit(layout);
         addr.set(layout, 0, value);
         return addr;
     }
 
     /**
      * Allocates a memory segment with the given layout and initializes it with the given int value.
-     * @implSpec the default implementation for this method calls
-     * {@code this.allocate(layout.byteSize(), layout.byteAlignment())}.
+     * @implSpec the default implementation for this method calls {@code this.allocate(layout)}.
      * @param layout the layout of the block of memory to be allocated.
      * @param value the value to be set on the newly allocated memory block.
      * @return a segment for the newly allocated memory block.
      */
     default MemorySegment allocateFrom(ValueLayout.OfInt layout, int value) {
         Objects.requireNonNull(layout);
-        MemorySegment addr = allocateNoInit(layout.byteSize(), layout.byteAlignment());
+        MemorySegment addr = allocateNoInit(layout);
         addr.set(layout, 0, value);
         return addr;
     }
 
     /**
      * Allocates a memory segment with the given layout and initializes it with the given float value.
-     * @implSpec the default implementation for this method calls
-     * {@code this.allocate(layout.byteSize(), layout.byteAlignment())}.
+     * @implSpec the default implementation for this method calls {@code this.allocate(layout)}.
      * @param layout the layout of the block of memory to be allocated.
      * @param value the value to be set on the newly allocated memory block.
      * @return a segment for the newly allocated memory block.
      */
     default MemorySegment allocateFrom(ValueLayout.OfFloat layout, float value) {
         Objects.requireNonNull(layout);
-        MemorySegment addr = allocateNoInit(layout.byteSize(), layout.byteAlignment());
+        MemorySegment addr = allocateNoInit(layout);
         addr.set(layout, 0, value);
         return addr;
     }
 
     /**
      * Allocates a memory segment with the given layout and initializes it with the given long value.
-     * @implSpec the default implementation for this method calls
-     * {@code this.allocate(layout.byteSize(), layout.byteAlignment())}.
+     * @implSpec the default implementation for this method calls {@code this.allocate(layout)}.
      * @param layout the layout of the block of memory to be allocated.
      * @param value the value to be set on the newly allocated memory block.
      * @return a segment for the newly allocated memory block.
      */
     default MemorySegment allocateFrom(ValueLayout.OfLong layout, long value) {
         Objects.requireNonNull(layout);
-        MemorySegment addr = allocateNoInit(layout.byteSize(), layout.byteAlignment());
+        MemorySegment addr = allocateNoInit(layout);
         addr.set(layout, 0, value);
         return addr;
     }
 
     /**
      * Allocates a memory segment with the given layout and initializes it with the given double value.
-     * @implSpec the default implementation for this method calls
-     * {@code this.allocate(layout.byteSize(), layout.byteAlignment())}.
+     * @implSpec the default implementation for this method calls {@code this.allocate(layout)}.
      * @param layout the layout of the block of memory to be allocated.
      * @param value the value to be set on the newly allocated memory block.
      * @return a segment for the newly allocated memory block.
      */
     default MemorySegment allocateFrom(ValueLayout.OfDouble layout, double value) {
         Objects.requireNonNull(layout);
-        MemorySegment addr = allocateNoInit(layout.byteSize(), layout.byteAlignment());
+        MemorySegment addr = allocateNoInit(layout);
         addr.set(layout, 0, value);
         return addr;
     }
@@ -242,8 +235,7 @@ public interface SegmentAllocator {
     /**
      * Allocates a memory segment with the given layout and initializes it with the given address value.
      * The address value might be narrowed according to the platform address size (see {@link ValueLayout#ADDRESS}).
-     * @implSpec the default implementation for this method calls
-     * {@code this.allocate(layout.byteSize(), layout.byteAlignment())}.
+     * @implSpec the default implementation for this method calls {@code this.allocate(layout)}.
      * @param layout the layout of the block of memory to be allocated.
      * @param value the value to be set on the newly allocated memory block.
      * @return a segment for the newly allocated memory block.
@@ -251,15 +243,14 @@ public interface SegmentAllocator {
     default MemorySegment allocateFrom(AddressLayout layout, MemorySegment value) {
         Objects.requireNonNull(value);
         Objects.requireNonNull(layout);
-        MemorySegment segment = allocateNoInit(layout.byteSize(), layout.byteAlignment());
+        MemorySegment segment = allocateNoInit(layout);
         segment.set(layout, 0, value);
         return segment;
     }
 
     /**
      * Allocates a memory segment with the given layout and initializes it with the given byte elements.
-     * @implSpec the default implementation for this method calls
-     * {@code this.allocate(elements.length * elementLayout.byteSize(), elementLayout.byteAlignment())}.
+     * @implSpec the default implementation for this method calls {@code this.allocate(layout, array.length)}.
      * @param elementLayout the element layout of the array to be allocated.
      * @param elements the byte elements to be copied to the newly allocated memory block.
      * @return a segment for the newly allocated memory block.
@@ -270,8 +261,7 @@ public interface SegmentAllocator {
 
     /**
      * Allocates a memory segment with the given layout and initializes it with the given short elements.
-     * @implSpec the default implementation for this method calls
-     * {@code this.allocate(elements.length * elementLayout.byteSize(), elementLayout.byteAlignment())}.
+     * @implSpec the default implementation for this method calls {@code this.allocate(layout, array.length)}.
      * @param elementLayout the element layout of the array to be allocated.
      * @param elements the short elements to be copied to the newly allocated memory block.
      * @return a segment for the newly allocated memory block.
@@ -282,8 +272,7 @@ public interface SegmentAllocator {
 
     /**
      * Allocates a memory segment with the given layout and initializes it with the given char elements.
-     * @implSpec the default implementation for this method calls
-     * {@code this.allocate(elements.length * elementLayout.byteSize(), elementLayout.byteAlignment())}.
+     * @implSpec the default implementation for this method calls {@code this.allocate(layout, array.length)}.
      * @param elementLayout the element layout of the array to be allocated.
      * @param elements the char elements to be copied to the newly allocated memory block.
      * @return a segment for the newly allocated memory block.
@@ -294,8 +283,7 @@ public interface SegmentAllocator {
 
     /**
      * Allocates a memory segment with the given layout and initializes it with the given int elements.
-     * @implSpec the default implementation for this method calls
-     * {@code this.allocate(elements.length * elementLayout.byteSize(), elementLayout.byteAlignment())}.
+     * @implSpec the default implementation for this method calls {@code this.allocate(layout, array.length)}.
      * @param elementLayout the element layout of the array to be allocated.
      * @param elements the int elements to be copied to the newly allocated memory block.
      * @return a segment for the newly allocated memory block.
@@ -306,8 +294,7 @@ public interface SegmentAllocator {
 
     /**
      * Allocates a memory segment with the given layout and initializes it with the given float elements.
-     * @implSpec the default implementation for this method calls
-     * {@code this.allocate(elements.length * elementLayout.byteSize(), elementLayout.byteAlignment())}.
+     * @implSpec the default implementation for this method calls {@code this.allocate(layout, array.length)}.
      * @param elementLayout the element layout of the array to be allocated.
      * @param elements the float elements to be copied to the newly allocated memory block.
      * @return a segment for the newly allocated memory block.
@@ -318,8 +305,7 @@ public interface SegmentAllocator {
 
     /**
      * Allocates a memory segment with the given layout and initializes it with the given long elements.
-     * @implSpec the default implementation for this method calls
-     * {@code this.allocate(elements.length * elementLayout.byteSize(), elementLayout.byteAlignment())}.
+     * @implSpec the default implementation for this method calls {@code this.allocate(layout, array.length)}.
      * @param elementLayout the element layout of the array to be allocated.
      * @param elements the long elements to be copied to the newly allocated memory block.
      * @return a segment for the newly allocated memory block.
@@ -330,8 +316,7 @@ public interface SegmentAllocator {
 
     /**
      * Allocates a memory segment with the given layout and initializes it with the given double elements.
-     * @implSpec the default implementation for this method calls
-     * {@code this.allocate(elements.length * elementLayout.byteSize(), elementLayout.byteAlignment())}.
+     * @implSpec the default implementation for this method calls {@code this.allocate(layout, array.length)}.
      * @param elementLayout the element layout of the array to be allocated.
      * @param elements the double elements to be copied to the newly allocated memory block.
      * @return a segment for the newly allocated memory block.
@@ -340,10 +325,10 @@ public interface SegmentAllocator {
         return copyArrayWithSwapIfNeeded(elements, elementLayout);
     }
 
+    @ForceInline
     private MemorySegment copyArrayWithSwapIfNeeded(Object array, ValueLayout elementLayout) {
         int size = Array.getLength(Objects.requireNonNull(array));
-        Objects.requireNonNull(elementLayout);
-        MemorySegment segment = allocateNoInit(elementLayout.byteSize() * size, elementLayout.byteAlignment());
+        MemorySegment segment = allocateNoInit(Objects.requireNonNull(elementLayout), size);
         if (size > 0) {
             MemorySegment.copy(array, 0, segment, elementLayout, 0, size);
         }
@@ -352,8 +337,7 @@ public interface SegmentAllocator {
 
     /**
      * Allocates a memory segment with the given layout.
-     * @implSpec the default implementation for this method calls
-     * {@code this.allocate(layout.byteSize(), layout.byteAlignment())}.
+     * @implSpec the default implementation for this method calls {@code this.allocate(layout.byteSize(), layout.byteAlignment())}.
      * @param layout the layout of the block of memory to be allocated.
      * @return a segment for the newly allocated memory block.
      */
@@ -364,8 +348,7 @@ public interface SegmentAllocator {
 
     /**
      * Allocates a memory segment with the given element layout and size.
-     * @implSpec the default implementation for this method calls
-     * {@code this.allocate(count * elementLayout.byteSize(), elementLayout.byteAlignment())}.
+     * @implSpec the default implementation for this method calls {@code this.allocate(MemoryLayout.sequenceLayout(count, elementLayout))}.
      * @param elementLayout the array element layout.
      * @param count the array element count.
      * @return a segment for the newly allocated memory block.
@@ -444,9 +427,23 @@ public interface SegmentAllocator {
     }
 
     @ForceInline
-    private MemorySegment allocateNoInit(long byteSize, long byteAlignment) {
+    private MemorySegment allocateNoInit(long byteSize) {
         return this instanceof ArenaImpl arenaImpl ?
-                arenaImpl.allocateNoInit(byteSize, byteAlignment) :
-                allocate(byteSize, byteAlignment);
+                arenaImpl.allocateNoInit(byteSize, 1) :
+                allocate(byteSize);
+    }
+
+    @ForceInline
+    private MemorySegment allocateNoInit(MemoryLayout layout) {
+        return this instanceof ArenaImpl arenaImpl ?
+                arenaImpl.allocateNoInit(layout.byteSize(), layout.byteAlignment()) :
+                allocate(layout);
+    }
+
+    @ForceInline
+    private MemorySegment allocateNoInit(MemoryLayout layout, long size) {
+        return this instanceof ArenaImpl arenaImpl ?
+                arenaImpl.allocateNoInit(layout.byteSize() * size, layout.byteAlignment()) :
+                allocate(layout, size);
     }
 }

--- a/src/java.base/share/classes/java/lang/foreign/SegmentAllocator.java
+++ b/src/java.base/share/classes/java/lang/foreign/SegmentAllocator.java
@@ -329,9 +329,7 @@ public interface SegmentAllocator {
     private MemorySegment copyArrayWithSwapIfNeeded(Object array, ValueLayout elementLayout) {
         int size = Array.getLength(Objects.requireNonNull(array));
         MemorySegment segment = allocateNoInit(Objects.requireNonNull(elementLayout), size);
-        if (size > 0) {
-            MemorySegment.copy(array, 0, segment, elementLayout, 0, size);
-        }
+        MemorySegment.copy(array, 0, segment, elementLayout, 0, size);
         return segment;
     }
 

--- a/test/jdk/java/foreign/TestSegmentAllocators.java
+++ b/test/jdk/java/foreign/TestSegmentAllocators.java
@@ -164,9 +164,17 @@ public class TestSegmentAllocators {
     @Test
     public void testArrayAllocateDelegation() {
         AtomicInteger calls = new AtomicInteger();
-        SegmentAllocator allocator = (bytesSize, byteAlignment) -> {
-            calls.incrementAndGet();
-            return null;
+        SegmentAllocator allocator = new SegmentAllocator() {
+            @Override
+            public MemorySegment allocate(long bytesSize, long byteAlignment) {
+                return null;
+            }
+
+            @Override
+            public MemorySegment allocate(MemoryLayout elementLayout, long count) {
+                calls.incrementAndGet();
+                return null;
+            };
         };
         allocator.allocateFrom(ValueLayout.JAVA_BYTE);
         allocator.allocateFrom(ValueLayout.JAVA_SHORT);
@@ -181,9 +189,18 @@ public class TestSegmentAllocators {
     @Test
     public void testStringAllocateDelegation() {
         AtomicInteger calls = new AtomicInteger();
-        SegmentAllocator allocator = (byteSize, byteAlignment) -> {
-            calls.incrementAndGet();
-            return Arena.ofAuto().allocate(byteSize, byteAlignment);
+        SegmentAllocator allocator = new SegmentAllocator() {
+            @Override
+
+            public MemorySegment allocate(long byteSize, long byteAlignment) {
+                return Arena.ofAuto().allocate(byteSize, byteAlignment);
+            }
+
+            @Override
+            public MemorySegment allocate(long size) {
+                calls.incrementAndGet();
+                return allocate(size, 1);
+            };
         };
         allocator.allocateFrom("Hello");
         assertEquals(calls.get(), 1);

--- a/test/jdk/java/foreign/TestSegmentAllocators.java
+++ b/test/jdk/java/foreign/TestSegmentAllocators.java
@@ -167,13 +167,13 @@ public class TestSegmentAllocators {
         SegmentAllocator allocator = new SegmentAllocator() {
             @Override
             public MemorySegment allocate(long bytesSize, long byteAlignment) {
-                return null;
+                return MemorySegment.NULL;
             }
 
             @Override
             public MemorySegment allocate(MemoryLayout elementLayout, long count) {
                 calls.incrementAndGet();
-                return null;
+                return MemorySegment.NULL;
             };
         };
         allocator.allocateFrom(ValueLayout.JAVA_BYTE);
@@ -191,7 +191,6 @@ public class TestSegmentAllocators {
         AtomicInteger calls = new AtomicInteger();
         SegmentAllocator allocator = new SegmentAllocator() {
             @Override
-
             public MemorySegment allocate(long byteSize, long byteAlignment) {
                 return Arena.ofAuto().allocate(byteSize, byteAlignment);
             }


### PR DESCRIPTION
This patch reverts the changes to the `implSpec` of the various default methods in `SegmentAllocator`.
We have realized that the changes there are irrelevant. What matters in order to get to optimal peak performance is that `SegmentAllocator::copyArrayWithSwapIfNeeded` is force-inlined.

The segment allocator test is also reverted to its former self.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Reviewers
 * [Jorn Vernee](https://openjdk.org/census#jvernee) (@JornVernee - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/panama-foreign.git pull/868/head:pull/868` \
`$ git checkout pull/868`

Update a local copy of the PR: \
`$ git checkout pull/868` \
`$ git pull https://git.openjdk.org/panama-foreign.git pull/868/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 868`

View PR using the GUI difftool: \
`$ git pr show -t 868`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/panama-foreign/pull/868.diff">https://git.openjdk.org/panama-foreign/pull/868.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/panama-foreign/pull/868#issuecomment-1682663662)