### PR TITLE
8315096: Allowed access modes in memory segment should depend on layout alignment

### DIFF
--- a/src/java.base/share/classes/java/lang/invoke/VarHandleSegmentViewBase.java
+++ b/src/java.base/share/classes/java/lang/invoke/VarHandleSegmentViewBase.java
@@ -56,4 +56,8 @@ abstract sealed class VarHandleSegmentViewBase extends VarHandle permits
     static IllegalArgumentException newIllegalArgumentExceptionForMisalignedAccess(long address) {
         return new IllegalArgumentException("Misaligned access at address: " + address);
     }
+
+    static UnsupportedOperationException newUnsupportedAccessModeForAlignment(long alignment) {
+        return new UnsupportedOperationException("Unsupported access mode for alignment: " + alignment);
+    }
 }

--- a/src/java.base/share/classes/java/lang/invoke/X-VarHandleSegmentView.java.template
+++ b/src/java.base/share/classes/java/lang/invoke/X-VarHandleSegmentView.java.template
@@ -43,7 +43,7 @@ final class VarHandleSegmentAs$Type$s extends VarHandleSegmentViewBase {
 
     static final ScopedMemoryAccess SCOPED_MEMORY_ACCESS = ScopedMemoryAccess.getScopedMemoryAccess();
 
-    static final int VM_ALIGN = $BoxType$.BYTES - 1;
+    static final int NON_PLAIN_ACCESS_MIN_ALIGN_MASK = $BoxType$.BYTES - 1;
 
     static final VarForm FORM = new VarForm(VarHandleSegmentAs$Type$s.class, MemorySegment.class, $type$.class, long.class);
 
@@ -104,16 +104,15 @@ final class VarHandleSegmentAs$Type$s extends VarHandleSegmentViewBase {
     }
 
     @ForceInline
-    static long offset(AbstractMemorySegmentImpl bb, long offset, long alignmentMask) {
-        long address = offsetNoVMAlignCheck(bb, offset, alignmentMask);
-        if ((address & VM_ALIGN) != 0) {
-            throw VarHandleSegmentViewBase.newIllegalArgumentExceptionForMisalignedAccess(address);
+    static long offsetNonPlain(AbstractMemorySegmentImpl bb, long offset, long alignmentMask) {
+        if ((alignmentMask & NON_PLAIN_ACCESS_MIN_ALIGN_MASK) != NON_PLAIN_ACCESS_MIN_ALIGN_MASK) {
+            throw VarHandleSegmentViewBase.newUnsupportedAccessModeForAlignment(alignmentMask + 1);
         }
-        return address;
+        return offsetPlain(bb, offset, alignmentMask);
     }
 
     @ForceInline
-    static long offsetNoVMAlignCheck(AbstractMemorySegmentImpl bb, long offset, long alignmentMask) {
+    static long offsetPlain(AbstractMemorySegmentImpl bb, long offset, long alignmentMask) {
         long base = bb.unsafeGetOffset();
         long address = base + offset;
         long maxAlignMask = bb.maxAlignMask();
@@ -130,18 +129,18 @@ final class VarHandleSegmentAs$Type$s extends VarHandleSegmentViewBase {
 #if[floatingPoint]
         $rawType$ rawValue = SCOPED_MEMORY_ACCESS.get$RawType$Unaligned(bb.sessionImpl(),
                 bb.unsafeGetBase(),
-                offsetNoVMAlignCheck(bb, base, handle.alignmentMask),
+                offsetPlain(bb, base, handle.alignmentMask),
                 handle.be);
         return $Type$.$rawType$BitsTo$Type$(rawValue);
 #else[floatingPoint]
 #if[byte]
         return SCOPED_MEMORY_ACCESS.get$Type$(bb.sessionImpl(),
                 bb.unsafeGetBase(),
-                offsetNoVMAlignCheck(bb, base, handle.alignmentMask));
+                offsetPlain(bb, base, handle.alignmentMask));
 #else[byte]
         return SCOPED_MEMORY_ACCESS.get$Type$Unaligned(bb.sessionImpl(),
                 bb.unsafeGetBase(),
-                offsetNoVMAlignCheck(bb, base, handle.alignmentMask),
+                offsetPlain(bb, base, handle.alignmentMask),
                 handle.be);
 #end[byte]
 #end[floatingPoint]
@@ -154,19 +153,19 @@ final class VarHandleSegmentAs$Type$s extends VarHandleSegmentViewBase {
 #if[floatingPoint]
         SCOPED_MEMORY_ACCESS.put$RawType$Unaligned(bb.sessionImpl(),
                 bb.unsafeGetBase(),
-                offsetNoVMAlignCheck(bb, base, handle.alignmentMask),
+                offsetPlain(bb, base, handle.alignmentMask),
                 $Type$.$type$ToRaw$RawType$Bits(value),
                 handle.be);
 #else[floatingPoint]
 #if[byte]
         SCOPED_MEMORY_ACCESS.put$Type$(bb.sessionImpl(),
                 bb.unsafeGetBase(),
-                offsetNoVMAlignCheck(bb, base, handle.alignmentMask),
+                offsetPlain(bb, base, handle.alignmentMask),
                 value);
 #else[byte]
         SCOPED_MEMORY_ACCESS.put$Type$Unaligned(bb.sessionImpl(),
                 bb.unsafeGetBase(),
-                offsetNoVMAlignCheck(bb, base, handle.alignmentMask),
+                offsetPlain(bb, base, handle.alignmentMask),
                 value,
                 handle.be);
 #end[byte]
@@ -180,7 +179,7 @@ final class VarHandleSegmentAs$Type$s extends VarHandleSegmentViewBase {
         return convEndian(handle.be,
                           SCOPED_MEMORY_ACCESS.get$RawType$Volatile(bb.sessionImpl(),
                                   bb.unsafeGetBase(),
-                                  offset(bb, base, handle.alignmentMask)));
+                                   offsetNonPlain(bb, base, handle.alignmentMask)));
     }
 
     @ForceInline
@@ -189,7 +188,7 @@ final class VarHandleSegmentAs$Type$s extends VarHandleSegmentViewBase {
         AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, false);
         SCOPED_MEMORY_ACCESS.put$RawType$Volatile(bb.sessionImpl(),
                 bb.unsafeGetBase(),
-                offset(bb, base, handle.alignmentMask),
+                 offsetNonPlain(bb, base, handle.alignmentMask),
                 convEndian(handle.be, value));
     }
 
@@ -200,7 +199,7 @@ final class VarHandleSegmentAs$Type$s extends VarHandleSegmentViewBase {
         return convEndian(handle.be,
                           SCOPED_MEMORY_ACCESS.get$RawType$Acquire(bb.sessionImpl(),
                                   bb.unsafeGetBase(),
-                                  offset(bb, base, handle.alignmentMask)));
+                                   offsetNonPlain(bb, base, handle.alignmentMask)));
     }
 
     @ForceInline
@@ -209,7 +208,7 @@ final class VarHandleSegmentAs$Type$s extends VarHandleSegmentViewBase {
         AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, false);
         SCOPED_MEMORY_ACCESS.put$RawType$Release(bb.sessionImpl(),
                 bb.unsafeGetBase(),
-                offset(bb, base, handle.alignmentMask),
+                 offsetNonPlain(bb, base, handle.alignmentMask),
                 convEndian(handle.be, value));
     }
 
