### PR TITLE
8315917: Passing struct by values seems under specified

### DIFF
--- a/src/java.base/share/classes/java/lang/foreign/Linker.java
+++ b/src/java.base/share/classes/java/lang/foreign/Linker.java
@@ -568,8 +568,13 @@ public sealed interface Linker permits AbstractLinker {
      * {@code T}, then the size of the returned segment is set to {@code T.byteSize()}.
      * <p>
      * The returned method handle will throw an {@link IllegalArgumentException} if the {@link MemorySegment}
-     * representing the target address of the foreign function is the {@link MemorySegment#NULL} address.
-     * The returned method handle will additionally throw {@link NullPointerException} if any argument passed to it is {@code null}.
+     * representing the target address of the foreign function is the {@link MemorySegment#NULL} address. If an argument
+     * is a {@link MemorySegment}, whose corresponding layout is an {@linkplain GroupLayout group layout}, that needs to
+     * be accessed by the linker implementation, one of the exceptions specified by the
+     * {@link MemorySegment#get(ValueLayout.OfByte, long)} or the
+     * {@link MemorySegment#copy(MemorySegment, long, ValueLayout, long, long)} methods may be thrown.
+     * The returned method handle will additionally throw {@link NullPointerException} if any argument
+     * passed to it is {@code null}.
      * <p>
      * This method is <a href="package-summary.html#restricted"><em>restricted</em></a>.
      * Restricted methods are unsafe, and, if used incorrectly, their use might crash


### PR DESCRIPTION
As discussed in the JBS issue, the exceptions thrown by a downcall method handle for invalid by-value struct arguments are currently not specified.

There are two cases in which we access a memory segment passed as an argument when unboxing it as part of a downcall handle invocation:
1. In the impl of the `BufferLoad` binding, where we call `MemorySegment::get`. This is on platforms that decompose the struct into registers, such as SysV. 
2. In the impl of `Copy`, where we call `MemorySegment::copy`. This is on Windows where we need to copy a struct to implement by-value semantics.

Since these by-value struct memory segments are given to us by the user, there can be various reasons why these segments can not be accessed, such as the scope already being closed, or the segment belonging to a different thread. The following exceptions may occur: `IllegalStateException`, `WrongThreadException`, `IndexOutOfBoundsException`, `UnsupportedOperationException`, and `IllegalArgumentException` (as specified by MS::get and MS::copy).

Solution: update the specification of `Linker::downcallHandle` to specify that an exception thrown by MS::get or MS::copy might be thrown when invoking the downcall handle.