### PR TITLE
Fix misc typos in FFM API javadoc

### DIFF
--- a/src/java.base/share/classes/java/lang/foreign/MemoryLayout.java
+++ b/src/java.base/share/classes/java/lang/foreign/MemoryLayout.java
@@ -49,7 +49,7 @@ import jdk.internal.vm.annotation.ForceInline;
 /**
  * A memory layout describes the contents of a memory segment.
  * <p>
- * There are two leaves in the layout hierarchy, {@linkplain ValueLayout value layouts}, which are used to represent values of given size and kind (see
+ * There are two leaves in the layout hierarchy, {@linkplain ValueLayout value layouts}, which are used to represent values of given size and kind
  * and {@linkplain PaddingLayout padding layouts} which are used, as the name suggests, to represent a portion of a memory
  * segment whose contents should be ignored, and which are primarily present for alignment reasons.
  * Some common value layout constants, such as {@link ValueLayout#JAVA_INT} and {@link ValueLayout#JAVA_FLOAT_UNALIGNED}
@@ -451,7 +451,7 @@ public sealed interface MemoryLayout permits SequenceLayout, GroupLayout, Paddin
      * according to the {@linkplain #byteAlignment() alignment constraint} of the root layout (this layout), or
      * an {@link IllegalArgumentException} will be issued. Note that the alignment constraint of the root layout
      * can be more strict (but not less) than the alignment constraint of the selected value layout.</li>
-     *     <li>The offset of the access operation (computed as above) must fall fall inside the spatial bounds of the
+     *     <li>The offset of the access operation (computed as above) must fall inside the spatial bounds of the
      * accessed memory segment, or an {@link IndexOutOfBoundsException} is thrown. This is the case when {@code O + A <= S},
      * where {@code O} is the accessed offset (computed as above), {@code A} is the size of the selected layout and {@code S}
      * is the size of the accessed memory segment.</li>
@@ -480,7 +480,7 @@ public sealed interface MemoryLayout permits SequenceLayout, GroupLayout, Paddin
      * {@snippet lang = "java":
      * VarHandle baseHandle = this.varHandle(P);
      * MemoryLayout target = ((AddressLayout)this.select(P)).targetLayout().get();
-     * VarHandle targetHandle = target.varHandle(P');
+     * VarHandle targetHandle = target.varHandle(P);
      * targetHandle = MethodHandles.insertCoordinates(targetHandle, 1, 0L); // always access nested targets at offset 0
      * targetHandle = MethodHandles.collectCoordinates(targetHandle, 0,
      *         baseHandle.toMethodHandle(VarHandle.AccessMode.GET));

--- a/src/java.base/share/classes/java/lang/foreign/MemoryLayout.java
+++ b/src/java.base/share/classes/java/lang/foreign/MemoryLayout.java
@@ -480,7 +480,7 @@ public sealed interface MemoryLayout permits SequenceLayout, GroupLayout, Paddin
      * {@snippet lang = "java":
      * VarHandle baseHandle = this.varHandle(P);
      * MemoryLayout target = ((AddressLayout)this.select(P)).targetLayout().get();
-     * VarHandle targetHandle = target.varHandle(P);
+     * VarHandle targetHandle = target.varHandle(P');
      * targetHandle = MethodHandles.insertCoordinates(targetHandle, 1, 0L); // always access nested targets at offset 0
      * targetHandle = MethodHandles.collectCoordinates(targetHandle, 0,
      *         baseHandle.toMethodHandle(VarHandle.AccessMode.GET));

--- a/src/java.base/share/classes/java/lang/foreign/MemorySegment.java
+++ b/src/java.base/share/classes/java/lang/foreign/MemorySegment.java
@@ -1068,7 +1068,7 @@ public sealed interface MemorySegment permits AbstractMemorySegmentImpl {
      * the first {@code '\0'} terminator character (assuming one is found).
      * @throws IllegalArgumentException if the size of the string is greater than the largest string supported by the platform.
      * @throws IndexOutOfBoundsException     if {@code offset < 0}.
-     * @throws IndexOutOfBoundsException     if {@code offset} > byteSize() - (B + 1)}, where {@code B} is the size,
+     * @throws IndexOutOfBoundsException     if {@code offset > byteSize() - (B + 1)}, where {@code B} is the size,
      * in bytes, of the string encoded using UTF-8 charset {@code str.getBytes(StandardCharsets.UTF_8).length}).
      * @throws IllegalStateException if the {@linkplain #scope() scope} associated with this segment is not
      * {@linkplain Scope#isAlive() alive}.
@@ -1093,7 +1093,7 @@ public sealed interface MemorySegment permits AbstractMemorySegmentImpl {
      * the first {@code '\0'} terminator character (assuming one is found).
      * @throws IllegalArgumentException      if the size of the string is greater than the largest string supported by the platform.
      * @throws IndexOutOfBoundsException     if {@code offset < 0}.
-     * @throws IndexOutOfBoundsException     if {@code offset} > byteSize() - (B + N)}, where:
+     * @throws IndexOutOfBoundsException     if {@code offset > byteSize() - (B + N)}, where:
      * <ul>
      *     <li>{@code B} is the size, in bytes, of the string encoded using the provided charset
      *     (e.g. {@code str.getBytes(charset).length});</li>
@@ -1123,7 +1123,7 @@ public sealed interface MemorySegment permits AbstractMemorySegmentImpl {
      *               the final address of this write operation can be expressed as {@code address() + offset}.
      * @param str the Java string to be written into this segment.
      * @throws IndexOutOfBoundsException     if {@code offset < 0}.
-     * @throws IndexOutOfBoundsException     if {@code offset} > byteSize() - (B + 1}, where {@code B} is the size,
+     * @throws IndexOutOfBoundsException     if {@code offset > byteSize() - (B + 1)}, where {@code B} is the size,
      * in bytes, of the string encoded using UTF-8 charset {@code str.getBytes(StandardCharsets.UTF_8).length}).
      * @throws IllegalStateException if the {@linkplain #scope() scope} associated with this segment is not
      * {@linkplain Scope#isAlive() alive}.
@@ -1154,7 +1154,7 @@ public sealed interface MemorySegment permits AbstractMemorySegmentImpl {
      * @param str     the Java string to be written into this segment.
      * @param charset the charset used to {@linkplain Charset#newEncoder() encode} the string bytes.
      * @throws IndexOutOfBoundsException     if {@code offset < 0}.
-     * @throws IndexOutOfBoundsException     if {@code offset} > byteSize() - (B + N)}, where:
+     * @throws IndexOutOfBoundsException     if {@code offset > byteSize() - (B + N)}, where:
      * <ul>
      *     <li>{@code B} is the size, in bytes, of the string encoded using the provided charset
      *     (e.g. {@code str.getBytes(charset).length});</li>


### PR DESCRIPTION
This PR fixes a bunch of issues found when running grammar code inspection in IntelliJ.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Reviewers
 * [Jorn Vernee](https://openjdk.org/census#jvernee) (@JornVernee - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/panama-foreign.git pull/873/head:pull/873` \
`$ git checkout pull/873`

Update a local copy of the PR: \
`$ git checkout pull/873` \
`$ git pull https://git.openjdk.org/panama-foreign.git pull/873/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 873`

View PR using the GUI difftool: \
`$ git pr show -t 873`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/panama-foreign/pull/873.diff">https://git.openjdk.org/panama-foreign/pull/873.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/panama-foreign/pull/873#issuecomment-1686455457)