### PR TITLE
8317324: Add an overload to bind a memory segment var handle at an offset

### DIFF
--- a/src/java.base/share/classes/java/lang/foreign/MemoryLayout.java
+++ b/src/java.base/share/classes/java/lang/foreign/MemoryLayout.java
@@ -424,6 +424,27 @@ public sealed interface MemoryLayout permits SequenceLayout, GroupLayout, Paddin
      * Creates a var handle that accesses a memory segment at the offset selected by the given layout path,
      * where the initial layout in the path is this layout.
      * <p>
+     * This method is equivalent to {@link #varHandle(PathElement...)},
+     * with the exception that the base offset coordinate of the returned var handle is bound to the provided value,
+     * as follows:
+     * {@snippet lang = "java":
+     * MethodHandles.insertCoordinates(varHandle(elements), 1, baseOffset);
+     * }
+     *
+     * @param baseOffset the offset to be bound to the returned var handle.
+     * @param elements the layout path elements.
+     * @return a var handle that accesses a memory segment at the offset selected by the given layout path.
+     * @throws IllegalArgumentException if the layout path is not <a href="#well-formedness">well-formed</a> for this layout.
+     * @throws IllegalArgumentException if the layout selected by the provided path is not a {@linkplain ValueLayout value layout}.
+     */
+    default VarHandle varHandle(long baseOffset, PathElement... elements) {
+        return MethodHandles.insertCoordinates(varHandle(elements), 1, baseOffset);
+    }
+
+    /**
+     * Creates a var handle that accesses a memory segment at the offset selected by the given layout path,
+     * where the initial layout in the path is this layout.
+     * <p>
      * The returned var handle has the following characteristics:
      * <ul>
      *     <li>its type is derived from the {@linkplain ValueLayout#carrier() carrier} of the

--- a/test/jdk/java/foreign/NativeTestHelper.java
+++ b/test/jdk/java/foreign/NativeTestHelper.java
@@ -273,10 +273,10 @@ public class NativeTestHelper {
     }
 
     private static UnaryOperator<MemorySegment> slicer(MemoryLayout containerLayout, MemoryLayout.PathElement fieldPath) {
-        MethodHandle slicer = containerLayout.sliceHandle(fieldPath);
+        MethodHandle slicer = containerLayout.sliceHandle(0L, fieldPath);
         return container -> {
               try {
-                return (MemorySegment) slicer.invokeExact(container, 0L);
+                return (MemorySegment) slicer.invokeExact(container);
             } catch (Throwable e) {
                 throw new IllegalStateException(e);
             }

--- a/test/jdk/java/foreign/TestAdaptVarHandles.java
+++ b/test/jdk/java/foreign/TestAdaptVarHandles.java
@@ -82,8 +82,7 @@ public class TestAdaptVarHandles {
         }
     }
 
-    static final VarHandle intHandleIndexed = MethodHandles.collectCoordinates(ValueLayout.JAVA_INT.varHandle(),
-            1, MethodHandles.insertArguments(ValueLayout.JAVA_INT.scaleHandle(), 0, 0L));
+    static final VarHandle intHandleIndexed = ValueLayout.JAVA_INT.arrayElementVarHandle(0L);
 
     static final VarHandle intHandle = ValueLayout.JAVA_INT.varHandle(0L);
 

--- a/test/jdk/java/foreign/TestAdaptVarHandles.java
+++ b/test/jdk/java/foreign/TestAdaptVarHandles.java
@@ -85,9 +85,9 @@ public class TestAdaptVarHandles {
     static final VarHandle intHandleIndexed = MethodHandles.collectCoordinates(ValueLayout.JAVA_INT.varHandle(),
             1, MethodHandles.insertArguments(ValueLayout.JAVA_INT.scaleHandle(), 0, 0L));
 
-    static final VarHandle intHandle = MethodHandles.insertCoordinates(ValueLayout.JAVA_INT.varHandle(), 1, 0L);
+    static final VarHandle intHandle = ValueLayout.JAVA_INT.varHandle(0L);
 
-    static final VarHandle floatHandle = MethodHandles.insertCoordinates(ValueLayout.JAVA_FLOAT.varHandle(), 1, 0L);
+    static final VarHandle floatHandle = ValueLayout.JAVA_FLOAT.varHandle(0L);
 
     @Test
     public void testFilterValue() throws Throwable {

--- a/test/jdk/java/foreign/TestArrayCopy.java
+++ b/test/jdk/java/foreign/TestArrayCopy.java
@@ -291,14 +291,9 @@ public class TestArrayCopy {
         return MemorySegment.ofArray(arr);
     }
 
-    private static VarHandle arrayVarHandle(ValueLayout layout) {
-        return MethodHandles.collectCoordinates(layout.varHandle(),
-                1, MethodHandles.insertArguments(layout.scaleHandle(), 0, 0L));
-    }
-
     public static MemorySegment truthSegment(MemorySegment srcSeg, CopyHelper<?, ?> helper, int indexShifts, CopyMode mode) {
-        VarHandle indexedHandleNO = arrayVarHandle(helper.elementLayout.withOrder(NATIVE_ORDER));
-        VarHandle indexedHandleNNO = arrayVarHandle(helper.elementLayout.withOrder(NON_NATIVE_ORDER));
+        VarHandle indexedHandleNO = helper.elementLayout.withOrder(NATIVE_ORDER).arrayElementVarHandle(0L);
+        VarHandle indexedHandleNNO = helper.elementLayout.withOrder(NON_NATIVE_ORDER).arrayElementVarHandle(0L);
         MemorySegment dstSeg = MemorySegment.ofArray(srcSeg.toArray(JAVA_BYTE));
         int indexLength = (int) dstSeg.byteSize() / (int)helper.elementLayout.byteSize();
         if (mode.direction) {

--- a/test/jdk/java/foreign/TestLayoutPaths.java
+++ b/test/jdk/java/foreign/TestLayoutPaths.java
@@ -156,9 +156,9 @@ public class TestLayoutPaths {
             });
             assertTrue(iae.getMessage().startsWith(expectedMessage));
 
-            MethodHandle sliceX = struct.sliceHandle(groupElement("x"));
+            MethodHandle sliceX = struct.sliceHandle(0L, groupElement("x"));
             iae = expectThrows(IllegalArgumentException.class, () -> {
-                MemorySegment slice = (MemorySegment) sliceX.invokeExact(seg, 0L);
+                MemorySegment slice = (MemorySegment) sliceX.invokeExact(seg);
             });
             assertTrue(iae.getMessage().startsWith(expectedMessage));
         }
@@ -306,9 +306,9 @@ public class TestLayoutPaths {
     @Test(dataProvider = "testLayouts")
     public void testOffsetHandle(MemoryLayout layout, PathElement[] pathElements, long[] indexes,
                                  long expectedByteOffset) throws Throwable {
-        MethodHandle byteOffsetHandle = layout.byteOffsetHandle(pathElements);
+        MethodHandle byteOffsetHandle = layout.byteOffsetHandle(0L, pathElements);
         byteOffsetHandle = byteOffsetHandle.asSpreader(long[].class, indexes.length);
-        long actualByteOffset = (long) byteOffsetHandle.invokeExact(0L, indexes);
+        long actualByteOffset = (long) byteOffsetHandle.invokeExact(indexes);
         assertEquals(actualByteOffset, expectedByteOffset);
     }
 

--- a/test/micro/org/openjdk/bench/java/lang/foreign/JavaLayouts.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/JavaLayouts.java
@@ -37,14 +37,9 @@ import static java.lang.foreign.ValueLayout.JAVA_LONG_UNALIGNED;
  */
 public class JavaLayouts {
 
-    static final VarHandle VH_INT_UNALIGNED = arrayVarHandle(JAVA_INT_UNALIGNED);
-    static final VarHandle VH_INT = arrayVarHandle(JAVA_INT);
+    static final VarHandle VH_INT_UNALIGNED = JAVA_INT_UNALIGNED.arrayElementVarHandle(0L);
+    static final VarHandle VH_INT = JAVA_INT.arrayElementVarHandle(0L);
 
-    static final VarHandle VH_LONG_UNALIGNED = arrayVarHandle(JAVA_LONG_UNALIGNED);
-    static final VarHandle VH_LONG = arrayVarHandle(JAVA_LONG);
-
-    private static VarHandle arrayVarHandle(ValueLayout layout) {
-        return MethodHandles.collectCoordinates(layout.varHandle(),
-            1, MethodHandles.insertArguments(layout.scaleHandle(), 0, 0L));
-    }
+    static final VarHandle VH_LONG_UNALIGNED = JAVA_LONG_UNALIGNED.arrayElementVarHandle(0L);
+    static final VarHandle VH_LONG = JAVA_LONG.arrayElementVarHandle(0L);
 }

--- a/test/micro/org/openjdk/bench/java/lang/foreign/MemorySegmentGetUnsafe.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/MemorySegmentGetUnsafe.java
@@ -65,10 +65,9 @@ public class MemorySegmentGetUnsafe {
         }
     }
 
