### PR TITLE
8315769: Add support for sliced allocation

### DIFF
--- a/src/java.base/share/classes/java/lang/foreign/SegmentAllocator.java
+++ b/src/java.base/share/classes/java/lang/foreign/SegmentAllocator.java
@@ -285,7 +285,7 @@ public interface SegmentAllocator {
         Objects.requireNonNull(sourceElementLayout);
         Objects.requireNonNull(elementLayout);
         MemorySegment dest = allocateNoInit(elementLayout, srcElementCount);
-        MemorySegment.copy(source, sourceElementLayout, sourceOffset, dest, elementLayout, 0, dest.byteSize());
+        MemorySegment.copy(source, sourceElementLayout, sourceOffset, dest, elementLayout, 0, srcElementCount);
         return dest;
     }
 

--- a/src/java.base/share/classes/java/lang/foreign/SegmentAllocator.java
+++ b/src/java.base/share/classes/java/lang/foreign/SegmentAllocator.java
@@ -296,8 +296,7 @@ public interface SegmentAllocator {
      * @implSpec the default implementation for this method is equivalent to the following code:
      * {@snippet lang = java:
      * this.allocateFrom(layout, MemorySegment.ofArray(array),
-     *                   layout.withOrder(ByteOrder.nativeOrder()),
-     *                   0, array.length)
+     *                   ValueLayout.JAVA_BYTE, 0, array.length)
      *}
      * @param elementLayout the element layout of the array to be allocated.
      * @param elements the byte elements to be copied to the newly allocated memory block.