@@ -220,7 +219,7 @@ final class VarHandleSegmentAs$Type$s extends VarHandleSegmentViewBase {
         return convEndian(handle.be,
                           SCOPED_MEMORY_ACCESS.get$RawType$Opaque(bb.sessionImpl(),
                                   bb.unsafeGetBase(),
-                                  offset(bb, base, handle.alignmentMask)));
+                                   offsetNonPlain(bb, base, handle.alignmentMask)));
     }
 
     @ForceInline
@@ -229,7 +228,7 @@ final class VarHandleSegmentAs$Type$s extends VarHandleSegmentViewBase {
         AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, false);
         SCOPED_MEMORY_ACCESS.put$RawType$Opaque(bb.sessionImpl(),
                 bb.unsafeGetBase(),
-                offset(bb, base, handle.alignmentMask),
+                 offsetNonPlain(bb, base, handle.alignmentMask),
                 convEndian(handle.be, value));
     }
 #if[CAS]
@@ -240,7 +239,7 @@ final class VarHandleSegmentAs$Type$s extends VarHandleSegmentViewBase {
         AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, false);
         return SCOPED_MEMORY_ACCESS.compareAndSet$RawType$(bb.sessionImpl(),
                 bb.unsafeGetBase(),
-                offset(bb, base, handle.alignmentMask),
+                 offsetNonPlain(bb, base, handle.alignmentMask),
                 convEndian(handle.be, expected), convEndian(handle.be, value));
     }
 
@@ -251,7 +250,7 @@ final class VarHandleSegmentAs$Type$s extends VarHandleSegmentViewBase {
         return convEndian(handle.be,
                           SCOPED_MEMORY_ACCESS.compareAndExchange$RawType$(bb.sessionImpl(),
                                   bb.unsafeGetBase(),
-                                  offset(bb, base, handle.alignmentMask),
+                                   offsetNonPlain(bb, base, handle.alignmentMask),
                                   convEndian(handle.be, expected), convEndian(handle.be, value)));
     }
 
@@ -262,7 +261,7 @@ final class VarHandleSegmentAs$Type$s extends VarHandleSegmentViewBase {
         return convEndian(handle.be,
                           SCOPED_MEMORY_ACCESS.compareAndExchange$RawType$Acquire(bb.sessionImpl(),
                                   bb.unsafeGetBase(),
-                                  offset(bb, base, handle.alignmentMask),
+                                   offsetNonPlain(bb, base, handle.alignmentMask),
                                   convEndian(handle.be, expected), convEndian(handle.be, value)));
     }
 
@@ -273,7 +272,7 @@ final class VarHandleSegmentAs$Type$s extends VarHandleSegmentViewBase {
         return convEndian(handle.be,
                           SCOPED_MEMORY_ACCESS.compareAndExchange$RawType$Release(bb.sessionImpl(),
                                   bb.unsafeGetBase(),
-                                  offset(bb, base, handle.alignmentMask),
+                                   offsetNonPlain(bb, base, handle.alignmentMask),
                                   convEndian(handle.be, expected), convEndian(handle.be, value)));
     }
 
@@ -283,7 +282,7 @@ final class VarHandleSegmentAs$Type$s extends VarHandleSegmentViewBase {
         AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, false);
         return SCOPED_MEMORY_ACCESS.weakCompareAndSet$RawType$Plain(bb.sessionImpl(),
                 bb.unsafeGetBase(),
-                offset(bb, base, handle.alignmentMask),
+                 offsetNonPlain(bb, base, handle.alignmentMask),
                 convEndian(handle.be, expected), convEndian(handle.be, value));
     }
 
@@ -293,7 +292,7 @@ final class VarHandleSegmentAs$Type$s extends VarHandleSegmentViewBase {
         AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, false);
         return SCOPED_MEMORY_ACCESS.weakCompareAndSet$RawType$(bb.sessionImpl(),
                 bb.unsafeGetBase(),
-                offset(bb, base, handle.alignmentMask),
+                 offsetNonPlain(bb, base, handle.alignmentMask),
                 convEndian(handle.be, expected), convEndian(handle.be, value));
     }
 
@@ -303,7 +302,7 @@ final class VarHandleSegmentAs$Type$s extends VarHandleSegmentViewBase {
         AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, false);
         return SCOPED_MEMORY_ACCESS.weakCompareAndSet$RawType$Acquire(bb.sessionImpl(),
                 bb.unsafeGetBase(),
-                offset(bb, base, handle.alignmentMask),
+                 offsetNonPlain(bb, base, handle.alignmentMask),
                 convEndian(handle.be, expected), convEndian(handle.be, value));
     }
 
@@ -313,7 +312,7 @@ final class VarHandleSegmentAs$Type$s extends VarHandleSegmentViewBase {
         AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, false);
         return SCOPED_MEMORY_ACCESS.weakCompareAndSet$RawType$Release(bb.sessionImpl(),
                 bb.unsafeGetBase(),
-                offset(bb, base, handle.alignmentMask),
+                 offsetNonPlain(bb, base, handle.alignmentMask),
                 convEndian(handle.be, expected), convEndian(handle.be, value));
     }
 
@@ -324,7 +323,7 @@ final class VarHandleSegmentAs$Type$s extends VarHandleSegmentViewBase {
         return convEndian(handle.be,
                           SCOPED_MEMORY_ACCESS.getAndSet$RawType$(bb.sessionImpl(),
                                   bb.unsafeGetBase(),
-                                  offset(bb, base, handle.alignmentMask),
+                                   offsetNonPlain(bb, base, handle.alignmentMask),
                                   convEndian(handle.be, value)));
     }
 
@@ -335,7 +334,7 @@ final class VarHandleSegmentAs$Type$s extends VarHandleSegmentViewBase {
         return convEndian(handle.be,
                           SCOPED_MEMORY_ACCESS.getAndSet$RawType$Acquire(bb.sessionImpl(),
                                   bb.unsafeGetBase(),
-                                  offset(bb, base, handle.alignmentMask),
+                                   offsetNonPlain(bb, base, handle.alignmentMask),
                                   convEndian(handle.be, value)));
     }
 
