### PR TITLE
Fix the use of final and static

### DIFF
--- a/src/java.base/share/classes/jdk/internal/foreign/MemorySessionImpl.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/MemorySessionImpl.java
@@ -81,7 +81,7 @@ public abstract sealed class MemorySessionImpl
     }
 
     @ForceInline
-    public static final MemorySessionImpl toMemorySession(Arena arena) {
+    public static MemorySessionImpl toMemorySession(Arena arena) {
         return (MemorySessionImpl) arena.scope();
     }
 
@@ -205,7 +205,7 @@ public abstract sealed class MemorySessionImpl
         }
     }
 
-    public static final void checkValidState(MemorySegment segment) {
+    public static void checkValidState(MemorySegment segment) {
         ((AbstractMemorySegmentImpl)segment).sessionImpl().checkValidState();
     }
 

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/AbstractLinker.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/AbstractLinker.java
@@ -91,7 +91,7 @@ public abstract sealed class AbstractLinker implements Linker permits LinuxAArch
         return downcallHandle0(function, options);
     }
 
-    private final MethodHandle downcallHandle0(FunctionDescriptor function, Option... options) {
+    private MethodHandle downcallHandle0(FunctionDescriptor function, Option... options) {
         Objects.requireNonNull(function);
         Objects.requireNonNull(options);
         checkLayouts(function);

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/riscv64/linux/LinuxRISCV64CallArranger.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/riscv64/linux/LinuxRISCV64CallArranger.java
@@ -253,8 +253,8 @@ public class LinuxRISCV64CallArranger {
                               Map.entry(STRUCT_REGISTER_XF, STRUCT_REGISTER_X));
     }
 
-    static class UnboxBindingCalculator extends BindingCalculator {
-        boolean forArguments;
+    static final class UnboxBindingCalculator extends BindingCalculator {
+        final boolean forArguments;
 
         UnboxBindingCalculator(boolean forArguments) {
             super(forArguments);

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/riscv64/linux/TypeClass.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/riscv64/linux/TypeClass.java
@@ -78,7 +78,7 @@ public enum TypeClass {
      * Struct will be flattened while classifying. That is, struct{struct{int, double}} will be treated
      * same as struct{int, double} and struct{int[2]} will be treated same as struct{int, int}.
      * */
-    private static record FieldCounter(long integerCnt, long floatCnt, long pointerCnt) {
+    private record FieldCounter(long integerCnt, long floatCnt, long pointerCnt) {
         static final FieldCounter EMPTY = new FieldCounter(0, 0, 0);
         static final FieldCounter SINGLE_INTEGER = new FieldCounter(1, 0, 0);
         static final FieldCounter SINGLE_FLOAT = new FieldCounter(0, 1, 0);
@@ -128,9 +128,7 @@ public enum TypeClass {
         }
     }
 
-    public static record FlattenedFieldDesc(TypeClass typeClass, long offset, ValueLayout layout) {
-
-    }
+    public record FlattenedFieldDesc(TypeClass typeClass, long offset, ValueLayout layout) { }
 
     private static List<FlattenedFieldDesc> getFlattenedFieldsInner(long offset, MemoryLayout layout) {
         if (layout instanceof ValueLayout valueLayout) {


### PR DESCRIPTION
This PR proposes to clean up some of the usages of the `final` and `static` keyword.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Reviewers
 * [Maurizio Cimadamore](https://openjdk.org/census#mcimadamore) (@mcimadamore - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/panama-foreign.git pull/889/head:pull/889` \
`$ git checkout pull/889`

Update a local copy of the PR: \
`$ git checkout pull/889` \
`$ git pull https://git.openjdk.org/panama-foreign.git pull/889/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 889`

View PR using the GUI difftool: \
`$ git pr show -t 889`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/panama-foreign/pull/889.diff">https://git.openjdk.org/panama-foreign/pull/889.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/panama-foreign/pull/889#issuecomment-1731294013)