### PR TITLE
8314592: Add shortcut to SymbolLookup::find

### DIFF
--- a/src/java.base/share/classes/java/lang/foreign/Linker.java
+++ b/src/java.base/share/classes/java/lang/foreign/Linker.java
@@ -81,7 +81,7 @@ import java.util.stream.Stream;
  * {@snippet lang = java:
  * Linker linker = Linker.nativeLinker();
  * MethodHandle strlen = linker.downcallHandle(
- *     linker.defaultLookup().find("strlen").orElseThrow(),
+ *     linker.defaultLookup().get("strlen"),
  *     FunctionDescriptor.of(JAVA_LONG, ADDRESS)
  * );
  * }
@@ -265,7 +265,7 @@ import java.util.stream.Stream;
  * {@snippet lang = java:
  * Linker linker = Linker.nativeLinker();
  * MethodHandle qsort = linker.downcallHandle(
- *     linker.defaultLookup().find("qsort").orElseThrow(),
+ *     linker.defaultLookup().get("qsort"),
  *         FunctionDescriptor.ofVoid(ADDRESS, JAVA_LONG, JAVA_LONG, ADDRESS)
  * );
  * }
@@ -346,12 +346,12 @@ import java.util.stream.Stream;
  * Linker linker = Linker.nativeLinker();
  *
  * MethodHandle malloc = linker.downcallHandle(
- *     linker.defaultLookup().find("malloc").orElseThrow(),
+ *     linker.defaultLookup().get("malloc"),
  *     FunctionDescriptor.of(ADDRESS, JAVA_LONG)
  * );
  *
  * MethodHandle free = linker.downcallHandle(
- *     linker.defaultLookup().find("free").orElseThrow(),
+ *     linker.defaultLookup().get("free"),
  *     FunctionDescriptor.ofVoid(ADDRESS)
  * );
  * }
@@ -461,7 +461,7 @@ import java.util.stream.Stream;
  * {@snippet lang = java:
  * Linker linker = Linker.nativeLinker();
  * MethodHandle printf = linker.downcallHandle(
- *     linker.defaultLookup().find("printf").orElseThrow(),
+ *     linker.defaultLookup().get("printf"),
  *         FunctionDescriptor.of(JAVA_INT, ADDRESS, JAVA_INT, JAVA_INT, JAVA_INT),
  *         Linker.Option.firstVariadicArg(1) // first int is variadic
  * );

--- a/src/java.base/share/classes/java/lang/foreign/SymbolLookup.java
+++ b/src/java.base/share/classes/java/lang/foreign/SymbolLookup.java
@@ -69,7 +69,7 @@ import java.util.function.BiFunction;
  * {@snippet lang = java:
  * try (Arena arena = Arena.ofConfined()) {
  *     SymbolLookup libGL = SymbolLookup.libraryLookup("libGL.so", arena); // libGL.so loaded here
- *     MemorySegment glGetString = libGL.find("glGetString").orElseThrow();
+ *     MemorySegment glGetString = libGL.get("glGetString");
  *     ...
  * } //  libGL.so unloaded here
  *}
@@ -82,7 +82,7 @@ import java.util.function.BiFunction;
  * System.loadLibrary("GL"); // libGL.so loaded here
  * ...
  * SymbolLookup libGL = SymbolLookup.loaderLookup();
- * MemorySegment glGetString = libGL.find("glGetString").orElseThrow();
+ * MemorySegment glGetString = libGL.get("glGetString");
  * }
  *
  * This symbol lookup, which is known as a <em>loader lookup</em>, is dynamic with respect to the libraries associated
@@ -115,7 +115,7 @@ import java.util.function.BiFunction;
  * {@snippet lang = java:
  * Linker nativeLinker = Linker.nativeLinker();
  * SymbolLookup stdlib = nativeLinker.defaultLookup();
- * MemorySegment malloc = stdlib.find("malloc").orElseThrow();
+ * MemorySegment malloc = stdlib.get("malloc");
  *}
  *
  * @since 22