@@ -346,7 +345,7 @@ final class VarHandleSegmentAs$Type$s extends VarHandleSegmentViewBase {
         return convEndian(handle.be,
                           SCOPED_MEMORY_ACCESS.getAndSet$RawType$Release(bb.sessionImpl(),
                                   bb.unsafeGetBase(),
-                                  offset(bb, base, handle.alignmentMask),
+                                   offsetNonPlain(bb, base, handle.alignmentMask),
                                   convEndian(handle.be, value)));
     }
 #end[CAS]
@@ -359,10 +358,10 @@ final class VarHandleSegmentAs$Type$s extends VarHandleSegmentViewBase {
         if (handle.be == BE) {
             return SCOPED_MEMORY_ACCESS.getAndAdd$RawType$(bb.sessionImpl(),
                     bb.unsafeGetBase(),
-                    offset(bb, base, handle.alignmentMask),
+                     offsetNonPlain(bb, base, handle.alignmentMask),
                     delta);
         } else {
-            return getAndAddConvEndianWithCAS(bb, offset(bb, base, handle.alignmentMask), delta);
+            return getAndAddConvEndianWithCAS(bb,  offsetNonPlain(bb, base, handle.alignmentMask), delta);
         }
     }
 
@@ -373,10 +372,10 @@ final class VarHandleSegmentAs$Type$s extends VarHandleSegmentViewBase {
         if (handle.be == BE) {
             return SCOPED_MEMORY_ACCESS.getAndAdd$RawType$Acquire(bb.sessionImpl(),
                     bb.unsafeGetBase(),
-                    offset(bb, base, handle.alignmentMask),
+                     offsetNonPlain(bb, base, handle.alignmentMask),
                     delta);
         } else {
-            return getAndAddConvEndianWithCAS(bb, offset(bb, base, handle.alignmentMask), delta);
+            return getAndAddConvEndianWithCAS(bb,  offsetNonPlain(bb, base, handle.alignmentMask), delta);
         }
     }
 
@@ -387,10 +386,10 @@ final class VarHandleSegmentAs$Type$s extends VarHandleSegmentViewBase {
         if (handle.be == BE) {
             return SCOPED_MEMORY_ACCESS.getAndAdd$RawType$Release(bb.sessionImpl(),
                     bb.unsafeGetBase(),
-                    offset(bb, base, handle.alignmentMask),
+                     offsetNonPlain(bb, base, handle.alignmentMask),
                     delta);
         } else {
-            return getAndAddConvEndianWithCAS(bb, offset(bb, base, handle.alignmentMask), delta);
+            return getAndAddConvEndianWithCAS(bb,  offsetNonPlain(bb, base, handle.alignmentMask), delta);
         }
     }
 
@@ -415,10 +414,10 @@ final class VarHandleSegmentAs$Type$s extends VarHandleSegmentViewBase {
         if (handle.be == BE) {
             return SCOPED_MEMORY_ACCESS.getAndBitwiseOr$RawType$(bb.sessionImpl(),
                     bb.unsafeGetBase(),
-                    offset(bb, base, handle.alignmentMask),
+                     offsetNonPlain(bb, base, handle.alignmentMask),
                     value);
         } else {
-            return getAndBitwiseOrConvEndianWithCAS(bb, offset(bb, base, handle.alignmentMask), value);
+            return getAndBitwiseOrConvEndianWithCAS(bb,  offsetNonPlain(bb, base, handle.alignmentMask), value);
         }
     }
 
@@ -429,10 +428,10 @@ final class VarHandleSegmentAs$Type$s extends VarHandleSegmentViewBase {
         if (handle.be == BE) {
             return SCOPED_MEMORY_ACCESS.getAndBitwiseOr$RawType$Release(bb.sessionImpl(),
                     bb.unsafeGetBase(),
-                    offset(bb, base, handle.alignmentMask),
+                     offsetNonPlain(bb, base, handle.alignmentMask),
                     value);
         } else {
-            return getAndBitwiseOrConvEndianWithCAS(bb, offset(bb, base, handle.alignmentMask), value);
+            return getAndBitwiseOrConvEndianWithCAS(bb,  offsetNonPlain(bb, base, handle.alignmentMask), value);
         }
     }
 
@@ -443,10 +442,10 @@ final class VarHandleSegmentAs$Type$s extends VarHandleSegmentViewBase {
         if (handle.be == BE) {
             return SCOPED_MEMORY_ACCESS.getAndBitwiseOr$RawType$Acquire(bb.sessionImpl(),
                     bb.unsafeGetBase(),
-                    offset(bb, base, handle.alignmentMask),
+                     offsetNonPlain(bb, base, handle.alignmentMask),
                     value);
         } else {
-            return getAndBitwiseOrConvEndianWithCAS(bb, offset(bb, base, handle.alignmentMask), value);
+            return getAndBitwiseOrConvEndianWithCAS(bb,  offsetNonPlain(bb, base, handle.alignmentMask), value);
         }
     }
 
@@ -469,10 +468,10 @@ final class VarHandleSegmentAs$Type$s extends VarHandleSegmentViewBase {
         if (handle.be == BE) {
             return SCOPED_MEMORY_ACCESS.getAndBitwiseAnd$RawType$(bb.sessionImpl(),
                     bb.unsafeGetBase(),
-                    offset(bb, base, handle.alignmentMask),
+                     offsetNonPlain(bb, base, handle.alignmentMask),
                     value);
         } else {
-            return getAndBitwiseAndConvEndianWithCAS(bb, offset(bb, base, handle.alignmentMask), value);
+            return getAndBitwiseAndConvEndianWithCAS(bb,  offsetNonPlain(bb, base, handle.alignmentMask), value);
         }
     }
 
@@ -483,10 +482,10 @@ final class VarHandleSegmentAs$Type$s extends VarHandleSegmentViewBase {
         if (handle.be == BE) {
             return SCOPED_MEMORY_ACCESS.getAndBitwiseAnd$RawType$Release(bb.sessionImpl(),
                     bb.unsafeGetBase(),
-                    offset(bb, base, handle.alignmentMask),
+                     offsetNonPlain(bb, base, handle.alignmentMask),
                     value);
         } else {
-            return getAndBitwiseAndConvEndianWithCAS(bb, offset(bb, base, handle.alignmentMask), value);
+            return getAndBitwiseAndConvEndianWithCAS(bb,  offsetNonPlain(bb, base, handle.alignmentMask), value);
         }
     }
 