@@ -307,7 +306,7 @@ public interface SegmentAllocator {
     @ForceInline
     default MemorySegment allocateFrom(ValueLayout.OfByte elementLayout, byte... elements) {
         return allocateFrom(elementLayout, MemorySegment.ofArray(elements),
-                elementLayout.withOrder(ByteOrder.nativeOrder()), 0, elements.length);
+                ValueLayout.JAVA_BYTE, 0, elements.length);
     }
 
     /**
@@ -315,8 +314,7 @@ public interface SegmentAllocator {
      * @implSpec the default implementation for this method is equivalent to the following code:
      * {@snippet lang = java:
      * this.allocateFrom(layout, MemorySegment.ofArray(array),
-     *                   layout.withOrder(ByteOrder.nativeOrder()),
-     *                   0, array.length)
+     *                   ValueLayout.JAVA_SHORT, 0, array.length)
      *}
      * @param elementLayout the element layout of the array to be allocated.
      * @param elements the short elements to be copied to the newly allocated memory block.
@@ -326,7 +324,7 @@ public interface SegmentAllocator {
     @ForceInline
     default MemorySegment allocateFrom(ValueLayout.OfShort elementLayout, short... elements) {
         return allocateFrom(elementLayout, MemorySegment.ofArray(elements),
-                elementLayout.withOrder(ByteOrder.nativeOrder()), 0, elements.length);
+                ValueLayout.JAVA_SHORT, 0, elements.length);
     }
 
     /**
@@ -334,8 +332,7 @@ public interface SegmentAllocator {
      * @implSpec the default implementation for this method is equivalent to the following code:
      * {@snippet lang = java:
      * this.allocateFrom(layout, MemorySegment.ofArray(array),
-     *                   layout.withOrder(ByteOrder.nativeOrder()),
-     *                   0, array.length)
+     *                   ValueLayout.JAVA_CHAR, 0, array.length)
      *}
      * @param elementLayout the element layout of the array to be allocated.
      * @param elements the char elements to be copied to the newly allocated memory block.
@@ -345,7 +342,7 @@ public interface SegmentAllocator {
     @ForceInline
     default MemorySegment allocateFrom(ValueLayout.OfChar elementLayout, char... elements) {
         return allocateFrom(elementLayout, MemorySegment.ofArray(elements),
-                elementLayout.withOrder(ByteOrder.nativeOrder()), 0, elements.length);
+                ValueLayout.JAVA_CHAR, 0, elements.length);
     }
 
     /**
@@ -353,8 +350,7 @@ public interface SegmentAllocator {
      * @implSpec the default implementation for this method is equivalent to the following code:
      * {@snippet lang = java:
      * this.allocateFrom(layout, MemorySegment.ofArray(array),
-     *                   layout.withOrder(ByteOrder.nativeOrder()),
-     *                   0, array.length)
+     *                   ValueLayout.JAVA_INT, 0, array.length)
      *}
      * @param elementLayout the element layout of the array to be allocated.
      * @param elements the int elements to be copied to the newly allocated memory block.
@@ -364,7 +360,7 @@ public interface SegmentAllocator {
     @ForceInline
     default MemorySegment allocateFrom(ValueLayout.OfInt elementLayout, int... elements) {
         return allocateFrom(elementLayout, MemorySegment.ofArray(elements),
-                elementLayout.withOrder(ByteOrder.nativeOrder()), 0, elements.length);
+                ValueLayout.JAVA_INT, 0, elements.length);
     }
 
     /**
@@ -372,8 +368,7 @@ public interface SegmentAllocator {
      * @implSpec the default implementation for this method is equivalent to the following code:
      * {@snippet lang = java:
      * this.allocateFrom(layout, MemorySegment.ofArray(array),
-     *                   layout.withOrder(ByteOrder.nativeOrder()),
-     *                   0, array.length)
+     *                   ValueLayout.JAVA_FLOAT, 0, array.length)
      *}
      * @param elementLayout the element layout of the array to be allocated.
      * @param elements the float elements to be copied to the newly allocated memory block.
@@ -383,7 +378,7 @@ public interface SegmentAllocator {
     @ForceInline
     default MemorySegment allocateFrom(ValueLayout.OfFloat elementLayout, float... elements) {
         return allocateFrom(elementLayout, MemorySegment.ofArray(elements),
-                elementLayout.withOrder(ByteOrder.nativeOrder()), 0, elements.length);
+                ValueLayout.JAVA_FLOAT, 0, elements.length);
     }
 
     /**
@@ -391,8 +386,7 @@ public interface SegmentAllocator {
      * @implSpec the default implementation for this method is equivalent to the following code:
      * {@snippet lang = java:
      * this.allocateFrom(layout, MemorySegment.ofArray(array),
-     *                   layout.withOrder(ByteOrder.nativeOrder()),
-     *                   0, array.length)
+     *                   ValueLayout.JAVA_LONG, 0, array.length)
      *}
      * @param elementLayout the element layout of the array to be allocated.
      * @param elements the long elements to be copied to the newly allocated memory block.
@@ -402,7 +396,7 @@ public interface SegmentAllocator {
     @ForceInline
     default MemorySegment allocateFrom(ValueLayout.OfLong elementLayout, long... elements) {
         return allocateFrom(elementLayout, MemorySegment.ofArray(elements),
-                elementLayout.withOrder(ByteOrder.nativeOrder()), 0, elements.length);
+                ValueLayout.JAVA_LONG, 0, elements.length);
     }
 
     /**
@@ -410,8 +404,7 @@ public interface SegmentAllocator {
      * @implSpec the default implementation for this method is equivalent to the following code:
      * {@snippet lang = java:
      * this.allocateFrom(layout, MemorySegment.ofArray(array),
-     *                   layout.withOrder(ByteOrder.nativeOrder()),
-     *                   0, array.length)
+     *                   ValueLayout.JAVA_DOUBLE, 0, array.length)
      *}
      * @param elementLayout the element layout of the array to be allocated.
      * @param elements the double elements to be copied to the newly allocated memory block.
@@ -421,7 +414,7 @@ public interface SegmentAllocator {
     @ForceInline
     default MemorySegment allocateFrom(ValueLayout.OfDouble elementLayout, double... elements) {
         return allocateFrom(elementLayout, MemorySegment.ofArray(elements),
-                elementLayout.withOrder(ByteOrder.nativeOrder()), 0, elements.length);
+                ValueLayout.JAVA_DOUBLE, 0, elements.length);
     }
 
     /**

--- a/src/java.base/share/classes/java/lang/foreign/SegmentAllocator.java
+++ b/src/java.base/share/classes/java/lang/foreign/SegmentAllocator.java
@@ -261,11 +261,11 @@ public interface SegmentAllocator {
      * Allocates a memory segment with the given layout and initializes it with the bytes in the provided
      * source memory segment.
      * @implSpec the default implementation for this method calls {@code this.allocate(elementLayout, elementCount)}.
-     * @param elementLayout the value to be set on the newly allocated memory block.
+     * @param elementLayout the element layout of the allocated array.
      * @param source the source segment.
      * @param sourceElementLayout the element layout of the source segment.
      * @param sourceOffset the starting offset, in bytes, of the source segment.
-     * @param srcElementCount the number of elements in the source segment to be copied.
+     * @param elementCount the number of elements in the source segment to be copied.
      * @return a segment for the newly allocated memory block.
      * @throws IllegalArgumentException if the element layouts have different sizes, if the source segment/offset are
      * <a href="MemorySegment.html#segment-alignment">incompatible with the alignment constraint</a> in the source
@@ -280,12 +280,12 @@ public interface SegmentAllocator {
      */
     @ForceInline
     default MemorySegment allocateFrom(ValueLayout elementLayout, MemorySegment source,
-                                       ValueLayout sourceElementLayout, long sourceOffset, long srcElementCount) {
+                                       ValueLayout sourceElementLayout, long sourceOffset, long elementCount) {
         Objects.requireNonNull(source);
         Objects.requireNonNull(sourceElementLayout);
         Objects.requireNonNull(elementLayout);
-        MemorySegment dest = allocateNoInit(elementLayout, srcElementCount);
-        MemorySegment.copy(source, sourceElementLayout, sourceOffset, dest, elementLayout, 0, srcElementCount);
+        MemorySegment dest = allocateNoInit(elementLayout, elementCount);
+        MemorySegment.copy(source, sourceElementLayout, sourceOffset, dest, elementLayout, 0, elementCount);
         return dest;
     }
 

