### PR TITLE
Beef up javadoc for base offset in var handles derived from layouts

### DIFF
--- a/src/java.base/share/classes/java/lang/foreign/MemoryLayout.java
+++ b/src/java.base/share/classes/java/lang/foreign/MemoryLayout.java
@@ -77,7 +77,7 @@ import jdk.internal.vm.annotation.ForceInline;
  * The above declaration can be modelled using a layout object, as follows:
  *
  * {@snippet lang=java :
- * SequenceLayout taggedValues = MemoryLayout.sequenceLayout(5,
+ * SequenceLayout TAGGED_VALUES = MemoryLayout.sequenceLayout(5,
  *     MemoryLayout.structLayout(
  *         ValueLayout.JAVA_BYTE.withName("kind"),
  *         MemoryLayout.paddingLayout(3),
@@ -132,13 +132,13 @@ import jdk.internal.vm.annotation.ForceInline;
  * For instance, given the {@code taggedValues} sequence layout constructed above, we can obtain the offset,
  * in bytes, of the member layout named <code>value</code> in the <em>first</em> sequence element, as follows:
  * {@snippet lang=java :
- * long valueOffset = taggedValues.byteOffset(PathElement.sequenceElement(0),
+ * long valueOffset = TAGGED_VALUES.byteOffset(PathElement.sequenceElement(0),
  *                                           PathElement.groupElement("value")); // yields 4
  * }
  *
  * Similarly, we can select the member layout named {@code value}, as follows:
  * {@snippet lang=java :
- * MemoryLayout value = taggedValues.select(PathElement.sequenceElement(),
+ * MemoryLayout value = TAGGED_VALUES.select(PathElement.sequenceElement(),
  *                                          PathElement.groupElement("value"));
  * }
  *
@@ -151,10 +151,13 @@ import jdk.internal.vm.annotation.ForceInline;
  * the open elements in the path:
  *
  * {@snippet lang=java :
- * VarHandle valueHandle = taggedValues.varHandle(PathElement.sequenceElement(),
+ * VarHandle valueHandle = TAGGED_VALUES.varHandle(PathElement.sequenceElement(),
  *                                                PathElement.groupElement("value"));
- * MemorySegment valuesSegment = ...
- * int val = (int) valueHandle.get(valuesSegment, 2); // reads the "value" field of the third struct in the array
+ * MemorySegment taggedValues = ...
+ * // reads the "value" field of the third struct in the array (taggedValues[2].value)
+ * int val = (int) valueHandle.get(taggedValues,
+ *         0L,  // base offset
+ *         2L); // sequence index
  * }
  *
  * <p>
@@ -164,10 +167,10 @@ import jdk.internal.vm.annotation.ForceInline;
  * of the sequence element whose offset is to be computed:
  *
  * {@snippet lang=java :
- * MethodHandle offsetHandle = taggedValues.byteOffsetHandle(PathElement.sequenceElement(),
+ * MethodHandle offsetHandle = TAGGED_VALUES.byteOffsetHandle(PathElement.sequenceElement(),
  *                                                           PathElement.groupElement("kind"));
- * long offset1 = (long) offsetHandle.invokeExact(1L); // 8
- * long offset2 = (long) offsetHandle.invokeExact(2L); // 16
+ * long offset1 = (long) offsetHandle.invokeExact(0L, 1L); // 0 + (1 * 8) = 8
+ * long offset2 = (long) offsetHandle.invokeExact(0L, 2L); // 0 + (2 * 8) = 16
  * }
  *
  * <h3 id="deref-path-elements">Dereference path elements</h3>
@@ -205,7 +208,10 @@ import jdk.internal.vm.annotation.ForceInline;
  * );
  *
  * MemorySegment rect = ...
- * int rect_y_4 = (int) rectPointYs.get(rect, 2); // rect.points[2]->y
+ * // dereferences the third point struct in the "points" array, and reads its "y" coordinate (rect.points[2]->y)
+ * int rect_y_2 = (int) rectPointYs.get(rect,
+ *     0L,  // base offset
+ *     2L); // sequence index
  * }
  *
  * <h3 id="well-formedness">Layout path well-formedness</h3>

--- a/src/java.base/share/classes/java/lang/foreign/MemoryLayout.java
+++ b/src/java.base/share/classes/java/lang/foreign/MemoryLayout.java
@@ -308,10 +308,10 @@ import jdk.internal.vm.annotation.ForceInline;
  *
  * StructLayout POLYGON = MemoryLayout.structLayout(
  *             ValueLayout.JAVA_INT.withName("size"),
- *             MemoryLayout.sequenceLayout(0, POINT_2D).withName("points")
+ *             MemoryLayout.sequenceLayout(0, POINT).withName("points")
  * );
  *
- * VarHandle POLYGON_SIZE = POLYGON_2D.varHandle(0, PathElement.groupElement("size"));
+ * VarHandle POLYGON_SIZE = POLYGON.varHandle(0, PathElement.groupElement("size"));
  * VarHandle POINT_X = POINT.varHandle(PathElement.groupElement("x"));
  * long POINTS_OFFSET = POLYGON.byteOffset(PathElement.groupElement("points"));
  * }

--- a/src/java.base/share/classes/java/lang/foreign/MemoryLayout.java
+++ b/src/java.base/share/classes/java/lang/foreign/MemoryLayout.java
@@ -277,7 +277,7 @@ import jdk.internal.vm.annotation.ForceInline;
  *
  * <h2 id="variable-length">Working with variable-length structs</h2>
  *
- * Memory layouts allow clients to describe the contents of a region of memory whose size is knonw <em>statically</em>.
+ * Memory layouts allow clients to describe the contents of a region of memory whose size is known <em>statically</em>.
  * There are, however, cases, where the size of a region of memory is only known <em>dynamically</em>, as it depends
  * on the value of one or more struct fields. Consider the following struct declaration in C:
  *

--- a/src/java.base/share/classes/java/lang/foreign/MemorySegment.java
+++ b/src/java.base/share/classes/java/lang/foreign/MemorySegment.java
@@ -143,7 +143,7 @@ import jdk.internal.vm.annotation.ForceInline;
  * {@snippet lang=java:
  * MethodHandle scale = ValueLayout.JAVA_INT.scaleHandle();              // (long, long)long
  * VarHandle intAtOffsetAndIndexHandle =
- *         MethodHandles.filterCoordinates(intAtOffsetHandle, 1, scale); // (MemorySegment, long, long)
+ *         MethodHandles.collectCoordinates(intAtOffsetHandle, 1, scale); // (MemorySegment, long, long)
  * int value = (int) intAtOffsetAndIndexHandle.get(segment, 2L, 3L);     // segment.get(ValueLayout.JAVA_INT, 2L + (3L * 4L))
  * }
  *

--- a/src/java.base/share/classes/java/lang/foreign/MemorySegment.java
+++ b/src/java.base/share/classes/java/lang/foreign/MemorySegment.java
@@ -26,6 +26,9 @@
 package java.lang.foreign;
 
 import java.io.UncheckedIOException;
+import java.lang.foreign.ValueLayout.OfInt;
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.VarHandle;
 import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
@@ -120,51 +123,42 @@ import jdk.internal.vm.annotation.ForceInline;
  * If the value to be read is stored in memory using {@linkplain ByteOrder#BIG_ENDIAN big-endian} encoding, the access operation
  * can be expressed as follows:
  * {@snippet lang=java :
- * MemorySegment segment = ...
  * int value = segment.get(ValueLayout.JAVA_INT.withOrder(BIG_ENDIAN), 0);
  * }
  *
- * More complex access operations can be implemented using var handles. The {@link ValueLayout#varHandle()}
- * method can be used to obtain a var handle that can be used to get/set values represented by the given value layout on a memory segment.
- * A var handle obtained from a layout supports several additional <a href=MemoryLayout.html#access-mode-restrictions>
- * access modes</a>. More importantly, var handles can be <em>combined</em> with method handles to express complex access
- * operations. For instance, a var handle that can be used to access an element of an {@code int} array at a given logical
+ * Access operations on memory segments are implemented using var handles. The {@link ValueLayout#varHandle()}
+ * method can be used to obtain a var handle that can be used to get/set values represented by the given value layout
+ * on a memory segment at the given offset:
+ *
+ * {@snippet lang=java:
+ * VarHandle intAtOffsetHandle = ValueLayout.JAVA_INT.varHandle(); // (MemorySegment, long)
+ * int value = (int) intAtOffsetHandle.get(segment, 10L);          // segment.get(ValueLayout.JAVA_INT, 10L)
+ * }
+ *
+ * The var handle returned by {@link ValueLayout#varHandle()} features a <em>base offset</em> parameter. This parameter
+ * allows clients to express complex access operations, by injecting additional offset computation into the var handle.
+ * For instance, a var handle that can be used to access an element of an {@code int} array at a given logical
  * index can be created as follows:
  *
  * {@snippet lang=java:
- * MemorySegment segment = ...
- * VarHandle intHandle = ValueLayout.JAVA_INT.varHandle(); // (MemorySegment, long)
- * MethodHandle scale = ValueLayout.JAVA_INT.scaleHandle(); // <base offset> + <index> * JAVA_INT.byteSize()
- *
- * intHandle = MethodHandles.filterCoordinates(intHandle, 1, scale);
- * int value = (int) intHandle.get(segment, 0L, 3L); // get int element at offset 0 + 3 * 4 = 12
+ * MethodHandle scale = ValueLayout.JAVA_INT.scaleHandle();              // (long, long)long
+ * VarHandle intAtOffsetAndIndexHandle =
+ *         MethodHandles.filterCoordinates(intAtOffsetHandle, 1, scale); // (MemorySegment, long, long)
+ * int value = (int) intAtOffsetAndIndexHandle.get(segment, 2L, 3L);     // segment.get(ValueLayout.JAVA_INT, 2L + (3L * 4L))
  * }
  *
- * To make the process of creating these var handles easier, the method
- * {@link MemoryLayout#varHandle(MemoryLayout.PathElement...)} can be used, by providing it a so called
- * <a href="MemoryLayout.html#layout-paths"><em>layout path</em></a>. A layout path, consisting of several <em>layout
- * path elements</em>, selects a value layout to be accessed, which can be nested inside another memory layout. For example,
- * we can express the access to an element of an {@code int} array using layout paths like so:
+ * <p>
+ * Clients can also drop the base offset parameter, in order to make the access expression simpler. This can be used to
+ * implement access operation such as {@link #getAtIndex(OfInt, long)}:
  *
- * {@snippet lang=java :
- * MemorySegment segment = ...
- * MemoryLayout segmentLayout = MemoryLayout.structLayout(
- *     ValueLayout.JAVA_INT.withName("size"),
- *     MemoryLayout.sequenceLayout(4, ValueLayout.JAVA_INT).withName("data") // array of 4 elements
- * );
- * VarHandle intHandle = segmentLayout.varHandle(MemoryLayout.PathElemenet.groupElement("data"),
- *                                               MemoryLayout.PathElement.sequenceElement());
- * int value = (int) intHandle.get(segment, 0L, 3L); // get int element at offset 0 + offsetof(data) + 3 * 4 = 12
+ * {@snippet lang=java:
+ * VarHandle intAtIndexHandle =
+ *         MethodHandles.insertCoordinates(intAtOffsetAndIndexHandle, 1, 0L); // (MemorySegment, long)
+ * int value = (int) intAtIndexHandle.get(segment, 3L);                       // segment.getAtIndex(ValueLayout.JAVA_INT, 3L);
  * }
- * Where {@code offsetof(data)} is the offset of the {@code data} element layout of the {@code segmentLayout} layout
  *
- * Both the var handle returned by {@link ValueLayout#varHandle()} and
- * {@link MemoryLayout#varHandle(MemoryLayout.PathElement...)}, as well as the method handle returned by
- * {@link MemoryLayout#byteOffsetHandle(MemoryLayout.PathElement...)} and {@link MemoryLayout#sliceHandle(MemoryLayout.PathElement...)}
- * feature a <em>base offset</em> parameter. This parameter represents a base offset for the offset computation. This
- * parameter allows a client to combine these handles further with additional offset computations. This is demonstrated
- * in the first of the two examples above, where {@code intHandle} is combined with a
- * {@linkplain MemoryLayout#scaleHandle() scale handle} obtained from {@code ValueLayout.JAVA_INT}.
+ * Var handles for more complex access expressions (e.g. struct field access, pointer dereference) can be created directly
+ * from memory layouts, using <a href="MemoryLayout.html#layout-paths"><em>layout paths</em></a>.
  *
  * <h2 id="slicing">Slicing memory segments</h2>
  *


### PR DESCRIPTION
This PR adds more javadoc to explain how base offsets in var handles obtained from layouts can be used.

First, a number of examples in the main `MemoryLayout` javadoc is rectified, as such examples did not use the additional base offset parameter (and were hence incorrect).

Second, the var handles part in the `MemorySegment` section on "accessing memory segment" has been rewritten to avoid duplication with the concepts exposed in `MemoryLayout`. Now we show how `MemorySegment::get` and `MemorySegment::getAtIndex` can be obtained using basic var handles and combinators. We mention that more complex var handles can be obtained using layout paths, but we now just reference the layout path section.

Last, I've added a new section on the `MemoryLayout` javadoc, with an example on how to deal with variable-length structs. This example showcases how var handles can be used in intricate situations, and combined with the new `scaleOffset` method.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Reviewers
 * [Jorn Vernee](https://openjdk.org/census#jvernee) (@JornVernee - Committer) ⚠️ Review applies to [add4ad14](https://git.openjdk.org/panama-foreign/pull/901/files/add4ad14c6b47808815086dfa038d49a2adbcb88)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/panama-foreign.git pull/901/head:pull/901` \
`$ git checkout pull/901`

Update a local copy of the PR: \
`$ git checkout pull/901` \
`$ git pull https://git.openjdk.org/panama-foreign.git pull/901/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 901`

View PR using the GUI difftool: \
`$ git pr show -t 901`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/panama-foreign/pull/901.diff">https://git.openjdk.org/panama-foreign/pull/901.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/panama-foreign/pull/901#issuecomment-1745140840)