@@ -497,10 +496,10 @@ final class VarHandleSegmentAs$Type$s extends VarHandleSegmentViewBase {
         if (handle.be == BE) {
             return SCOPED_MEMORY_ACCESS.getAndBitwiseAnd$RawType$Acquire(bb.sessionImpl(),
                     bb.unsafeGetBase(),
-                    offset(bb, base, handle.alignmentMask),
+                     offsetNonPlain(bb, base, handle.alignmentMask),
                     value);
         } else {
-            return getAndBitwiseAndConvEndianWithCAS(bb, offset(bb, base, handle.alignmentMask), value);
+            return getAndBitwiseAndConvEndianWithCAS(bb,  offsetNonPlain(bb, base, handle.alignmentMask), value);
         }
     }
 
@@ -524,10 +523,10 @@ final class VarHandleSegmentAs$Type$s extends VarHandleSegmentViewBase {
         if (handle.be == BE) {
             return SCOPED_MEMORY_ACCESS.getAndBitwiseXor$RawType$(bb.sessionImpl(),
                     bb.unsafeGetBase(),
-                    offset(bb, base, handle.alignmentMask),
+                     offsetNonPlain(bb, base, handle.alignmentMask),
                     value);
         } else {
-            return getAndBitwiseXorConvEndianWithCAS(bb, offset(bb, base, handle.alignmentMask), value);
+            return getAndBitwiseXorConvEndianWithCAS(bb,  offsetNonPlain(bb, base, handle.alignmentMask), value);
         }
     }
 
@@ -538,10 +537,10 @@ final class VarHandleSegmentAs$Type$s extends VarHandleSegmentViewBase {
         if (handle.be == BE) {
             return SCOPED_MEMORY_ACCESS.getAndBitwiseXor$RawType$Release(bb.sessionImpl(),
                     bb.unsafeGetBase(),
-                    offset(bb, base, handle.alignmentMask),
+                     offsetNonPlain(bb, base, handle.alignmentMask),
                     value);
         } else {
-            return getAndBitwiseXorConvEndianWithCAS(bb, offset(bb, base, handle.alignmentMask), value);
+            return getAndBitwiseXorConvEndianWithCAS(bb,  offsetNonPlain(bb, base, handle.alignmentMask), value);
         }
     }
 
@@ -552,10 +551,10 @@ final class VarHandleSegmentAs$Type$s extends VarHandleSegmentViewBase {
         if (handle.be == BE) {
             return SCOPED_MEMORY_ACCESS.getAndBitwiseXor$RawType$Acquire(bb.sessionImpl(),
                     bb.unsafeGetBase(),
-                    offset(bb, base, handle.alignmentMask),
+                     offsetNonPlain(bb, base, handle.alignmentMask),
                     value);
         } else {
-            return getAndBitwiseXorConvEndianWithCAS(bb, offset(bb, base, handle.alignmentMask), value);
+            return getAndBitwiseXorConvEndianWithCAS(bb,  offsetNonPlain(bb, base, handle.alignmentMask), value);
         }
     }
 

--- a/src/java.base/share/classes/java/lang/invoke/X-VarHandleSegmentView.java.template
+++ b/src/java.base/share/classes/java/lang/invoke/X-VarHandleSegmentView.java.template
@@ -179,7 +179,7 @@ final class VarHandleSegmentAs$Type$s extends VarHandleSegmentViewBase {
         return convEndian(handle.be,
                           SCOPED_MEMORY_ACCESS.get$RawType$Volatile(bb.sessionImpl(),
                                   bb.unsafeGetBase(),
-                                   offsetNonPlain(bb, base, handle.alignmentMask)));
+                                  offsetNonPlain(bb, base, handle.alignmentMask)));
     }
 
     @ForceInline
@@ -188,7 +188,7 @@ final class VarHandleSegmentAs$Type$s extends VarHandleSegmentViewBase {
         AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, false);
         SCOPED_MEMORY_ACCESS.put$RawType$Volatile(bb.sessionImpl(),
                 bb.unsafeGetBase(),
-                 offsetNonPlain(bb, base, handle.alignmentMask),
+                offsetNonPlain(bb, base, handle.alignmentMask),
                 convEndian(handle.be, value));
     }
 
@@ -199,7 +199,7 @@ final class VarHandleSegmentAs$Type$s extends VarHandleSegmentViewBase {
         return convEndian(handle.be,
                           SCOPED_MEMORY_ACCESS.get$RawType$Acquire(bb.sessionImpl(),
                                   bb.unsafeGetBase(),
-                                   offsetNonPlain(bb, base, handle.alignmentMask)));
+                                  offsetNonPlain(bb, base, handle.alignmentMask)));
     }
 
     @ForceInline
@@ -208,7 +208,7 @@ final class VarHandleSegmentAs$Type$s extends VarHandleSegmentViewBase {
         AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, false);
         SCOPED_MEMORY_ACCESS.put$RawType$Release(bb.sessionImpl(),
                 bb.unsafeGetBase(),
-                 offsetNonPlain(bb, base, handle.alignmentMask),
+                offsetNonPlain(bb, base, handle.alignmentMask),
                 convEndian(handle.be, value));
     }
 
@@ -219,7 +219,7 @@ final class VarHandleSegmentAs$Type$s extends VarHandleSegmentViewBase {
         return convEndian(handle.be,
                           SCOPED_MEMORY_ACCESS.get$RawType$Opaque(bb.sessionImpl(),
                                   bb.unsafeGetBase(),
-                                   offsetNonPlain(bb, base, handle.alignmentMask)));
+                                  offsetNonPlain(bb, base, handle.alignmentMask)));
     }
 
     @ForceInline
@@ -228,7 +228,7 @@ final class VarHandleSegmentAs$Type$s extends VarHandleSegmentViewBase {
         AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, false);
         SCOPED_MEMORY_ACCESS.put$RawType$Opaque(bb.sessionImpl(),
                 bb.unsafeGetBase(),
-                 offsetNonPlain(bb, base, handle.alignmentMask),
+                offsetNonPlain(bb, base, handle.alignmentMask),
                 convEndian(handle.be, value));
     }
 #if[CAS]
@@ -239,7 +239,7 @@ final class VarHandleSegmentAs$Type$s extends VarHandleSegmentViewBase {
         AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, false);
         return SCOPED_MEMORY_ACCESS.compareAndSet$RawType$(bb.sessionImpl(),
                 bb.unsafeGetBase(),
-                 offsetNonPlain(bb, base, handle.alignmentMask),
+                offsetNonPlain(bb, base, handle.alignmentMask),
                 convEndian(handle.be, expected), convEndian(handle.be, value));
     }
 
@@ -250,7 +250,7 @@ final class VarHandleSegmentAs$Type$s extends VarHandleSegmentViewBase {
         return convEndian(handle.be,
                           SCOPED_MEMORY_ACCESS.compareAndExchange$RawType$(bb.sessionImpl(),
                                   bb.unsafeGetBase(),
-                                   offsetNonPlain(bb, base, handle.alignmentMask),
+                                  offsetNonPlain(bb, base, handle.alignmentMask),
                                   convEndian(handle.be, expected), convEndian(handle.be, value)));
     }
 
