### PR TITLE
Add AllocTest benchmark

### DIFF
--- a/test/micro/org/openjdk/bench/java/lang/foreign/AllocTest.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/AllocTest.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package org.openjdk.bench.java.lang.foreign;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Warmup;
+
+import java.lang.foreign.Arena;
+import java.lang.foreign.FunctionDescriptor;
+import java.lang.foreign.Linker;
+import java.lang.foreign.MemorySegment;
+import java.lang.foreign.MemorySegment.Scope;
+import java.lang.foreign.SegmentAllocator;
+import java.lang.foreign.ValueLayout;
+import java.lang.invoke.MethodHandle;
+import java.util.concurrent.TimeUnit;
+
+@BenchmarkMode(Mode.AverageTime)
+@Warmup(iterations = 5, time = 500, timeUnit = TimeUnit.MILLISECONDS)
+@Measurement(iterations = 10, time = 500, timeUnit = TimeUnit.MILLISECONDS)
+@State(org.openjdk.jmh.annotations.Scope.Thread)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Fork(value = 3, jvmArgsAppend = { "--enable-native-access=ALL-UNNAMED" })
+public class AllocTest extends CLayouts {
+
+    Arena arena = Arena.ofConfined();
+
+    @Param({"5", "20", "100", "500", "1000"})
+    public int size;
+
+    @TearDown
+    public void tearDown() {
+        arena.close();
+    }
+
+    @Benchmark
+    public MemorySegment alloc_confined() {
+        Arena arena = Arena.ofConfined();
+        MemorySegment segment = arena.allocate(size);
+        arena.close();
+        return segment;
+    }
+
+    @Benchmark
+    public long alloc_calloc_arena() {
+        CallocArena arena = new CallocArena();
+        MemorySegment segment = arena.allocate(size);
+        arena.close();
+        return segment.address();
+    }
+
+    @Benchmark
+    public long alloc_unsafe_arena() {
+        UnsafeArena arena = new UnsafeArena();
+        MemorySegment segment = arena.allocate(size);
+        arena.close();
+        return segment.address();
+    }
+
+    public static class CallocArena implements Arena {
+
+        static final MethodHandle CALLOC = Linker.nativeLinker()
+                .downcallHandle(
+                        Linker.nativeLinker().defaultLookup().find("calloc").get(),
+                        FunctionDescriptor.of(ValueLayout.ADDRESS, ValueLayout.JAVA_LONG, ValueLayout.JAVA_LONG));
+
+        static MemorySegment calloc(long size) {
+            try {
+                return (MemorySegment)CALLOC.invokeExact(size, 1L);
+            } catch (Throwable ex) {
+                throw new IllegalStateException(ex);
+            }
+        }
+
+        final Arena arena = Arena.ofConfined();
+
+        @Override
+        public Scope scope() {
+            return arena.scope();
+        }
+
+        @Override
+        public void close() {
+            arena.close();
+        }
+
+        @Override
+        public MemorySegment allocate(long byteSize, long byteAlignment) {
+            return calloc(byteSize)
+                    .reinterpret(byteSize, arena, CLayouts::freeMemory);
+        }
+    }
+
+    public static class UnsafeArena implements Arena {
+
+        final Arena arena = Arena.ofConfined();
+
+        @Override
+        public Scope scope() {
+            return arena.scope();
+        }
+
+        @Override
+        public void close() {
+            arena.close();
+        }
+
+        @Override
+        public MemorySegment allocate(long byteSize, long byteAlignment) {
+            MemorySegment segment = MemorySegment.ofAddress(Utils.unsafe.allocateMemory(byteSize));
+            Utils.unsafe.setMemory(segment.address(), byteSize, (byte)0);
+            return segment.reinterpret(byteSize, arena, ms -> Utils.unsafe.freeMemory(segment.address()));
+        }
+    }
+}