-    static final VarHandle INT_HANDLE = adaptSegmentHandle(JAVA_INT.varHandle());
+    static final VarHandle INT_HANDLE = adaptSegmentHandle(JAVA_INT.varHandle(0L));
 
     static VarHandle adaptSegmentHandle(VarHandle handle) {
-        handle = MethodHandles.insertCoordinates(handle, 1, 0L);
         handle = MethodHandles.filterCoordinates(handle, 0, OF_ADDRESS_UNSAFE);
         return handle;
     }


### PR DESCRIPTION
This PR adds an overload which binds a memory segment var handle offset coordinate to a provided constant value.

This is useful when the client knows that the accessed offset will be e.g. zero, or some other known constant value, thus reducing the number of coordinates that var handles clients will have to provide on each access.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8317324](https://bugs.openjdk.org/browse/JDK-8317324): Add an overload to bind a memory segment var handle at an offset (**Enhancement** - P4)


### Reviewers
 * [Jorn Vernee](https://openjdk.org/census#jvernee) (@JornVernee - Committer) ⚠️ Review applies to [54c931c6](https://git.openjdk.org/panama-foreign/pull/900/files/54c931c6ce8c58f3460e5b8ca281db954f7516dd)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/panama-foreign.git pull/900/head:pull/900` \
`$ git checkout pull/900`

Update a local copy of the PR: \
`$ git checkout pull/900` \
`$ git pull https://git.openjdk.org/panama-foreign.git pull/900/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 900`

View PR using the GUI difftool: \
`$ git pr show -t 900`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/panama-foreign/pull/900.diff">https://git.openjdk.org/panama-foreign/pull/900.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/panama-foreign/pull/900#issuecomment-1741197703)