### PR TITLE
Fix arithmetic bug in SegmentAllocator

### DIFF
--- a/src/java.base/share/classes/java/lang/foreign/SegmentAllocator.java
+++ b/src/java.base/share/classes/java/lang/foreign/SegmentAllocator.java
@@ -126,7 +126,7 @@ public interface SegmentAllocator {
         Objects.requireNonNull(str);
         int termCharSize = StringSupport.CharsetKind.of(charset).terminatorCharSize();
         byte[] bytes = str.getBytes(charset);
-        MemorySegment segment = allocateNoInit(bytes.length + termCharSize);
+        MemorySegment segment = allocateNoInit((long) bytes.length + termCharSize);
         MemorySegment.copy(bytes, 0, segment, ValueLayout.JAVA_BYTE, 0, bytes.length);
         for (int i = 0 ; i < termCharSize ; i++) {
             segment.set(ValueLayout.JAVA_BYTE, bytes.length + i, (byte)0);


### PR DESCRIPTION
This PR proposes to fix an arithmetic bug that can manifest itself for large strings and multi-byte encoding.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Reviewers
 * [Maurizio Cimadamore](https://openjdk.org/census#mcimadamore) (@mcimadamore - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/panama-foreign.git pull/903/head:pull/903` \
`$ git checkout pull/903`

Update a local copy of the PR: \
`$ git checkout pull/903` \
`$ git pull https://git.openjdk.org/panama-foreign.git pull/903/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 903`

View PR using the GUI difftool: \
`$ git pr show -t 903`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/panama-foreign/pull/903.diff">https://git.openjdk.org/panama-foreign/pull/903.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/panama-foreign/pull/903#issuecomment-1753691668)