--- a/src/java.base/share/classes/java/lang/foreign/SegmentAllocator.java
+++ b/src/java.base/share/classes/java/lang/foreign/SegmentAllocator.java
@@ -267,9 +267,11 @@ public interface SegmentAllocator {
      * @param sourceOffset the starting offset, in bytes, of the source segment.
      * @param elementCount the number of elements in the source segment to be copied.
      * @return a segment for the newly allocated memory block.
-     * @throws IllegalArgumentException if the element layouts have different sizes, if the source segment/offset are
-     * <a href="MemorySegment.html#segment-alignment">incompatible with the alignment constraint</a> in the source
-     * element layout, or if the source element layout alignment is greater than its size.
+     * @throws IllegalArgumentException if {@code elementLayout.byteSize() != sourceElementLayout.byteSize()}.
+     * @throws IllegalArgumentException if the source segment/offset are <a href="MemorySegment.html#segment-alignment">incompatible with the alignment constraint</a>
+     * in the source element layout.
+     * @throws IllegalArgumentException if {@code elementLayout.byteAlignment() > elementLayout.byteSize()}.
+     * @throws IllegalArgumentException if {@code sourceElementLayout.byteAlignment() > sourceElementLayout.byteSize()}.
      * @throws IllegalStateException if the {@linkplain MemorySegment#scope() scope} associated with {@code source} is not
      * {@linkplain MemorySegment.Scope#isAlive() alive}.
      * @throws WrongThreadException if this method is called from a thread {@code T},
@@ -300,6 +302,7 @@ public interface SegmentAllocator {
      * @param elementLayout the element layout of the array to be allocated.
      * @param elements the byte elements to be copied to the newly allocated memory block.
      * @return a segment for the newly allocated memory block.
+     * @throws IllegalArgumentException if {@code elementLayout.byteAlignment() > elementLayout.byteSize()}.
      */
     @ForceInline
     default MemorySegment allocateFrom(ValueLayout.OfByte elementLayout, byte... elements) {
@@ -318,6 +321,7 @@ public interface SegmentAllocator {
      * @param elementLayout the element layout of the array to be allocated.
      * @param elements the short elements to be copied to the newly allocated memory block.
      * @return a segment for the newly allocated memory block.
+     * @throws IllegalArgumentException if {@code elementLayout.byteAlignment() > elementLayout.byteSize()}.
      */
     @ForceInline
     default MemorySegment allocateFrom(ValueLayout.OfShort elementLayout, short... elements) {
@@ -336,6 +340,7 @@ public interface SegmentAllocator {
      * @param elementLayout the element layout of the array to be allocated.
      * @param elements the char elements to be copied to the newly allocated memory block.
      * @return a segment for the newly allocated memory block.
+     * @throws IllegalArgumentException if {@code elementLayout.byteAlignment() > elementLayout.byteSize()}.
      */
     @ForceInline
     default MemorySegment allocateFrom(ValueLayout.OfChar elementLayout, char... elements) {
@@ -354,6 +359,7 @@ public interface SegmentAllocator {
      * @param elementLayout the element layout of the array to be allocated.
      * @param elements the int elements to be copied to the newly allocated memory block.
      * @return a segment for the newly allocated memory block.
+     * @throws IllegalArgumentException if {@code elementLayout.byteAlignment() > elementLayout.byteSize()}.
      */
     @ForceInline
     default MemorySegment allocateFrom(ValueLayout.OfInt elementLayout, int... elements) {
@@ -372,6 +378,7 @@ public interface SegmentAllocator {
      * @param elementLayout the element layout of the array to be allocated.
      * @param elements the float elements to be copied to the newly allocated memory block.
      * @return a segment for the newly allocated memory block.
+     * @throws IllegalArgumentException if {@code elementLayout.byteAlignment() > elementLayout.byteSize()}.
      */
     @ForceInline
     default MemorySegment allocateFrom(ValueLayout.OfFloat elementLayout, float... elements) {
@@ -390,6 +397,7 @@ public interface SegmentAllocator {
      * @param elementLayout the element layout of the array to be allocated.
      * @param elements the long elements to be copied to the newly allocated memory block.
      * @return a segment for the newly allocated memory block.
+     * @throws IllegalArgumentException if {@code elementLayout.byteAlignment() > elementLayout.byteSize()}.
      */
     @ForceInline
     default MemorySegment allocateFrom(ValueLayout.OfLong elementLayout, long... elements) {
@@ -408,6 +416,7 @@ public interface SegmentAllocator {
      * @param elementLayout the element layout of the array to be allocated.
      * @param elements the double elements to be copied to the newly allocated memory block.
      * @return a segment for the newly allocated memory block.
+     * @throws IllegalArgumentException if {@code elementLayout.byteAlignment() > elementLayout.byteSize()}.
      */
     @ForceInline
     default MemorySegment allocateFrom(ValueLayout.OfDouble elementLayout, double... elements) {

--- a/src/java.base/share/classes/java/lang/foreign/SegmentAllocator.java
+++ b/src/java.base/share/classes/java/lang/foreign/SegmentAllocator.java
@@ -25,7 +25,7 @@
 
 package java.lang.foreign;
 
-import java.lang.reflect.Array;
+import java.nio.ByteOrder;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.Objects;
@@ -258,88 +258,161 @@ public interface SegmentAllocator {
     }
 
     /**
+     * Allocates a memory segment with the given layout and initializes it with the bytes in the provided
+     * source memory segment.
+     * @implSpec the default implementation for this method calls {@code this.allocate(elementLayout, elementCount)}.
+     * @param elementLayout the value to be set on the newly allocated memory block.
+     * @param source the source segment.
+     * @param sourceElementLayout the element layout of the source segment.
+     * @param sourceOffset the starting offset, in bytes, of the source segment.
+     * @param srcElementCount the number of elements in the source segment to be copied.
+     * @return a segment for the newly allocated memory block.
+     * @throws IllegalArgumentException if the element layouts have different sizes, if the source segment/offset are
+     * <a href="MemorySegment.html#segment-alignment">incompatible with the alignment constraint</a> in the source
+     * element layout, or if the source element layout alignment is greater than its size.
+     * @throws IllegalStateException if the {@linkplain MemorySegment#scope() scope} associated with {@code source} is not
+     * {@linkplain MemorySegment.Scope#isAlive() alive}.
+     * @throws WrongThreadException if this method is called from a thread {@code T},
+     * such that {@code source.isAccessibleBy(T) == false}.
+     * @throws IndexOutOfBoundsException if {@code elementCount * sourceElementLayout.byteSize()} overflows.
+     * @throws IndexOutOfBoundsException if {@code sourceOffset > source.byteSize() - (elementCount * sourceElementLayout.byteSize())}.
+     * @throws IndexOutOfBoundsException if either {@code sourceOffset} or {@code elementCount} are {@code < 0}.
+     */
+    @ForceInline
+    default MemorySegment allocateFrom(ValueLayout elementLayout, MemorySegment source,
+                                       ValueLayout sourceElementLayout, long sourceOffset, long srcElementCount) {
+        Objects.requireNonNull(source);
+        Objects.requireNonNull(sourceElementLayout);
+        Objects.requireNonNull(elementLayout);
+        MemorySegment dest = allocateNoInit(elementLayout, srcElementCount);
+        MemorySegment.copy(source, sourceElementLayout, sourceOffset, dest, elementLayout, 0, dest.byteSize());
+        return dest;
+    }
+
+    /**
      * Allocates a memory segment with the given layout and initializes it with the given byte elements.
-     * @implSpec the default implementation for this method calls {@code this.allocate(layout, array.length)}.
+     * @implSpec the default implementation for this method is equivalent to the following code:
+     * {@snippet lang = java:
+     * this.allocateFrom(layout, MemorySegment.ofArray(array),
+     *                   layout.withOrder(ByteOrder.nativeOrder()),
+     *                   0, array.length)
+     *}
      * @param elementLayout the element layout of the array to be allocated.
      * @param elements the byte elements to be copied to the newly allocated memory block.
      * @return a segment for the newly allocated memory block.
      */
+    @ForceInline
     default MemorySegment allocateFrom(ValueLayout.OfByte elementLayout, byte... elements) {
-        return copyArrayWithSwapIfNeeded(elements, elementLayout);
+        return allocateFrom(elementLayout, MemorySegment.ofArray(elements),
+                elementLayout.withOrder(ByteOrder.nativeOrder()), 0, elements.length);
     }
 
     /**
      * Allocates a memory segment with the given layout and initializes it with the given short elements.
-     * @implSpec the default implementation for this method calls {@code this.allocate(layout, array.length)}.
+     * @implSpec the default implementation for this method is equivalent to the following code:
+     * {@snippet lang = java:
+     * this.allocateFrom(layout, MemorySegment.ofArray(array),
+     *                   layout.withOrder(ByteOrder.nativeOrder()),
+     *                   0, array.length)
+     *}
      * @param elementLayout the element layout of the array to be allocated.
      * @param elements the short elements to be copied to the newly allocated memory block.
      * @return a segment for the newly allocated memory block.
      */
+    @ForceInline
     default MemorySegment allocateFrom(ValueLayout.OfShort elementLayout, short... elements) {
-        return copyArrayWithSwapIfNeeded(elements, elementLayout);
+        return allocateFrom(elementLayout, MemorySegment.ofArray(elements),
+                elementLayout.withOrder(ByteOrder.nativeOrder()), 0, elements.length);
     }
 
     /**
      * Allocates a memory segment with the given layout and initializes it with the given char elements.
-     * @implSpec the default implementation for this method calls {@code this.allocate(layout, array.length)}.
+     * @implSpec the default implementation for this method is equivalent to the following code:
+     * {@snippet lang = java:
+     * this.allocateFrom(layout, MemorySegment.ofArray(array),
+     *                   layout.withOrder(ByteOrder.nativeOrder()),
+     *                   0, array.length)
+     *}
      * @param elementLayout the element layout of the array to be allocated.
      * @param elements the char elements to be copied to the newly allocated memory block.
      * @return a segment for the newly allocated memory block.
      */
+    @ForceInline
     default MemorySegment allocateFrom(ValueLayout.OfChar elementLayout, char... elements) {
-        return copyArrayWithSwapIfNeeded(elements, elementLayout);
+        return allocateFrom(elementLayout, MemorySegment.ofArray(elements),
+                elementLayout.withOrder(ByteOrder.nativeOrder()), 0, elements.length);
     }
 
     /**
      * Allocates a memory segment with the given layout and initializes it with the given int elements.
-     * @implSpec the default implementation for this method calls {@code this.allocate(layout, array.length)}.
+     * @implSpec the default implementation for this method is equivalent to the following code:
+     * {@snippet lang = java:
+     * this.allocateFrom(layout, MemorySegment.ofArray(array),
+     *                   layout.withOrder(ByteOrder.nativeOrder()),
+     *                   0, array.length)
+     *}
      * @param elementLayout the element layout of the array to be allocated.
      * @param elements the int elements to be copied to the newly allocated memory block.
      * @return a segment for the newly allocated memory block.
      */
+    @ForceInline
     default MemorySegment allocateFrom(ValueLayout.OfInt elementLayout, int... elements) {
-        return copyArrayWithSwapIfNeeded(elements, elementLayout);
+        return allocateFrom(elementLayout, MemorySegment.ofArray(elements),
+                elementLayout.withOrder(ByteOrder.nativeOrder()), 0, elements.length);
     }
 
     /**
      * Allocates a memory segment with the given layout and initializes it with the given float elements.
-     * @implSpec the default implementation for this method calls {@code this.allocate(layout, array.length)}.
+     * @implSpec the default implementation for this method is equivalent to the following code:
+     * {@snippet lang = java:
+     * this.allocateFrom(layout, MemorySegment.ofArray(array),
+     *                   layout.withOrder(ByteOrder.nativeOrder()),
+     *                   0, array.length)
+     *}
      * @param elementLayout the element layout of the array to be allocated.
      * @param elements the float elements to be copied to the newly allocated memory block.
      * @return a segment for the newly allocated memory block.
      */
+    @ForceInline
     default MemorySegment allocateFrom(ValueLayout.OfFloat elementLayout, float... elements) {
-        return copyArrayWithSwapIfNeeded(elements, elementLayout);
+        return allocateFrom(elementLayout, MemorySegment.ofArray(elements),
+                elementLayout.withOrder(ByteOrder.nativeOrder()), 0, elements.length);
     }
 
     /**
      * Allocates a memory segment with the given layout and initializes it with the given long elements.
-     * @implSpec the default implementation for this method calls {@code this.allocate(layout, array.length)}.
+     * @implSpec the default implementation for this method is equivalent to the following code:
+     * {@snippet lang = java:
+     * this.allocateFrom(layout, MemorySegment.ofArray(array),
+     *                   layout.withOrder(ByteOrder.nativeOrder()),
+     *                   0, array.length)
+     *}
      * @param elementLayout the element layout of the array to be allocated.
      * @param elements the long elements to be copied to the newly allocated memory block.
      * @return a segment for the newly allocated memory block.
      */
+    @ForceInline
     default MemorySegment allocateFrom(ValueLayout.OfLong elementLayout, long... elements) {
-        return copyArrayWithSwapIfNeeded(elements, elementLayout);
+        return allocateFrom(elementLayout, MemorySegment.ofArray(elements),
+                elementLayout.withOrder(ByteOrder.nativeOrder()), 0, elements.length);
     }
 
     /**
      * Allocates a memory segment with the given layout and initializes it with the given double elements.
-     * @implSpec the default implementation for this method calls {@code this.allocate(layout, array.length)}.
+     * @implSpec the default implementation for this method is equivalent to the following code:
+     * {@snippet lang = java:
+     * this.allocateFrom(layout, MemorySegment.ofArray(array),
+     *                   layout.withOrder(ByteOrder.nativeOrder()),
+     *                   0, array.length)
+     *}
      * @param elementLayout the element layout of the array to be allocated.
      * @param elements the double elements to be copied to the newly allocated memory block.
      * @return a segment for the newly allocated memory block.
      */
-    default MemorySegment allocateFrom(ValueLayout.OfDouble elementLayout, double... elements) {
-        return copyArrayWithSwapIfNeeded(elements, elementLayout);
-    }
-
     @ForceInline
-    private MemorySegment copyArrayWithSwapIfNeeded(Object array, ValueLayout elementLayout) {
-        int size = Array.getLength(Objects.requireNonNull(array));
-        MemorySegment segment = allocateNoInit(Objects.requireNonNull(elementLayout), size);
-        MemorySegment.copy(array, 0, segment, elementLayout, 0, size);
-        return segment;
+    default MemorySegment allocateFrom(ValueLayout.OfDouble elementLayout, double... elements) {
+        return allocateFrom(elementLayout, MemorySegment.ofArray(elements),
+                elementLayout.withOrder(ByteOrder.nativeOrder()), 0, elements.length);
     }
 
     /**

--- a/test/jdk/java/foreign/TestSegmentAllocators.java
+++ b/test/jdk/java/foreign/TestSegmentAllocators.java
@@ -171,7 +171,7 @@ public class TestSegmentAllocators {
             }
 
             @Override
-            public MemorySegment allocateFrom(ValueLayout elementLayout, MemorySegment source, ValueLayout sourceElementLayout, long sourceOffset, long srcElementCount) {
+            public MemorySegment allocateFrom(ValueLayout elementLayout, MemorySegment source, ValueLayout sourceElementLayout, long sourceOffset, long elementCount) {
                 calls.incrementAndGet();
                 return MemorySegment.NULL;
             }

--- a/test/jdk/java/foreign/TestSegmentAllocators.java
+++ b/test/jdk/java/foreign/TestSegmentAllocators.java
@@ -171,10 +171,10 @@ public class TestSegmentAllocators {
             }
 
             @Override
-            public MemorySegment allocate(MemoryLayout elementLayout, long count) {
+            public MemorySegment allocateFrom(ValueLayout elementLayout, MemorySegment source, ValueLayout sourceElementLayout, long sourceOffset, long srcElementCount) {
                 calls.incrementAndGet();
                 return MemorySegment.NULL;
-            };
+            }
         };
         allocator.allocateFrom(ValueLayout.JAVA_BYTE);
         allocator.allocateFrom(ValueLayout.JAVA_SHORT);

--- a/test/micro/org/openjdk/bench/java/lang/foreign/AllocFromSliceTest.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/AllocFromSliceTest.java
@@ -1,3 +1,26 @@
+/*
+ *  Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ *  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ *  This code is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License version 2 only, as
+ *  published by the Free Software Foundation.
+ *
+ *  This code is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ *  version 2 for more details (a copy is included in the LICENSE file that
+ *  accompanied this code).
+ *
+ *  You should have received a copy of the GNU General Public License version
+ *  2 along with this work; if not, write to the Free Software Foundation,
+ *  Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ *  Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ *  or visit www.oracle.com if you need additional information or have any
+ *  questions.
+ */
+
 package org.openjdk.bench.java.lang.foreign;
 
 import org.openjdk.jmh.annotations.Benchmark;

--- a/test/micro/org/openjdk/bench/java/lang/foreign/AllocFromSliceTest.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/AllocFromSliceTest.java
@@ -1,0 +1,57 @@
+package org.openjdk.bench.java.lang.foreign;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Warmup;
+
+import java.lang.foreign.Arena;
+import java.lang.foreign.MemorySegment;
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+
+@BenchmarkMode(Mode.AverageTime)
+@Warmup(iterations = 5, time = 500, timeUnit = TimeUnit.MILLISECONDS)
+@Measurement(iterations = 10, time = 500, timeUnit = TimeUnit.MILLISECONDS)
+@State(org.openjdk.jmh.annotations.Scope.Thread)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Fork(value = 3, jvmArgsAppend = { "--enable-native-access=ALL-UNNAMED" })
+public class AllocFromSliceTest extends CLayouts {
+
+    @Param({"5", "20", "100", "500", "1000"})
+    public int size;
+    public int start;
+    public byte[] arr;
+
+    @Setup
+    public void setup() {
+        arr = new byte[1024];
+        Random random = new Random(0);
+        random.nextBytes(arr);
+        start = random.nextInt(1024 - size);
+    }
+
+    @Benchmark
+    public MemorySegment alloc_confined() {
+        Arena arena = Arena.ofConfined();
+        MemorySegment segment = arena.allocate(size);
+        MemorySegment.copy(arr, start, segment, C_CHAR, 0, size);
+        arena.close();
+        return segment;
+    }
+
+    @Benchmark
+    public MemorySegment alloc_confined_slice() {
+        Arena arena = Arena.ofConfined();
+        MemorySegment segment = arena.allocateFrom(C_CHAR, MemorySegment.ofArray(arr), C_CHAR, start, size);
+        arena.close();
+        return segment;
+    }
+}


### PR DESCRIPTION
This PR adds a new method in `SegmentAllocator`:

```
default MemorySegment allocateFrom(ValueLayout elementLayout, MemorySegment source,
                                       ValueLayout sourceElementLayout, long sourceOffset, long srcElementCount) {
```

This method allows clients to allocate a new memory segment and copy the contents of a portion of an existing segment into the newly allocated region of memory. As such it can be used to address the following use cases:

* allocate from a `ByteBuffer`
* allocate from another memory segment
* allocate from a Java array slice

All these cases were not covered by the existing API points, which meant that developers had to use a more general allocation request (such as `allocate(long, long)`) and then pay a performance cost (because of memory zeroing). In other words, the new method in this PR completes the allocation API, by providing a flexible way to allocate a new segment from an existing source (another segment) with given offset and length.

Given that the new method is more general than the existing array-accepting `allocateFrom`, this PR rewires the existing array-accepting method to be rewritten on top of the new overload (and tweaks the javadoc of such methods accordingly).

One detail to note is that the new method takes _two_ element layouts - one is the layout of the newly allocated segment, whereas the other is the layout of the source segment. Such layouts must have same alignment and same carrier - but they can have different endianness (in which case a bulk copy with swap is performed). This is not too different from the most general `MemorySegment::copy` static overload.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8315769](https://bugs.openjdk.org/browse/JDK-8315769): Add support for sliced allocation (**Enhancement** - P3)


### Reviewers
 * [Jorn Vernee](https://openjdk.org/census#jvernee) (@JornVernee - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/panama-foreign.git pull/878/head:pull/878` \
`$ git checkout pull/878`

Update a local copy of the PR: \
`$ git checkout pull/878` \
`$ git pull https://git.openjdk.org/panama-foreign.git pull/878/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 878`

View PR using the GUI difftool: \
`$ git pr show -t 878`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/panama-foreign/pull/878.diff">https://git.openjdk.org/panama-foreign/pull/878.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/panama-foreign/pull/878#issuecomment-1708144558)