@@ -129,6 +129,17 @@ public interface SymbolLookup {
      * @return a zero-length memory segment whose address indicates the address of the symbol, if found.
      */
     Optional<MemorySegment> find(String name);
+
+    /**
+     * Returns the address of the symbol with the given name.
+     * @implSpec the default implementation for this method calls {@code this.find(name).get()}.
+     * @param name the symbol name.
+     * @return a zero-length memory segment whose address indicates the address of the symbol.
+     * @throws java.util.NoSuchElementException if no symbol with the given name exists.
+     */
+    default MemorySegment get(String name) {
+        return find(name).get();
+    }
 
     /**
      * {@return a composed symbol lookup that returns result of finding the symbol with this lookup if found,

--- a/src/java.base/share/classes/java/lang/foreign/SymbolLookup.java
+++ b/src/java.base/share/classes/java/lang/foreign/SymbolLookup.java
@@ -37,6 +37,7 @@ import jdk.internal.reflect.Reflection;
 
 import java.lang.invoke.MethodHandles;
 import java.nio.file.Path;
+import java.util.NoSuchElementException;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.function.BiFunction;
@@ -138,7 +139,13 @@ public interface SymbolLookup {
      * @throws java.util.NoSuchElementException if no symbol with the given name exists.
      */
     default MemorySegment get(String name) {
-        return find(name).get();
+        var address = this.find(name);
+        // Note: the code below could use orElseThrow, but that would require a capturing lambda
+        if (address.isPresent()) {
+            return address.get();
+        } else {
+            throw new NoSuchElementException("Unable to find a symbol with name '" + name + "'");
+        }
     }
 
     /**

--- a/src/java.base/share/classes/java/lang/foreign/package-info.java
+++ b/src/java.base/share/classes/java/lang/foreign/package-info.java
@@ -89,7 +89,7 @@
  * Linker linker = Linker.nativeLinker();
  * SymbolLookup stdlib = linker.defaultLookup();
  * MethodHandle strlen = linker.downcallHandle(
- *     stdlib.find("strlen").orElseThrow(),
+ *     stdlib.get("strlen"),
  *     FunctionDescriptor.of(ValueLayout.JAVA_LONG, ValueLayout.ADDRESS)
  * );
  *
@@ -100,7 +100,7 @@
  *}
  *
  * Here, we obtain a {@linkplain java.lang.foreign.Linker#nativeLinker() native linker} and we use it
- * to {@linkplain java.lang.foreign.SymbolLookup#find(java.lang.String) look up} the {@code strlen} function in the
+ * to {@linkplain java.lang.foreign.SymbolLookup#get(java.lang.String) look up} the {@code strlen} function in the
  * standard C library; a <em>downcall method handle</em> targeting said function is subsequently
  * {@linkplain java.lang.foreign.Linker#downcallHandle(FunctionDescriptor, Linker.Option...) obtained}.
  * To complete the linking successfully, we must provide a {@link java.lang.foreign.FunctionDescriptor} instance,

--- a/src/java.base/share/classes/java/lang/foreign/snippet-files/Snippets.java
+++ b/src/java.base/share/classes/java/lang/foreign/snippet-files/Snippets.java
@@ -162,7 +162,7 @@ class Snippets {
         void downcall() throws Throwable {
             Linker linker = Linker.nativeLinker();
             MethodHandle strlen = linker.downcallHandle(
-                    linker.defaultLookup().find("strlen").orElseThrow(),
+                    linker.defaultLookup().get("strlen"),
                     FunctionDescriptor.of(JAVA_LONG, ADDRESS)
             );
 
@@ -176,7 +176,7 @@ class Snippets {
         void qsort() throws Throwable {
             Linker linker = Linker.nativeLinker();
             MethodHandle qsort = linker.downcallHandle(
-                    linker.defaultLookup().find("qsort").orElseThrow(),
+                    linker.defaultLookup().get("qsort"),
                     FunctionDescriptor.ofVoid(ADDRESS, JAVA_LONG, JAVA_LONG, ADDRESS)
             );
 
@@ -207,12 +207,12 @@ class Snippets {
             Linker linker = Linker.nativeLinker();
 
             MethodHandle malloc = linker.downcallHandle(
-                    linker.defaultLookup().find("malloc").orElseThrow(),
+                    linker.defaultLookup().get("malloc"),
                     FunctionDescriptor.of(ADDRESS, JAVA_LONG)
             );
 
             MethodHandle free = linker.downcallHandle(
-                    linker.defaultLookup().find("free").orElseThrow(),
+                    linker.defaultLookup().get("free"),
                     FunctionDescriptor.ofVoid(ADDRESS)
             );
 
@@ -281,7 +281,7 @@ class Snippets {
 
             Linker linker = Linker.nativeLinker();
             MethodHandle printf = linker.downcallHandle(
-                    linker.defaultLookup().find("printf").orElseThrow(),
+                    linker.defaultLookup().get("printf"),
                     FunctionDescriptor.of(JAVA_INT, ADDRESS, JAVA_INT, JAVA_INT, JAVA_INT),
                     Linker.Option.firstVariadicArg(1) // first int is variadic
             );
@@ -567,7 +567,7 @@ class Snippets {
             Linker linker = Linker.nativeLinker();
             SymbolLookup stdlib = linker.defaultLookup();
             MethodHandle strlen = linker.downcallHandle(
-                    stdlib.find("strlen").orElseThrow(),
+                    stdlib.get("strlen"),
                     FunctionDescriptor.of(ValueLayout.JAVA_LONG, ValueLayout.ADDRESS)
             );
 
@@ -625,14 +625,14 @@ class Snippets {
         void header() {
             try (Arena arena = Arena.ofConfined()) {
                 SymbolLookup libGL = libraryLookup("libGL.so", arena); // libGL.so loaded here
-                MemorySegment glGetString = libGL.find("glGetString").orElseThrow();
+                MemorySegment glGetString = libGL.get("glGetString");
                 // ...
             } //  libGL.so unloaded here
 
             System.loadLibrary("GL"); // libGL.so loaded here
             // ...
             SymbolLookup libGL = loaderLookup();
-            MemorySegment glGetString = libGL.find("glGetString").orElseThrow();
+            MemorySegment glGetString = libGL.get("glGetString");
 
 
             Arena arena = Arena.ofAuto();
@@ -646,7 +646,7 @@ class Snippets {
 
             Linker nativeLinker = Linker.nativeLinker();
             SymbolLookup stdlib = nativeLinker.defaultLookup();
-            MemorySegment malloc = stdlib.find("malloc").orElseThrow();
+            MemorySegment malloc = stdlib.get("malloc");
         }
 
     }

--- a/src/java.base/share/classes/jdk/internal/foreign/SystemLookup.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/SystemLookup.java
@@ -86,7 +86,7 @@ public final class SystemLookup implements SymbolLookup {
             SymbolLookup fallbackLibLookup =
                     libLookup(libs -> libs.load(jdkLibraryPath("syslookup")));
 
-            MemorySegment funcs = fallbackLibLookup.find("funcs").orElseThrow()
+            MemorySegment funcs = fallbackLibLookup.get("funcs")
                     .reinterpret(WindowsFallbackSymbols.LAYOUT.byteSize());
 
             Function<String, Optional<MemorySegment>> fallbackLookup = name -> Optional.ofNullable(WindowsFallbackSymbols.valueOfOrNull(name))

--- a/test/micro/org/openjdk/bench/java/lang/foreign/CLayouts.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/CLayouts.java
@@ -74,10 +74,10 @@ public class CLayouts {
     private static Linker LINKER = Linker.nativeLinker();
 
     private static final MethodHandle FREE = LINKER.downcallHandle(
-            LINKER.defaultLookup().find("free").get(), FunctionDescriptor.ofVoid(C_POINTER));
+            LINKER.defaultLookup().get("free"), FunctionDescriptor.ofVoid(C_POINTER));
 
     private static final MethodHandle MALLOC = LINKER.downcallHandle(
-            LINKER.defaultLookup().find("malloc").get(), FunctionDescriptor.of(C_POINTER, ValueLayout.JAVA_LONG));
+            LINKER.defaultLookup().get("malloc"), FunctionDescriptor.of(C_POINTER, ValueLayout.JAVA_LONG));
 
     public static void freeMemory(MemorySegment address) {
         try {

--- a/test/micro/org/openjdk/bench/java/lang/foreign/CallOverheadHelper.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/CallOverheadHelper.java
@@ -109,7 +109,7 @@ public class CallOverheadHelper extends CLayouts {
         System.loadLibrary("CallOverhead");
         SymbolLookup loaderLibs = SymbolLookup.loaderLookup();
         {
-            func_addr = loaderLibs.find("func").orElseThrow();
+            func_addr = loaderLibs.get("func");
             MethodType mt = MethodType.methodType(void.class);
             FunctionDescriptor fd = FunctionDescriptor.ofVoid();
             func_v = abi.downcallHandle(fd);
@@ -118,59 +118,59 @@ public class CallOverheadHelper extends CLayouts {
             func_critical = insertArguments(func_critical_v, 0, func_addr);
         }
         {
-            identity_addr = loaderLibs.find("identity").orElseThrow();
+            identity_addr = loaderLibs.get("identity");
             FunctionDescriptor fd = FunctionDescriptor.of(C_INT, C_INT);
             identity_v = abi.downcallHandle(fd);
             identity_critical_v = abi.downcallHandle(fd, Linker.Option.critical());
             identity = insertArguments(identity_v, 0, identity_addr);
             identity_critical = insertArguments(identity_critical_v, 0, identity_addr);
         }
-        identity_struct_addr = loaderLibs.find("identity_struct").orElseThrow();
+        identity_struct_addr = loaderLibs.get("identity_struct");
         identity_struct_v = abi.downcallHandle(
                 FunctionDescriptor.of(POINT_LAYOUT, POINT_LAYOUT));
         identity_struct = insertArguments(identity_struct_v, 0, identity_struct_addr);
 
-        identity_struct_3_addr = loaderLibs.find("identity_struct_3").orElseThrow();
+        identity_struct_3_addr = loaderLibs.get("identity_struct_3");
         identity_struct_3_v = abi.downcallHandle(
                 FunctionDescriptor.of(POINT_LAYOUT, POINT_LAYOUT, POINT_LAYOUT, POINT_LAYOUT));
         identity_struct_3 = insertArguments(identity_struct_3_v, 0, identity_struct_3_addr);
 
-        identity_memory_address_addr = loaderLibs.find("identity_memory_address").orElseThrow();
+        identity_memory_address_addr = loaderLibs.get("identity_memory_address");
         identity_memory_address_v = abi.downcallHandle(
                 FunctionDescriptor.of(C_POINTER, C_POINTER));
         identity_memory_address = insertArguments(identity_memory_address_v, 0, identity_memory_address_addr);
 
-        identity_memory_address_3_addr = loaderLibs.find("identity_memory_address_3").orElseThrow();
+        identity_memory_address_3_addr = loaderLibs.get("identity_memory_address_3");
         identity_memory_address_3_v = abi.downcallHandle(
                 FunctionDescriptor.of(C_POINTER, C_POINTER, C_POINTER, C_POINTER));
         identity_memory_address_3 = insertArguments(identity_memory_address_3_v, 0, identity_memory_address_3_addr);
 
-        args1_addr = loaderLibs.find("args1").orElseThrow();
+        args1_addr = loaderLibs.get("args1");
         args1_v = abi.downcallHandle(
                 FunctionDescriptor.ofVoid(C_LONG_LONG));
         args1 = insertArguments(args1_v, 0, args1_addr);
 
-        args2_addr = loaderLibs.find("args2").orElseThrow();
+        args2_addr = loaderLibs.get("args2");
         args2_v = abi.downcallHandle(
                 FunctionDescriptor.ofVoid(C_LONG_LONG, C_DOUBLE));
         args2 = insertArguments(args2_v, 0, args2_addr);
 
-        args3_addr = loaderLibs.find("args3").orElseThrow();
+        args3_addr = loaderLibs.get("args3");
         args3_v = abi.downcallHandle(
                 FunctionDescriptor.ofVoid(C_LONG_LONG, C_DOUBLE, C_LONG_LONG));
         args3 = insertArguments(args3_v, 0, args3_addr);
 
-        args4_addr = loaderLibs.find("args4").orElseThrow();
+        args4_addr = loaderLibs.get("args4");
         args4_v = abi.downcallHandle(
                 FunctionDescriptor.ofVoid(C_LONG_LONG, C_DOUBLE, C_LONG_LONG, C_DOUBLE));
         args4 = insertArguments(args4_v, 0, args4_addr);
 
-        args5_addr = loaderLibs.find("args5").orElseThrow();
+        args5_addr = loaderLibs.get("args5");
         args5_v = abi.downcallHandle(
                 FunctionDescriptor.ofVoid(C_LONG_LONG, C_DOUBLE, C_LONG_LONG, C_DOUBLE, C_LONG_LONG));
         args5 = insertArguments(args5_v, 0, args5_addr);
 
-        args10_addr = loaderLibs.find("args10").orElseThrow();
+        args10_addr = loaderLibs.get("args10");
         args10_v = abi.downcallHandle(
                 FunctionDescriptor.ofVoid(C_LONG_LONG, C_DOUBLE, C_LONG_LONG, C_DOUBLE, C_LONG_LONG,
                                           C_DOUBLE, C_LONG_LONG, C_DOUBLE, C_LONG_LONG, C_DOUBLE));

--- a/test/micro/org/openjdk/bench/java/lang/foreign/PointerInvoke.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/PointerInvoke.java
@@ -60,13 +60,13 @@ public class PointerInvoke extends CLayouts {
     static {
         Linker abi = Linker.nativeLinker();
         SymbolLookup loaderLibs = SymbolLookup.loaderLookup();
-        F_LONG_LONG = abi.downcallHandle(loaderLibs.find("id_long_long").get(),
+        F_LONG_LONG = abi.downcallHandle(loaderLibs.get("id_long_long"),
                 FunctionDescriptor.of(C_LONG_LONG, C_LONG_LONG));
-        F_PTR_LONG = abi.downcallHandle(loaderLibs.find("id_ptr_long").get(),
+        F_PTR_LONG = abi.downcallHandle(loaderLibs.get("id_ptr_long"),
                 FunctionDescriptor.of(C_LONG_LONG, C_POINTER));
-        F_LONG_PTR = abi.downcallHandle(loaderLibs.find("id_long_ptr").get(),
+        F_LONG_PTR = abi.downcallHandle(loaderLibs.get("id_long_ptr"),
                 FunctionDescriptor.of(C_POINTER, C_LONG_LONG));
-        F_PTR_PTR = abi.downcallHandle(loaderLibs.find("id_ptr_ptr").get(),
+        F_PTR_PTR = abi.downcallHandle(loaderLibs.get("id_ptr_ptr"),
                 FunctionDescriptor.of(C_POINTER, C_POINTER));
     }
 

--- a/test/micro/org/openjdk/bench/java/lang/foreign/QSort.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/QSort.java
@@ -58,7 +58,7 @@ public class QSort extends CLayouts {
     static final int[] INPUT = { 5, 3, 2, 7, 8, 12, 1, 7 };
     static final MemorySegment INPUT_SEGMENT;
 
-    static MemorySegment qsort_addr = abi.defaultLookup().find("qsort").get();
+    static MemorySegment qsort_addr = abi.defaultLookup().get("qsort");
 
     static {
         MemoryLayout layout = MemoryLayout.sequenceLayout(INPUT.length, JAVA_INT);
@@ -74,7 +74,7 @@ public class QSort extends CLayouts {
                     FunctionDescriptor.ofVoid(C_POINTER, C_LONG_LONG, C_LONG_LONG, C_POINTER)
             );
             System.loadLibrary("QSort");
-            native_compar = SymbolLookup.loaderLookup().find("compar").orElseThrow();
+            native_compar = SymbolLookup.loaderLookup().get("compar");
             panama_upcall_compar = abi.upcallStub(
                     lookup().findStatic(QSort.class,
                             "panama_upcall_compar",

--- a/test/micro/org/openjdk/bench/java/lang/foreign/StrLenTest.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/StrLenTest.java
@@ -71,7 +71,7 @@ public class StrLenTest extends CLayouts {
 
     static {
         Linker abi = Linker.nativeLinker();
-        STRLEN = abi.downcallHandle(abi.defaultLookup().find("strlen").get(),
+        STRLEN = abi.downcallHandle(abi.defaultLookup().get("strlen"),
                 FunctionDescriptor.of(C_INT, C_POINTER));
     }
 

--- a/test/micro/org/openjdk/bench/java/lang/foreign/Upcalls.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/Upcalls.java
@@ -120,7 +120,7 @@ public class Upcalls extends CLayouts {
 
     static MethodHandle linkFunc(String name, FunctionDescriptor baseDesc) {
         return abi.downcallHandle(
-                SymbolLookup.loaderLookup().find(name).orElseThrow(),
+                SymbolLookup.loaderLookup().get(name),
                 baseDesc.appendArgumentLayouts(C_POINTER)
         );
     }

--- a/test/micro/org/openjdk/bench/java/lang/foreign/points/support/PanamaPoint.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/points/support/PanamaPoint.java
@@ -48,11 +48,11 @@ public class PanamaPoint extends CLayouts implements AutoCloseable {
         System.loadLibrary("Point");
         SymbolLookup loaderLibs = SymbolLookup.loaderLookup();
         MH_distance = abi.downcallHandle(
-                loaderLibs.find("distance").get(),
+                loaderLibs.get("distance"),
                 FunctionDescriptor.of(C_DOUBLE, LAYOUT, LAYOUT)
         );
         MH_distance_ptrs = abi.downcallHandle(
-                loaderLibs.find("distance_ptrs").get(),
+                loaderLibs.get("distance_ptrs"),
                 FunctionDescriptor.of(C_DOUBLE, C_POINTER, C_POINTER)
         );
     }


### PR DESCRIPTION
This patch adds a default method in `SymbolLookup`, namely `SymbolLookup::get`. Its implementation is very simple: it calls `SymbolLookup::find` and then `Optional::get` on the result. This allows to simplify many clients that end up calling `Optional::get` or `Optional::orElseThrow` after a symbol lookup, but still retains the compositional advantage of the optional-returning lookup primitive.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8314592](https://bugs.openjdk.org/browse/JDK-8314592): Add shortcut to SymbolLookup::find (**Enhancement** - P3)


### Reviewers
 * [Per Minborg](https://openjdk.org/census#pminborg) (@minborg - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/panama-foreign.git pull/871/head:pull/871` \
`$ git checkout pull/871`

Update a local copy of the PR: \
`$ git checkout pull/871` \
`$ git pull https://git.openjdk.org/panama-foreign.git pull/871/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 871`

View PR using the GUI difftool: \
`$ git pr show -t 871`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/panama-foreign/pull/871.diff">https://git.openjdk.org/panama-foreign/pull/871.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/panama-foreign/pull/871#issuecomment-1684206067)