### PR TITLE
8315041: Optimize Java to C string conversion by avoiding double copy

### DIFF
--- a/src/java.base/share/classes/java/lang/String.java
+++ b/src/java.base/share/classes/java/lang/String.java
@@ -28,6 +28,8 @@ package java.lang;
 import java.io.ObjectStreamField;
 import java.io.UnsupportedEncodingException;
 import java.lang.annotation.Native;
+import java.lang.foreign.MemorySegment;
+import java.lang.foreign.ValueLayout;
 import java.lang.invoke.MethodHandles;
 import java.lang.constant.Constable;
 import java.lang.constant.ConstantDesc;
@@ -1834,6 +1836,21 @@ public final class String
      */
     public byte[] getBytes() {
         return encode(Charset.defaultCharset(), coder(), value);
+    }
+
+    boolean bytesCompatible(Charset charset) {
+        if (coder == LATIN1 && charset == ISO_8859_1.INSTANCE) {
+            return true;
+        } else if (coder == LATIN1 && (charset == UTF_8.INSTANCE || charset == US_ASCII.INSTANCE) &&
+                !StringCoding.hasNegatives(value, 0, value.length)) {
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    void copyToSegmentRaw(MemorySegment segment, long offset) {
+        MemorySegment.copy(value, 0, segment, ValueLayout.JAVA_BYTE, offset, value.length);
     }
 
     /**

--- a/src/java.base/share/classes/java/lang/System.java
+++ b/src/java.base/share/classes/java/lang/System.java
@@ -35,6 +35,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.PrintStream;
 import java.lang.annotation.Annotation;
+import java.lang.foreign.MemorySegment;
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodType;
 import java.lang.invoke.StringConcatFactory;
@@ -87,7 +88,6 @@ import jdk.internal.vm.Continuation;
 import jdk.internal.vm.ContinuationScope;
 import jdk.internal.vm.StackableScope;
 import jdk.internal.vm.ThreadContainer;
-import jdk.internal.vm.annotation.ForceInline;
 import jdk.internal.vm.annotation.IntrinsicCandidate;
 import jdk.internal.vm.annotation.Stable;
 import sun.nio.fs.DefaultFileSystemProvider;
@@ -2664,6 +2664,16 @@ public final class System {
 
             public String getLoaderNameID(ClassLoader loader) {
                 return loader.nameAndId();
+            }
+
+            @Override
+            public void copyToSegmentRaw(String string, MemorySegment segment, long offset) {
+                string.copyToSegmentRaw(segment, offset);
+            }
+
+            @Override
+            public boolean bytesCompatible(String string, Charset charset) {
+                return string.bytesCompatible(charset);
             }
         });
     }

--- a/src/java.base/share/classes/java/lang/foreign/SegmentAllocator.java
+++ b/src/java.base/share/classes/java/lang/foreign/SegmentAllocator.java
@@ -125,11 +125,20 @@ public interface SegmentAllocator {
         Objects.requireNonNull(charset);
         Objects.requireNonNull(str);
         int termCharSize = StringSupport.CharsetKind.of(charset).terminatorCharSize();
-        byte[] bytes = str.getBytes(charset);
-        MemorySegment segment = allocateNoInit(bytes.length + termCharSize);
-        MemorySegment.copy(bytes, 0, segment, ValueLayout.JAVA_BYTE, 0, bytes.length);
+        MemorySegment segment;
+        int length;
+        if (StringSupport.bytesCompatible(str, charset)) {
+            length = str.length();
+            segment = allocateNoInit(length + termCharSize);
+            StringSupport.copyToSegmentRaw(str, segment, 0);
+        } else {
+            byte[] bytes = str.getBytes(charset);
+            length = bytes.length;
+            segment = allocateNoInit(bytes.length + termCharSize);
+            MemorySegment.copy(bytes, 0, segment, ValueLayout.JAVA_BYTE, 0, bytes.length);
+        }
         for (int i = 0 ; i < termCharSize ; i++) {
-            segment.set(ValueLayout.JAVA_BYTE, bytes.length + i, (byte)0);
+            segment.set(ValueLayout.JAVA_BYTE, length + i, (byte)0);
         }
         return segment;
     }

--- a/src/java.base/share/classes/jdk/internal/access/JavaLangAccess.java
+++ b/src/java.base/share/classes/jdk/internal/access/JavaLangAccess.java
@@ -27,6 +27,7 @@ package jdk.internal.access;
 
 import java.io.InputStream;
 import java.lang.annotation.Annotation;
+import java.lang.foreign.MemorySegment;
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodType;
 import java.lang.module.ModuleDescriptor;
@@ -574,4 +575,14 @@ public interface JavaLangAccess {
      * explicitly set otherwise <qualified-class-name> @<id>
      */
     String getLoaderNameID(ClassLoader loader);
+
+    /**
+     * Copy the string bytes to an existing segment, avoiding intermediate copies.
+     */
+    void copyToSegmentRaw(String string, MemorySegment segment, long offset);
+
+    /**
+     * Are the string bytes compatible with the given charset?
+     */
+    boolean bytesCompatible(String string, Charset charset);
 }

--- a/src/java.base/share/classes/jdk/internal/foreign/StringSupport.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/StringSupport.java
@@ -25,11 +25,15 @@
 
 package jdk.internal.foreign;
 
+import jdk.internal.access.JavaLangAccess;
+import jdk.internal.access.SharedSecrets;
 import jdk.internal.foreign.abi.SharedUtils;
 import jdk.internal.util.ArraysSupport;
+import sun.security.action.GetPropertyAction;
 
 import java.lang.foreign.MemorySegment;
 import java.nio.charset.Charset;
+import java.util.function.IntFunction;
 
 import static java.lang.foreign.ValueLayout.*;
 
@@ -37,6 +41,10 @@ import static java.lang.foreign.ValueLayout.*;
  * Miscellaneous functions to read and write strings, in various charsets.
  */
 public final class StringSupport {
+
+    static final JavaLangAccess JAVA_LANG_ACCESS = SharedSecrets.getJavaLangAccess();
+    public static final boolean SKIP_STRING_COPY = Boolean.parseBoolean(
+            GetPropertyAction.privilegedGetProperty("jdk.internal.foreign.StringSupport.SKIP_STRING_COPY", "true"));
 
     private StringSupport() {}
 
@@ -64,9 +72,8 @@ public final class StringSupport {
     }
 
     private static void writeByte(MemorySegment segment, long offset, Charset charset, String string) {
-        byte[] bytes = string.getBytes(charset);
-        MemorySegment.copy(bytes, 0, segment, JAVA_BYTE, offset, bytes.length);
-        segment.set(JAVA_BYTE, offset + bytes.length, (byte)0);
+        int bytes = copyBytes(string, segment, charset, offset);
+        segment.set(JAVA_BYTE, offset + bytes, (byte)0);
     }
 
     private static String readShort(MemorySegment segment, long offset, Charset charset) {
@@ -77,9 +84,8 @@ public final class StringSupport {
     }
 
     private static void writeShort(MemorySegment segment, long offset, Charset charset, String string) {
-        byte[] bytes = string.getBytes(charset);
-        MemorySegment.copy(bytes, 0, segment, JAVA_BYTE, offset, bytes.length);
-        segment.set(JAVA_SHORT, offset + bytes.length, (short)0);
+        int bytes = copyBytes(string, segment, charset, offset);
+        segment.set(JAVA_SHORT, offset + bytes, (short)0);
     }
 
     private static String readInt(MemorySegment segment, long offset, Charset charset) {
@@ -90,9 +96,8 @@ public final class StringSupport {
     }
 
     private static void writeInt(MemorySegment segment, long offset, Charset charset, String string) {
-        byte[] bytes = string.getBytes(charset);
-        MemorySegment.copy(bytes, 0, segment, JAVA_BYTE, offset, bytes.length);
-        segment.set(JAVA_INT, offset + bytes.length, 0);
+        int bytes = copyBytes(string, segment, charset, offset);
+        segment.set(JAVA_INT, offset + bytes, 0);
     }
 
     /**
@@ -302,6 +307,25 @@ public final class StringSupport {
                 throw new UnsupportedOperationException("Unsupported charset: " + charset);
             }
         }
+    }
+
+    public static boolean bytesCompatible(String string, Charset charset) {
+        return SKIP_STRING_COPY && JAVA_LANG_ACCESS.bytesCompatible(string, charset);
+    }
+
+    public static int copyBytes(String string, MemorySegment segment, Charset charset, long offset) {
+        if (bytesCompatible(string, charset)) {
+            copyToSegmentRaw(string, segment, offset);
+            return string.length();
+        } else {
+            byte[] bytes = string.getBytes(charset);
+            MemorySegment.copy(bytes, 0, segment, JAVA_BYTE, offset, bytes.length);
+            return bytes.length;
+        }
+    }
+
+    public static void copyToSegmentRaw(String string, MemorySegment segment, long offset) {
+        JAVA_LANG_ACCESS.copyToSegmentRaw(string, segment, offset);
     }
 
     private static IllegalArgumentException newIaeStringTooLarge() {


### PR DESCRIPTION
When converting a Java string to a C string, we need to call String::getBytes first, with the desired charset.
This will end up creating a temporary byte array where the decoded string chars are saved.
Now, the string implementation is already quite efficient, and in most cases, this will boil down to a simple call to the array's `clone` method.
That said, we could still avoid allocation of an intermediate buffer, if we know that the desired charset is compatible with the string's intenal byte representation.
For instance, if the string we want to convert has its coder set to `LATIN1` then:
* we can just use the raw bits if the desired coder is also `LATIN1`.
* if desired coder is either `ASCII` or `UTF8`, we can perform a quick check to see if all the bytes in the string are zero or positive. If so we can, again, just use the raw string bits.

Note that the method to determine whether the string bytes are positive (`StringCoder::countPositives`) is already a JVM intrinsics, and it is quite efficient. This means that calling this predicate will generally be faster than copying the entire string bytes into a new buffer.

This patch adds some logic to detect whether we can use the raw string bytes, and then a method which copies the string bytes into an existing segment. These two functionalities are added to `JavaLangAccess`.

It would have been possible to simplify the code by adding a single internal method to expose the raw string bytes, but we decided against it, given the potential for misuse (even inside the JDK itself).

