### PR TITLE
8316196: Use hexadecimal form for address outputs in java.lang.foreign

### DIFF
--- a/src/java.base/share/classes/java/lang/invoke/VarHandleSegmentViewBase.java
+++ b/src/java.base/share/classes/java/lang/invoke/VarHandleSegmentViewBase.java
@@ -25,6 +25,8 @@
 
 package java.lang.invoke;
 
+import jdk.internal.foreign.Utils;
+
 /**
  * Base class for memory segment var handle view implementations.
  */
@@ -54,7 +56,7 @@ abstract sealed class VarHandleSegmentViewBase extends VarHandle permits
     }
 
     static IllegalArgumentException newIllegalArgumentExceptionForMisalignedAccess(long address) {
-        return new IllegalArgumentException("Misaligned access at address: " + address);
+        return new IllegalArgumentException("Misaligned access at address: " + Utils.toHexString(address));
     }
 
     static UnsupportedOperationException newUnsupportedAccessModeForAlignment(long alignment) {

--- a/src/java.base/share/classes/jdk/internal/foreign/Utils.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/Utils.java
@@ -146,7 +146,7 @@ public final class Utils {
     @ForceInline
     public static MemorySegment longToAddress(long addr, long size, long align) {
         if (!isAligned(addr, align)) {
-            throw new IllegalArgumentException("Invalid alignment constraint for address: " + addr);
+            throw new IllegalArgumentException("Invalid alignment constraint for address: " + toHexString(addr));
         }
         return NativeMemorySegmentImpl.makeNativeSegmentUnchecked(addr, size);
     }
@@ -154,7 +154,7 @@ public final class Utils {
     @ForceInline
     public static MemorySegment longToAddress(long addr, long size, long align, MemorySessionImpl scope) {
         if (!isAligned(addr, align)) {
-            throw new IllegalArgumentException("Invalid alignment constraint for address: " + addr);
+            throw new IllegalArgumentException("Invalid alignment constraint for address: " + toHexString(addr));
         }
         return NativeMemorySegmentImpl.makeNativeSegmentUnchecked(addr, size, scope);
     }

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/UpcallStubs.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/UpcallStubs.java
@@ -28,6 +28,7 @@ import java.lang.foreign.MemorySegment;
 import java.lang.foreign.Arena;
 
 import jdk.internal.foreign.MemorySessionImpl;
+import jdk.internal.foreign.Utils;
 
 public final class UpcallStubs {
 
@@ -36,7 +37,7 @@ public final class UpcallStubs {
 
     private static void freeUpcallStub(long stubAddress) {
         if (!freeUpcallStub0(stubAddress)) {
-            throw new IllegalStateException("Not a stub address: " + stubAddress);
+            throw new IllegalStateException("Not a stub address: " + Utils.toHexString(stubAddress));
         }
     }
 


### PR DESCRIPTION
This PR proposes to change address output from decimal to hexadecimal.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8316196](https://bugs.openjdk.org/browse/JDK-8316196): Use hexadecimal form for address outputs in java.lang.foreign (**Enhancement** - P4)


### Reviewers
 * [Jorn Vernee](https://openjdk.org/census#jvernee) (@JornVernee - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/panama-foreign.git pull/885/head:pull/885` \
`$ git checkout pull/885`

Update a local copy of the PR: \
`$ git checkout pull/885` \
`$ git pull https://git.openjdk.org/panama-foreign.git pull/885/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 885`

View PR using the GUI difftool: \
`$ git pr show -t 885`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/panama-foreign/pull/885.diff">https://git.openjdk.org/panama-foreign/pull/885.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/panama-foreign/pull/885#issuecomment-1721338456)