### PR TITLE
Add missing canonicalLayouts to PPC64 and s390 linkers

### DIFF
--- a/src/java.base/share/classes/jdk/internal/foreign/abi/ppc64/linux/LinuxPPC64Linker.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/ppc64/linux/LinuxPPC64Linker.java
@@ -27,14 +27,21 @@ package jdk.internal.foreign.abi.ppc64.linux;
 
 import jdk.internal.foreign.abi.AbstractLinker;
 import jdk.internal.foreign.abi.LinkerOptions;
+import jdk.internal.foreign.abi.SharedUtils;
 import jdk.internal.foreign.abi.ppc64.CallArranger;
 
 import java.lang.foreign.FunctionDescriptor;
+import java.lang.foreign.MemoryLayout;
+import java.lang.foreign.ValueLayout;
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodType;
 import java.nio.ByteOrder;
+import java.util.Map;
 
 public final class LinuxPPC64Linker extends AbstractLinker {
+
+    static final Map<String, MemoryLayout> CANONICAL_LAYOUTS =
+        SharedUtils.canonicalLayouts(ValueLayout.JAVA_LONG, ValueLayout.JAVA_LONG, ValueLayout.JAVA_INT);
 
     public static LinuxPPC64Linker getInstance() {
         final class Holder {
@@ -61,5 +68,10 @@ public final class LinuxPPC64Linker extends AbstractLinker {
     @Override
     protected ByteOrder linkerByteOrder() {
         return ByteOrder.BIG_ENDIAN;
+    }
+
+    @Override
+    public Map<String, MemoryLayout> canonicalLayouts() {
+        return CANONICAL_LAYOUTS;
     }
 }

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/s390/linux/LinuxS390Linker.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/s390/linux/LinuxS390Linker.java
@@ -27,13 +27,20 @@ package jdk.internal.foreign.abi.s390.linux;
 
 import jdk.internal.foreign.abi.AbstractLinker;
 import jdk.internal.foreign.abi.LinkerOptions;
+import jdk.internal.foreign.abi.SharedUtils;
 
 import java.lang.foreign.FunctionDescriptor;
+import java.lang.foreign.MemoryLayout;
+import java.lang.foreign.ValueLayout;
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodType;
 import java.nio.ByteOrder;
+import java.util.Map;
 
 public final class LinuxS390Linker extends AbstractLinker {
+
+    private static final Map<String, MemoryLayout> CANONICAL_LAYOUTS =
+            SharedUtils.canonicalLayouts(ValueLayout.JAVA_LONG, ValueLayout.JAVA_LONG, ValueLayout.JAVA_INT);
 
     public static LinuxS390Linker getInstance() {
         final class Holder {
@@ -60,5 +67,10 @@ public final class LinuxS390Linker extends AbstractLinker {
     @Override
     protected ByteOrder linkerByteOrder() {
         return ByteOrder.BIG_ENDIAN;
+    }
+
+    @Override
+    public Map<String, MemoryLayout> canonicalLayouts() {
+        return CANONICAL_LAYOUTS;
     }
 }


### PR DESCRIPTION
Some changes I forgot to commit when doing the earlier merge [1]. These are needed to build

[1]: https://github.com/openjdk/panama-foreign/pull/882

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Reviewers
 * [Per Minborg](https://openjdk.org/census#pminborg) (@minborg - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/panama-foreign.git pull/883/head:pull/883` \
`$ git checkout pull/883`

Update a local copy of the PR: \
`$ git checkout pull/883` \
`$ git pull https://git.openjdk.org/panama-foreign.git pull/883/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 883`

View PR using the GUI difftool: \
`$ git pr show -t 883`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/panama-foreign/pull/883.diff">https://git.openjdk.org/panama-foreign/pull/883.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/panama-foreign/pull/883#issuecomment-1715585757)