### PR TITLE
8317137: Time out in TestStringEncoding

### DIFF
--- a/test/jdk/java/foreign/TestStringEncodingJumbo.java
+++ b/test/jdk/java/foreign/TestStringEncodingJumbo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
  *  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  *  This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/java/foreign/TestStringEncodingJumbo.java
+++ b/test/jdk/java/foreign/TestStringEncodingJumbo.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2021, 2023, Oracle and/or its affiliates. All rights reserved.
+ *  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ *  This code is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License version 2 only, as
+ *  published by the Free Software Foundation.
+ *
+ *  This code is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ *  version 2 for more details (a copy is included in the LICENSE file that
+ *  accompanied this code).
+ *
+ *  You should have received a copy of the GNU General Public License version
+ *  2 along with this work; if not, write to the Free Software Foundation,
+ *  Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ *   Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ *  or visit www.oracle.com if you need additional information or have any
+ *  questions.
+ *
+ */
+
+import org.testng.annotations.*;
+
+import java.io.IOException;
+import java.io.RandomAccessFile;
+import java.lang.foreign.Arena;
+import java.lang.foreign.MemorySegment;
+import java.nio.channels.FileChannel;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.function.Consumer;
+
+import static java.lang.foreign.ValueLayout.*;
+import static org.testng.Assert.*;
+
+/*
+ * @test
+ * @modules java.base/jdk.internal.foreign
+ * @requires sun.arch.data.model == "64"
+ *
+ * @run testng/othervm -Xmx6G TestStringEncodingJumbo
+ */
+
+public class TestStringEncodingJumbo {
+
+    @Test()
+    public void testJumboSegment() {
+        testWithJumboSegment("testJumboSegment", segment -> {
+            segment.fill((byte) 1);
+            segment.set(JAVA_BYTE, Integer.MAX_VALUE + 10L, (byte) 0);
+            String big = segment.getString(100);
+            assertEquals(big.length(), Integer.MAX_VALUE - (100 - 10));
+        });
+    }
+
+    @Test()
+    public void testStringLargerThanMaxInt() {
+        testWithJumboSegment("testStringLargerThanMaxInt", segment -> {
+            segment.fill((byte) 1);
+            segment.set(JAVA_BYTE, Integer.MAX_VALUE + 10L, (byte) 0);
+            assertThrows(IllegalArgumentException.class, () -> {
+                segment.getString(0);
+            });
+        });
+    }
+
+    private static void testWithJumboSegment(String testName, Consumer<MemorySegment> tester) {
+        Path path = Paths.get("mapped_file");
+        try {
+            // Relly try to make sure the file is deleted after use
+            path.toFile().deleteOnExit();
+            deleteIfExistsOrThrow(path);
+            try (RandomAccessFile raf = new RandomAccessFile(path.toFile(), "rw")) {
+                FileChannel fc = raf.getChannel();
+                try (Arena arena = Arena.ofConfined()) {
+                    var segment = fc.map(FileChannel.MapMode.READ_WRITE, 0L, (long) Integer.MAX_VALUE + 100, arena);
+                    tester.accept(segment);
+                }
+            }
+        } catch (Exception e) {
+            throw new AssertionError(e);
+        } catch (OutOfMemoryError oome) {
+            // Unfortunately, we run out of memory and cannot run this test in this configuration
+            System.out.println("Skipping test because of insufficient memory: " + testName);
+        } finally {
+            deleteIfExistsOrThrow(path);
+        }
+    }
+
+    private static void deleteIfExistsOrThrow(Path file) {
+        try {
+            Files.deleteIfExists(file);
+        } catch (IOException ioe) {
+            throw new AssertionError("Unable to delete mapped file: " + file);
+        }
+    }
+
+}

--- a/test/jdk/java/foreign/TestStringEncodingJumbo.java
+++ b/test/jdk/java/foreign/TestStringEncodingJumbo.java
@@ -1,25 +1,24 @@
 /*
  * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
- *  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
- *  This code is free software; you can redistribute it and/or modify it
- *  under the terms of the GNU General Public License version 2 only, as
- *  published by the Free Software Foundation.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
  *
- *  This code is distributed in the hope that it will be useful, but WITHOUT
- *  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- *  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
- *  version 2 for more details (a copy is included in the LICENSE file that
- *  accompanied this code).
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
  *
- *  You should have received a copy of the GNU General Public License version
- *  2 along with this work; if not, write to the Free Software Foundation,
- *  Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
  *
- *   Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
- *  or visit www.oracle.com if you need additional information or have any
- *  questions.
- *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
  */
 
 import org.testng.annotations.*;


### PR DESCRIPTION
This PR suggests splitting up a test class into two and only run the slow one on 64-bit systems.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8317137](https://bugs.openjdk.org/browse/JDK-8317137): Time out in TestStringEncoding (**Bug** - P3)


### Reviewers
 * [Jorn Vernee](https://openjdk.org/census#jvernee) (@JornVernee - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/panama-foreign.git pull/908/head:pull/908` \
`$ git checkout pull/908`

Update a local copy of the PR: \
`$ git checkout pull/908` \
`$ git pull https://git.openjdk.org/panama-foreign.git pull/908/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 908`

View PR using the GUI difftool: \
`$ git pr show -t 908`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/panama-foreign/pull/908.diff">https://git.openjdk.org/panama-foreign/pull/908.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/panama-foreign/pull/908#issuecomment-1755480558)