@@ -261,7 +261,7 @@ final class VarHandleSegmentAs$Type$s extends VarHandleSegmentViewBase {
         return convEndian(handle.be,
                           SCOPED_MEMORY_ACCESS.compareAndExchange$RawType$Acquire(bb.sessionImpl(),
                                   bb.unsafeGetBase(),
-                                   offsetNonPlain(bb, base, handle.alignmentMask),
+                                  offsetNonPlain(bb, base, handle.alignmentMask),
                                   convEndian(handle.be, expected), convEndian(handle.be, value)));
     }
 
@@ -272,7 +272,7 @@ final class VarHandleSegmentAs$Type$s extends VarHandleSegmentViewBase {
         return convEndian(handle.be,
                           SCOPED_MEMORY_ACCESS.compareAndExchange$RawType$Release(bb.sessionImpl(),
                                   bb.unsafeGetBase(),
-                                   offsetNonPlain(bb, base, handle.alignmentMask),
+                                  offsetNonPlain(bb, base, handle.alignmentMask),
                                   convEndian(handle.be, expected), convEndian(handle.be, value)));
     }
 
@@ -282,7 +282,7 @@ final class VarHandleSegmentAs$Type$s extends VarHandleSegmentViewBase {
         AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, false);
         return SCOPED_MEMORY_ACCESS.weakCompareAndSet$RawType$Plain(bb.sessionImpl(),
                 bb.unsafeGetBase(),
-                 offsetNonPlain(bb, base, handle.alignmentMask),
+                offsetNonPlain(bb, base, handle.alignmentMask),
                 convEndian(handle.be, expected), convEndian(handle.be, value));
     }
 
@@ -292,7 +292,7 @@ final class VarHandleSegmentAs$Type$s extends VarHandleSegmentViewBase {
         AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, false);
         return SCOPED_MEMORY_ACCESS.weakCompareAndSet$RawType$(bb.sessionImpl(),
                 bb.unsafeGetBase(),
-                 offsetNonPlain(bb, base, handle.alignmentMask),
+                offsetNonPlain(bb, base, handle.alignmentMask),
                 convEndian(handle.be, expected), convEndian(handle.be, value));
     }
 
@@ -302,7 +302,7 @@ final class VarHandleSegmentAs$Type$s extends VarHandleSegmentViewBase {
         AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, false);
         return SCOPED_MEMORY_ACCESS.weakCompareAndSet$RawType$Acquire(bb.sessionImpl(),
                 bb.unsafeGetBase(),
-                 offsetNonPlain(bb, base, handle.alignmentMask),
+                offsetNonPlain(bb, base, handle.alignmentMask),
                 convEndian(handle.be, expected), convEndian(handle.be, value));
     }
 
@@ -312,7 +312,7 @@ final class VarHandleSegmentAs$Type$s extends VarHandleSegmentViewBase {
         AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, false);
         return SCOPED_MEMORY_ACCESS.weakCompareAndSet$RawType$Release(bb.sessionImpl(),
                 bb.unsafeGetBase(),
-                 offsetNonPlain(bb, base, handle.alignmentMask),
+                offsetNonPlain(bb, base, handle.alignmentMask),
                 convEndian(handle.be, expected), convEndian(handle.be, value));
     }
 
@@ -323,7 +323,7 @@ final class VarHandleSegmentAs$Type$s extends VarHandleSegmentViewBase {
         return convEndian(handle.be,
                           SCOPED_MEMORY_ACCESS.getAndSet$RawType$(bb.sessionImpl(),
                                   bb.unsafeGetBase(),
-                                   offsetNonPlain(bb, base, handle.alignmentMask),
+                                  offsetNonPlain(bb, base, handle.alignmentMask),
                                   convEndian(handle.be, value)));
     }
 
@@ -334,7 +334,7 @@ final class VarHandleSegmentAs$Type$s extends VarHandleSegmentViewBase {
         return convEndian(handle.be,
                           SCOPED_MEMORY_ACCESS.getAndSet$RawType$Acquire(bb.sessionImpl(),
                                   bb.unsafeGetBase(),
-                                   offsetNonPlain(bb, base, handle.alignmentMask),
+                                  offsetNonPlain(bb, base, handle.alignmentMask),
                                   convEndian(handle.be, value)));
     }
 
@@ -345,7 +345,7 @@ final class VarHandleSegmentAs$Type$s extends VarHandleSegmentViewBase {
         return convEndian(handle.be,
                           SCOPED_MEMORY_ACCESS.getAndSet$RawType$Release(bb.sessionImpl(),
                                   bb.unsafeGetBase(),
-                                   offsetNonPlain(bb, base, handle.alignmentMask),
+                                  offsetNonPlain(bb, base, handle.alignmentMask),
                                   convEndian(handle.be, value)));
     }
 #end[CAS]
@@ -358,10 +358,10 @@ final class VarHandleSegmentAs$Type$s extends VarHandleSegmentViewBase {
         if (handle.be == BE) {
             return SCOPED_MEMORY_ACCESS.getAndAdd$RawType$(bb.sessionImpl(),
                     bb.unsafeGetBase(),
-                     offsetNonPlain(bb, base, handle.alignmentMask),
+                    offsetNonPlain(bb, base, handle.alignmentMask),
                     delta);
         } else {
-            return getAndAddConvEndianWithCAS(bb,  offsetNonPlain(bb, base, handle.alignmentMask), delta);
+            return getAndAddConvEndianWithCAS(bb, offsetNonPlain(bb, base, handle.alignmentMask), delta);
         }
     }
 
@@ -372,10 +372,10 @@ final class VarHandleSegmentAs$Type$s extends VarHandleSegmentViewBase {
         if (handle.be == BE) {
             return SCOPED_MEMORY_ACCESS.getAndAdd$RawType$Acquire(bb.sessionImpl(),
                     bb.unsafeGetBase(),
-                     offsetNonPlain(bb, base, handle.alignmentMask),
+                    offsetNonPlain(bb, base, handle.alignmentMask),
                     delta);
         } else {
-            return getAndAddConvEndianWithCAS(bb,  offsetNonPlain(bb, base, handle.alignmentMask), delta);
+            return getAndAddConvEndianWithCAS(bb, offsetNonPlain(bb, base, handle.alignmentMask), delta);
         }
     }
 
