### PR TITLE
8317514: Ensure MemorySegment is initialized before touching NativeMemorySegmentImpl 

### DIFF
--- a/src/java.base/share/classes/jdk/internal/foreign/ArenaImpl.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/ArenaImpl.java
@@ -35,6 +35,8 @@ public final class ArenaImpl implements Arena {
     static {
         try {
             // initialize MemorySegment before touching NativeMemorySegmentImpl to avoid deadlock
+            // if multiple threads try to initialize NativeMemorySegmentImpl and MS through allocateNoInit
+            // and a method on MS at the same time
             MethodHandles.lookup().ensureInitialized(MemorySegment.class);
         } catch (ReflectiveOperationException e) {
             throw new ExceptionInInitializerError(e);

--- a/src/java.base/share/classes/jdk/internal/foreign/ArenaImpl.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/ArenaImpl.java
@@ -28,8 +28,18 @@ package jdk.internal.foreign;
 import java.lang.foreign.Arena;
 import java.lang.foreign.MemorySegment;
 import java.lang.foreign.MemorySegment.Scope;
+import java.lang.invoke.MethodHandles;
 
 public final class ArenaImpl implements Arena {
+
+    static {
+        try {
+            // initialize MemorySegment before touching NativeMemorySegmentImpl to avoid deadlock
+            MethodHandles.lookup().ensureInitialized(MemorySegment.class);
+        } catch (ReflectiveOperationException e) {
+            throw new ExceptionInInitializerError(e);
+        }
+    }
 
     private final MemorySessionImpl session;
     private final boolean shouldReserveMemory;

--- a/src/java.base/share/classes/jdk/internal/foreign/ArenaImpl.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/ArenaImpl.java
@@ -28,19 +28,16 @@ package jdk.internal.foreign;
 import java.lang.foreign.Arena;
 import java.lang.foreign.MemorySegment;
 import java.lang.foreign.MemorySegment.Scope;
-import java.lang.invoke.MethodHandles;
+
+import jdk.internal.misc.Unsafe;
 
 public final class ArenaImpl implements Arena {
 
     static {
-        try {
-            // initialize MemorySegment before touching NativeMemorySegmentImpl to avoid deadlock
-            // if multiple threads try to initialize NativeMemorySegmentImpl and MS through allocateNoInit
-            // and a method on MS at the same time
-            MethodHandles.lookup().ensureInitialized(MemorySegment.class);
-        } catch (ReflectiveOperationException e) {
-            throw new ExceptionInInitializerError(e);
-        }
+        // initialize MemorySegment before touching NativeMemorySegmentImpl to avoid deadlock
+        // if multiple threads try to initialize NativeMemorySegmentImpl and MS through allocateNoInit
+        // and a method on MS at the same time
+        Unsafe.getUnsafe().ensureClassInitialized(MemorySegment.class);
     }
 
     private final MemorySessionImpl session;

--- a/src/java.base/share/classes/jdk/internal/foreign/Utils.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/Utils.java
@@ -56,6 +56,17 @@ public final class Utils {
 
     public static final boolean IS_WINDOWS = privilegedGetProperty("os.name").startsWith("Windows");
 
+    static {
+        try {
+            // initialize MemorySegment before touching NativeMemorySegmentImpl to avoid deadlock
+            // if multiple threads try to initialize NativeMemorySegmentImpl and MS through longToAddress
+            // and a method on MS at the same time
+            MethodHandles.lookup().ensureInitialized(MemorySegment.class);
+        } catch (ReflectiveOperationException e) {
+            throw new ExceptionInInitializerError(e);
+        }
+    }
+
     // Suppresses default constructor, ensuring non-instantiability.
     private Utils() {}
 

--- a/src/java.base/share/classes/jdk/internal/foreign/Utils.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/Utils.java
@@ -57,14 +57,10 @@ public final class Utils {
     public static final boolean IS_WINDOWS = privilegedGetProperty("os.name").startsWith("Windows");
 
     static {
-        try {
-            // initialize MemorySegment before touching NativeMemorySegmentImpl to avoid deadlock
-            // if multiple threads try to initialize NativeMemorySegmentImpl and MS through longToAddress
-            // and a method on MS at the same time
-            MethodHandles.lookup().ensureInitialized(MemorySegment.class);
-        } catch (ReflectiveOperationException e) {
-            throw new ExceptionInInitializerError(e);
-        }
+        // initialize MemorySegment before touching NativeMemorySegmentImpl to avoid deadlock
+        // if multiple threads try to initialize NativeMemorySegmentImpl and MS through longToAddress
+        // and a method on MS at the same time
+        Unsafe.getUnsafe().ensureClassInitialized(MemorySegment.class);
     }
 
     // Suppresses default constructor, ensuring non-instantiability.

--- a/src/java.base/share/classes/sun/nio/ch/FileChannelImpl.java
+++ b/src/java.base/share/classes/sun/nio/ch/FileChannelImpl.java
@@ -105,6 +105,9 @@ public class FileChannelImpl
     // Cleanable with an action which closes this channel's file descriptor
     private final Cleanable closer;
 
+    // for ensureClassInitialized
+    private static final Unsafe UNSAFE = Unsafe.getUnsafe();
+
     private static class Closer implements Runnable {
         private final FileDescriptor fd;
 
@@ -1335,6 +1338,8 @@ public class FileChannelImpl
         if (mode == MapMode.READ_ONLY) {
             readOnly = true;
         }
+        // enure MS is initialized before touching subclasses directly to avoid deadlock
+        UNSAFE.ensureClassInitialized(MemorySegment.class);
         if (unmapper != null) {
             AbstractMemorySegmentImpl segment =
                 new MappedMemorySegmentImpl(unmapper.address(), unmapper, size,

--- a/test/jdk/java/foreign/TestDeadlock.java
+++ b/test/jdk/java/foreign/TestDeadlock.java
@@ -22,32 +22,63 @@
  */
 
 /*
- * @test
- * @run main/othervm/timeout=5 --enable-native-access=ALL-UNNAMED -Xlog:class+init TestDeadlock
+ * @test id=Arena_allocateFrom
+ * @run main/othervm/timeout=5 --enable-native-access=ALL-UNNAMED -Xlog:class+init TestDeadlock Arena
+ */
+
+/*
+ * @test id=FileChannel_map
+ * @run main/othervm/timeout=5 --enable-native-access=ALL-UNNAMED -Xlog:class+init TestDeadlock FileChannel
  */
 
 import java.lang.foreign.*;
+import java.io.IOException;
+import java.nio.channels.FileChannel;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
 import java.util.concurrent.CountDownLatch;
 
 public class TestDeadlock {
     public static void main(String[] args) throws Throwable {
         CountDownLatch latch = new CountDownLatch(2);
 
-        Thread t1 = Thread.ofPlatform().start(() -> {
-            Arena arena = Arena.global();
-            arena.scope(); // init ArenaImpl
-            ValueLayout.JAVA_INT.byteSize(); // init ValueLayout (and impls)
-            latch.countDown();
-            try {
-                latch.await();
-            } catch(InterruptedException e) {
-                throw new RuntimeException(e);
-            }
+        Runnable tester = switch (args[0]) {
+            case "Arena" -> () -> {
+                Arena arena = Arena.global();
+                arena.scope(); // init ArenaImpl
+                ValueLayout.JAVA_INT.byteSize(); // init ValueLayout (and impls)
+                latch.countDown();
+                try {
+                    latch.await();
+                } catch(InterruptedException e) {
+                    throw new RuntimeException(e);
+                }
 
-            // Access ArenaImpl -> NativeMemorySegmentImpl -> MemorySegment
-            arena.allocateFrom(ValueLayout.JAVA_INT, 42);
-        });
+                // Access ArenaImpl -> NativeMemorySegmentImpl -> MemorySegment
+                arena.allocateFrom(ValueLayout.JAVA_INT, 42);
+            };
+            case "FileChannel" -> () -> {
+                try {
+                    Arena arena = Arena.global();
+                    Path p = Files.createFile(Path.of("test.out"));
 
+                    try (FileChannel channel = FileChannel.open(p, StandardOpenOption.READ, StandardOpenOption.WRITE)) {
+                        channel.map(FileChannel.MapMode.READ_WRITE, 0, 4); // create MappedByteBuffer to initialize other things
+                        latch.countDown();
+                        latch.await();
+
+                        // Access MappedMemorySegmentImpl -> MemorySegment
+                        channel.map(FileChannel.MapMode.READ_WRITE, 0, 4, arena);
+                    }
+                } catch(InterruptedException | IOException e) {
+                    throw new RuntimeException(e);
+                }
+            };
+            default -> throw new IllegalArgumentException("Unknown test selection: " + args[0]);
+        };
+
+        Thread t1 = Thread.ofPlatform().start(tester);
         Thread t2 = Thread.ofPlatform().start(() -> {
             latch.countDown();
             try {

--- a/test/jdk/java/foreign/TestDeadlock.java
+++ b/test/jdk/java/foreign/TestDeadlock.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @run main/othervm/timeout=5 --enable-native-access=ALL-UNNAMED -Xlog:class+init TestDeadlock
+ */
+
+import java.lang.foreign.*;
+import java.util.concurrent.CountDownLatch;
+
+public class TestDeadlock {
+    public static void main(String[] args) throws Throwable {
+        CountDownLatch latch = new CountDownLatch(2);
+
+        Thread t1 = Thread.ofPlatform().start(() -> {
+            Arena arena = Arena.global();
+            arena.scope(); // init ArenaImpl
+            ValueLayout.JAVA_INT.byteSize(); // init ValueLayout (and impls)
+            latch.countDown();
+            try {
+                latch.await();
+            } catch(InterruptedException e) {
+                throw new RuntimeException(e);
+            }
+
+            // Access ArenaImpl -> NativeMemorySegmentImpl -> MemorySegment
+            arena.allocateFrom(ValueLayout.JAVA_INT, 42);
+        });
+
+        Thread t2 = Thread.ofPlatform().start(() -> {
+            latch.countDown();
+            try {
+                latch.await();
+            } catch(InterruptedException e) {
+                throw new RuntimeException(e);
+            }
+
+            // Access MemorySegment -> NativeMemorySegmentImpl
+            MemorySegment.ofAddress(42);
+        });
+
+        // wait for potential deadlock
+
+        t1.join();
+        t2.join();
+
+        // all good
+    }
+}


### PR DESCRIPTION
Please review this fix for a class initializer deadlock.

The issue is that `MemorySegment` references `NativeMemorySegmentImpl` in its initializer, through the `NULL` constant. `NativeMemorySegmentImpl` also depends on `MemorySegment` to be initialized, since it's a super interface with default methods. The VM does not drop the initialization monitor of `NativeMemorySegmentImpl` while trying to initialize super classes/interfaces (as mandated by the JVM spec).

When 2 threads try to intialize `MemorySegment` (e.g. through `ofAddress`) and `NativeMemorySegmentImpl` (e.g. through Arena::allocateFrom), at the same time, a deadlock can occur.

This PR fixes this issue by ensuring `MemorySegment` is initialized in all cases where we directly access `NativeMemorySegmentImpl` or `MappedMemorySegmentImpl`.

We might consider a fix that removes the cycle in the future as well.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8317514](https://bugs.openjdk.org/browse/JDK-8317514): Ensure MemorySegment is initialized before touching NativeMemorySegmentImpl (**Bug** - P3) ⚠️ Issue is already resolved. Consider making this a "backport pull request" by setting the PR title to `Backport <hash>` with the hash of the original commit. See [Backports](https://wiki.openjdk.org/display/SKARA/Backports).


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/panama-foreign.git pull/902/head:pull/902` \
`$ git checkout pull/902`

Update a local copy of the PR: \
`$ git checkout pull/902` \
`$ git pull https://git.openjdk.org/panama-foreign.git pull/902/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 902`

View PR using the GUI difftool: \
`$ git pr show -t 902`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/panama-foreign/pull/902.diff">https://git.openjdk.org/panama-foreign/pull/902.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/panama-foreign/pull/902#issuecomment-1753462865)