### PR TITLE
Clarify javadoc w.r.t. exceptions thrown by a memory access var handle (part two)

### DIFF
--- a/src/java.base/share/classes/java/lang/foreign/MemoryLayout.java
+++ b/src/java.base/share/classes/java/lang/foreign/MemoryLayout.java
@@ -444,19 +444,22 @@ public sealed interface MemoryLayout permits SequenceLayout, GroupLayout, Paddin
      * {@snippet lang = "java":
      * offset = this.offsetHandle(P).invokeExact(B, I1, I2, ... In);
      * }
-     *
-     * The physical address of the accessed memory segment must be <a href="MemorySegment.html#segment-alignment">aligned</a>
+     * <p>
+     * Accessing a memory segment using the var handle returned by this method is subject to the following checks:
+     * <ul>
+     *     <li>The physical address of the accessed memory segment must be <a href="MemorySegment.html#segment-alignment">aligned</a>
      * according to the {@linkplain #byteAlignment() alignment constraint} of the root layout (this layout), or
      * an {@link IllegalArgumentException} will be issued. Note that the alignment constraint of the root layout
-     * can be more strict (but not less) than the alignment constraint of the selected value layout.
-     * <p>
-     * Moreover, if the access operation (computed as above) falls outside the spatial bounds of the
-     * accessed memory segment, an {@link IndexOutOfBoundsException} is thrown. This is the case when {@code O + A > S},
+     * can be more strict (but not less) than the alignment constraint of the selected value layout.</li>
+     *     <li>The offset of the access operation (computed as above) must fall fall inside the spatial bounds of the
+     * accessed memory segment, or an {@link IndexOutOfBoundsException} is thrown. This is the case when {@code O + A <= S},
      * where {@code O} is the accessed offset (computed as above), {@code A} is the size of the selected layout and {@code S}
-     * is the size of the accessed memory segment.
-     * <p>
-     * Finally, if the {@linkplain MemorySegment#scope() scope} associated with the accessed segment is not
-     * {@linkplain MemorySegment.Scope#isAlive() alive}, the access operation will result in an {@link IllegalStateException}.
+     * is the size of the accessed memory segment.</li>
+     *     <li>The accessed memory segment must be {@link MemorySegment#isAccessibleBy(Thread) accessible} from the
+     * thread performing the access operation, or a {@link WrongThreadException} is thrown.</li>
+     *     <li>The {@linkplain MemorySegment#scope() scope} associated with the accessed segment must be
+     * {@linkplain MemorySegment.Scope#isAlive() alive}, or an {@link IllegalStateException} is thrown.</li>
+     * </ul>
      * <p>
      * If the selected layout is an {@linkplain AddressLayout address layout}, calling {@link VarHandle#get(Object...)}
      * on the returned var handle will return a new memory segment. The segment is associated with a fresh scope that is
@@ -532,9 +535,17 @@ public sealed interface MemoryLayout permits SequenceLayout, GroupLayout, Paddin
      * The offset of the returned segment is computed as if by a call to a
      * {@linkplain #byteOffsetHandle(PathElement...) byte offset handle} constructed using the given path elements.
      * <p>
-     * The segment to be sliced must be <a href="MemorySegment.html#segment-alignment">aligned</a> according to the
-     * {@linkplain #byteAlignment() alignment constraint} of the root layout (this layout). Note that this can be more
-     * strict (but not less) than the alignment constraint of the selected value layout.
+     * Computing a slice of a memory segment using the method handle returned by this method is subject to the following checks:
+     * <ul>
+     *     <li>The physical address of the accessed memory segment must be <a href="MemorySegment.html#segment-alignment">aligned</a>
+     * according to the {@linkplain #byteAlignment() alignment constraint} of the root layout (this layout), or
+     * an {@link IllegalArgumentException} will be issued. Note that the alignment constraint of the root layout
+     * can be more strict (but not less) than the alignment constraint of the selected layout.</li>
+     *     <li>The start offset of the slicing operation (computed as above) must fall fall inside the spatial bounds of the
+     * accessed memory segment, or an {@link IndexOutOfBoundsException} is thrown. This is the case when {@code O + A <= S},
+     * where {@code O} is the start offset of the slicing operation (computed as above), {@code A} is the size of the
+     * selected layout and {@code S} is the size of the accessed memory segment.</li>
+     * </ul>
      *
      * @apiNote The returned method handle can be used to obtain a memory segment slice, similarly to {@link MemorySegment#asSlice(long, long)},
      * but more flexibly, as some indices can be specified when invoking the method handle.


### PR DESCRIPTION
This is a follow-up on https://git.openjdk.org/panama-foreign/pull/869 which fixes two issues:
* the rectified javadoc still did not mention possibility of `WrongThreadException`
* `MemoryLayout::sliceHandle` needs similar clarifications (albeit some exceptions can't occur there)

To make the javadoc a bit more streamlined, I've collected all the checks in bullet lists.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Reviewers
 * [Per Minborg](https://openjdk.org/census#pminborg) (@minborg - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/panama-foreign.git pull/872/head:pull/872` \
`$ git checkout pull/872`

Update a local copy of the PR: \
`$ git checkout pull/872` \
`$ git pull https://git.openjdk.org/panama-foreign.git pull/872/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 872`

View PR using the GUI difftool: \
`$ git pr show -t 872`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/panama-foreign/pull/872.diff">https://git.openjdk.org/panama-foreign/pull/872.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/panama-foreign/pull/872#issuecomment-1686256117)