@@ -386,10 +386,10 @@ final class VarHandleSegmentAs$Type$s extends VarHandleSegmentViewBase {
         if (handle.be == BE) {
             return SCOPED_MEMORY_ACCESS.getAndAdd$RawType$Release(bb.sessionImpl(),
                     bb.unsafeGetBase(),
-                     offsetNonPlain(bb, base, handle.alignmentMask),
+                    offsetNonPlain(bb, base, handle.alignmentMask),
                     delta);
         } else {
-            return getAndAddConvEndianWithCAS(bb,  offsetNonPlain(bb, base, handle.alignmentMask), delta);
+            return getAndAddConvEndianWithCAS(bb, offsetNonPlain(bb, base, handle.alignmentMask), delta);
         }
     }
 
@@ -414,10 +414,10 @@ final class VarHandleSegmentAs$Type$s extends VarHandleSegmentViewBase {
         if (handle.be == BE) {
             return SCOPED_MEMORY_ACCESS.getAndBitwiseOr$RawType$(bb.sessionImpl(),
                     bb.unsafeGetBase(),
-                     offsetNonPlain(bb, base, handle.alignmentMask),
+                    offsetNonPlain(bb, base, handle.alignmentMask),
                     value);
         } else {
-            return getAndBitwiseOrConvEndianWithCAS(bb,  offsetNonPlain(bb, base, handle.alignmentMask), value);
+            return getAndBitwiseOrConvEndianWithCAS(bb, offsetNonPlain(bb, base, handle.alignmentMask), value);
         }
     }
 
@@ -428,10 +428,10 @@ final class VarHandleSegmentAs$Type$s extends VarHandleSegmentViewBase {
         if (handle.be == BE) {
             return SCOPED_MEMORY_ACCESS.getAndBitwiseOr$RawType$Release(bb.sessionImpl(),
                     bb.unsafeGetBase(),
-                     offsetNonPlain(bb, base, handle.alignmentMask),
+                    offsetNonPlain(bb, base, handle.alignmentMask),
                     value);
         } else {
-            return getAndBitwiseOrConvEndianWithCAS(bb,  offsetNonPlain(bb, base, handle.alignmentMask), value);
+            return getAndBitwiseOrConvEndianWithCAS(bb, offsetNonPlain(bb, base, handle.alignmentMask), value);
         }
     }
 
@@ -442,10 +442,10 @@ final class VarHandleSegmentAs$Type$s extends VarHandleSegmentViewBase {
         if (handle.be == BE) {
             return SCOPED_MEMORY_ACCESS.getAndBitwiseOr$RawType$Acquire(bb.sessionImpl(),
                     bb.unsafeGetBase(),
-                     offsetNonPlain(bb, base, handle.alignmentMask),
+                    offsetNonPlain(bb, base, handle.alignmentMask),
                     value);
         } else {
-            return getAndBitwiseOrConvEndianWithCAS(bb,  offsetNonPlain(bb, base, handle.alignmentMask), value);
+            return getAndBitwiseOrConvEndianWithCAS(bb, offsetNonPlain(bb, base, handle.alignmentMask), value);
         }
     }
 
@@ -468,10 +468,10 @@ final class VarHandleSegmentAs$Type$s extends VarHandleSegmentViewBase {
         if (handle.be == BE) {
             return SCOPED_MEMORY_ACCESS.getAndBitwiseAnd$RawType$(bb.sessionImpl(),
                     bb.unsafeGetBase(),
-                     offsetNonPlain(bb, base, handle.alignmentMask),
+                    offsetNonPlain(bb, base, handle.alignmentMask),
                     value);
         } else {
-            return getAndBitwiseAndConvEndianWithCAS(bb,  offsetNonPlain(bb, base, handle.alignmentMask), value);
+            return getAndBitwiseAndConvEndianWithCAS(bb, offsetNonPlain(bb, base, handle.alignmentMask), value);
         }
     }
 
@@ -482,10 +482,10 @@ final class VarHandleSegmentAs$Type$s extends VarHandleSegmentViewBase {
         if (handle.be == BE) {
             return SCOPED_MEMORY_ACCESS.getAndBitwiseAnd$RawType$Release(bb.sessionImpl(),
                     bb.unsafeGetBase(),
-                     offsetNonPlain(bb, base, handle.alignmentMask),
+                    offsetNonPlain(bb, base, handle.alignmentMask),
                     value);
         } else {
-            return getAndBitwiseAndConvEndianWithCAS(bb,  offsetNonPlain(bb, base, handle.alignmentMask), value);
+            return getAndBitwiseAndConvEndianWithCAS(bb, offsetNonPlain(bb, base, handle.alignmentMask), value);
         }
     }
 
@@ -496,10 +496,10 @@ final class VarHandleSegmentAs$Type$s extends VarHandleSegmentViewBase {
         if (handle.be == BE) {
             return SCOPED_MEMORY_ACCESS.getAndBitwiseAnd$RawType$Acquire(bb.sessionImpl(),
                     bb.unsafeGetBase(),
-                     offsetNonPlain(bb, base, handle.alignmentMask),
+                    offsetNonPlain(bb, base, handle.alignmentMask),
                     value);
         } else {
-            return getAndBitwiseAndConvEndianWithCAS(bb,  offsetNonPlain(bb, base, handle.alignmentMask), value);
+            return getAndBitwiseAndConvEndianWithCAS(bb, offsetNonPlain(bb, base, handle.alignmentMask), value);
         }
     }
 
@@ -523,10 +523,10 @@ final class VarHandleSegmentAs$Type$s extends VarHandleSegmentViewBase {
         if (handle.be == BE) {
             return SCOPED_MEMORY_ACCESS.getAndBitwiseXor$RawType$(bb.sessionImpl(),
                     bb.unsafeGetBase(),
-                     offsetNonPlain(bb, base, handle.alignmentMask),
+                    offsetNonPlain(bb, base, handle.alignmentMask),
                     value);
         } else {
-            return getAndBitwiseXorConvEndianWithCAS(bb,  offsetNonPlain(bb, base, handle.alignmentMask), value);
+            return getAndBitwiseXorConvEndianWithCAS(bb, offsetNonPlain(bb, base, handle.alignmentMask), value);
         }
     }
 
@@ -537,10 +537,10 @@ final class VarHandleSegmentAs$Type$s extends VarHandleSegmentViewBase {
         if (handle.be == BE) {
             return SCOPED_MEMORY_ACCESS.getAndBitwiseXor$RawType$Release(bb.sessionImpl(),
                     bb.unsafeGetBase(),
-                     offsetNonPlain(bb, base, handle.alignmentMask),
+                    offsetNonPlain(bb, base, handle.alignmentMask),
                     value);
         } else {
-            return getAndBitwiseXorConvEndianWithCAS(bb,  offsetNonPlain(bb, base, handle.alignmentMask), value);
+            return getAndBitwiseXorConvEndianWithCAS(bb, offsetNonPlain(bb, base, handle.alignmentMask), value);
         }
     }
 
