### PR TITLE
Add missing @implSpec to AddressLayout

### DIFF
--- a/src/java.base/share/classes/java/lang/foreign/AddressLayout.java
+++ b/src/java.base/share/classes/java/lang/foreign/AddressLayout.java
@@ -50,6 +50,9 @@ import java.util.Optional;
  *     <li>When creating an upcall stub, using {@link Linker#upcallStub(MethodHandle, FunctionDescriptor, Arena, Option...)}.
  * </ul>
  *
+ * @implSpec
+ * This class is immutable, thread-safe and <a href="{@docRoot}/java.base/java/lang/doc-files/ValueBased.html">value-based</a>.
+ *
  * @see #ADDRESS
  * @see #ADDRESS_UNALIGNED
  * @since 22


### PR DESCRIPTION
As the title of this PR says, this simple patch adds a missing `@implSpec` doclet on `AddressLayout`, to bring it in sync with other layout classes.