--- a/test/micro/org/openjdk/bench/java/lang/foreign/AllocTest.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/AllocTest.java
@@ -1,26 +1,24 @@
 /*
- * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
- * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *  Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ *  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
- * This code is free software; you can redistribute it and/or modify it
- * under the terms of the GNU General Public License version 2 only, as
- * published by the Free Software Foundation.  Oracle designates this
- * particular file as subject to the "Classpath" exception as provided
- * by Oracle in the LICENSE file that accompanied this code.
+ *  This code is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License version 2 only, as
+ *  published by the Free Software Foundation.
  *
- * This code is distributed in the hope that it will be useful, but WITHOUT
- * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
- * version 2 for more details (a copy is included in the LICENSE file that
- * accompanied this code).
+ *  This code is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ *  version 2 for more details (a copy is included in the LICENSE file that
+ *  accompanied this code).
  *
- * You should have received a copy of the GNU General Public License version
- * 2 along with this work; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *  You should have received a copy of the GNU General Public License version
+ *  2 along with this work; if not, write to the Free Software Foundation,
+ *  Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
  *
- * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
- * or visit www.oracle.com if you need additional information or have any
- * questions.
+ *  Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ *  or visit www.oracle.com if you need additional information or have any
+ *  questions.
  */
 
 package org.openjdk.bench.java.lang.foreign;


### PR DESCRIPTION
This patch adds a benchmark that tests a simple allocation (of varying size).
The allocation request requires zeroing, so we compare against calloc, and bare use of Unsafe::allocateMemory/setMemory/freeMemory.

Results are as follows:

```
Benchmark                     (size)  Mode  Cnt   Score   Error  Units
AllocTest.alloc_calloc_arena       5  avgt   30  40.620 ? 0.360  ns/op
AllocTest.alloc_calloc_arena      20  avgt   30  41.648 ? 1.460  ns/op
AllocTest.alloc_calloc_arena     100  avgt   30  39.885 ? 0.478  ns/op
AllocTest.alloc_calloc_arena     500  avgt   30  67.802 ? 2.258  ns/op
AllocTest.alloc_calloc_arena    1000  avgt   30  67.403 ? 1.034  ns/op
AllocTest.alloc_confined           5  avgt   30  51.874 ? 0.554  ns/op
AllocTest.alloc_confined          20  avgt   30  52.717 ? 1.214  ns/op
AllocTest.alloc_confined         100  avgt   30  52.760 ? 0.716  ns/op
AllocTest.alloc_confined         500  avgt   30  58.661 ? 2.379  ns/op
AllocTest.alloc_confined        1000  avgt   30  65.374 ? 0.711  ns/op
AllocTest.alloc_unsafe_arena       5  avgt   30  56.086 ? 0.710  ns/op
AllocTest.alloc_unsafe_arena      20  avgt   30  52.492 ? 0.835  ns/op
AllocTest.alloc_unsafe_arena     100  avgt   30  54.579 ? 0.748  ns/op
AllocTest.alloc_unsafe_arena     500  avgt   30  60.528 ? 1.024  ns/op
AllocTest.alloc_unsafe_arena    1000  avgt   30  67.619 ? 1.020  ns/op
```

So, confined arenas are quite close to calloc. There remains a gap, especially on lower allocation sizes, which is a consequence of:
https://bugs.openjdk.org/browse/JDK-8314294

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Reviewers
 * [Jorn Vernee](https://openjdk.org/census#jvernee) (@JornVernee - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/panama-foreign.git pull/870/head:pull/870` \
`$ git checkout pull/870`

Update a local copy of the PR: \
`$ git checkout pull/870` \
`$ git pull https://git.openjdk.org/panama-foreign.git pull/870/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 870`

View PR using the GUI difftool: \
`$ git pr show -t 870`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/panama-foreign/pull/870.diff">https://git.openjdk.org/panama-foreign/pull/870.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/panama-foreign/pull/870#issuecomment-1684184359)