@@ -551,10 +551,10 @@ final class VarHandleSegmentAs$Type$s extends VarHandleSegmentViewBase {
         if (handle.be == BE) {
             return SCOPED_MEMORY_ACCESS.getAndBitwiseXor$RawType$Acquire(bb.sessionImpl(),
                     bb.unsafeGetBase(),
-                     offsetNonPlain(bb, base, handle.alignmentMask),
+                    offsetNonPlain(bb, base, handle.alignmentMask),
                     value);
         } else {
-            return getAndBitwiseXorConvEndianWithCAS(bb,  offsetNonPlain(bb, base, handle.alignmentMask), value);
+            return getAndBitwiseXorConvEndianWithCAS(bb, offsetNonPlain(bb, base, handle.alignmentMask), value);
         }
     }
 

--- a/test/jdk/java/foreign/TestAccessModes.java
+++ b/test/jdk/java/foreign/TestAccessModes.java
@@ -1,0 +1,194 @@
+/*
+ *  Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
+ *  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ *  This code is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License version 2 only, as
+ *  published by the Free Software Foundation.
+ *
+ *  This code is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ *  version 2 for more details (a copy is included in the LICENSE file that
+ *  accompanied this code).
+ *
+ *  You should have received a copy of the GNU General Public License version
+ *  2 along with this work; if not, write to the Free Software Foundation,
+ *  Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ *  Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ *  or visit www.oracle.com if you need additional information or have any
+ *  questions.
+ */
+
+/*
+ * @test
+ * @run testng/othervm -Djava.lang.invoke.VarHandle.VAR_HANDLE_GUARDS=true -Djava.lang.invoke.VarHandle.VAR_HANDLE_IDENTITY_ADAPT=false -Xverify:all TestAccessModes
+ * @run testng/othervm -Djava.lang.invoke.VarHandle.VAR_HANDLE_GUARDS=true -Djava.lang.invoke.VarHandle.VAR_HANDLE_IDENTITY_ADAPT=true -Xverify:all TestAccessModes
+ * @run testng/othervm -Djava.lang.invoke.VarHandle.VAR_HANDLE_GUARDS=false -Djava.lang.invoke.VarHandle.VAR_HANDLE_IDENTITY_ADAPT=false -Xverify:all TestAccessModes
+ * @run testng/othervm -Djava.lang.invoke.VarHandle.VAR_HANDLE_GUARDS=false -Djava.lang.invoke.VarHandle.VAR_HANDLE_IDENTITY_ADAPT=true -Xverify:all TestAccessModes
+ */
+
+import java.lang.foreign.AddressLayout;
+import java.lang.foreign.Arena;
+import java.lang.foreign.MemoryLayout;
+import java.lang.foreign.MemorySegment;
+import java.lang.foreign.ValueLayout;
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+import java.lang.invoke.VarHandle;
+import java.lang.invoke.VarHandle.AccessMode;
+import java.util.ArrayList;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Set;
+
+import org.testng.annotations.*;
+
+import static org.testng.Assert.*;
+public class TestAccessModes {
+
+    @Test(dataProvider = "segmentsAndLayoutsAndModes")
+    public void testAccessModes(MemorySegment segment, ValueLayout layout, AccessMode mode) throws Throwable {
+        VarHandle varHandle = layout.varHandle();
+        MethodHandle methodHandle = varHandle.toMethodHandle(mode);
+        boolean compatible = AccessModeKind.supportedModes(layout).contains(AccessModeKind.of(mode));
+        try {
+            Object o = methodHandle.invokeWithArguments(makeArgs(segment, varHandle.accessModeType(mode)));
+            assertTrue(compatible);
+        } catch (UnsupportedOperationException ex) {
+            assertFalse(compatible);
+        } catch (IllegalArgumentException ex) {
+            // access is unaligned, but access mode is supported
+            assertTrue(compatible);
+        }
+    }
+
+    Object[] makeArgs(MemorySegment segment, MethodType type) throws Throwable {
+        List<Object> args = new ArrayList<>();
+        args.add(segment);
+        for (Class argType : type.dropParameterTypes(0, 1).parameterList()) {
+            args.add(defaultValue(argType));
+        }
+        return args.toArray();
+    }
+
+    Object defaultValue(Class<?> clazz) throws Throwable {
+        if (clazz == MemorySegment.class) {
+            return MemorySegment.NULL;
+        } else if (clazz.isPrimitive()) {
+            return MethodHandles.zero(clazz).invoke();
+        } else {
+            throw new UnsupportedOperationException();
+        }
+    }
+
+    /*
+     * From the javadoc of MemoryLayout::varHandle...
+     * <ul>
+     * <li>read write access modes for all {@code T}, with the exception of
+     *     access modes {@code get} and {@code set} for {@code long} and
+     *     {@code double} on 32-bit platforms.
+     * <li>atomic update access modes for {@code int}, {@code long},
+     *     {@code float}, {@code double} or {@link MemorySegment}.
+     *     (Future major platform releases of the JDK may support additional
+     *     types for certain currently unsupported access modes.)
+     * <li>numeric atomic update access modes for {@code int}, {@code long} and {@link MemorySegment}.
+     *     (Future major platform releases of the JDK may support additional
+     *     numeric types for certain currently unsupported access modes.)
+     * <li>bitwise atomic update access modes for {@code int}, {@code long} and {@link MemorySegment}.
+     *     (Future major platform releases of the JDK may support additional
+     *     numeric types for certain currently unsupported access modes.)
+     * </ul>
+     */
+    enum AccessModeKind {
+        PLAIN,
+        READ_WRITE,
+        ATOMIC_UPDATE,
+        ATOMIC_NUMERIC_UPDATE,
+        ATOMIC_BITWISE_UPDATE;
+
+        static AccessModeKind of(AccessMode mode) {
+            return switch (mode) {
+                case GET, SET -> PLAIN;
+                case GET_ACQUIRE, GET_OPAQUE, GET_VOLATILE, SET_VOLATILE,
+                        SET_OPAQUE, SET_RELEASE -> READ_WRITE;
+                case GET_AND_SET, GET_AND_SET_ACQUIRE, GET_AND_SET_RELEASE,
+                        WEAK_COMPARE_AND_SET, WEAK_COMPARE_AND_SET_RELEASE,
+                        WEAK_COMPARE_AND_SET_ACQUIRE, WEAK_COMPARE_AND_SET_PLAIN,
+                        COMPARE_AND_EXCHANGE, COMPARE_AND_EXCHANGE_ACQUIRE,
+                        COMPARE_AND_EXCHANGE_RELEASE, COMPARE_AND_SET -> ATOMIC_UPDATE;
+                case GET_AND_ADD, GET_AND_ADD_ACQUIRE, GET_AND_ADD_RELEASE -> ATOMIC_NUMERIC_UPDATE;
+                default -> ATOMIC_BITWISE_UPDATE;
+            };
+        }
+
+        static Set<AccessModeKind> supportedModes(ValueLayout layout) {
+            Set<AccessModeKind> supportedModes = EnumSet.noneOf(AccessModeKind.class);
+            supportedModes.add(PLAIN);
+            if (layout.byteAlignment() >= layout.byteSize()) {
+                supportedModes.add(READ_WRITE);
+                if (layout instanceof ValueLayout.OfInt || layout instanceof ValueLayout.OfLong ||
+                        layout instanceof ValueLayout.OfFloat || layout instanceof ValueLayout.OfDouble ||
+                        layout instanceof AddressLayout) {
+                    supportedModes.add(ATOMIC_UPDATE);
+                }
+                if (layout instanceof ValueLayout.OfInt || layout instanceof ValueLayout.OfLong ||
+                        layout instanceof AddressLayout) {
+                    supportedModes.add(ATOMIC_NUMERIC_UPDATE);
+                    supportedModes.add(ATOMIC_BITWISE_UPDATE);
+                }
+            }
+            return supportedModes;
+        }
+    }
+
+    static MemoryLayout[] layouts() {
+        MemoryLayout[] valueLayouts = {
+                ValueLayout.JAVA_BOOLEAN,
+                ValueLayout.JAVA_CHAR,
+                ValueLayout.JAVA_BYTE,
+                ValueLayout.JAVA_SHORT,
+                ValueLayout.JAVA_INT,
+                ValueLayout.JAVA_FLOAT,
+                ValueLayout.JAVA_LONG,
+                ValueLayout.JAVA_DOUBLE,
+                ValueLayout.ADDRESS
+        };
+        List<MemoryLayout> layouts = new ArrayList<>();
+        for (MemoryLayout layout : valueLayouts) {
+            for (int align : new int[] { 1, 2, 4, 8 }) {
+                layouts.add(layout.withByteAlignment(align));
+            }
+        }
+        return layouts.toArray(new MemoryLayout[0]);
+    }
+
+    static MemorySegment[] segments() {
+        return new MemorySegment[]{
+                Arena.ofAuto().allocate(8),
+                MemorySegment.ofArray(new byte[8]),
+                MemorySegment.ofArray(new char[4]),
+                MemorySegment.ofArray(new short[4]),
+                MemorySegment.ofArray(new int[2]),
+                MemorySegment.ofArray(new float[2]),
+                MemorySegment.ofArray(new long[1]),
+                MemorySegment.ofArray(new double[1])
+        };
+    }
+
+    @DataProvider(name = "segmentsAndLayoutsAndModes")
+    static Object[][] segmentsAndLayoutsAndModes() {
+        List<Object[]> segmentsAndLayouts = new ArrayList<>();
+        for (MemorySegment segment : segments()) {
+            for (MemoryLayout layout : layouts()) {
+                for (AccessMode mode : AccessMode.values()) {
+                    segmentsAndLayouts.add(new Object[]{segment, layout, mode});
+                }
+            }
+        }
+        return segmentsAndLayouts.toArray(new Object[0][]);
+    }
+
+}

--- a/test/jdk/java/foreign/TestAccessModes.java
+++ b/test/jdk/java/foreign/TestAccessModes.java
@@ -85,22 +85,7 @@ public class TestAccessModes {
     }
 
     /*
-     * From the javadoc of MemoryLayout::varHandle...
-     * <ul>
-     * <li>read write access modes for all {@code T}, with the exception of
-     *     access modes {@code get} and {@code set} for {@code long} and
-     *     {@code double} on 32-bit platforms.
-     * <li>atomic update access modes for {@code int}, {@code long},
-     *     {@code float}, {@code double} or {@link MemorySegment}.
-     *     (Future major platform releases of the JDK may support additional
-     *     types for certain currently unsupported access modes.)
-     * <li>numeric atomic update access modes for {@code int}, {@code long} and {@link MemorySegment}.
-     *     (Future major platform releases of the JDK may support additional
-     *     numeric types for certain currently unsupported access modes.)
-     * <li>bitwise atomic update access modes for {@code int}, {@code long} and {@link MemorySegment}.
-     *     (Future major platform releases of the JDK may support additional
-     *     numeric types for certain currently unsupported access modes.)
-     * </ul>
+     * See the javadoc of MemoryLayout::varHandle.
      */
     enum AccessModeKind {
         PLAIN,


### PR DESCRIPTION
There are some issues with the way memory segment var handle are specified and implemented: if an access mode is not supported, then using such access mode should result in an `UnsupportedOperationException`. But in our implementation, all alignment issues result in `IllegalArgumentException`.

This means that clients can get the same exception if:

* they try to read a 4-byte aligned int at a physical address that is not multiple of 4 (use-site error, IAE is good)
* they try to do a compareAndSwap on a var handle obtained using an unaligned int layout (decl-site error, IAE is not good, and UOE should be used instead).

This PR rectifies this issue: now a var handle is either *aligned* (meaning it is constructed with a value layout which respects the *size* of the accessed carrier type), or *unaligned*. Aligned var handles enjoy more access modes. Unaligned var handle only support `get`/`set`. Trying to use any other access mode on an unaligned var handle will now result in `UOE` regardless of the address being accessed - which makes the code more robust and portable.

This PR also clarifies the javadoc, by avoiding using the term "atomic access" to mean "absence of tearing". This is confusing because we then refer to terms such as "atomic updates" also to refer to operations such as CAS.

The proposed javadoc now uses the term "Word Tearing" which is taken from the memory model section of the JLS (and even has a link to it).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8315096](https://bugs.openjdk.org/browse/JDK-8315096): Allowed access modes in memory segment should depend on layout alignment (**Bug** - P3)


### Reviewers
 * [Paul Sandoz](https://openjdk.org/census#psandoz) (@PaulSandoz - Committer) ⚠️ Review applies to [b86a6860](https://git.openjdk.org/panama-foreign/pull/876/files/b86a686076f1f303cb6d538bbd0a5c6ef24aa9d6)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/panama-foreign.git pull/876/head:pull/876` \
`$ git checkout pull/876`

Update a local copy of the PR: \
`$ git checkout pull/876` \
`$ git pull https://git.openjdk.org/panama-foreign.git pull/876/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 876`

View PR using the GUI difftool: \
`$ git pr show -t 876`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/panama-foreign/pull/876.diff">https://git.openjdk.org/panama-foreign/pull/876.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/panama-foreign/pull/876#issuecomment-1695564048)